### PR TITLE
Add min/max row/columns to resize card editor

### DIFF
--- a/src/components/ha-grid-size-picker.ts
+++ b/src/components/ha-grid-size-picker.ts
@@ -42,6 +42,14 @@ export class HaGridSizeEditor extends LitElement {
   }
 
   protected render() {
+    const disabledColumns =
+      this.columnMin !== undefined &&
+      this.columnMin !== undefined &&
+      this.columnMin === this.columnMax;
+    const disabledRows =
+      this.rowMin !== undefined &&
+      this.rowMin !== undefined &&
+      this.rowMin === this.rowMax;
     return html`
       <div class="grid">
         <ha-grid-layout-slider
@@ -55,6 +63,7 @@ export class HaGridSizeEditor extends LitElement {
           .value=${this.value?.columns}
           @value-changed=${this._valueChanged}
           @slider-moved=${this._sliderMoved}
+          .disabled=${disabledColumns}
         ></ha-grid-layout-slider>
         <ha-grid-layout-slider
           aria-label=${this.hass.localize(
@@ -68,6 +77,7 @@ export class HaGridSizeEditor extends LitElement {
           .value=${this.value?.rows}
           @value-changed=${this._valueChanged}
           @slider-moved=${this._sliderMoved}
+          .disabled=${disabledRows}
         ></ha-grid-layout-slider>
         ${!this.isDefault
           ? html`

--- a/src/components/ha-grid-size-picker.ts
+++ b/src/components/ha-grid-size-picker.ts
@@ -7,6 +7,7 @@ import { mdiRestore } from "@mdi/js";
 import { styleMap } from "lit/directives/style-map";
 import { fireEvent } from "../common/dom/fire_event";
 import { HomeAssistant } from "../types";
+import { conditionalClamp } from "../common/number/clamp";
 
 type GridSizeValue = {
   rows?: number;
@@ -106,17 +107,11 @@ export class HaGridSizeEditor extends LitElement {
               .map((_, index) => {
                 const row = Math.floor(index / this.columns) + 1;
                 const column = (index % this.columns) + 1;
-                const disabled =
-                  (this.rowMin !== undefined && row < this.rowMin) ||
-                  (this.rowMax !== undefined && row > this.rowMax) ||
-                  (this.columnMin !== undefined && column < this.columnMin) ||
-                  (this.columnMax !== undefined && column > this.columnMax);
                 return html`
                   <div
                     class="cell"
                     data-row=${row}
                     data-column=${column}
-                    ?disabled=${disabled}
                     @click=${this._cellClick}
                   ></div>
                 `;
@@ -132,11 +127,16 @@ export class HaGridSizeEditor extends LitElement {
 
   _cellClick(ev) {
     const cell = ev.currentTarget as HTMLElement;
-    if (cell.getAttribute("disabled") !== null) return;
     const rows = Number(cell.getAttribute("data-row"));
     const columns = Number(cell.getAttribute("data-column"));
+    const clampedRow = conditionalClamp(rows, this.rowMin, this.rowMax);
+    const clampedColumn = conditionalClamp(
+      columns,
+      this.columnMin,
+      this.columnMax
+    );
     fireEvent(this, "value-changed", {
-      value: { rows, columns },
+      value: { rows: clampedRow, columns: clampedColumn },
     });
   }
 

--- a/src/components/ha-grid-size-picker.ts
+++ b/src/components/ha-grid-size-picker.ts
@@ -43,13 +43,9 @@ export class HaGridSizeEditor extends LitElement {
 
   protected render() {
     const disabledColumns =
-      this.columnMin !== undefined &&
-      this.columnMin !== undefined &&
-      this.columnMin === this.columnMax;
+      this.columnMin !== undefined && this.columnMin === this.columnMax;
     const disabledRows =
-      this.rowMin !== undefined &&
-      this.rowMin !== undefined &&
-      this.rowMin === this.rowMax;
+      this.rowMin !== undefined && this.rowMin === this.rowMax;
     return html`
       <div class="grid">
         <ha-grid-layout-slider

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -145,9 +145,16 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
       this._config?.show_icon &&
       (this._config?.show_name || this._config?.show_state)
     ) {
-      return { grid_rows: 2, grid_columns: 2 };
+      return {
+        grid_rows: 2,
+        grid_columns: 2,
+        grid_min_rows: 2,
+      };
     }
-    return { grid_rows: 1, grid_columns: 1 };
+    return {
+      grid_rows: 1,
+      grid_columns: 1,
+    };
   }
 
   public setConfig(config: ButtonCardConfig): void {

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -36,7 +36,11 @@ import { findEntities } from "../common/find-entities";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import { createHeaderFooterElement } from "../create-element/create-header-footer-element";
-import { LovelaceCard, LovelaceHeaderFooter } from "../types";
+import {
+  LovelaceCard,
+  LovelaceHeaderFooter,
+  LovelaceLayoutOptions,
+} from "../types";
 import { HuiErrorCard } from "./hui-error-card";
 import { EntityCardConfig } from "./types";
 
@@ -239,6 +243,20 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
 
   private _handleClick(): void {
     fireEvent(this, "hass-more-info", { entityId: this._config!.entity });
+  }
+
+  public getLayoutOptions(): LovelaceLayoutOptions {
+    if (this._config?.footer) {
+      return {
+        grid_columns: 2,
+      };
+    }
+    return {
+      grid_columns: 2,
+      grid_rows: 2,
+      grid_min_rows: 2,
+      grid_max_rows: 2,
+    };
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -246,11 +246,6 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
   }
 
   public getLayoutOptions(): LovelaceLayoutOptions {
-    if (this._config?.footer) {
-      return {
-        grid_columns: 2,
-      };
-    }
     return {
       grid_columns: 2,
       grid_rows: 2,

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -255,7 +255,6 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
       grid_columns: 2,
       grid_rows: 2,
       grid_min_rows: 2,
-      grid_max_rows: 2,
     };
   }
 

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -249,6 +249,7 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
     return {
       grid_columns: 2,
       grid_rows: 2,
+      grid_min_columns: 2,
       grid_min_rows: 2,
     };
   }

--- a/src/panels/lovelace/cards/hui-humidifier-card.ts
+++ b/src/panels/lovelace/cards/hui-humidifier-card.ts
@@ -22,7 +22,11 @@ import { HomeAssistant } from "../../../types";
 import "../card-features/hui-card-features";
 import { findEntities } from "../common/find-entities";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
-import { LovelaceCard, LovelaceCardEditor } from "../types";
+import {
+  LovelaceCard,
+  LovelaceCardEditor,
+  LovelaceLayoutOptions,
+} from "../types";
 import { HumidifierCardConfig } from "./types";
 
 @customElement("hui-humidifier-card")
@@ -171,6 +175,24 @@ export class HuiHumidifierCard extends LitElement implements LovelaceCard {
         ></hui-card-features>
       </ha-card>
     `;
+  }
+
+  public getLayoutOptions(): LovelaceLayoutOptions {
+    const grid_columns = 4;
+    let grid_rows = 5;
+    let grid_min_rows = 2;
+    const grid_min_columns = 2;
+    if (this._config?.features?.length) {
+      const featureHeight = Math.ceil((this._config.features.length * 2) / 3);
+      grid_rows += featureHeight;
+      grid_min_rows += featureHeight;
+    }
+    return {
+      grid_columns,
+      grid_rows,
+      grid_min_rows,
+      grid_min_columns,
+    };
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/lovelace/cards/hui-iframe-card.ts
+++ b/src/panels/lovelace/cards/hui-iframe-card.ts
@@ -119,6 +119,7 @@ export class HuiIframeCard extends LitElement implements LovelaceCard {
     return {
       grid_columns: 4,
       grid_rows: 4,
+      grid_min_rows: 2,
     };
   }
 

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -432,6 +432,8 @@ class HuiMapCard extends LitElement implements LovelaceCard {
     return {
       grid_columns: 4,
       grid_rows: 4,
+      grid_min_columns: 2,
+      grid_min_rows: 2,
     };
   }
 

--- a/src/panels/lovelace/cards/hui-media-control-card.ts
+++ b/src/panels/lovelace/cards/hui-media-control-card.ts
@@ -40,7 +40,11 @@ import { findEntities } from "../common/find-entities";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-marquee";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
-import type { LovelaceCard, LovelaceCardEditor } from "../types";
+import type {
+  LovelaceCard,
+  LovelaceCardEditor,
+  LovelaceLayoutOptions,
+} from "../types";
 import { MediaControlCardConfig } from "./types";
 
 @customElement("hui-media-control-card")
@@ -580,6 +584,15 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
     if (this._marqueeActive) {
       this._marqueeActive = false;
     }
+  }
+
+  public getLayoutOptions(): LovelaceLayoutOptions {
+    return {
+      grid_columns: 4,
+      grid_min_columns: 2,
+      grid_rows: 3,
+      grid_min_rows: 3,
+    };
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/lovelace/cards/hui-sensor-card.ts
+++ b/src/panels/lovelace/cards/hui-sensor-card.ts
@@ -76,6 +76,7 @@ class HuiSensorCard extends HuiEntityCard {
     return {
       grid_columns: 2,
       grid_rows: 2,
+      grid_min_rows: 2,
     };
   }
 

--- a/src/panels/lovelace/cards/hui-sensor-card.ts
+++ b/src/panels/lovelace/cards/hui-sensor-card.ts
@@ -76,6 +76,7 @@ class HuiSensorCard extends HuiEntityCard {
     return {
       grid_columns: 2,
       grid_rows: 2,
+      grid_min_columns: 2,
       grid_min_rows: 2,
     };
   }

--- a/src/panels/lovelace/cards/hui-statistic-card.ts
+++ b/src/panels/lovelace/cards/hui-statistic-card.ts
@@ -1,10 +1,10 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import {
-  css,
   CSSResultGroup,
-  html,
   LitElement,
   PropertyValues,
+  css,
+  html,
   nothing,
 } from "lit";
 import { customElement, property, state } from "lit/decorators";
@@ -16,12 +16,12 @@ import "../../../components/ha-alert";
 import "../../../components/ha-card";
 import "../../../components/ha-state-icon";
 import {
+  StatisticsMetaData,
   fetchStatistic,
   getDisplayUnit,
   getStatisticLabel,
   getStatisticMetadata,
   isExternalStatistic,
-  StatisticsMetaData,
 } from "../../../data/recorder";
 import { HomeAssistant } from "../../../types";
 import { computeCardSize } from "../common/compute-card-size";
@@ -32,6 +32,7 @@ import {
   LovelaceCard,
   LovelaceCardEditor,
   LovelaceHeaderFooter,
+  LovelaceLayoutOptions,
 } from "../types";
 import { HuiErrorCard } from "./hui-error-card";
 import { EntityCardConfig, StatisticCardConfig } from "./types";
@@ -252,6 +253,15 @@ export class HuiStatisticCard extends LitElement implements LovelaceCard {
 
   private _handleClick(): void {
     fireEvent(this, "hass-more-info", { entityId: this._config!.entity });
+  }
+
+  public getLayoutOptions(): LovelaceLayoutOptions {
+    return {
+      grid_columns: 2,
+      grid_rows: 2,
+      grid_min_columns: 2,
+      grid_min_rows: 2,
+    };
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -22,7 +22,11 @@ import { HomeAssistant } from "../../../types";
 import "../card-features/hui-card-features";
 import { findEntities } from "../common/find-entities";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
-import { LovelaceCard, LovelaceCardEditor } from "../types";
+import {
+  LovelaceCard,
+  LovelaceCardEditor,
+  LovelaceLayoutOptions,
+} from "../types";
 import { ThermostatCardConfig } from "./types";
 
 @customElement("hui-thermostat-card")
@@ -163,6 +167,24 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
         ></hui-card-features>
       </ha-card>
     `;
+  }
+
+  public getLayoutOptions(): LovelaceLayoutOptions {
+    const grid_columns = 4;
+    let grid_rows = 5;
+    let grid_min_rows = 2;
+    const grid_min_columns = 2;
+    if (this._config?.features?.length) {
+      const featureHeight = Math.ceil((this._config.features.length * 2) / 3);
+      grid_rows += featureHeight;
+      grid_min_rows += featureHeight;
+    }
+    return {
+      grid_columns,
+      grid_rows,
+      grid_min_rows,
+      grid_min_columns,
+    };
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -125,7 +125,8 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     const grid_columns = 2;
     let grid_rows = 1;
     if (this._config?.features?.length) {
-      grid_rows += Math.ceil((this._config.features.length * 2) / 3);
+      const featureHeight = Math.ceil((this._config.features.length * 2) / 3);
+      grid_rows += featureHeight;
     }
     if (this._config?.vertical) {
       grid_rows!++;

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -135,7 +135,6 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       grid_columns,
       grid_rows,
       grid_min_rows: grid_rows,
-      grid_max_rows: grid_rows,
       grid_min_columns: grid_columns,
     };
   }

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -122,17 +122,21 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
   }
 
   public getLayoutOptions(): LovelaceLayoutOptions {
-    const options = {
-      grid_columns: 2,
-      grid_rows: 1,
-    };
+    const grid_columns = 2;
+    let grid_rows = 1;
     if (this._config?.features?.length) {
-      options.grid_rows += Math.ceil((this._config.features.length * 2) / 3);
+      grid_rows += Math.ceil((this._config.features.length * 2) / 3);
     }
     if (this._config?.vertical) {
-      options.grid_rows++;
+      grid_rows!++;
     }
-    return options;
+    return {
+      grid_columns,
+      grid_rows,
+      grid_min_rows: grid_rows,
+      grid_max_rows: grid_rows,
+      grid_min_columns: grid_columns,
+    };
   }
 
   private _handleAction(ev: ActionHandlerEvent) {

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -38,7 +38,11 @@ import { handleAction } from "../common/handle-action";
 import { hasAction } from "../common/has-action";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
-import type { LovelaceCard, LovelaceCardEditor } from "../types";
+import type {
+  LovelaceCard,
+  LovelaceCardEditor,
+  LovelaceLayoutOptions,
+} from "../types";
 import type { WeatherForecastCardConfig } from "./types";
 
 @customElement("hui-weather-forecast-card")
@@ -419,6 +423,26 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
 
   private _showValue(item?: any): boolean {
     return typeof item !== "undefined" && item !== null;
+  }
+
+  public getLayoutOptions(): LovelaceLayoutOptions {
+    if (
+      this._config?.show_current !== false &&
+      this._config?.show_forecast !== false
+    ) {
+      return {
+        grid_columns: 4,
+        grid_min_columns: 2,
+        grid_rows: 3,
+        grid_min_rows: 3,
+      };
+    }
+    return {
+      grid_columns: 4,
+      grid_min_columns: 2,
+      grid_rows: 2,
+      grid_min_rows: 1,
+    };
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/lovelace/editor/card-editor/ha-grid-layout-slider.ts
+++ b/src/panels/lovelace/editor/card-editor/ha-grid-layout-slider.ts
@@ -255,15 +255,14 @@ export class HaGridLayoutSlider extends LitElement {
       >
         <div id="slider" class="slider">
           <div class="track">
-            <div class="background">
-              <div
-                class="active"
-                style=${styleMap({
-                  "--min": `${this.min / this._range}`,
-                  "--max": `${1 - this.max / this._range}`,
-                })}
-              ></div>
-            </div>
+            <div class="background"></div>
+            <div
+              class="active"
+              style=${styleMap({
+                "--min": `${this.min / this._range}`,
+                "--max": `${1 - this.max / this._range}`,
+              })}
+            ></div>
           </div>
           ${this.value !== undefined
             ? html`<div class="handle"></div>`
@@ -323,11 +322,12 @@ export class HaGridLayoutSlider extends LitElement {
         position: absolute;
         inset: 0;
         background: var(--disabled-color);
-        opacity: 0.5;
+        opacity: 0.2;
       }
       .active {
         position: absolute;
         background: grey;
+        opacity: 0.7;
         top: 0;
         right: calc(var(--max) * 100%);
         bottom: 0;
@@ -374,6 +374,9 @@ export class HaGridLayoutSlider extends LitElement {
       }
       :host(:disabled) .slider {
         cursor: not-allowed;
+      }
+      :host(:disabled) .handle:after {
+        background: var(--disabled-color);
       }
       .pressed .handle {
         transition: none;

--- a/src/panels/lovelace/editor/card-editor/hui-card-layout-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-layout-editor.ts
@@ -19,7 +19,7 @@ import { LovelaceCardConfig } from "../../../../data/lovelace/config/card";
 import { haStyle } from "../../../../resources/styles";
 import { HomeAssistant } from "../../../../types";
 import { HuiCard } from "../../cards/hui-card";
-import { DEFAULT_GRID_OPTIONS } from "../../sections/hui-grid-section";
+import { computeSizeOnGrid } from "../../sections/hui-grid-section";
 import { LovelaceLayoutOptions } from "../../types";
 
 @customElement("hui-card-layout-editor")
@@ -38,21 +38,17 @@ export class HuiCardLayoutEditor extends LitElement {
 
   private _cardElement?: HuiCard;
 
-  private _gridSizeValue = memoizeOne(
+  private _mergedOptions = memoizeOne(
     (
       options?: LovelaceLayoutOptions,
       defaultOptions?: LovelaceLayoutOptions
     ) => ({
-      rows:
-        options?.grid_rows ??
-        defaultOptions?.grid_rows ??
-        DEFAULT_GRID_OPTIONS.grid_rows,
-      columns:
-        options?.grid_columns ??
-        defaultOptions?.grid_columns ??
-        DEFAULT_GRID_OPTIONS.grid_columns,
+      ...defaultOptions,
+      ...options,
     })
   );
+
+  private _gridSizeValue = memoizeOne(computeSizeOnGrid);
 
   private _isDefault = memoizeOne(
     (options?: LovelaceLayoutOptions) =>
@@ -60,6 +56,11 @@ export class HuiCardLayoutEditor extends LitElement {
   );
 
   render() {
+    const options = this._mergedOptions(
+      this.config.layout_options,
+      this._defaultLayoutOptions
+    );
+
     return html`
       <div class="header">
         <p class="intro">
@@ -123,12 +124,13 @@ export class HuiCardLayoutEditor extends LitElement {
         : html`
             <ha-grid-size-picker
               .hass=${this.hass}
-              .value=${this._gridSizeValue(
-                this.config.layout_options,
-                this._defaultLayoutOptions
-              )}
+              .value=${this._gridSizeValue(options)}
               .isDefault=${this._isDefault(this.config.layout_options)}
               @value-changed=${this._gridSizeChanged}
+              .rowMin=${options.grid_min_rows}
+              .rowMax=${options.grid_max_rows}
+              .columnMin=${options.grid_min_columns}
+              .columnMax=${options.grid_max_columns}
             ></ha-grid-size-picker>
           `}
     `;

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -43,6 +43,10 @@ export interface LovelaceBadge extends HTMLElement {
 export type LovelaceLayoutOptions = {
   grid_columns?: number;
   grid_rows?: number;
+  grid_max_columns?: number;
+  grid_min_columns?: number;
+  grid_min_rows?: number;
+  grid_max_rows?: number;
 };
 
 export interface LovelaceCard extends HTMLElement {


### PR DESCRIPTION
## Proposed change

Allows card to provide a min and max rows and columns for resize card editor in a grid.
I implemented it on 11 cards (future PRs will be open for others cards): 
- tile card
- entity card
- thermostat card
- humidifier card
- button card
- media card
- sensor card
- map card
- iframe card
- statistic card
- weather forecast card

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic grid layout calculations for various Lovelace cards and components, allowing for more flexible and responsive user interfaces.
  
- **Improvements**
  - Enhanced the `HuiEntityCard`, `HuiHumidifierCard`, `HuiThermostatCard`, and `HuiTileCard` with new methods to determine layout options based on card configurations.
  - Improved the `HaGridLayoutSlider` with refined styles and behaviors for better user interaction.
  - Updated the `HuiCardLayoutEditor` to better handle default and computed grid size options.

- **Refactor**
  - Replaced direct grid size assignments with a new `computeSizeOnGrid` function to ensure values are within specified bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->