### PR TITLE
Add available state option for filters

### DIFF
--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -198,6 +198,10 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
 
   private _states = memoize((localize: LocalizeFunc) => [
     {
+      value: "available",
+      label: localize("ui.panel.config.entities.picker.status.available"),
+    },
+    {
       value: "disabled",
       label: localize("ui.panel.config.entities.picker.status.disabled"),
     },
@@ -397,6 +401,8 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         !stateFilters?.length || stateFilters.includes("hidden");
       const showUnavailable =
         !stateFilters?.length || stateFilters.includes("unavailable");
+      const showAvailable =
+        !stateFilters?.length || stateFilters.includes("available");
 
       let filteredEntities = showReadOnly
         ? entities.concat(stateEntities)
@@ -474,11 +480,18 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
       for (const entry of filteredEntities) {
         const entity = this.hass.states[entry.entity_id];
         const unavailable = entity?.state === UNAVAILABLE;
+        const available = entity?.state && !unavailable;
         const restored = entity?.attributes.restored === true;
         const areaId = entry.area_id ?? devices[entry.device_id!]?.area_id;
         const area = areaId ? areas[areaId] : undefined;
+        const readonly = entry.readonly;
+        const hidden = !!entry.hidden_by;
 
         if (!showUnavailable && unavailable) {
+          continue;
+        }
+
+        if (!showAvailable && available && !readonly && !hidden) {
           continue;
         }
 
@@ -861,7 +874,7 @@ ${
   protected firstUpdated() {
     this._filters = {
       "ha-filter-states": {
-        value: ["unavailable", "readonly"],
+        value: ["available", "unavailable", "readonly"],
         items: undefined,
       },
     };


### PR DESCRIPTION

## Proposed change

Add `available` state to filter. This allow to display only hidden entities, only readonly entity, only disabled entity, etc...
Before this PR, available entity was always displayed no matter which selector was checked.

### Before 

https://github.com/home-assistant/frontend/assets/5878303/04e47f58-f516-455c-bdc1-3c9eec51f596

### After

https://github.com/home-assistant/frontend/assets/5878303/29ce9fb6-9cd3-4d9d-9e5b-fe8ece23e447

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
