### PR TITLE
ZHA (Zigbee) visualization enhancement

### DIFF
--- a/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
@@ -315,6 +315,9 @@ export class ZHANetworkVisualizationPage extends LitElement {
     } else {
       label += "\n<b>Device is not in <i>'zigbee.db'</i></b>";
     }
+    if (device.area_id) {
+      label += `\n<b>Area ID: </b>${device.area_id}`;
+    }
     return label;
   }
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
@@ -238,6 +238,9 @@ export class ZHANetworkVisualizationPage extends LitElement {
         label: this._buildLabel(device),
         shape: this._getShape(device),
         mass: this._getMass(device),
+        color: {
+          background: device.available ? "#66FF99" : "#FF9999",
+        },
       });
       if (device.neighbors && device.neighbors.length > 0) {
         device.neighbors.forEach((neighbor) => {
@@ -311,9 +314,6 @@ export class ZHANetworkVisualizationPage extends LitElement {
       label += `\n<b>Device: </b>${device.manufacturer} ${device.model}`;
     } else {
       label += "\n<b>Device is not in <i>'zigbee.db'</i></b>";
-    }
-    if (!device.available) {
-      label += "\n<b>Device is <i>Offline</i></b>";
     }
     return label;
   }

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
@@ -424,7 +424,7 @@ export class ZHANetworkVisualizationPage extends LitElement {
         ? {
             physics: {
               barnesHut: {
-                springConstant: 0,
+                springConstant: 0.05,
                 avoidOverlap: 10,
                 damping: 0.09,
               },

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
@@ -252,13 +252,29 @@ export class ZHANetworkVisualizationPage extends LitElement {
               from: device.ieee,
               to: neighbor.ieee,
               label: neighbor.lqi + "",
-              color: this._getLQI(parseInt(neighbor.lqi)),
+              color: this._getLQI(parseInt(neighbor.lqi)).color,
+              width: this._getLQI(parseInt(neighbor.lqi)).width,
+              length: 2000 - 4 * parseInt(neighbor.lqi),
+              arrows: {
+                from: {
+                  enabled: neighbor.relationship !== "Child",
+                },
+              },
+              dashes: neighbor.relationship !== "Child",
             });
           } else {
             edges[idx].color = this._getLQI(
               (parseInt(edges[idx].label!) + parseInt(neighbor.lqi)) / 2
-            );
+            ).color;
+            edges[idx].width = this._getLQI(
+              (parseInt(edges[idx].label!) + parseInt(neighbor.lqi)) / 2
+            ).width;
+            edges[idx].length =
+              2000 -
+              6 * ((parseInt(edges[idx].label!) + parseInt(neighbor.lqi)) / 2);
             edges[idx].label += "/" + neighbor.lqi;
+            delete edges[idx].arrows;
+            delete edges[idx].dashes;
           }
         });
       }
@@ -267,17 +283,17 @@ export class ZHANetworkVisualizationPage extends LitElement {
     this._network?.setData({ nodes: this._nodes, edges: edges });
   }
 
-  private _getLQI(lqi: number): EdgeOptions["color"] {
+  private _getLQI(lqi: number): EdgeOptions {
     if (lqi > 192) {
-      return { color: "#17ab00", highlight: "#17ab00" };
+      return { color: { color: "#17ab00", highlight: "#17ab00" }, width: 4 };
     }
     if (lqi > 128) {
-      return { color: "#e6b402", highlight: "#e6b402" };
+      return { color: { color: "#e6b402", highlight: "#e6b402" }, width: 3 };
     }
     if (lqi > 80) {
-      return { color: "#fc4c4c", highlight: "#fc4c4c" };
+      return { color: { color: "#fc4c4c", highlight: "#fc4c4c" }, width: 2 };
     }
-    return { color: "#bfbfbf", highlight: "#bfbfbf" };
+    return { color: { color: "#bfbfbf", highlight: "#bfbfbf" }, width: 1 };
   }
 
   private _getMass(device: ZHADevice): number {

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
@@ -297,6 +297,9 @@ export class ZHANetworkVisualizationPage extends LitElement {
   }
 
   private _getMass(device: ZHADevice): number {
+    if (!device.available) {
+      return 6;
+    }
     if (device.device_type === "Coordinator") {
       return 2;
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This change makes ZHA (Zigbee) network visualization better for network planning and adds overall usability by

* Showing device availability by color. Before all devices look the same and you had to zoom in to see text "Device is Offline". Now available devices are green and unavailable ones are red.
* Adding device area name. There is no friendly name lookup but area ID is informative in most cases too. It makes much easier to understand the topology without adding names to every device. I have a lot of routers in networks that do not have any name.
* Making relations more visible by using signal strength to increase line widths in addition to colors. Thicker lines are much better visible with default zoom too.
* Adding "springs" to links to pull devices with stronger signals closer to each other.
* Adding arrows and making links dashed between routers when their relation is only known by one side (very weak signal in most cases).
* Pushing unavailable devices more farther by gravity.

Spring physics is disabled by opening visualization but will be changed when manually switching physics from disabled to enabled. This means that opened visualization still looks the same but after double clicking "Enable physics" toggle, the visualization tries to consider signal strength as well.

This was the visualization before:

![Screenshot 2024-04-13 at 23-17-57 Settings – Home Assistant](https://github.com/home-assistant/frontend/assets/60040/5c616551-1d60-4061-92cd-62d6b11f8c31)

This is how it looks like with this patch applied by default (light and dark theme):

![Screenshot 2024-04-13 at 22-41-36 Settings – Home Assistant](https://github.com/home-assistant/frontend/assets/60040/fcc32367-f7ec-4bd5-9064-fb2663f5e522)
![Screenshot 2024-04-13 at 22-44-00 Settings – Home Assistant](https://github.com/home-assistant/frontend/assets/60040/1235963f-66df-4be8-9bf9-fac4499188df)

With physics based on signal strength there will be visible "islands" of close by devices:

![Screenshot 2024-04-13 at 22-46-33 Settings – Home Assistant](https://github.com/home-assistant/frontend/assets/60040/e3d16a46-f528-48ec-bd9a-e1af4e8ac537)

Closer view where link changes and area information is also visible:

![Screenshot 2024-04-13 at 22-58-34 Settings – Home Assistant](https://github.com/home-assistant/frontend/assets/60040/ebff8109-ba55-4f27-ab83-603043d100f7)

I'm not sure, if it is still good idea to use different gravity for end devices. Would be good if somebody with much more devices would test that.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
