### PR TITLE
Allow customizing display name for energy device

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -91,6 +91,7 @@ export type EnergySolarForecasts = {
 export interface DeviceConsumptionEnergyPreference {
   // This is an ever increasing value
   stat_consumption: string;
+  name?: string;
 }
 
 export interface FlowFromGridSourceEnergyPreference {

--- a/src/panels/config/energy/components/ha-energy-device-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-device-settings.ts
@@ -89,7 +89,8 @@ export class EnergyDeviceSettings extends LitElement {
                   .stateObj=${entityState}
                 ></ha-state-icon>
                 <span class="content"
-                  >${getStatisticLabel(
+                  >${device.name ||
+                  getStatisticLabel(
                     this.hass,
                     device.stat_consumption,
                     this.statsMetadata?.[device.stat_consumption]

--- a/src/panels/config/energy/components/ha-energy-device-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-device-settings.ts
@@ -1,5 +1,5 @@
 import "@material/mwc-button/mwc-button";
-import { mdiDelete, mdiDevices } from "@mdi/js";
+import { mdiDelete, mdiDevices, mdiPencil } from "@mdi/js";
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
@@ -83,7 +83,7 @@ export class EnergyDeviceSettings extends LitElement {
           ${this.preferences.device_consumption.map((device) => {
             const entityState = this.hass.states[device.stat_consumption];
             return html`
-              <div class="row">
+              <div class="row" .device=${device}>
                 <ha-state-icon
                   .hass=${this.hass}
                   .stateObj=${entityState}
@@ -95,6 +95,11 @@ export class EnergyDeviceSettings extends LitElement {
                     this.statsMetadata?.[device.stat_consumption]
                   )}</span
                 >
+                <ha-icon-button
+                  .label=${this.hass.localize("ui.common.edit")}
+                  @click=${this._editDevice}
+                  .path=${mdiPencil}
+                ></ha-icon-button>
                 <ha-icon-button
                   .label=${this.hass.localize("ui.common.delete")}
                   @click=${this._deleteDevice}
@@ -115,6 +120,24 @@ export class EnergyDeviceSettings extends LitElement {
         </div>
       </ha-card>
     `;
+  }
+
+  private _editDevice(ev) {
+    const origDevice: DeviceConsumptionEnergyPreference =
+      ev.currentTarget.closest(".row").device;
+    showEnergySettingsDeviceDialog(this, {
+      device: { ...origDevice },
+      device_consumptions: this.preferences
+        .device_consumption as DeviceConsumptionEnergyPreference[],
+      saveCallback: async (newDevice) => {
+        await this._savePreferences({
+          ...this.preferences,
+          device_consumption: this.preferences.device_consumption.map((d) =>
+            d === origDevice ? newDevice : d
+          ),
+        });
+      },
+    });
   }
 
   private _addDevice() {

--- a/src/panels/config/energy/dialogs/show-dialogs-energy.ts
+++ b/src/panels/config/energy/dialogs/show-dialogs-energy.ts
@@ -70,6 +70,7 @@ export interface EnergySettingsWaterDialogParams {
 }
 
 export interface EnergySettingsDeviceDialogParams {
+  device?: DeviceConsumptionEnergyPreference;
   device_consumptions: DeviceConsumptionEnergyPreference[];
   saveCallback: (device: DeviceConsumptionEnergyPreference) => Promise<void>;
 }

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
@@ -328,11 +328,13 @@ export class HuiEnergyDevicesDetailGraphCard
       );
 
       data.push({
-        label: getStatisticLabel(
-          this.hass,
-          source.stat_consumption,
-          statisticsMetaData[source.stat_consumption]
-        ),
+        label:
+          source.name ||
+          getStatisticLabel(
+            this.hass,
+            source.stat_consumption,
+            statisticsMetaData[source.stat_consumption]
+          ),
         hidden:
           this._hiddenStats.has(source.stat_consumption) || itemExceedsMax,
         borderColor: compare ? color + "7F" : color,

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
@@ -127,11 +127,7 @@ export class HuiEnergyDevicesGraphCard
               const statisticId = (
                 this._chartData.datasets[0].data[index] as ScatterDataPoint
               ).y;
-              return getStatisticLabel(
-                this.hass,
-                statisticId as any,
-                this._data?.statsMetadata[statisticId]
-              );
+              return this.getDeviceName(statisticId as any as string);
             },
           },
         },
@@ -149,11 +145,7 @@ export class HuiEnergyDevicesGraphCard
           callbacks: {
             title: (item) => {
               const statisticId = item[0].label;
-              return getStatisticLabel(
-                this.hass,
-                statisticId,
-                this._data?.statsMetadata[statisticId]
-              );
+              return this.getDeviceName(statisticId);
             },
             label: (context) =>
               `${context.dataset.label}: ${formatNumber(
@@ -180,6 +172,19 @@ export class HuiEnergyDevicesGraphCard
       },
     })
   );
+
+  private getDeviceName(statisticId: string): string {
+    return (
+      this._data?.prefs.device_consumption.find(
+        (d) => d.stat_consumption === statisticId
+      )?.name ||
+      getStatisticLabel(
+        this.hass,
+        statisticId,
+        this._data?.statsMetadata[statisticId]
+      )
+    );
+  }
 
   private async _getStatistics(energyData: EnergyData): Promise<void> {
     const data = energyData.stats;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2005,6 +2005,7 @@
             "add_device": "Add device",
             "dialog": {
               "header": "Add a device",
+              "display_name": "Display name",
               "device_consumption_energy": "Device consumption energy",
               "selected_stat_intro": "Select the energy sensor that measures the device's energy usage in either of {unit}."
             }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change

Allow for storing a custom display name with individual device consumptions for energy dashboard. This allows users for a cleaner and less cluttered dashboard, as entity names for energy devices often have terms like "Energy", "Consumption", "Daily", "Weekly", "Total", etc which are not relevant for the energy dashboard, but may still be wanted as part of the entity name when looking at it out of the context of energy dashboard. 

Also space is at a premium for smaller/mobile devices, and the visual display can be improved with shorter names to minimize space consumption of the legend. 

![image](https://github.com/home-assistant/frontend/assets/32912880/7ba8a555-689d-4ca8-97cc-a3130b2f75bb)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://community.home-assistant.io/t/energy-custom-names-for-individual-devices/372943
https://community.home-assistant.io/t/wth-can-t-i-change-name-on-energy-dashboard-monitor-individual-devices/472496
https://community.home-assistant.io/t/to-have-the-ability-to-rename-in-energy-dashboard/503823
https://community.home-assistant.io/t/rename-energys-individual-devices/378360
https://community.home-assistant.io/t/wth-cant-i-still-not-change-source-names-for-energy-dashboard/470467
https://community.home-assistant.io/t/detail-devices-energy-card-entity-friendly-name-labels/700475
https://community.home-assistant.io/t/energy-dashboard-change-names/442989/8
https://github.com/home-assistant/frontend/discussions/20024
https://github.com/home-assistant/frontend/discussions/19983
https://github.com/home-assistant/frontend/discussions/18215

- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
