### PR TITLE
Fix Webpack bundling of recorder worklet

### DIFF
--- a/src/util/audio-recorder.ts
+++ b/src/util/audio-recorder.ts
@@ -70,17 +70,18 @@ export class AudioRecorder {
   }
 
   private async _createContext() {
-    // @ts-ignore-next-line
-    this._context = new (window.AudioContext || window.webkitAudioContext)();
+    // @ts-expect-error webkitAudioContext is not recognized
+    const context = new (AudioContext || webkitAudioContext)();
     this._stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-
-    await this._context.audioWorklet.addModule(
-      new URL("./recorder.worklet.js", import.meta.url)
+    // Syntax here must match an item of `parser.worker` in Webpack config nin
+    // order for module to be parsed and a chunk to be properly created.
+    await context.audioWorklet.addModule(
+      /* webpackChunkName: "recorder-worklet" */
+      new URL("./recorder-worklet.js", import.meta.url)
     );
-
+    this._context = context;
     this._source = this._context.createMediaStreamSource(this._stream);
-    this._recorder = new AudioWorkletNode(this._context, "recorder.worklet");
-
+    this._recorder = new AudioWorkletNode(this._context, "recorder-worklet");
     this._recorder.port.onmessage = (e) => {
       if (!this._active) {
         return;

--- a/src/util/audio-recorder.ts
+++ b/src/util/audio-recorder.ts
@@ -73,7 +73,7 @@ export class AudioRecorder {
     // @ts-expect-error webkitAudioContext is not recognized
     const context = new (AudioContext || webkitAudioContext)();
     this._stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    // Syntax here must match an item of `parser.worker` in Webpack config nin
+    // Syntax here must match an item of `parser.worker` in Webpack config in
     // order for module to be parsed and a chunk to be properly created.
     await context.audioWorklet.addModule(
       /* webpackChunkName: "recorder-worklet" */

--- a/src/util/recorder-worklet.js
+++ b/src/util/recorder-worklet.js
@@ -18,4 +18,4 @@ class RecorderProcessor extends AudioWorkletProcessor {
   }
 }
 
-registerProcessor("recorder.worklet", RecorderProcessor);
+registerProcessor("recorder-worklet", RecorderProcessor);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Webpack is not currently parsing the audio recorder worklet for imports or creating a proper chunk.  It happened to work prior to #20676 for the modern build because there were luckily no imports of polyfills or Babel helpers.  The legacy version never could have worked.

This adjusts the code which adds the worklet and the Webpack config to fix that problem.  Also, it keeps the worklet from splitting because of several bugs in Webpack related to loading any external chunks.  The worklet is small enough that this doesn't really matter.

So this fixes the regression for the modern build and also gets it working for the legacy build.  A follow up could better transpile the worklet similar to #21177 and also implement better feature detection instead of a try/catch.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #21234 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio recording reliability by updating the `AudioRecorder` context creation logic and module loading syntax.

- **Refactor**
  - Streamlined webpack configuration for better support of web workers and worklets, enhancing overall build performance.

- **Style**
  - Updated naming conventions for audio worklet processors to ensure consistency and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->