### PR TITLE
Add css var for meta theme-color attribute

### DIFF
--- a/src/resources/styles-data.ts
+++ b/src/resources/styles-data.ts
@@ -102,6 +102,7 @@ export const derivedStyles = {
   "mdc-theme-error": "var(--error-color)",
   "app-header-text-color": "var(--text-primary-color)",
   "app-header-background-color": "var(--primary-color)",
+  "app-theme-color": "var(--primary-color)",
   "mdc-checkbox-unchecked-color": "rgba(var(--rgb-primary-text-color), 0.54)",
   "mdc-checkbox-disabled-color": "var(--disabled-text-color)",
   "mdc-radio-unchecked-color": "rgba(var(--rgb-primary-text-color), 0.54)",

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -130,9 +130,8 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
 
       const themeMeta = document.querySelector("meta[name=theme-color]");
       const computedStyles = getComputedStyle(document.documentElement);
-      const themeMetaColor = computedStyles.getPropertyValue(
-        "--app-theme-color"
-      );
+      const themeMetaColor =
+        computedStyles.getPropertyValue("--app-theme-color");
 
       document.documentElement.style.backgroundColor =
         computedStyles.getPropertyValue("--primary-background-color");

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -130,8 +130,8 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
 
       const themeMeta = document.querySelector("meta[name=theme-color]");
       const computedStyles = getComputedStyle(document.documentElement);
-      const headerColor = computedStyles.getPropertyValue(
-        "--app-header-background-color"
+      const themeMetaColor = computedStyles.getPropertyValue(
+        "--app-theme-color"
       );
 
       document.documentElement.style.backgroundColor =
@@ -145,7 +145,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
           );
         }
         const themeColor =
-          headerColor?.trim() ||
+          themeMetaColor?.trim() ||
           (themeMeta.getAttribute("default-content") as string);
         themeMeta.setAttribute("content", themeColor);
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Previously, it wasn't possible to specifically change the color of the "theme-color" meta tag, which is used on some browsers to color the top bar, or on mobile devices.
```html
<meta name="theme-color" content="#4285f4" />
```

The only way was to modify `app-header-background-color`, which also modified the bar at the top of the page, rendering an ugly result.
In addition, the tag was correctly updated in light mode, but in dark mode it reverted to blue, regardless of the `primary-color`, which was also ugly.

I added `app-theme-color` to specifically modify this tag, and it inherits `primary-color` by default to keep the same behavior as before, fixing forced blue in dark mode.

Before, with red primary color :
![Capture d'écran 2024-04-19 230806](https://github.com/home-assistant/frontend/assets/46629108/56630123-f4df-4125-808d-b1b0e0522541)

![Capture d'écran 2024-04-19 225612](https://github.com/home-assistant/frontend/assets/46629108/f2b64633-ae1d-480b-bc29-6bd8cc1d32d0)




After: 
![Capture d'écran 2024-04-19 230822](https://github.com/home-assistant/frontend/assets/46629108/26142b77-79e3-4898-8534-2ced0c8d8a13)

![Capture d'écran 2024-04-19 225643](https://github.com/home-assistant/frontend/assets/46629108/c472d60e-8e8a-4b9a-a3e9-a1187c3706ba)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
frontend:
  themes:
    dev:
      modes:
        light:
          primary-color: "#D23232"
          accent-color: orange
        dark:
          app-header-background-color: "#ff0000"
          app-theme-color: "#00ff00"
          primary-color: "#D23232"
          accent-color: orange
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
