### PR TITLE
Fix icon header labels in Automations, Scene and Script tables

### DIFF
--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -265,7 +265,7 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
       const columns: DataTableColumnContainer<AutomationItem> = {
         icon: {
           title: "",
-          label: localize("ui.panel.config.automation.picker.headers.state"),
+          label: localize("ui.panel.config.automation.picker.headers.icon"),
           type: "icon",
           moveable: false,
           showNarrow: true,

--- a/src/panels/config/scene/ha-scene-dashboard.ts
+++ b/src/panels/config/scene/ha-scene-dashboard.ts
@@ -243,7 +243,7 @@ class HaSceneDashboard extends SubscribeMixin(LitElement) {
       const columns: DataTableColumnContainer<SceneItem> = {
         icon: {
           title: "",
-          label: localize("ui.panel.config.scene.picker.headers.state"),
+          label: localize("ui.panel.config.scene.picker.headers.icon"),
           moveable: false,
           showNarrow: true,
           type: "icon",

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -252,7 +252,7 @@ class HaScriptPicker extends SubscribeMixin(LitElement) {
           title: "",
           showNarrow: true,
           moveable: false,
-          label: localize("ui.panel.config.script.picker.headers.state"),
+          label: localize("ui.panel.config.script.picker.headers.icon"),
           type: "icon",
           template: (script) =>
             html`<ha-state-icon

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2733,7 +2733,8 @@
               "actions": "Actions",
               "state": "State",
               "category": "Category",
-              "area": "Area"
+              "area": "Area",
+              "icon": "Icon"
             },
             "bulk_action": "Action",
             "bulk_actions": {
@@ -3608,7 +3609,8 @@
               "name": "Name",
               "state": "State",
               "category": "Category",
-              "area": "Area"
+              "area": "Area",
+              "icon": "Icon"
             },
             "edit_category": "[%key:ui::panel::config::automation::picker::edit_category%]",
             "assign_category": "[%key:ui::panel::config::automation::picker::assign_category%]",
@@ -3727,7 +3729,8 @@
               "name": "Name",
               "last_activated": "Last activated",
               "category": "Category",
-              "area": "Area"
+              "area": "Area",
+              "icon": "Icon"
             },
             "edit_category": "[%key:ui::panel::config::automation::picker::edit_category%]",
             "assign_category": "[%key:ui::panel::config::automation::picker::assign_category%]",


### PR DESCRIPTION
## Proposed change

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #21199
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Updated labels in the automation, scene, and script pickers from "state" to "icon" for better clarity.
  - Improved UI configuration translations by adding the term "Icon" for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->