### PR TITLE
Add configurable actions to Gauge Card

### DIFF
--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -235,6 +235,9 @@ export interface GaugeCardConfig extends LovelaceCardConfig {
   theme?: string;
   needle?: boolean;
   segments?: GaugeSegment[];
+  tap_action?: ActionConfig;
+  hold_action?: ActionConfig;
+  double_tap_action?: ActionConfig;
 }
 
 export interface ConfigEntity extends EntityConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
@@ -17,6 +17,7 @@ import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
 import type { GaugeCardConfig } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
+import { actionConfigStruct } from "../structs/action-struct";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import { DEFAULT_MIN, DEFAULT_MAX } from "../../cards/hui-gauge-card";
 
@@ -38,6 +39,9 @@ const cardConfigStruct = assign(
     theme: optional(string()),
     needle: optional(boolean()),
     segments: optional(array(gaugeSegmentStruct)),
+    tap_action: optional(actionConfigStruct),
+    hold_action: optional(actionConfigStruct),
+    double_tap_action: optional(actionConfigStruct),
   })
 );
 

--- a/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
@@ -9,6 +9,7 @@ import {
   number,
   object,
   optional,
+  refine,
   string,
 } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
@@ -20,6 +21,9 @@ import type { LovelaceCardEditor } from "../../types";
 import { actionConfigStruct } from "../structs/action-struct";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import { DEFAULT_MIN, DEFAULT_MAX } from "../../cards/hui-gauge-card";
+import { UiAction } from "../../components/hui-action-editor";
+
+const TAP_ACTIONS = ["navigate", "url", "call-service", "none"];
 
 const gaugeSegmentStruct = object({
   from: number(),
@@ -39,7 +43,11 @@ const cardConfigStruct = assign(
     theme: optional(string()),
     needle: optional(boolean()),
     segments: optional(array(gaugeSegmentStruct)),
-    tap_action: optional(actionConfigStruct),
+    tap_action: optional(
+      refine(actionConfigStruct, TAP_ACTIONS.toString(), (value) =>
+        TAP_ACTIONS.includes(value.action)
+      )
+    ),
     hold_action: optional(actionConfigStruct),
     double_tap_action: optional(actionConfigStruct),
   })
@@ -125,6 +133,15 @@ export class HuiGaugeCardEditor
               },
             ] as const)
           : []),
+        {
+          name: "tap_action",
+          selector: {
+            ui_action: {
+              actions: TAP_ACTIONS as UiAction[],
+              default_action: "more-info",
+            },
+          },
+        },
       ] as const
   );
 
@@ -214,6 +231,12 @@ export class HuiGaugeCardEditor
         return this.hass!.localize(
           "ui.panel.lovelace.editor.card.generic.unit"
         );
+      case "tap_action":
+        return `${this.hass!.localize(
+          `ui.panel.lovelace.editor.card.generic.${schema.name}`
+        )} (${this.hass!.localize(
+          "ui.panel.lovelace.editor.card.config.optional"
+        )})`;
       default:
         // "green" | "yellow" | "red"
         return this.hass!.localize(

--- a/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
@@ -23,7 +23,7 @@ import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import { DEFAULT_MIN, DEFAULT_MAX } from "../../cards/hui-gauge-card";
 import { UiAction } from "../../components/hui-action-editor";
 
-const TAP_ACTIONS: UiActions[] = ["navigate", "url", "call-service", "none"];
+const TAP_ACTIONS: UiAction[] = ["navigate", "url", "call-service", "none"];
 
 const gaugeSegmentStruct = object({
   from: number(),

--- a/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
@@ -23,7 +23,7 @@ import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import { DEFAULT_MIN, DEFAULT_MAX } from "../../cards/hui-gauge-card";
 import { UiAction } from "../../components/hui-action-editor";
 
-const TAP_ACTIONS = ["navigate", "url", "call-service", "none"];
+const TAP_ACTIONS: UiActions[] = ["navigate", "url", "call-service", "none"];
 
 const gaugeSegmentStruct = object({
   from: number(),
@@ -137,7 +137,7 @@ export class HuiGaugeCardEditor
           name: "tap_action",
           selector: {
             ui_action: {
-              actions: TAP_ACTIONS as UiAction[],
+              actions: TAP_ACTIONS,
               default_action: "more-info",
             },
           },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add the standard suite of configurable actions to gauge card. It seems oft requested, and I see no reason to disallow it. 

https://community.home-assistant.io/t/tappable-gauge/503012
https://community.home-assistant.io/t/extend-tap-action-to-gauge-card/406829
https://community.home-assistant.io/t/expand-gauge-card-with-tap-action-for-example-navigate-to-dashboard/731011
https://community.home-assistant.io/t/wth-dashboard-gauges-custom-tap-hold-action/472368
https://community.home-assistant.io/t/wth-does-the-gauge-card-not-have-the-tap-action-option/478638

Will PR docs on approval. 

I have mixed opinions on if it should be added to the visual editor. Some cards do, and some do not, it's not entirely consistent. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
