### PR TITLE
Fix zones on mobile, align mobile and non mobile view

### DIFF
--- a/src/panels/config/core/ha-config-section-general.ts
+++ b/src/panels/config/core/ha-config-section-general.ts
@@ -1,7 +1,6 @@
 import "@material/mwc-list/mwc-list-item";
 import { css, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import memoizeOne from "memoize-one";
 import { UNIT_C } from "../../../common/const";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { navigate } from "../../../common/navigate";
@@ -18,8 +17,6 @@ import "../../../components/ha-language-picker";
 import "../../../components/ha-radio";
 import type { HaRadio } from "../../../components/ha-radio";
 import "../../../components/ha-select";
-import "../../../components/ha-selector/ha-selector-location";
-import type { LocationSelectorValue } from "../../../data/selector";
 import "../../../components/ha-settings-row";
 import "../../../components/ha-textfield";
 import type { HaTextField } from "../../../components/ha-textfield";
@@ -29,8 +26,6 @@ import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box
 import "../../../layouts/hass-subpage";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant, ValueChangedEvent } from "../../../types";
-
-const LOCATION_SELECTOR = { location: {} };
 
 @customElement("ha-config-section-general")
 class HaConfigSectionGeneral extends LitElement {
@@ -244,36 +239,22 @@ class HaConfigSectionGeneral extends LitElement {
               >
               </ha-language-picker>
             </div>
-            ${this.narrow
-              ? html`
-                  <ha-selector-location
-                    .hass=${this.hass}
-                    .selector=${LOCATION_SELECTOR}
-                    .value=${this._selectorLocation(
-                      this.hass.config.latitude,
-                      this.hass.config.longitude,
-                      this._location
-                    )}
-                    @value-changed=${this._locationChanged}
-                  ></ha-selector-location>
-                `
-              : html`
-                  <ha-settings-row>
-                    <div slot="heading">
-                      ${this.hass.localize(
-                        "ui.panel.config.core.section.core.core_config.edit_location"
-                      )}
-                    </div>
-                    <div slot="description" class="secondary">
-                      ${this.hass.localize(
-                        "ui.panel.config.core.section.core.core_config.edit_location_description"
-                      )}
-                    </div>
-                    <mwc-button @click=${this._editLocation}
-                      >${this.hass.localize("ui.common.edit")}</mwc-button
-                    >
-                  </ha-settings-row>
-                `}
+
+            <ha-settings-row>
+              <div slot="heading">
+                ${this.hass.localize(
+                  "ui.panel.config.core.section.core.core_config.edit_location"
+                )}
+              </div>
+              <div slot="description" class="secondary">
+                ${this.hass.localize(
+                  "ui.panel.config.core.section.core.core_config.edit_location_description"
+                )}
+              </div>
+              <mwc-button @click=${this._editLocation}
+                >${this.hass.localize("ui.common.edit")}</mwc-button
+              >
+            </ha-settings-row>
             <div class="card-actions">
               <ha-progress-button @click=${this._updateEntry}>
                 ${this.hass!.localize("ui.panel.config.zone.detail.update")}
@@ -383,17 +364,6 @@ class HaConfigSectionGeneral extends LitElement {
       button.progress = false;
     }
   }
-
-  private _selectorLocation = memoizeOne(
-    (
-      latDefault: number,
-      lngDefault: number,
-      location?: [number, number]
-    ): LocationSelectorValue => ({
-      latitude: location != null ? location[0] : latDefault,
-      longitude: location != null ? location[1] : lngDefault,
-    })
-  );
 
   private _editLocation() {
     navigate("/config/zone/edit/zone.home");

--- a/src/panels/config/core/ha-config-section-general.ts
+++ b/src/panels/config/core/ha-config-section-general.ts
@@ -303,10 +303,6 @@ class HaConfigSectionGeneral extends LitElement {
     this._updateUnits = (ev.target as HaCheckbox).checked;
   }
 
-  private _locationChanged(ev: CustomEvent) {
-    this._location = [ev.detail.value.latitude, ev.detail.value.longitude];
-  }
-
   private async _updateEntry(ev: CustomEvent) {
     const button = ev.target as HaProgressButton;
     if (button.progress) {


### PR DESCRIPTION


## Proposed change

On mobile home zone editing didnt work.

Align UI from core config between mobile and non mobile


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
