### PR TITLE
Change how external QR code scanning works

### DIFF
--- a/src/external_app/external_messaging.ts
+++ b/src/external_app/external_messaging.ts
@@ -36,7 +36,7 @@ interface EMOutgoingMessageConfigGet extends EMMessage {
 }
 
 interface EMOutgoingMessageScanBarCode extends EMMessage {
-  type: "qr_code/scan";
+  type: "bar_code/scan";
   title: string;
   description: string;
   alternative_option_label?: string;
@@ -55,7 +55,7 @@ type EMOutgoingMessageWithAnswer = {
     request: EMOutgoingMessageConfigGet;
     response: ExternalConfig;
   };
-  "qr_code/scan": {
+  "bar_code/scan": {
     request: EMOutgoingMessageScanBarCode;
     response:
       | EMIncomingMessageBarCodeResponseCanceled
@@ -183,7 +183,7 @@ export interface EMIncomingMessageBarCodeResponseAlternativeOptions {
 export interface EMIncomingMessageBarCodeResponseScanResult {
   action: "scan_result";
   // A string decoded from the barcode data.
-  result: string;
+  rawValue: string;
   // https://developer.mozilla.org/en-US/docs/Web/API/Barcode_Detection_API#supported_barcode_formats
   format:
     | "aztec"
@@ -224,7 +224,7 @@ export interface ExternalConfig {
   canCommissionMatter: boolean;
   canImportThreadCredentials: boolean;
   hasAssist: boolean;
-  hasQRScanner: number;
+  hasBarCodeScanner: number;
 }
 
 export class ExternalMessaging {

--- a/src/external_app/external_messaging.ts
+++ b/src/external_app/external_messaging.ts
@@ -44,9 +44,6 @@ interface EMOutgoingMessageStartBarCodeScan extends EMMessage {
 
 interface EMOutgoingMessageStopBarCodeScan extends EMMessage {
   type: "bar_code/close";
-  title: string;
-  description: string;
-  alternative_option_label?: string;
 }
 
 interface EMOutgoingMessageMatterCommission extends EMMessage {

--- a/src/external_app/external_messaging.ts
+++ b/src/external_app/external_messaging.ts
@@ -35,15 +35,20 @@ interface EMOutgoingMessageConfigGet extends EMMessage {
   type: "config/get";
 }
 
-interface EMOutgoingMessageStartBarCodeScan extends EMMessage {
+interface EMOutgoingMessageBarCodeScan extends EMMessage {
   type: "bar_code/scan";
   title: string;
   description: string;
   alternative_option_label?: string;
 }
 
-interface EMOutgoingMessageStopBarCodeScan extends EMMessage {
+interface EMOutgoingMessageBarCodeClose extends EMMessage {
   type: "bar_code/close";
+}
+
+interface EMOutgoingMessageBarCodeNotify extends EMMessage {
+  type: "bar_code/notify";
+  message: string;
 }
 
 interface EMOutgoingMessageMatterCommission extends EMMessage {
@@ -125,6 +130,9 @@ type EMOutgoingMessageWithoutAnswer =
   | EMMessageResultSuccess
   | EMOutgoingMessageAppConfiguration
   | EMOutgoingMessageAssistShow
+  | EMOutgoingMessageBarCodeClose
+  | EMOutgoingMessageBarCodeNotify
+  | EMOutgoingMessageBarCodeScan
   | EMOutgoingMessageConnectionStatus
   | EMOutgoingMessageExoplayerPlayHLS
   | EMOutgoingMessageExoplayerResize
@@ -133,8 +141,6 @@ type EMOutgoingMessageWithoutAnswer =
   | EMOutgoingMessageImportThreadCredentials
   | EMOutgoingMessageMatterCommission
   | EMOutgoingMessageSidebarShow
-  | EMOutgoingMessageStartBarCodeScan
-  | EMOutgoingMessageStopBarCodeScan
   | EMOutgoingMessageTagWrite
   | EMOutgoingMessageThemeUpdate;
 

--- a/src/external_app/external_messaging.ts
+++ b/src/external_app/external_messaging.ts
@@ -35,7 +35,7 @@ interface EMOutgoingMessageConfigGet extends EMMessage {
   type: "config/get";
 }
 
-interface EMOutgoingMessageScanQRCode extends EMMessage {
+interface EMOutgoingMessageScanBarCode extends EMMessage {
   type: "qr_code/scan";
   title: string;
   description: string;
@@ -56,11 +56,11 @@ type EMOutgoingMessageWithAnswer = {
     response: ExternalConfig;
   };
   "qr_code/scan": {
-    request: EMOutgoingMessageScanQRCode;
+    request: EMOutgoingMessageScanBarCode;
     response:
-      | EMIncomingMessageQRCodeResponseCanceled
-      | EMIncomingMessageQRCodeResponseAlternativeOptions
-      | EMIncomingMessageQRCodeResponseScanResult;
+      | EMIncomingMessageBarCodeResponseCanceled
+      | EMIncomingMessageBarCodeResponseAlternativeOptions
+      | EMIncomingMessageBarCodeResponseScanResult;
   };
 };
 
@@ -172,17 +172,34 @@ interface EMIncomingMessageShowAutomationEditor {
   };
 }
 
-export interface EMIncomingMessageQRCodeResponseCanceled {
+export interface EMIncomingMessageBarCodeResponseCanceled {
   action: "canceled";
 }
 
-export interface EMIncomingMessageQRCodeResponseAlternativeOptions {
+export interface EMIncomingMessageBarCodeResponseAlternativeOptions {
   action: "alternative_options";
 }
 
-export interface EMIncomingMessageQRCodeResponseScanResult {
+export interface EMIncomingMessageBarCodeResponseScanResult {
   action: "scan_result";
+  // A string decoded from the barcode data.
   result: string;
+  // https://developer.mozilla.org/en-US/docs/Web/API/Barcode_Detection_API#supported_barcode_formats
+  format:
+    | "aztec"
+    | "code_128"
+    | "code_39"
+    | "code_93"
+    | "codabar"
+    | "data_matrix"
+    | "ean_13"
+    | "ean_8"
+    | "itf"
+    | "pdf417"
+    | "qr_code"
+    | "upc_a"
+    | "upc_e"
+    | "unknown";
 }
 
 export type EMIncomingMessageCommands =


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Based on feedback from Bram, change the way the external QR code scanner is integrated.

New format means the QR code scanner lifecycle is now fully controlled by the frontend.

Example interaction:

1. **frontend:** Open QR code scanner (send `bar_code/scan` message)
1. **app:** Opens the QR code scanner and start scanning
1. **app:** Find result (send `bar_code/scan_result` message)
1. **frontend:** Check if the result is ok. This time it's not so ignores result. Notify user by sending `bar_code/notify` message.
1. **app:** Find result (send `bar_code/scan_result` message)
1. **frontend:** Approves result. Tell app to close QR code scanner (send `bar_code/close` message)

If the user aborts the native QR code scanner, the app sends `bar_code/aborted` with a payload containing a reason: `"canceled" | "alternative_options"`.

To test that this model works I have created an example consumer for the frontend. The only thing that is missing is listening to the external bus messaging:

```ts
import { HomeAssistant } from "../types";
import { EMIncomingMessageBarCodeScanResult } from "./external_messaging";

export class BarCodeError extends Error {
  public reason: string;

  constructor(reason: string) {
    super("Bar code scanning aborted");
    this.reason = reason;
  }
}

export const scanExternalBarCode = async (
  hass: HomeAssistant,
  title: string,
  description: string,
  isAcceptedBarCode: (format: string, barcode: string) => Promise<boolean>,
  alternativeOptionLabel?: string
): Promise<EMIncomingMessageBarCodeScanResult["payload"]> => {
  if (!hass.auth.external || !hass.auth.external.config.hasBarCodeScanner) {
    throw new Error("No external app bar code scanner available");
  }

  hass.auth.external.fireMessage({
    type: "bar_code/scan",
    title,
    description,
    alternative_option_label: alternativeOptionLabel,
  });

  // This class does not exist.
  const externalQRCodeMessages = new ExternalQRCodeMessages();

  const seen = new Set<string>();

  try {
    for await (const message of externalQRCodeMessages.listen()) {
      if (message.type === "bar_code/aborted") {
        throw new BarCodeError(message.payload.reason);
      }

      if (message.type === "bar_code/scan_result") {
        const key = `${message.payload.format}/${message.payload.code}`;

        // Prevent duplicate scans
        if (seen.has(key)) {
          continue;
        }

        if (
          await isAcceptedBarCode(message.payload.format, message.payload.code)
        ) {
          return message.payload;
        }

        hass.auth.external.fireMessage({
          type: "bar_code/notify",
          message: "Invalid bar code",
        });
        seen.add(key);
        continue;
      }

      // eslint-disable-next-line no-console
      console.warn("Unexpected bar code message", message);
    }

    throw new BarCodeError("stream_stopped");
  } finally {
    hass.auth.external.fireMessage({
      type: "bar_code/close",
    });
    externalQRCodeMessages.tearDown();
  }
};

```



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
