### PR TITLE
Add reconfigure config entry

### DIFF
--- a/demo/src/stubs/config_entries.ts
+++ b/demo/src/stubs/config_entries.ts
@@ -10,6 +10,7 @@ export const mockConfigEntries = (hass: MockHomeAssistant) => {
     supports_options: false,
     supports_remove_device: false,
     supports_unload: true,
+    supports_reconfigure: true,
     pref_disable_new_entities: false,
     pref_disable_polling: false,
     disabled_by: null,

--- a/gallery/src/pages/misc/integration-card.ts
+++ b/gallery/src/pages/misc/integration-card.ts
@@ -31,6 +31,7 @@ const createConfigEntry = (
   supports_options: false,
   supports_remove_device: false,
   supports_unload: true,
+  supports_reconfigure: true,
   disabled_by: null,
   pref_disable_new_entities: false,
   pref_disable_polling: false,

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -18,6 +18,7 @@ export interface ConfigEntry {
   supports_options: boolean;
   supports_remove_device: boolean;
   supports_unload: boolean;
+  supports_reconfigure: boolean;
   pref_disable_new_entities: boolean;
   pref_disable_polling: boolean;
   disabled_by: "user" | null;

--- a/src/data/config_flow.ts
+++ b/src/data/config_flow.ts
@@ -29,8 +29,7 @@ const HEADERS = {
 export const createConfigFlow = (
   hass: HomeAssistant,
   handler: string,
-  source?: string,
-  entryId?: string
+  entry_id?: string
 ) =>
   hass.callApi<DataEntryFlowStep>(
     "POST",
@@ -38,8 +37,7 @@ export const createConfigFlow = (
     {
       handler,
       show_advanced_options: Boolean(hass.userData?.showAdvanced),
-      source: source,
-      entry_id: entryId,
+      entry_id,
     },
     HEADERS
   );

--- a/src/data/config_flow.ts
+++ b/src/data/config_flow.ts
@@ -26,13 +26,18 @@ const HEADERS = {
   "HA-Frontend-Base": `${location.protocol}//${location.host}`,
 };
 
-export const createConfigFlow = (hass: HomeAssistant, handler: string) =>
+export const createConfigFlow = (
+  hass: HomeAssistant,
+  handler: string,
+  source?: string
+) =>
   hass.callApi<DataEntryFlowStep>(
     "POST",
     "config/config_entries/flow",
     {
       handler,
       show_advanced_options: Boolean(hass.userData?.showAdvanced),
+      source: source,
     },
     HEADERS
   );

--- a/src/data/config_flow.ts
+++ b/src/data/config_flow.ts
@@ -29,7 +29,8 @@ const HEADERS = {
 export const createConfigFlow = (
   hass: HomeAssistant,
   handler: string,
-  source?: string
+  source?: string,
+  entryId?: string
 ) =>
   hass.callApi<DataEntryFlowStep>(
     "POST",
@@ -38,6 +39,7 @@ export const createConfigFlow = (
       handler,
       show_advanced_options: Boolean(hass.userData?.showAdvanced),
       source: source,
+      entry_id: entryId,
     },
     HEADERS
   );

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -23,7 +23,7 @@ export const showConfigFlowDialog = (
     loadDevicesAndAreas: true,
     createFlow: async (hass, handler) => {
       const [step] = await Promise.all([
-        createConfigFlow(hass, handler),
+        createConfigFlow(hass, handler, dialogParams.source),
         hass.loadFragmentTranslation("config"),
         hass.loadBackendTranslation("config", handler),
         hass.loadBackendTranslation("selector", handler),

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -23,12 +23,7 @@ export const showConfigFlowDialog = (
     loadDevicesAndAreas: true,
     createFlow: async (hass, handler) => {
       const [step] = await Promise.all([
-        createConfigFlow(
-          hass,
-          handler,
-          dialogParams.source,
-          dialogParams.entryId
-        ),
+        createConfigFlow(hass, handler, dialogParams.entryId),
         hass.loadFragmentTranslation("config"),
         hass.loadBackendTranslation("config", handler),
         hass.loadBackendTranslation("selector", handler),

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -23,7 +23,12 @@ export const showConfigFlowDialog = (
     loadDevicesAndAreas: true,
     createFlow: async (hass, handler) => {
       const [step] = await Promise.all([
-        createConfigFlow(hass, handler, dialogParams.source),
+        createConfigFlow(
+          hass,
+          handler,
+          dialogParams.source,
+          dialogParams.entryId
+        ),
         hass.loadFragmentTranslation("config"),
         hass.loadBackendTranslation("config", handler),
         hass.loadBackendTranslation("selector", handler),

--- a/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
@@ -139,7 +139,6 @@ export interface DataEntryFlowDialogParams {
   }) => void;
   flowConfig: FlowConfig;
   showAdvanced?: boolean;
-  source?: string;
   entryId?: string;
   dialogParentElement?: HTMLElement;
 }

--- a/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
@@ -140,6 +140,7 @@ export interface DataEntryFlowDialogParams {
   flowConfig: FlowConfig;
   showAdvanced?: boolean;
   source?: string;
+  entryId?: string;
   dialogParentElement?: HTMLElement;
 }
 

--- a/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
@@ -139,6 +139,7 @@ export interface DataEntryFlowDialogParams {
   }) => void;
   flowConfig: FlowConfig;
   showAdvanced?: boolean;
+  source?: string;
   dialogParentElement?: HTMLElement;
 }
 

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -808,7 +808,6 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
             </a>`
           : ""}
         ${!item.disabled_by &&
-        RECOVERABLE_STATES.includes(item.state) &&
         item.supports_reconfigure &&
         item.source !== "system"
           ? html`<ha-list-item
@@ -1288,7 +1287,6 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
       startFlowHandler: configEntry.domain,
       showAdvanced: this.hass.userData?.showAdvanced,
       manifest: await fetchIntegrationManifest(this.hass, configEntry.domain),
-      source: "reconfigure",
       entryId: configEntry.entry_id,
     });
   }

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -23,6 +23,7 @@ import {
   mdiRenameBox,
   mdiShapeOutline,
   mdiStopCircleOutline,
+  mdiWrench,
 } from "@mdi/js";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import {
@@ -806,6 +807,20 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
               </ha-list-item>
             </a>`
           : ""}
+        ${!item.disabled_by &&
+        RECOVERABLE_STATES.includes(item.state) &&
+        item.supports_reconfigure &&
+        item.source !== "system"
+          ? html`<ha-list-item
+              @request-selected=${this._handleReconfigure}
+              graphic="icon"
+            >
+              ${this.hass.localize(
+                "ui.panel.config.integrations.config_entry.reconfigure"
+              )}
+              <ha-svg-icon slot="graphic" .path=${mdiWrench}></ha-svg-icon>
+            </ha-list-item>`
+          : ""}
 
         <ha-list-item
           @request-selected=${this._handleSystemOptions}
@@ -1040,6 +1055,15 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
     );
   }
 
+  private _handleReconfigure(ev: CustomEvent<RequestSelectedDetail>): void {
+    if (!shouldHandleRequestSelectedEvent(ev)) {
+      return;
+    }
+    this._reconfigureIntegration(
+      ((ev.target as HTMLElement).closest(".config_entry") as any).configEntry
+    );
+  }
+
   private _handleDelete(ev: CustomEvent<RequestSelectedDetail>): void {
     if (!shouldHandleRequestSelectedEvent(ev)) {
       return;
@@ -1256,6 +1280,15 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
       text: this.hass.localize(
         `ui.panel.config.integrations.config_entry.${locale_key}`
       ),
+    });
+  }
+
+  private async _reconfigureIntegration(configEntry: ConfigEntry) {
+    showConfigFlowDialog(this, {
+      startFlowHandler: configEntry.domain,
+      showAdvanced: this.hass.userData?.showAdvanced,
+      manifest: await fetchIntegrationManifest(this.hass, configEntry.domain),
+      source: "reconfigure",
     });
   }
 

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -1289,6 +1289,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
       showAdvanced: this.hass.userData?.showAdvanced,
       manifest: await fetchIntegrationManifest(this.hass, configEntry.domain),
       source: "reconfigure",
+      entryId: configEntry.entry_id,
     });
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3921,6 +3921,7 @@
             "delete_confirm_title": "Delete {title}?",
             "delete_confirm_text": "Its devices and entities will be permanently deleted.",
             "enable_debug_logging": "Enable debug logging",
+            "reconfigure": "Reconfigure",
             "reload": "Reload",
             "restart_confirm": "Restart Home Assistant to finish removing this integration",
             "reload_confirm": "The integration was reloaded",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This adds ability to reconfigure a config entry by explicitly running the `async_step_reconfigure` step.
Core PR: https://github.com/home-assistant/core/pull/108794

![image](https://github.com/home-assistant/frontend/assets/62932417/9088820c-d7f3-4489-a6c9-66125efe8437)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
