### PR TITLE
Don't display keyboard shortcut hints if keyboard shortcuts are disabled

### DIFF
--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -93,9 +93,18 @@ const randomTip = (hass: HomeAssistant, narrow: boolean) => {
       weight: 2,
       narrow: true,
     },
-    { content: hass.localize("ui.tips.key_c_hint"), weight: 1, narrow: false },
-    { content: hass.localize("ui.tips.key_m_hint"), weight: 1, narrow: false },
   ];
+
+  if (hass?.enableShortcuts) {
+    tips.push(
+      {
+        content: hass.localize("ui.tips.key_c_hint"),
+        weight: 1,
+        narrow: false,
+      },
+      { content: hass.localize("ui.tips.key_m_hint"), weight: 1, narrow: false }
+    );
+  }
 
   if (narrow) {
     tips = tips.filter((tip) => tip.narrow);
@@ -310,7 +319,9 @@ class HaConfigDashboard extends SubscribeMixin(LitElement) {
   private _showQuickBar(): void {
     showQuickBar(this, {
       commandMode: true,
-      hint: this.hass.localize("ui.dialogs.quick-bar.key_c_hint"),
+      hint: this.hass.enableShortcuts
+        ? this.hass.localize("ui.dialogs.quick-bar.key_c_hint")
+        : undefined,
     });
   }
 

--- a/src/panels/developer-tools/state/developer-tools-state.ts
+++ b/src/panels/developer-tools/state/developer-tools-state.ts
@@ -128,9 +128,11 @@ class HaPanelDevState extends LitElement {
               allow-custom-entity
               item-label-path="entity_id"
             ></ha-entity-picker>
-            <ha-tip .hass=${this.hass}
-              >${this.hass.localize("ui.tips.key_e_hint")}</ha-tip
-            >
+            ${this.hass.enableShortcuts
+              ? html` <ha-tip .hass=${this.hass}
+                  >${this.hass.localize("ui.tips.key_e_hint")}</ha-tip
+                >`
+              : nothing}
             <ha-textfield
               .label=${this.hass.localize(
                 "ui.panel.developer-tools.tabs.states.state"

--- a/src/panels/developer-tools/state/developer-tools-state.ts
+++ b/src/panels/developer-tools/state/developer-tools-state.ts
@@ -129,7 +129,7 @@ class HaPanelDevState extends LitElement {
               item-label-path="entity_id"
             ></ha-entity-picker>
             ${this.hass.enableShortcuts
-              ? html` <ha-tip .hass=${this.hass}
+              ? html`<ha-tip .hass=${this.hass}
                   >${this.hass.localize("ui.tips.key_e_hint")}</ha-tip
                 >`
               : nothing}


### PR DESCRIPTION
## Proposed change
Don't display keyboard shortcut hints if keyboard shortcuts are disabled.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #20422
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
