### PR TITLE
Add visibility option to sections (conditional section)

### DIFF
--- a/src/common/dom/media_query.ts
+++ b/src/common/dom/media_query.ts
@@ -1,3 +1,5 @@
+export type MediaQueriesListener = () => void;
+
 /**
  * Attach a media query. Listener is called right away and when it matches.
  * @param mediaQuery media query to match.
@@ -7,7 +9,7 @@
 export const listenMediaQuery = (
   mediaQuery: string,
   matchesChanged: (matches: boolean) => void
-) => {
+): MediaQueriesListener => {
   const mql = matchMedia(mediaQuery);
   const listener = (e) => matchesChanged(e.matches);
   mql.addListener(listener);

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -317,32 +317,34 @@ export class HaChartBase extends LitElement {
 
   private async _setupChart() {
     if (this._loading) return;
-    this._loading = true;
     const ctx: CanvasRenderingContext2D = this.renderRoot
       .querySelector("canvas")!
       .getContext("2d")!;
+    this._loading = true;
+    try {
+      const ChartConstructor = (await import("../../resources/chartjs")).Chart;
 
-    const ChartConstructor = (await import("../../resources/chartjs")).Chart;
+      const computedStyles = getComputedStyle(this);
 
-    const computedStyles = getComputedStyle(this);
+      ChartConstructor.defaults.borderColor =
+        computedStyles.getPropertyValue("--divider-color");
+      ChartConstructor.defaults.color = computedStyles.getPropertyValue(
+        "--secondary-text-color"
+      );
+      ChartConstructor.defaults.font.family =
+        computedStyles.getPropertyValue("--mdc-typography-body1-font-family") ||
+        computedStyles.getPropertyValue("--mdc-typography-font-family") ||
+        "Roboto, Noto, sans-serif";
 
-    ChartConstructor.defaults.borderColor =
-      computedStyles.getPropertyValue("--divider-color");
-    ChartConstructor.defaults.color = computedStyles.getPropertyValue(
-      "--secondary-text-color"
-    );
-    ChartConstructor.defaults.font.family =
-      computedStyles.getPropertyValue("--mdc-typography-body1-font-family") ||
-      computedStyles.getPropertyValue("--mdc-typography-font-family") ||
-      "Roboto, Noto, sans-serif";
-
-    this.chart = new ChartConstructor(ctx, {
-      type: this.chartType,
-      data: this.data,
-      options: this._createOptions(),
-      plugins: this._createPlugins(),
-    });
-    this._loading = false;
+      this.chart = new ChartConstructor(ctx, {
+        type: this.chartType,
+        data: this.data,
+        options: this._createOptions(),
+        plugins: this._createPlugins(),
+      });
+    } finally {
+      this._loading = false;
+    }
   }
 
   private _createOptions() {

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -313,7 +313,11 @@ export class HaChartBase extends LitElement {
     `;
   }
 
+  private _loading = false;
+
   private async _setupChart() {
+    if (this._loading) return;
+    this._loading = true;
     const ctx: CanvasRenderingContext2D = this.renderRoot
       .querySelector("canvas")!
       .getContext("2d")!;
@@ -338,6 +342,7 @@ export class HaChartBase extends LitElement {
       options: this._createOptions(),
       plugins: this._createPlugins(),
     });
+    this._loading = false;
   }
 
   private _createOptions() {

--- a/src/components/map/ha-map.ts
+++ b/src/components/map/ha-map.ts
@@ -178,7 +178,11 @@ export class HaMap extends ReactiveElement {
     map!.classList.toggle("forced-light", this.themeMode === "light");
   }
 
+  private _loading = false;
+
   private async _loadMap(): Promise<void> {
+    if (this._loading) return;
+    this._loading = true;
     let map = this.shadowRoot!.getElementById("map");
     if (!map) {
       map = document.createElement("div");
@@ -188,6 +192,7 @@ export class HaMap extends ReactiveElement {
     [this.leafletMap, this.Leaflet] = await setupLeafletMap(map);
     this._updateMapStyle();
     this._loaded = true;
+    this._loading = false;
   }
 
   public fitMap(options?: { zoom?: number; pad?: number }): void {

--- a/src/components/map/ha-map.ts
+++ b/src/components/map/ha-map.ts
@@ -182,17 +182,20 @@ export class HaMap extends ReactiveElement {
 
   private async _loadMap(): Promise<void> {
     if (this._loading) return;
-    this._loading = true;
     let map = this.shadowRoot!.getElementById("map");
     if (!map) {
       map = document.createElement("div");
       map.id = "map";
       this.shadowRoot!.append(map);
     }
-    [this.leafletMap, this.Leaflet] = await setupLeafletMap(map);
-    this._updateMapStyle();
-    this._loaded = true;
-    this._loading = false;
+    this._loading = true;
+    try {
+      [this.leafletMap, this.Leaflet] = await setupLeafletMap(map);
+      this._updateMapStyle();
+      this._loaded = true;
+    } finally {
+      this._loading = false;
+    }
   }
 
   public fitMap(options?: { zoom?: number; pad?: number }): void {

--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -1,8 +1,10 @@
+import type { Condition } from "../../../panels/lovelace/common/validate-condition";
 import type { LovelaceCardConfig } from "./card";
 import type { LovelaceStrategyConfig } from "./strategy";
 
 export interface LovelaceBaseSectionConfig {
   title?: string;
+  visibility?: Condition[];
 }
 
 export interface LovelaceSectionConfig extends LovelaceBaseSectionConfig {

--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -308,3 +308,15 @@ export function addEntityToCondition(
   }
   return condition;
 }
+
+export function extractMediaQueries(conditions: Condition[]): string[] {
+  return conditions.reduce<string[]>((array, c) => {
+    if ("conditions" in c && c.conditions) {
+      array.push(...extractMediaQueries(c.conditions));
+    }
+    if (c.condition === "screen" && c.media_query) {
+      array.push(c.media_query);
+    }
+    return array;
+  }, []);
+}

--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -325,29 +325,31 @@ export function extractMediaQueries(conditions: Condition[]): string[] {
   }, []);
 }
 
-export function createConditionMediaQueriesListeners(
+export function attachConditionMediaQueriesListeners(
   conditions: Condition[],
   hass: HomeAssistant,
   onChange: (visibility: boolean) => void
 ): MediaQueriesListener[] {
+  // For performance, if there is only one condition and it's a screen condition, set the visibility directly
+  if (
+    conditions.length === 1 &&
+    conditions[0].condition === "screen" &&
+    conditions[0].media_query
+  ) {
+    const listener = listenMediaQuery(conditions[0].media_query, (matches) => {
+      onChange(matches);
+    });
+    return [listener];
+  }
+
   const mediaQueries = extractMediaQueries(conditions);
 
-  const listeners: MediaQueriesListener[] = [];
-  mediaQueries.forEach((query) => {
-    const listener = listenMediaQuery(query, (matches) => {
-      // For performance, if there is only one condition and it's a screen condition, set the visibility directly
-      if (
-        conditions.length === 1 &&
-        "condition" in conditions[0] &&
-        conditions[0].condition === "screen"
-      ) {
-        onChange(matches);
-        return;
-      }
+  const listeners = mediaQueries.map((query) => {
+    const listener = listenMediaQuery(query, () => {
       const visibility = checkConditionsMet(conditions, hass);
       onChange(visibility);
     });
-    listeners.push(listener);
+    return listener;
   });
 
   return listeners;

--- a/src/panels/lovelace/components/hui-conditional-base.ts
+++ b/src/panels/lovelace/components/hui-conditional-base.ts
@@ -1,12 +1,13 @@
 import { PropertyValues, ReactiveElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { listenMediaQuery } from "../../../common/dom/media_query";
+import { MediaQueriesListener } from "../../../common/dom/media_query";
 import { deepEqual } from "../../../common/util/deep-equal";
 import { HomeAssistant } from "../../../types";
 import { ConditionalCardConfig } from "../cards/types";
 import {
   Condition,
   checkConditionsMet,
+  createConditionMediaQueriesListeners,
   extractMediaQueries,
   validateConditionalConfig,
 } from "../common/validate-condition";
@@ -23,7 +24,7 @@ export class HuiConditionalBase extends ReactiveElement {
 
   protected _element?: LovelaceCard | LovelaceRow;
 
-  private _mediaQueriesListeners: Array<() => void> = [];
+  private _listeners: MediaQueriesListener[] = [];
 
   private _mediaQueries: string[] = [];
 
@@ -65,43 +66,31 @@ export class HuiConditionalBase extends ReactiveElement {
   }
 
   private _clearMediaQueries() {
-    this._mediaQueries = [];
-    while (this._mediaQueriesListeners.length) {
-      this._mediaQueriesListeners.pop()!();
-    }
+    this._listeners.forEach((unsub) => unsub());
+    this._listeners = [];
   }
 
   private _listenMediaQueries() {
-    if (!this._config) {
+    if (!this._config || !this.hass) {
       return;
     }
 
-    const mediaQueries = extractMediaQueries(
-      this._config.conditions.filter((c) => "condition" in c) as Condition[]
-    );
+    const supportedConditions = this._config.conditions.filter(
+      (c) => "condition" in c
+    ) as Condition[];
+    const mediaQueries = extractMediaQueries(supportedConditions);
 
     if (deepEqual(mediaQueries, this._mediaQueries)) return;
 
-    this._mediaQueries = mediaQueries;
-    while (this._mediaQueriesListeners.length) {
-      this._mediaQueriesListeners.pop()!();
-    }
+    this._clearMediaQueries();
 
-    mediaQueries.forEach((query) => {
-      const listener = listenMediaQuery(query, (matches) => {
-        // For performance, if there is only one condition and it's a screen condition, set the visibility directly
-        if (
-          this._config!.conditions.length === 1 &&
-          "condition" in this._config!.conditions[0] &&
-          this._config!.conditions[0].condition === "screen"
-        ) {
-          this._setVisibility(matches);
-          return;
-        }
-        this._updateVisibility();
-      });
-      this._mediaQueriesListeners.push(listener);
-    });
+    this._listeners = createConditionMediaQueriesListeners(
+      supportedConditions,
+      this.hass,
+      (visibility) => {
+        this._setVisibility(visibility);
+      }
+    );
   }
 
   protected update(changed: PropertyValues): void {

--- a/src/panels/lovelace/components/hui-conditional-base.ts
+++ b/src/panels/lovelace/components/hui-conditional-base.ts
@@ -6,26 +6,12 @@ import { HomeAssistant } from "../../../types";
 import { ConditionalCardConfig } from "../cards/types";
 import {
   Condition,
-  LegacyCondition,
   checkConditionsMet,
+  extractMediaQueries,
   validateConditionalConfig,
 } from "../common/validate-condition";
 import { ConditionalRowConfig, LovelaceRow } from "../entity-rows/types";
 import { LovelaceCard } from "../types";
-
-function extractMediaQueries(
-  conditions: (Condition | LegacyCondition)[]
-): string[] {
-  return conditions.reduce<string[]>((array, c) => {
-    if ("conditions" in c && c.conditions) {
-      array.push(...extractMediaQueries(c.conditions));
-    }
-    if ("condition" in c && c.condition === "screen" && c.media_query) {
-      array.push(c.media_query);
-    }
-    return array;
-  }, []);
-}
 
 @customElement("hui-conditional-base")
 export class HuiConditionalBase extends ReactiveElement {
@@ -90,7 +76,9 @@ export class HuiConditionalBase extends ReactiveElement {
       return;
     }
 
-    const mediaQueries = extractMediaQueries(this._config.conditions);
+    const mediaQueries = extractMediaQueries(
+      this._config.conditions.filter((c) => "condition" in c) as Condition[]
+    );
 
     if (deepEqual(mediaQueries, this._mediaQueries)) return;
 

--- a/src/panels/lovelace/components/hui-conditional-base.ts
+++ b/src/panels/lovelace/components/hui-conditional-base.ts
@@ -7,7 +7,7 @@ import { ConditionalCardConfig } from "../cards/types";
 import {
   Condition,
   checkConditionsMet,
-  createConditionMediaQueriesListeners,
+  attachConditionMediaQueriesListeners,
   extractMediaQueries,
   validateConditionalConfig,
 } from "../common/validate-condition";
@@ -84,7 +84,7 @@ export class HuiConditionalBase extends ReactiveElement {
 
     this._clearMediaQueries();
 
-    this._listeners = createConditionMediaQueriesListeners(
+    this._listeners = attachConditionMediaQueriesListeners(
       supportedConditions,
       this.hass,
       (visibility) => {

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
@@ -24,15 +24,15 @@ import {
   computeCards,
   computeSection,
 } from "../../common/generate-lovelace-config";
+import {
+  findLovelaceContainer,
+  parseLovelaceContainerPath,
+} from "../lovelace-path";
 import "./hui-card-picker";
 import "./hui-entity-picker-table";
 import { CreateCardDialogParams } from "./show-create-card-dialog";
 import { showEditCardDialog } from "./show-edit-card-dialog";
 import { showSuggestCardDialog } from "./show-suggest-card-dialog";
-import {
-  findLovelaceContainer,
-  parseLovelaceContainerPath,
-} from "../lovelace-path";
 
 declare global {
   interface HASSDomEvents {
@@ -274,15 +274,17 @@ export class HuiCreateDialogCard
 
     let sectionOptions: Partial<LovelaceSectionConfig> = {};
 
-    const { sectionIndex } = parseLovelaceContainerPath(this._params!.path);
+    const { viewIndex, sectionIndex } = parseLovelaceContainerPath(
+      this._params!.path
+    );
     const isSection = sectionIndex !== undefined;
 
     // If we are in a section, we want to keep the section options for the preview
     if (isSection) {
       const containerConfig = findLovelaceContainer(
         this._params!.lovelaceConfig!,
-        this._params!.path!
-      ) as LovelaceSectionConfig;
+        [viewIndex, sectionIndex]
+      );
       if (!isStrategySection(containerConfig)) {
         const { cards, title, ...rest } = containerConfig;
         sectionOptions = rest;

--- a/src/panels/lovelace/editor/conditions/ha-card-conditions-editor.ts
+++ b/src/panels/lovelace/editor/conditions/ha-card-conditions-editor.ts
@@ -1,16 +1,8 @@
 import { mdiPlus } from "@mdi/js";
-import {
-  CSSResultGroup,
-  LitElement,
-  PropertyValues,
-  css,
-  html,
-  nothing,
-} from "lit";
+import { CSSResultGroup, LitElement, PropertyValues, css, html } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { stopPropagation } from "../../../../common/dom/stop_propagation";
-import "../../../../components/ha-alert";
 import "../../../../components/ha-button";
 import "../../../../components/ha-list-item";
 import type { HaSelect } from "../../../../components/ha-select";
@@ -21,12 +13,12 @@ import { Condition, LegacyCondition } from "../../common/validate-condition";
 import "./ha-card-condition-editor";
 import type { HaCardConditionEditor } from "./ha-card-condition-editor";
 import { LovelaceConditionEditorConstructor } from "./types";
+import "./types/ha-card-condition-and";
 import "./types/ha-card-condition-numeric_state";
+import "./types/ha-card-condition-or";
 import "./types/ha-card-condition-screen";
 import "./types/ha-card-condition-state";
 import "./types/ha-card-condition-user";
-import "./types/ha-card-condition-or";
-import "./types/ha-card-condition-and";
 
 const UI_CONDITION = [
   "numeric_state",
@@ -45,8 +37,6 @@ export class HaCardConditionsEditor extends LitElement {
     | Condition
     | LegacyCondition
   )[];
-
-  @property({ type: Boolean }) public nested = false;
 
   private _focusLastConditionOnChange = false;
 
@@ -83,15 +73,6 @@ export class HaCardConditionsEditor extends LitElement {
   protected render() {
     return html`
       <div class="conditions">
-        ${!this.nested
-          ? html`
-              <ha-alert alert-type="info">
-                ${this.hass!.localize(
-                  "ui.panel.lovelace.editor.condition-editor.explanation"
-                )}
-              </ha-alert>
-            `
-          : nothing}
         ${this.conditions.map(
           (cond, idx) => html`
             <ha-card-condition-editor
@@ -172,9 +153,6 @@ export class HaCardConditionsEditor extends LitElement {
   static get styles(): CSSResultGroup {
     return [
       css`
-        mwc-tab-bar {
-          border-bottom: 1px solid var(--divider-color);
-        }
         ha-alert {
           display: block;
           margin-top: 12px;

--- a/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
@@ -8,6 +8,7 @@ import { customElement, property, query, state } from "lit/decorators";
 import { any, array, assert, assign, object, optional } from "superstruct";
 import { storage } from "../../../../common/decorators/storage";
 import { HASSDomEvent, fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-alert";
 import "../../../../components/ha-button";
 import "../../../../components/ha-list-item";
 import "../../../../components/ha-svg-icon";
@@ -142,6 +143,11 @@ export class HuiConditionalCardEditor
             </div>
           `
         : html`
+            <ha-alert alert-type="info">
+              ${this.hass!.localize(
+                "ui.panel.lovelace.editor.condition-editor.explanation"
+              )}
+            </ha-alert>
             <ha-card-conditions-editor
               .hass=${this.hass}
               .conditions=${this._config.conditions}
@@ -230,6 +236,10 @@ export class HuiConditionalCardEditor
       css`
         mwc-tab-bar {
           border-bottom: 1px solid var(--divider-color);
+        }
+        ha-alert {
+          display: block;
+          margin-top: 12px;
         }
         .card {
           margin-top: 8px;

--- a/src/panels/lovelace/editor/config-util.ts
+++ b/src/panels/lovelace/editor/config-util.ts
@@ -226,7 +226,7 @@ export const addSection = (
   viewIndex: number,
   sectionConfig: LovelaceSectionRawConfig
 ): LovelaceConfig => {
-  const view = findLovelaceContainer(config, [viewIndex]) as LovelaceViewConfig;
+  const view = findLovelaceContainer(config, [viewIndex]);
   if (isStrategyView(view)) {
     throw new Error("Deleting sections in a strategy is not supported.");
   }
@@ -246,7 +246,7 @@ export const deleteSection = (
   viewIndex: number,
   sectionIndex: number
 ): LovelaceConfig => {
-  const view = findLovelaceContainer(config, [viewIndex]) as LovelaceViewConfig;
+  const view = findLovelaceContainer(config, [viewIndex]);
   if (isStrategyView(view)) {
     throw new Error("Deleting sections in a strategy is not supported.");
   }
@@ -267,7 +267,7 @@ export const insertSection = (
   sectionIndex: number,
   sectionConfig: LovelaceSectionRawConfig
 ): LovelaceConfig => {
-  const view = findLovelaceContainer(config, [viewIndex]) as LovelaceViewConfig;
+  const view = findLovelaceContainer(config, [viewIndex]);
   if (isStrategyView(view)) {
     throw new Error("Inserting sections in a strategy is not supported.");
   }
@@ -291,10 +291,7 @@ export const moveSection = (
   fromPath: [number, number],
   toPath: [number, number]
 ): LovelaceConfig => {
-  const section = findLovelaceContainer(
-    config,
-    fromPath
-  ) as LovelaceSectionRawConfig;
+  const section = findLovelaceContainer(config, fromPath);
 
   let newConfig = deleteSection(config, fromPath[0], fromPath[1]);
   newConfig = insertSection(newConfig, toPath[0], toPath[1], section);

--- a/src/panels/lovelace/editor/lovelace-path.ts
+++ b/src/panels/lovelace/editor/lovelace-path.ts
@@ -46,7 +46,15 @@ export const getLovelaceContainerPath = (
   path: LovelaceCardPath
 ): LovelaceContainerPath => path.slice(0, -1) as LovelaceContainerPath;
 
-export const findLovelaceContainer = (
+type FindLovelaceContainer = {
+  (config: LovelaceConfig, path: [number]): LovelaceViewRawConfig;
+  (config: LovelaceConfig, path: [number, number]): LovelaceSectionRawConfig;
+  (
+    config: LovelaceConfig,
+    path: LovelaceContainerPath
+  ): LovelaceViewRawConfig | LovelaceSectionRawConfig;
+};
+export const findLovelaceContainer: FindLovelaceContainer = (
   config: LovelaceConfig,
   path: LovelaceContainerPath
 ): LovelaceViewRawConfig | LovelaceSectionRawConfig => {

--- a/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
@@ -1,0 +1,285 @@
+import { ActionDetail } from "@material/mwc-list";
+import { mdiCheck, mdiClose, mdiDotsVertical } from "@mdi/js";
+import "@polymer/paper-tabs/paper-tab";
+import "@polymer/paper-tabs/paper-tabs";
+import {
+  CSSResultGroup,
+  LitElement,
+  PropertyValues,
+  TemplateResult,
+  css,
+  html,
+  nothing,
+} from "lit";
+import { customElement, property, query, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import { stopPropagation } from "../../../../common/dom/stop_propagation";
+import "../../../../components/ha-button";
+import "../../../../components/ha-button-menu";
+import "../../../../components/ha-circular-progress";
+import "../../../../components/ha-dialog";
+import "../../../../components/ha-dialog-header";
+import "../../../../components/ha-icon-button";
+import "../../../../components/ha-list-item";
+import "../../../../components/ha-yaml-editor";
+import type { HaYamlEditor } from "../../../../components/ha-yaml-editor";
+import { LovelaceSectionRawConfig } from "../../../../data/lovelace/config/section";
+import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
+import { haStyleDialog } from "../../../../resources/styles";
+import type { HomeAssistant } from "../../../../types";
+import { findLovelaceContainer } from "../lovelace-path";
+import type { EditSectionDialogParams } from "./show-edit-section-dialog";
+
+const TABS = ["tab-settings", "tab-visibility"] as const;
+
+@customElement("hui-dialog-edit-section")
+export class HuiDialogEditSection
+  extends LitElement
+  implements HassDialog<EditSectionDialogParams>
+{
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _params?: EditSectionDialogParams;
+
+  @state() private _config?: LovelaceSectionRawConfig;
+
+  @state() private _yamlMode = false;
+
+  @state() private _curTab: (typeof TABS)[number] = TABS[0];
+
+  @query("ha-yaml-editor") private _editor?: HaYamlEditor;
+
+  protected updated(changedProperties: PropertyValues) {
+    if (this._yamlMode && changedProperties.has("_yamlMode")) {
+      const viewConfig = {
+        ...this._config,
+      };
+      this._editor?.setValue(viewConfig);
+    }
+  }
+
+  public async showDialog(params: EditSectionDialogParams): Promise<void> {
+    this._params = params;
+
+    this._config = findLovelaceContainer(this._params.lovelaceConfig, [
+      this._params.viewIndex,
+      this._params.sectionIndex,
+    ]) as LovelaceSectionRawConfig;
+  }
+
+  public closeDialog() {
+    this._params = undefined;
+    this._yamlMode = false;
+    this._config = undefined;
+    this._curTab = TABS[0];
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render() {
+    if (!this._params) {
+      return nothing;
+    }
+
+    const heading = this.hass!.localize(
+      "ui.panel.lovelace.editor.edit_section.header"
+    );
+
+    let content: TemplateResult<1> | typeof nothing = nothing;
+
+    if (this._yamlMode) {
+      content = html`
+        <ha-yaml-editor
+          .hass=${this.hass}
+          dialogInitialFocus
+          @value-changed=${this._viewYamlChanged}
+        ></ha-yaml-editor>
+      `;
+    } else {
+      switch (this._curTab) {
+        case "tab-settings":
+          content = html`Settings`;
+          break;
+        case "tab-visibility":
+          content = html`Visibility`;
+          break;
+      }
+    }
+
+    return html`
+      <ha-dialog
+        open
+        scrimClickAction
+        @keydown=${this._ignoreKeydown}
+        @closed=${this._cancel}
+        .heading=${heading}
+        class=${classMap({
+          "yaml-mode": this._yamlMode,
+        })}
+      >
+        <ha-dialog-header show-border slot="heading">
+          <ha-icon-button
+            slot="navigationIcon"
+            dialogAction="cancel"
+            .label=${this.hass.localize("ui.common.close")}
+            .path=${mdiClose}
+          ></ha-icon-button>
+          <span slot="title">${heading}</span>
+          <ha-button-menu
+            slot="actionItems"
+            fixed
+            corner="BOTTOM_END"
+            menuCorner="END"
+            @closed=${stopPropagation}
+            @action=${this._handleAction}
+          >
+            <ha-icon-button
+              slot="trigger"
+              .label=${this.hass!.localize("ui.common.menu")}
+              .path=${mdiDotsVertical}
+            ></ha-icon-button>
+            <ha-list-item graphic="icon">
+              ${this.hass!.localize(
+                "ui.panel.lovelace.editor.edit_section.edit_ui"
+              )}
+              ${!this._yamlMode
+                ? html`<ha-svg-icon
+                    class="selected_menu_item"
+                    slot="graphic"
+                    .path=${mdiCheck}
+                  ></ha-svg-icon>`
+                : ``}
+            </ha-list-item>
+
+            <ha-list-item graphic="icon">
+              ${this.hass!.localize(
+                "ui.panel.lovelace.editor.edit_section.edit_yaml"
+              )}
+              ${this._yamlMode
+                ? html`<ha-svg-icon
+                    class="selected_menu_item"
+                    slot="graphic"
+                    .path=${mdiCheck}
+                  ></ha-svg-icon>`
+                : ``}
+            </ha-list-item>
+          </ha-button-menu>
+          ${!this._yamlMode
+            ? html`
+                <paper-tabs
+                  scrollable
+                  hide-scroll-buttons
+                  .selected=${TABS.indexOf(this._curTab)}
+                  @selected-item-changed=${this._handleTabSelected}
+                >
+                  ${TABS.map(
+                    (tab, index) => html`
+                      <paper-tab id=${tab} .dialogInitialFocus=${index === 0}>
+                        ${this.hass!.localize(
+                          `ui.panel.lovelace.editor.edit_section.${tab.replace("-", "_")}`
+                        )}
+                      </paper-tab>
+                    `
+                  )}
+                </paper-tabs>
+              `
+            : nothing}
+        </ha-dialog-header>
+        ${content}
+        <ha-button slot="secondaryAction">
+          ${this.hass!.localize("ui.common.cancel")}
+        </ha-button>
+
+        <ha-button slot="primaryAction" @click=${this._save}>
+          ${this.hass!.localize("ui.common.save")}
+        </ha-button>
+      </ha-dialog>
+    `;
+  }
+
+  private _handleTabSelected(ev: CustomEvent): void {
+    if (!ev.detail.value) {
+      return;
+    }
+    this._curTab = ev.detail.value.id;
+  }
+
+  private async _handleAction(ev: CustomEvent<ActionDetail>) {
+    ev.stopPropagation();
+    ev.preventDefault();
+    switch (ev.detail.index) {
+      case 0:
+        this._yamlMode = false;
+        break;
+      case 1:
+        this._yamlMode = true;
+        break;
+    }
+  }
+
+  private _viewYamlChanged(ev: CustomEvent) {
+    ev.stopPropagation();
+    if (!ev.detail.isValid) {
+      return;
+    }
+    this._config = ev.detail.value;
+  }
+
+  private _ignoreKeydown(ev: KeyboardEvent) {
+    ev.stopPropagation();
+  }
+
+  private _cancel(ev?: Event) {
+    if (ev) {
+      ev.stopPropagation();
+    }
+    this.closeDialog();
+  }
+
+  private async _save(): Promise<void> {
+    this.closeDialog();
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyleDialog,
+      css`
+        ha-dialog {
+          /* Set the top top of the dialog to a fixed position, so it doesnt jump when the content changes size */
+          --vertical-align-dialog: flex-start;
+          --dialog-surface-margin-top: 40px;
+        }
+
+        @media all and (max-width: 450px), all and (max-height: 500px) {
+          /* When in fullscreen dialog should be attached to top */
+          ha-dialog {
+            --dialog-surface-margin-top: 0px;
+          }
+        }
+        ha-dialog.yaml-mode {
+          --dialog-content-padding: 0;
+        }
+        paper-tabs {
+          --paper-tabs-selection-bar-color: var(--primary-color);
+          color: var(--primary-text-color);
+          text-transform: uppercase;
+          padding: 0 20px;
+        }
+        .selected_menu_item {
+          color: var(--primary-color);
+        }
+        @media all and (min-width: 600px) {
+          ha-dialog {
+            --mdc-dialog-min-width: 600px;
+          }
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-dialog-edit-section": HuiDialogEditSection;
+  }
+}

--- a/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
@@ -29,6 +29,7 @@ import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
 import { haStyleDialog } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import "../conditions/ha-card-conditions-editor";
+import "./hui-section-settings-editor";
 import {
   findLovelaceContainer,
   updateLovelaceContainer,
@@ -103,7 +104,13 @@ export class HuiDialogEditSection
     } else {
       switch (this._curTab) {
         case "tab-settings":
-          content = html`Settings`;
+          content = html`
+          <hui-section-settings-editor
+              .hass=${this.hass}
+              .config=${this._config}
+              @value-changed=${this._handleSettingsChanged}
+            >
+            </ha-card-conditions-editor>`;
           break;
         case "tab-visibility":
           content = html`
@@ -220,6 +227,11 @@ export class HuiDialogEditSection
       delete newConfig.visibility;
     }
     this._config = newConfig;
+  }
+
+  private _handleSettingsChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    this._config = ev.detail.value;
   }
 
   private _handleTabSelected(ev: CustomEvent): void {

--- a/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
@@ -28,14 +28,13 @@ import { LovelaceSectionRawConfig } from "../../../../data/lovelace/config/secti
 import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
 import { haStyleDialog } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
-import "../conditions/ha-card-conditions-editor";
-import "./hui-section-settings-editor";
 import {
   findLovelaceContainer,
   updateLovelaceContainer,
 } from "../lovelace-path";
+import "./hui-section-settings-editor";
+import "./hui-section-visibility-editor";
 import type { EditSectionDialogParams } from "./show-edit-section-dialog";
-import { Condition } from "../../common/validate-condition";
 
 const TABS = ["tab-settings", "tab-visibility"] as const;
 
@@ -105,21 +104,22 @@ export class HuiDialogEditSection
       switch (this._curTab) {
         case "tab-settings":
           content = html`
-          <hui-section-settings-editor
+            <hui-section-settings-editor
               .hass=${this.hass}
               .config=${this._config}
-              @value-changed=${this._handleSettingsChanged}
+              @value-changed=${this._configChanged}
             >
-            </ha-card-conditions-editor>`;
+            </hui-section-settings-editor>
+          `;
           break;
         case "tab-visibility":
           content = html`
-            <ha-card-conditions-editor
+            <hui-section-visibility-editor
               .hass=${this.hass}
-              .conditions=${this._config.visibility ?? []}
-              @value-changed=${this._handleConditionChanged}
+              .config=${this._config}
+              @value-changed=${this._configChanged}
             >
-            </ha-card-conditions-editor>
+            </hui-section-visibility-editor>
           `;
           break;
       }
@@ -216,20 +216,7 @@ export class HuiDialogEditSection
     `;
   }
 
-  private _handleConditionChanged(ev: CustomEvent): void {
-    ev.stopPropagation();
-    const conditions = ev.detail.value as Condition[];
-    const newConfig: LovelaceSectionRawConfig = {
-      ...this._config,
-      visibility: conditions,
-    };
-    if (newConfig.visibility?.length === 0) {
-      delete newConfig.visibility;
-    }
-    this._config = newConfig;
-  }
-
-  private _handleSettingsChanged(ev: CustomEvent): void {
+  private _configChanged(ev: CustomEvent): void {
     ev.stopPropagation();
     this._config = ev.detail.value;
   }

--- a/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
@@ -70,7 +70,7 @@ export class HuiDialogEditSection
     this._config = findLovelaceContainer(this._params.lovelaceConfig, [
       this._params.viewIndex,
       this._params.sectionIndex,
-    ]) as LovelaceSectionRawConfig;
+    ]);
   }
 
   public closeDialog() {

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -30,17 +30,27 @@ export class HuiDialogEditSection extends LitElement {
       title: this.config.title || "",
     };
 
-    return html`<ha-form
-      .hass=${this.hass}
-      .data=${data}
-      .schema=${SCHEMA}
-      .computeLabel=${this._computeLabel}
-      @value-changed=${this._valueChanged}
-      dialogInitialFocus
-    ></ha-form>`;
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${SCHEMA}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
   }
 
-  private _computeLabel = (schema: SchemaUnion<typeof SCHEMA>) => schema.name;
+  private _computeLabel = (schema: SchemaUnion<typeof SCHEMA>) =>
+    this.hass.localize(
+      `ui.panel.lovelace.editor.edit_section.settings.${schema.name}`
+    );
+
+  private _computeHelper = (schema: SchemaUnion<typeof SCHEMA>) =>
+    this.hass.localize(
+      `ui.panel.lovelace.editor.edit_section.settings.${schema.name}_helper`
+    ) || "";
 
   private _valueChanged(ev: CustomEvent) {
     ev.stopPropagation();

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -1,0 +1,66 @@
+import { LitElement, html } from "lit";
+import { customElement, property } from "lit/decorators";
+import { LovelaceSectionRawConfig } from "../../../../data/lovelace/config/section";
+import { HomeAssistant } from "../../../../types";
+import {
+  HaFormSchema,
+  SchemaUnion,
+} from "../../../../components/ha-form/types";
+import { fireEvent } from "../../../../common/dom/fire_event";
+
+const SCHEMA = [
+  {
+    name: "title",
+    selector: { text: {} },
+  },
+] as const satisfies HaFormSchema[];
+
+type SettingsData = {
+  title: string;
+};
+
+@customElement("hui-section-settings-editor")
+export class HuiDialogEditSection extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public config!: LovelaceSectionRawConfig;
+
+  render() {
+    const data: SettingsData = {
+      title: this.config.title || "",
+    };
+
+    return html`<ha-form
+      .hass=${this.hass}
+      .data=${data}
+      .schema=${SCHEMA}
+      .computeLabel=${this._computeLabel}
+      @value-changed=${this._valueChanged}
+      dialogInitialFocus
+    ></ha-form>`;
+  }
+
+  private _computeLabel = (schema: SchemaUnion<typeof SCHEMA>) => schema.name;
+
+  private _valueChanged(ev: CustomEvent) {
+    ev.stopPropagation();
+    const newData = ev.detail.value as SettingsData;
+
+    const newConfig: LovelaceSectionRawConfig = {
+      ...this.config,
+      title: newData.title,
+    };
+
+    if (!newConfig.title) {
+      delete newConfig.title;
+    }
+
+    fireEvent(this, "value-changed", { value: newConfig });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-section-settings-editor": HuiDialogEditSection;
+  }
+}

--- a/src/panels/lovelace/editor/section-editor/hui-section-visibility-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-visibility-editor.ts
@@ -1,0 +1,51 @@
+import { LitElement, html } from "lit";
+import { customElement, property } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-alert";
+import { LovelaceSectionRawConfig } from "../../../../data/lovelace/config/section";
+import { HomeAssistant } from "../../../../types";
+import { Condition } from "../../common/validate-condition";
+import "../conditions/ha-card-conditions-editor";
+
+@customElement("hui-section-visibility-editor")
+export class HuiDialogEditSection extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public config!: LovelaceSectionRawConfig;
+
+  render() {
+    const conditions = this.config.visibility ?? [];
+    return html`
+      <ha-alert alert-type="info">
+        ${this.hass.localize(
+          `ui.panel.lovelace.editor.edit_section.visibility.explanation`
+        )}
+      </ha-alert>
+      <ha-card-conditions-editor
+        .hass=${this.hass}
+        .conditions=${conditions}
+        @value-changed=${this._valueChanged}
+      >
+      </ha-card-conditions-editor>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const conditions = ev.detail.value as Condition[];
+    const newConfig: LovelaceSectionRawConfig = {
+      ...this.config,
+      visibility: conditions,
+    };
+    if (newConfig.visibility?.length === 0) {
+      delete newConfig.visibility;
+    }
+    fireEvent(this, "value-changed", { value: newConfig });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-section-visibility-editor": HuiDialogEditSection;
+  }
+}

--- a/src/panels/lovelace/editor/section-editor/show-edit-section-dialog.ts
+++ b/src/panels/lovelace/editor/section-editor/show-edit-section-dialog.ts
@@ -1,0 +1,22 @@
+import { fireEvent } from "../../../../common/dom/fire_event";
+import { LovelaceConfig } from "../../../../data/lovelace/config/types";
+
+export type EditSectionDialogParams = {
+  lovelaceConfig: LovelaceConfig;
+  saveConfig: (config: LovelaceConfig) => void;
+  viewIndex: number;
+  sectionIndex: number;
+};
+
+const importEditSectionDialog = () => import("./hui-dialog-edit-section");
+
+export const showEditSectionDialog = (
+  element: HTMLElement,
+  editSectionDialogParams: EditSectionDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "hui-dialog-edit-section",
+    dialogImport: importEditSectionDialog,
+    dialogParams: editSectionDialogParams,
+  });
+};

--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -150,7 +150,7 @@ export class HuiSection extends ReactiveElement {
     if (!this.config.visibility) {
       return;
     }
-
+    this._clearMediaQueries();
     this._listeners = createConditionMediaQueriesListeners(
       this.config.visibility,
       this.hass,

--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -13,7 +13,7 @@ import type { HomeAssistant } from "../../../types";
 import type { HuiErrorCard } from "../cards/hui-error-card";
 import {
   checkConditionsMet,
-  createConditionMediaQueriesListeners,
+  attachConditionMediaQueriesListeners,
 } from "../common/validate-condition";
 import { createCardElement } from "../create-element/create-card-element";
 import {
@@ -151,7 +151,7 @@ export class HuiSection extends ReactiveElement {
       return;
     }
     this._clearMediaQueries();
-    this._listeners = createConditionMediaQueriesListeners(
+    this._listeners = attachConditionMediaQueriesListeners(
       this.config.visibility,
       this.hass,
       (visibility) => {

--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -1,5 +1,6 @@
 import { PropertyValues, ReactiveElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { MediaQueriesListener } from "../../../common/dom/media_query";
 import "../../../components/ha-svg-icon";
 import type { LovelaceSectionElement } from "../../../data/lovelace";
 import { LovelaceCardConfig } from "../../../data/lovelace/config/card";
@@ -10,6 +11,10 @@ import {
 } from "../../../data/lovelace/config/section";
 import type { HomeAssistant } from "../../../types";
 import type { HuiErrorCard } from "../cards/hui-error-card";
+import {
+  checkConditionsMet,
+  createConditionMediaQueriesListeners,
+} from "../common/validate-condition";
 import { createCardElement } from "../create-element/create-card-element";
 import {
   createErrorCardConfig,
@@ -37,14 +42,13 @@ export class HuiSection extends ReactiveElement {
 
   @property({ type: Number }) public viewIndex!: number;
 
-  // eslint-disable-next-line lit/no-native-attributes
-  @property({ type: Boolean, reflect: true }) public hidden = false;
-
   @state() private _cards: Array<LovelaceCard | HuiErrorCard> = [];
 
   private _layoutElementType?: string;
 
   private _layoutElement?: LovelaceSectionElement;
+
+  private _listeners: MediaQueriesListener[] = [];
 
   // Public to make demo happy
   public createCardElement(cardConfig: LovelaceCardConfig) {
@@ -98,6 +102,17 @@ export class HuiSection extends ReactiveElement {
     }
   }
 
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    this._clearMediaQueries();
+  }
+
+  public connectedCallback() {
+    super.connectedCallback();
+    this._listenMediaQueries();
+    this._updateElement();
+  }
+
   protected update(changedProperties) {
     super.update(changedProperties);
 
@@ -112,7 +127,6 @@ export class HuiSection extends ReactiveElement {
             this._rebuildCard(element, createErrorCardConfig(e.message, null));
           }
         });
-
         this._layoutElement.hass = this.hass;
       }
       if (changedProperties.has("lovelace")) {
@@ -121,10 +135,30 @@ export class HuiSection extends ReactiveElement {
       if (changedProperties.has("_cards")) {
         this._layoutElement.cards = this._cards;
       }
-      if (changedProperties.has("hidden")) {
+      if (changedProperties.has("hass") || changedProperties.has("lovelace")) {
         this._updateElement();
       }
     }
+  }
+
+  private _clearMediaQueries() {
+    this._listeners.forEach((unsub) => unsub());
+    this._listeners = [];
+  }
+
+  private _listenMediaQueries() {
+    if (!this.config.visibility) {
+      return;
+    }
+
+    this._listeners = createConditionMediaQueriesListeners(
+      this.config.visibility,
+      this.hass,
+      (visibility) => {
+        const visible = visibility || this.lovelace!.editMode;
+        this._updateElement(visible);
+      }
+    );
   }
 
   private async _initializeConfig() {
@@ -171,13 +205,21 @@ export class HuiSection extends ReactiveElement {
     }
   }
 
-  private _updateElement() {
+  private _updateElement(forceVisible?: boolean) {
     if (!this._layoutElement) {
       return;
     }
-    if (this.hidden && this._layoutElement.parentElement) {
+    const visible =
+      forceVisible ??
+      (this.lovelace.editMode ||
+        !this.config.visibility ||
+        checkConditionsMet(this.config.visibility, this.hass));
+
+    this.style.setProperty("display", visible ? "" : "none");
+    this.toggleAttribute("hidden", !visible);
+    if (!visible && this._layoutElement.parentElement) {
       this.removeChild(this._layoutElement);
-    } else if (!this.hidden && !this._layoutElement.parentElement) {
+    } else if (visible && !this._layoutElement.parentElement) {
       this.appendChild(this._layoutElement);
     }
   }

--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -37,6 +37,9 @@ export class HuiSection extends ReactiveElement {
 
   @property({ type: Number }) public viewIndex!: number;
 
+  // eslint-disable-next-line lit/no-native-attributes
+  @property({ type: Boolean, reflect: true }) public hidden = false;
+
   @state() private _cards: Array<LovelaceCard | HuiErrorCard> = [];
 
   private _layoutElementType?: string;
@@ -118,6 +121,9 @@ export class HuiSection extends ReactiveElement {
       if (changedProperties.has("_cards")) {
         this._layoutElement.cards = this._cards;
       }
+      if (changedProperties.has("hidden")) {
+        this._updateElement();
+      }
     }
   }
 
@@ -161,7 +167,18 @@ export class HuiSection extends ReactiveElement {
       while (this.lastChild) {
         this.removeChild(this.lastChild);
       }
-      this.appendChild(this._layoutElement!);
+      this._updateElement();
+    }
+  }
+
+  private _updateElement() {
+    if (!this._layoutElement) {
+      return;
+    }
+    if (this.hidden && this._layoutElement.parentElement) {
+      this.removeChild(this._layoutElement);
+    } else if (!this.hidden && !this._layoutElement.parentElement) {
+      this.appendChild(this._layoutElement);
     }
   }
 

--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -24,6 +24,13 @@ import { parseLovelaceCardPath } from "../editor/lovelace-path";
 import { generateLovelaceSectionStrategy } from "../strategies/get-strategy";
 import type { Lovelace, LovelaceCard } from "../types";
 import { DEFAULT_SECTION_LAYOUT } from "./const";
+import {
+  Condition,
+  checkConditionsMet,
+  extractMediaQueries,
+} from "../common/validate-condition";
+import { deepEqual } from "../../../common/util/deep-equal";
+import { listenMediaQuery } from "../../../common/dom/media_query";
 
 @customElement("hui-section")
 export class HuiSection extends ReactiveElement {
@@ -38,6 +45,10 @@ export class HuiSection extends ReactiveElement {
   @property({ type: Number }) public viewIndex!: number;
 
   @state() private _cards: Array<LovelaceCard | HuiErrorCard> = [];
+
+  private _mediaQueriesListeners: Array<() => void> = [];
+
+  private _mediaQueries: string[] = [];
 
   private _layoutElementType?: string;
 
@@ -92,6 +103,8 @@ export class HuiSection extends ReactiveElement {
       (!oldConfig || this.config !== oldConfig)
     ) {
       this._initializeConfig();
+    } else {
+      this._updateVisibility();
     }
   }
 
@@ -161,7 +174,36 @@ export class HuiSection extends ReactiveElement {
       while (this.lastChild) {
         this.removeChild(this.lastChild);
       }
-      this.appendChild(this._layoutElement!);
+    }
+    this._updateVisibility();
+  }
+
+  private _updateVisibility() {
+    if (!this._layoutElement) {
+      return;
+    }
+
+    const visibility =
+      !this.config.visibility ||
+      checkConditionsMet(this.config.visibility, this.hass!);
+
+    this._setVisibility(visibility);
+  }
+
+  private _setVisibility(visilibity: boolean) {
+    const element = this._layoutElement;
+    if (!element) {
+      return;
+    }
+    const visible = this.lovelace.editMode || visilibity;
+    this.toggleAttribute("hidden", !visible);
+    if (visible) {
+      element.hass = this.hass;
+      if (!element!.parentElement) {
+        this.appendChild(element!);
+      }
+    } else if (element.parentElement) {
+      this.removeChild(element!);
     }
   }
 
@@ -237,6 +279,57 @@ export class HuiSection extends ReactiveElement {
     this._cards = this._cards!.map((curCardEl) =>
       curCardEl === cardElToReplace ? newCardEl : curCardEl
     );
+  }
+
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    this._clearMediaQueries();
+  }
+
+  public connectedCallback() {
+    super.connectedCallback();
+    this._listenMediaQueries();
+    this._updateVisibility();
+  }
+
+  private _clearMediaQueries() {
+    this._mediaQueries = [];
+    while (this._mediaQueriesListeners.length) {
+      this._mediaQueriesListeners.pop()!();
+    }
+  }
+
+  private _listenMediaQueries() {
+    if (!this.config.visibility) {
+      return;
+    }
+
+    const mediaQueries = extractMediaQueries(
+      this.config.visibility.filter((c) => "condition" in c) as Condition[]
+    );
+
+    if (deepEqual(mediaQueries, this._mediaQueries)) return;
+
+    this._mediaQueries = mediaQueries;
+    while (this._mediaQueriesListeners.length) {
+      this._mediaQueriesListeners.pop()!();
+    }
+
+    mediaQueries.forEach((query) => {
+      const listener = listenMediaQuery(query, (matches) => {
+        // For performance, if there is only one condition and it's a screen condition, set the visibility directly
+        if (
+          this.config.visibility!.length === 1 &&
+          "condition" in this.config.visibility![0] &&
+          this.config.visibility![0].condition === "screen"
+        ) {
+          this._setVisibility(matches);
+          return;
+        }
+        this._updateVisibility();
+      });
+      this._mediaQueriesListeners.push(listener);
+    });
   }
 }
 

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -186,38 +186,6 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
       viewIndex: this.index!,
       sectionIndex: index,
     });
-
-    // const section = findLovelaceContainer(
-    //   this.lovelace!.config,
-    //   path
-    // ) as LovelaceRawSectionConfig;
-
-    // const newTitle = !section.title;
-
-    // const title = await showPromptDialog(this, {
-    //   title: this.hass.localize(
-    //     `ui.panel.lovelace.editor.edit_section_title.${newTitle ? "title_new" : "title"}`
-    //   ),
-    //   inputLabel: this.hass.localize(
-    //     "ui.panel.lovelace.editor.edit_section_title.input_label"
-    //   ),
-    //   inputType: "string",
-    //   defaultValue: section.title,
-    //   confirmText: newTitle
-    //     ? this.hass.localize("ui.common.add")
-    //     : this.hass.localize("ui.common.save"),
-    // });
-
-    // if (title === null) {
-    //   return;
-    // }
-
-    // const newConfig = updateLovelaceContainer(this.lovelace!.config, path, {
-    //   ...section,
-    //   title: title || undefined,
-    // });
-
-    // this.lovelace!.saveConfig(newConfig);
   }
 
   private async _deleteSection(ev) {

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -120,38 +120,33 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
             (section, idx) => {
               (section as any).itemPath = [idx];
               return html`
-                  ${
-                    editMode
-                      ? html`
-                          <div class="section">
-                            <div class="section-overlay">
-                              <div class="section-actions">
-                                <ha-svg-icon
-                                  aria-hidden="true"
-                                  class="handle"
-                                  .path=${mdiArrowAll}
-                                ></ha-svg-icon>
-                                <ha-icon-button
-                                  .label=${this.hass.localize("ui.common.edit")}
-                                  @click=${this._editSection}
-                                  .index=${idx}
-                                  .path=${mdiPencil}
-                                ></ha-icon-button>
-                                <ha-icon-button
-                                  .label=${this.hass.localize(
-                                    "ui.common.delete"
-                                  )}
-                                  @click=${this._deleteSection}
-                                  .index=${idx}
-                                  .path=${mdiDelete}
-                                ></ha-icon-button>
-                              </div>
-                            </div>
-                            ${section}
+                <div class="section">
+                  ${editMode
+                    ? html`
+                        <div class="section-overlay">
+                          <div class="section-actions">
+                            <ha-svg-icon
+                              aria-hidden="true"
+                              class="handle"
+                              .path=${mdiArrowAll}
+                            ></ha-svg-icon>
+                            <ha-icon-button
+                              .label=${this.hass.localize("ui.common.edit")}
+                              @click=${this._editSection}
+                              .index=${idx}
+                              .path=${mdiPencil}
+                            ></ha-icon-button>
+                            <ha-icon-button
+                              .label=${this.hass.localize("ui.common.delete")}
+                              @click=${this._deleteSection}
+                              .index=${idx}
+                              .path=${mdiDelete}
+                            ></ha-icon-button>
                           </div>
-                        `
-                      : section
-                  }
+                        </div>
+                      `
+                    : nothing}
+                  ${section}
                 </div>
               `;
             }
@@ -297,6 +292,10 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
 
       .section {
         border-radius: var(--ha-card-border-radius, 12px);
+      }
+
+      .section:not(:has(> *:not([hidden]))) {
+        display: none;
       }
 
       .container {

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -14,7 +14,6 @@ import "../../../components/ha-icon-button";
 import "../../../components/ha-sortable";
 import "../../../components/ha-svg-icon";
 import type { LovelaceViewElement } from "../../../data/lovelace";
-import { LovelaceSectionRawConfig } from "../../../data/lovelace/config/section";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
 import type { HomeAssistant } from "../../../types";
@@ -193,10 +192,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
 
     const path = [this.index!, index] as [number, number];
 
-    const section = findLovelaceContainer(
-      this.lovelace!.config,
-      path
-    ) as LovelaceSectionRawConfig;
+    const section = findLovelaceContainer(this.lovelace!.config, path);
 
     const title = section.title?.trim();
     const cardCount = "cards" in section && section.cards?.length;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5536,12 +5536,14 @@
             "tab_visibility": "[%key:ui::panel::lovelace::editor::edit_view::tab_visibility%]",
             "tab_settings": "[%key:ui::panel::lovelace::editor::edit_view::tab_settings%]",
             "edit_ui": "[%key:ui::panel::lovelace::editor::edit_view::edit_ui%]",
-            "edit_yaml": "[%key:ui::panel::lovelace::editor::edit_view::edit_yaml%]"
-          },
-          "edit_section_title": {
-            "title": "Edit name",
-            "title_new": "Add name",
-            "input_label": "Name"
+            "edit_yaml": "[%key:ui::panel::lovelace::editor::edit_view::edit_yaml%]",
+            "settings": {
+              "title": "Title",
+              "title_helper": "The title will appear at the top of section. Leave empty to hide the title."
+            },
+            "visibility": {
+              "explanation": "The section will be shown when ALL conditions below are fulfilled. If no conditions are set, the section will always be shown."
+            }
           },
           "suggest_card": {
             "header": "We created a suggestion for you",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5531,6 +5531,13 @@
             "text_named_section_cards": "''{name}'' section and all its cards will be deleted.",
             "text_unnamed_section_cards": "This section and all its cards will be deleted."
           },
+          "edit_section": {
+            "header": "Edit section",
+            "tab_visibility": "[%key:ui::panel::lovelace::editor::edit_view::tab_visibility%]",
+            "tab_settings": "[%key:ui::panel::lovelace::editor::edit_view::tab_settings%]",
+            "edit_ui": "[%key:ui::panel::lovelace::editor::edit_view::edit_ui%]",
+            "edit_yaml": "[%key:ui::panel::lovelace::editor::edit_view::edit_yaml%]"
+          },
           "edit_section_title": {
             "title": "Edit name",
             "title_new": "Add name",


### PR DESCRIPTION
## Proposed change

Adds the possibility to hide/show sections based on certains conditions. For example, you may want to only display a section on mobile, where you're at home and when the kitchen lights are on.

It uses the same conditions as condition cards (https://www.home-assistant.io/dashboards/conditional/#conditions-options) which are :
- Entity numeric state
- Entity state
- User
- Screen
- And
- Or

It's not a new section but a new `visibility` options in the section config.

Example of UI configuration

![CleanShot 2024-05-16 at 12 40 44](https://github.com/home-assistant/frontend/assets/5878303/89c09bc1-bdc6-41f8-90e6-56a5993b821b)

Example of YAML configuration

```yaml
title: Kitchen
type: grid
cards:
   - 
visibility:
  - condition: user
    users:
      - 6b64d00c17624ce4a7b7bf438eb63813
  - condition: state
    entity: person.paul
    state: home
  - condition: screen
    media_query: "(min-width: 0px) and (max-width: 767px)"
  - condition: state
    entity: light.kitchen_lights
    state: "on"
```

### Demo time 🎉

https://github.com/home-assistant/frontend/assets/5878303/001754bc-06f6-4ddf-bae9-359965796cf1

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
