### PR TITLE
Adjust schedule helper UI with minute granularity

### DIFF
--- a/src/components/ha-selector/ha-selector-time.ts
+++ b/src/components/ha-selector/ha-selector-time.ts
@@ -29,7 +29,7 @@ export class HaTimeSelector extends LitElement {
         .required=${this.required}
         .helper=${this.helper}
         .label=${this.label}
-        enable-second
+        .enableSecond=${!this.selector.time?.no_second}
       ></ha-time-input>
     `;
   }

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -425,8 +425,7 @@ export interface ThemeSelector {
   theme: { include_default?: boolean } | null;
 }
 export interface TimeSelector {
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  time: {} | null;
+  time: { no_second?: boolean } | null;
 }
 
 export interface TriggerSelector {

--- a/src/panels/config/helpers/forms/dialog-schedule-block-info.ts
+++ b/src/panels/config/helpers/forms/dialog-schedule-block-info.ts
@@ -1,9 +1,9 @@
-import "@material/mwc-button";
 import { CSSResultGroup, html, LitElement, nothing } from "lit";
 import { property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { createCloseHeading } from "../../../../components/ha-dialog";
 import "../../../../components/ha-form/ha-form";
+import "../../../../components/ha-button";
 import { haStyleDialog } from "../../../../resources/styles";
 import { HomeAssistant } from "../../../../types";
 import {
@@ -72,16 +72,16 @@ class DialogScheduleBlockInfo extends LitElement {
             @value-changed=${this._valueChanged}
           ></ha-form>
         </div>
-        <mwc-button
+        <ha-button
           slot="secondaryAction"
           class="warning"
           @click=${this._deleteBlock}
         >
           ${this.hass!.localize("ui.common.delete")}
-        </mwc-button>
-        <mwc-button slot="primaryAction" @click=${this._updateBlock}>
+        </ha-button>
+        <ha-button slot="primaryAction" @click=${this._updateBlock}>
           ${this.hass!.localize("ui.common.save")}
-        </mwc-button>
+        </ha-button>
       </ha-dialog>
     `;
   }

--- a/src/panels/config/helpers/forms/dialog-schedule-block-info.ts
+++ b/src/panels/config/helpers/forms/dialog-schedule-block-info.ts
@@ -1,0 +1,133 @@
+import "@material/mwc-button";
+import { CSSResultGroup, html, LitElement, nothing } from "lit";
+import { property, state } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import { createCloseHeading } from "../../../../components/ha-dialog";
+import "../../../../components/ha-form/ha-form";
+import { haStyleDialog } from "../../../../resources/styles";
+import { HomeAssistant } from "../../../../types";
+import {
+  ScheduleBlockInfo,
+  ScheduleBlockInfoDialogParams,
+} from "./show-dialog-schedule-block-info";
+import type { SchemaUnion } from "../../../../components/ha-form/types";
+
+const SCHEMA = [
+  {
+    name: "from",
+    required: true,
+    selector: { time: { no_second: true } },
+  },
+  {
+    name: "to",
+    required: true,
+    selector: { time: { no_second: true } },
+  },
+];
+
+class DialogScheduleBlockInfo extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _error?: Record<string, string>;
+
+  @state() private _data?: ScheduleBlockInfo;
+
+  @state() private _params?: ScheduleBlockInfoDialogParams;
+
+  public showDialog(params: ScheduleBlockInfoDialogParams): void {
+    this._params = params;
+    this._error = undefined;
+    this._data = params.block;
+  }
+
+  public closeDialog(): void {
+    this._params = undefined;
+    this._data = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render() {
+    if (!this._params || !this._data) {
+      return nothing;
+    }
+
+    return html`
+      <ha-dialog
+        open
+        @closed=${this.closeDialog}
+        .heading=${createCloseHeading(
+          this.hass,
+          this.hass!.localize(
+            "ui.dialogs.helper_settings.schedule.edit_schedule_block"
+          )
+        )}
+      >
+        <div>
+          <ha-form
+            .hass=${this.hass}
+            .schema=${SCHEMA}
+            .data=${this._data}
+            .error=${this._error}
+            .computeLabel=${this._computeLabelCallback}
+            @value-changed=${this._valueChanged}
+          ></ha-form>
+        </div>
+        <mwc-button
+          slot="secondaryAction"
+          class="warning"
+          @click=${this._deleteBlock}
+        >
+          ${this.hass!.localize("ui.common.delete")}
+        </mwc-button>
+        <mwc-button slot="primaryAction" @click=${this._updateBlock}>
+          ${this.hass!.localize("ui.common.save")}
+        </mwc-button>
+      </ha-dialog>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent) {
+    this._error = undefined;
+    this._data = ev.detail.value;
+  }
+
+  private _updateBlock() {
+    try {
+      this._params!.updateBlock!(this._data!);
+      this.closeDialog();
+    } catch (err: any) {
+      this._error = { base: err ? err.message : "Unknown error" };
+    }
+  }
+
+  private _deleteBlock() {
+    try {
+      this._params!.deleteBlock!();
+      this.closeDialog();
+    } catch (err: any) {
+      this._error = { base: err ? err.message : "Unknown error" };
+    }
+  }
+
+  private _computeLabelCallback = (schema: SchemaUnion<typeof SCHEMA>) => {
+    switch (schema.name) {
+      case "from":
+        return this.hass!.localize("ui.dialogs.helper_settings.schedule.start");
+      case "to":
+        return this.hass!.localize("ui.dialogs.helper_settings.schedule.end");
+    }
+    return "";
+  };
+
+  static get styles(): CSSResultGroup {
+    return [haStyleDialog];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-schedule-block-info": DialogScheduleBlockInfo;
+  }
+}
+
+customElements.define("dialog-schedule-block-info", DialogScheduleBlockInfo);

--- a/src/panels/config/helpers/forms/show-dialog-schedule-block-info.ts
+++ b/src/panels/config/helpers/forms/show-dialog-schedule-block-info.ts
@@ -1,0 +1,26 @@
+import { fireEvent } from "../../../../common/dom/fire_event";
+
+export interface ScheduleBlockInfo {
+  from: string;
+  to: string;
+}
+
+export interface ScheduleBlockInfoDialogParams {
+  block: ScheduleBlockInfo;
+  updateBlock?: (update: ScheduleBlockInfo) => void;
+  deleteBlock?: () => void;
+}
+
+export const loadScheduleBlockInfoDialog = () =>
+  import("./dialog-schedule-block-info");
+
+export const showScheduleBlockInfoDialog = (
+  element: HTMLElement,
+  params: ScheduleBlockInfoDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-schedule-block-info",
+    dialogImport: loadScheduleBlockInfoDialog,
+    dialogParams: params,
+  });
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1511,7 +1511,7 @@
         "schedule": {
           "delete": "Delete item?",
           "confirm_delete": "Do you want to delete this item?",
-          "edit_schedule_block": "Edit Schedule Block",
+          "edit_schedule_block": "Edit schedule block",
           "start": "Start",
           "end": "End"
         },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1510,7 +1510,10 @@
         },
         "schedule": {
           "delete": "Delete item?",
-          "confirm_delete": "Do you want to delete this item?"
+          "confirm_delete": "Do you want to delete this item?",
+          "edit_schedule_block": "Edit Schedule Block",
+          "start": "Start",
+          "end": "End"
         },
         "template": {
           "time": "[%key:ui::panel::developer-tools::tabs::templates::time%]",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
When selecting items in the schedule helper, offer ability to adjust with minute-granularity. 

Some caveats:
 - adjusting individual blocks doesn't really do any error checking, this is delegated to when the user ultimately clicks update in more-info and we get the backend response for invalid settings (end < start, or overlapping blocks). I could duplicate the error checking but not sure if it is necessary. Timegrid seems to handle this all fine so it doesn't break the UI and is easily recoverable. 
 
 
 - Pressing `Escape` in the edit block dialog closes both that and the more-info at the same time, which is not desired, but I didn't discover a way to prevent it (didn't look that hard though). 

![image](https://github.com/home-assistant/frontend/assets/32912880/650788b1-49ea-45ef-9c69-1437debce2ae)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://community.home-assistant.io/t/weekly-schedule-helper-improvements/458472
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dialog component for editing and managing schedule block information, allowing users to specify time ranges, update, and delete blocks.
  - Added new translations for editing schedule blocks and defining start and end times to enhance the UI for schedule management.

- **Updates**
  - Updated time selector to support a new property that allows hiding seconds in the time selection.
  - Improved event handling in the schedule form to show a new dialog for managing schedule blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->