### PR TITLE
Add azimuth to sun.sun dialog's more-info section

### DIFF
--- a/src/data/entity_attributes.ts
+++ b/src/data/entity_attributes.ts
@@ -70,6 +70,7 @@ export const DOMAIN_ATTRIBUTES_UNITS = {
     brightness: "%",
   },
   sun: {
+    azimuth: "°",
     elevation: "°",
   },
   vacuum: {

--- a/src/dialogs/more-info/controls/more-info-sun.ts
+++ b/src/dialogs/more-info/controls/more-info-sun.ts
@@ -58,6 +58,14 @@ class MoreInfoSun extends LitElement {
           ${this.hass.formatEntityAttributeValue(this.stateObj, "elevation")}
         </div>
       </div>
+      <div class="row">
+        <div class="key">
+          ${this.hass.localize("ui.dialogs.more_info_control.sun.azimuth")}
+        </div>
+        <div class="value">
+          ${this.hass.formatEntityAttributeValue(this.stateObj, "azimuth")}
+        </div>
+      </div>
     `;
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1038,6 +1038,7 @@
           "last_triggered": "Last triggered"
         },
         "sun": {
+          "azimuth": "Azimuth",
           "elevation": "Elevation",
           "rising": "Rising",
           "setting": "Setting"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add the sun's azimuth attribute to the more info dialog. 

The dialog already includes the sun's elevation, and now the azimuth is displayed similarly. Added new translation key and azimuth's unit measurement (degrees, °). 

### Before
<img width="621" alt="Screenshot before" src="https://github.com/home-assistant/frontend/assets/927830/7d94695c-56ca-4752-b70c-e2218b6cacba">

### After
<img width="647" alt="Screenshot after" src="https://github.com/home-assistant/frontend/assets/927830/c8db3242-bddc-40b9-9d54-4d5822dc5025">


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
