### PR TITLE
Add a "Fix all" button to statistics tab on developer tools

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6607,6 +6607,14 @@
             },
             "fix_issue": {
               "fix": "Fix issue",
+              "fix_all": "Fix all",
+              "auto_fix": {
+                "title": "Fix all auto-fixable issues",
+                "info_text_not_available": "There are no auto-fixable issues, no action will be taken.",
+                "info_text_1": "This will delete long term statistics of all entities that either have an unsupported state class or have no state.",
+                "info_text_2": "Do you want to permanently delete {statistic_count} long term statistics from your database?",
+                "info_text_3": "The following statistics will be deleted:"
+              },
               "no_support": {
                 "title": "Fix issue",
                 "info_text_1": "Fixing this issue is not supported yet."


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Home Assistant instances that have been set up for a long time or that had past integrations that added a lot of entities might end up with lots of broken entities in the statistics tab of the developer tools dashboard. Currently, there's no way of bulk-cleaning these broken statistics from the UI.

This PR adds a "Fix all" button to the dashboard that allows the user to bulk remove entities that have no state or that have an unsupported state class.

### Screenshots
![image](https://github.com/home-assistant/frontend/assets/13923364/4e890265-ecd6-412e-89df-cef33d5e9b14)
![image](https://github.com/home-assistant/frontend/assets/13923364/b765b3f1-9dee-4c3c-a1c5-d32b8f9a4af4)
![image](https://github.com/home-assistant/frontend/assets/13923364/83fb28cb-9c65-41bc-bacb-c14136c8e98f)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

No configuration required.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #12644
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
