### PR TITLE
Replace button to manually add a Thread border router with more info button

### DIFF
--- a/src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts
@@ -54,6 +54,7 @@ import { haStyle } from "../../../../../resources/styles";
 import { HomeAssistant } from "../../../../../types";
 import { brandsUrl } from "../../../../../util/brands-url";
 import { fileDownload } from "../../../../../util/file_download";
+import { documentationUrl } from "../../../../../util/documentation-url";
 
 interface ThreadNetwork {
   name: string;
@@ -123,11 +124,16 @@ export class ThreadConfigPanel extends SubscribeMixin(LitElement) {
                     )}
                   </h3>
                   <ha-svg-icon .path=${mdiDevices}></ha-svg-icon>
-                  <mwc-button @click=${this._addOTBR}
-                    >${this.hass.localize(
-                      "ui.panel.config.thread.add_open_thread_border_router"
-                    )}</mwc-button
+                  <a
+                    href=${documentationUrl(this.hass, `/integrations/thread`)}
+                    target="_blank"
                   >
+                    <mwc-button
+                      >${this.hass.localize(
+                        "ui.panel.config.thread.more_info"
+                      )}</mwc-button
+                    >
+                  </a>
                 </div>
               </ha-card>`}
           ${networks.networks.length

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4127,6 +4127,7 @@
           "other_networks": "Other networks",
           "my_network": "Preferred network",
           "no_preferred_network": "You don't have a preferred network yet.",
+          "more_info": "More Info",
           "add_open_thread_border_router": "Add an OpenThread border router",
           "reset_border_router": "Reset border router",
           "add_to_my_network": "Add to preferred network",


### PR DESCRIPTION
## Proposed change
If a user visits the Thread config panel when there are no preferred networks set-up it shows a button to add Thread Border router manually by URL and they get very confused. This is a leftover from early days and should be removed.

This PR shows a "more info" button on the location where the "Add an OpenThread border router" button was before that links to the documentation.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


![Scherm­afbeelding 2024-02-28 om 12 23 08](https://github.com/home-assistant/frontend/assets/6389780/001b0825-80d4-4496-b0af-419956daf23f)

