### PR TITLE
Show ungrouped group when there are results

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -565,36 +565,30 @@ export class HaDataTable extends LitElement {
           }, {});
         const groupedItems: DataTableRowData[] = [];
         Object.entries(sorted).forEach(([groupName, rows]) => {
-          if (
-            groupName !== UNDEFINED_GROUP_KEY ||
-            Object.keys(sorted).length > 1
-          ) {
-            groupedItems.push({
-              append: true,
-              content: html`<div
-                class="mdc-data-table__cell group-header"
-                role="cell"
-                .group=${groupName}
-                @click=${this._collapseGroup}
+          groupedItems.push({
+            append: true,
+            content: html`<div
+              class="mdc-data-table__cell group-header"
+              role="cell"
+              .group=${groupName}
+              @click=${this._collapseGroup}
+            >
+              <ha-icon-button
+                .path=${mdiChevronUp}
+                class=${this._collapsedGroups.includes(groupName)
+                  ? "collapsed"
+                  : ""}
               >
-                <ha-icon-button
-                  .path=${mdiChevronUp}
-                  class=${this._collapsedGroups.includes(groupName)
-                    ? "collapsed"
-                    : ""}
-                >
-                </ha-icon-button>
-                ${groupName === UNDEFINED_GROUP_KEY
-                  ? this.hass.localize("ui.components.data-table.ungrouped")
-                  : groupName || ""}
-              </div>`,
-            });
-          }
+              </ha-icon-button>
+              ${groupName === UNDEFINED_GROUP_KEY
+                ? this.hass.localize("ui.components.data-table.ungrouped")
+                : groupName || ""}
+            </div>`,
+          });
           if (!this._collapsedGroups.includes(groupName)) {
             groupedItems.push(...rows);
           }
         });
-
         items = groupedItems;
       }
 


### PR DESCRIPTION
## Proposed change
When there are results in the "ungrouped" group and it's collapsed, the results are filtered away upon search when there are results to show. This changes the grouping to show the "ungrouped" group if there are results to show. See the issue for another example. 

Edit: Since the original issue got cleaned up somehow, have 2 automations with a different name whereof one is assigned to a category referred to the first automation and one unassigned being the second automation. Then do the following: 
* nothing collapsed: search first automation will show first automation and search second automation will show second automation
* collapse the category: search first automation will show first automation and search second automation will show second automation
* collapse the ungrouped group:  search first automation will show first automation and search seconds automation will not show second automation

This behavior is somewhat annoying when  you're assigned categories to ungrouped automations because you want to collapse it so you don't see all the ungrouped automations but want to search for one to assign it to a category. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #20672
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
