### PR TITLE
Fix persistent notification count on server restart

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -210,6 +210,8 @@ class HaSidebar extends SubscribeMixin(LitElement) {
 
   private _editStyleLoaded = false;
 
+  private _unsubPersistentNotifications;
+
   @storage({
     key: "sidebarPanelOrder",
     state: true,
@@ -283,15 +285,26 @@ class HaSidebar extends SubscribeMixin(LitElement) {
       hass.localize !== oldHass.localize ||
       hass.locale !== oldHass.locale ||
       hass.states !== oldHass.states ||
-      hass.defaultPanel !== oldHass.defaultPanel
+      hass.defaultPanel !== oldHass.defaultPanel ||
+      hass.connected !== oldHass.connected
     );
   }
 
   protected firstUpdated(changedProps: PropertyValues) {
     super.firstUpdated(changedProps);
-    subscribeNotifications(this.hass.connection, (notifications) => {
-      this._notifications = notifications;
-    });
+    this.subscribePersistentNotifications();
+  }
+
+  private subscribePersistentNotifications(): void {
+    if (this._unsubPersistentNotifications) {
+      this._unsubPersistentNotifications();
+    }
+    this._unsubPersistentNotifications = subscribeNotifications(
+      this.hass.connection,
+      (notifications) => {
+        this._notifications = notifications;
+      }
+    );
   }
 
   protected updated(changedProps) {
@@ -304,6 +317,14 @@ class HaSidebar extends SubscribeMixin(LitElement) {
     }
     if (!changedProps.has("hass")) {
       return;
+    }
+
+    if (
+      this.hass &&
+      changedProps.get("hass")?.connected === false &&
+      this.hass.connected === true
+    ) {
+      this.subscribePersistentNotifications();
     }
 
     this._calculateCounts();

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -210,7 +210,7 @@ class HaSidebar extends SubscribeMixin(LitElement) {
 
   private _editStyleLoaded = false;
 
-  private _unsubPersistentNotifications;
+  private _unsubPersistentNotifications: UnsubscribeFunc | undefined;
 
   @storage({
     key: "sidebarPanelOrder",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
When hass reconnects after a disconnect (e.g. server restart), drop the persistent notifications subscription and resubscribe to get a fresh count. Otherwise we will be holding stale notifications that no longer exist. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17137
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of persistent notifications in the sidebar, ensuring they are properly subscribed and updated based on connection status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->