### PR TITLE
Add multi select to automations

### DIFF
--- a/src/components/chips/ha-assist-chip.ts
+++ b/src/components/chips/ha-assist-chip.ts
@@ -22,14 +22,6 @@ export class HaAssistChip extends MdAssistChip {
         );
         --md-assist-chip-outline-color: var(--outline-color);
         --md-assist-chip-label-text-weight: 400;
-        --ha-assist-chip-filled-container-color: rgba(
-          var(--rgb-primary-text-color),
-          0.15
-        );
-        --ha-assist-chip-active-container-color: rgba(
-          var(--rgb-primary-color),
-          0.15
-        );
       }
       /** Material 3 doesn't have a filled chip, so we have to make our own **/
       .filled {
@@ -51,6 +43,10 @@ export class HaAssistChip extends MdAssistChip {
       .trailing.icon svg {
         margin-inline-end: unset;
         margin-inline-start: var(--_icon-label-space);
+      }
+      ::before {
+        background: var(--ha-assist-chip-container-color);
+        opacity: var(--ha-assist-chip-container-opacity);
       }
       :where(.active)::before {
         background: var(--ha-assist-chip-active-container-color);

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -181,6 +181,13 @@ export class HaDataTable extends LitElement {
     this._checkedRowsChanged();
   }
 
+  public selectAll(): void {
+    this._checkedRows = this._filteredData
+      .filter((data) => data.selectable !== false)
+      .map((data) => data[this.id]);
+    this._checkedRowsChanged();
+  }
+
   public connectedCallback() {
     super.connectedCallback();
     if (this._items.length) {
@@ -593,10 +600,7 @@ export class HaDataTable extends LitElement {
   private _handleHeaderRowCheckboxClick(ev: Event) {
     const checkbox = ev.target as HaCheckbox;
     if (checkbox.checked) {
-      this._checkedRows = this._filteredData
-        .filter((data) => data.selectable !== false)
-        .map((data) => data[this.id]);
-      this._checkedRowsChanged();
+      this.selectAll();
     } else {
       this._checkedRows = [];
       this._checkedRowsChanged();

--- a/src/components/ha-button-menu-new.ts
+++ b/src/components/ha-button-menu-new.ts
@@ -1,10 +1,10 @@
 import { Button } from "@material/mwc-button";
-import "@material/web/menu/menu";
-import type { MdMenu } from "@material/web/menu/menu";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import { FOCUS_TARGET } from "../dialogs/make-dialog-manager";
 import type { HaIconButton } from "./ha-icon-button";
+import "./ha-menu";
+import type { HaMenu } from "./ha-menu";
 
 @customElement("ha-button-menu-new")
 export class HaButtonMenuNew extends LitElement {
@@ -17,7 +17,7 @@ export class HaButtonMenuNew extends LitElement {
   @property({ type: Boolean, attribute: "has-overflow" }) public hasOverflow =
     false;
 
-  @query("md-menu", true) private _menu!: MdMenu;
+  @query("ha-menu", true) private _menu!: HaMenu;
 
   public get items() {
     return this._menu.items;
@@ -36,12 +36,12 @@ export class HaButtonMenuNew extends LitElement {
       <div @click=${this._handleClick}>
         <slot name="trigger" @slotchange=${this._setTriggerAria}></slot>
       </div>
-      <md-menu
+      <ha-menu
         .positioning=${this.positioning}
         .hasOverflow=${this.hasOverflow}
       >
         <slot></slot>
-      </md-menu>
+      </ha-menu>
     `;
   }
 
@@ -77,24 +77,6 @@ export class HaButtonMenuNew extends LitElement {
       }
       ::slotted([disabled]) {
         color: var(--disabled-text-color);
-      }
-      /* TODO: Migrate to ha-menu and ha-menu-item */
-      md-menu {
-        --md-menu-container-color: var(--card-background-color);
-      }
-      ::slotted(*) {
-        --md-menu-item-label-text-color: var(--primary-text-color);
-        --md-list-item-selected-label-text-color: var(--primary-text-color);
-        --md-sys-color-on-surface-variant: var(--secondary-text-color);
-        --mdc-icon-size: 16px;
-        --md-menu-item-selected-container-color: rgba(
-          var(--rgb-primary-color),
-          0.15
-        );
-        --md-menu-item-selected-label-text-color: var(--primary-text-color);
-      }
-      ::slotted(md-menu-item.selected) {
-        --md-menu-item-label-text-color: var(--primary-color);
       }
     `;
   }

--- a/src/components/ha-button-menu-new.ts
+++ b/src/components/ha-button-menu-new.ts
@@ -1,0 +1,104 @@
+import { Button } from "@material/mwc-button";
+import "@material/web/menu/menu";
+import type { MdMenu } from "@material/web/menu/menu";
+import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { customElement, property, query } from "lit/decorators";
+import { FOCUS_TARGET } from "../dialogs/make-dialog-manager";
+import type { HaIconButton } from "./ha-icon-button";
+
+@customElement("ha-button-menu-new")
+export class HaButtonMenuNew extends LitElement {
+  protected readonly [FOCUS_TARGET];
+
+  @property({ type: Boolean }) public disabled = false;
+
+  @property() public positioning?: "fixed" | "absolute" | "popover";
+
+  @property({ type: Boolean, attribute: "has-overflow" }) public hasOverflow =
+    false;
+
+  @query("md-menu", true) private _menu!: MdMenu;
+
+  public get items() {
+    return this._menu.items;
+  }
+
+  public override focus() {
+    if (this._menu.open) {
+      this._menu.focus();
+    } else {
+      this._triggerButton?.focus();
+    }
+  }
+
+  protected render(): TemplateResult {
+    return html`
+      <div @click=${this._handleClick}>
+        <slot name="trigger" @slotchange=${this._setTriggerAria}></slot>
+      </div>
+      <md-menu
+        .positioning=${this.positioning}
+        .hasOverflow=${this.hasOverflow}
+      >
+        <slot></slot>
+      </md-menu>
+    `;
+  }
+
+  private _handleClick(): void {
+    if (this.disabled) {
+      return;
+    }
+    this._menu.anchorElement = this;
+    if (this._menu.open) {
+      this._menu.close();
+    } else {
+      this._menu.show();
+    }
+  }
+
+  private get _triggerButton() {
+    return this.querySelector(
+      'ha-icon-button[slot="trigger"], mwc-button[slot="trigger"], ha-assist-chip[slot="trigger"]'
+    ) as HaIconButton | Button | null;
+  }
+
+  private _setTriggerAria() {
+    if (this._triggerButton) {
+      this._triggerButton.ariaHasPopup = "menu";
+    }
+  }
+
+  static get styles(): CSSResultGroup {
+    return css`
+      :host {
+        display: inline-block;
+        position: relative;
+      }
+      ::slotted([disabled]) {
+        color: var(--disabled-text-color);
+      }
+      /* TODO: Migrate to ha-menu and ha-menu-item */
+      md-menu {
+        --md-menu-container-color: var(--card-background-color);
+      }
+      ::slotted(*) {
+        --md-menu-item-label-text-color: var(--primary-text-color);
+        --mdc-icon-size: 16px;
+        --md-menu-item-selected-container-color: rgba(
+          var(--rgb-primary-color),
+          0.15
+        );
+      }
+      ::slotted(md-menu-item.selected) {
+        --md-menu-item-label-text-color: var(--primary-color);
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-button-menu-new": HaButtonMenuNew;
+  }
+}

--- a/src/components/ha-button-menu-new.ts
+++ b/src/components/ha-button-menu-new.ts
@@ -84,11 +84,14 @@ export class HaButtonMenuNew extends LitElement {
       }
       ::slotted(*) {
         --md-menu-item-label-text-color: var(--primary-text-color);
+        --md-list-item-selected-label-text-color: var(--primary-text-color);
+        --md-sys-color-on-surface-variant: var(--secondary-text-color);
         --mdc-icon-size: 16px;
         --md-menu-item-selected-container-color: rgba(
           var(--rgb-primary-color),
           0.15
         );
+        --md-menu-item-selected-label-text-color: var(--primary-text-color);
       }
       ::slotted(md-menu-item.selected) {
         --md-menu-item-label-text-color: var(--primary-color);

--- a/src/components/ha-sub-menu.ts
+++ b/src/components/ha-sub-menu.ts
@@ -1,0 +1,38 @@
+import { customElement } from "lit/decorators";
+import "element-internals-polyfill";
+import { CSSResult, css } from "lit";
+import { MdSubMenu } from "@material/web/menu/sub-menu";
+
+@customElement("ha-sub-menu")
+// @ts-expect-error
+export class HaSubMenu extends MdSubMenu {
+  static override styles: CSSResult[] = [
+    MdSubMenu.styles,
+    css`
+      :host {
+        --ha-icon-display: block;
+        --md-sys-color-primary: var(--primary-text-color);
+        --md-sys-color-on-primary: var(--primary-text-color);
+        --md-sys-color-secondary: var(--secondary-text-color);
+        --md-sys-color-surface: var(--card-background-color);
+        --md-sys-color-on-surface: var(--primary-text-color);
+        --md-sys-color-on-surface-variant: var(--secondary-text-color);
+        --md-sys-color-secondary-container: rgba(
+          var(--rgb-primary-color),
+          0.15
+        );
+        --md-sys-color-on-secondary-container: var(--text-primary-color);
+        --mdc-icon-size: 16px;
+
+        --md-sys-color-on-primary-container: var(--primary-text-color);
+        --md-sys-color-on-secondary-container: var(--primary-text-color);
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-sub-menu": HaSubMenu;
+  }
+}

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -6,8 +6,8 @@ import {
   mdiArrowDown,
   mdiArrowUp,
   mdiClose,
-  mdiFilterVariantRemove,
   mdiFilterVariant,
+  mdiFilterVariantRemove,
   mdiFormatListChecks,
   mdiMenuDown,
 } from "@mdi/js";
@@ -34,13 +34,13 @@ import type {
 } from "../components/data-table/ha-data-table";
 import "../components/ha-button-menu-new";
 import "../components/ha-dialog";
-import "../components/search-input-outlined";
 import "../components/ha-menu";
 import "../components/ha-menu-item";
+import "../components/search-input-outlined";
 import type { HomeAssistant, Route } from "../types";
 import "./hass-tabs-subpage";
 import type { PageNavigation } from "./hass-tabs-subpage";
-import type { HaMenu } from "../components/ha-menu";
+import { HaMenu } from "../components/ha-menu";
 
 declare global {
   // for fire event
@@ -179,6 +179,10 @@ export class HaTabsSubpageDataTable extends LitElement {
 
   @query("ha-data-table", true) private _dataTable!: HaDataTable;
 
+  @query("#group-by-menu") private _groupByMenu!: HaMenu;
+
+  @query("#sort-by-menu") private _sortByMenu!: HaMenu;
+
   private _showPaneController = new ResizeController(this, {
     callback: (entries) => entries[0]?.contentRect.width > 750,
   });
@@ -191,6 +195,14 @@ export class HaTabsSubpageDataTable extends LitElement {
     if (this.initialGroupColumn) {
       this._groupColumn = this.initialGroupColumn;
     }
+  }
+
+  private _toggleGroupBy() {
+    this._groupByMenu.open = !this._groupByMenu.open;
+  }
+
+  private _toggleSortBy() {
+    this._sortByMenu.open = !this._sortByMenu.open;
   }
 
   protected render(): TemplateResult {
@@ -236,89 +248,33 @@ export class HaTabsSubpageDataTable extends LitElement {
 
     const sortByMenu = Object.values(this.columns).find((col) => col.sortable)
       ? html`
-          <ha-button-menu-new positioning="popover">
-            <ha-assist-chip
-              .label=${localize("ui.components.subpage-data-table.sort_by", {
-                sortColumn: this._sortColumn
-                  ? ` ${this.columns[this._sortColumn].title || this.columns[this._sortColumn].label}`
-                  : "",
-              })}
-              slot="trigger"
-            >
-              <ha-svg-icon
-                slot="trailing-icon"
-                .path=${mdiMenuDown}
-              ></ha-svg-icon
-            ></ha-assist-chip>
-            ${Object.entries(this.columns).map(([id, column]) =>
-              column.sortable
-                ? html`
-                    <md-menu-item
-                      .value=${id}
-                      @click=${this._handleSortBy}
-                      keep-open
-                      .selected=${id === this._sortColumn}
-                      class=${classMap({ selected: id === this._sortColumn })}
-                    >
-                      ${this._sortColumn === id
-                        ? html`
-                            <ha-svg-icon
-                              slot="end"
-                              .path=${this._sortDirection === "desc"
-                                ? mdiArrowDown
-                                : mdiArrowUp}
-                            ></ha-svg-icon>
-                          `
-                        : nothing}
-                      ${column.title || column.label}
-                    </md-menu-item>
-                  `
-                : nothing
-            )}
-          </ha-button-menu-new>
+          <ha-assist-chip
+            .label=${localize("ui.components.subpage-data-table.sort_by", {
+              sortColumn: this._sortColumn
+                ? ` ${this.columns[this._sortColumn].title || this.columns[this._sortColumn].label}`
+                : "",
+            })}
+            id="sort-by-anchor"
+            @click=${this._toggleSortBy}
+          >
+            <ha-svg-icon slot="trailing-icon" .path=${mdiMenuDown}></ha-svg-icon
+          ></ha-assist-chip>
         `
       : nothing;
 
     const groupByMenu = Object.values(this.columns).find((col) => col.groupable)
       ? html`
-          <ha-button-menu-new positioning="popover">
-            <ha-assist-chip
-              slot="trigger"
-              .label=${localize("ui.components.subpage-data-table.group_by", {
-                groupColumn: this._groupColumn
-                  ? ` ${this.columns[this._groupColumn].title || this.columns[this._groupColumn].label}`
-                  : "",
-              })}
-            >
-              <ha-svg-icon
-                slot="trailing-icon"
-                .path=${mdiMenuDown}
-              ></ha-svg-icon>
-            </ha-assist-chip>
-            ${Object.entries(this.columns).map(([id, column]) =>
-              column.groupable
-                ? html`
-                    <md-menu-item
-                      .value=${id}
-                      @click=${this._handleGroupBy}
-                      .selected=${id === this._groupColumn}
-                      class=${classMap({ selected: id === this._groupColumn })}
-                    >
-                      ${column.title || column.label}
-                    </md-menu-item>
-                  `
-                : nothing
-            )}
-            <md-divider role="separator" tabindex="-1"></md-divider>
-            <md-menu-item
-              .value=${undefined}
-              @click=${this._handleGroupBy}
-              .selected=${this._groupColumn === undefined}
-              class=${classMap({ selected: this._groupColumn === undefined })}
-            >
-              ${localize("ui.components.subpage-data-table.dont_group_by")}
-            </md-menu-item>
-          </ha-button-menu-new>
+          <ha-assist-chip
+            .label=${localize("ui.components.subpage-data-table.group_by", {
+              groupColumn: this._groupColumn
+                ? ` ${this.columns[this._groupColumn].title || this.columns[this._groupColumn].label}`
+                : "",
+            })}
+            id="group-by-anchor"
+            @click=${this._toggleGroupBy}
+          >
+            <ha-svg-icon slot="trailing-icon" .path=${mdiMenuDown}></ha-svg-icon
+          ></ha-assist-chip>
         `
       : nothing;
 
@@ -347,7 +303,7 @@ export class HaTabsSubpageDataTable extends LitElement {
                     "ui.components.subpage-data-table.exit_selection_mode"
                   )}
                 ></ha-icon-button>
-                <ha-button-menu-new positioning="popover">
+                <ha-button-menu-new positioning="absolute">
                   <ha-assist-chip
                     .label=${localize(
                       "ui.components.subpage-data-table.select"
@@ -363,20 +319,20 @@ export class HaTabsSubpageDataTable extends LitElement {
                       .path=${mdiMenuDown}
                     ></ha-svg-icon
                   ></ha-assist-chip>
-                  <md-menu-item .value=${undefined} @click=${this._selectAll}
+                  <ha-menu-item .value=${undefined} @click=${this._selectAll}
                     >${localize("ui.components.subpage-data-table.select_all")}
-                  </md-menu-item>
-                  <md-menu-item .value=${undefined} @click=${this._selectNone}
+                  </ha-menu-item>
+                  <ha-menu-item .value=${undefined} @click=${this._selectNone}
                     >${localize("ui.components.subpage-data-table.select_none")}
-                  </md-menu-item>
+                  </ha-menu-item>
                   <md-divider role="separator" tabindex="-1"></md-divider>
-                  <md-menu-item
+                  <ha-menu-item
                     .value=${undefined}
                     @click=${this._disableSelectMode}
                     >${localize(
                       "ui.components.subpage-data-table.close_select_mode"
                     )}
-                  </md-menu-item>
+                  </ha-menu-item>
                 </ha-button-menu-new>
                 <p>
                   ${localize("ui.components.subpage-data-table.selected", {
@@ -502,6 +458,58 @@ export class HaTabsSubpageDataTable extends LitElement {
               </ha-data-table>`}
         <div slot="fab"><slot name="fab"></slot></div>
       </hass-tabs-subpage>
+      <ha-menu anchor="group-by-anchor" id="group-by-menu" positioning="fixed">
+        ${Object.entries(this.columns).map(([id, column]) =>
+          column.groupable
+            ? html`
+                <ha-menu-item
+                  .value=${id}
+                  @click=${this._handleGroupBy}
+                  .selected=${id === this._groupColumn}
+                  class=${classMap({ selected: id === this._groupColumn })}
+                >
+                  ${column.title || column.label}
+                </ha-menu-item>
+              `
+            : nothing
+        )}
+        <md-divider role="separator" tabindex="-1"></md-divider>
+        <ha-menu-item
+          .value=${undefined}
+          @click=${this._handleGroupBy}
+          .selected=${this._groupColumn === undefined}
+          class=${classMap({ selected: this._groupColumn === undefined })}
+        >
+          ${localize("ui.components.subpage-data-table.dont_group_by")}
+        </ha-menu-item>
+      </ha-menu>
+      <ha-menu anchor="sort-by-anchor" id="sort-by-menu" positioning="fixed">
+        ${Object.entries(this.columns).map(([id, column]) =>
+          column.sortable
+            ? html`
+                <ha-menu-item
+                  .value=${id}
+                  @click=${this._handleSortBy}
+                  keep-open
+                  .selected=${id === this._sortColumn}
+                  class=${classMap({ selected: id === this._sortColumn })}
+                >
+                  ${this._sortColumn === id
+                    ? html`
+                        <ha-svg-icon
+                          slot="end"
+                          .path=${this._sortDirection === "desc"
+                            ? mdiArrowDown
+                            : mdiArrowUp}
+                        ></ha-svg-icon>
+                      `
+                    : nothing}
+                  ${column.title || column.label}
+                </ha-menu-item>
+              `
+            : nothing
+        )}
+      </ha-menu>
     `;
   }
 
@@ -770,6 +778,9 @@ export class HaTabsSubpageDataTable extends LitElement {
         display: flex;
         flex-direction: column;
       }
+
+      #sort-by-anchor,
+      #group-by-anchor,
       ha-button-menu-new ha-assist-chip {
         --md-assist-chip-trailing-space: 8px;
       }

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -256,8 +256,11 @@ export class HaTabsSubpageDataTable extends LitElement {
             id="sort-by-anchor"
             @click=${this._toggleSortBy}
           >
-            <ha-svg-icon slot="trailing-icon" .path=${mdiMenuDown}></ha-svg-icon
-          ></ha-assist-chip>
+            <ha-svg-icon
+              slot="trailing-icon"
+              .path=${mdiMenuDown}
+            ></ha-svg-icon>
+          </ha-assist-chip>
         `
       : nothing;
 
@@ -743,6 +746,7 @@ export class HaTabsSubpageDataTable extends LitElement {
       .center-vertical {
         display: flex;
         align-items: center;
+        gap: 8px;
       }
 
       .relative {

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -34,13 +34,12 @@ import type {
 } from "../components/data-table/ha-data-table";
 import "../components/ha-button-menu-new";
 import "../components/ha-dialog";
-import "../components/ha-menu";
+import { HaMenu } from "../components/ha-menu";
 import "../components/ha-menu-item";
 import "../components/search-input-outlined";
 import type { HomeAssistant, Route } from "../types";
 import "./hass-tabs-subpage";
 import type { PageNavigation } from "./hass-tabs-subpage";
-import { HaMenu } from "../components/ha-menu";
 
 declare global {
   // for fire event
@@ -229,7 +228,7 @@ export class HaTabsSubpageDataTable extends LitElement {
             class="has-dropdown select-mode-chip"
             .active=${this._selectMode}
             @click=${this._enableSelectMode}
-            .label=${localize(
+            .title=${localize(
               "ui.components.subpage-data-table.enter_selection_mode"
             )}
           >

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -236,7 +236,7 @@ export class HaTabsSubpageDataTable extends LitElement {
 
     const sortByMenu = Object.values(this.columns).find((col) => col.sortable)
       ? html`
-          <ha-button-menu-new positioning="fixed">
+          <ha-button-menu-new positioning="popover">
             <ha-assist-chip
               .label=${localize("ui.components.subpage-data-table.sort_by", {
                 sortColumn: this._sortColumn
@@ -256,6 +256,7 @@ export class HaTabsSubpageDataTable extends LitElement {
                     <md-menu-item
                       .value=${id}
                       @click=${this._handleSortBy}
+                      keep-open
                       .selected=${id === this._sortColumn}
                       class=${classMap({ selected: id === this._sortColumn })}
                     >
@@ -280,7 +281,7 @@ export class HaTabsSubpageDataTable extends LitElement {
 
     const groupByMenu = Object.values(this.columns).find((col) => col.groupable)
       ? html`
-          <ha-button-menu-new positioning="fixed">
+          <ha-button-menu-new positioning="popover">
             <ha-assist-chip
               slot="trigger"
               .label=${localize("ui.components.subpage-data-table.group_by", {
@@ -346,7 +347,7 @@ export class HaTabsSubpageDataTable extends LitElement {
                     "ui.components.subpage-data-table.exit_selection_mode"
                   )}
                 ></ha-icon-button>
-                <ha-button-menu-new positioning="fixed">
+                <ha-button-menu-new positioning="popover">
                   <ha-assist-chip
                     .label=${localize(
                       "ui.components.subpage-data-table.select"
@@ -518,8 +519,6 @@ export class HaTabsSubpageDataTable extends LitElement {
   }
 
   private _handleSortBy(ev) {
-    ev.stopPropagation();
-    ev.preventDefault();
     const columnId = ev.currentTarget.value;
     if (!this._sortDirection || this._sortColumn !== columnId) {
       this._sortDirection = "asc";

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -493,7 +493,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
           @expanded-changed=${this._filterExpanded}
         ></ha-filter-blueprints>
         <div slot="selection-bar">
-          <ha-button-menu-new positioning="fixed" has-overflow>
+          <ha-button-menu-new has-overflow>
             <ha-assist-chip
               .label=${this.hass.localize(
                 "ui.panel.config.automation.picker.bulk_action"

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -5,6 +5,7 @@ import {
   mdiCog,
   mdiContentDuplicate,
   mdiDelete,
+  mdiDotsVertical,
   mdiHelpCircle,
   mdiInformationOutline,
   mdiMenuDown,
@@ -389,6 +390,40 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
   }
 
   protected render(): TemplateResult {
+    const categoryItems = html`${this._categories?.map(
+        (category) =>
+          html`<ha-menu-item
+            .value=${category.category_id}
+            @click=${this._handleBulkCategory}
+          >
+            ${category.icon
+              ? html`<ha-icon slot="start" .icon=${category.icon}></ha-icon>`
+              : html`<ha-svg-icon slot="start" .path=${mdiTag}></ha-svg-icon>`}
+            <div slot="headline">${category.name}</div>
+          </ha-menu-item>`
+      )}
+      <ha-menu-item .value=${null} @click=${this._handleBulkCategory}>
+        <div slot="headline">
+          ${this.hass.localize(
+            "ui.panel.config.automation.picker.bulk_actions.no_category"
+          )}
+        </div>
+      </ha-menu-item>`;
+    const labelItems = html` ${this._labels?.map((label) => {
+      const color = label.color ? computeCssColor(label.color) : undefined;
+      return html`<ha-menu-item
+        .value=${label.label_id}
+        @click=${this._handleBulkLabel}
+      >
+        <ha-label style=${color ? `--color: ${color}` : ""}>
+          ${label.icon
+            ? html`<ha-icon slot="icon" .icon=${label.icon}></ha-icon>`
+            : nothing}
+          ${label.name}
+        </ha-label>
+      </ha-menu-item>`;
+    })}`;
+
     return html`
       <hass-tabs-subpage-data-table
         .hass=${this.hass}
@@ -401,9 +436,10 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
         .selected=${this._selected.length}
         @selection-changed=${this._handleSelectionChanged}
         hasFilters
-        .filters=${Object.values(this._filters).filter(
-          (filter) => filter.value?.length
-        ).length}
+        .filters=${
+          Object.values(this._filters).filter((filter) => filter.value?.length)
+            .length
+        }
         .columns=${this._columns(
           this.narrow,
           this.hass.localize,
@@ -492,87 +528,101 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
           .narrow=${this.narrow}
           @expanded-changed=${this._filterExpanded}
         ></ha-filter-blueprints>
-        <div slot="selection-bar">
-          <ha-button-menu-new has-overflow>
-            <ha-assist-chip
-              .label=${this.hass.localize(
-                "ui.panel.config.automation.picker.bulk_action"
-              )}
-              slot="trigger"
-            >
+          ${
+            !this.narrow
+              ? html`<ha-button-menu-new slot="selection-bar">
+                    <ha-assist-chip
+                      slot="trigger"
+                      .label=${this.hass.localize(
+                        "ui.panel.config.automation.picker.bulk_actions.move_category"
+                      )}
+                    >
+                      <ha-svg-icon
+                        slot="trailing-icon"
+                        .path=${mdiMenuDown}
+                      ></ha-svg-icon>
+                    </ha-assist-chip>
+                    ${categoryItems}
+                  </ha-button-menu-new>
+                  ${this.hass.dockedSidebar === "docked"
+                    ? nothing
+                    : html`<ha-button-menu-new slot="selection-bar">
+                        <ha-assist-chip
+                          slot="trigger"
+                          .label=${this.hass.localize(
+                            "ui.panel.config.automation.picker.bulk_actions.add_label"
+                          )}
+                        >
+                          <ha-svg-icon
+                            slot="trailing-icon"
+                            .path=${mdiMenuDown}
+                          ></ha-svg-icon>
+                        </ha-assist-chip>
+                        ${labelItems}
+                      </ha-button-menu-new>`}`
+              : nothing
+          }
+          <ha-button-menu-new has-overflow slot="selection-bar">
+            ${
+              this.narrow
+                ? html`<ha-assist-chip
+                    .label=${this.hass.localize(
+                      "ui.panel.config.automation.picker.bulk_action"
+                    )}
+                    slot="trigger"
+                  >
+                    <ha-svg-icon
+                      slot="trailing-icon"
+                      .path=${mdiMenuDown}
+                    ></ha-svg-icon>
+                  </ha-assist-chip>`
+                : html`<ha-icon-button
+                    .path=${mdiDotsVertical}
+                    .label=${"ui.panel.config.automation.picker.bulk_action"}
+                    slot="trigger"
+                  ></ha-icon-button>`
+            }
               <ha-svg-icon
                 slot="trailing-icon"
                 .path=${mdiMenuDown}
               ></ha-svg-icon
             ></ha-assist-chip>
-            <ha-sub-menu>
-              <ha-menu-item slot="item">
-                <div slot="headline">
-                  ${this.hass.localize(
-                    "ui.panel.config.automation.picker.bulk_actions.move_category"
-                  )}
-                </div>
-                <ha-svg-icon slot="end" .path=${mdiChevronRight}></ha-svg-icon>
-              </ha-menu-item>
-              <ha-menu slot="menu">
-                ${this._categories?.map(
-                  (category) =>
-                    html`<ha-menu-item
-                      .value=${category.category_id}
-                      @click=${this._handleBulkCategory}
-                    >
-                      ${category.icon
-                        ? html`<ha-icon
-                            slot="start"
-                            .icon=${category.icon}
-                          ></ha-icon>`
-                        : html`<ha-svg-icon
-                            slot="start"
-                            .path=${mdiTag}
-                          ></ha-svg-icon>`}
-                      <div slot="headline">${category.name}</div>
-                    </ha-menu-item>`
-                )}
-                <ha-menu-item .value=${null} @click=${this._handleBulkCategory}>
-                  <div slot="headline">
-                    ${this.hass.localize(
-                      "ui.panel.config.automation.picker.bulk_actions.no_category"
-                    )}
-                  </div>
-                </ha-menu-item>
-              </ha-menu>
-            </ha-sub-menu>
-            <ha-sub-menu>
-              <ha-menu-item slot="item">
-                <div slot="headline">
-                  ${this.hass.localize(
-                    "ui.panel.config.automation.picker.bulk_actions.add_label"
-                  )}
-                </div>
-                <ha-svg-icon slot="end" .path=${mdiChevronRight}></ha-svg-icon>
-              </ha-menu-item>
-              <ha-menu slot="menu">
-                ${this._labels?.map((label) => {
-                  const color = label.color
-                    ? computeCssColor(label.color)
-                    : undefined;
-                  return html`<ha-menu-item
-                    .value=${label.label_id}
-                    @click=${this._handleBulkLabel}
-                  >
-                    <ha-label style=${color ? `--color: ${color}` : ""}>
-                      ${label.icon
-                        ? html`<ha-icon
-                            slot="icon"
-                            .icon=${label.icon}
-                          ></ha-icon>`
-                        : nothing}
-                      ${label.name}
-                    </ha-label>
-                  </ha-menu-item>`;
-                })}
-              </ha-menu>
-            </ha-sub-menu>
+            ${
+              this.narrow
+                ? html`<ha-sub-menu>
+                    <ha-menu-item slot="item">
+                      <div slot="headline">
+                        ${this.hass.localize(
+                          "ui.panel.config.automation.picker.bulk_actions.move_category"
+                        )}
+                      </div>
+                      <ha-svg-icon
+                        slot="end"
+                        .path=${mdiChevronRight}
+                      ></ha-svg-icon>
+                    </ha-menu-item>
+                    <ha-menu slot="menu">${categoryItems}</ha-menu>
+                  </ha-sub-menu>`
+                : nothing
+            }
+            ${
+              this.narrow || this.hass.dockedSidebar === "docked"
+                ? html` <ha-sub-menu>
+                    <ha-menu-item slot="item">
+                      <div slot="headline">
+                        ${this.hass.localize(
+                          "ui.panel.config.automation.picker.bulk_actions.add_label"
+                        )}
+                      </div>
+                      <ha-svg-icon
+                        slot="end"
+                        .path=${mdiChevronRight}
+                      ></ha-svg-icon>
+                    </ha-menu-item>
+                    <ha-menu slot="menu">${labelItems}</ha-menu>
+                  </ha-sub-menu>`
+                : nothing
+            }
             <ha-menu-item @click=${this._handleBulkEnable}>
               <ha-svg-icon slot="start" .path=${mdiToggleSwitch}></ha-svg-icon>
               <div slot="headline">
@@ -593,37 +643,41 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
               </div>
             </ha-menu-item>
           </ha-button-menu-new>
-        </div>
-        ${!this.automations.length
-          ? html`<div class="empty" slot="empty">
-              <ha-svg-icon .path=${mdiRobotHappy}></ha-svg-icon>
-              <h1>
-                ${this.hass.localize(
-                  "ui.panel.config.automation.picker.empty_header"
-                )}
-              </h1>
-              <p>
-                ${this.hass.localize(
-                  "ui.panel.config.automation.picker.empty_text_1"
-                )}
-              </p>
-              <p>
-                ${this.hass.localize(
-                  "ui.panel.config.automation.picker.empty_text_2",
-                  { user: this.hass.user?.name || "Alice" }
-                )}
-              </p>
-              <a
-                href=${documentationUrl(this.hass, "/docs/automation/editor/")}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <ha-button>
-                  ${this.hass.localize("ui.panel.config.common.learn_more")}
-                </ha-button>
-              </a>
-            </div>`
-          : nothing}
+        ${
+          !this.automations.length
+            ? html`<div class="empty" slot="empty">
+                <ha-svg-icon .path=${mdiRobotHappy}></ha-svg-icon>
+                <h1>
+                  ${this.hass.localize(
+                    "ui.panel.config.automation.picker.empty_header"
+                  )}
+                </h1>
+                <p>
+                  ${this.hass.localize(
+                    "ui.panel.config.automation.picker.empty_text_1"
+                  )}
+                </p>
+                <p>
+                  ${this.hass.localize(
+                    "ui.panel.config.automation.picker.empty_text_2",
+                    { user: this.hass.user?.name || "Alice" }
+                  )}
+                </p>
+                <a
+                  href=${documentationUrl(
+                    this.hass,
+                    "/docs/automation/editor/"
+                  )}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <ha-button>
+                    ${this.hass.localize("ui.panel.config.common.learn_more")}
+                  </ha-button>
+                </a>
+              </div>`
+            : nothing
+        }
         <ha-fab
           slot="fab"
           .label=${this.hass.localize(

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -16,6 +16,8 @@ import {
   mdiRobotHappy,
   mdiStopCircleOutline,
   mdiTag,
+  mdiToggleSwitch,
+  mdiToggleSwitchOffOutline,
   mdiTransitConnection,
 } from "@mdi/js";
 import { differenceInDays } from "date-fns/esm";
@@ -95,6 +97,7 @@ import { turnOnOffEntity } from "../../lovelace/common/entity/turn-on-off-entity
 import { showAssignCategoryDialog } from "../category/show-dialog-assign-category";
 import { configSections } from "../ha-panel-config";
 import { showNewAutomationDialog } from "./show-dialog-new-automation";
+import { computeCssColor } from "../../../common/color/compute-color";
 
 type AutomationItem = AutomationEntity & {
   name: string;
@@ -518,9 +521,25 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
                       .value=${category.category_id}
                       @click=${this._handleBulkCategory}
                     >
+                      ${category.icon
+                        ? html`<ha-icon
+                            slot="start"
+                            .icon=${category.icon}
+                          ></ha-icon>`
+                        : html`<ha-svg-icon
+                            slot="start"
+                            .path=${mdiTag}
+                          ></ha-svg-icon>`}
                       <div slot="headline">${category.name}</div>
                     </md-menu-item>`
                 )}
+                <md-menu-item .value=${null} @click=${this._handleBulkCategory}>
+                  <div slot="headline">
+                    ${this.hass.localize(
+                      "ui.panel.config.automation.picker.bulk_actions.no_category"
+                    )}
+                  </div>
+                </md-menu-item>
               </md-menu>
             </md-sub-menu>
             <md-sub-menu>
@@ -533,27 +552,46 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
                 <ha-svg-icon slot="end" .path=${mdiChevronRight}></ha-svg-icon>
               </md-menu-item>
               <md-menu slot="menu">
-                ${this._labels?.map(
-                  (label) =>
-                    html`<md-menu-item
-                      .value=${label.label_id}
-                      @click=${this._handleBulkLabel}
-                    >
-                      <div slot="headline">${label.name}</div>
-                    </md-menu-item>`
-                )}
+                ${this._labels?.map((label) => {
+                  const color = label.color
+                    ? computeCssColor(label.color)
+                    : undefined;
+                  return html`<md-menu-item
+                    .value=${label.label_id}
+                    @click=${this._handleBulkLabel}
+                  >
+                    <ha-label style=${color ? `--color: ${color}` : ""}>
+                      ${label.icon
+                        ? html`<ha-icon
+                            slot="icon"
+                            .icon=${label.icon}
+                          ></ha-icon>`
+                        : nothing}
+                      ${label.name}
+                    </ha-label>
+                  </md-menu-item>`;
+                })}
               </md-menu>
             </md-sub-menu>
-            <md-menu-item @click=${this._handleBulkEnable}
-              >${this.hass.localize(
-                "ui.panel.config.automation.picker.bulk_actions.enable"
-              )}</md-menu-item
-            >
-            <md-menu-item @click=${this._handleBulkDisable}
-              >${this.hass.localize(
-                "ui.panel.config.automation.picker.bulk_actions.disable"
-              )}</md-menu-item
-            >
+            <md-menu-item @click=${this._handleBulkEnable}>
+              <ha-svg-icon slot="start" .path=${mdiToggleSwitch}></ha-svg-icon>
+              <div slot="headline">
+                ${this.hass.localize(
+                  "ui.panel.config.automation.picker.bulk_actions.enable"
+                )}
+              </div>
+            </md-menu-item>
+            <md-menu-item @click=${this._handleBulkDisable}>
+              <ha-svg-icon
+                slot="start"
+                .path=${mdiToggleSwitchOffOutline}
+              ></ha-svg-icon>
+              <div slot="headline">
+                ${this.hass.localize(
+                  "ui.panel.config.automation.picker.bulk_actions.disable"
+                )}
+              </div>
+            </md-menu-item>
           </ha-button-menu-new>
         </div>
         ${!this.automations.length
@@ -949,6 +987,10 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
         }
         ha-button-menu-new ha-assist-chip {
           --md-assist-chip-trailing-space: 8px;
+        }
+        ha-label {
+          --ha-label-background-color: var(--color, var(--grey-color));
+          --ha-label-background-opacity: 0.5;
         }
       `,
     ];

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -1,10 +1,8 @@
 import { consume } from "@lit-labs/context";
 import "@lrnwebcomponents/simple-tooltip/simple-tooltip";
-import "@material/web/menu/menu-item";
-import "@material/web/menu/sub-menu";
 import {
-  mdiCog,
   mdiChevronRight,
+  mdiCog,
   mdiContentDuplicate,
   mdiDelete,
   mdiHelpCircle,
@@ -34,6 +32,7 @@ import {
 import { customElement, property, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
+import { computeCssColor } from "../../../common/color/compute-color";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { formatShortDateTime } from "../../../common/datetime/format_date_time";
 import { relativeTime } from "../../../common/datetime/relative_time";
@@ -58,6 +57,8 @@ import "../../../components/ha-filter-floor-areas";
 import "../../../components/ha-filter-labels";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-icon-overflow-menu";
+import "../../../components/ha-menu-item";
+import "../../../components/ha-sub-menu";
 import "../../../components/ha-svg-icon";
 import {
   AutomationEntity,
@@ -97,7 +98,6 @@ import { turnOnOffEntity } from "../../lovelace/common/entity/turn-on-off-entity
 import { showAssignCategoryDialog } from "../category/show-dialog-assign-category";
 import { configSections } from "../ha-panel-config";
 import { showNewAutomationDialog } from "./show-dialog-new-automation";
-import { computeCssColor } from "../../../common/color/compute-color";
 
 type AutomationItem = AutomationEntity & {
   name: string;
@@ -505,19 +505,19 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
                 .path=${mdiMenuDown}
               ></ha-svg-icon
             ></ha-assist-chip>
-            <md-sub-menu>
-              <md-menu-item slot="item">
+            <ha-sub-menu>
+              <ha-menu-item slot="item">
                 <div slot="headline">
                   ${this.hass.localize(
                     "ui.panel.config.automation.picker.bulk_actions.move_category"
                   )}
                 </div>
                 <ha-svg-icon slot="end" .path=${mdiChevronRight}></ha-svg-icon>
-              </md-menu-item>
-              <md-menu slot="menu">
+              </ha-menu-item>
+              <ha-menu slot="menu">
                 ${this._categories?.map(
                   (category) =>
-                    html`<md-menu-item
+                    html`<ha-menu-item
                       .value=${category.category_id}
                       @click=${this._handleBulkCategory}
                     >
@@ -531,32 +531,32 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
                             .path=${mdiTag}
                           ></ha-svg-icon>`}
                       <div slot="headline">${category.name}</div>
-                    </md-menu-item>`
+                    </ha-menu-item>`
                 )}
-                <md-menu-item .value=${null} @click=${this._handleBulkCategory}>
+                <ha-menu-item .value=${null} @click=${this._handleBulkCategory}>
                   <div slot="headline">
                     ${this.hass.localize(
                       "ui.panel.config.automation.picker.bulk_actions.no_category"
                     )}
                   </div>
-                </md-menu-item>
-              </md-menu>
-            </md-sub-menu>
-            <md-sub-menu>
-              <md-menu-item slot="item">
+                </ha-menu-item>
+              </ha-menu>
+            </ha-sub-menu>
+            <ha-sub-menu>
+              <ha-menu-item slot="item">
                 <div slot="headline">
                   ${this.hass.localize(
                     "ui.panel.config.automation.picker.bulk_actions.add_label"
                   )}
                 </div>
                 <ha-svg-icon slot="end" .path=${mdiChevronRight}></ha-svg-icon>
-              </md-menu-item>
-              <md-menu slot="menu">
+              </ha-menu-item>
+              <ha-menu slot="menu">
                 ${this._labels?.map((label) => {
                   const color = label.color
                     ? computeCssColor(label.color)
                     : undefined;
-                  return html`<md-menu-item
+                  return html`<ha-menu-item
                     .value=${label.label_id}
                     @click=${this._handleBulkLabel}
                   >
@@ -569,19 +569,19 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
                         : nothing}
                       ${label.name}
                     </ha-label>
-                  </md-menu-item>`;
+                  </ha-menu-item>`;
                 })}
-              </md-menu>
-            </md-sub-menu>
-            <md-menu-item @click=${this._handleBulkEnable}>
+              </ha-menu>
+            </ha-sub-menu>
+            <ha-menu-item @click=${this._handleBulkEnable}>
               <ha-svg-icon slot="start" .path=${mdiToggleSwitch}></ha-svg-icon>
               <div slot="headline">
                 ${this.hass.localize(
                   "ui.panel.config.automation.picker.bulk_actions.enable"
                 )}
               </div>
-            </md-menu-item>
-            <md-menu-item @click=${this._handleBulkDisable}>
+            </ha-menu-item>
+            <ha-menu-item @click=${this._handleBulkDisable}>
               <ha-svg-icon
                 slot="start"
                 .path=${mdiToggleSwitchOffOutline}
@@ -591,7 +591,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
                   "ui.panel.config.automation.picker.bulk_actions.disable"
                 )}
               </div>
-            </md-menu-item>
+            </ha-menu-item>
           </ha-button-menu-new>
         </div>
         ${!this.automations.length

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -527,11 +527,11 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         .filters=${Object.values(this._filters).filter(
           (filter) => filter.value?.length
         ).length}
-        .selected=${this._selectedEntities.length}
         .filter=${this._filter}
         selectable
-        clickable
+        .selected=${this._selectedEntities.length}
         @selection-changed=${this._handleSelectionChanged}
+        clickable
         @clear-filter=${this._clearFilter}
         @search-changed=${this._handleSearchChange}
         @row-click=${this._openEditEntry}

--- a/src/resources/styles-data.ts
+++ b/src/resources/styles-data.ts
@@ -143,7 +143,10 @@ export const derivedStyles = {
   "mdc-select-disabled-ink-color": "var(--input-disabled-ink-color)",
   "mdc-select-dropdown-icon-color": "var(--input-dropdown-icon-color)",
   "mdc-select-disabled-dropdown-icon-color": "var(--input-disabled-ink-color)",
-
+  "ha-assist-chip-filled-container-color":
+    "rgba(var(--rgb-primary-text-color),0.15)",
+  "ha-assist-chip-active-container-color":
+    "rgba(var(--rgb-primary-color),0.15)",
   "chip-background-color": "rgba(var(--rgb-primary-text-color), 0.15)",
   // Vaadin
   "material-body-text-color": "var(--primary-text-color)",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2700,6 +2700,7 @@
             "bulk_action": "Action",
             "bulk_actions": {
               "move_category": "Move to category",
+              "no_category": "No category",
               "add_label": "Add label",
               "enable": "Enable",
               "disable": "Disable"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -509,7 +509,10 @@
         "group_by": "Group by {groupColumn}",
         "dont_group_by": "Don't group",
         "select": "Select",
-        "selected": "Selected {selected}"
+        "selected": "Selected {selected}",
+        "close_select_mode": "Close selection mode",
+        "select_all": "Select all",
+        "select_none": "Select none"
       },
       "config-entry-picker": {
         "config_entry": "Integration"
@@ -2693,6 +2696,13 @@
               "actions": "Actions",
               "state": "State",
               "category": "Category"
+            },
+            "bulk_action": "Action",
+            "bulk_actions": {
+              "move_category": "Move to category",
+              "add_label": "Add label",
+              "enable": "Enable",
+              "disable": "Disable"
             },
             "empty_header": "Start automating",
             "empty_text_1": "Automations make Home Assistant automatically respond to things happening in and around your home.",


### PR DESCRIPTION


## Proposed change

Adds multi select to the automation config panel, allows to bulk:
- change category
- add label
- enable
- disable


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
