### PR TITLE
Rename energy 'Today' button to 'Now'

### DIFF
--- a/src/panels/lovelace/components/hui-energy-period-selector.ts
+++ b/src/panels/lovelace/components/hui-energy-period-selector.ts
@@ -261,9 +261,9 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
         </div>
 
         ${!this.narrow
-          ? html`<mwc-button dense outlined @click=${this._pickToday}>
+          ? html`<mwc-button dense outlined @click=${this._pickNow}>
               ${this.hass.localize(
-                "ui.panel.lovelace.components.energy_period_selector.today"
+                "ui.panel.lovelace.components.energy_period_selector.now"
               )}
             </mwc-button>`
           : nothing}
@@ -376,7 +376,7 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
     this._updateCollectionPeriod();
   }
 
-  private _pickToday() {
+  private _pickNow() {
     if (!this._startDate) return;
 
     const range = this._simpleRange(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6183,7 +6183,7 @@
             "invalid_format": "Invalid display format"
           },
           "energy_period_selector": {
-            "today": "Today",
+            "now": "Now",
             "previous": "Previous",
             "next": "Next",
             "compare": "Compare data"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Requested by Matthias: https://github.com/home-assistant/frontend/issues/18743#issuecomment-1844954381

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18743
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Updated the label for the current time period selection button from "Today" to "Now" in the energy period selector. 

This change ensures a more intuitive understanding for users selecting the current time period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->