### PR TITLE
Fix automation picker overflow menu for keyboard

### DIFF
--- a/src/components/ha-menu-item.ts
+++ b/src/components/ha-menu-item.ts
@@ -1,9 +1,12 @@
 import { MdMenuItem } from "@material/web/menu/menu-item";
+import type { CloseMenuEvent } from "@material/web/menu/menu";
 import { css } from "lit";
-import { customElement } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 
 @customElement("ha-menu-item")
 export class HaMenuItem extends MdMenuItem {
+  @property() closeAction?: (ev: CloseMenuEvent) => void;
+
   static override styles = [
     ...super.styles,
     css`

--- a/src/components/ha-menu-item.ts
+++ b/src/components/ha-menu-item.ts
@@ -1,11 +1,10 @@
 import { MdMenuItem } from "@material/web/menu/menu-item";
-import type { CloseMenuEvent } from "@material/web/menu/menu";
 import { css } from "lit";
 import { customElement, property } from "lit/decorators";
 
 @customElement("ha-menu-item")
 export class HaMenuItem extends MdMenuItem {
-  @property() closeAction?: (ev: CloseMenuEvent) => void;
+  @property({ attribute: false }) clickAction?: (item?: HTMLElement) => void;
 
   static override styles = [
     ...super.styles,

--- a/src/components/ha-menu.ts
+++ b/src/components/ha-menu.ts
@@ -1,10 +1,12 @@
 import { MdMenu } from "@material/web/menu/menu";
+import type { CloseMenuEvent } from "@material/web/menu/menu";
 import {
   CloseReason,
   KeydownCloseKey,
 } from "@material/web/menu/internal/controllers/shared";
 import { css } from "lit";
 import { customElement } from "lit/decorators";
+import type { HaMenuItem } from "./ha-menu-item";
 
 @customElement("ha-menu")
 export class HaMenu extends MdMenu {
@@ -18,13 +20,13 @@ export class HaMenu extends MdMenu {
     this.removeEventListener("close-menu", this._handleCloseMenu);
   }
 
-  _handleCloseMenu(ev) {
+  private _handleCloseMenu(ev: CloseMenuEvent) {
     if (
       ev.detail.reason.kind === CloseReason.KEYDOWN &&
       ev.detail.reason.key === KeydownCloseKey.ESCAPE
     )
       return;
-    ev.target.closeAction?.(ev);
+    (ev.detail.initiator as HaMenuItem).closeAction?.(ev);
   }
 
   static override styles = [
@@ -40,5 +42,9 @@ export class HaMenu extends MdMenu {
 declare global {
   interface HTMLElementTagNameMap {
     "ha-menu": HaMenu;
+  }
+
+  interface HTMLElementEventMap {
+    "close-menu": CloseMenuEvent;
   }
 }

--- a/src/components/ha-menu.ts
+++ b/src/components/ha-menu.ts
@@ -15,11 +15,6 @@ export class HaMenu extends MdMenu {
     this.addEventListener("close-menu", this._handleCloseMenu);
   }
 
-  disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this.removeEventListener("close-menu", this._handleCloseMenu);
-  }
-
   private _handleCloseMenu(ev: CloseMenuEvent) {
     if (
       ev.detail.reason.kind === CloseReason.KEYDOWN &&

--- a/src/components/ha-menu.ts
+++ b/src/components/ha-menu.ts
@@ -1,9 +1,32 @@
 import { MdMenu } from "@material/web/menu/menu";
+import {
+  CloseReason,
+  KeydownCloseKey,
+} from "@material/web/menu/internal/controllers/shared";
 import { css } from "lit";
 import { customElement } from "lit/decorators";
 
 @customElement("ha-menu")
 export class HaMenu extends MdMenu {
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.addEventListener("close-menu", this._handleCloseMenu);
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.removeEventListener("close-menu", this._handleCloseMenu);
+  }
+
+  _handleCloseMenu(ev) {
+    if (
+      ev.detail.reason.kind === CloseReason.KEYDOWN &&
+      ev.detail.reason.key === KeydownCloseKey.ESCAPE
+    )
+      return;
+    ev.target.closeAction?.(ev);
+  }
+
   static override styles = [
     ...super.styles,
     css`

--- a/src/components/ha-menu.ts
+++ b/src/components/ha-menu.ts
@@ -19,9 +19,10 @@ export class HaMenu extends MdMenu {
     if (
       ev.detail.reason.kind === CloseReason.KEYDOWN &&
       ev.detail.reason.key === KeydownCloseKey.ESCAPE
-    )
+    ) {
       return;
-    (ev.detail.initiator as HaMenuItem).closeAction?.(ev);
+    }
+    (ev.detail.initiator as HaMenuItem).clickAction?.(ev.detail.initiator);
   }
 
   static override styles = [

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -822,8 +822,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
         </ha-fab>
       </hass-tabs-subpage-data-table>
       <ha-menu id="overflow-menu" positioning="fixed">
-        <ha-menu-item .action=${this._showInfo}
-          @close-menu=${this._handleMenuClose}>
+        <ha-menu-item .closeAction=${this._showInfo}>
           <ha-svg-icon
             .path=${mdiInformationOutline}
             slot="start"
@@ -833,8 +832,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
           </div>
         </ha-menu-item>
 
-        <ha-menu-item .action=${this._showSettings}
-          @close-menu=${this._handleMenuClose}>
+        <ha-menu-item .closeAction=${this._showSettings}>
           <ha-svg-icon .path=${mdiCog} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize(
@@ -842,8 +840,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
             )}
           </div>
         </ha-menu-item>
-        <ha-menu-item .action=${this._editCategory}
-          @close-menu=${this._handleMenuClose}>
+        <ha-menu-item .closeAction=${this._editCategory}>
           <ha-svg-icon .path=${mdiTag} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize(
@@ -851,15 +848,13 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
             )}
           </div>
         </ha-menu-item>
-        <ha-menu-item .action=${this._runActions}
-          @close-menu=${this._handleMenuClose}>
+        <ha-menu-item .closeAction=${this._runActions}>
           <ha-svg-icon .path=${mdiPlay} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize("ui.panel.config.automation.editor.run")}
           </div>
         </ha-menu-item>
-        <ha-menu-item .action=${this._showTrace}
-          @close-menu=${this._handleMenuClose}>
+        <ha-menu-item .closeAction=${this._showTrace}>
           <ha-svg-icon .path=${mdiTransitConnection} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize(
@@ -868,15 +863,13 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
           </div>
         </ha-menu-item>
         <md-divider role="separator" tabindex="-1"></md-divider>
-        <ha-menu-item .action=${this._duplicate}
-          @close-menu=${this._handleMenuClose}>
+        <ha-menu-item .closeAction=${this._duplicate}>
           <ha-svg-icon .path=${mdiContentDuplicate} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize("ui.panel.config.automation.picker.duplicate")}
           </div>
         </ha-menu-item>
-        <ha-menu-item .action=${this._toggle}
-          @close-menu=${this._handleMenuClose}>
+        <ha-menu-item .closeAction=${this._toggle}>
           <ha-svg-icon
             .path=${
               this._overflowAutomation?.state === "off"
@@ -895,8 +888,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
             }
           </div>
         </ha-menu-item>
-        <ha-menu-item .action=${this._deleteConfirm} class="warning"
-          @close-menu=${this._handleMenuClose}>
+        <ha-menu-item .closeAction=${this._deleteConfirm} class="warning">
           <ha-svg-icon .path=${mdiDelete} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize("ui.panel.config.automation.picker.delete")}
@@ -904,12 +896,6 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
         </ha-menu-item>
       </ha-menu>
     `;
-  }
-
-  private _handleMenuClose(ev) {
-    if (ev.detail.reason.key === "Escape") return;
-    const action = ev.currentTarget.action.bind(this);
-    action(ev);
   }
 
   protected updated(changedProps: PropertyValues) {
@@ -1065,28 +1051,28 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
     this._applyFilters();
   }
 
-  private _showInfo(ev) {
-    const automation = ev.currentTarget.parentElement.anchorElement.automation;
+  private _showInfo = (ev) => {
+    const automation = ev.currentTarget.anchorElement.automation;
     fireEvent(this, "hass-more-info", { entityId: automation.entity_id });
-  }
+  };
 
-  private _showSettings(ev) {
-    const automation = ev.currentTarget.parentElement.anchorElement.automation;
+  private _showSettings = (ev) => {
+    const automation = ev.currentTarget.anchorElement.automation;
 
     fireEvent(this, "hass-more-info", {
       entityId: automation.entity_id,
       view: "settings",
     });
-  }
+  };
 
-  private _runActions(ev) {
-    const automation = ev.currentTarget.parentElement.anchorElement.automation;
+  private _runActions = (ev) => {
+    const automation = ev.currentTarget.anchorElement.automation;
 
     triggerAutomationActions(this.hass, automation.entity_id);
-  }
+  };
 
-  private _editCategory(ev) {
-    const automation = ev.currentTarget.parentElement.anchorElement.automation;
+  private _editCategory = (ev) => {
+    const automation = ev.currentTarget.anchorElement.automation;
 
     const entityReg = this._entityReg.find(
       (reg) => reg.entity_id === automation.entity_id
@@ -1106,10 +1092,10 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
       scope: "automation",
       entityReg,
     });
-  }
+  };
 
-  private _showTrace(ev) {
-    const automation = ev.currentTarget.parentElement.anchorElement.automation;
+  private _showTrace = (ev) => {
+    const automation = ev.currentTarget.anchorElement.automation;
 
     if (!automation.attributes.id) {
       showAlertDialog(this, {
@@ -1122,19 +1108,19 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
     navigate(
       `/config/automation/trace/${encodeURIComponent(automation.attributes.id)}`
     );
-  }
+  };
 
-  private async _toggle(ev): Promise<void> {
-    const automation = ev.currentTarget.parentElement.anchorElement.automation;
+  private _toggle = async (ev): Promise<void> => {
+    const automation = ev.currentTarget.anchorElement.automation;
 
     const service = automation.state === "off" ? "turn_on" : "turn_off";
     await this.hass.callService("automation", service, {
       entity_id: automation.entity_id,
     });
-  }
+  };
 
-  private async _deleteConfirm(ev) {
-    const automation = ev.currentTarget.parentElement.anchorElement.automation;
+  private _deleteConfirm = async (ev) => {
+    const automation = ev.currentTarget.anchorElement.automation;
 
     showConfirmationDialog(this, {
       title: this.hass.localize(
@@ -1149,7 +1135,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
       confirm: () => this._delete(automation),
       destructive: true,
     });
-  }
+  };
 
   private async _delete(automation) {
     try {
@@ -1169,8 +1155,8 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
     }
   }
 
-  private async _duplicate(ev) {
-    const automation = ev.currentTarget.parentElement.anchorElement.automation;
+  private _duplicate = async (ev) => {
+    const automation = ev.currentTarget.anchorElement.automation;
 
     try {
       const config = await fetchAutomationFileConfig(
@@ -1194,7 +1180,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
         ),
       });
     }
-  }
+  };
 
   private _showHelp() {
     showAlertDialog(this, {

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -822,7 +822,8 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
         </ha-fab>
       </hass-tabs-subpage-data-table>
       <ha-menu id="overflow-menu" positioning="fixed">
-        <ha-menu-item @click=${this._showInfo}>
+        <ha-menu-item .action=${this._showInfo}
+          @close-menu=${this._handleMenuClose}>
           <ha-svg-icon
             .path=${mdiInformationOutline}
             slot="start"
@@ -832,7 +833,8 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
           </div>
         </ha-menu-item>
 
-        <ha-menu-item @click=${this._showSettings}>
+        <ha-menu-item .action=${this._showSettings}
+          @close-menu=${this._handleMenuClose}>
           <ha-svg-icon .path=${mdiCog} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize(
@@ -840,7 +842,8 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
             )}
           </div>
         </ha-menu-item>
-        <ha-menu-item @click=${this._editCategory}>
+        <ha-menu-item .action=${this._editCategory}
+          @close-menu=${this._handleMenuClose}>
           <ha-svg-icon .path=${mdiTag} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize(
@@ -848,13 +851,15 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
             )}
           </div>
         </ha-menu-item>
-        <ha-menu-item @click=${this._runActions}>
+        <ha-menu-item .action=${this._runActions}
+          @close-menu=${this._handleMenuClose}>
           <ha-svg-icon .path=${mdiPlay} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize("ui.panel.config.automation.editor.run")}
           </div>
         </ha-menu-item>
-        <ha-menu-item @click=${this._showTrace}>
+        <ha-menu-item .action=${this._showTrace}
+          @close-menu=${this._handleMenuClose}>
           <ha-svg-icon .path=${mdiTransitConnection} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize(
@@ -863,13 +868,15 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
           </div>
         </ha-menu-item>
         <md-divider role="separator" tabindex="-1"></md-divider>
-        <ha-menu-item @click=${this._duplicate}>
+        <ha-menu-item .action=${this._duplicate}
+          @close-menu=${this._handleMenuClose}>
           <ha-svg-icon .path=${mdiContentDuplicate} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize("ui.panel.config.automation.picker.duplicate")}
           </div>
         </ha-menu-item>
-        <ha-menu-item @click=${this._toggle}>
+        <ha-menu-item .action=${this._toggle}
+          @close-menu=${this._handleMenuClose}>
           <ha-svg-icon
             .path=${
               this._overflowAutomation?.state === "off"
@@ -888,7 +895,8 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
             }
           </div>
         </ha-menu-item>
-        <ha-menu-item @click=${this._deleteConfirm} class="warning">
+        <ha-menu-item .action=${this._deleteConfirm} class="warning"
+          @close-menu=${this._handleMenuClose}>
           <ha-svg-icon .path=${mdiDelete} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize("ui.panel.config.automation.picker.delete")}
@@ -896,6 +904,12 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
         </ha-menu-item>
       </ha-menu>
     `;
+  }
+
+  private _handleMenuClose(ev) {
+    if (ev.detail.reason.key === "Escape") return;
+    const action = ev.currentTarget.action.bind(this);
+    action(ev);
   }
 
   protected updated(changedProps: PropertyValues) {

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -68,6 +68,7 @@ import "../../../components/ha-icon-overflow-menu";
 import "../../../components/ha-menu";
 import type { HaMenu } from "../../../components/ha-menu";
 import "../../../components/ha-menu-item";
+import type { HaMenuItem } from "../../../components/ha-menu-item";
 import "../../../components/ha-sub-menu";
 import "../../../components/ha-svg-icon";
 import { createAreaRegistryEntry } from "../../../data/area_registry";
@@ -822,7 +823,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
         </ha-fab>
       </hass-tabs-subpage-data-table>
       <ha-menu id="overflow-menu" positioning="fixed">
-        <ha-menu-item .closeAction=${this._showInfo}>
+        <ha-menu-item .clickAction=${this._showInfo}>
           <ha-svg-icon
             .path=${mdiInformationOutline}
             slot="start"
@@ -832,7 +833,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
           </div>
         </ha-menu-item>
 
-        <ha-menu-item .closeAction=${this._showSettings}>
+        <ha-menu-item .clickAction=${this._showSettings}>
           <ha-svg-icon .path=${mdiCog} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize(
@@ -840,7 +841,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
             )}
           </div>
         </ha-menu-item>
-        <ha-menu-item .closeAction=${this._editCategory}>
+        <ha-menu-item .clickAction=${this._editCategory}>
           <ha-svg-icon .path=${mdiTag} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize(
@@ -848,13 +849,13 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
             )}
           </div>
         </ha-menu-item>
-        <ha-menu-item .closeAction=${this._runActions}>
+        <ha-menu-item .clickAction=${this._runActions}>
           <ha-svg-icon .path=${mdiPlay} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize("ui.panel.config.automation.editor.run")}
           </div>
         </ha-menu-item>
-        <ha-menu-item .closeAction=${this._showTrace}>
+        <ha-menu-item .clickAction=${this._showTrace}>
           <ha-svg-icon .path=${mdiTransitConnection} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize(
@@ -863,13 +864,13 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
           </div>
         </ha-menu-item>
         <md-divider role="separator" tabindex="-1"></md-divider>
-        <ha-menu-item .closeAction=${this._duplicate}>
+        <ha-menu-item .clickAction=${this._duplicate}>
           <ha-svg-icon .path=${mdiContentDuplicate} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize("ui.panel.config.automation.picker.duplicate")}
           </div>
         </ha-menu-item>
-        <ha-menu-item .closeAction=${this._toggle}>
+        <ha-menu-item .clickAction=${this._toggle}>
           <ha-svg-icon
             .path=${
               this._overflowAutomation?.state === "off"
@@ -888,7 +889,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
             }
           </div>
         </ha-menu-item>
-        <ha-menu-item .closeAction=${this._deleteConfirm} class="warning">
+        <ha-menu-item .clickAction=${this._deleteConfirm} class="warning">
           <ha-svg-icon .path=${mdiDelete} slot="start"></ha-svg-icon>
           <div slot="headline">
             ${this.hass.localize("ui.panel.config.automation.picker.delete")}
@@ -1051,13 +1052,15 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
     this._applyFilters();
   }
 
-  private _showInfo = (ev) => {
-    const automation = ev.currentTarget.anchorElement.automation;
+  private _showInfo = (item: HaMenuItem) => {
+    const automation = ((item.parentElement as HaMenu)!.anchorElement as any)!
+      .automation;
     fireEvent(this, "hass-more-info", { entityId: automation.entity_id });
   };
 
-  private _showSettings = (ev) => {
-    const automation = ev.currentTarget.anchorElement.automation;
+  private _showSettings = (item: HaMenuItem) => {
+    const automation = ((item.parentElement as HaMenu)!.anchorElement as any)!
+      .automation;
 
     fireEvent(this, "hass-more-info", {
       entityId: automation.entity_id,
@@ -1065,14 +1068,16 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
     });
   };
 
-  private _runActions = (ev) => {
-    const automation = ev.currentTarget.anchorElement.automation;
+  private _runActions = (item: HaMenuItem) => {
+    const automation = ((item.parentElement as HaMenu)!.anchorElement as any)!
+      .automation;
 
     triggerAutomationActions(this.hass, automation.entity_id);
   };
 
-  private _editCategory = (ev) => {
-    const automation = ev.currentTarget.anchorElement.automation;
+  private _editCategory = (item: HaMenuItem) => {
+    const automation = ((item.parentElement as HaMenu)!.anchorElement as any)!
+      .automation;
 
     const entityReg = this._entityReg.find(
       (reg) => reg.entity_id === automation.entity_id
@@ -1094,8 +1099,9 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
     });
   };
 
-  private _showTrace = (ev) => {
-    const automation = ev.currentTarget.anchorElement.automation;
+  private _showTrace = (item: HaMenuItem) => {
+    const automation = ((item.parentElement as HaMenu)!.anchorElement as any)!
+      .automation;
 
     if (!automation.attributes.id) {
       showAlertDialog(this, {
@@ -1110,8 +1116,9 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
     );
   };
 
-  private _toggle = async (ev): Promise<void> => {
-    const automation = ev.currentTarget.anchorElement.automation;
+  private _toggle = async (item: HaMenuItem): Promise<void> => {
+    const automation = ((item.parentElement as HaMenu)!.anchorElement as any)!
+      .automation;
 
     const service = automation.state === "off" ? "turn_on" : "turn_off";
     await this.hass.callService("automation", service, {
@@ -1119,8 +1126,9 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
     });
   };
 
-  private _deleteConfirm = async (ev) => {
-    const automation = ev.currentTarget.anchorElement.automation;
+  private _deleteConfirm = async (item: HaMenuItem) => {
+    const automation = ((item.parentElement as HaMenu)!.anchorElement as any)!
+      .automation;
 
     showConfirmationDialog(this, {
       title: this.hass.localize(
@@ -1155,8 +1163,9 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
     }
   }
 
-  private _duplicate = async (ev) => {
-    const automation = ev.currentTarget.anchorElement.automation;
+  private _duplicate = async (item: HaMenuItem) => {
+    const automation = ((item.parentElement as HaMenu)!.anchorElement as any)!
+      .automation;
 
     try {
       const config = await fetchAutomationFileConfig(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The current overflow menu in a lot of the new data tables cannot be used with the keyboard, as far as I can tell. Both enter or space close the menu without doing anything, neither of them trigger the click event. That seems like it is only triggered for `<a>` links, and only for Enter. 

Just reading https://material-web.dev/components/menu/ it seems like maybe `@close-event` could be a reasonable event to use instead of `@click` so it can have keyboard support? The only drawback is it is also triggered by the escape key, which I've added a helper event to prevent actions on that. 

I'm not clear if this is intentional behavior of md-menu-item, could be slightly related to issue 5577 from github.com/material-components/material-web,  but I'm not sure if a fix there would necessarily fix this either. 

There are many menus that are affected by this, but I'll just start with this one to discuss a good pattern for a solution. 



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #21028
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added event listeners to handle `close-menu` events in the navigation menu.
  - Introduced a `clickAction` property for custom actions in menu items.

- **Improvements**
  - Enhanced clarity and context maintenance in automation picker by replacing direct event handlers with arrow functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->