### PR TITLE
Show a fallback string when repair translation fails

### DIFF
--- a/src/panels/config/repairs/dialog-repairs-issue.ts
+++ b/src/panels/config/repairs/dialog-repairs-issue.ts
@@ -79,7 +79,8 @@ class DialogRepairsIssue extends LitElement {
                 this._issue.translation_key || this._issue.issue_id
               }.description`,
               this._issue.translation_placeholders
-            )}
+            ) ||
+            `${this._issue.domain}: ${this._issue.translation_key || this._issue.issue_id}`}
           ></ha-markdown>
           ${this._issue.dismissed_version
             ? html`

--- a/src/panels/config/repairs/ha-config-repairs.ts
+++ b/src/panels/config/repairs/ha-config-repairs.ts
@@ -74,7 +74,8 @@ class HaConfigRepairs extends LitElement {
                     issue.translation_key || issue.issue_id
                   }.title`,
                   issue.translation_placeholders || {}
-                )}</span
+                ) ||
+                `${issue.domain}: ${issue.translation_key || issue.issue_id}`}</span
               >
               <span slot="secondary" class="secondary">
                 ${issue.severity === "critical" || issue.severity === "error"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
If core raise a repair issue, but get the translation key wrong, it can be confusing for users, e.g. (taken from forum support ticket):

![image](https://github.com/user-attachments/assets/ba4071b4-1aa8-4b3f-9a58-a2cf6e34146a)

We could at least print the integration and the issue key, so that user at least have something to go on to locate further assistance.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a fallback display for issue descriptions in repair dialogs to improve information visibility.
  - Introduced a fallback mechanism for displaying issue titles when translation keys are missing, showing the domain along with the key or issue ID for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->