### PR TITLE
Expose dialog to custom card helpers

### DIFF
--- a/src/data/lock.ts
+++ b/src/data/lock.ts
@@ -3,7 +3,7 @@ import {
   HassEntityBase,
 } from "home-assistant-js-websocket";
 import { getExtendedEntityRegistryEntry } from "./entity_registry";
-import { showEnterCodeDialogDialog } from "../dialogs/enter-code/show-enter-code-dialog";
+import { showEnterCodeDialog } from "../dialogs/enter-code/show-enter-code-dialog";
 import { HomeAssistant } from "../types";
 
 export const FORMAT_TEXT = "text";
@@ -38,7 +38,7 @@ export const callProtectedLockService = async (
   const defaultCode = lockRegistryEntry?.options?.lock?.default_code;
 
   if (stateObj!.attributes.code_format && !defaultCode) {
-    const response = await showEnterCodeDialogDialog(element, {
+    const response = await showEnterCodeDialog(element, {
       codeFormat: "text",
       codePattern: stateObj!.attributes.code_format,
       title: hass.localize(`ui.card.lock.${service}`),

--- a/src/dialogs/enter-code/show-enter-code-dialog.ts
+++ b/src/dialogs/enter-code/show-enter-code-dialog.ts
@@ -10,7 +10,7 @@ export interface EnterCodeDialogParams {
   cancel?: () => void;
 }
 
-export const showEnterCodeDialogDialog = (
+export const showEnterCodeDialog = (
   element: HTMLElement,
   dialogParams: EnterCodeDialogParams
 ) =>

--- a/src/dialogs/more-info/controls/more-info-alarm_control_panel.ts
+++ b/src/dialogs/more-info/controls/more-info-alarm_control_panel.ts
@@ -8,7 +8,7 @@ import "../../../components/ha-state-icon";
 import { AlarmControlPanelEntity } from "../../../data/alarm_control_panel";
 import "../../../state-control/alarm_control_panel/ha-state-control-alarm_control_panel-modes";
 import type { HomeAssistant } from "../../../types";
-import { showEnterCodeDialogDialog } from "../../enter-code/show-enter-code-dialog";
+import { showEnterCodeDialog } from "../../enter-code/show-enter-code-dialog";
 import "../components/ha-more-info-state-header";
 import { moreInfoControlStyle } from "../components/more-info-control-style";
 
@@ -22,7 +22,7 @@ class MoreInfoAlarmControlPanel extends LitElement {
     let code: string | undefined;
 
     if (this.stateObj!.attributes.code_format) {
-      const response = await showEnterCodeDialogDialog(this, {
+      const response = await showEnterCodeDialog(this, {
         codeFormat: this.stateObj!.attributes.code_format,
         title: this.hass.localize("ui.card.alarm_control_panel.disarm"),
         submitText: this.hass.localize("ui.card.alarm_control_panel.disarm"),

--- a/src/panels/lovelace/card-features/hui-alarm-modes-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-alarm-modes-card-feature.ts
@@ -21,7 +21,7 @@ import { UNAVAILABLE } from "../../../data/entity";
 import { HomeAssistant } from "../../../types";
 import { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import { AlarmModesCardFeatureConfig } from "./types";
-import { showEnterCodeDialogDialog } from "../../../dialogs/enter-code/show-enter-code-dialog";
+import { showEnterCodeDialog } from "../../../dialogs/enter-code/show-enter-code-dialog";
 
 export const supportsAlarmModesCardFeature = (stateObj: HassEntity) => {
   const domain = computeDomain(stateObj.entity_id);
@@ -131,7 +131,7 @@ class HuiAlarmModeCardFeature
     ) {
       const disarm = mode === "disarmed";
 
-      const response = await showEnterCodeDialogDialog(this, {
+      const response = await showEnterCodeDialog(this, {
         codeFormat: this.stateObj!.attributes.code_format,
         title: this.hass!.localize(
           `ui.card.alarm_control_panel.${disarm ? "disarm" : "arm"}`

--- a/src/panels/lovelace/custom-card-helpers.ts
+++ b/src/panels/lovelace/custom-card-helpers.ts
@@ -1,3 +1,9 @@
+export { showEnterCodeDialog } from "../../dialogs/enter-code/show-enter-code-dialog";
+export {
+  showAlertDialog,
+  showConfirmationDialog,
+  showPromptDialog,
+} from "../../dialogs/generic/show-dialog-box";
 export { importMoreInfoControl } from "../../dialogs/more-info/state_more_info_control";
 export { createBadgeElement } from "./create-element/create-badge-element";
 export { createCardElement } from "./create-element/create-card-element";

--- a/src/state-control/alarm_control_panel/ha-state-control-alarm_control_panel-modes.ts
+++ b/src/state-control/alarm_control_panel/ha-state-control-alarm_control_panel-modes.ts
@@ -13,7 +13,7 @@ import {
   AlarmMode,
 } from "../../data/alarm_control_panel";
 import { UNAVAILABLE } from "../../data/entity";
-import { showEnterCodeDialogDialog } from "../../dialogs/enter-code/show-enter-code-dialog";
+import { showEnterCodeDialog } from "../../dialogs/enter-code/show-enter-code-dialog";
 import { HomeAssistant } from "../../types";
 
 @customElement("ha-state-control-alarm_control_panel-modes")
@@ -56,7 +56,7 @@ export class HaStateControlAlarmControlPanelModes extends LitElement {
     ) {
       const disarm = mode === "disarmed";
 
-      const response = await showEnterCodeDialogDialog(this, {
+      const response = await showEnterCodeDialog(this, {
         codeFormat: this.stateObj!.attributes.code_format,
         title: this.hass!.localize(
           `ui.card.alarm_control_panel.${disarm ? "disarm" : "arm"}`


### PR DESCRIPTION
## Proposed change

Exposes 4 functions to open dialogs in custom cards helpers so custom cards can use the same dialog as HA.
- showEnterCodeDialog
- showAlertDialog
- showConfirmationDialog
- showPromptDialog

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
