### PR TITLE
Rebuild stack card when a child card rebuilds

### DIFF
--- a/src/panels/lovelace/cards/hui-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-stack-card.ts
@@ -7,6 +7,7 @@ import {
   nothing,
 } from "lit";
 import { property, state } from "lit/decorators";
+import { fireEvent } from "../../../common/dom/fire_event";
 import { LovelaceCardConfig } from "../../../data/lovelace/config/card";
 import { HomeAssistant } from "../../../types";
 import { createCardElement } from "../create-element/create-card-element";
@@ -111,6 +112,7 @@ export abstract class HuiStackCard<T extends StackCardConfig = StackCardConfig>
       (ev) => {
         ev.stopPropagation();
         this._rebuildCard(element, cardConfig);
+        fireEvent(this, "ll-rebuild");
       },
       { once: true }
     );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

I'm unsure if this is the correct fix, but this proposal does fix a bug I have encountered where the masonry layout is not stable in some cases, because cardsize is not calculated for custom cards in stacks the first time the page loads.

This cause the masonry layout to be unstable and cards to move around depending on if it is the first or subsequent time a page is visited. 

As a fix, this proposes anytime a card in a stack fires the `ll-rebuild` event, this has the stack also fire a rebuild event, so that the stack is rebuilt and the size is properly calculated. 

Unsure if this is the best performance solution, or if a different event which just retriggered `createColumns`, but not necessarily recreating the element over again would be preferable. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #16262
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
