### PR TITLE
Fix status text centering for cast launch screen

### DIFF
--- a/cast/src/receiver/layout/hc-launch-screen.ts
+++ b/cast/src/receiver/layout/hc-launch-screen.ts
@@ -15,7 +15,7 @@ class HcLaunchScreen extends LitElement {
           alt="Nabu Casa logo on left, Home Assistant logo on right, and red heart in center"
           src="https://cast.home-assistant.io/images/nabu-loves-hass.png"
         />
-        <div>
+        <div class="status">
           ${this.hass ? "Connected" : "Not Connected"}
           ${this.error ? html` <p>Error: ${this.error}</p> ` : ""}
         </div>

--- a/cast/src/receiver/layout/hc-launch-screen.ts
+++ b/cast/src/receiver/layout/hc-launch-screen.ts
@@ -15,7 +15,7 @@ class HcLaunchScreen extends LitElement {
           alt="Nabu Casa logo on left, Home Assistant logo on right, and red heart in center"
           src="https://cast.home-assistant.io/images/nabu-loves-hass.png"
         />
-        <div class="status">
+        <div>
           ${this.hass ? "Connected" : "Not Connected"}
           ${this.error ? html` <p>Error: ${this.error}</p> ` : ""}
         </div>
@@ -42,11 +42,6 @@ class HcLaunchScreen extends LitElement {
       img {
         max-width: 80%;
         object-fit: cover;
-      }
-      .status {
-        padding-right: 54px;
-        padding-inline-end: 54px;
-        padding-inline-start: initial;
       }
     `;
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Remove the margins from the status text on the cast launch screen so that it is centered.

<img width="959" alt="Screenshot 2024-02-08 at 4 32 08 PM" src="https://github.com/home-assistant/frontend/assets/46114593/f5c06a1a-bf42-4d6f-9a13-2e313ba98a14">


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #19745 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [NA] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [NA] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
