### PR TITLE
Add enable_millisecond to duration selector

### DIFF
--- a/src/components/ha-selector/ha-selector-duration.ts
+++ b/src/components/ha-selector/ha-selector-duration.ts
@@ -30,6 +30,7 @@ export class HaTimeDuration extends LitElement {
         .disabled=${this.disabled}
         .required=${this.required}
         ?enableDay=${this.selector.duration?.enable_day}
+        ?enableMillisecond=${this.selector.duration?.enable_millisecond}
       ></ha-duration-input>
     `;
   }

--- a/src/components/ha-selector/ha-selector-selector.ts
+++ b/src/components/ha-selector/ha-selector-selector.ts
@@ -57,6 +57,10 @@ const SELECTOR_SCHEMAS = {
       name: "enable_day",
       selector: { boolean: {} },
     },
+    {
+      name: "enable_millisecond",
+      selector: { boolean: {} },
+    },
   ] as const,
   entity: [
     {

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -203,6 +203,7 @@ export interface LegacyDeviceSelector {
 export interface DurationSelector {
   duration: {
     enable_day?: boolean;
+    enable_millisecond?: boolean;
   } | null;
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Allow duration selector schema to pass `enable_millisecond` to the duration input. Use of milliseconds for duration selector was requested for some blueprints, as it maps nicely to the delay/wait script actions which also support milliseconds. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://community.home-assistant.io/t/add-milliseconds-to-the-duration-selector/647936
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `enableMillisecond` option in the duration input component, allowing users to select time durations including milliseconds.
	- Added a new boolean selector for `enable_millisecond` to enhance configurability in time selection.
  
- **Improvements**
	- Updated the duration selection interface to support optional millisecond inclusion, improving granularity of time settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->