### PR TITLE
Dont load unnecessary translations for helper dialog

### DIFF
--- a/src/panels/config/helpers/dialog-helper-detail.ts
+++ b/src/panels/config/helpers/dialog-helper-detail.ts
@@ -123,13 +123,10 @@ export class DialogHelperDetail extends LitElement {
     this._opened = true;
     await this.updateComplete;
     this.hass.loadFragmentTranslation("config");
-    Promise.all([
-      getConfigFlowHandlers(this.hass, ["helper"]),
-      // Ensure the titles are loaded before we render the flows.
-      this.hass.loadBackendTranslation("title", undefined, true),
-    ]).then(([flows]) => {
-      this._helperFlows = flows;
-    });
+    const flows = await getConfigFlowHandlers(this.hass, ["helper"]);
+    await this.hass.loadBackendTranslation("title", flows, true);
+    // Ensure the titles are loaded before we render the flows.
+    this._helperFlows = flows;
   }
 
   public closeDialog(): void {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
When I click the "add helper" button with a cold browser cache, there's a ~1s hiccup while the dialog loads, and in my core log I see many hundreds of lines of:
```
...
2024-08-03 07:48:39.175 INFO (SyncWorker_44) [homeassistant.loader] Loaded poolsense from homeassistant.components.poolsense
2024-08-03 07:48:39.176 INFO (SyncWorker_44) [homeassistant.loader] Loaded wolflink from homeassistant.components.wolflink
2024-08-03 07:48:39.177 INFO (SyncWorker_44) [homeassistant.loader] Loaded rpi_power from homeassistant.components.rpi_power
2024-08-03 07:48:39.179 INFO (SyncWorker_44) [homeassistant.loader] Loaded suez_water from homeassistant.components.suez_water
...
```

It seems we are asking for every integration to be loaded, so that we can get the translation titles? 

This change restricts the translation fetch to helper integrations only. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of configuration flow and backend translations to enhance sequential processing and error handling.

- **Refactor**
  - Simplified control flow by shifting from concurrent to sequential execution, enhancing readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->