### PR TITLE
Apply initial values to forms of device trigger extra fields

### DIFF
--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
@@ -6,6 +6,7 @@ import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/device/ha-device-picker";
 import "../../../../../components/device/ha-device-trigger-picker";
 import "../../../../../components/ha-form/ha-form";
+import { computeInitialHaFormData } from "../../../../../components/ha-form/compute-initial-ha-form-data";
 import { fullEntitiesContext } from "../../../../../data/context";
 import {
   deviceAutomationsEqual,
@@ -44,12 +45,12 @@ export class HaDeviceTrigger extends LitElement {
 
   private _extraFieldsData = memoizeOne(
     (trigger: DeviceTrigger, capabilities: DeviceCapabilities) => {
-      const extraFieldsData: Record<string, any> = {};
+      const extraFieldsData = computeInitialHaFormData(
+        capabilities.extra_fields
+      );
       capabilities.extra_fields.forEach((item) => {
         if (trigger[item.name] !== undefined) {
           extraFieldsData![item.name] = trigger[item.name];
-        } else if (item.default !== undefined) {
-          extraFieldsData![item.name] = item.default;
         }
       });
       return extraFieldsData;

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
@@ -48,6 +48,8 @@ export class HaDeviceTrigger extends LitElement {
       capabilities.extra_fields.forEach((item) => {
         if (trigger[item.name] !== undefined) {
           extraFieldsData![item.name] = trigger[item.name];
+        } else if (item.default !== undefined) {
+          extraFieldsData![item.name] = item.default;
         }
       });
       return extraFieldsData;


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This applies a schemas initial values for device trigger extra fields. 

This can be tested with a core-branch adding a new device trigger for "Sun" with some dummy extra_fields
https://github.com/home-assistant/core/pull/115846

Here the "bool" switch is "off", even though the default value is `True`.
<img width="574" alt="Bildschirmfoto 2024-04-19 um 19 14 00" src="https://github.com/home-assistant/frontend/assets/12422879/3aae5367-a254-400f-8eb9-bf1397e1c174">

<hr>

Here are some more selectors without default values with following configuration:

```py
"extra_fields": vol.Schema(
    {
        vol.Required("bool", default=True): selector.BooleanSelector(),
        vol.Required("const", default=True): selector.ConstantSelector(
            selector.ConstantSelectorConfig(label="Constant", value=True)
        ),
        vol.Required("time"): selector.TimeSelector(
            selector.TimeSelectorConfig()
        ),
        vol.Required("datetime"): selector.DateTimeSelector(
            selector.DateTimeSelectorConfig()
        ),
        vol.Required("duration"): selector.DurationSelector(
            selector.DurationSelectorConfig(enable_day=False)
        ),
        vol.Required("number"): selector.NumberSelector(
            selector.NumberSelectorConfig(min=10, max=100)
        ),
        vol.Required("entity"): selector.EntitySelector(
            selector.EntitySelectorConfig(
                filter=selector.EntityFilterSelectorConfig(integration="sun")
            )
        ),
    }
)
```
| previous | with initial ha-form data |
|--------|--------|
| <img width="575" alt="Bildschirmfoto 2024-04-20 um 11 20 28" src="https://github.com/home-assistant/frontend/assets/12422879/6da8fb4c-78f5-43df-9af1-cda7f67fa924"> | <img width="575" alt="Bildschirmfoto 2024-04-20 um 11 20 59" src="https://github.com/home-assistant/frontend/assets/12422879/c8712a9e-642f-41f3-9b69-40e16cebd94e"> | 

<hr>

I'm not very familiar with `ha-form` so I'm not sure why it does ignore a `default` value of a `schema` item that looks like 
```json
{"selector": {"boolean": {}}, "name": "test", "required": true, "default": true}
```
when the key is not included in the `data` in https://github.com/home-assistant/frontend/blob/319a2d860242a6ae32fab9f56b5efa835a24d071/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts#L82-L85

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
