### PR TITLE
Add state content component

### DIFF
--- a/src/components/entity/ha-entity-state-content-picker.ts
+++ b/src/components/entity/ha-entity-state-content-picker.ts
@@ -1,0 +1,313 @@
+import { mdiDrag } from "@mdi/js";
+import { HassEntity } from "home-assistant-js-websocket";
+import { LitElement, PropertyValues, css, html, nothing } from "lit";
+import { customElement, property, query, state } from "lit/decorators";
+import { repeat } from "lit/directives/repeat";
+import memoizeOne from "memoize-one";
+import { ensureArray } from "../../common/array/ensure-array";
+import { fireEvent } from "../../common/dom/fire_event";
+import { computeDomain } from "../../common/entity/compute_domain";
+import {
+  STATE_DISPLAY_SPECIAL_CONTENT,
+  STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS,
+} from "../../state-display/state-display";
+import { HomeAssistant, ValueChangedEvent } from "../../types";
+import "../ha-combo-box";
+import type { HaComboBox } from "../ha-combo-box";
+
+const HIDDEN_ATTRIBUTES = [
+  "access_token",
+  "available_modes",
+  "code_arm_required",
+  "code_format",
+  "color_modes",
+  "device_class",
+  "editable",
+  "effect_list",
+  "entity_id",
+  "entity_picture",
+  "event_types",
+  "fan_modes",
+  "fan_speed_list",
+  "friendly_name",
+  "frontend_stream_type",
+  "has_date",
+  "has_time",
+  "hvac_modes",
+  "icon",
+  "id",
+  "max_color_temp_kelvin",
+  "max_mireds",
+  "max_temp",
+  "max",
+  "min_color_temp_kelvin",
+  "min_mireds",
+  "min_temp",
+  "min",
+  "mode",
+  "operation_list",
+  "options",
+  "percentage_step",
+  "precipitation_unit",
+  "preset_modes",
+  "pressure_unit",
+  "sound_mode_list",
+  "source_list",
+  "state_class",
+  "step",
+  "supported_color_modes",
+  "supported_features",
+  "swing_modes",
+  "target_temp_step",
+  "temperature_unit",
+  "token",
+  "unit_of_measurement",
+  "visibility_unit",
+  "wind_speed_unit",
+  "battery_icon",
+  "battery_level",
+];
+
+@customElement("ha-entity-state-content-picker")
+class HaEntityStatePicker extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public entityId?: string;
+
+  @property({ type: Boolean }) public autofocus = false;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  @property({ type: Boolean }) public required = false;
+
+  @property() public label?: string;
+
+  @property() public value?: string[] | string;
+
+  @property() public helper?: string;
+
+  @state() private _opened = false;
+
+  @query("ha-combo-box", true) private _comboBox!: HaComboBox;
+
+  protected shouldUpdate(changedProps: PropertyValues) {
+    return !(!changedProps.has("_opened") && this._opened);
+  }
+
+  private options = memoizeOne((entityId?: string, stateObj?: HassEntity) => {
+    const domain = entityId ? computeDomain(entityId) : undefined;
+    return [
+      {
+        label: this.hass.localize("ui.components.state-content-picker.state"),
+        value: "state",
+      },
+      {
+        label: this.hass.localize(
+          "ui.components.state-content-picker.last_changed"
+        ),
+        value: "last_changed",
+      },
+      {
+        label: this.hass.localize(
+          "ui.components.state-content-picker.last_updated"
+        ),
+        value: "last_updated",
+      },
+      ...(domain
+        ? STATE_DISPLAY_SPECIAL_CONTENT.filter((content) =>
+            STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS[content]?.includes(domain)
+          ).map((content) => ({
+            label: this.hass.localize(
+              `ui.components.state-content-picker.${content}`
+            ),
+            value: content,
+          }))
+        : []),
+      ...Object.keys(stateObj?.attributes ?? {})
+        .filter((a) => !HIDDEN_ATTRIBUTES.includes(a))
+        .map((attribute) => ({
+          value: attribute,
+          label: this.hass.formatEntityAttributeName(stateObj!, attribute),
+        })),
+    ];
+  });
+
+  private _filter = "";
+
+  protected render() {
+    if (!this.hass) {
+      return nothing;
+    }
+
+    const value = this._value;
+
+    const stateObj = this.entityId
+      ? this.hass.states[this.entityId]
+      : undefined;
+
+    const options = this.options(this.entityId, stateObj);
+    const optionItems = options.filter(
+      (option) => !this._value.includes(option.value)
+    );
+
+    return html`
+      ${value?.length
+        ? html`
+            <ha-sortable
+              no-style
+              @item-moved=${this._moveItem}
+              .disabled=${this.disabled}
+            >
+              <ha-chip-set>
+                ${repeat(
+                  this._value,
+                  (item) => item,
+                  (item, idx) => {
+                    const label =
+                      options.find((option) => option.value === item)?.label ||
+                      item;
+                    return html`
+                      <ha-input-chip
+                        .idx=${idx}
+                        @remove=${this._removeItem}
+                        .label=${label}
+                        selected
+                      >
+                        <ha-svg-icon
+                          slot="icon"
+                          .path=${mdiDrag}
+                          data-handle
+                        ></ha-svg-icon>
+
+                        ${label}
+                      </ha-input-chip>
+                    `;
+                  }
+                )}
+              </ha-chip-set>
+            </ha-sortable>
+          `
+        : nothing}
+
+      <ha-combo-box
+        item-value-path="value"
+        item-label-path="label"
+        .hass=${this.hass}
+        .label=${this.label}
+        .helper=${this.helper}
+        .disabled=${this.disabled}
+        .required=${this.required && !value.length}
+        .value=${""}
+        .items=${optionItems}
+        .allowCustomValue
+        @filter-changed=${this._filterChanged}
+        @value-changed=${this._comboBoxValueChanged}
+        @opened-changed=${this._openedChanged}
+      ></ha-combo-box>
+    `;
+  }
+
+  private get _value() {
+    return !this.value ? [] : ensureArray(this.value);
+  }
+
+  private _openedChanged(ev: ValueChangedEvent<boolean>) {
+    this._opened = ev.detail.value;
+  }
+
+  private _filterChanged(ev?: CustomEvent): void {
+    this._filter = ev?.detail.value || "";
+
+    const filteredItems = this._comboBox.items?.filter((item) => {
+      const label = item.label || item.value;
+      return label.toLowerCase().includes(this._filter?.toLowerCase());
+    });
+
+    if (this._filter) {
+      filteredItems?.unshift({ label: this._filter, value: this._filter });
+    }
+
+    this._comboBox.filteredItems = filteredItems;
+  }
+
+  private async _moveItem(ev: CustomEvent) {
+    ev.stopPropagation();
+    const { oldIndex, newIndex } = ev.detail;
+    const value = this._value;
+    const newValue = value.concat();
+    const element = newValue.splice(oldIndex, 1)[0];
+    newValue.splice(newIndex, 0, element);
+    this._setValue(newValue);
+    await this.updateComplete;
+    this._filterChanged();
+  }
+
+  private async _removeItem(ev) {
+    ev.stopPropagation();
+    const value: string[] = [...this._value];
+    value.splice(ev.target.idx, 1);
+    this._setValue(value);
+    await this.updateComplete;
+    this._filterChanged();
+  }
+
+  private _comboBoxValueChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const newValue = ev.detail.value;
+
+    if (this.disabled || newValue === "") {
+      return;
+    }
+
+    const currentValue = this._value;
+
+    if (currentValue.includes(newValue)) {
+      return;
+    }
+
+    setTimeout(() => {
+      this._filterChanged();
+      this._comboBox.setInputValue("");
+    }, 0);
+
+    this._setValue([...currentValue, newValue]);
+  }
+
+  private _setValue(value: string[]) {
+    const newValue =
+      value.length === 0 ? undefined : value.length === 1 ? value[0] : value;
+    this.value = newValue;
+    fireEvent(this, "value-changed", {
+      value: newValue,
+    });
+  }
+
+  static styles = css`
+    :host {
+      position: relative;
+    }
+
+    ha-chip-set {
+      padding: 8px 0;
+    }
+
+    .sortable-fallback {
+      display: none;
+      opacity: 0;
+    }
+
+    .sortable-ghost {
+      opacity: 0.4;
+    }
+
+    .sortable-drag {
+      cursor: grabbing;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-entity-state-content-picker": HaEntityStatePicker;
+  }
+}

--- a/src/components/entity/ha-entity-state-content-picker.ts
+++ b/src/components/entity/ha-entity-state-content-picker.ts
@@ -199,7 +199,7 @@ class HaEntityStatePicker extends LitElement {
         .required=${this.required && !value.length}
         .value=${""}
         .items=${optionItems}
-        .allowCustomValue
+        allow-custom-value
         @filter-changed=${this._filterChanged}
         @value-changed=${this._comboBoxValueChanged}
         @opened-changed=${this._openedChanged}

--- a/src/components/entity/ha-entity-state-content-picker.ts
+++ b/src/components/entity/ha-entity-state-content-picker.ts
@@ -116,7 +116,7 @@ class HaEntityStatePicker extends LitElement {
       },
       ...(domain
         ? STATE_DISPLAY_SPECIAL_CONTENT.filter((content) =>
-            STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS[content]?.includes(domain)
+            STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS[domain]?.includes(content)
           ).map((content) => ({
             label: this.hass.localize(
               `ui.components.state-content-picker.${content}`

--- a/src/components/entity/ha-entity-state-content-picker.ts
+++ b/src/components/entity/ha-entity-state-content-picker.ts
@@ -18,6 +18,8 @@ import type { HaComboBox } from "../ha-combo-box";
 const HIDDEN_ATTRIBUTES = [
   "access_token",
   "available_modes",
+  "battery_icon",
+  "battery_level",
   "code_arm_required",
   "code_format",
   "color_modes",
@@ -51,6 +53,7 @@ const HIDDEN_ATTRIBUTES = [
   "precipitation_unit",
   "preset_modes",
   "pressure_unit",
+  "remaining",
   "sound_mode_list",
   "source_list",
   "state_class",
@@ -64,8 +67,6 @@ const HIDDEN_ATTRIBUTES = [
   "unit_of_measurement",
   "visibility_unit",
   "wind_speed_unit",
-  "battery_icon",
-  "battery_level",
 ];
 
 @customElement("ha-entity-state-content-picker")

--- a/src/components/ha-selector/ha-selector-ui-state-content.ts
+++ b/src/components/ha-selector/ha-selector-ui-state-content.ts
@@ -1,0 +1,48 @@
+import { html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import { UiStateContentSelector } from "../../data/selector";
+import { SubscribeMixin } from "../../mixins/subscribe-mixin";
+import { HomeAssistant } from "../../types";
+import "../entity/ha-entity-state-content-picker";
+
+@customElement("ha-selector-ui_state_content")
+export class HaSelectorUiStateContent extends SubscribeMixin(LitElement) {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public selector!: UiStateContentSelector;
+
+  @property() public value?: string | string[];
+
+  @property() public label?: string;
+
+  @property() public helper?: string;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  @property({ type: Boolean }) public required = true;
+
+  @property({ attribute: false }) public context?: {
+    filter_entity?: string;
+  };
+
+  protected render() {
+    return html`
+      <ha-entity-state-content-picker
+        .hass=${this.hass}
+        .entityId=${this.selector.ui_state_content?.entity_id ||
+        this.context?.filter_entity}
+        .value=${this.value}
+        .label=${this.label}
+        .helper=${this.helper}
+        .disabled=${this.disabled}
+        .required=${this.required}
+      ></ha-entity-state-content-picker>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-selector-ui_state_content": HaSelectorUiStateContent;
+  }
+}

--- a/src/components/ha-selector/ha-selector.ts
+++ b/src/components/ha-selector/ha-selector.ts
@@ -57,6 +57,7 @@ const LOAD_ELEMENTS = {
   color_temp: () => import("./ha-selector-color-temp"),
   ui_action: () => import("./ha-selector-ui-action"),
   ui_color: () => import("./ha-selector-ui-color"),
+  ui_state_content: () => import("./ha-selector-ui-state-content"),
 };
 
 const LEGACY_UI_SELECTORS = new Set(["ui-action", "ui-color"]);

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -2,6 +2,8 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import { ensureArray } from "../common/array/ensure-array";
 import { computeStateDomain } from "../common/entity/compute_state_domain";
 import { supportsFeature } from "../common/entity/supports-feature";
+import type { CropOptions } from "../dialogs/image-cropper-dialog/show-image-cropper-dialog";
+import { isHelperDomain } from "../panels/config/helpers/const";
 import { UiAction } from "../panels/lovelace/components/hui-action-editor";
 import { HomeAssistant, ItemPath } from "../types";
 import {
@@ -13,8 +15,6 @@ import {
   EntityRegistryEntry,
 } from "./entity_registry";
 import { EntitySources } from "./entity_sources";
-import { isHelperDomain } from "../panels/config/helpers/const";
-import type { CropOptions } from "../dialogs/image-cropper-dialog/show-image-cropper-dialog";
 
 export type Selector =
   | ActionSelector
@@ -64,7 +64,8 @@ export type Selector =
   | TTSSelector
   | TTSVoiceSelector
   | UiActionSelector
-  | UiColorSelector;
+  | UiColorSelector
+  | UiStateContentSelector;
 
 export interface ActionSelector {
   action: {
@@ -453,6 +454,13 @@ export interface UiActionSelector {
 export interface UiColorSelector {
   // eslint-disable-next-line @typescript-eslint/ban-types
   ui_color: { default_color?: boolean } | null;
+}
+
+export interface UiStateContentSelector {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  ui_state_content: {
+    entity_id?: string;
+  } | null;
 }
 
 export const expandLabelTarget = (

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -195,36 +195,6 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     }
   );
 
-  private _defaultStateContent = memoizeOne(
-    (domain: string, active: boolean): string | string[] => {
-      if (domain === "light" && active) {
-        return "brightness";
-      }
-      if (domain === "fan" && active) {
-        return "percentage";
-      }
-      if (domain === "cover" && active) {
-        return ["state", "current_position"];
-      }
-      if (domain === "valve" && active) {
-        return ["state", "current_position"];
-      }
-      if (domain === "humidifier") {
-        return ["state", "current_humidity"];
-      }
-      if (domain === "climate") {
-        return ["state", "current_temperature"];
-      }
-      if (domain === "update") {
-        return "install_status";
-      }
-      if (domain === "timer") {
-        return "reamining_time";
-      }
-      return "state";
-    }
-  );
-
   get hasCardAction() {
     return (
       !this._config?.tap_action ||
@@ -281,8 +251,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
           <state-display
             .stateObj=${stateObj}
             .hass=${this.hass}
-            .content=${this._config.state_content ||
-            this._defaultStateContent(domain, active)}
+            .content=${this._config.state_content}
           >
           </state-display>
         `;

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -216,10 +216,10 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
         return ["state", "current_temperature"];
       }
       if (domain === "update") {
-        return "update_state";
+        return "install_status";
       }
       if (domain === "timer") {
-        return "timer_state";
+        return "reamining_time";
       }
       return "state";
     }

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -1,19 +1,11 @@
 import { mdiExclamationThick, mdiHelp } from "@mdi/js";
 import { HassEntity } from "home-assistant-js-websocket";
-import {
-  CSSResultGroup,
-  LitElement,
-  TemplateResult,
-  css,
-  html,
-  nothing,
-} from "lit";
+import { CSSResultGroup, LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
-import { ensureArray } from "../../../common/array/ensure-array";
 import { computeCssColor } from "../../../common/color/compute-color";
 import { hsv2rgb, rgb2hex, rgb2hsv } from "../../../common/color/convert-color";
 import { DOMAINS_TOGGLE } from "../../../common/const";
@@ -30,17 +22,14 @@ import "../../../components/tile/ha-tile-image";
 import type { TileImageStyle } from "../../../components/tile/ha-tile-image";
 import "../../../components/tile/ha-tile-info";
 import { cameraUrlWithWidthHeight } from "../../../data/camera";
-import { isUnavailableState } from "../../../data/entity";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
-import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../../../data/sensor";
-import { UpdateEntity, computeUpdateStateDisplay } from "../../../data/update";
+import "../../../state-display/state-display";
 import { HomeAssistant } from "../../../types";
 import "../card-features/hui-card-features";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { findEntities } from "../common/find-entities";
 import { handleAction } from "../common/handle-action";
 import { hasAction } from "../common/has-action";
-import "../components/hui-timestamp-display";
 import type {
   LovelaceCard,
   LovelaceCardEditor,
@@ -48,8 +37,6 @@ import type {
 } from "../types";
 import { renderTileBadge } from "./tile/badges/tile-badge";
 import type { ThermostatCardConfig, TileCardConfig } from "./types";
-
-const TIMESTAMP_STATE_DOMAINS = ["button", "input_button", "scene"];
 
 export const getEntityDefaultTileIconAction = (entityId: string) => {
   const domain = computeDomain(entityId);
@@ -208,126 +195,35 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     }
   );
 
-  private _renderStateContent(
-    stateObj: HassEntity,
-    stateContent: string | string[]
-  ) {
-    const contents = ensureArray(stateContent);
-
-    const values = contents
-      .map((content) => {
-        if (content === "state") {
-          const domain = computeDomain(stateObj.entity_id);
-          if (
-            (stateObj.attributes.device_class ===
-              SENSOR_DEVICE_CLASS_TIMESTAMP ||
-              TIMESTAMP_STATE_DOMAINS.includes(domain)) &&
-            !isUnavailableState(stateObj.state)
-          ) {
-            return html`
-              <hui-timestamp-display
-                .hass=${this.hass}
-                .ts=${new Date(stateObj.state)}
-                format="relative"
-                capitalize
-              ></hui-timestamp-display>
-            `;
-          }
-
-          return this.hass!.formatEntityState(stateObj);
-        }
-        if (content === "last-changed") {
-          return html`
-            <ha-relative-time
-              .hass=${this.hass}
-              .datetime=${stateObj.last_changed}
-            ></ha-relative-time>
-          `;
-        }
-        if (content === "last-updated") {
-          return html`
-            <ha-relative-time
-              .hass=${this.hass}
-              .datetime=${stateObj.last_updated}
-            ></ha-relative-time>
-          `;
-        }
-        if (content === "last_triggered") {
-          return html`
-            <ha-relative-time
-              .hass=${this.hass}
-              .datetime=${stateObj.attributes.last_triggered}
-            ></ha-relative-time>
-          `;
-        }
-        if (stateObj.attributes[content] == null) {
-          return undefined;
-        }
-        return this.hass!.formatEntityAttributeValue(stateObj, content);
-      })
-      .filter(Boolean);
-
-    if (!values.length) {
-      return html`${this.hass!.formatEntityState(stateObj)}`;
+  private _defaultStateContent = memoizeOne(
+    (domain: string, active: boolean): string | string[] => {
+      if (domain === "light" && active) {
+        return "brightness";
+      }
+      if (domain === "fan" && active) {
+        return "percentage";
+      }
+      if (domain === "cover" && active) {
+        return ["state", "current_position"];
+      }
+      if (domain === "valve" && active) {
+        return ["state", "current_position"];
+      }
+      if (domain === "humidifier") {
+        return ["state", "current_humidity"];
+      }
+      if (domain === "climate") {
+        return ["state", "current_temperature"];
+      }
+      if (domain === "update") {
+        return "update_state";
+      }
+      if (domain === "timer") {
+        return "timer_state";
+      }
+      return "state";
     }
-
-    return html`
-      ${values.map(
-        (value, index, array) =>
-          html`${value}${index < array.length - 1 ? " ⸱ " : nothing}`
-      )}
-    `;
-  }
-
-  private _renderState(stateObj: HassEntity): TemplateResult | typeof nothing {
-    const domain = computeDomain(stateObj.entity_id);
-    const active = stateActive(stateObj);
-
-    if (domain === "light" && active) {
-      return this._renderStateContent(stateObj, ["brightness"]);
-    }
-
-    if (domain === "fan" && active) {
-      return this._renderStateContent(stateObj, ["percentage"]);
-    }
-
-    if (domain === "cover" && active) {
-      return this._renderStateContent(stateObj, ["state", "current_position"]);
-    }
-
-    if (domain === "valve" && active) {
-      return this._renderStateContent(stateObj, ["state", "current_position"]);
-    }
-
-    if (domain === "humidifier") {
-      return this._renderStateContent(stateObj, ["state", "current_humidity"]);
-    }
-
-    if (domain === "climate") {
-      return this._renderStateContent(stateObj, [
-        "state",
-        "current_temperature",
-      ]);
-    }
-
-    if (domain === "update") {
-      return html`
-        ${computeUpdateStateDisplay(stateObj as UpdateEntity, this.hass!)}
-      `;
-    }
-
-    if (domain === "timer") {
-      import("../../../state-display/state-display-timer");
-      return html`
-        <state-display-timer
-          .hass=${this.hass}
-          .stateObj=${stateObj}
-        ></state-display-timer>
-      `;
-    }
-
-    return this._renderStateContent(stateObj, "state");
-  }
+  );
 
   get hasCardAction() {
     return (
@@ -375,16 +271,21 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     }
 
     const name = this._config.name || stateObj.attributes.friendly_name;
-
-    const localizedState = this._config.hide_state
-      ? nothing
-      : this._config.state_content
-        ? this._renderStateContent(stateObj, this._config.state_content)
-        : this._renderState(stateObj);
-
     const active = stateActive(stateObj);
     const color = this._computeStateColor(stateObj, this._config.color);
     const domain = computeDomain(stateObj.entity_id);
+
+    const localizedState = this._config.hide_state
+      ? nothing
+      : html`
+          <state-display
+            .stateObj=${stateObj}
+            .hass=${this.hass}
+            .content=${this._config.state_content ||
+            this._defaultStateContent(domain, active)}
+          >
+          </state-display>
+        `;
 
     const style = {
       "--tile-color": color,

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -37,6 +37,8 @@ import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import { EditSubElementEvent, SubElementEditorConfig } from "../types";
 import { configElementStyle } from "./config-elements-style";
 import "./hui-card-features-editor";
+import { STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS } from "../../../../state-display/state-display";
+import { computeDomain } from "../../../../common/entity/compute_domain";
 
 const HIDDEN_ATTRIBUTES = [
   "access_token",
@@ -131,8 +133,9 @@ export class HuiTileCardEditor
       entityId: string | undefined,
       stateObj: HassEntity | undefined,
       hideState: boolean
-    ) =>
-      [
+    ) => {
+      const domain = entityId ? computeDomain(entityId) : undefined;
+      return [
         { name: "entity", selector: { entity: {} } },
         {
           name: "",
@@ -197,16 +200,31 @@ export class HuiTileCardEditor
                           },
                           {
                             label: localize(
-                              `ui.panel.lovelace.editor.card.tile.state_content_options.last-changed`
+                              `ui.panel.lovelace.editor.card.tile.state_content_options.last_changed`
                             ),
-                            value: "last-changed",
+                            value: "last_changed",
                           },
                           {
                             label: localize(
-                              `ui.panel.lovelace.editor.card.tile.state_content_options.last-updated`
+                              `ui.panel.lovelace.editor.card.tile.state_content_options.last_updated`
                             ),
-                            value: "last-updated",
+                            value: "last_updated",
                           },
+                          ...(domain
+                            ? Object.keys(STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS)
+                                .filter((content) =>
+                                  STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS[
+                                    content
+                                  ]?.includes(domain)
+                                )
+                                .map((content) => ({
+                                  label:
+                                    localize(
+                                      `ui.panel.lovelace.editor.card.tile.state_content_options.${content}`
+                                    ) || content,
+                                  value: content,
+                                }))
+                            : []),
                           ...Object.keys(stateObj?.attributes ?? {})
                             .filter((a) => !HIDDEN_ATTRIBUTES.includes(a))
                             .map((attribute) => ({
@@ -250,7 +268,8 @@ export class HuiTileCardEditor
             },
           ],
         },
-      ] as const satisfies readonly HaFormSchema[]
+      ] as const satisfies readonly HaFormSchema[];
+    }
   );
 
   private _context = memoizeOne(

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -1,5 +1,4 @@
 import { mdiGestureTap, mdiPalette } from "@mdi/js";
-import { HassEntity } from "home-assistant-js-websocket";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -14,9 +13,7 @@ import {
   string,
   union,
 } from "superstruct";
-import { ensureArray } from "../../../../common/array/ensure-array";
 import { HASSDomEvent, fireEvent } from "../../../../common/dom/fire_event";
-import { formatEntityAttributeNameFunc } from "../../../../common/translations/entity-state";
 import { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-form/ha-form";
 import type {
@@ -37,61 +34,6 @@ import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import { EditSubElementEvent, SubElementEditorConfig } from "../types";
 import { configElementStyle } from "./config-elements-style";
 import "./hui-card-features-editor";
-import { STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS } from "../../../../state-display/state-display";
-import { computeDomain } from "../../../../common/entity/compute_domain";
-
-const HIDDEN_ATTRIBUTES = [
-  "access_token",
-  "available_modes",
-  "code_arm_required",
-  "code_format",
-  "color_modes",
-  "device_class",
-  "editable",
-  "effect_list",
-  "entity_id",
-  "entity_picture",
-  "event_types",
-  "fan_modes",
-  "fan_speed_list",
-  "friendly_name",
-  "frontend_stream_type",
-  "has_date",
-  "has_time",
-  "hvac_modes",
-  "icon",
-  "id",
-  "max_color_temp_kelvin",
-  "max_mireds",
-  "max_temp",
-  "max",
-  "min_color_temp_kelvin",
-  "min_mireds",
-  "min_temp",
-  "min",
-  "mode",
-  "operation_list",
-  "options",
-  "percentage_step",
-  "precipitation_unit",
-  "preset_modes",
-  "pressure_unit",
-  "sound_mode_list",
-  "source_list",
-  "state_class",
-  "step",
-  "supported_color_modes",
-  "supported_features",
-  "swing_modes",
-  "target_temp_step",
-  "temperature_unit",
-  "token",
-  "unit_of_measurement",
-  "visibility_unit",
-  "wind_speed_unit",
-  "battery_icon",
-  "battery_level",
-];
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -129,13 +71,10 @@ export class HuiTileCardEditor
   private _schema = memoizeOne(
     (
       localize: LocalizeFunc,
-      formatEntityAttributeName: formatEntityAttributeNameFunc,
       entityId: string | undefined,
-      stateObj: HassEntity | undefined,
       hideState: boolean
-    ) => {
-      const domain = entityId ? computeDomain(entityId) : undefined;
-      return [
+    ) =>
+      [
         { name: "entity", selector: { entity: {} } },
         {
           name: "",
@@ -186,56 +125,10 @@ export class HuiTileCardEditor
                   {
                     name: "state_content",
                     selector: {
-                      select: {
-                        mode: "dropdown",
-                        reorder: true,
-                        custom_value: true,
-                        multiple: true,
-                        options: [
-                          {
-                            label: localize(
-                              `ui.panel.lovelace.editor.card.tile.state_content_options.state`
-                            ),
-                            value: "state",
-                          },
-                          {
-                            label: localize(
-                              `ui.panel.lovelace.editor.card.tile.state_content_options.last_changed`
-                            ),
-                            value: "last_changed",
-                          },
-                          {
-                            label: localize(
-                              `ui.panel.lovelace.editor.card.tile.state_content_options.last_updated`
-                            ),
-                            value: "last_updated",
-                          },
-                          ...(domain
-                            ? Object.keys(STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS)
-                                .filter((content) =>
-                                  STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS[
-                                    content
-                                  ]?.includes(domain)
-                                )
-                                .map((content) => ({
-                                  label:
-                                    localize(
-                                      `ui.panel.lovelace.editor.card.tile.state_content_options.${content}`
-                                    ) || content,
-                                  value: content,
-                                }))
-                            : []),
-                          ...Object.keys(stateObj?.attributes ?? {})
-                            .filter((a) => !HIDDEN_ATTRIBUTES.includes(a))
-                            .map((attribute) => ({
-                              value: attribute,
-                              label: formatEntityAttributeName(
-                                stateObj!,
-                                attribute
-                              ),
-                            })),
-                        ],
-                      },
+                      ui_state_content: {},
+                    },
+                    context: {
+                      filter_entity: "entity",
                     },
                   },
                 ] as const satisfies readonly HaFormSchema[])
@@ -268,8 +161,7 @@ export class HuiTileCardEditor
             },
           ],
         },
-      ] as const satisfies readonly HaFormSchema[];
-    }
+      ] as const satisfies readonly HaFormSchema[]
   );
 
   private _context = memoizeOne(
@@ -287,9 +179,7 @@ export class HuiTileCardEditor
 
     const schema = this._schema(
       this.hass!.localize,
-      this.hass.formatEntityAttributeName,
       this._config.entity,
-      stateObj,
       this._config.hide_state ?? false
     );
 
@@ -306,10 +196,7 @@ export class HuiTileCardEditor
       `;
     }
 
-    const data = {
-      ...this._config,
-      state_content: ensureArray(this._config.state_content),
-    };
+    const data = this._config;
 
     return html`
       <ha-form
@@ -346,12 +233,8 @@ export class HuiTileCardEditor
       delete config.state_content;
     }
 
-    if (config.state_content) {
-      if (config.state_content.length === 0) {
-        delete config.state_content;
-      } else if (config.state_content.length === 1) {
-        config.state_content = config.state_content[0];
-      }
+    if (!config.state_content) {
+      delete config.state_content;
     }
 
     fireEvent(this, "config-changed", { config });

--- a/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
@@ -1,6 +1,6 @@
 import { LitElement, PropertyValues, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import "../../../state-display/state-display-timer";
+import "../../../state-display/ha-timer-remaining-time";
 import { HomeAssistant } from "../../../types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
@@ -38,10 +38,10 @@ class HuiTimerEntityRow extends LitElement {
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         <div class="text-content">
-          <state-display-timer
+          <ha-timer-remaining-time
             .hass=${this.hass}
             .stateObj=${stateObj}
-          ></state-display-timer>
+          ></ha-timer-remaining-time>
         </div>
       </hui-generic-entity-row>
     `;

--- a/src/state-display/ha-timer-remaining-time.ts
+++ b/src/state-display/ha-timer-remaining-time.ts
@@ -4,8 +4,8 @@ import { customElement, property, state } from "lit/decorators";
 import { computeDisplayTimer, timerTimeRemaining } from "../data/timer";
 import type { HomeAssistant } from "../types";
 
-@customElement("state-display-timer")
-class StateDisplayTimer extends ReactiveElement {
+@customElement("ha-timer-remaining-time")
+class HaTimerRemainingTime extends ReactiveElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public stateObj!: HassEntity;
@@ -69,6 +69,6 @@ class StateDisplayTimer extends ReactiveElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "state-display-timer": StateDisplayTimer;
+    "ha-timer-remaining-time": HaTimerRemainingTime;
   }
 }

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -12,7 +12,15 @@ import type { HomeAssistant } from "../types";
 
 const TIMESTAMP_STATE_DOMAINS = ["button", "input_button", "scene"];
 
-export const STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS: Record<string, string[]> = {
+export const STATE_DISPLAY_SPECIAL_CONTENT = [
+  "timer_status",
+  "install_status",
+] as const;
+
+export const STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS: Record<
+  (typeof STATE_DISPLAY_SPECIAL_CONTENT)[number],
+  string[]
+> = {
   timer_status: ["timer"],
   install_status: ["update"],
 };

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -13,7 +13,7 @@ import type { HomeAssistant } from "../types";
 const TIMESTAMP_STATE_DOMAINS = ["button", "input_button", "scene"];
 
 export const STATE_DISPLAY_SPECIAL_CONTENT = [
-  "live_timer",
+  "remaining_time",
   "install_status",
 ] as const;
 
@@ -21,7 +21,7 @@ export const STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS: Record<
   (typeof STATE_DISPLAY_SPECIAL_CONTENT)[number],
   string[]
 > = {
-  live_timer: ["timer"],
+  remaining_time: ["timer"],
   install_status: ["update"],
 };
 
@@ -94,13 +94,13 @@ class StateDisplay extends LitElement {
           ${computeUpdateStateDisplay(stateObj as UpdateEntity, this.hass!)}
         `;
       }
-      if (content === "live_timer") {
-        import("./state-display-timer");
+      if (content === "remaining_time") {
+        import("./ha-timer-remaining-time");
         return html`
-          <state-display-timer
+          <ha-timer-remaining-time
             .hass=${this.hass}
             .stateObj=${stateObj}
-          ></state-display-timer>
+          ></ha-timer-remaining-time>
         `;
       }
     }

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -1,0 +1,131 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { html, LitElement, nothing, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators";
+import { ensureArray } from "../common/array/ensure-array";
+import { computeStateDomain } from "../common/entity/compute_state_domain";
+import "../components/ha-relative-time";
+import { isUnavailableState } from "../data/entity";
+import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../data/sensor";
+import { computeUpdateStateDisplay, UpdateEntity } from "../data/update";
+import "../panels/lovelace/components/hui-timestamp-display";
+import type { HomeAssistant } from "../types";
+
+const TIMESTAMP_STATE_DOMAINS = ["button", "input_button", "scene"];
+
+export const STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS: Record<string, string[]> = {
+  timer_status: ["timer"],
+  install_status: ["update"],
+};
+
+@customElement("state-display")
+class StateDisplay extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public stateObj!: HassEntity;
+
+  @property({ attribute: false }) public content: string | string[] = "state";
+
+  protected createRenderRoot() {
+    return this;
+  }
+
+  private _computeContent(
+    content: string
+  ): TemplateResult<1> | string | undefined {
+    const stateObj = this.stateObj;
+    const domain = computeStateDomain(stateObj);
+
+    if (content === "state") {
+      if (
+        (stateObj.attributes.device_class === SENSOR_DEVICE_CLASS_TIMESTAMP ||
+          TIMESTAMP_STATE_DOMAINS.includes(domain)) &&
+        !isUnavailableState(stateObj.state)
+      ) {
+        return html`
+          <hui-timestamp-display
+            .hass=${this.hass}
+            .ts=${new Date(stateObj.state)}
+            format="relative"
+            capitalize
+          ></hui-timestamp-display>
+        `;
+      }
+
+      return this.hass!.formatEntityState(stateObj);
+    }
+    // Check last-changed for backwards compatibility
+    if (content === "last_changed" || content === "last-changed") {
+      return html`
+        <ha-relative-time
+          .hass=${this.hass}
+          .datetime=${stateObj.last_changed}
+        ></ha-relative-time>
+      `;
+    }
+    // Check last_updated for backwards compatibility
+    if (content === "last_updated" || content === "last-updated") {
+      return html`
+        <ha-relative-time
+          .hass=${this.hass}
+          .datetime=${stateObj.last_updated}
+        ></ha-relative-time>
+      `;
+    }
+    if (content === "last_triggered") {
+      return html`
+        <ha-relative-time
+          .hass=${this.hass}
+          .datetime=${stateObj.attributes.last_triggered}
+        ></ha-relative-time>
+      `;
+    }
+
+    if (STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS[content]?.includes(domain)) {
+      if (content === "install_status") {
+        return html`
+          ${computeUpdateStateDisplay(stateObj as UpdateEntity, this.hass!)}
+        `;
+      }
+      if (content === "timer_status") {
+        import("./state-display-timer");
+        return html`
+          <state-display-timer
+            .hass=${this.hass}
+            .stateObj=${stateObj}
+          ></state-display-timer>
+        `;
+      }
+    }
+
+    if (stateObj.attributes[content] == null) {
+      return undefined;
+    }
+    return this.hass!.formatEntityAttributeValue(stateObj, content);
+  }
+
+  protected render() {
+    const stateObj = this.stateObj;
+    const contents = ensureArray(this.content);
+
+    const values = contents
+      .map((content) => this._computeContent(content))
+      .filter(Boolean);
+
+    if (!values.length) {
+      return html`${this.hass!.formatEntityState(stateObj)}`;
+    }
+
+    return html`
+      ${values.map(
+        (value, index, array) =>
+          html`${value}${index < array.length - 1 ? " ⸱ " : nothing}`
+      )}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "state-display": StateDisplay;
+  }
+}

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -13,7 +13,7 @@ import type { HomeAssistant } from "../types";
 const TIMESTAMP_STATE_DOMAINS = ["button", "input_button", "scene"];
 
 export const STATE_DISPLAY_SPECIAL_CONTENT = [
-  "timer_status",
+  "live_timer",
   "install_status",
 ] as const;
 
@@ -21,7 +21,7 @@ export const STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS: Record<
   (typeof STATE_DISPLAY_SPECIAL_CONTENT)[number],
   string[]
 > = {
-  timer_status: ["timer"],
+  live_timer: ["timer"],
   install_status: ["update"],
 };
 
@@ -94,7 +94,7 @@ class StateDisplay extends LitElement {
           ${computeUpdateStateDisplay(stateObj as UpdateEntity, this.hass!)}
         `;
       }
-      if (content === "timer_status") {
+      if (content === "live_timer") {
         import("./state-display-timer");
         return html`
           <state-display-timer

--- a/src/state-summary/state-card-timer.ts
+++ b/src/state-summary/state-card-timer.ts
@@ -3,7 +3,7 @@ import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
 import "../components/entity/state-info";
 import { haStyle } from "../resources/styles";
-import "../state-display/state-display-timer";
+import "../state-display/ha-timer-remaining-time";
 import { HomeAssistant } from "../types";
 
 @customElement("state-card-timer")
@@ -23,10 +23,10 @@ class StateCardTimer extends LitElement {
           .inDialog=${this.inDialog}
         ></state-info>
         <div class="state">
-          <state-display-timer
+          <ha-timer-remaining-time
             .hass=${this.hass}
             .stateObj=${this.stateObj}
-          ></state-display-timer>
+          ></ha-timer-remaining-time>
         </div>
       </div>
     `;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5984,8 +5984,10 @@
               "state_content": "State content",
               "state_content_options": {
                 "state": "State",
-                "last-changed": "Last changed",
-                "last-updated": "Last updated"
+                "last_changed": "Last changed",
+                "last_updated": "Last updated",
+                "timer_status": "Timer status",
+                "install_status": "Install status"
               }
             },
             "vertical-stack": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1023,7 +1023,7 @@
         "state": "State",
         "last_changed": "Last changed",
         "last_updated": "Last updated",
-        "live_timer": "Live timer",
+        "remaining_time": "Remaining time",
         "install_status": "Install status"
       }
     },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1018,6 +1018,13 @@
       },
       "yaml-editor": {
         "copy_to_clipboard": "[%key:ui::panel::config::automation::editor::copy_to_clipboard%]"
+      },
+      "state-content-picker": {
+        "state": "State",
+        "last_changed": "Last changed",
+        "last_updated": "Last updated",
+        "timer_status": "Timer status",
+        "install_status": "Install status"
       }
     },
     "dialogs": {
@@ -5981,14 +5988,7 @@
               "show_entity_picture": "Show entity picture",
               "vertical": "Vertical",
               "hide_state": "Hide state",
-              "state_content": "State content",
-              "state_content_options": {
-                "state": "State",
-                "last_changed": "Last changed",
-                "last_updated": "Last updated",
-                "timer_status": "Timer status",
-                "install_status": "Install status"
-              }
+              "state_content": "State content"
             },
             "vertical-stack": {
               "name": "Vertical stack",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1023,7 +1023,7 @@
         "state": "State",
         "last_changed": "Last changed",
         "last_updated": "Last updated",
-        "timer_status": "Timer status",
+        "live_timer": "Live timer",
         "install_status": "Install status"
       }
     },


### PR DESCRIPTION
## Proposed change

Create a new component to display the state and multiple attributes. This logic was in the tile card and is now in its own component. This allow usage of this content outside of tile card (e.g. in future badge 👀).

Also, a selector as been created to be used in others card/badge editor.

Also , two new specials state content has been added : 
- `remaining_time` : Display a live timer of remaining time of an timer entity.
- `install_status`: Display the install status of an update entity (progress when install, previous version when skipped)

These special contents were available before as default value for those domains and can now be mixed with other contents as suggested by @silamon (https://github.com/home-assistant/frontend/pull/21290#pullrequestreview-2167007647)

Also, `last-changed` and `last-updated` has renamed by `last_changed` and `last_updated`. Backward compatibility has been added to not break user dashboards.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `StateDisplay` class for enhanced state information display.
  - Added `ha-entity-state-content-picker` for users to pick and display entity state content with a filtering and sorting combo box interface.

- **Enhancements**
  - Improved state rendering logic and introduced memoization for default state content in `HuiTileCard` component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->