### PR TITLE
Directly prompt for lock code in dashboards

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-lock-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-lock-entity-row.ts
@@ -14,6 +14,7 @@ import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import { EntityConfig, LovelaceRow } from "./types";
+import { callProtectedLockService } from "../../../data/lock";
 
 @customElement("hui-lock-entity-row")
 class HuiLockEntityRow extends LitElement implements LovelaceRow {
@@ -75,10 +76,11 @@ class HuiLockEntityRow extends LitElement implements LovelaceRow {
   private _callService(ev): void {
     ev.stopPropagation();
     const stateObj = this.hass!.states[this._config!.entity];
-    this.hass!.callService(
-      "lock",
-      stateObj.state === "locked" ? "unlock" : "lock",
-      { entity_id: stateObj.entity_id }
+    callProtectedLockService(
+      this,
+      this.hass!,
+      stateObj,
+      stateObj.state === "locked" ? "unlock" : "lock"
     );
   }
 }

--- a/src/state-summary/state-card-lock.ts
+++ b/src/state-summary/state-card-lock.ts
@@ -11,7 +11,7 @@ import {
 import { customElement, property } from "lit/decorators";
 import { supportsFeature } from "../common/entity/supports-feature";
 import "../components/entity/state-info";
-import { LockEntityFeature } from "../data/lock";
+import { callProtectedLockService, LockEntityFeature } from "../data/lock";
 import { HomeAssistant } from "../types";
 import { haStyle } from "../resources/styles";
 
@@ -56,10 +56,10 @@ class StateCardLock extends LitElement {
   private async _callService(ev) {
     ev.stopPropagation();
     const service = ev.target.dataset.service;
-    const data = {
-      entity_id: this.stateObj.entity_id,
-    };
-    await this.hass.callService("lock", service, data);
+    if (!this.hass || !this.stateObj) {
+      return;
+    }
+    await callProtectedLockService(this, this.hass, this.stateObj, service);
   }
 
   static get styles(): CSSResultGroup {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Currently, a `lock` with a `code_format` is unusable from a dashboard row when no default code is set. When clicking on "unlock" or "lock" button, only an error toast message is displayed reading "The code for lock.test_with_code doesn't match pattern ...". Only when (un)locking from the entity info dialog, the code prompt is opened.

After this PR, the prompt is displayed in more places where a lock is displayed with its default entity card.

### Before:
![grafik](https://github.com/home-assistant/frontend/assets/57918757/efd80018-a9ae-4313-a5ac-21c0b1214bfd)

### After:
![grafik](https://github.com/home-assistant/frontend/assets/57918757/2cabf430-a505-4c99-9fe1-56f590307e4e)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
