### PR TITLE
Add a destructive confirmation when deleting a picture-elements element

### DIFF
--- a/src/panels/lovelace/editor/hui-picture-elements-card-row-editor.ts
+++ b/src/panels/lovelace/editor/hui-picture-elements-card-row-editor.ts
@@ -8,6 +8,7 @@ import "../../../components/ha-svg-icon";
 import { HomeAssistant } from "../../../types";
 import "../../../components/ha-select";
 import type { HaSelect } from "../../../components/ha-select";
+import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
 import {
   ConditionalElementConfig,
   IconElementConfig,
@@ -77,7 +78,7 @@ export class HuiPictureElementsCardRowEditor extends LitElement {
                   `
                 : nothing}
               <ha-icon-button
-                .label=${this.hass!.localize("ui.common.clear")}
+                .label=${this.hass!.localize("ui.common.delete")}
                 .path=${mdiClose}
                 class="remove-icon"
                 .index=${index}
@@ -187,11 +188,28 @@ export class HuiPictureElementsCardRowEditor extends LitElement {
 
   private _removeRow(ev: CustomEvent): void {
     const index = (ev.currentTarget as any).index;
-    const newElements = this.elements!.concat();
-
-    newElements.splice(index, 1);
-
-    fireEvent(this, "elements-changed", { elements: newElements });
+    const element = this.elements?.[index];
+    if (!element) {
+      return;
+    }
+    showConfirmationDialog(this, {
+      text: this.hass!.localize(
+        "ui.panel.lovelace.editor.card.picture-elements.confirm_delete_element",
+        {
+          type:
+            this.hass!.localize(
+              `ui.panel.lovelace.editor.card.picture-elements.element_types.${element.type}`
+            ) || element.type,
+        }
+      ),
+      confirmText: this.hass!.localize("ui.common.delete"),
+      destructive: true,
+      confirm: () => {
+        const newElements = this.elements!.concat();
+        newElements.splice(index, 1);
+        fireEvent(this, "elements-changed", { elements: newElements });
+      },
+    });
   }
 
   private _editRow(ev: CustomEvent): void {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5989,6 +5989,7 @@
               "card_options": "Card Options",
               "elements": "Elements",
               "new_element": "Add new element",
+              "confirm_delete_element": "Are you sure you want to delete the {type} element?",
               "dark_mode_image": "Dark mode image path",
               "state_filter": "State filter",
               "dark_mode_filter": "Dark mode state filter",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
When clicking the X to remove a picture-elements element, show a confirmation dialog. 

The X is right next to the edit button, so prefer to be a little safer to prevent accidental deletes, given the number and complexity of possible sub-options.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a confirmation dialog for removing elements, enhancing user control and reducing accidental deletions.
	- Added a new confirmation message in English to improve user awareness before deletion actions. 

These changes collectively enhance the user experience by ensuring that deletions are intentional and clearly communicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->