### PR TITLE
Add visibility editor to card editor

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-card-element-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-element-editor.ts
@@ -80,7 +80,9 @@ export class HuiCardElementEditor extends HuiElementEditor<LovelaceCardConfig> {
         ${TABS.map(
           (tab, index) => html`
             <paper-tab id=${tab} .dialogInitialFocus=${index === 0}>
-              ${tab}
+              ${this.hass.localize(
+                `ui.panel.lovelace.editor.edit_card.tab-${tab}`
+              )}
             </paper-tab>
           `
         )}
@@ -98,6 +100,7 @@ export class HuiCardElementEditor extends HuiElementEditor<LovelaceCardConfig> {
           color: var(--primary-text-color);
           text-transform: uppercase;
           margin-bottom: 16px;
+          border-bottom: 1px solid var(--divider-color);
         }
       `,
     ];

--- a/src/panels/lovelace/editor/card-editor/hui-card-element-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-element-editor.ts
@@ -15,7 +15,7 @@ export class HuiCardElementEditor extends HuiElementEditor<LovelaceCardConfig> {
   @state() private _curTab: (typeof TABS)[number] = TABS[0];
 
   @property({ type: Boolean, attribute: "show-visibility-tab" })
-  public showVisibilityTab: boolean = false;
+  public showVisibilityTab = false;
 
   protected async getConfigElement(): Promise<LovelaceCardEditor | undefined> {
     const elClass = await getCardElementClass(this.configElementType!);

--- a/src/panels/lovelace/editor/card-editor/hui-card-element-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-element-editor.ts
@@ -1,11 +1,22 @@
-import { customElement } from "lit/decorators";
+import "@polymer/paper-tabs/paper-tab";
+import "@polymer/paper-tabs/paper-tabs";
+import { CSSResultGroup, TemplateResult, css, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
 import { LovelaceCardConfig } from "../../../../data/lovelace/config/card";
 import { getCardElementClass } from "../../create-element/create-card-element";
 import type { LovelaceCardEditor, LovelaceConfigForm } from "../../types";
 import { HuiElementEditor } from "../hui-element-editor";
+import "./hui-card-visibility-editor";
+
+const TABS = ["config", "visibility"] as const;
 
 @customElement("hui-card-element-editor")
 export class HuiCardElementEditor extends HuiElementEditor<LovelaceCardConfig> {
+  @state() private _curTab: (typeof TABS)[number] = TABS[0];
+
+  @property({ type: Boolean, attribute: "show-visibility-tab" })
+  public showVisibilityTab: boolean = false;
+
   protected async getConfigElement(): Promise<LovelaceCardEditor | undefined> {
     const elClass = await getCardElementClass(this.configElementType!);
 
@@ -26,6 +37,70 @@ export class HuiCardElementEditor extends HuiElementEditor<LovelaceCardConfig> {
     }
 
     return undefined;
+  }
+
+  private _handleTabSelected(ev: CustomEvent): void {
+    if (!ev.detail.value) {
+      return;
+    }
+    this._curTab = ev.detail.value.id;
+  }
+
+  private _configChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    this.value = ev.detail.value;
+  }
+
+  protected renderConfigElement(): TemplateResult {
+    if (!this.showVisibilityTab) return super.renderConfigElement();
+
+    let content: TemplateResult<1> | typeof nothing = nothing;
+
+    switch (this._curTab) {
+      case "config":
+        content = html`${super.renderConfigElement()}`;
+        break;
+      case "visibility":
+        content = html`
+          <hui-card-visibility-editor
+            .hass=${this.hass}
+            .config=${this.value}
+            @value-changed=${this._configChanged}
+          ></hui-card-visibility-editor>
+        `;
+        break;
+    }
+    return html`
+      <paper-tabs
+        scrollable
+        hide-scroll-buttons
+        .selected=${TABS.indexOf(this._curTab)}
+        @selected-item-changed=${this._handleTabSelected}
+      >
+        ${TABS.map(
+          (tab, index) => html`
+            <paper-tab id=${tab} .dialogInitialFocus=${index === 0}>
+              ${tab}
+            </paper-tab>
+          `
+        )}
+      </paper-tabs>
+      ${content}
+    `;
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      HuiElementEditor.styles,
+      css`
+        paper-tabs {
+          --paper-tabs-selection-bar-color: var(--primary-color);
+          color: var(--primary-text-color);
+          text-transform: uppercase;
+          margin-bottom: 16px;
+        }
+      `,
+    ];
   }
 }
 

--- a/src/panels/lovelace/editor/card-editor/hui-card-visibility-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-visibility-editor.ts
@@ -1,0 +1,51 @@
+import { LitElement, html } from "lit";
+import { customElement, property } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-alert";
+import { LovelaceCardConfig } from "../../../../data/lovelace/config/card";
+import { HomeAssistant } from "../../../../types";
+import { Condition } from "../../common/validate-condition";
+import "../conditions/ha-card-conditions-editor";
+
+@customElement("hui-card-visibility-editor")
+export class HuiCardVisibilityEditor extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public config!: LovelaceCardConfig;
+
+  render() {
+    const conditions = this.config.visibility ?? [];
+    return html`
+      <ha-alert alert-type="info">
+        ${this.hass.localize(
+          `ui.panel.lovelace.editor.edit_card.visibility.explanation`
+        )}
+      </ha-alert>
+      <ha-card-conditions-editor
+        .hass=${this.hass}
+        .conditions=${conditions}
+        @value-changed=${this._valueChanged}
+      >
+      </ha-card-conditions-editor>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const conditions = ev.detail.value as Condition[];
+    const newConfig: LovelaceCardConfig = {
+      ...this.config,
+      visibility: conditions,
+    };
+    if (newConfig.visibility?.length === 0) {
+      delete newConfig.visibility;
+    }
+    fireEvent(this, "value-changed", { value: newConfig });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-card-visibility-editor": HuiCardVisibilityEditor;
+  }
+}

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -234,6 +234,7 @@ export class HuiDialogEditCard
         <div class="content">
           <div class="element-editor">
             <hui-card-element-editor
+              .showVisibilityTab=${this._cardConfig?.type !== "conditional"}
               .hass=${this.hass}
               .lovelace=${this._params.lovelaceConfig}
               .value=${this._cardConfig}
@@ -407,30 +408,31 @@ export class HuiDialogEditCard
           --code-mirror-max-height: calc(100vh - 176px);
         }
 
+        ha-dialog {
+          --mdc-dialog-max-width: 100px;
+          --dialog-z-index: 6;
+          --dialog-surface-position: fixed;
+          --dialog-surface-top: 40px;
+          --mdc-dialog-max-width: 90vw;
+          --dialog-content-padding: 24px 12px;
+        }
+
         @media all and (max-width: 450px), all and (max-height: 500px) {
           /* overrule the ha-style-dialog max-height on small screens */
           ha-dialog {
-            --mdc-dialog-max-height: 100%;
             height: 100%;
+            --mdc-dialog-max-height: 100%;
+            --dialog-surface-top: 0px;
+            --mdc-dialog-max-width: 100vw;
           }
         }
 
-        @media all and (min-width: 850px) {
-          ha-dialog {
-            --mdc-dialog-min-width: 845px;
-            --mdc-dialog-max-height: calc(100% - 72px);
-          }
-        }
-
-        ha-dialog {
-          --mdc-dialog-max-width: 845px;
-          --dialog-z-index: 6;
+        .content {
+          width: 1000px;
+          max-width: calc(90vw - 48px);
         }
 
         @media all and (min-width: 451px) and (min-height: 501px) {
-          ha-dialog {
-            --mdc-dialog-max-width: 90vw;
-          }
           :host([large]) .content {
             width: calc(90vw - 48px);
           }
@@ -444,8 +446,8 @@ export class HuiDialogEditCard
         .content {
           display: flex;
           flex-direction: column;
-          margin: 0 -10px;
         }
+
         .content hui-card-preview {
           margin: 4px auto;
           max-width: 390px;
@@ -454,15 +456,7 @@ export class HuiDialogEditCard
           margin: 0 10px;
         }
 
-        @media (min-width: 1200px) {
-          ha-dialog {
-            --mdc-dialog-max-width: calc(100% - 32px);
-            --mdc-dialog-min-width: 1000px;
-            --dialog-surface-position: fixed;
-            --dialog-surface-top: 40px;
-            --mdc-dialog-max-height: calc(100% - 72px);
-          }
-
+        @media (min-width: 1000px) {
           .content {
             flex-direction: row;
           }

--- a/src/panels/lovelace/editor/hui-element-editor.ts
+++ b/src/panels/lovelace/editor/hui-element-editor.ts
@@ -20,13 +20,14 @@ import { LovelaceCardConfig } from "../../../data/lovelace/config/card";
 import { LovelaceStrategyConfig } from "../../../data/lovelace/config/strategy";
 import { LovelaceConfig } from "../../../data/lovelace/config/types";
 import type { HomeAssistant } from "../../../types";
+import { LovelaceCardFeatureConfig } from "../card-features/types";
 import type { LovelaceRowConfig } from "../entity-rows/types";
 import { LovelaceHeaderFooterConfig } from "../header-footer/types";
-import { LovelaceCardFeatureConfig } from "../card-features/types";
 import type {
   LovelaceConfigForm,
   LovelaceGenericElementEditor,
 } from "../types";
+import "./card-editor/hui-card-visibility-editor";
 import type { HuiFormEditor } from "./config-elements/hui-form-editor";
 import "./config-elements/hui-generic-entity-row-editor";
 import { GUISupportError } from "./gui-support-error";
@@ -198,6 +199,10 @@ export abstract class HuiElementEditor<T, C = any> extends LitElement {
     return this.value ? (this.value as any).type : undefined;
   }
 
+  protected renderConfigElement(): TemplateResult {
+    return html`${this._configElement}`;
+  }
+
   protected render(): TemplateResult {
     return html`
       <div class="wrapper">
@@ -211,7 +216,7 @@ export abstract class HuiElementEditor<T, C = any> extends LitElement {
                         class="center margin-bot"
                       ></ha-circular-progress>
                     `
-                  : this._configElement}
+                  : this.renderConfigElement()}
               </div>
             `
           : html`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5518,7 +5518,10 @@
             "decrease_position": "Decrease card position",
             "increase_position": "Increase card position",
             "options": "More options",
-            "search_cards": "Search cards"
+            "search_cards": "Search cards",
+            "visibility": {
+              "explanation": "The card will be shown when ALL conditions below are fulfilled. If no conditions are set, the card will always be shown."
+            }
           },
           "move_card": {
             "header": "Choose a view to move the card to",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5519,6 +5519,8 @@
             "increase_position": "Increase card position",
             "options": "More options",
             "search_cards": "Search cards",
+            "tab-config": "Config",
+            "tab-visibility": "Visibility",
             "visibility": {
               "explanation": "The card will be shown when ALL conditions below are fulfilled. If no conditions are set, the card will always be shown."
             }


### PR DESCRIPTION
## Proposed change

Add visibility editor to every card editor.
The visibility tab is not visible for conditional card to avoid confusion.
It's also not visible for nested card (inside conditional card, stack card)

Also, the responsiveness on the dialog has been improved with bigger dialog on desktop.

![CleanShot 2024-05-30 at 16 45 10](https://github.com/home-assistant/frontend/assets/5878303/ce460c10-ddcc-49ac-89cc-cb9fe625b4a3)
![CleanShot 2024-05-30 at 16 45 34](https://github.com/home-assistant/frontend/assets/5878303/dd982029-081f-401e-8522-a40df2683df3)

Not available for nested cards

![CleanShot 2024-05-30 at 16 45 57](https://github.com/home-assistant/frontend/assets/5878303/83be04fa-d4cf-4bbe-acd5-fbc6123c82bb)

Not available for conditional card

![CleanShot 2024-05-30 at 16 39 39](https://github.com/home-assistant/frontend/assets/5878303/5f8ae32e-3ad6-408e-8136-bed1f207d865)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced tab handling for configuration and visibility in the card editor.
  - Added a new visibility editor for Lovelace cards to manage visibility conditions.

- **Enhancements**
  - Updated rendering logic to support the new tabbed interface for better user experience.
  - Improved translations for configuration and visibility tabs.

- **Bug Fixes**
  - Adjusted CSS properties for dialogs and content to improve display on different screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->