### PR TITLE
Don't eat spaces while searching

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -597,7 +597,7 @@ export class HaDataTable extends LitElement {
       filteredData = await this._memFilterData(
         this.data,
         this._sortColumns,
-        this._filter
+        this._filter.trim()
       );
     }
 

--- a/src/components/search-input-outlined.ts
+++ b/src/components/search-input-outlined.ts
@@ -79,7 +79,7 @@ class SearchInputOutlined extends LitElement {
   }
 
   private async _filterInputChanged(e) {
-    this._filterChanged(e.target.value?.trim());
+    this._filterChanged(e.target.value);
   }
 
   private async _clearSearch() {

--- a/src/components/search-input.ts
+++ b/src/components/search-input.ts
@@ -67,7 +67,7 @@ class SearchInput extends LitElement {
   }
 
   private async _filterInputChanged(e) {
-    this._filterChanged(e.target.value?.trim());
+    this._filterChanged(e.target.value);
   }
 
   private async _clearSearch() {


### PR DESCRIPTION
## Proposed change
Alternative fix for #20825 to fix #21325. This doesn't modify the search value in the search field anymore, but trims spaces in front or back of the value when search is being executed. 

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #21325
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved data filtering for the data table component by enhancing input handling.
	- Adjusted search input processing to allow for untrimmed values, potentially affecting search behavior.
  
- **Bug Fixes**
	- Adjusted filtering logic to ensure whitespace does not interfere with data display accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->