### PR TITLE
Add spacing between icon and name in entity button bar

### DIFF
--- a/src/panels/lovelace/components/hui-buttons-base.ts
+++ b/src/panels/lovelace/components/hui-buttons-base.ts
@@ -52,7 +52,6 @@ export class HuiButtonsBase extends LitElement {
                       .stateObj=${stateObj}
                       .overrideIcon=${entityConf.icon}
                       .overrideImage=${entityConf.image}
-                      class=${name ? "" : "no-text"}
                       .stateColor=${true}
                       slot="icon"
                     ></state-badge>

--- a/src/panels/lovelace/components/hui-buttons-base.ts
+++ b/src/panels/lovelace/components/hui-buttons-base.ts
@@ -92,26 +92,7 @@ export class HuiButtonsBase extends LitElement {
           color: var(--secondary-text-color);
           align-items: center;
           justify-content: center;
-          width: 24px;
-          height: 24px;
-          margin-left: -4px;
-          margin-inline-start: -4px;
-          margin-inline-end: initial;
           margin-top: -2px;
-        }
-        state-badge.no-text {
-          width: 26px;
-          height: 26px;
-          margin-left: -3px;
-          margin-inline-start: -3px;
-          margin-inline-end: initial;
-          margin-top: -3px;
-        }
-        ha-assist-chip state-badge {
-          margin-right: -4px;
-          margin-inline-end: -4px;
-          margin-inline-start: initial;
-          --mdc-icon-size: 18px;
         }
         @media all and (max-width: 450px), all and (max-height: 500px) {
           .ha-scrollbar {


### PR DESCRIPTION
## Proposed change
Fix #20471. I'm removing the margins so the default margins from the ha-assist-chip apply. 
Looks like: 
![image](https://github.com/home-assistant/frontend/assets/32477463/3cd787ac-2634-4fc7-9154-660542de0468)


## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #20471
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
