### PR TITLE
Avoid duplicate entity ids in history

### DIFF
--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -531,56 +531,51 @@ class HaPanelHistory extends LitElement {
       const targetFloors = new Set(ensureArray(targetPickerValue.floor_id));
       const targetLabels = new Set(ensureArray(targetPickerValue.label_id));
 
-      if (targetLabels.size) {
-        targetLabels.forEach((labelId) => {
-          const expanded = expandLabelTarget(
-            this.hass,
-            labelId,
-            areas,
-            devices,
-            entities,
-            targetSelector
-          );
-          expanded.devices.forEach((id) => targetDevices.add(id));
-          expanded.entities.forEach((id) => targetEntities.add(id));
-          expanded.areas.forEach((id) => targetAreas.add(id));
-        });
-      }
-      if (targetFloors.size) {
-        targetFloors.forEach((floorId) => {
-          const expanded = expandFloorTarget(
-            this.hass,
-            floorId,
-            areas,
-            targetSelector
-          );
-          expanded.areas.forEach((id) => targetAreas.add(id));
-        });
-      }
-      if (targetAreas.size) {
-        targetAreas.forEach((areaId) => {
-          const expanded = expandAreaTarget(
-            this.hass,
-            areaId,
-            devices,
-            entities,
-            targetSelector
-          );
-          expanded.devices.forEach((id) => targetDevices.add(id));
-          expanded.entities.forEach((id) => targetEntities.add(id));
-        });
-      }
-      if (targetDevices.size) {
-        targetDevices.forEach((deviceId) => {
-          const expanded = expandDeviceTarget(
-            this.hass,
-            deviceId,
-            entities,
-            targetSelector
-          );
-          expanded.entities.forEach((id) => targetEntities.add(id));
-        });
-      }
+      targetLabels.forEach((labelId) => {
+        const expanded = expandLabelTarget(
+          this.hass,
+          labelId,
+          areas,
+          devices,
+          entities,
+          targetSelector
+        );
+        expanded.devices.forEach((id) => targetDevices.add(id));
+        expanded.entities.forEach((id) => targetEntities.add(id));
+        expanded.areas.forEach((id) => targetAreas.add(id));
+      });
+
+      targetFloors.forEach((floorId) => {
+        const expanded = expandFloorTarget(
+          this.hass,
+          floorId,
+          areas,
+          targetSelector
+        );
+        expanded.areas.forEach((id) => targetAreas.add(id));
+      });
+
+      targetAreas.forEach((areaId) => {
+        const expanded = expandAreaTarget(
+          this.hass,
+          areaId,
+          devices,
+          entities,
+          targetSelector
+        );
+        expanded.devices.forEach((id) => targetDevices.add(id));
+        expanded.entities.forEach((id) => targetEntities.add(id));
+      });
+
+      targetDevices.forEach((deviceId) => {
+        const expanded = expandDeviceTarget(
+          this.hass,
+          deviceId,
+          entities,
+          targetSelector
+        );
+        expanded.entities.forEach((id) => targetEntities.add(id));
+      });
 
       return Array.from(targetEntities);
     }

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -525,14 +525,13 @@ class HaPanelHistory extends LitElement {
       }
 
       const targetSelector = { target: {} };
-      const targetEntities =
-        ensureArray(targetPickerValue.entity_id)?.slice() || [];
-      const targetDevices =
-        ensureArray(targetPickerValue.device_id)?.slice() || [];
-      const targetAreas = ensureArray(targetPickerValue.area_id)?.slice() || [];
-      const targetFloors = ensureArray(targetPickerValue.floor_id)?.slice();
-      const targetLabels = ensureArray(targetPickerValue.label_id)?.slice();
-      if (targetLabels) {
+      const targetEntities = new Set(ensureArray(targetPickerValue.entity_id));
+      const targetDevices = new Set(ensureArray(targetPickerValue.device_id));
+      const targetAreas = new Set(ensureArray(targetPickerValue.area_id));
+      const targetFloors = new Set(ensureArray(targetPickerValue.floor_id));
+      const targetLabels = new Set(ensureArray(targetPickerValue.label_id));
+
+      if (targetLabels.size) {
         targetLabels.forEach((labelId) => {
           const expanded = expandLabelTarget(
             this.hass,
@@ -542,12 +541,12 @@ class HaPanelHistory extends LitElement {
             entities,
             targetSelector
           );
-          targetDevices.push(...expanded.devices);
-          targetEntities.push(...expanded.entities);
-          targetAreas.push(...expanded.areas);
+          expanded.devices.forEach((id) => targetDevices.add(id));
+          expanded.entities.forEach((id) => targetEntities.add(id));
+          expanded.areas.forEach((id) => targetAreas.add(id));
         });
       }
-      if (targetFloors) {
+      if (targetFloors.size) {
         targetFloors.forEach((floorId) => {
           const expanded = expandFloorTarget(
             this.hass,
@@ -555,10 +554,10 @@ class HaPanelHistory extends LitElement {
             areas,
             targetSelector
           );
-          targetAreas.push(...expanded.areas);
+          expanded.areas.forEach((id) => targetAreas.add(id));
         });
       }
-      if (targetAreas.length) {
+      if (targetAreas.size) {
         targetAreas.forEach((areaId) => {
           const expanded = expandAreaTarget(
             this.hass,
@@ -567,20 +566,23 @@ class HaPanelHistory extends LitElement {
             entities,
             targetSelector
           );
-          targetEntities.push(...expanded.entities);
-          targetDevices.push(...expanded.devices);
+          expanded.devices.forEach((id) => targetDevices.add(id));
+          expanded.entities.forEach((id) => targetEntities.add(id));
         });
       }
-      if (targetDevices.length) {
+      if (targetDevices.size) {
         targetDevices.forEach((deviceId) => {
-          targetEntities.push(
-            ...expandDeviceTarget(this.hass, deviceId, entities, targetSelector)
-              .entities
+          const expanded = expandDeviceTarget(
+            this.hass,
+            deviceId,
+            entities,
+            targetSelector
           );
+          expanded.entities.forEach((id) => targetEntities.add(id));
         });
       }
 
-      return targetEntities;
+      return Array.from(targetEntities);
     }
   );
 


### PR DESCRIPTION
## Proposed change

Use set to avoid duplicated entity_id sent to the backend to retrieve history.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
