### PR TITLE
Use domain translation in filter for domain search

### DIFF
--- a/src/components/ha-filter-domains.ts
+++ b/src/components/ha-filter-domains.ts
@@ -12,6 +12,11 @@ import "./ha-domain-icon";
 import "./search-input-outlined";
 import { computeDomain } from "../common/entity/compute_domain";
 
+type DomainTranslation = {
+  domain: string;
+  translation: string;
+};
+
 @customElement("ha-filter-domains")
 export class HaFilterDomains extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -63,17 +68,17 @@ export class HaFilterDomains extends LitElement {
                   (i) => i,
                   (domain) =>
                     html`<ha-check-list-item
-                      .value=${domain}
-                      .selected=${(this.value || []).includes(domain)}
+                      .value=${domain.domain}
+                      .selected=${(this.value || []).includes(domain.domain)}
                       graphic="icon"
                     >
                       <ha-domain-icon
                         slot="graphic"
                         .hass=${this.hass}
-                        .domain=${domain}
+                        .domain=${domain.domain}
                         brandFallback
                       ></ha-domain-icon>
-                      ${domainToName(this.hass.localize, domain)}
+                      ${domain.translation}
                     </ha-check-list-item>`
                 )}
               </mwc-list> `
@@ -83,13 +88,22 @@ export class HaFilterDomains extends LitElement {
   }
 
   private _domains = memoizeOne((states, filter) => {
-    const domains = new Set<string>();
+    const domains = new Map<string, DomainTranslation>();
     Object.keys(states).forEach((entityId) => {
-      domains.add(computeDomain(entityId));
+      const computedDomain = computeDomain(entityId);
+      domains.set(computedDomain, {
+        domain: computedDomain,
+        translation: domainToName(this.hass.localize, computedDomain),
+      });
     });
-    return Array.from(domains)
-      .filter((domain) => !filter || domain.toLowerCase().includes(filter))
-      .sort((a, b) => stringCompare(a, b, this.hass.locale.language));
+
+    return Array.from(domains.values())
+      .filter(
+        (entry) => !filter || entry.translation.toLowerCase().includes(filter)
+      )
+      .sort((a, b) =>
+        stringCompare(a.translation, b.translation, this.hass.locale.language)
+      );
   });
 
   protected updated(changed) {


### PR DESCRIPTION
## Proposed change
At the moment, when searching for domains in the filter, it is filtered by the domain name itself, which is not translated. For example, if you search for "Licht" in German, the light domain will not be displayed:

<img width="251" alt="image" src="https://github.com/home-assistant/frontend/assets/3989428/824a4a60-7b4f-42b3-8b5b-e263dcab6c7e">
<img width="244" alt="image" src="https://github.com/home-assistant/frontend/assets/3989428/1c4228c0-10f1-4cdf-a313-0d98763ad2b4">

This PR addresses this with the use of the domain translation for the search:

<img width="258" alt="image" src="https://github.com/home-assistant/frontend/assets/3989428/42a31dff-4e80-4c95-95de-7c91edfd72d2">
<img width="257" alt="image" src="https://github.com/home-assistant/frontend/assets/3989428/a07088d0-b9f7-497a-961c-d02efb35d20a">


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
