### PR TITLE
Fix device integration filter for entityless devices

### DIFF
--- a/src/components/ha-selector/ha-selector-area.ts
+++ b/src/components/ha-selector/ha-selector-area.ts
@@ -11,6 +11,7 @@ import {
   fetchEntitySourcesWithCache,
 } from "../../data/entity_sources";
 import type { AreaSelector } from "../../data/selector";
+import { ConfigEntry, getConfigEntries } from "../../data/config_entries";
 import {
   filterSelectorDevices,
   filterSelectorEntities,
@@ -36,6 +37,8 @@ export class HaAreaSelector extends LitElement {
   @property({ type: Boolean }) public required = true;
 
   @state() private _entitySources?: EntitySources;
+
+  @state() private _configEntries?: ConfigEntry[];
 
   private _deviceIntegrationLookup = memoizeOne(getDeviceIntegrationLookup);
 
@@ -70,6 +73,12 @@ export class HaAreaSelector extends LitElement {
     ) {
       fetchEntitySourcesWithCache(this.hass).then((sources) => {
         this._entitySources = sources;
+      });
+    }
+    if (!this._configEntries && this._hasIntegration(this.selector)) {
+      this._configEntries = [];
+      getConfigEntries(this.hass).then((entries) => {
+        this._configEntries = entries;
       });
     }
   }
@@ -136,7 +145,9 @@ export class HaAreaSelector extends LitElement {
     const deviceIntegrations = this._entitySources
       ? this._deviceIntegrationLookup(
           this._entitySources,
-          Object.values(this.hass.entities)
+          Object.values(this.hass.entities),
+          Object.values(this.hass.devices),
+          this._configEntries
         )
       : undefined;
 

--- a/src/components/ha-selector/ha-selector-device.ts
+++ b/src/components/ha-selector/ha-selector-device.ts
@@ -11,6 +11,7 @@ import {
   fetchEntitySourcesWithCache,
 } from "../../data/entity_sources";
 import type { DeviceSelector } from "../../data/selector";
+import { ConfigEntry, getConfigEntries } from "../../data/config_entries";
 import {
   filterSelectorDevices,
   filterSelectorEntities,
@@ -26,6 +27,8 @@ export class HaDeviceSelector extends LitElement {
   @property({ attribute: false }) public selector!: DeviceSelector;
 
   @state() private _entitySources?: EntitySources;
+
+  @state() private _configEntries?: ConfigEntry[];
 
   @property() public value?: any;
 
@@ -73,6 +76,12 @@ export class HaDeviceSelector extends LitElement {
     ) {
       fetchEntitySourcesWithCache(this.hass).then((sources) => {
         this._entitySources = sources;
+      });
+    }
+    if (!this._configEntries && this._hasIntegration(this.selector)) {
+      this._configEntries = [];
+      getConfigEntries(this.hass).then((entries) => {
+        this._configEntries = entries;
       });
     }
   }
@@ -123,7 +132,9 @@ export class HaDeviceSelector extends LitElement {
     const deviceIntegrations = this._entitySources
       ? this._deviceIntegrationLookup(
           this._entitySources,
-          Object.values(this.hass.entities)
+          Object.values(this.hass.entities),
+          Object.values(this.hass.devices),
+          this._configEntries
         )
       : undefined;
 

--- a/src/components/ha-selector/ha-selector-floor.ts
+++ b/src/components/ha-selector/ha-selector-floor.ts
@@ -11,6 +11,7 @@ import {
   fetchEntitySourcesWithCache,
 } from "../../data/entity_sources";
 import type { FloorSelector } from "../../data/selector";
+import { ConfigEntry, getConfigEntries } from "../../data/config_entries";
 import {
   filterSelectorDevices,
   filterSelectorEntities,
@@ -36,6 +37,8 @@ export class HaFloorSelector extends LitElement {
   @property({ type: Boolean }) public required = true;
 
   @state() private _entitySources?: EntitySources;
+
+  @state() private _configEntries?: ConfigEntry[];
 
   private _deviceIntegrationLookup = memoizeOne(getDeviceIntegrationLookup);
 
@@ -70,6 +73,12 @@ export class HaFloorSelector extends LitElement {
     ) {
       fetchEntitySourcesWithCache(this.hass).then((sources) => {
         this._entitySources = sources;
+      });
+    }
+    if (!this._configEntries && this._hasIntegration(this.selector)) {
+      this._configEntries = [];
+      getConfigEntries(this.hass).then((entries) => {
+        this._configEntries = entries;
       });
     }
   }
@@ -136,7 +145,9 @@ export class HaFloorSelector extends LitElement {
     const deviceIntegrations = this._entitySources
       ? this._deviceIntegrationLookup(
           this._entitySources,
-          Object.values(this.hass.entities)
+          Object.values(this.hass.entities),
+          Object.values(this.hass.devices),
+          this._configEntries
         )
       : undefined;
 

--- a/src/data/device_registry.ts
+++ b/src/data/device_registry.ts
@@ -146,8 +146,8 @@ export const getDeviceIntegrationLookup = (
   entities: EntityRegistryDisplayEntry[] | EntityRegistryEntry[],
   devices?: DeviceRegistryEntry[],
   configEntries?: ConfigEntry[]
-): Record<string, string[]> => {
-  const deviceIntegrations: Record<string, string[]> = {};
+): Record<string, Set<string>> => {
+  const deviceIntegrations: Record<string, Set<string>> = {};
 
   for (const entity of entities) {
     const source = entitySources[entity.entity_id];
@@ -155,25 +155,19 @@ export const getDeviceIntegrationLookup = (
       continue;
     }
 
-    if (!deviceIntegrations[entity.device_id!]) {
-      deviceIntegrations[entity.device_id!] = [];
-    }
-    deviceIntegrations[entity.device_id!].push(source.domain);
+    deviceIntegrations[entity.device_id!] =
+      deviceIntegrations[entity.device_id!] || new Set<string>();
+    deviceIntegrations[entity.device_id!].add(source.domain);
   }
   // Lookup devices that have no entities
   if (devices && configEntries) {
     for (const device of devices) {
-      if (!deviceIntegrations[device.id]) {
-        for (const config_entry_id of device.config_entries) {
-          const entry = configEntries.find(
-            (e) => e.entry_id === config_entry_id
-          );
-          if (entry?.domain) {
-            (
-              deviceIntegrations[device.id] ||
-              (deviceIntegrations[device.id] = [])
-            ).push(entry.domain);
-          }
+      for (const config_entry_id of device.config_entries) {
+        const entry = configEntries.find((e) => e.entry_id === config_entry_id);
+        if (entry?.domain) {
+          deviceIntegrations[device.id] =
+            deviceIntegrations[device.id] || new Set<string>();
+          deviceIntegrations[device.id].add(entry.domain);
         }
       }
     }

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -696,7 +696,7 @@ export const entityMeetsTargetSelector = (
 export const filterSelectorDevices = (
   filterDevice: DeviceSelectorFilter,
   device: DeviceRegistryEntry,
-  deviceIntegrationLookup?: Record<string, string[]> | undefined
+  deviceIntegrationLookup?: Record<string, Set<string>> | undefined
 ): boolean => {
   const {
     manufacturer: filterManufacturer,
@@ -713,7 +713,7 @@ export const filterSelectorDevices = (
   }
 
   if (filterIntegration && deviceIntegrationLookup) {
-    if (!deviceIntegrationLookup?.[device.id]?.includes(filterIntegration)) {
+    if (!deviceIntegrationLookup?.[device.id]?.has(filterIntegration)) {
       return false;
     }
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The current way we lookup device integrations is to use a core command to get the integration for every entity, and then check all the entities of a device, and then map the integrations of those entities to the device. 

This does not work for devices without entities, as per #21060. This change leverages the config registry to get all the config entries when needed, and then checks the config entries for a device and gets the domains from there. 

I'm not confident if this method should be used _in addition to_ the existing per entity lookup, or if it can entirely replace the old method. Not sure if devices can have multiple domains or can have entities from different domains. So to be safe I just added this check in addition to the previous check, so it just adds more possible integrations that a device can be associated with. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #21060
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced area, device, and floor selectors to include configuration entries for improved integration.

- **Bug Fixes**
	- Improved device lookup reliability by using more robust data structures and methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->