### PR TITLE
Clear Matter ping result when closing the dialog

### DIFF
--- a/src/panels/config/integrations/integration-panels/matter/dialog-matter-ping-node.ts
+++ b/src/panels/config/integrations/integration-panels/matter/dialog-matter-ping-node.ts
@@ -137,6 +137,7 @@ class DialogMatterPingNode extends LitElement {
   public closeDialog(): void {
     this.device_id = undefined;
     this._status = undefined;
+    this._pingResult = undefined;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 


### PR DESCRIPTION
## Proposed change
The result wasn't cleared when closing the ping dialog of Matter.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/110739
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
