### PR TITLE
Revert "Filter unrecorded entities from history panel (#19621)"

### DIFF
--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -12,14 +12,6 @@ export interface RecorderInfo {
   thread_running: boolean;
 }
 
-export interface RecordedEntities {
-  entity_ids: string[];
-}
-export interface RecordedExcludedEntities {
-  recorded_ids: string[];
-  excluded_ids: string[];
-}
-
 export type StatisticType = "change" | "state" | "sum" | "min" | "max" | "mean";
 
 export interface Statistics {
@@ -332,25 +324,3 @@ export const getDisplayUnit = (
 
 export const isExternalStatistic = (statisticsId: string): boolean =>
   statisticsId.includes(":");
-
-let recordedExcludedEntitiesCache: RecordedExcludedEntities | undefined;
-
-export const getRecordedExcludedEntities = async (
-  hass: HomeAssistant
-): Promise<RecordedExcludedEntities> => {
-  if (recordedExcludedEntitiesCache) {
-    return recordedExcludedEntitiesCache;
-  }
-  const recordedEntities = await hass.callWS<RecordedEntities>({
-    type: "recorder/recorded_entities",
-  });
-
-  recordedExcludedEntitiesCache = {
-    recorded_ids: recordedEntities.entity_ids,
-    excluded_ids: Object.keys(hass.states).filter(
-      (id) => !recordedEntities.entity_ids.includes(id)
-    ),
-  };
-
-  return recordedExcludedEntitiesCache;
-};

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -6,7 +6,6 @@ import {
 } from "@mdi/js";
 import { ActionDetail } from "@material/mwc-list";
 import { differenceInHours } from "date-fns";
-import { HassEntity } from "home-assistant-js-websocket";
 import {
   HassServiceTarget,
   UnsubscribeFunc,
@@ -46,11 +45,7 @@ import {
   computeHistory,
   subscribeHistory,
 } from "../../data/history";
-import {
-  fetchStatistics,
-  Statistics,
-  getRecordedExcludedEntities,
-} from "../../data/recorder";
+import { Statistics, fetchStatistics } from "../../data/recorder";
 import {
   expandAreaTarget,
   expandDeviceTarget,
@@ -99,8 +94,6 @@ class HaPanelHistory extends LitElement {
   private _subscribed?: Promise<UnsubscribeFunc>;
 
   private _interval?: number;
-
-  private _excludedEntities?: string[];
 
   public constructor() {
     super();
@@ -192,7 +185,6 @@ class HaPanelHistory extends LitElement {
               .hass=${this.hass}
               .value=${this._targetPickerValue}
               .disabled=${this._isLoading}
-              .entityFilter=${this._entityFilter}
               addOnTop
               @value-changed=${this._targetsChanged}
             ></ha-target-picker>
@@ -218,10 +210,6 @@ class HaPanelHistory extends LitElement {
       </ha-top-app-bar-fixed>
     `;
   }
-
-  private _entityFilter = (entity: HassEntity): boolean =>
-    !this._excludedEntities ||
-    !this._excludedEntities.includes(entity.entity_id);
 
   private mergeHistoryResults(
     ltsResult: HistoryResult,
@@ -374,17 +362,8 @@ class HaPanelHistory extends LitElement {
     }
   }
 
-  private async _getRecordedExcludedEntities() {
-    const { recorded_ids: _recordedIds, excluded_ids: excludedIds } =
-      await getRecordedExcludedEntities(this.hass);
-    this._excludedEntities = excludedIds;
-  }
-
   protected firstUpdated(changedProps: PropertyValues) {
     super.firstUpdated(changedProps);
-
-    this._getRecordedExcludedEntities();
-
     const searchParams = extractSearchParamsObject();
     if (searchParams.back === "1" && history.length > 1) {
       this._showBack = true;


### PR DESCRIPTION
This reverts commit d88670034a7c272ec0b9ad545eff173a03f9a09c.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

After testing this some more, I've realized this feature has some subtle differences from how I initially thought it would work, and it makes me a bit uncomfortable with the implications. I'd like to consider dropping this change, but would like some extra opinions to see if my concerns are correct or not. 

How I initially thought this would work is that the API would return a list of the entities for which recording is enabled, _regardless_ of if they had any current recorded records at the time the request was made. 

The actual situation I've come to understand is that it only returns a list of entities which have at least one record in the database. This means that any entity which has not changed since the user's number of purge days will appear equivalent to an entity which has recording disabled, and be unselectable in the history picker. 

Since I cached the list, this also means that any entity that did not have a record at the time the API request was made, but subsequently changes and writes new records, will _still_ be unselectable in the history panel until the session ends; that seems possibly confusing. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified entity filter logic and initialization process in history panel.
  - Streamlined imports and removed unused properties in history panel.

- **Chores**
  - Removed deprecated interfaces and functions related to recorded entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->