### PR TITLE
Add CSS variables to ha-toast

### DIFF
--- a/src/managers/notification-manager.ts
+++ b/src/managers/notification-manager.ts
@@ -63,8 +63,6 @@ class NotificationManager extends LitElement {
         leading
         open
         dir=${computeRTL(this.hass) ? "rtl" : "ltr"}
-        .fill-color="var(--ha-toast-background-color, rgb(51, 51, 51)"
-        .label-ink-color="var(--ha-toast-text-color, rgba(255, 255, 255, 0.87)"
         .labelText=${this._parameters.message}
         .timeoutMs=${this._parameters.duration!}
         @MDCSnackbar:closed=${this._toastClosed}
@@ -89,6 +87,20 @@ class NotificationManager extends LitElement {
       </ha-toast>
     `;
   }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      css`
+        .mdc-snackbar__surface  {
+          background-color: var(--ha-toast-background-color, rgba(51, 51, 51, 1));
+          color: var(--ha-toast-text-color, rgba(255, 255, 255, 0.87));
+         }
+      `,
+    ];
+  }
+}
+
 
   private buttonClicked() {
     this._toast?.close("action");

--- a/src/managers/notification-manager.ts
+++ b/src/managers/notification-manager.ts
@@ -63,6 +63,8 @@ class NotificationManager extends LitElement {
         leading
         open
         dir=${computeRTL(this.hass) ? "rtl" : "ltr"}
+        .fill-color="var(--ha-toast-background-color, rgb(51, 51, 51)"
+        .label-ink-color="var(--ha-toast-text-color, rgba(255, 255, 255, 0.87)"
         .labelText=${this._parameters.message}
         .timeoutMs=${this._parameters.duration!}
         @MDCSnackbar:closed=${this._toastClosed}

--- a/src/managers/notification-manager.ts
+++ b/src/managers/notification-manager.ts
@@ -100,7 +100,7 @@ class NotificationManager extends LitElement {
         background-color: var(--ha-toast-background-color, rgba(51, 51, 51, 1));
         color: var(--ha-toast-text-color, rgba(255, 255, 255, 0.87));
        }
-    `,
+    `;
   }
 }
 

--- a/src/managers/notification-manager.ts
+++ b/src/managers/notification-manager.ts
@@ -1,4 +1,10 @@
-import { html, LitElement, nothing } from "lit";
+import {
+  css,
+  CSSResultGroup,
+  html,
+  LitElement,
+  nothing,
+} from "lit";
 import { property, state, query } from "lit/decorators";
 import { mdiClose } from "@mdi/js";
 import { computeRTL } from "../common/util/compute_rtl";
@@ -90,7 +96,6 @@ class NotificationManager extends LitElement {
 
   static get styles(): CSSResultGroup {
     return [
-      haStyle,
       css`
         .mdc-snackbar__surface  {
           background-color: var(--ha-toast-background-color, rgba(51, 51, 51, 1));

--- a/src/managers/notification-manager.ts
+++ b/src/managers/notification-manager.ts
@@ -3,7 +3,7 @@ import {
   CSSResultGroup,
   html,
   LitElement,
-  nothing,
+  nothing
 } from "lit";
 import { property, state, query } from "lit/decorators";
 import { mdiClose } from "@mdi/js";
@@ -95,14 +95,12 @@ class NotificationManager extends LitElement {
   }
 
   static get styles(): CSSResultGroup {
-    return [
-      css`
-        .mdc-snackbar__surface  {
-          background-color: var(--ha-toast-background-color, rgba(51, 51, 51, 1));
-          color: var(--ha-toast-text-color, rgba(255, 255, 255, 0.87));
-         }
-      `,
-    ];
+    return css`
+      .mdc-snackbar__surface  {
+        background-color: var(--ha-toast-background-color, rgba(51, 51, 51, 1));
+        color: var(--ha-toast-text-color, rgba(255, 255, 255, 0.87));
+       }
+    `,
   }
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Added two variables for styling ha-toast. One for the background and one for the text color. Unfortunatly, I'm  not on a good enough laptop to check if code works. According to https://m2.material.io/components/snackbars/web#javascript-api these variables should work.



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

theme.yaml:
```yaml
theme:
  ha-toast-background-color: var(--ha-card-background-color)
  ha-toast-text-color: var(--primary-text-color)

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
