### PR TITLE
Clean generated config for tile in sections

### DIFF
--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -112,9 +112,9 @@ export const computeSection = (
       ({
         type: "tile",
         entity,
-        ...(["person", "camera", "image"].includes(computeDomain(entity))
-          ? { show_entity_picture: true }
-          : {}),
+        show_entity_picture: ["person", "camera", "image"].includes(
+          computeDomain(entity)
+        ) || undefined,
       }) as TileCardConfig
   ),
   ...sectionOptions,

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -112,9 +112,9 @@ export const computeSection = (
       ({
         type: "tile",
         entity,
-        show_entity_picture: ["person", "camera", "image"].includes(
-          computeDomain(entity)
-        ) || undefined,
+        show_entity_picture:
+          ["person", "camera", "image"].includes(computeDomain(entity)) ||
+          undefined,
       }) as TileCardConfig
   ),
   ...sectionOptions,

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -112,9 +112,9 @@ export const computeSection = (
       ({
         type: "tile",
         entity,
-        show_entity_picture: ["person", "camera", "image"].includes(
-          computeDomain(entity)
-        ),
+        ...(["person", "camera", "image"].includes(computeDomain(entity))
+          ? { show_entity_picture: true }
+          : {}),
       }) as TileCardConfig
   ),
   ...sectionOptions,


### PR DESCRIPTION
## Proposed change

Do not include `show_entity_picture: false` in tile card config when generated card for the entity picker.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
