### PR TITLE
Show in Assist dialog if assistant is unable to control Home Assistant

### DIFF
--- a/src/data/conversation.ts
+++ b/src/data/conversation.ts
@@ -1,6 +1,10 @@
 import { ensureArray } from "../common/array/ensure-array";
 import { HomeAssistant } from "../types";
 
+export const enum ConversationEntityFeature {
+  CONTROL = 1,
+}
+
 interface IntentTarget {
   type: "area" | "device" | "entity" | "domain" | "device_class" | "custom";
   name: string;

--- a/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
@@ -41,6 +41,8 @@ import { AudioRecorder } from "../../util/audio-recorder";
 import { documentationUrl } from "../../util/documentation-url";
 import { showAlertDialog } from "../generic/show-dialog-box";
 import { VoiceCommandDialogParams } from "./show-ha-voice-command-dialog";
+import { supportsFeature } from "../../common/entity/supports-feature";
+import { ConversationEntityFeature } from "../../data/conversation";
 
 interface Message {
   who: string;
@@ -136,6 +138,12 @@ export class HaVoiceCommandDialog extends LitElement {
       return nothing;
     }
 
+    const controlHA = !this._pipeline
+      ? false
+      : supportsFeature(
+          this.hass.states[this._pipeline?.conversation_engine],
+          ConversationEntityFeature.CONTROL
+        );
     const supportsMicrophone = AudioRecorder.isSupported;
     const supportsSTT = this._pipeline?.stt_engine;
 
@@ -212,6 +220,15 @@ export class HaVoiceCommandDialog extends LitElement {
             ></ha-icon-button>
           </a>
         </ha-dialog-header>
+        ${controlHA
+          ? nothing
+          : html`
+              <ha-alert>
+                ${this.hass.localize(
+                  "ui.dialogs.voice_command.conversation_no_control"
+                )}
+              </ha-alert>
+            `}
         <div class="messages">
           <div class="messages-container" id="scroll-container">
             ${this._conversation!.map(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1125,6 +1125,7 @@
         "did_not_understand": "Didn't quite get that",
         "found": "I found the following for you:",
         "error": "Oops, an error has occurred",
+        "conversation_no_control": "This assistant cannot control Home Assistant.",
         "how_can_i_help": "How can I assist?",
         "input_label": "Enter a request",
         "send_text": "Send text",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1125,7 +1125,7 @@
         "did_not_understand": "Didn't quite get that",
         "found": "I found the following for you:",
         "error": "Oops, an error has occurred",
-        "conversation_no_control": "This assistant cannot control Home Assistant.",
+        "conversation_no_control": "This assistant cannot control your home.",
         "how_can_i_help": "How can I assist?",
         "input_label": "Enter a request",
         "send_text": "Send text",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Adds an info message to the Assist dialog if the selected assistant is unable to control Home Assistant.

<img width="427" alt="image" src="https://github.com/user-attachments/assets/eeb094aa-6257-427a-ad76-e5fc4afaa37b">


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new feature check for conversation entities, enhancing future capabilities.
	- Added user alerts in the voice command dialog to indicate when control features are unavailable.

- **Enhancements**
	- Improved user feedback by clarifying the limitations of the assistant's control over home automation with a new message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->