### PR TITLE
Fix a bug in energy batteryToGrid calculation

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
@@ -177,7 +177,7 @@ class HuiEnergyDistrubutionCard
       if (hasBattery) {
         batteryFromGrid = solarConsumption * -1;
         if (batteryFromGrid > totalFromGrid) {
-          batteryToGrid = Math.min(0, batteryFromGrid - totalFromGrid);
+          batteryToGrid = batteryFromGrid - totalFromGrid;
           batteryFromGrid = totalFromGrid;
         }
       }

--- a/src/panels/lovelace/cards/energy/hui-energy-self-sufficiency-gauge-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-self-sufficiency-gauge-card.ts
@@ -150,7 +150,7 @@ class HuiEnergySelfSufficiencyGaugeCard
       if (hasBattery) {
         batteryFromGrid = solarConsumption * -1;
         if (batteryFromGrid > totalFromGrid) {
-          batteryToGrid = Math.min(0, batteryFromGrid - totalFromGrid);
+          batteryToGrid = batteryFromGrid - totalFromGrid;
           batteryFromGrid = totalFromGrid;
         }
       }

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -434,10 +434,8 @@ export class HuiEnergyUsageGraphCard
           if (summedData.to_battery) {
             grid_to_battery[start] = used_solar[start] * -1;
             if (grid_to_battery[start] > (summedData.from_grid?.[start] || 0)) {
-              battery_to_grid[start] = Math.min(
-                0,
-                grid_to_battery[start] - (summedData.from_grid?.[start] || 0)
-              );
+              battery_to_grid[start] =
+                grid_to_battery[start] - (summedData.from_grid?.[start] || 0);
               grid_to_battery[start] = summedData.from_grid?.[start];
             }
           }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
I've been tracking down an error in a energy scenario, where when exporting battery storage to grid the energy seems to be double counted as both export and consumption. 

After reviewing the code I see something that looks strange and seems like it was probably a bug when writing the battery calculations, for calculating the battery to grid energy.

Here is the pseudocode for this calculation
```
            if (grid_to_battery > from_grid) {
              battery_to_grid = Math.min(0,  grid_to_battery - from_grid);
            }
```

This `battery_to_grid` assignment only executed if `grid_to_battery` is greater than `from_grid`, implying that when this line is executed the result of their subtraction is guaranteed to be a positive number. 

But then taking the minimum of 0 and a positive number is guaranteed to be zero, that just means that this statement **always** returns zero, which does not seem like what was intended here.

I considered if maybe it was supposed to be math.max instead, but that doesn't make sense either, as the value is guaranteed positive, so that would also be a no-op.

I find that if I just remove the min function that fixes the bug I was tracking, so I'm wondering if that could be the correct calculation.

If needed I can provide example datasets and chart screenshots that show the specific case I was analyzing. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://github.com/home-assistant/frontend/issues/10163
https://github.com/home-assistant/frontend/issues/11947
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
