### PR TITLE
Link old service worker to new name

### DIFF
--- a/build-scripts/gulp/compress.js
+++ b/build-scripts/gulp/compress.js
@@ -29,7 +29,7 @@ const compressDistZopfli = (rootDir, modernDir) =>
       [
         `${rootDir}/**/${filesGlob}`,
         `!${modernDir}/**/${filesGlob}`,
-        `!${rootDir}/sw-modern.js`,
+        `!${rootDir}/{sw-modern,service_worker}.js`,
         `${rootDir}/{authorize,onboarding}.html`,
       ],
       { base: rootDir }

--- a/src/util/register-service-worker.ts
+++ b/src/util/register-service-worker.ts
@@ -23,13 +23,6 @@ export const registerServiceWorker = async (
     return;
   }
 
-  if (reg?.active?.scriptURL.includes("service_worker.js")) {
-    // We are running an old version of the service worker. Force reload.
-    await reg.unregister();
-    // @ts-ignore Firefox supports force reload
-    location.reload(true);
-  }
-
   reg.addEventListener("updatefound", () => {
     const installingWorker = reg.installing;
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Fixes #21542 by pointing the old service worker name to the new one, and revert #21561 as it is ineffective (new frontend never gets installed, so it will never see that code).  This PR needs https://github.com/home-assistant/core/pull/123131.

What is happening is that the HTML is being served by the old SW.  This then loads the old frontend and continues to try to register the SW under the old name, which gets a 404 and so it won't get the update.  The HTML is being handled with a "stale while revalidate" strategy, so it would be expected that the browser would just get the update anyway on the next visit.  Browsers and the iOS app seem to do just that, but android web view seems to get in the way of this for some reason.

I'd have to do more digging to figure out why, but this change should fix it regardless.  It might be that other browsers effectively unregister the old SW on the 404 and android doesn't, or that [android's service worker controller](https://developer.android.com/reference/android/webkit/ServiceWorkerController) is altering behavior. 🤷🏻‍♂️ 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced service worker generation process with the ability to create symbolic links for modern builds, improving file management.

- **Bug Fixes**
  - Removed outdated service worker check, which may affect how the application handles service worker updates.

- **Refactor**
  - Improved code clarity and maintainability by adjusting how the destination for the service worker file is assigned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->