### PR TITLE
Make migration warning alert sticky at the top for views

### DIFF
--- a/src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts
@@ -57,8 +57,6 @@ import { EditViewDialogParams } from "./show-edit-view-dialog";
 export class HuiDialogEditView extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
-  @state() private _currentType?: string;
-
   @state() private _params?: EditViewDialogParams;
 
   @state() private _config?: LovelaceViewConfig;
@@ -113,7 +111,6 @@ export class HuiDialogEditView extends LitElement {
       this._badges = [];
       return;
     }
-    this._currentType = view.type;
     const { badges, ...viewConfig } = view;
     this._config = viewConfig;
     this._badges = badges ? processEditorEntities(badges) : [];
@@ -214,14 +211,12 @@ export class HuiDialogEditView extends LitElement {
       }
     }
 
-    const isEmpty =
-      !this._config?.cards?.length && !this._config?.sections?.length;
-
     const isCompatibleViewType =
-      isEmpty ||
-      (this._currentType === SECTION_VIEW_LAYOUT
-        ? this._config?.type === SECTION_VIEW_LAYOUT
-        : this._config?.type !== SECTION_VIEW_LAYOUT);
+      this._config?.type === SECTION_VIEW_LAYOUT
+        ? this._config?.type === SECTION_VIEW_LAYOUT &&
+          !this._config?.cards?.length
+        : this._config?.type !== SECTION_VIEW_LAYOUT &&
+          !this._config?.sections?.length;
 
     return html`
       <ha-dialog
@@ -281,6 +276,19 @@ export class HuiDialogEditView extends LitElement {
                 : ``}
             </mwc-list-item>
           </ha-button-menu>
+          ${!isCompatibleViewType
+            ? html`
+                <ha-alert class="incompatible" alert-type="warning">
+                  ${this._config?.type === SECTION_VIEW_LAYOUT
+                    ? this.hass!.localize(
+                        "ui.panel.lovelace.editor.edit_view.type_warning_sections"
+                      )
+                    : this.hass!.localize(
+                        "ui.panel.lovelace.editor.edit_view.type_warning_others"
+                      )}
+                </ha-alert>
+              `
+            : nothing}
           ${!this._yamlMode
             ? html`<paper-tabs
                 scrollable
@@ -318,19 +326,6 @@ export class HuiDialogEditView extends LitElement {
                   "ui.panel.lovelace.editor.edit_view.delete"
                 )}
               </mwc-button>
-            `
-          : nothing}
-        ${!isCompatibleViewType
-          ? html`
-              <ha-alert class="incompatible" alert-type="warning">
-                ${this._config?.type === SECTION_VIEW_LAYOUT
-                  ? this.hass!.localize(
-                      "ui.panel.lovelace.editor.edit_view.type_warning_sections"
-                    )
-                  : this.hass!.localize(
-                      "ui.panel.lovelace.editor.edit_view.type_warning_others"
-                    )}
-              </ha-alert>
             `
           : nothing}
         <mwc-button
@@ -425,14 +420,13 @@ export class HuiDialogEditView extends LitElement {
     }
 
     this._saving = true;
-
     const viewConf: LovelaceViewConfig = {
       ...this._config,
       badges: this._badges,
     };
 
     if (viewConf.type === SECTION_VIEW_LAYOUT && !viewConf.sections?.length) {
-      viewConf.sections = [{ cards: [] }];
+      viewConf.sections = [{ type: "grid", cards: [] }];
     } else if (!viewConf.cards?.length) {
       viewConf.cards = [];
     }
@@ -584,7 +578,6 @@ export class HuiDialogEditView extends LitElement {
         }
         .incompatible {
           display: block;
-          margin-top: 16px;
         }
 
         @media all and (min-width: 600px) {


### PR DESCRIPTION
## Proposed change

So it's always displayed in yaml and UI views. 
I also tweaked the rules to allow user to migrate using yaml if they want. The view doesn't have to be empty but compatible (sections views must not have cards and other views must not have sections).

![CleanShot 2024-03-04 at 11 37 23](https://github.com/home-assistant/frontend/assets/5878303/58d74529-74ce-4e18-9fa7-514a1905ec8b)

![CleanShot 2024-03-04 at 11 37 06](https://github.com/home-assistant/frontend/assets/5878303/21b0ec8c-1252-40fb-8d99-2e2235d4e562)



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
