### PR TITLE
Call a service: Split remaining service_data's into data and target

### DIFF
--- a/src/components/buttons/ha-call-service-button.ts
+++ b/src/components/buttons/ha-call-service-button.ts
@@ -1,5 +1,6 @@
 import { LitElement, TemplateResult, html } from "lit";
 import { customElement, property } from "lit/decorators";
+import { HassServiceTarget } from "home-assistant-js-websocket";
 import { showConfirmationDialog } from "../../dialogs/generic/show-dialog-box";
 import "./ha-progress-button";
 import { HomeAssistant } from "../../types";
@@ -17,7 +18,9 @@ class HaCallServiceButton extends LitElement {
 
   @property() public service!: string;
 
-  @property({ type: Object }) public serviceData = {};
+  @property({ type: Object }) public target!: HassServiceTarget;
+
+  @property({ type: Object }) public data = {};
 
   @property() public confirmation?;
 
@@ -39,7 +42,8 @@ class HaCallServiceButton extends LitElement {
     const eventData = {
       domain: this.domain,
       service: this.service,
-      serviceData: this.serviceData,
+      data: this.data,
+      target: this.target,
       success: false,
     };
 
@@ -47,7 +51,12 @@ class HaCallServiceButton extends LitElement {
       this.shadowRoot!.querySelector("ha-progress-button")!;
 
     try {
-      await this.hass.callService(this.domain, this.service, this.serviceData);
+      await this.hass.callService(
+        this.domain,
+        this.service,
+        this.data,
+        this.target
+      );
       this.progress = false;
       progressElement.actionSuccess();
       eventData.success = true;
@@ -85,7 +94,8 @@ declare global {
     "hass-service-called": {
       domain: string;
       service: string;
-      serviceData: object;
+      target: HassServiceTarget;
+      data: object;
       success: boolean;
     };
   }

--- a/src/panels/config/integrations/integration-panels/zha/zha-cluster-attributes.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-cluster-attributes.ts
@@ -134,7 +134,7 @@ export class ZHAClusterAttributes extends LitElement {
           .hass=${this.hass}
           domain="zha"
           service="set_zigbee_cluster_attribute"
-          .serviceData=${this._setAttributeServiceData}
+          .data=${this._setAttributeServiceData}
         >
           ${this.hass!.localize(
             "ui.panel.config.zha.cluster_attributes.write_zigbee_attribute"

--- a/src/panels/config/integrations/integration-panels/zha/zha-cluster-commands.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-cluster-commands.ts
@@ -115,7 +115,7 @@ export class ZHAClusterCommands extends LitElement {
                   .hass=${this.hass}
                   domain="zha"
                   service="issue_zigbee_cluster_command"
-                  .serviceData=${this._issueClusterCommandServiceData}
+                  .data=${this._issueClusterCommandServiceData}
                   .disabled=${!this._canIssueCommand}
                 >
                   ${this.hass!.localize(

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
@@ -6,7 +6,6 @@ import { fireEvent } from "../../../../../common/dom/fire_event";
 import { computeStateName } from "../../../../../common/entity/compute_state_name";
 import { stringCompare } from "../../../../../common/string/compare";
 import { slugify } from "../../../../../common/string/slugify";
-import "../../../../../components/buttons/ha-call-service-button";
 import "../../../../../components/entity/state-badge";
 import "../../../../../components/ha-area-picker";
 import "../../../../../components/ha-card";

--- a/src/panels/lovelace/elements/hui-service-button-element.ts
+++ b/src/panels/lovelace/elements/hui-service-button-element.ts
@@ -40,12 +40,17 @@ export class HuiServiceButtonElement
       return nothing;
     }
 
+    const updatedTarget = this._config.target ?? {
+      entity_id: this._config.service_data?.entity_id,
+    };
+
     return html`
       <ha-call-service-button
         .hass=${this.hass}
         .domain=${this._domain}
         .service=${this._service}
-        .serviceData=${this._config.service_data}
+        .data=${this._config.data ?? this._config.service_data}
+        .target=${updatedTarget}
         >${this._config.title}</ha-call-service-button
       >
     `;

--- a/src/panels/lovelace/elements/hui-service-button-element.ts
+++ b/src/panels/lovelace/elements/hui-service-button-element.ts
@@ -40,8 +40,14 @@ export class HuiServiceButtonElement
       return nothing;
     }
 
+    const { entity_id, label_id, floor_id, device_id, area_id } =
+      this._config.service_data ?? {};
     const updatedTarget = this._config.target ?? {
-      entity_id: this._config.service_data?.entity_id,
+      entity_id,
+      label_id,
+      floor_id,
+      device_id,
+      area_id,
     };
 
     return html`

--- a/src/panels/lovelace/elements/types.ts
+++ b/src/panels/lovelace/elements/types.ts
@@ -1,3 +1,4 @@
+import { HassServiceTarget } from "home-assistant-js-websocket";
 import { ActionConfig } from "../../../data/lovelace/config/action";
 import { HomeAssistant } from "../../../types";
 import { Condition } from "../common/validate-condition";
@@ -56,7 +57,10 @@ export interface ImageElementConfig extends LovelaceElementConfigBase {
 export interface ServiceButtonElementConfig extends LovelaceElementConfigBase {
   title?: string;
   service?: string;
+  target?: HassServiceTarget;
+  // "service_data" is kept for backwards compatibility. Replaced by "data".
   service_data?: Record<string, unknown>;
+  data?: Record<string, unknown>;
 }
 
 export interface StateBadgeElementConfig extends LovelaceElementConfigBase {


### PR DESCRIPTION
## Proposed change
It's been a while you can use `data` and `target` to call a service as a replacelement for `service_data`.  This migrates the remaining parts to use data and target. Take a good look if you can, since I'm still unsure if this doesn't introduce breaking changes.

It also introduces changes in the picture elements card so the service call button supports that as well. That will need a documentation change to be done. 

```
type: picture-elements
elements:
  - type: service-button
    title: 81% (old)
    style:
      top: 55%
      left: 30%
    service: light.turn_on
    service_data:
      entity_id: light.bed_light
      brightness_pct: 81
  - type: service-button
    title: 81% (new)
    style:
      top: 65%
      left: 30%
    service: light.turn_on
    data:
      brightness_pct: 81
    target:
      entity_id: light.bed_light
  - type: service-button
    title: off (old)
    style:
      top: 55%
      left: 60%
    service: light.turn_off
    service_data:
      entity_id: light.bed_light
  - type: service-button
    title: off (new)
    style:
      top: 65%
      left: 60%
    service: light.turn_off
    target:
      entity_id: light.bed_light
image: https://demo.home-assistant.io/stub_config/floorplan.png
```

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13827
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `target` property for specifying service call targets, enhancing service invocation precision.
  - Added a `data` property for improved service data handling, replacing the previous `serviceData`.

- **Bug Fixes**
  - Improved fallback mechanisms for target and data configurations in the service button, enhancing usability in various scenarios.

- **Documentation**
  - Updated interface `ServiceButtonElementConfig` to include new optional properties, promoting clearer service handling in configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->