### PR TITLE
Translation support for device automation extra fields

### DIFF
--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -249,6 +249,22 @@ export const localizeDeviceAutomationTrigger = (
   ) ||
   (trigger.subtype ? `"${trigger.subtype}" ${trigger.type}` : trigger.type!);
 
+export const localizeExtraFieldsComputeLabelCallback =
+  (hass: HomeAssistant, deviceAutomation: DeviceAutomation) =>
+  // Returns a callback for ha-form to calculate labels per schema object
+  (schema): string =>
+    hass.localize(
+      `component.${deviceAutomation.domain}.device_automation.extra_fields.${schema.name}`
+    ) || schema.name;
+
+export const localizeExtraFieldsComputeHelperCallback =
+  (hass: HomeAssistant, deviceAutomation: DeviceAutomation) =>
+  // Returns a callback for ha-form to calculate helper texts per schema object
+  (schema): string | undefined =>
+    hass.localize(
+      `component.${deviceAutomation.domain}.device_automation.extra_fields_descriptions.${schema.name}`
+    );
+
 export const sortDeviceAutomations = (
   automationA: DeviceAutomation,
   automationB: DeviceAutomation

--- a/src/panels/config/automation/action/types/ha-automation-action-device_id.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-device_id.ts
@@ -12,6 +12,8 @@ import {
   deviceAutomationsEqual,
   DeviceCapabilities,
   fetchDeviceActionCapabilities,
+  localizeExtraFieldsComputeLabelCallback,
+  localizeExtraFieldsComputeHelperCallback,
 } from "../../../../../data/device_automation";
 import { EntityRegistryEntry } from "../../../../../data/entity_registry";
 import { HomeAssistant } from "../../../../../types";
@@ -84,8 +86,13 @@ export class HaDeviceAction extends LitElement {
               .data=${this._extraFieldsData(this.action, this._capabilities)}
               .schema=${this._capabilities.extra_fields}
               .disabled=${this.disabled}
-              .computeLabel=${this._extraFieldsComputeLabelCallback(
-                this.hass.localize
+              .computeLabel=${localizeExtraFieldsComputeLabelCallback(
+                this.hass,
+                this.action
+              )}
+              .computeHelper=${localizeExtraFieldsComputeHelperCallback(
+                this.hass,
+                this.action
               )}
               @value-changed=${this._extraFieldsChanged}
             ></ha-form>
@@ -150,14 +157,6 @@ export class HaDeviceAction extends LitElement {
         ...ev.detail.value,
       },
     });
-  }
-
-  private _extraFieldsComputeLabelCallback(localize) {
-    // Returns a callback for ha-form to calculate labels per schema object
-    return (schema) =>
-      localize(
-        `ui.panel.config.automation.editor.actions.type.device_id.extra_fields.${schema.name}`
-      ) || schema.name;
   }
 
   static styles = css`

--- a/src/panels/config/automation/condition/types/ha-automation-condition-device.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-device.ts
@@ -12,6 +12,8 @@ import {
   DeviceCapabilities,
   DeviceCondition,
   fetchDeviceConditionCapabilities,
+  localizeExtraFieldsComputeLabelCallback,
+  localizeExtraFieldsComputeHelperCallback,
 } from "../../../../../data/device_automation";
 import { EntityRegistryEntry } from "../../../../../data/entity_registry";
 import type { HomeAssistant } from "../../../../../types";
@@ -84,8 +86,13 @@ export class HaDeviceCondition extends LitElement {
               .data=${this._extraFieldsData(this.condition, this._capabilities)}
               .schema=${this._capabilities.extra_fields}
               .disabled=${this.disabled}
-              .computeLabel=${this._extraFieldsComputeLabelCallback(
-                this.hass.localize
+              .computeLabel=${localizeExtraFieldsComputeLabelCallback(
+                this.hass,
+                this.condition
+              )}
+              .computeHelper=${localizeExtraFieldsComputeHelperCallback(
+                this.hass,
+                this.condition
               )}
               @value-changed=${this._extraFieldsChanged}
             ></ha-form>
@@ -151,14 +158,6 @@ export class HaDeviceCondition extends LitElement {
         ...ev.detail.value,
       },
     });
-  }
-
-  private _extraFieldsComputeLabelCallback(localize) {
-    // Returns a callback for ha-form to calculate labels per schema object
-    return (schema) =>
-      localize(
-        `ui.panel.config.automation.editor.conditions.type.device.extra_fields.${schema.name}`
-      ) || schema.name;
   }
 
   static styles = css`

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
@@ -186,10 +186,10 @@ export class HaDeviceTrigger extends LitElement {
     // Returns a callback for ha-form to calculate labels per schema object
     return (schema): string =>
       localize(
-        `ui.panel.config.automation.editor.triggers.type.device.extra_fields.${schema.name}`
+        `component.${trigger.domain}.device_automation.extra_fields.${schema.name}`
       ) ||
       localize(
-        `component.${trigger.domain}.device_automation.extra_fields.${schema.name}`
+        `ui.panel.config.automation.editor.triggers.type.device.extra_fields.${schema.name}`
       ) ||
       schema.name;
   }
@@ -198,10 +198,10 @@ export class HaDeviceTrigger extends LitElement {
     // Returns a callback for ha-form to calculate helper texts per schema object
     return (schema): string | undefined =>
       localize(
-        `ui.panel.config.automation.editor.triggers.type.device.extra_fields_descriptions.${schema.name}`
+        `component.${trigger.domain}.device_automation.extra_fields_descriptions.${schema.name}`
       ) ||
       localize(
-        `component.${trigger.domain}.device_automation.extra_fields_descriptions.${schema.name}`
+        `ui.panel.config.automation.editor.triggers.type.device.extra_fields_descriptions.${schema.name}`
       );
   }
 

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
@@ -89,7 +89,12 @@ export class HaDeviceTrigger extends LitElement {
               .schema=${this._capabilities.extra_fields}
               .disabled=${this.disabled}
               .computeLabel=${this._extraFieldsComputeLabelCallback(
-                this.hass.localize
+                this.hass.localize,
+                this.trigger
+              )}
+              .computeHelper=${this._extraFieldsComputeHelperCallback(
+                this.hass.localize,
+                this.trigger
               )}
               @value-changed=${this._extraFieldsChanged}
             ></ha-form>
@@ -177,12 +182,27 @@ export class HaDeviceTrigger extends LitElement {
     });
   }
 
-  private _extraFieldsComputeLabelCallback(localize) {
+  private _extraFieldsComputeLabelCallback(localize, trigger: DeviceTrigger) {
     // Returns a callback for ha-form to calculate labels per schema object
-    return (schema) =>
+    return (schema): string =>
       localize(
         `ui.panel.config.automation.editor.triggers.type.device.extra_fields.${schema.name}`
-      ) || schema.name;
+      ) ||
+      localize(
+        `component.${trigger.domain}.device_automation.extra_fields.${schema.name}`
+      ) ||
+      schema.name;
+  }
+
+  private _extraFieldsComputeHelperCallback(localize, trigger: DeviceTrigger) {
+    // Returns a callback for ha-form to calculate helper texts per schema object
+    return (schema): string | undefined =>
+      localize(
+        `ui.panel.config.automation.editor.triggers.type.device.extra_fields_descriptions.${schema.name}`
+      ) ||
+      localize(
+        `component.${trigger.domain}.device_automation.extra_fields_descriptions.${schema.name}`
+      );
   }
 
   static styles = css`

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
@@ -187,11 +187,7 @@ export class HaDeviceTrigger extends LitElement {
     return (schema): string =>
       localize(
         `component.${trigger.domain}.device_automation.extra_fields.${schema.name}`
-      ) ||
-      localize(
-        `ui.panel.config.automation.editor.triggers.type.device.extra_fields.${schema.name}`
-      ) ||
-      schema.name;
+      ) || schema.name;
   }
 
   private _extraFieldsComputeHelperCallback(localize, trigger: DeviceTrigger) {
@@ -199,9 +195,6 @@ export class HaDeviceTrigger extends LitElement {
     return (schema): string | undefined =>
       localize(
         `component.${trigger.domain}.device_automation.extra_fields_descriptions.${schema.name}`
-      ) ||
-      localize(
-        `ui.panel.config.automation.editor.triggers.type.device.extra_fields_descriptions.${schema.name}`
       );
   }
 

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
@@ -14,6 +14,8 @@ import {
   DeviceCapabilities,
   DeviceTrigger,
   fetchDeviceTriggerCapabilities,
+  localizeExtraFieldsComputeLabelCallback,
+  localizeExtraFieldsComputeHelperCallback,
 } from "../../../../../data/device_automation";
 import { EntityRegistryEntry } from "../../../../../data/entity_registry";
 import { HomeAssistant } from "../../../../../types";
@@ -88,12 +90,12 @@ export class HaDeviceTrigger extends LitElement {
               .data=${this._extraFieldsData(this.trigger, this._capabilities)}
               .schema=${this._capabilities.extra_fields}
               .disabled=${this.disabled}
-              .computeLabel=${this._extraFieldsComputeLabelCallback(
-                this.hass.localize,
+              .computeLabel=${localizeExtraFieldsComputeLabelCallback(
+                this.hass,
                 this.trigger
               )}
-              .computeHelper=${this._extraFieldsComputeHelperCallback(
-                this.hass.localize,
+              .computeHelper=${localizeExtraFieldsComputeHelperCallback(
+                this.hass,
                 this.trigger
               )}
               @value-changed=${this._extraFieldsChanged}
@@ -180,22 +182,6 @@ export class HaDeviceTrigger extends LitElement {
         ...ev.detail.value,
       },
     });
-  }
-
-  private _extraFieldsComputeLabelCallback(localize, trigger: DeviceTrigger) {
-    // Returns a callback for ha-form to calculate labels per schema object
-    return (schema): string =>
-      localize(
-        `component.${trigger.domain}.device_automation.extra_fields.${schema.name}`
-      ) || schema.name;
-  }
-
-  private _extraFieldsComputeHelperCallback(localize, trigger: DeviceTrigger) {
-    // Returns a callback for ha-form to calculate helper texts per schema object
-    return (schema): string | undefined =>
-      localize(
-        `component.${trigger.domain}.device_automation.extra_fields_descriptions.${schema.name}`
-      );
   }
 
   static styles = css`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2862,12 +2862,6 @@
                 "device": {
                   "label": "Device",
                   "trigger": "Trigger",
-                  "extra_fields": {
-                    "above": "Above",
-                    "below": "Below",
-                    "for": "Duration (optional)",
-                    "zone": "[%key:ui::panel::config::automation::editor::triggers::type::zone::label%]"
-                  },
                   "description": {
                     "picker": "When something happens to a device. Great way to start."
                   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3099,13 +3099,6 @@
                 "device": {
                   "label": "Device",
                   "condition": "Condition",
-                  "extra_fields": {
-                    "above": "Above",
-                    "below": "Below",
-                    "for": "Duration",
-                    "hvac_mode": "HVAC mode",
-                    "preset_mode": "Preset mode"
-                  },
                   "description": {
                     "picker": "Set of conditions provided by your device. Great way to start."
                   }
@@ -3336,17 +3329,6 @@
                 "device_id": {
                   "label": "Device",
                   "action": "Action",
-                  "extra_fields": {
-                    "code": "Code",
-                    "message": "Message",
-                    "title": "Title",
-                    "position": "[%key:ui::card::cover::position%]",
-                    "mode": "Mode",
-                    "humidity": "Humidity",
-                    "value": "Value",
-                    "brightness_pct": "[%key:ui::card::light::brightness%]",
-                    "flash": "Flash"
-                  },
                   "description": {
                     "picker": "Do something on a device. Great way to start.",
                     "no_device": "Device action"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add translation support for integration specific device trigger extra fields. 

Core PR to allow new keys in `strings.json`: https://github.com/home-assistant/core/pull/115892

This can be tested with a core-branch adding a new device trigger for "Sun" with some dummy extra_fields
https://github.com/home-assistant/core/pull/115846

Given an integrations `strings.json`
```json
{
  "device_automation": {
    "trigger_type": {
      "test_sun_trigger": "Sun trigger 🌞"
    },
    "extra_fields": {
      "bool": "Boolean",
      "time": "Time ⏰",
      "number": "Number 🔢",
      "datetime": "Date and time",
      "duration": "Duration ⏳",
      "cv_bool": "Config validation boolean",
      "plain_bool": "Plain boolean"
    },
    "extra_fields_descriptions": {
      "bool": "Boolean helper text",
      "time": "A nice time",
      "number": "Some number between 10 and 100",
      "datetime": "Today may be the day 📅",
      "duration": "Duration ⏳"
    }
  }
}
```

| previous | extra field translation support |
|--------|--------|
| <img width="576" alt="Bildschirmfoto 2024-04-20 um 16 46 25" src="https://github.com/home-assistant/frontend/assets/12422879/813c1648-f560-4753-9e52-cd12b0199b58"> | <img width="576" alt="Bildschirmfoto 2024-04-20 um 16 45 25" src="https://github.com/home-assistant/frontend/assets/12422879/e2c1e54c-f9db-41e8-b624-e3bad6e6b0de"> | 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced localization for automation actions, conditions, and triggers by adding new callbacks for computing labels and helper texts.
- **Improvements**
	- Streamlined UI by removing redundant translation keys, simplifying descriptions for device triggers, conditions, and actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->