### PR TITLE
When munging statistics to history, assume always numeric

### DIFF
--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -422,7 +422,8 @@ export const computeHistory = (
   entityIds: string[],
   localize: LocalizeFunc,
   sensorNumericalDeviceClasses: string[],
-  splitDeviceClasses = false
+  splitDeviceClasses = false,
+  forceNumeric = false
 ): HistoryResult => {
   const lineChartDevices: { [unit: string]: HistoryStates } = {};
   const timelineDevices: TimelineEntity[] = [];
@@ -468,6 +469,7 @@ export const computeHistory = (
     let unit: string | undefined;
 
     const isNumeric =
+      forceNumeric ||
       isNumericFromDomain(domain) ||
       (currentState != null &&
         isNumericFromAttributes(currentState.attributes)) ||

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -421,6 +421,7 @@ class HaPanelHistory extends LitElement {
       [],
       this.hass.localize,
       sensorNumericDeviceClasses,
+      true,
       true
     );
     // remap states array to statistics array


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

Presently if we have an orphaned statistic, for which we have old data but there is no active entity, it can't be displayed in history panel as the munging process incorrectly identifies it as non-numeric because we have no unit or state_class or device_class on record (as there is only data but no entity).

As collected statistics are always numeric, just bypass the numeric type check when munging statistics, so the old statistics can be reliably viewed. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
