### PR TITLE
Support open / opening state in LockEntity

### DIFF
--- a/src/common/entity/get_states.ts
+++ b/src/common/entity/get_states.ts
@@ -28,7 +28,15 @@ export const FIXED_DOMAIN_STATES = {
   input_button: [],
   lawn_mower: ["error", "paused", "mowing", "docked"],
   light: ["on", "off"],
-  lock: ["jammed", "locked", "locking", "unlocked", "unlocking"],
+  lock: [
+    "jammed",
+    "locked",
+    "locking",
+    "unlocked",
+    "unlocking",
+    "opening",
+    "open",
+  ],
   media_player: [
     "off",
     "on",

--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -358,6 +358,10 @@ export const localizeStateMessage = (
           return localize(`${LOGBOOK_LOCALIZE_PATH}.is_locking`);
         case "unlocking":
           return localize(`${LOGBOOK_LOCALIZE_PATH}.is_unlocking`);
+        case "opening":
+          return localize(`${LOGBOOK_LOCALIZE_PATH}.is_opening`);
+        case "open":
+          return localize(`${LOGBOOK_LOCALIZE_PATH}.is_opened`);
         case "locked":
           return localize(`${LOGBOOK_LOCALIZE_PATH}.was_locked`);
         case "jammed":

--- a/src/fake_data/entity_component_icons.ts
+++ b/src/fake_data/entity_component_icons.ts
@@ -231,6 +231,8 @@ export const ENTITY_COMPONENT_ICONS: Record<string, ComponentIcons> = {
         locking: "mdi:lock-clock",
         unlocked: "mdi:lock-open",
         unlocking: "mdi:lock-clock",
+        opening: "mdi:lock-clock",
+        open: "mdi:lock-open-variant",
       },
     },
   },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -437,6 +437,7 @@
           "was_opened": "was opened",
           "was_closed": "was closed",
           "is_opening": "is opening",
+          "is_opened": "is opened",
           "is_closing": "is closing",
           "was_unlocked": "was unlocked",
           "was_locked": "was locked",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Adds support to frontend for `open` and `opening` state to `LockEntity`

Core PR: https://github.com/home-assistant/core/pull/111968

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
