### PR TITLE
Use event for section visibility instead of mutation observer

### DIFF
--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -26,6 +26,13 @@ import { parseLovelaceCardPath } from "../editor/lovelace-path";
 import { generateLovelaceSectionStrategy } from "../strategies/get-strategy";
 import type { Lovelace } from "../types";
 import { DEFAULT_SECTION_LAYOUT } from "./const";
+import { fireEvent } from "../../../common/dom/fire_event";
+
+declare global {
+  interface HASSDomEvents {
+    "section-visibility-changed": { value: boolean };
+  }
+}
 
 @customElement("hui-section")
 export class HuiSection extends ReactiveElement {
@@ -219,8 +226,12 @@ export class HuiSection extends ReactiveElement {
       !this.config.visibility ||
       checkConditionsMet(this.config.visibility, this.hass);
 
-    this.style.setProperty("display", visible ? "" : "none");
-    this.toggleAttribute("hidden", !visible);
+    if (this.hidden !== !visible) {
+      this.style.setProperty("display", visible ? "" : "none");
+      this.toggleAttribute("hidden", !visible);
+      fireEvent(this, "section-visibility-changed", { value: visible });
+    }
+
     if (!visible && this._layoutElement.parentElement) {
       this.removeChild(this._layoutElement);
     } else if (visible && !this._layoutElement.parentElement) {

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -54,29 +54,22 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
     return this._sectionConfigKeys.get(sectionConfig)!;
   }
 
-  private _sectionObserver?: MutationObserver;
-
   private _computeSectionsCount() {
     this._sectionCount = this.sections.filter(
       (section) => !section.hidden
     ).length;
   }
 
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.addEventListener("section-visibility-changed", () => {
+      this._computeSectionsCount();
+    });
+  }
+
   willUpdate(changedProperties: PropertyValues<typeof this>): void {
-    if (!this._sectionObserver) {
-      this._sectionObserver = new MutationObserver(() => {
-        this._computeSectionsCount();
-      });
-    }
     if (changedProperties.has("sections")) {
       this._computeSectionsCount();
-      this._sectionObserver.disconnect();
-      this.sections.forEach((section) => {
-        this._sectionObserver!.observe(section, {
-          attributes: true,
-          attributeFilter: ["hidden"],
-        });
-      });
     }
   }
 


### PR DESCRIPTION
## Proposed change

Use event for section visibility instead of mutation observer

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the `section-visibility-changed` event in the sections view, enhancing dynamic visibility tracking.
  
- **Refactor**
  - Simplified section visibility tracking by replacing `MutationObserver` with event listeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->