### PR TITLE
Add lock commands feature to tile card

### DIFF
--- a/gallery/src/pages/lovelace/tile-card.ts
+++ b/gallery/src/pages/lovelace/tile-card.ts
@@ -2,6 +2,7 @@ import { html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { customElement, query } from "lit/decorators";
 import { CoverEntityFeature } from "../../../../src/data/cover";
 import { LightColorMode } from "../../../../src/data/light";
+import { LockEntityFeature } from "../../../../src/data/lock";
 import { VacuumEntityFeature } from "../../../../src/data/vacuum";
 import { getEntity } from "../../../../src/fake_data/entity";
 import { provideHass } from "../../../../src/fake_data/provide_hass";
@@ -19,6 +20,11 @@ const ENTITIES = [
   }),
   getEntity("light", "unavailable", "unavailable", {
     friendly_name: "Unavailable entity",
+  }),
+  getEntity("lock", "front_door", "locked", {
+    friendly_name: "Front Door Lock",
+    device_class: "lock",
+    supported_features: LockEntityFeature.OPEN,
   }),
   getEntity("climate", "thermostat", "heat", {
     current_temperature: 73,
@@ -136,6 +142,15 @@ const CONFIGS = [
   entity: light.bed_light
   features:
     - type: "color-temp"
+    `,
+  },
+  {
+    heading: "Lock commands feature",
+    config: `
+- type: tile
+  entity: lock.front_door
+  features:
+    - type: "lock-commands"
     `,
   },
   {

--- a/src/data/lock.ts
+++ b/src/data/lock.ts
@@ -5,9 +5,7 @@ import {
 import { getExtendedEntityRegistryEntry } from "./entity_registry";
 import { showEnterCodeDialogDialog } from "../dialogs/enter-code/show-enter-code-dialog";
 import { HomeAssistant } from "../types";
-
-export const FORMAT_TEXT = "text";
-export const FORMAT_NUMBER = "number";
+import { UNAVAILABLE } from "./entity";
 
 export const enum LockEntityFeature {
   OPEN = 1,
@@ -23,6 +21,29 @@ export interface LockEntity extends HassEntityBase {
 }
 
 type ProtectedLockService = "lock" | "unlock" | "open";
+
+export function isUnlocking(stateObj: LockEntity) {
+  return stateObj.state === "unlocking";
+}
+
+export function isLocking(stateObj: LockEntity) {
+  return stateObj.state === "locking";
+}
+
+export function isJammed(stateObj: LockEntity) {
+  return stateObj.state === "jammed";
+}
+
+export function isAvailable(stateObj: LockEntity) {
+  if (stateObj.state === UNAVAILABLE) {
+    return false;
+  }
+  const assumedState = stateObj.attributes.assumed_state === true;
+  return (
+    assumedState ||
+    (!isLocking(stateObj) && !isUnlocking(stateObj) && !isJammed(stateObj))
+  );
+}
 
 export const callProtectedLockService = async (
   element: HTMLElement,

--- a/src/panels/lovelace/card-features/hui-lock-commands-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-lock-commands-card-feature.ts
@@ -1,0 +1,119 @@
+import { mdiDoorOpen, mdiLock, mdiLockOpen } from "@mdi/js";
+import { HassEntity } from "home-assistant-js-websocket";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { computeDomain } from "../../../common/entity/compute_domain";
+
+import { supportsFeature } from "../../../common/entity/supports-feature";
+import "../../../components/ha-control-button";
+import "../../../components/ha-control-button-group";
+import {
+  LockEntityFeature,
+  callProtectedLockService,
+  isAvailable,
+} from "../../../data/lock";
+import { HomeAssistant } from "../../../types";
+import { LovelaceCardFeature } from "../types";
+import { LockCommandsCardFeatureConfig } from "./types";
+import { forwardHaptic } from "../../../data/haptics";
+
+export const supportsLockCommandsCardFeature = (stateObj: HassEntity) => {
+  const domain = computeDomain(stateObj.entity_id);
+  return domain === "lock" && supportsFeature(stateObj, LockEntityFeature.OPEN);
+};
+
+@customElement("hui-lock-commands-card-feature")
+class HuiLockCommandsCardFeature
+  extends LitElement
+  implements LovelaceCardFeature
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public stateObj?: HassEntity;
+
+  @state() private _config?: LockCommandsCardFeatureConfig;
+
+  static getStubConfig(): LockCommandsCardFeatureConfig {
+    return {
+      type: "lock-commands",
+    };
+  }
+
+  public setConfig(config: LockCommandsCardFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  private _onToggleTap(ev): void {
+    ev.stopPropagation();
+    if (!this.hass || !this.stateObj) {
+      return;
+    }
+    forwardHaptic("light");
+    callProtectedLockService(
+      this,
+      this.hass,
+      this.stateObj,
+      this.stateObj.state === "locked" ? "unlock" : "lock"
+    );
+  }
+
+  private _onOpenTap(ev): void {
+    ev.stopPropagation();
+    if (!this.hass || !this.stateObj) {
+      return;
+    }
+    forwardHaptic("light");
+    callProtectedLockService(this, this.hass, this.stateObj, "open");
+  }
+
+  protected render() {
+    if (
+      !this._config ||
+      !this.hass ||
+      !this.stateObj ||
+      !supportsLockCommandsCardFeature(this.stateObj)
+    ) {
+      return nothing;
+    }
+    const isLocked = this.stateObj.state === "locked";
+
+    return html`
+      <ha-control-button-group>
+        <ha-control-button
+          .label=${isLocked
+            ? this.hass.localize("ui.card.lock.unlock")
+            : this.hass.localize("ui.card.lock.lock")}
+          @click=${this._onToggleTap}
+          .disabled=${!isAvailable(this.stateObj)}
+        >
+          <ha-svg-icon .path=${isLocked ? mdiLockOpen : mdiLock}></ha-svg-icon>
+        </ha-control-button>
+        <ha-control-button
+          .label=${this.hass.localize("ui.card.lock.unlock")}
+          @click=${this._onOpenTap}
+          .disabled=${!isAvailable(this.stateObj)}
+        >
+          <ha-svg-icon .path=${mdiDoorOpen}></ha-svg-icon>
+        </ha-control-button>
+      </ha-control-button-group>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      ha-control-button-group {
+        margin: 0 12px 12px 12px;
+        --control-button-group-spacing: 12px;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-lock-commands-card-feature": HuiLockCommandsCardFeature;
+  }
+}

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -26,6 +26,10 @@ export interface LightColorTempCardFeatureConfig {
   type: "light-color-temp";
 }
 
+export interface LockCommandsCardFeatureConfig {
+  type: "lock-commands";
+}
+
 export interface FanPresetModesCardFeatureConfig {
   type: "fan-preset-modes";
   style?: "dropdown" | "icons";
@@ -136,6 +140,7 @@ export type LovelaceCardFeatureConfig =
   | LawnMowerCommandsCardFeatureConfig
   | LightBrightnessCardFeatureConfig
   | LightColorTempCardFeatureConfig
+  | LockCommandsCardFeatureConfig
   | NumericInputCardFeatureConfig
   | SelectOptionsCardFeatureConfig
   | TargetHumidityCardFeatureConfig

--- a/src/panels/lovelace/create-element/create-card-feature-element.ts
+++ b/src/panels/lovelace/create-element/create-card-feature-element.ts
@@ -13,6 +13,7 @@ import "../card-features/hui-humidifier-toggle-card-feature";
 import "../card-features/hui-lawn-mower-commands-card-feature";
 import "../card-features/hui-light-brightness-card-feature";
 import "../card-features/hui-light-color-temp-card-feature";
+import "../card-features/hui-lock-commands-card-feature";
 import "../card-features/hui-numeric-input-card-feature";
 import "../card-features/hui-select-options-card-feature";
 import "../card-features/hui-target-temperature-card-feature";
@@ -43,6 +44,7 @@ const TYPES: Set<LovelaceCardFeatureConfig["type"]> = new Set([
   "lawn-mower-commands",
   "light-brightness",
   "light-color-temp",
+  "lock-commands",
   "numeric-input",
   "select-options",
   "target-humidity",

--- a/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
@@ -34,6 +34,7 @@ import { supportsHumidifierToggleCardFeature } from "../../card-features/hui-hum
 import { supportsLawnMowerCommandCardFeature } from "../../card-features/hui-lawn-mower-commands-card-feature";
 import { supportsLightBrightnessCardFeature } from "../../card-features/hui-light-brightness-card-feature";
 import { supportsLightColorTempCardFeature } from "../../card-features/hui-light-color-temp-card-feature";
+import { supportsLockCommandsCardFeature } from "../../card-features/hui-lock-commands-card-feature";
 import { supportsNumericInputCardFeature } from "../../card-features/hui-numeric-input-card-feature";
 import { supportsSelectOptionsCardFeature } from "../../card-features/hui-select-options-card-feature";
 import { supportsTargetHumidityCardFeature } from "../../card-features/hui-target-humidity-card-feature";
@@ -54,8 +55,8 @@ const UI_FEATURE_TYPES = [
   "climate-preset-modes",
   "cover-open-close",
   "cover-position",
-  "cover-tilt-position",
   "cover-tilt",
+  "cover-tilt-position",
   "fan-preset-modes",
   "fan-speed",
   "humidifier-modes",
@@ -63,6 +64,7 @@ const UI_FEATURE_TYPES = [
   "lawn-mower-commands",
   "light-brightness",
   "light-color-temp",
+  "lock-commands",
   "numeric-input",
   "select-options",
   "target-humidity",
@@ -107,6 +109,7 @@ const SUPPORTS_FEATURE_TYPES: Record<
   "lawn-mower-commands": supportsLawnMowerCommandCardFeature,
   "light-brightness": supportsLightBrightnessCardFeature,
   "light-color-temp": supportsLightColorTempCardFeature,
+  "lock-commands": supportsLockCommandsCardFeature,
   "numeric-input": supportsNumericInputCardFeature,
   "select-options": supportsSelectOptionsCardFeature,
   "target-humidity": supportsTargetHumidityCardFeature,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5587,6 +5587,9 @@
               "light-color-temp": {
                 "label": "Light color temperature"
               },
+              "lock-commands": {
+                "label": "Lock commands"
+              },
               "vacuum-commands": {
                 "label": "Vacuum commands",
                 "commands": "Commands",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Added lock-commands feature for the tile card inspired from the mushroom lock card from @piitaya 

![image](https://github.com/home-assistant/frontend/assets/11457346/f7b8c7be-e00f-4de3-9007-f608263f978b)
![image](https://github.com/home-assistant/frontend/assets/11457346/01c34b20-9328-40f3-9293-d49ebe86b15c)
![image](https://github.com/home-assistant/frontend/assets/11457346/13be36d3-e3a9-4614-96fe-e0e9063af764)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: tile
entity: lock.front_door
features:
  - type: lock-commands
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
