### PR TITLE
Improve service filtering

### DIFF
--- a/src/components/ha-service-picker.ts
+++ b/src/components/ha-service-picker.ts
@@ -114,14 +114,15 @@ class HaServicePicker extends LitElement {
       if (!filter) {
         return processedServices;
       }
-      const split_filter = filter.split(' ')
-      return processedServices.filter(
-        (service) => {
-          const lower_service_name = service.name.toLowerCase();
-          const lower_service = service.service.toLowerCase();
-          return split_filter.every(f => lower_service_name.includes(f)) || split_filter.every(f => lower_service.toLowerCase().includes(f))
-        }
-      );
+      const split_filter = filter.split(" ");
+      return processedServices.filter((service) => {
+        const lower_service_name = service.name.toLowerCase();
+        const lower_service = service.service.toLowerCase();
+        return (
+          split_filter.every((f) => lower_service_name.includes(f)) ||
+          split_filter.every((f) => lower_service.toLowerCase().includes(f))
+        );
+      });
     }
   );
 

--- a/src/components/ha-service-picker.ts
+++ b/src/components/ha-service-picker.ts
@@ -120,7 +120,7 @@ class HaServicePicker extends LitElement {
         const lower_service = service.service.toLowerCase();
         return (
           split_filter.every((f) => lower_service_name.includes(f)) ||
-          split_filter.every((f) => lower_service.toLowerCase().includes(f))
+          split_filter.every((f) => lower_service.includes(f))
         );
       });
     }

--- a/src/components/ha-service-picker.ts
+++ b/src/components/ha-service-picker.ts
@@ -114,10 +114,13 @@ class HaServicePicker extends LitElement {
       if (!filter) {
         return processedServices;
       }
+      const split_filter = filter.split(' ')
       return processedServices.filter(
-        (service) =>
-          service.service.toLowerCase().includes(filter) ||
-          service.name?.toLowerCase().includes(filter)
+        (service) => {
+          const lower_service_name = service.name.toLowerCase();
+          const lower_service = service.service.toLowerCase();
+          return split_filter.every(f => lower_service_name.includes(f)) || split_filter.every(f => lower_service.toLowerCase().includes(f))
+        }
       );
     }
   );

--- a/src/components/ha-service-picker.ts
+++ b/src/components/ha-service-picker.ts
@@ -118,7 +118,9 @@ class HaServicePicker extends LitElement {
       return processedServices.filter((service) => {
         const lower_service_name = service.name.toLowerCase();
         const lower_service = service.service.toLowerCase();
-        return split_filter.every((f) => lower_service_name.includes(f) || lower_service.includes(f))
+        return split_filter.every(
+          (f) => lower_service_name.includes(f) || lower_service.includes(f)
+        );
       });
     }
   );

--- a/src/components/ha-service-picker.ts
+++ b/src/components/ha-service-picker.ts
@@ -118,10 +118,7 @@ class HaServicePicker extends LitElement {
       return processedServices.filter((service) => {
         const lower_service_name = service.name.toLowerCase();
         const lower_service = service.service.toLowerCase();
-        return (
-          split_filter.every((f) => lower_service_name.includes(f)) ||
-          split_filter.every((f) => lower_service.includes(f))
-        );
+        return split_filter.every((f) => lower_service_name.includes(f) || lower_service.includes(f))
       });
     }
   );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
I've always struggled with filtering this list, you have to match the service name or code exactly to get it to show up.

With this change it has a lot smoother UX, for instance "cloud disconnect" and "google tts" matches where it previously didn't.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Go to developer tools > services and type words in any order to match services easier.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
