### PR TITLE
Add indicator/alert to YAML integrations on integration page

### DIFF
--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -13,6 +13,7 @@ import {
   mdiDevices,
   mdiDotsVertical,
   mdiDownload,
+  mdiFileCodeOutline,
   mdiHandExtendedOutline,
   mdiOpenInNew,
   mdiPackageVariant,
@@ -326,6 +327,22 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                       ><ha-svg-icon slot="icon" path=${mdiCloud}></ha-svg-icon
                       >${this.hass.localize(
                         "ui.panel.config.integrations.config_entry.depends_on_cloud"
+                      )}</ha-alert
+                    >`
+                  : ""}
+                ${normalEntries.length === 0 &&
+                this._manifest &&
+                !this._manifest.config_flow &&
+                this.hass.config.components.find(
+                  (comp) => comp.split(".")[0] === this.domain
+                )
+                  ? html`<ha-alert alert-type="info"
+                      ><ha-svg-icon
+                        slot="icon"
+                        path=${mdiFileCodeOutline}
+                      ></ha-svg-icon
+                      >${this.hass.localize(
+                        "ui.panel.config.integrations.config_entry.no_config_flow"
                       )}</ha-alert
                     >`
                   : ""}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Process feedback by @jlpouffier, the icon that is show in the integration dashboard, let it return on the integration page. This adds context to what the icon means and is consistent with all the others we show / have.

![image](https://github.com/user-attachments/assets/17133f18-fbb5-448e-a63b-b7959bdb8a2f)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new SVG icon to enhance the alert message for integrations with no available configuration flows.
	- Added informative messaging to improve user feedback regarding integration configuration status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->