### PR TITLE
Add devices to energy collection

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -331,11 +331,7 @@ export const getReferencedStatisticIds = (
       }
     }
   }
-  if (
-    includeTypes &&
-    includeTypes.includes("device") &&
-    prefs.device_consumption
-  ) {
+  if (!(includeTypes && !includeTypes.includes("device"))) {
     statIDs.push(...prefs.device_consumption.map((d) => d.stat_consumption));
   }
 

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -331,6 +331,13 @@ export const getReferencedStatisticIds = (
       }
     }
   }
+  if (
+    includeTypes &&
+    includeTypes.includes("device") &&
+    prefs.device_consumption
+  ) {
+    statIDs.push(...prefs.device_consumption.map((d) => d.stat_consumption));
+  }
 
   return statIDs;
 };
@@ -383,6 +390,7 @@ const getEnergyData = async (
     "solar",
     "battery",
     "gas",
+    "device",
   ]);
   const waterStatIds = getReferencedStatisticIds(prefs, info, ["water"]);
 

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
@@ -72,7 +72,7 @@ export class HuiEnergyDevicesDetailGraphCard
     return [
       getEnergyDataCollection(this.hass, {
         key: this._config?.collection_key,
-      }).subscribe(async (data) => {
+      }).subscribe((data) => {
         this._data = data;
         this._processStatistics();
       }),
@@ -194,7 +194,7 @@ export class HuiEnergyDevicesDetailGraphCard
     }
   );
 
-  private async _processStatistics() {
+  private _processStatistics() {
     const energyData = this._data!;
     const data = energyData.stats;
     const compareData = energyData.statsCompare;

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
@@ -6,7 +6,6 @@ import {
   ScatterDataPoint,
 } from "chart.js";
 import { getRelativePosition } from "chart.js/helpers";
-import { differenceInDays } from "date-fns/esm";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import {
   css,
@@ -31,10 +30,7 @@ import "../../../../components/ha-card";
 import { EnergyData, getEnergyDataCollection } from "../../../../data/energy";
 import {
   calculateStatisticSumGrowth,
-  fetchStatistics,
   getStatisticLabel,
-  Statistics,
-  StatisticsUnitConfiguration,
 } from "../../../../data/recorder";
 import { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
@@ -186,47 +182,8 @@ export class HuiEnergyDevicesGraphCard
   );
 
   private async _getStatistics(energyData: EnergyData): Promise<void> {
-    const dayDifference = differenceInDays(
-      energyData.end || new Date(),
-      energyData.start
-    );
-
-    const devices = energyData.prefs.device_consumption.map(
-      (device) => device.stat_consumption
-    );
-
-    const period =
-      dayDifference > 35 ? "month" : dayDifference > 2 ? "day" : "hour";
-
-    const lengthUnit = this.hass.config.unit_system.length || "";
-    const units: StatisticsUnitConfiguration = {
-      energy: "kWh",
-      volume: lengthUnit === "km" ? "m³" : "ft³",
-    };
-
-    const data = await fetchStatistics(
-      this.hass,
-      energyData.start,
-      energyData.end,
-      devices,
-      period,
-      units,
-      ["change"]
-    );
-
-    let compareData: Statistics | undefined;
-
-    if (energyData.startCompare && energyData.endCompare) {
-      compareData = await fetchStatistics(
-        this.hass,
-        energyData.startCompare,
-        energyData.endCompare,
-        devices,
-        period,
-        units,
-        ["change"]
-      );
-    }
+    const data = energyData.stats;
+    const compareData = energyData.statsCompare;
 
     const chartData: Array<ChartDataset<"bar", ParsedDataType<"bar">>["data"]> =
       [];


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Add individual devices to the energy collection. It's not clear to me why they were not there originally, I'm either missing something conceptually or it was just an oversight. 

Currently they are not in the collection and the devices card just fetches the stats individually each time it loads. This is not efficient since I added the devices-detail graph, since now I realize that we are double fetching the device statistics, once in the summary card, and once in the detail card. 

This simplifies the overall statistics fetching for devices graph cards, as they were just duplicating the logic that the energy collection was already performing. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
