### PR TITLE
Restore getHassTranslationsPre109

### DIFF
--- a/src/data/translation.ts
+++ b/src/data/translation.ts
@@ -97,3 +97,14 @@ export const getHassTranslations = async (
   });
   return result.resources;
 };
+
+export const getHassTranslationsPre109 = async (
+  hass: HomeAssistant,
+  language: string
+): Promise<Record<string, unknown>> => {
+  const result = await hass.callWS<{ resources: Record<string, unknown> }>({
+    type: "frontend/get_translations",
+    language,
+  });
+  return result.resources;
+};

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -169,10 +169,6 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
     // @ts-ignore
     this._loadHassTranslations(this.hass!.language, "entity");
 
-    // Backwards compatibility for custom integrations
-    // @ts-ignore
-    this._loadHassTranslations(this.hass!.language, "state");
-
     document.addEventListener(
       "visibilitychange",
       () => this._checkVisibility(),

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -169,6 +169,10 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
     // @ts-ignore
     this._loadHassTranslations(this.hass!.language, "entity");
 
+    // Backwards compatibility for custom integrations
+    // @ts-ignore
+    this._loadHassTranslations(this.hass!.language, "state");
+
     document.addEventListener(
       "visibilitychange",
       () => this._checkVisibility(),

--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -1,3 +1,4 @@
+import { atLeastVersion } from "../common/config/version";
 import { fireEvent } from "../common/dom/fire_event";
 import { computeLocalize, LocalizeFunc } from "../common/translations/localize";
 import {
@@ -8,6 +9,7 @@ import { debounce } from "../common/util/debounce";
 import {
   FirstWeekday,
   getHassTranslations,
+  getHassTranslationsPre109,
   NumberFormat,
   saveTranslationPreferences,
   TimeFormat,
@@ -284,6 +286,23 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       configFlow?: Parameters<typeof getHassTranslations>[4],
       force = false
     ): Promise<LocalizeFunc> {
+      if (
+        __BACKWARDS_COMPAT__ &&
+        !atLeastVersion(this.hass!.connection.haVersion, 0, 109)
+      ) {
+        if (category !== "state") {
+          return this.hass!.localize;
+        }
+        const resources = await getHassTranslationsPre109(this.hass!, language);
+
+        // Ignore the repsonse if user switched languages before we got response
+        if (this.hass!.language !== language) {
+          return this.hass!.localize;
+        }
+
+        return this._updateResources(language, resources);
+      }
+
       let alreadyLoaded: LoadedTranslationCategory;
 
       if (category in this.__loadedTranslations) {


### PR DESCRIPTION
Partially reverts home-assistant/frontend#20536 to restore getHassTranslationsPre109
See https://github.com/home-assistant/frontend/pull/20536#discussion_r1576997774