### PR TITLE
Improve more info dialog navigation for specific view

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1125,6 +1125,7 @@
         "edit": "Edit entity",
         "details": "Details",
         "back_to_info": "Back to info",
+        "info": "Information",
         "related": "Related",
         "history": "History",
         "logbook": "Logbook",


### PR DESCRIPTION
## Proposed change

https://github.com/home-assistant/frontend/pull/20286 introduced directly open settings view for entity more info.

This PR replaces the back icon to a close icon and move the back action to an overflow to avoid double click to close the dialog.

###  Before

![CleanShot 2024-04-02 at 11 14 17](https://github.com/home-assistant/frontend/assets/5878303/bea4cf36-a190-422b-b4c4-a158506ae809)

### After

![CleanShot 2024-04-02 at 11 14 25](https://github.com/home-assistant/frontend/assets/5878303/38459e15-a2d8-4466-9483-bc97cdb16c14)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
