### PR TITLE
Fix calendar range selection

### DIFF
--- a/src/components/date-range-picker.ts
+++ b/src/components/date-range-picker.ts
@@ -11,10 +11,10 @@ import {
 } from "../common/datetime/localize_date";
 import { mainWindow } from "../common/dom/get_main_window";
 
-// Set the current date to the left picker instead of the right picker because the right is hidden
 const CustomDateRangePicker = Vue.extend({
   mixins: [DateRangePicker],
   methods: {
+    // Set the current date to the left picker instead of the right picker because the right is hidden
     selectMonthDate() {
       const dt: Date = this.end || new Date();
       // @ts-ignore
@@ -22,6 +22,33 @@ const CustomDateRangePicker = Vue.extend({
         year: dt.getFullYear(),
         month: dt.getMonth() + 1,
       });
+    },
+    // Fix the start/end date calculation when selecting a date range. The
+    // original code keeps track of the first clicked date (in_selection) but it
+    // never sets it to either the start or end date variables, so if the
+    // in_selection date is between the start and end date that were set by the
+    // hover the selection will enter a broken state that's counter-intuitive
+    // when hovering between weeks and leads to a random date when selecting a
+    // range across months. This bug doesn't seem to be present on v0.6.7 of the
+    // lib
+    hoverDate(value: Date) {
+      if (this.readonly) return;
+
+      if (this.in_selection) {
+        const pickA = this.in_selection as Date;
+        const pickB = value;
+
+        this.start = this.normalizeDatetime(
+          Math.min(pickA.valueOf(), pickB.valueOf()),
+          this.start
+        );
+        this.end = this.normalizeDatetime(
+          Math.max(pickA.valueOf(), pickB.valueOf()),
+          this.end
+        );
+      }
+
+      this.$emit("hover-date", value);
     },
   },
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Fixes an issue with the date range selection when selecting days across different weeks or months. The bug is present in the `vue2-daterange-picker` package but was fixed using the `Vue.extend` method because this dependency seems to be abandoned.

As can be seen in the gifs below, the broken version doesn't respect the date first clicked (April 17), instead, it jumps around other dates when hovering the mouse. Finally, after selecting another month it ends up with April 6 instead of 17.

The fixed version never loses track of the April 17 clicked and ends up with the correct date range when changing months.

| Broken | Fixed |
| ------ | ----- |
| ![broken](https://github.com/home-assistant/frontend/assets/13923364/757a7e5b-29ee-4e0c-a59a-0ec5aed5b9c4) | ![fixed](https://github.com/home-assistant/frontend/assets/13923364/76748ba3-5905-49ee-b83c-20d3301bcfad) |

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

No configuration required.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue or discussion:</br> https://github.com/Innologica/vue2-daterange-picker/issues/321 </br> https://github.com/Innologica/vue2-daterange-picker/issues/285 </br> https://github.com/Innologica/vue2-daterange-picker/pull/294
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
