### PR TITLE
Fix pick-theme-row and behavior of default theme mode

### DIFF
--- a/src/panels/profile/ha-pick-theme-row.ts
+++ b/src/panels/profile/ha-pick-theme-row.ts
@@ -37,6 +37,8 @@ export class HaPickThemeRow extends LitElement {
   protected render(): TemplateResult {
     const hasThemes =
       this.hass.themes.themes && Object.keys(this.hass.themes.themes).length;
+
+    const curThemeIsUseDefault = this.hass.selectedTheme?.theme === "";
     const curTheme = this.hass.selectedTheme?.theme
       ? this.hass.selectedTheme?.theme
       : this.hass.themes.darkMode
@@ -86,6 +88,9 @@ export class HaPickThemeRow extends LitElement {
         </ha-select>
       </ha-settings-row>
       ${curTheme === HOME_ASSISTANT_THEME ||
+      (curThemeIsUseDefault &&
+        this.hass.themes.default_dark_theme &&
+        this.hass.themes.default_theme) ||
       this._supportsModeSelection(curTheme)
         ? html` <div class="inputs">
             <ha-formfield

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -84,14 +84,14 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
             }
           : this.hass.selectedTheme;
 
-      const themeName =
-        themeSettings?.theme ||
-        (darkPreferred && this.hass.themes.default_dark_theme
-          ? this.hass.themes.default_dark_theme
-          : this.hass.themes.default_theme);
-
       let darkMode =
         themeSettings?.dark === undefined ? darkPreferred : themeSettings.dark;
+
+      const themeName =
+        themeSettings?.theme ||
+        (darkMode && this.hass.themes.default_dark_theme
+          ? this.hass.themes.default_dark_theme
+          : this.hass.themes.default_theme);
 
       const selectedTheme = themeName
         ? this.hass.themes.themes[themeName]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
I do not believe the `Use default theme` setting is currently working fully correctly. 

For example, consider these two example themes from the website:
```
    happy:
      primary-color: pink
      text-primary-color: purple
    sad:
      primary-color: steelblue
      modes:
        dark:
          secondary-text-color: slategray
```

Say that user makes two service calls, and sets `happy` as the default light theme:
```
service: frontend.set_theme
data:
  mode: light
  name: happy
```  


and `sad` as the default dark theme:
```
service: frontend.set_theme
data:
  mode: dark
  name: sad
```


My expectation now would be that in the user profile, the user can pick `Use default theme` from the theme picker, and then should see the Auto/Light/Dark radio set. When `Light` is selected, we should use `happy` theme. When `Dark` is selected, we should use dark-variant of `sad` theme. When `Auto` is selected, we would either use `happy` (if browser does not prefer dark) or dark-variant of `sad` (if browser prefers dark). 

What currently actually happens:

- if `light` mode is currently selected, the auto/light/dark radio set is not displayed, based on the fact that the default light mode theme (`happy`) does not have a dark mode. This seems wrong, and we should show the radio set due to the default theme having default light and dark modes defined.  If `dark` mode is currently selected, we do see the radio set, but if you click on `light`, the set instantly disappears and you cannot go back to `dark`. 

- if `light` mode is currently selected, I would expect to see the happy theme applied. However the theme mixin is instead applying the light-variant of `sad`, due to my browser/OS setting is to prefer dark. Unless darkMode is set to `Auto`, I would not expect the browser preference to be considered. 



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
