### PR TITLE
Update entity status filter and grouping

### DIFF
--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -309,7 +309,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
                   <ha-svg-icon .path=${mdiPencilOff}></ha-svg-icon>
                   <simple-tooltip animation-delay="0" position="left">
                     ${this.hass.localize(
-                      "ui.panel.config.entities.picker.status.readonly"
+                      "ui.panel.config.entities.picker.status.unmanageable"
                     )}
                   </simple-tooltip>
                 </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4062,12 +4062,14 @@
             "search": "Search {number} entities",
             "unnamed_entity": "Unnamed entity",
             "status": {
-              "restored": "Restored",
               "available": "Available",
               "unavailable": "Unavailable",
+              "enabled": "Enabled",
               "disabled": "Disabled",
-              "readonly": "Read-only",
-              "hidden": "Hidden"
+              "visible": "Visible",
+              "hidden": "Hidden",
+              "not_provided": "Not provided",
+              "unmanageable": "Unmanageable"
             },
             "headers": {
               "state_icon": "State icon",
@@ -4077,7 +4079,10 @@
               "area": "Area",
               "disabled_by": "Disabled by",
               "status": "Status",
-              "domain": "Domain"
+              "domain": "Domain",
+              "availability": "Availability",
+              "visibility": "Visibility",
+              "enabled": "Enabled"
             },
             "selected": "{number} selected",
             "enable_selected": {


### PR DESCRIPTION



## Proposed change

Adds the positive variants of the states to the states filter
splits the status grouping in 3 separate groups (availability, visibility, enabled)
Renames some of the statuses (read only -> unmanageable, restored -> not provided)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
