### PR TITLE
Location/zone editor updates

### DIFF
--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -251,7 +251,11 @@ export interface LanguageSelector {
 }
 
 export interface LocationSelector {
-  location: { radius?: boolean; icon?: string } | null;
+  location: {
+    radius?: boolean;
+    radius_readonly?: boolean;
+    icon?: string;
+  } | null;
 }
 
 export interface LocationSelectorValue {

--- a/src/data/zone.ts
+++ b/src/data/zone.ts
@@ -11,6 +11,11 @@ export interface Zone {
   radius?: number;
 }
 
+export interface HomeZoneMutableParams {
+  latitude: number;
+  longitude: number;
+}
+
 export interface ZoneMutableParams {
   name: string;
   icon?: string;

--- a/src/panels/config/core/ha-config-section-general.ts
+++ b/src/panels/config/core/ha-config-section-general.ts
@@ -18,17 +18,19 @@ import "../../../components/ha-language-picker";
 import "../../../components/ha-radio";
 import type { HaRadio } from "../../../components/ha-radio";
 import "../../../components/ha-select";
+import "../../../components/ha-selector/ha-selector-location";
+import type { LocationSelectorValue } from "../../../data/selector";
 import "../../../components/ha-settings-row";
 import "../../../components/ha-textfield";
 import type { HaTextField } from "../../../components/ha-textfield";
 import "../../../components/ha-timezone-picker";
-import "../../../components/map/ha-locations-editor";
-import type { MarkerLocation } from "../../../components/map/ha-locations-editor";
 import { ConfigUpdateValues, saveCoreConfig } from "../../../data/core";
 import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-subpage";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant, ValueChangedEvent } from "../../../types";
+
+const LOCATION_SELECTOR = { location: {} };
 
 @customElement("ha-config-section-general")
 class HaConfigSectionGeneral extends LitElement {
@@ -244,15 +246,16 @@ class HaConfigSectionGeneral extends LitElement {
             </div>
             ${this.narrow
               ? html`
-                  <ha-locations-editor
+                  <ha-selector-location
                     .hass=${this.hass}
-                    .locations=${this._markerLocation(
+                    .selector=${LOCATION_SELECTOR}
+                    .value=${this._selectorLocation(
                       this.hass.config.latitude,
                       this.hass.config.longitude,
                       this._location
                     )}
-                    @location-updated=${this._locationChanged}
-                  ></ha-locations-editor>
+                    @value-changed=${this._locationChanged}
+                  ></ha-selector-location>
                 `
               : html`
                   <ha-settings-row>
@@ -320,7 +323,7 @@ class HaConfigSectionGeneral extends LitElement {
   }
 
   private _locationChanged(ev: CustomEvent) {
-    this._location = ev.detail.location;
+    this._location = [ev.detail.value.latitude, ev.detail.value.longitude];
   }
 
   private async _updateEntry(ev: CustomEvent) {
@@ -381,19 +384,15 @@ class HaConfigSectionGeneral extends LitElement {
     }
   }
 
-  private _markerLocation = memoizeOne(
+  private _selectorLocation = memoizeOne(
     (
-      lat: number,
-      lng: number,
+      latDefault: number,
+      lngDefault: number,
       location?: [number, number]
-    ): MarkerLocation[] => [
-      {
-        id: "location",
-        latitude: location ? location[0] : lat,
-        longitude: location ? location[1] : lng,
-        location_editable: true,
-      },
-    ]
+    ): LocationSelectorValue => ({
+      latitude: location != null ? location[0] : latDefault,
+      longitude: location != null ? location[1] : lngDefault,
+    })
   );
 
   private _editLocation() {
@@ -440,11 +439,6 @@ class HaConfigSectionGeneral extends LitElement {
       a.find-value {
         margin-top: 8px;
         display: inline-block;
-      }
-      ha-locations-editor {
-        display: block;
-        height: 400px;
-        padding: 16px;
       }
     `,
   ];

--- a/src/panels/config/zone/dialog-home-zone-detail.ts
+++ b/src/panels/config/zone/dialog-home-zone-detail.ts
@@ -1,0 +1,150 @@
+import "@material/mwc-button";
+import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
+import { property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { fireEvent } from "../../../common/dom/fire_event";
+import { createCloseHeading } from "../../../components/ha-dialog";
+import "../../../components/ha-form/ha-form";
+import { HomeZoneMutableParams } from "../../../data/zone";
+import { haStyleDialog } from "../../../resources/styles";
+import { HomeAssistant } from "../../../types";
+import { HomeZoneDetailDialogParams } from "./show-dialog-home-zone-detail";
+
+const SCHEMA = [
+  {
+    name: "location",
+    required: true,
+    selector: { location: { radius: true, radius_readonly: true } },
+  },
+];
+
+class DialogHomeZoneDetail extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _error?: Record<string, string>;
+
+  @state() private _data?: HomeZoneMutableParams;
+
+  @state() private _params?: HomeZoneDetailDialogParams;
+
+  @state() private _submitting = false;
+
+  public showDialog(params: HomeZoneDetailDialogParams): void {
+    this._params = params;
+    this._error = undefined;
+    this._data = {
+      latitude: this.hass.config.latitude,
+      longitude: this.hass.config.longitude,
+    };
+  }
+
+  public closeDialog(): void {
+    this._params = undefined;
+    this._data = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render() {
+    if (!this._params || !this._data) {
+      return nothing;
+    }
+    const latInvalid = String(this._data.latitude) === "";
+    const lngInvalid = String(this._data.longitude) === "";
+
+    const valid = !latInvalid && !lngInvalid;
+
+    return html`
+      <ha-dialog
+        open
+        @closed=${this.closeDialog}
+        scrimClickAction
+        escapeKeyAction
+        .heading=${createCloseHeading(
+          this.hass,
+          this.hass!.localize("ui.panel.config.zone.edit_home")
+        )}
+      >
+        <div>
+          <ha-form
+            .hass=${this.hass}
+            .schema=${SCHEMA}
+            .data=${this._formData(this._data)}
+            .error=${this._error}
+            .computeLabel=${this._computeLabel}
+            @value-changed=${this._valueChanged}
+          ></ha-form>
+          <p>
+            ${this.hass!.localize(
+              "ui.panel.config.zone.detail.no_edit_home_zone_radius"
+            )}
+          </p>
+        </div>
+        <mwc-button
+          slot="primaryAction"
+          @click=${this._updateEntry}
+          .disabled=${!valid || this._submitting}
+        >
+          ${this.hass!.localize("ui.panel.config.zone.detail.update")}
+        </mwc-button>
+      </ha-dialog>
+    `;
+  }
+
+  private _formData = memoizeOne((data: HomeZoneMutableParams) => ({
+    ...data,
+    location: {
+      latitude: data.latitude,
+      longitude: data.longitude,
+      radius: this.hass.states["zone.home"]?.attributes?.radius || 100,
+    },
+  }));
+
+  private _valueChanged(ev: CustomEvent) {
+    this._error = undefined;
+    const value = { ...ev.detail.value };
+    value.latitude = value.location.latitude;
+    value.longitude = value.location.longitude;
+    delete value.location;
+    this._data = value;
+  }
+
+  private _computeLabel = (): string => "";
+
+  private async _updateEntry() {
+    this._submitting = true;
+    try {
+      await this._params!.updateEntry!(this._data!);
+      this.closeDialog();
+    } catch (err: any) {
+      this._error = { base: err ? err.message : "Unknown error" };
+    } finally {
+      this._submitting = false;
+    }
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyleDialog,
+      css`
+        ha-dialog {
+          --mdc-dialog-min-width: min(600px, 95vw);
+        }
+        @media all and (max-width: 450px), all and (max-height: 500px) {
+          ha-dialog {
+            --mdc-dialog-min-width: calc(
+              100vw - env(safe-area-inset-right) - env(safe-area-inset-left)
+            );
+          }
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-home-zone-detail": DialogHomeZoneDetail;
+  }
+}
+
+customElements.define("dialog-home-zone-detail", DialogHomeZoneDetail);

--- a/src/panels/config/zone/dialog-zone-detail.ts
+++ b/src/panels/config/zone/dialog-zone-detail.ts
@@ -145,30 +145,8 @@ class DialogZoneDetail extends LitElement {
           required: true,
           selector: { location: { radius: true, icon } },
         },
-        {
-          name: "",
-          type: "grid",
-          schema: [
-            {
-              name: "latitude",
-              required: true,
-              selector: { number: {} },
-            },
-            {
-              name: "longitude",
-              required: true,
-
-              selector: { number: {} },
-            },
-          ],
-        },
         { name: "passive_note", type: "constant" },
         { name: "passive", selector: { boolean: {} } },
-        {
-          name: "radius",
-          required: false,
-          selector: { number: { min: 0, max: 999999, mode: "box" } },
-        },
       ] as const
   );
 
@@ -184,15 +162,9 @@ class DialogZoneDetail extends LitElement {
   private _valueChanged(ev: CustomEvent) {
     this._error = undefined;
     const value = { ...ev.detail.value };
-    if (
-      value.location.latitude !== this._data!.latitude ||
-      value.location.longitude !== this._data!.longitude ||
-      value.location.radius !== this._data!.radius
-    ) {
-      value.latitude = value.location.latitude;
-      value.longitude = value.location.longitude;
-      value.radius = Math.round(value.location.radius);
-    }
+    value.latitude = value.location.latitude;
+    value.longitude = value.location.longitude;
+    value.radius = value.location.radius;
     delete value.location;
     if (!value.icon) {
       delete value.icon;

--- a/src/panels/config/zone/show-dialog-home-zone-detail.ts
+++ b/src/panels/config/zone/show-dialog-home-zone-detail.ts
@@ -1,0 +1,20 @@
+import { fireEvent } from "../../../common/dom/fire_event";
+import { HomeZoneMutableParams } from "../../../data/zone";
+
+export interface HomeZoneDetailDialogParams {
+  updateEntry?: (updates: HomeZoneMutableParams) => Promise<unknown>;
+}
+
+export const loadHomeZoneDetailDialog = () =>
+  import("./dialog-home-zone-detail");
+
+export const showHomeZoneDetailDialog = (
+  element: HTMLElement,
+  params: HomeZoneDetailDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-home-zone-detail",
+    dialogImport: loadHomeZoneDetailDialog,
+    dialogParams: params,
+  });
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -374,6 +374,11 @@
           "upload_failed": "Upload failed",
           "unknown_file": "Unknown file"
         },
+        "location": {
+          "latitude": "[%key:ui::panel::config::zone::detail::latitude%]",
+          "longitude": "[%key:ui::panel::config::zone::detail::longitude%]",
+          "radius": "[%key:ui::panel::config::zone::detail::radius%]"
+        },
         "selector": {
           "options": "Selector Options",
           "types": {
@@ -3841,10 +3846,6 @@
           "confirm_delete": "Are you sure you want to delete this zone?",
           "can_not_edit": "Unable to edit zone",
           "configured_in_yaml": "Zones configured via configuration.yaml cannot be edited via the UI.",
-          "edit_home_zone": "The radius of the Home zone can't be edited from the frontend yet. Drag the marker on the map to move the home zone.",
-          "edit_home_zone_narrow": "The radius of the Home zone can't be edited from the frontend yet. The location can be changed from the general configuration.",
-          "go_to_core_config": "Go to general configuration?",
-          "home_zone_core_config": "The location of your home zone is editable from the general configuration page. The radius of the Home zone can't be edited from the frontend yet. Do you want to go to the general configuration?",
           "detail": {
             "new_zone": "New zone",
             "name": "Name",
@@ -3859,7 +3860,8 @@
             "required_error_msg": "This field is required",
             "delete": "Delete",
             "create": "Add",
-            "update": "Update"
+            "update": "Update",
+            "no_edit_home_zone_radius": "The radius of the home zone is not editable in the UI."
           },
           "core_location_dialog": "Home Assistant location"
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Various improvements to locations & zones:

 - For location selector, automatically include latitude and longitude textboxes below the map (and radius if enabled).
 - Use location selector in various zone editing dialogs (to include said textboxes). 
 - In zone editing config page, add a limited dialog box for editing the home zone, instead of a hyperlink to config/general. This was very confusing, as config/general directs you to the zone config page to edit the home zone, but when you click on the button to edit the home zone on that page, it sent you back to config/general, which was just a circular loop of redirecting without an obvious way to edit the location. 
 
 
![image](https://github.com/home-assistant/frontend/assets/32912880/0d0f4133-c6d2-455a-b502-007cacca97c6)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://github.com/home-assistant/frontend/issues/5991
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
