### PR TITLE
Show descriptions in script editor

### DIFF
--- a/src/data/script.ts
+++ b/src/data/script.ts
@@ -93,6 +93,7 @@ export type ScriptConfig = ManualScriptConfig | BlueprintScriptConfig;
 
 export interface ManualScriptConfig {
   alias: string;
+  description?: string;
   sequence: Action | Action[];
   icon?: string;
   mode?: (typeof MODES)[number];

--- a/src/panels/config/automation/blueprint-automation-editor.ts
+++ b/src/panels/config/automation/blueprint-automation-editor.ts
@@ -1,11 +1,12 @@
 import "@material/mwc-button/mwc-button";
 import { HassEntity } from "home-assistant-js-websocket";
-import { html } from "lit";
+import { html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import "../../../components/ha-alert";
 import { BlueprintAutomationConfig } from "../../../data/automation";
 import { fetchBlueprints } from "../../../data/blueprint";
 import { HaBlueprintGenericEditor } from "../blueprint/blueprint-generic-editor";
+import "../../../components/ha-markdown";
 
 @customElement("blueprint-automation-editor")
 export class HaBlueprintAutomationEditor extends HaBlueprintGenericEditor {
@@ -26,7 +27,7 @@ export class HaBlueprintAutomationEditor extends HaBlueprintGenericEditor {
               ${this.hass.localize("ui.panel.config.automation.editor.migrate")}
             </mwc-button>
           </ha-alert>`
-        : ""}
+        : nothing}
       ${this.stateObj?.state === "off"
         ? html`
             <ha-alert alert-type="info">
@@ -42,8 +43,12 @@ export class HaBlueprintAutomationEditor extends HaBlueprintGenericEditor {
           `
         : ""}
       ${this.config.description
-        ? html`<p class="description">${this.config.description}</p>`
-        : ""}
+        ? html`<ha-markdown
+            class="description"
+            breaks
+            .content=${this.config.description}
+          ></ha-markdown>`
+        : nothing}
       ${this.renderCard()}
     `;
   }

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -59,14 +59,14 @@ export class HaManualAutomationEditor extends LitElement {
               </mwc-button>
             </ha-alert>
           `
-        : ""}
+        : nothing}
       ${this.config.description
         ? html`<ha-markdown
             class="description"
             breaks
             .content=${this.config.description}
           ></ha-markdown>`
-        : ""}
+        : nothing}
       <div class="header">
         <h2 id="triggers-heading" class="name">
           ${this.hass.localize(

--- a/src/panels/config/script/blueprint-script-editor.ts
+++ b/src/panels/config/script/blueprint-script-editor.ts
@@ -1,9 +1,11 @@
-import { html } from "lit";
+import "@material/mwc-button/mwc-button";
+import { html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import "../../../components/ha-alert";
 import { BlueprintScriptConfig } from "../../../data/script";
 import { fetchBlueprints } from "../../../data/blueprint";
 import { HaBlueprintGenericEditor } from "../blueprint/blueprint-generic-editor";
+import "../../../components/ha-markdown";
 
 @customElement("blueprint-script-editor")
 export class HaBlueprintScriptEditor extends HaBlueprintGenericEditor {
@@ -22,7 +24,14 @@ export class HaBlueprintScriptEditor extends HaBlueprintGenericEditor {
               ${this.hass.localize("ui.panel.config.script.editor.migrate")}
             </mwc-button>
           </ha-alert>`
-        : ""}
+        : nothing}
+      ${this.config.description
+        ? html`<ha-markdown
+            class="description"
+            breaks
+            .content=${this.config.description}
+          ></ha-markdown>`
+        : nothing}
       ${this.renderCard()}
     `;
   }

--- a/src/panels/config/script/manual-script-editor.ts
+++ b/src/panels/config/script/manual-script-editor.ts
@@ -6,6 +6,7 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import { nestedArrayMove } from "../../../common/util/array-move";
 import "../../../components/ha-card";
 import "../../../components/ha-icon-button";
+import "../../../components/ha-markdown";
 import { Action, Fields, ScriptConfig } from "../../../data/script";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
@@ -66,7 +67,14 @@ export class HaManualScriptEditor extends LitElement {
               ${this.hass.localize("ui.panel.config.script.editor.migrate")}
             </mwc-button>
           </ha-alert>`
-        : ""}
+        : nothing}
+      ${this.config.description
+        ? html`<ha-markdown
+            class="description"
+            breaks
+            .content=${this.config.description}
+          ></ha-markdown>`
+        : nothing}
       ${this.config.fields
         ? html`<div class="header">
               <h2 id="fields-heading" class="name">


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Render the description field for scripts in the editor in the same way that we do for automations. 

This would likely benefit from further work to add the description field editor to the UI (in the rename dialog like the automation editor), but for now we can at least show the description for users which have configured it in YAML. 

I am also working on moving the script editor to be more like the automation editor as well, in a separate PR. 


![image](https://github.com/home-assistant/frontend/assets/32912880/474d7916-7d62-41f4-8d36-8580fd295009)






## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://community.home-assistant.io/t/add-description-field-in-ui-script-editor/726084
https://github.com/home-assistant/frontend/discussions/16259


- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
