### PR TITLE
Add error handling to device delete

### DIFF
--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -999,11 +999,20 @@ export class HaConfigDevicePage extends LitElement {
               return;
             }
 
-            await removeConfigEntryFromDevice(
-              this.hass!,
-              this.deviceId,
-              entry.entry_id
-            );
+            try {
+              await removeConfigEntryFromDevice(
+                this.hass!,
+                this.deviceId,
+                entry.entry_id
+              );
+            } catch (err: any) {
+              showAlertDialog(this, {
+                title: this.hass.localize(
+                  "ui.panel.config.devices.error_delete"
+                ),
+                text: err.message,
+              });
+            }
           },
           classes: "warning",
           icon: mdiDelete,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4068,6 +4068,7 @@
           "delete": "Delete",
           "confirm_delete": "Are you sure you want to delete this device?",
           "confirm_delete_integration": "Are you sure you want to remove this device from {integration}?",
+          "error_delete": "Error deleting device",
           "picker": {
             "search": "Search {number} devices",
             "state": "State",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Currently, if device delete fails, the frontend stays silent. The user might get hints in the Core logs, but nothing shown on the frontend.

This adds error handling similar to other places.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for removing devices from configuration. Users will now see an error message if the removal process fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->