### PR TITLE
Remove empty electricity grid state

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -173,7 +173,7 @@ export interface WaterSourceTypeEnergyPreference {
   unit_of_measurement?: string | null;
 }
 
-type EnergySource =
+export type EnergySource =
   | SolarSourceTypeEnergyPreference
   | GridSourceTypeEnergyPreference
   | BatterySourceTypeEnergyPreference

--- a/src/panels/config/energy/components/ha-energy-grid-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-grid-settings.ts
@@ -449,11 +449,7 @@ export class EnergyGridSettings extends LitElement {
       ),
     };
 
-    try {
-      await this._savePreferences(preferences);
-    } catch (err: any) {
-      showAlertDialog(this, { title: `Failed to save config: ${err.message}` });
-    }
+    await this._deleteSource(preferences);
   }
 
   private async _deleteToSource(ev) {
@@ -479,16 +475,34 @@ export class EnergyGridSettings extends LitElement {
       ),
     };
 
-    try {
-      await this._savePreferences(preferences);
-    } catch (err: any) {
-      showAlertDialog(this, { title: `Failed to save config: ${err.message}` });
+    await this._deleteSource(preferences);
+  }
+
+  private async _deleteSource(preferences: EnergyPreferences) {
+    // Check if grid sources became an empty type and remove if so
+    const hasEmptyGridSources = preferences.energy_sources.some(
+      (source) =>
+        source.type === "grid" &&
+        source.flow_from.length === 0 &&
+        source.flow_to.length === 0
+    );
+
+    if (hasEmptyGridSources) {
+      preferences.energy_sources = preferences.energy_sources.filter(
+        (source) => source.type !== "grid"
+      );
     }
+
+    await this._savePreferences(preferences);
   }
 
   private async _savePreferences(preferences: EnergyPreferences) {
-    const result = await saveEnergyPreferences(this.hass, preferences);
-    fireEvent(this, "value-changed", { value: result });
+    try {
+      const result = await saveEnergyPreferences(this.hass, preferences);
+      fireEvent(this, "value-changed", { value: result });
+    } catch (err: any) {
+      showAlertDialog(this, { title: `Failed to save config: ${err.message}` });
+    }
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/energy/components/ha-energy-grid-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-grid-settings.ts
@@ -449,7 +449,8 @@ export class EnergyGridSettings extends LitElement {
       ),
     };
 
-    await this._deleteSource(preferences);
+    const cleanedPreferences = this._removeEmptySources(preferences);
+    await this._savePreferences(cleanedPreferences);
   }
 
   private async _deleteToSource(ev) {
@@ -475,10 +476,11 @@ export class EnergyGridSettings extends LitElement {
       ),
     };
 
-    await this._deleteSource(preferences);
+    const cleanedPreferences = this._removeEmptySources(preferences);
+    await this._savePreferences(cleanedPreferences);
   }
 
-  private async _deleteSource(preferences: EnergyPreferences) {
+  private _removeEmptySources(preferences: EnergyPreferences) {
     // Check if grid sources became an empty type and remove if so
     const hasEmptyGridSources = preferences.energy_sources.some(
       (source) =>
@@ -493,7 +495,7 @@ export class EnergyGridSettings extends LitElement {
       );
     }
 
-    await this._savePreferences(preferences);
+    return preferences;
   }
 
   private async _savePreferences(preferences: EnergyPreferences) {

--- a/src/panels/config/energy/components/ha-energy-grid-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-grid-settings.ts
@@ -22,6 +22,7 @@ import {
   EnergyPreferencesValidation,
   energySourcesByType,
   EnergyValidationIssue,
+  EnergySource,
   FlowFromGridSourceEnergyPreference,
   FlowToGridSourceEnergyPreference,
   GridSourceTypeEnergyPreference,
@@ -482,18 +483,18 @@ export class EnergyGridSettings extends LitElement {
 
   private _removeEmptySources(preferences: EnergyPreferences) {
     // Check if grid sources became an empty type and remove if so
-    const hasEmptyGridSources = preferences.energy_sources.some(
-      (source) =>
-        source.type === "grid" &&
-        source.flow_from.length === 0 &&
-        source.flow_to.length === 0
-    );
-
-    if (hasEmptyGridSources) {
-      preferences.energy_sources = preferences.energy_sources.filter(
-        (source) => source.type !== "grid"
-      );
-    }
+    preferences.energy_sources = preferences.energy_sources.reduce<
+      EnergySource[]
+    >((acc, source) => {
+      if (
+        source.type !== "grid" ||
+        source.flow_from.length > 0 ||
+        source.flow_to.length > 0
+      ) {
+        acc.push(source);
+      }
+      return acc;
+    }, []);
 
     return preferences;
   }


### PR DESCRIPTION
## Proposed change
When there's no longer a grid consumption or return to grid defined in the electricity grid section, the whole electricity grid section should be removed. 

This is how it used to save after removing all grid sources: 
``` 
    "energy_sources": [
      {
        "type": "grid",
        "flow_from": [],
        "flow_to": [],
        "cost_adjustment_day": 0.0
      }
    ],
    "device_consumption": []
 ```
This is how it will now save: 
``` 
    "energy_sources": [],
    "device_consumption": []
```

Given this situation, it now allows to say:
* that "hasGrid" only has to look to see if the type is defined but since installations may have an empty grid state already, checks have been added in #20785
* better detect when an energy dashboard will become empty to return the setup wizard again, what was added in #19765

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced the energy grid settings by automatically removing empty grid sources before saving preferences, ensuring better data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->