### PR TITLE
Device trigger - sync value with initialHaFormData

### DIFF
--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
@@ -3,6 +3,7 @@ import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../../common/dom/fire_event";
+import { deepEqual } from "../../../../../common/util/deep-equal";
 import "../../../../../components/device/ha-device-picker";
 import "../../../../../components/device/ha-device-trigger-picker";
 import "../../../../../components/ha-form/ha-form";
@@ -125,6 +126,20 @@ export class HaDeviceTrigger extends LitElement {
     this._capabilities = trigger.domain
       ? await fetchDeviceTriggerCapabilities(this.hass, trigger)
       : undefined;
+
+    if (this._capabilities) {
+      // Match yaml to what is displayed in the form from computeInitialHaFormData
+      const newTrigger = {
+        ...this.trigger,
+        ...this._extraFieldsData(this.trigger, this._capabilities),
+      };
+
+      if (!deepEqual(this.trigger, newTrigger)) {
+        fireEvent(this, "value-changed", {
+          value: newTrigger,
+        });
+      }
+    }
   }
 
   private _devicePicked(ev) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
When `computeInitialHaFormData` sets up the form for the first time in device triggers, we need to actually push those selections to the value as well, or else the trigger can be broken. Consider this trigger:

<img width="1211" alt="550e1c16f162ccfb704581315cf79652066273af" src="https://github.com/home-assistant/frontend/assets/32912880/17a0552f-739d-4a9c-bf53-fed95104b0c8">

`computeInitialHaFormData` sees the trigger contains a required select selector with 1 item, and defaults to selecting the first item. But until user interacts with the form there is no actual `zone` key published to the trigger value. Since it is already selected, clicking it again does nothing. Therefore this trigger is broken and there's no way to make the visual editor accept this trigger (without dropping into yaml mode), as seen by the error that there is a required zone, but it is already selected. 

I might have thought we needed something similar for device conditions or device actions, but those don't use `computeInitialHaFormData` 🤷 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
