### PR TITLE
Don't duplicate the label as the description in Z-Wave Config

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -235,7 +235,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
         ${item.metadata.label}
       </span>
       <span slot="description">
-        ${item.metadata.description || item.metadata.label}
+        ${item.metadata.description}
         ${item.metadata.description !== null && !item.metadata.writeable
           ? html`<br />`
           : nothing}


### PR DESCRIPTION
## Proposed change
In the Z-Wave parameter config view, if a configuration item doesn't have a description, it would show the label again in the description field. This cleans that up so it's not shown twice.

Before:
![image](https://github.com/home-assistant/frontend/assets/7545841/9f8f4cd8-dc99-4932-9e99-076b8585707e)

After:
![image](https://github.com/home-assistant/frontend/assets/7545841/103fb95e-fa2f-4a74-962a-9dfcf67eed91)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
