### PR TITLE
Fix cloud page design on mobile

### DIFF
--- a/src/components/ha-settings-row.ts
+++ b/src/components/ha-settings-row.ts
@@ -8,6 +8,9 @@ export class HaSettingsRow extends LitElement {
   @property({ type: Boolean, attribute: "three-line" })
   public threeLine = false;
 
+  @property({ type: Boolean, attribute: "wrap-heading", reflect: true })
+  public wrapHeading = false;
+
   protected render(): TemplateResult {
     return html`
       <div class="prefix-wrap">
@@ -51,7 +54,7 @@ export class HaSettingsRow extends LitElement {
       .body[three-line] {
         min-height: var(--paper-item-body-three-line-min-height, 88px);
       }
-      .body > * {
+      :host(:not([wrap-heading])) > * {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;

--- a/src/panels/config/cloud/account/cloud-account.ts
+++ b/src/panels/config/cloud/account/cloud-account.ts
@@ -187,6 +187,7 @@ export class CloudAccount extends SubscribeMixin(LitElement) {
 
             <cloud-remote-pref
               .hass=${this.hass}
+              .narrow=${this.narrow}
               .cloudStatus=${this.cloudStatus}
             ></cloud-remote-pref>
 

--- a/src/panels/config/cloud/account/cloud-remote-pref.ts
+++ b/src/panels/config/cloud/account/cloud-remote-pref.ts
@@ -32,6 +32,8 @@ export class CloudRemotePref extends LitElement {
 
   @property({ attribute: false }) public cloudStatus?: CloudStatusLoggedIn;
 
+  @property({ type: Boolean }) public narrow = false;
+
   @state() private _unmaskedUrl = false;
 
   protected render() {
@@ -229,11 +231,15 @@ export class CloudRemotePref extends LitElement {
                     ${this.hass.localize(
                       "ui.panel.config.cloud.account.remote.strict_connection_option_guard_page_secondary"
                     )}
-                    <br /><br />
-                    ⚠️
-                    ${this.hass.localize(
-                      "ui.panel.config.cloud.account.remote.strict_connection_option_guard_page_warning"
-                    )}
+                    ${strict_connection === "guard_page"
+                      ? html`
+                          <br /><br />
+                          ⚠️
+                          ${this.hass.localize(
+                            "ui.panel.config.cloud.account.remote.strict_connection_option_guard_page_warning"
+                          )}
+                        `
+                      : nothing}
                   </div>
                 </div>
               </ha-formfield>
@@ -255,11 +261,15 @@ export class CloudRemotePref extends LitElement {
                     ${this.hass.localize(
                       "ui.panel.config.cloud.account.remote.strict_connection_option_drop_connection_secondary"
                     )}
-                    <br /><br />
-                    ⚠️
-                    ${this.hass.localize(
-                      "ui.panel.config.cloud.account.remote.strict_connection_option_drop_connection_warning"
-                    )}
+                    ${strict_connection === "drop_connection"
+                      ? html`
+                          <br /><br />
+                          ⚠️
+                          ${this.hass.localize(
+                            "ui.panel.config.cloud.account.remote.strict_connection_option_drop_connection_warning"
+                          )}
+                        `
+                      : nothing}
                   </div>
                 </div>
               </ha-formfield>
@@ -267,7 +277,7 @@ export class CloudRemotePref extends LitElement {
 
             ${strict_connection !== "disabled"
               ? html`
-                  <ha-settings-row>
+                  <ha-settings-row .narrow=${this.narrow}>
                     <span slot="heading"
                       >${this.hass.localize(
                         "ui.panel.config.cloud.account.remote.strict_connection_link"
@@ -288,7 +298,7 @@ export class CloudRemotePref extends LitElement {
               : nothing}
 
             <hr />
-            <ha-settings-row>
+            <ha-settings-row wrap-heading>
               <span slot="heading"
                 >${this.hass.localize(
                   "ui.panel.config.cloud.account.remote.external_activation"
@@ -305,7 +315,7 @@ export class CloudRemotePref extends LitElement {
               ></ha-switch>
             </ha-settings-row>
             <hr />
-            <ha-settings-row>
+            <ha-settings-row .narrow=${this.narrow}>
               <span slot="heading"
                 >${this.hass.localize(
                   "ui.panel.config.cloud.account.remote.certificate_info"
@@ -494,6 +504,7 @@ export class CloudRemotePref extends LitElement {
       }
       ha-settings-row {
         padding: 0;
+        border-top: none !important;
       }
       ha-expansion-panel {
         --expansion-panel-content-padding: 0 16px;
@@ -543,6 +554,7 @@ export class CloudRemotePref extends LitElement {
       .strict-connection-container .primary {
         font-size: 14px;
         margin-top: 12px;
+        margin-bottom: 4px;
       }
       .strict-connection-container .secondary {
         color: var(--secondary-text-color);

--- a/src/panels/config/cloud/account/cloud-tts-pref.ts
+++ b/src/panels/config/cloud/account/cloud-tts-pref.ts
@@ -188,6 +188,7 @@ export class CloudTTSPref extends LitElement {
       }
       .row > * {
         flex: 1;
+        width: 0;
       }
       .row > *:first-child {
         margin-right: 8px;


### PR DESCRIPTION
## Proposed change

Fix cloud page settings on mobile. Also, the secondary line with the warning for strict connection is now hidden when not selected.

### Before 
![CleanShot 2024-04-29 at 15 47 37](https://github.com/home-assistant/frontend/assets/5878303/6bf74cc1-31b0-4811-a800-5cb5e8a25046)
![CleanShot 2024-04-29 at 15 49 38](https://github.com/home-assistant/frontend/assets/5878303/f65d9d07-e37d-4f26-be1e-aae92d37895b)

### After 
![CleanShot 2024-04-29 at 15 47 10](https://github.com/home-assistant/frontend/assets/5878303/bbb65fc2-f07e-4e52-ba0c-731ef0dbfcb3)
![CleanShot 2024-04-29 at 15 50 09](https://github.com/home-assistant/frontend/assets/5878303/84a97059-feda-4c5d-9b74-2a028ddf48ad)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/20640
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
