### PR TITLE
Add step validation to input_number and number selectors

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
@@ -179,9 +179,10 @@ class HuiNumberEntityRow extends LitElement implements LovelaceRow {
 
   private _selectedValueChanged(ev): void {
     const stateObj = this.hass!.states[this._config!.entity];
+    const target = ev.target as HTMLInputElement;
 
-    if (ev.target.value !== stateObj.state) {
-      setValue(this.hass!, stateObj.entity_id, ev.target.value!);
+    if (target.value !== stateObj.state && !target.validity.stepMismatch) {
+      setValue(this.hass!, stateObj.entity_id, target.value);
     }
   }
 }

--- a/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
@@ -177,7 +177,7 @@ class HuiNumberEntityRow extends LitElement implements LovelaceRow {
     }
   }
 
-  private _selectedValueChanged(ev): void {
+  private _selectedValueChanged(ev: Event): void {
     const stateObj = this.hass!.states[this._config!.entity];
     const target = ev.target as HTMLInputElement;
 

--- a/src/state-summary/state-card-number.ts
+++ b/src/state-summary/state-card-number.ts
@@ -75,6 +75,7 @@ class StateCardNumber extends LitElement {
           `
         : html` <div class="flex state">
             <ha-textfield
+              autoValidate
               .disabled=${isUnavailableState(this.stateObj.state)}
               pattern="[0-9]+([\\.][0-9]+)?"
               .step=${Number(this.stateObj.attributes.step)}

--- a/src/state-summary/state-card-number.ts
+++ b/src/state-summary/state-card-number.ts
@@ -120,8 +120,9 @@ class StateCardNumber extends LitElement {
   }
 
   private async _selectedValueChanged(ev: Event) {
-    const value = (ev.target as HTMLInputElement).value;
-    if (value === this.stateObj.state) {
+    const target = ev.target as HTMLInputElement;
+    const value = target.value;
+    if (value === this.stateObj.state || target.validity.stepMismatch) {
       return;
     }
     await this.hass.callService("number", "set_value", {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add step validation to `number` selectors to only call the `setValue` API if there is a valid step value selected.

The entity row UI number control has a red border when the step is invalid (`autoValidate`).
Enabled `autoValidate` on the state card to ensure the same behavior.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
The MQTT number config example below can help to test the change (turn debug logging on for `mqtt`).

```yaml
mqtt:
  - number:
      command_topic: test/number
      min: -18
      max: 40
      name: Test number
      mode: box
      step: 5
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #20168
- This PR is related to issue or discussion: https://github.com/home-assistant/core/issues/113956
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
