### PR TITLE
Fix `ha-filter-states` clear filter behaviour

### DIFF
--- a/src/components/ha-filter-devices.ts
+++ b/src/components/ha-filter-devices.ts
@@ -94,7 +94,7 @@ export class HaFilterDevices extends LitElement {
       ? nothing
       : html`<ha-check-list-item
           .value=${device.id}
-          .selected=${this.value?.includes(device.id)}
+          .selected=${this.value?.includes(device.id) ?? false}
         >
           ${computeDeviceName(device, this.hass)}
         </ha-check-list-item>`;

--- a/src/components/ha-filter-entities.ts
+++ b/src/components/ha-filter-entities.ts
@@ -108,7 +108,7 @@ export class HaFilterEntities extends LitElement {
       ? nothing
       : html`<ha-check-list-item
           .value=${entity.entity_id}
-          .selected=${this.value?.includes(entity.entity_id)}
+          .selected=${this.value?.includes(entity.entity_id) ?? false}
           graphic="icon"
         >
           <ha-state-icon

--- a/src/components/ha-filter-states.ts
+++ b/src/components/ha-filter-states.ts
@@ -62,8 +62,8 @@ export class HaFilterStates extends LitElement {
                   (item) =>
                     html`<ha-check-list-item
                       .value=${item.value}
-                      .selected=${this.value?.includes(item.value)}
-                      .graphic=${hasIcon ? "icon" : undefined}
+                      .selected=${this.value?.includes(item.value) ?? false}
+                      .graphic=${hasIcon ? "icon" : null}
                     >
                       ${item.icon
                         ? html`<ha-icon


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The clear filter method of `ha-filter-states` didn't work correctly. Using it would render all items selected (and fire events for each) instead of deselect all. Using it a second time would deselect all, but prevent filtering until one item was manually deselected.

| previous | fix |
|--------|--------|
| https://github.com/home-assistant/frontend/assets/12422879/32dfc78c-e2ff-420a-a620-64ab97d98e8f | https://github.com/home-assistant/frontend/assets/12422879/0c83b499-8a12-4a25-97d7-4209b98c2b1c | 

`ha-check-list-item`s `.selected` attribute seems to not handle `undefined` like a `false` here. 

I did the same fix for `ha-filter-devices` and `ha-filter-entities` although I could not reproduce the error there (but it fixes a `no-incompatible-type-binding` warning). I'm not exactly sure why not. It may be because of `lit-virtualizer` or because of `ha-filter-states` uses `multi` in `mwc-list`. https://github.com/home-assistant/frontend/blob/ffdd661b1f00333704071675af3e344a59e8d93b/src/components/ha-filter-states.ts#L58  If someone could explain this, I'd be happy to learn 😀

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
