### PR TITLE
Improve error messages in config entries

### DIFF
--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -744,7 +744,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
           .path=${mdiDotsVertical}
         ></ha-icon-button>
         ${item.supports_options && stateText
-          ? html`<ha-menu-item @request-selected=${this._showOptions}>
+          ? html`<ha-menu-item @click=${this._showOptions}>
               <ha-svg-icon slot="start" .path=${mdiCog}></ha-svg-icon>
               ${this.hass.localize(
                 "ui.panel.config.integrations.config_entry.configure"

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -1413,6 +1413,9 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         ha-alert:first-of-type {
           margin-top: 16px;
         }
+        ha-list-item-new.discovered {
+          height: 72px;
+        }
         a {
           text-decoration: none;
         }

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -686,6 +686,10 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
     return html` <ha-list-item-new
       class=${classMap({
         config_entry: true,
+        "state-not-loaded": item!.state === "not_loaded",
+        "state-failed-unload": item!.state === "failed_unload",
+        "state-setup": item!.state === "setup_in_progress",
+        "state-error": ERROR_STATES.includes(item!.state),
         "state-disabled": item.disabled_by !== null,
       })}
       data-entry-id=${item.entry_id}
@@ -698,17 +702,14 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         <div>${devicesLine}</div>
         ${stateText
           ? html`
-              <ha-alert
-                alert-type=${item!.state === "failed_unload"
-                  ? "warning"
-                  : ERROR_STATES.includes(item!.state)
-                    ? "error"
-                    : "info"}
-                title=${this.hass.localize(...stateText)}
-              >
-                <ha-svg-icon slot="icon" .path=${icon}></ha-svg-icon>
-                ${stateTextExtra}
-              </ha-alert>
+              <div class="message">
+                <ha-svg-icon .path=${icon}></ha-svg-icon>
+                <div>
+                  ${this.hass.localize(...stateText)}${stateTextExtra
+                    ? html`: ${stateTextExtra}`
+                    : ""}
+                </div>
+              </div>
             `
           : ""}
       </div>
@@ -753,7 +754,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         ${item.disabled_by && devices.length
           ? html`
               <ha-menu-item
-                href=${devices.length === 1
+                .href=${devices.length === 1
                   ? `/config/devices/device/${devices[0].id}`
                   : `/config/devices/dashboard?historyBack=1&config_entry=${item.entry_id}`}
               >
@@ -768,7 +769,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
           : ""}
         ${item.disabled_by && services.length
           ? html`<ha-menu-item
-              href=${services.length === 1
+              .href=${services.length === 1
                 ? `/config/devices/device/${services[0].id}`
                 : `/config/devices/dashboard?historyBack=1&config_entry=${item.entry_id}`}
             >
@@ -786,7 +787,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         ${item.disabled_by && entities.length
           ? html`
               <ha-menu-item
-                href=${`/config/entities?historyBack=1&config_entry=${item.entry_id}`}
+                .href=${`/config/entities?historyBack=1&config_entry=${item.entry_id}`}
               >
                 <ha-svg-icon
                   .path=${mdiShapeOutline}
@@ -826,7 +827,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         ${this._diagnosticHandler && item.state === "loaded"
           ? html`
               <ha-menu-item
-                href=${getConfigEntryDiagnosticsDownloadUrl(item.entry_id)}
+                .href=${getConfigEntryDiagnosticsDownloadUrl(item.entry_id)}
                 target="_blank"
                 @click=${this._signUrl}
               >
@@ -1416,6 +1417,16 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         ha-list-item-new.discovered {
           height: 72px;
         }
+        ha-list-item-new.config_entry::after {
+          position: absolute;
+          top: 8px;
+          right: 0;
+          bottom: 8px;
+          left: 0;
+          opacity: 0.12;
+          pointer-events: none;
+          content: "";
+        }
         a {
           text-decoration: none;
         }
@@ -1427,6 +1438,50 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         }
         .warning {
           color: var(--error-color);
+        }
+        .state-error {
+          --state-message-color: var(--error-color);
+          --text-on-state-color: var(--text-primary-color);
+        }
+        .state-error::after {
+          background-color: var(--error-color);
+        }
+        .state-failed-unload {
+          --state-message-color: var(--warning-color);
+          --text-on-state-color: var(--primary-text-color);
+        }
+        .state-failed::after {
+          background-color: var(--warning-color);
+        }
+        .state-not-loaded {
+          --state-message-color: var(--primary-text-color);
+        }
+        .state-setup {
+          --state-message-color: var(--secondary-text-color);
+        }
+        .message {
+          font-weight: bold;
+          display: flex;
+          align-items: center;
+        }
+        .message ha-svg-icon {
+          color: var(--state-message-color);
+        }
+        .message div {
+          flex: 1;
+          margin-left: 8px;
+          margin-inline-start: 8px;
+          margin-inline-end: initial;
+          padding-top: 2px;
+          padding-right: 2px;
+          padding-inline-end: 2px;
+          padding-inline-start: initial;
+          overflow-wrap: break-word;
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 7;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
         .state-disabled [slot="headline"],
         .state-disabled [slot="supporting-text"] {


### PR DESCRIPTION
## Proposed change
https://github.com/home-assistant/frontend/pull/20764 has been a source of bugs during the beta. After fixing the config flow in second beta, it was still not possible to enable a config entry again since the new material list disable everything (there's an opacity layer and pointer-events none on the whole container). Also found some remaining items that started to show up wrongly in the config menu, I've converted those those menu-items as well. <s>Then lastly, decided to pull in ha-alerts to display the errors so we don't need custom logic. </s>

![image](https://github.com/home-assistant/frontend/assets/32477463/33f79b44-ee69-4462-8e4c-520ffececf57)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #20931
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the rendering logic for attention and normal entries with added dividers.
  - Introduced `ha-alert` elements for displaying different states.
  - Added menu items for configuration options and device navigation.

- **Style**
  - Updated styling for disabled states, including opacity adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->