### PR TITLE
Add credential to user after creation

### DIFF
--- a/src/panels/config/users/dialog-add-user.ts
+++ b/src/panels/config/users/dialog-add-user.ts
@@ -290,6 +290,11 @@ export class DialogAddUser extends LitElement {
     }
 
     user.username = this._username;
+    user.credentials = [
+      {
+        type: "homeassistant",
+      },
+    ];
     this._params!.userAddedCallback(user);
     this._close();
   }


### PR DESCRIPTION
## Proposed change

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #21208
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced user creation dialog to automatically set user credentials type to "homeassistant," ensuring proper integration with Home Assistant services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->