### PR TITLE
Add support for translation domain in data entry flows

### DIFF
--- a/src/data/data_entry_flow.ts
+++ b/src/data/data_entry_flow.ts
@@ -33,6 +33,7 @@ export interface DataEntryFlowStepForm {
   description_placeholders?: Record<string, string>;
   last_step: boolean | null;
   preview?: string;
+  translation_domain?: string;
 }
 
 export interface DataEntryFlowStepExternal {
@@ -42,6 +43,7 @@ export interface DataEntryFlowStepExternal {
   step_id: string;
   url: string;
   description_placeholders: Record<string, string>;
+  translation_domain?: string;
 }
 
 export interface DataEntryFlowStepCreateEntry {
@@ -53,6 +55,7 @@ export interface DataEntryFlowStepCreateEntry {
   result?: ConfigEntry;
   description: string;
   description_placeholders?: Record<string, string>;
+  translation_domain?: string;
 }
 
 export interface DataEntryFlowStepAbort {
@@ -61,6 +64,7 @@ export interface DataEntryFlowStepAbort {
   handler: string;
   reason: string;
   description_placeholders?: Record<string, string>;
+  translation_domain?: string;
 }
 
 export interface DataEntryFlowStepProgress {
@@ -70,6 +74,7 @@ export interface DataEntryFlowStepProgress {
   step_id: string;
   progress_action: string;
   description_placeholders?: Record<string, string>;
+  translation_domain?: string;
 }
 
 export interface DataEntryFlowStepMenu {
@@ -80,6 +85,7 @@ export interface DataEntryFlowStepMenu {
   /** If array, use value to lookup translations in strings.json */
   menu_options: string[] | Record<string, string>;
   description_placeholders?: Record<string, string>;
+  translation_domain?: string;
 }
 
 export type DataEntryFlowStep =

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -44,7 +44,7 @@ export const showConfigFlowDialog = (
 
     renderAbortDescription(hass, step) {
       const description = hass.localize(
-        `component.${step.handler}.config.abort.${step.reason}`,
+        `component.${step.translation_domain || step.handler}.config.abort.${step.reason}`,
         step.description_placeholders
       );
 
@@ -58,7 +58,7 @@ export const showConfigFlowDialog = (
     renderShowFormStepHeader(hass, step) {
       return (
         hass.localize(
-          `component.${step.handler}.config.step.${step.step_id}.title`,
+          `component.${step.translation_domain || step.handler}.config.step.${step.step_id}.title`,
           step.description_placeholders
         ) || hass.localize(`component.${step.handler}.title`)
       );
@@ -66,7 +66,7 @@ export const showConfigFlowDialog = (
 
     renderShowFormStepDescription(hass, step) {
       const description = hass.localize(
-        `component.${step.handler}.config.step.${step.step_id}.description`,
+        `component.${step.translation_domain || step.handler}.config.step.${step.step_id}.description`,
         step.description_placeholders
       );
       return description
@@ -84,7 +84,7 @@ export const showConfigFlowDialog = (
 
     renderShowFormStepFieldHelper(hass, step, field) {
       const description = hass.localize(
-        `component.${step.handler}.config.step.${step.step_id}.data_description.${field.name}`,
+        `component.${step.translation_domain || step.handler}.config.step.${step.step_id}.data_description.${field.name}`,
         step.description_placeholders
       );
       return description
@@ -95,7 +95,7 @@ export const showConfigFlowDialog = (
     renderShowFormStepFieldError(hass, step, error) {
       return (
         hass.localize(
-          `component.${step.handler}.config.error.${error}`,
+          `component.${step.translation_domain || step.translation_domain || step.handler}.config.error.${error}`,
           step.description_placeholders
         ) || error
       );
@@ -131,7 +131,7 @@ export const showConfigFlowDialog = (
 
     renderExternalStepDescription(hass, step) {
       const description = hass.localize(
-        `component.${step.handler}.config.${step.step_id}.description`,
+        `component.${step.translation_domain || step.handler}.config.${step.step_id}.description`,
         step.description_placeholders
       );
 
@@ -155,7 +155,7 @@ export const showConfigFlowDialog = (
 
     renderCreateEntryDescription(hass, step) {
       const description = hass.localize(
-        `component.${step.handler}.config.create_entry.${
+        `component.${step.translation_domain || step.handler}.config.create_entry.${
           step.description || "default"
         }`,
         step.description_placeholders
@@ -190,7 +190,7 @@ export const showConfigFlowDialog = (
 
     renderShowFormProgressDescription(hass, step) {
       const description = hass.localize(
-        `component.${step.handler}.config.progress.${step.progress_action}`,
+        `component.${step.translation_domain || step.handler}.config.progress.${step.progress_action}`,
         step.description_placeholders
       );
       return description
@@ -210,7 +210,7 @@ export const showConfigFlowDialog = (
 
     renderMenuDescription(hass, step) {
       const description = hass.localize(
-        `component.${step.handler}.config.step.${step.step_id}.description`,
+        `component.${step.translation_domain || step.handler}.config.step.${step.step_id}.description`,
         step.description_placeholders
       );
       return description
@@ -222,7 +222,7 @@ export const showConfigFlowDialog = (
 
     renderMenuOption(hass, step, option) {
       return hass.localize(
-        `component.${step.handler}.config.step.${step.step_id}.menu_options.${option}`,
+        `component.${step.translation_domain || step.handler}.config.step.${step.step_id}.menu_options.${option}`,
         step.description_placeholders
       );
     },

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -53,7 +53,7 @@ export const showOptionsFlowDialog = (
 
       renderAbortDescription(hass, step) {
         const description = hass.localize(
-          `component.${configEntry.domain}.options.abort.${step.reason}`,
+          `component.${step.translation_domain || configEntry.domain}.options.abort.${step.reason}`,
           step.description_placeholders
         );
 
@@ -71,7 +71,7 @@ export const showOptionsFlowDialog = (
       renderShowFormStepHeader(hass, step) {
         return (
           hass.localize(
-            `component.${configEntry.domain}.options.step.${step.step_id}.title`,
+            `component.${step.translation_domain || configEntry.domain}.options.step.${step.step_id}.title`,
             step.description_placeholders
           ) || hass.localize(`ui.dialogs.options_flow.form.header`)
         );
@@ -79,7 +79,7 @@ export const showOptionsFlowDialog = (
 
       renderShowFormStepDescription(hass, step) {
         const description = hass.localize(
-          `component.${configEntry.domain}.options.step.${step.step_id}.description`,
+          `component.${step.translation_domain || configEntry.domain}.options.step.${step.step_id}.description`,
           step.description_placeholders
         );
         return description
@@ -101,7 +101,7 @@ export const showOptionsFlowDialog = (
 
       renderShowFormStepFieldHelper(hass, step, field) {
         const description = hass.localize(
-          `component.${configEntry.domain}.options.step.${step.step_id}.data_description.${field.name}`,
+          `component.${step.translation_domain || configEntry.domain}.options.step.${step.step_id}.data_description.${field.name}`,
           step.description_placeholders
         );
         return description
@@ -112,7 +112,7 @@ export const showOptionsFlowDialog = (
       renderShowFormStepFieldError(hass, step, error) {
         return (
           hass.localize(
-            `component.${configEntry.domain}.options.error.${error}`,
+            `component.${step.translation_domain || configEntry.domain}.options.error.${error}`,
             step.description_placeholders
           ) || error
         );
@@ -159,7 +159,7 @@ export const showOptionsFlowDialog = (
 
       renderShowFormProgressDescription(hass, step) {
         const description = hass.localize(
-          `component.${configEntry.domain}.options.progress.${step.progress_action}`,
+          `component.${step.translation_domain || configEntry.domain}.options.progress.${step.progress_action}`,
           step.description_placeholders
         );
         return description
@@ -183,7 +183,7 @@ export const showOptionsFlowDialog = (
 
       renderMenuDescription(hass, step) {
         const description = hass.localize(
-          `component.${configEntry.domain}.options.step.${step.step_id}.description`,
+          `component.${step.translation_domain || configEntry.domain}.options.step.${step.step_id}.description`,
           step.description_placeholders
         );
         return description
@@ -199,7 +199,7 @@ export const showOptionsFlowDialog = (
 
       renderMenuOption(hass, step, option) {
         return hass.localize(
-          `component.${configEntry.domain}.options.step.${step.step_id}.menu_options.${option}`,
+          `component.${step.translation_domain || configEntry.domain}.options.step.${step.step_id}.menu_options.${option}`,
           step.description_placeholders
         );
       },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add support for translation domain in data entry flows

Only added for config and option flows:
- issue flows already solve this by storing the translation domain in the issue itself
- auth flows have their translations in frontend, not backend

Relevant core PR: https://github.com/home-assistant/core/pull/111637

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
