### PR TITLE
Show integration page if no integrations are configured

### DIFF
--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -88,7 +88,7 @@ class HaConfigIntegrations extends SubscribeMixin(HassRouterPage) {
                 window.setTimeout(resolve, 0);
               })
           );
-          let fullUpdate = false;
+          let fullUpdate = this._configEntries === undefined;
           const newEntries: ConfigEntryExtended[] = [];
           messages.forEach((message) => {
             if (message.type === null || message.type === "added") {
@@ -119,9 +119,6 @@ class HaConfigIntegrations extends SubscribeMixin(HassRouterPage) {
             }
           });
           if (!newEntries.length && !fullUpdate) {
-            if (!this._configEntries) {
-              this._configEntries = [];
-            }
             return;
           }
           const existingEntries = fullUpdate ? [] : this._configEntries;

--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -119,6 +119,9 @@ class HaConfigIntegrations extends SubscribeMixin(HassRouterPage) {
             }
           });
           if (!newEntries.length && !fullUpdate) {
+            if (!this._configEntries) {
+              this._configEntries = [];
+            }
             return;
           }
           const existingEntries = fullUpdate ? [] : this._configEntries;


### PR DESCRIPTION
## Proposed change
Fix #19436. When no integrations are configured, no messages are received and configEntries remain undefined. In this case, you end up with an instance where you can't configure any config flows since the loading spinner never finish. This change sets configEntries to an empty array so the page can load. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
