### PR TITLE
Expand createDomains to more selectors

### DIFF
--- a/src/components/entity/ha-entities-picker.ts
+++ b/src/components/entity/ha-entities-picker.ts
@@ -76,6 +76,8 @@ class HaEntitiesPickerLight extends LitElement {
   @property({ attribute: false })
   public entityFilter?: HaEntityPickerEntityFilterFunc;
 
+  @property({ type: Array }) public createDomains?: string[];
+
   protected render() {
     if (!this.hass) {
       return nothing;
@@ -103,6 +105,7 @@ class HaEntitiesPickerLight extends LitElement {
               .value=${entityId}
               .label=${this.pickedEntityLabel}
               .disabled=${this.disabled}
+              .createDomains=${this.createDomains}
               @value-changed=${this._entityChanged}
             ></ha-entity-picker>
           </div>
@@ -122,6 +125,7 @@ class HaEntitiesPickerLight extends LitElement {
           .label=${this.pickEntityLabel}
           .helper=${this.helper}
           .disabled=${this.disabled}
+          .createDomains=${this.createDomains}
           .required=${this.required && !currentEntities.length}
           @value-changed=${this._addEntity}
         ></ha-entity-picker>

--- a/src/components/ha-selector/ha-selector-entity.ts
+++ b/src/components/ha-selector/ha-selector-entity.ts
@@ -8,7 +8,10 @@ import {
   fetchEntitySourcesWithCache,
 } from "../../data/entity_sources";
 import type { EntitySelector } from "../../data/selector";
-import { filterSelectorEntities } from "../../data/selector";
+import {
+  filterSelectorEntities,
+  computeCreateDomains,
+} from "../../data/selector";
 import { HomeAssistant } from "../../types";
 import "../entity/ha-entities-picker";
 import "../entity/ha-entity-picker";
@@ -30,6 +33,8 @@ export class HaEntitySelector extends LitElement {
   @property({ type: Boolean }) public disabled = false;
 
   @property({ type: Boolean }) public required = true;
+
+  @state() private _createDomains: string[] | undefined;
 
   private _hasIntegration(selector: EntitySelector) {
     return (
@@ -64,6 +69,7 @@ export class HaEntitySelector extends LitElement {
         .includeEntities=${this.selector.entity?.include_entities}
         .excludeEntities=${this.selector.entity?.exclude_entities}
         .entityFilter=${this._filterEntities}
+        .createDomains=${this._createDomains}
         .disabled=${this.disabled}
         .required=${this.required}
         allow-custom-entity
@@ -79,6 +85,7 @@ export class HaEntitySelector extends LitElement {
         .includeEntities=${this.selector.entity.include_entities}
         .excludeEntities=${this.selector.entity.exclude_entities}
         .entityFilter=${this._filterEntities}
+        .createDomains=${this._createDomains}
         .disabled=${this.disabled}
         .required=${this.required}
       ></ha-entities-picker>
@@ -95,6 +102,9 @@ export class HaEntitySelector extends LitElement {
       fetchEntitySourcesWithCache(this.hass).then((sources) => {
         this._entitySources = sources;
       });
+    }
+    if (changedProps.has("selector")) {
+      this._createDomains = computeCreateDomains(this.selector);
     }
   }
 

--- a/src/components/ha-selector/ha-selector-target.ts
+++ b/src/components/ha-selector/ha-selector-target.ts
@@ -22,6 +22,7 @@ import {
   filterSelectorDevices,
   filterSelectorEntities,
   TargetSelector,
+  computeCreateDomains,
 } from "../../data/selector";
 import type { HomeAssistant } from "../../types";
 import "../ha-target-picker";
@@ -41,6 +42,8 @@ export class HaTargetSelector extends LitElement {
   @property({ type: Boolean }) public disabled = false;
 
   @state() private _entitySources?: EntitySources;
+
+  @state() private _createDomains: string[] | undefined;
 
   private _deviceIntegrationLookup = memoizeOne(getDeviceIntegrationLookup);
 
@@ -68,6 +71,9 @@ export class HaTargetSelector extends LitElement {
         this._entitySources = sources;
       });
     }
+    if (changedProperties.has("selector")) {
+      this._createDomains = computeCreateDomains(this.selector);
+    }
   }
 
   protected render() {
@@ -82,7 +88,7 @@ export class HaTargetSelector extends LitElement {
       .deviceFilter=${this._filterDevices}
       .entityFilter=${this._filterEntities}
       .disabled=${this.disabled}
-      .createDomains=${this.selector.target?.create_domains}
+      .createDomains=${this._createDomains}
     ></ha-target-picker>`;
   }
 

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -44,7 +44,6 @@ import "./ha-service-picker";
 import "./ha-settings-row";
 import "./ha-yaml-editor";
 import type { HaYamlEditor } from "./ha-yaml-editor";
-import { isHelperDomain } from "../panels/config/helpers/const";
 
 const attributeFilter = (values: any[], attribute: any) => {
   if (typeof attribute === "object") {
@@ -366,12 +365,8 @@ export class HaServiceControl extends LitElement {
   }
 
   private _targetSelector = memoizeOne(
-    (targetSelector: TargetSelector | null | undefined, domain?: string) => {
-      const create_domains = isHelperDomain(domain) ? [domain] : undefined;
-      return targetSelector
-        ? { target: { ...targetSelector, create_domains } }
-        : { target: { create_domains } };
-    }
+    (targetSelector: TargetSelector | null | undefined) =>
+      targetSelector ? { target: { ...targetSelector } } : { target: {} }
   );
 
   protected render() {
@@ -462,8 +457,7 @@ export class HaServiceControl extends LitElement {
           ><ha-selector
             .hass=${this.hass}
             .selector=${this._targetSelector(
-              serviceData.target as TargetSelector,
-              domain
+              serviceData.target as TargetSelector
             )}
             .disabled=${this.disabled}
             @value-changed=${this._targetChanged}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The new feature to create helpers from a selector currently only is available from the service call target picker. This change expands this to any target or entity picker which has a domain filter, and the filter includes helper domains. 

This means any blueprint that has an entity picker or target picker that selects a helper domain will automatically include this option, as well as a couple frontend card editors that have domain specific entity selectors, e.g. gauge editor will offer to create `input_number` or `counter` as an option in its entity picker. 


![image](https://github.com/home-assistant/frontend/assets/32912880/640dbe7e-acd9-4185-9917-875eaf1a710d)


Pickers without any domain filter will _not_ include this feature. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
