### PR TITLE
Use valid locale for translation test

### DIFF
--- a/build-scripts/gulp/translations.js
+++ b/build-scripts/gulp/translations.js
@@ -19,6 +19,7 @@ const inBackendDir = "translations/backend";
 const workDir = "build/translations";
 const outDir = join(workDir, "output");
 const EN_SRC = join(paths.translations_src, "en.json");
+const TEST_LOCALE = "en-x-test";
 
 let mergeBackend = false;
 
@@ -150,7 +151,7 @@ const createTestTranslation = () =>
     : gulp
         .src(EN_SRC)
         .pipe(new CustomJSON(null, testReviver))
-        .pipe(rename("test.json"))
+        .pipe(rename(`${TEST_LOCALE}.json`))
         .pipe(gulp.dest(workDir));
 
 /**
@@ -192,7 +193,7 @@ const createTranslations = async () => {
   // each locale, then fragmentizes and flattens the data for final output.
   const translationFiles = await glob([
     `${inFrontendDir}/!(en).json`,
-    ...(env.isProdBuild() ? [] : [`${workDir}/test.json`]),
+    ...(env.isProdBuild() ? [] : [`${workDir}/${TEST_LOCALE}.json`]),
   ]);
   const hashStream = new Transform({
     objectMode: true,
@@ -254,8 +255,8 @@ const createTranslations = async () => {
     const mergeFiles = [];
     for (let i = 1; i <= subtags.length; i++) {
       const lang = subtags.slice(0, i).join("-");
-      if (lang === "test") {
-        mergeFiles.push(`${workDir}/test.json`);
+      if (lang === TEST_LOCALE) {
+        mergeFiles.push(`${workDir}/${TEST_LOCALE}.json`);
       } else if (lang !== "en") {
         mergeFiles.push(`${inFrontendDir}/${lang}.json`);
         if (mergeBackend) {
@@ -284,7 +285,7 @@ const writeTranslationMetaData = () =>
       new CustomJSON((meta) => {
         // Add the test translation in development.
         if (!env.isProdBuild()) {
-          meta.test = { nativeName: "Test" };
+          meta[TEST_LOCALE] = { nativeName: "Translation Test" };
         }
         // Filter out locales without a native name, and add the hashes.
         for (const locale of Object.keys(meta)) {

--- a/gallery/src/pages/date-time/date-time-numeric.ts
+++ b/gallery/src/pages/date-time/date-time-numeric.ts
@@ -56,48 +56,46 @@ export class DemoDateTimeDateTimeNumeric extends LitElement {
           <div class="center">12 Hours</div>
           <div class="center">24 Hours</div>
         </div>
-        ${Object.entries(translationMetadata.translations)
-          .filter(([key, _]) => key !== "test")
-          .map(
-            ([key, value]) => html`
-              <div class="container">
-                <div>${value.nativeName}</div>
-                <div class="center">
-                  ${formatDateTimeNumeric(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.language,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatDateTimeNumeric(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.am_pm,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatDateTimeNumeric(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.twenty_four,
-                    },
-                    demoConfig
-                  )}
-                </div>
+        ${Object.entries(translationMetadata.translations).map(
+          ([key, value]) => html`
+            <div class="container">
+              <div>${value.nativeName}</div>
+              <div class="center">
+                ${formatDateTimeNumeric(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.language,
+                  },
+                  demoConfig
+                )}
               </div>
-            `
-          )}
+              <div class="center">
+                ${formatDateTimeNumeric(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.am_pm,
+                  },
+                  demoConfig
+                )}
+              </div>
+              <div class="center">
+                ${formatDateTimeNumeric(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.twenty_four,
+                  },
+                  demoConfig
+                )}
+              </div>
+            </div>
+          `
+        )}
       </mwc-list>
     `;
   }

--- a/gallery/src/pages/date-time/date-time-seconds.ts
+++ b/gallery/src/pages/date-time/date-time-seconds.ts
@@ -56,48 +56,46 @@ export class DemoDateTimeDateTimeSeconds extends LitElement {
           <div class="center">12 Hours</div>
           <div class="center">24 Hours</div>
         </div>
-        ${Object.entries(translationMetadata.translations)
-          .filter(([key, _]) => key !== "test")
-          .map(
-            ([key, value]) => html`
-              <div class="container">
-                <div>${value.nativeName}</div>
-                <div class="center">
-                  ${formatDateTimeWithSeconds(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.language,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatDateTimeWithSeconds(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.am_pm,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatDateTimeWithSeconds(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.twenty_four,
-                    },
-                    demoConfig
-                  )}
-                </div>
+        ${Object.entries(translationMetadata.translations).map(
+          ([key, value]) => html`
+            <div class="container">
+              <div>${value.nativeName}</div>
+              <div class="center">
+                ${formatDateTimeWithSeconds(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.language,
+                  },
+                  demoConfig
+                )}
               </div>
-            `
-          )}
+              <div class="center">
+                ${formatDateTimeWithSeconds(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.am_pm,
+                  },
+                  demoConfig
+                )}
+              </div>
+              <div class="center">
+                ${formatDateTimeWithSeconds(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.twenty_four,
+                  },
+                  demoConfig
+                )}
+              </div>
+            </div>
+          `
+        )}
       </mwc-list>
     `;
   }

--- a/gallery/src/pages/date-time/date-time-short-year.ts
+++ b/gallery/src/pages/date-time/date-time-short-year.ts
@@ -56,48 +56,46 @@ export class DemoDateTimeDateTimeShortYear extends LitElement {
           <div class="center">12 Hours</div>
           <div class="center">24 Hours</div>
         </div>
-        ${Object.entries(translationMetadata.translations)
-          .filter(([key, _]) => key !== "test")
-          .map(
-            ([key, value]) => html`
-              <div class="container">
-                <div>${value.nativeName}</div>
-                <div class="center">
-                  ${formatShortDateTimeWithYear(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.language,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatShortDateTimeWithYear(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.am_pm,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatShortDateTimeWithYear(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.twenty_four,
-                    },
-                    demoConfig
-                  )}
-                </div>
+        ${Object.entries(translationMetadata.translations).map(
+          ([key, value]) => html`
+            <div class="container">
+              <div>${value.nativeName}</div>
+              <div class="center">
+                ${formatShortDateTimeWithYear(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.language,
+                  },
+                  demoConfig
+                )}
               </div>
-            `
-          )}
+              <div class="center">
+                ${formatShortDateTimeWithYear(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.am_pm,
+                  },
+                  demoConfig
+                )}
+              </div>
+              <div class="center">
+                ${formatShortDateTimeWithYear(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.twenty_four,
+                  },
+                  demoConfig
+                )}
+              </div>
+            </div>
+          `
+        )}
       </mwc-list>
     `;
   }

--- a/gallery/src/pages/date-time/date-time-short.ts
+++ b/gallery/src/pages/date-time/date-time-short.ts
@@ -56,48 +56,46 @@ export class DemoDateTimeDateTimeShort extends LitElement {
           <div class="center">12 Hours</div>
           <div class="center">24 Hours</div>
         </div>
-        ${Object.entries(translationMetadata.translations)
-          .filter(([key, _]) => key !== "test")
-          .map(
-            ([key, value]) => html`
-              <div class="container">
-                <div>${value.nativeName}</div>
-                <div class="center">
-                  ${formatShortDateTime(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.language,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatShortDateTime(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.am_pm,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatShortDateTime(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.twenty_four,
-                    },
-                    demoConfig
-                  )}
-                </div>
+        ${Object.entries(translationMetadata.translations).map(
+          ([key, value]) => html`
+            <div class="container">
+              <div>${value.nativeName}</div>
+              <div class="center">
+                ${formatShortDateTime(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.language,
+                  },
+                  demoConfig
+                )}
               </div>
-            `
-          )}
+              <div class="center">
+                ${formatShortDateTime(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.am_pm,
+                  },
+                  demoConfig
+                )}
+              </div>
+              <div class="center">
+                ${formatShortDateTime(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.twenty_four,
+                  },
+                  demoConfig
+                )}
+              </div>
+            </div>
+          `
+        )}
       </mwc-list>
     `;
   }

--- a/gallery/src/pages/date-time/date-time.ts
+++ b/gallery/src/pages/date-time/date-time.ts
@@ -56,48 +56,46 @@ export class DemoDateTimeDateTime extends LitElement {
           <div class="center">12 Hours</div>
           <div class="center">24 Hours</div>
         </div>
-        ${Object.entries(translationMetadata.translations)
-          .filter(([key, _]) => key !== "test")
-          .map(
-            ([key, value]) => html`
-              <div class="container">
-                <div>${value.nativeName}</div>
-                <div class="center">
-                  ${formatDateTime(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.language,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatDateTime(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.am_pm,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatDateTime(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.twenty_four,
-                    },
-                    demoConfig
-                  )}
-                </div>
+        ${Object.entries(translationMetadata.translations).map(
+          ([key, value]) => html`
+            <div class="container">
+              <div>${value.nativeName}</div>
+              <div class="center">
+                ${formatDateTime(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.language,
+                  },
+                  demoConfig
+                )}
               </div>
-            `
-          )}
+              <div class="center">
+                ${formatDateTime(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.am_pm,
+                  },
+                  demoConfig
+                )}
+              </div>
+              <div class="center">
+                ${formatDateTime(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.twenty_four,
+                  },
+                  demoConfig
+                )}
+              </div>
+            </div>
+          `
+        )}
       </mwc-list>
     `;
   }

--- a/gallery/src/pages/date-time/date.ts
+++ b/gallery/src/pages/date-time/date.ts
@@ -35,59 +35,57 @@ export class DemoDateTimeDate extends LitElement {
           <div class="center">Month-Day-Year</div>
           <div class="center">Year-Month-Day</div>
         </div>
-        ${Object.entries(translationMetadata.translations)
-          .filter(([key, _]) => key !== "test")
-          .map(
-            ([key, value]) => html`
-              <div class="container">
-                <div>${value.nativeName}</div>
-                <div class="center">
-                  ${formatDateNumeric(
-                    date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      date_format: DateFormat.language,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatDateNumeric(
-                    date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      date_format: DateFormat.DMY,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatDateNumeric(
-                    date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      date_format: DateFormat.MDY,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatDateNumeric(
-                    date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      date_format: DateFormat.YMD,
-                    },
-                    demoConfig
-                  )}
-                </div>
+        ${Object.entries(translationMetadata.translations).map(
+          ([key, value]) => html`
+            <div class="container">
+              <div>${value.nativeName}</div>
+              <div class="center">
+                ${formatDateNumeric(
+                  date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    date_format: DateFormat.language,
+                  },
+                  demoConfig
+                )}
               </div>
-            `
-          )}
+              <div class="center">
+                ${formatDateNumeric(
+                  date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    date_format: DateFormat.DMY,
+                  },
+                  demoConfig
+                )}
+              </div>
+              <div class="center">
+                ${formatDateNumeric(
+                  date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    date_format: DateFormat.MDY,
+                  },
+                  demoConfig
+                )}
+              </div>
+              <div class="center">
+                ${formatDateNumeric(
+                  date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    date_format: DateFormat.YMD,
+                  },
+                  demoConfig
+                )}
+              </div>
+            </div>
+          `
+        )}
       </mwc-list>
     `;
   }

--- a/gallery/src/pages/date-time/time-seconds.ts
+++ b/gallery/src/pages/date-time/time-seconds.ts
@@ -56,48 +56,46 @@ export class DemoDateTimeTimeSeconds extends LitElement {
           <div class="center">12 Hours</div>
           <div class="center">24 Hours</div>
         </div>
-        ${Object.entries(translationMetadata.translations)
-          .filter(([key, _]) => key !== "test")
-          .map(
-            ([key, value]) => html`
-              <div class="container">
-                <div>${value.nativeName}</div>
-                <div class="center">
-                  ${formatTimeWithSeconds(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.language,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatTimeWithSeconds(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.am_pm,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatTimeWithSeconds(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.twenty_four,
-                    },
-                    demoConfig
-                  )}
-                </div>
+        ${Object.entries(translationMetadata.translations).map(
+          ([key, value]) => html`
+            <div class="container">
+              <div>${value.nativeName}</div>
+              <div class="center">
+                ${formatTimeWithSeconds(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.language,
+                  },
+                  demoConfig
+                )}
               </div>
-            `
-          )}
+              <div class="center">
+                ${formatTimeWithSeconds(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.am_pm,
+                  },
+                  demoConfig
+                )}
+              </div>
+              <div class="center">
+                ${formatTimeWithSeconds(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.twenty_four,
+                  },
+                  demoConfig
+                )}
+              </div>
+            </div>
+          `
+        )}
       </mwc-list>
     `;
   }

--- a/gallery/src/pages/date-time/time-weekday.ts
+++ b/gallery/src/pages/date-time/time-weekday.ts
@@ -56,48 +56,46 @@ export class DemoDateTimeTimeWeekday extends LitElement {
           <div class="center">12 Hours</div>
           <div class="center">24 Hours</div>
         </div>
-        ${Object.entries(translationMetadata.translations)
-          .filter(([key, _]) => key !== "test")
-          .map(
-            ([key, value]) => html`
-              <div class="container">
-                <div>${value.nativeName}</div>
-                <div class="center">
-                  ${formatTimeWeekday(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.language,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatTimeWeekday(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.am_pm,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatTimeWeekday(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.twenty_four,
-                    },
-                    demoConfig
-                  )}
-                </div>
+        ${Object.entries(translationMetadata.translations).map(
+          ([key, value]) => html`
+            <div class="container">
+              <div>${value.nativeName}</div>
+              <div class="center">
+                ${formatTimeWeekday(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.language,
+                  },
+                  demoConfig
+                )}
               </div>
-            `
-          )}
+              <div class="center">
+                ${formatTimeWeekday(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.am_pm,
+                  },
+                  demoConfig
+                )}
+              </div>
+              <div class="center">
+                ${formatTimeWeekday(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.twenty_four,
+                  },
+                  demoConfig
+                )}
+              </div>
+            </div>
+          `
+        )}
       </mwc-list>
     `;
   }

--- a/gallery/src/pages/date-time/time.ts
+++ b/gallery/src/pages/date-time/time.ts
@@ -56,48 +56,46 @@ export class DemoDateTimeTime extends LitElement {
           <div class="center">12 Hours</div>
           <div class="center">24 Hours</div>
         </div>
-        ${Object.entries(translationMetadata.translations)
-          .filter(([key, _]) => key !== "test")
-          .map(
-            ([key, value]) => html`
-              <div class="container">
-                <div>${value.nativeName}</div>
-                <div class="center">
-                  ${formatTime(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.language,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatTime(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.am_pm,
-                    },
-                    demoConfig
-                  )}
-                </div>
-                <div class="center">
-                  ${formatTime(
-                    this.date,
-                    {
-                      ...defaultLocale,
-                      language: key,
-                      time_format: TimeFormat.twenty_four,
-                    },
-                    demoConfig
-                  )}
-                </div>
+        ${Object.entries(translationMetadata.translations).map(
+          ([key, value]) => html`
+            <div class="container">
+              <div>${value.nativeName}</div>
+              <div class="center">
+                ${formatTime(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.language,
+                  },
+                  demoConfig
+                )}
               </div>
-            `
-          )}
+              <div class="center">
+                ${formatTime(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.am_pm,
+                  },
+                  demoConfig
+                )}
+              </div>
+              <div class="center">
+                ${formatTime(
+                  this.date,
+                  {
+                    ...defaultLocale,
+                    language: key,
+                    time_format: TimeFormat.twenty_four,
+                  },
+                  demoConfig
+                )}
+              </div>
+            </div>
+          `
+        )}
       </mwc-list>
     `;
   }

--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -65,20 +65,10 @@ export const formatNumber = (
     localeOptions?.number_format !== NumberFormat.none &&
     !Number.isNaN(Number(num))
   ) {
-    try {
-      return new Intl.NumberFormat(
-        locale,
-        getDefaultFormatOptions(num, options)
-      ).format(Number(num));
-    } catch (err: any) {
-      // Don't fail when using "TEST" language
-      // eslint-disable-next-line no-console
-      console.error(err);
-      return new Intl.NumberFormat(
-        undefined,
-        getDefaultFormatOptions(num, options)
-      ).format(Number(num));
-    }
+    return new Intl.NumberFormat(
+      locale,
+      getDefaultFormatOptions(num, options)
+    ).format(Number(num));
   }
 
   if (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Use a valid locale of "en-x-test" for the translation test language on development builds (English with a private use "test" extension).  This resolves any errors that would otherwise ensue by giving something invalid to native `Intl` or the polyfills.  Also removes production code that works around the test language.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #19171 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced date-time format rendering for different languages and time formats in the gallery pages.

- **Refactor**
  - Optimized the rendering logic for date-time and time formats, improving code readability and efficiency.
  - Simplified error handling in number formatting to streamline performance.

- **Chores**
  - Introduced a constant for test locale to standardize test translation handling across the script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->