### PR TITLE
[Lovelace] [Section Layout] Configurable Columns per Section

### DIFF
--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -3,6 +3,7 @@ import type { LovelaceCardConfig } from "./card";
 import type { LovelaceStrategyConfig } from "./strategy";
 
 export interface LovelaceBaseSectionConfig {
+  columns?: number;
   title?: string;
   visibility?: Condition[];
 }

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -13,10 +13,21 @@ const SCHEMA = [
     name: "title",
     selector: { text: {} },
   },
+  {
+    name: "columns",
+    selector: {
+      number: {
+        min: 1,
+        max: 10,
+        mode: "slider",
+      },
+    },
+  },
 ] as const satisfies HaFormSchema[];
 
 type SettingsData = {
   title: string;
+  columns: number;
 };
 
 @customElement("hui-section-settings-editor")
@@ -28,6 +39,7 @@ export class HuiDialogEditSection extends LitElement {
   render() {
     const data: SettingsData = {
       title: this.config.title || "",
+      columns: this.config.columns || 1,
     };
 
     return html`
@@ -59,10 +71,15 @@ export class HuiDialogEditSection extends LitElement {
     const newConfig: LovelaceSectionRawConfig = {
       ...this.config,
       title: newData.title,
+      columns: newData.columns,
     };
 
     if (!newConfig.title) {
       delete newConfig.title;
+    }
+
+    if (!newConfig.columns) {
+      delete newConfig.columns;
     }
 
     fireEvent(this, "value-changed", { value: newConfig });

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5637,7 +5637,9 @@
             "edit_yaml": "[%key:ui::panel::lovelace::editor::edit_view::edit_yaml%]",
             "settings": {
               "title": "Title",
-              "title_helper": "The title will appear at the top of section. Leave empty to hide the title."
+              "title_helper": "The title will appear at the top of section. Leave empty to hide the title.",
+              "columns": "Columns",
+              "columns_helper": "Expand the section to take up more columns in the view."
             },
             "visibility": {
               "explanation": "The section will be shown when ALL conditions below are fulfilled. If no conditions are set, the section will always be shown."


### PR DESCRIPTION
## Proposed change
This is my first contribution to HAAS, so if I miss something please let me know and I will modify or fix it. 
I saw the meet video about this new Section Layout and I tried immediately.
I notice that one of the big back-draws are if you wanna use some sections with more columns it's impossible for introduce a big map, or some banners for each section of your dashboard.
This PR introduce the possibility to configure how many columns should be use that section, for multi device compatibility I need reduce the `grid-column span` on that element if the `auto-fit` .

[Demo Video](https://www.youtube.com/watch?v=8I_tyQ0gnNM)

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
```yaml
type: grid
cards:
  - type: picture
    image: https://demo.home-assistant.io/stub_config/t-shirt-promo.png
    layout_options:
      grid_columns: 4
      grid_rows: 1
columns: 4
title: Banner
```

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `columns` property for section configuration, allowing users to specify the number of columns for improved layout flexibility.
	- Added a slider interface for configuring the number of columns (1 to 10) in the section settings.

- **Enhancements**
	- Improved section layout management to adapt dynamically to viewport size, ensuring a responsive user experience.

- **Translations**
	- Added new translation keys for the `columns` setting, providing user-friendly helper text for enhanced configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->