### PR TITLE
Plot 'untracked consumption' on devices detail energy graph

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
@@ -252,7 +252,7 @@ export class HuiEnergyDevicesDetailGraphCard
 
     const { summedData, compareSummedData } = getSummedData(energyData);
 
-    const hasProduction =
+    const showUntracked =
       "from_grid" in summedData ||
       "solar" in summedData ||
       "from_battery" in summedData;
@@ -260,11 +260,11 @@ export class HuiEnergyDevicesDetailGraphCard
     const {
       consumption: consumptionData,
       compareConsumption: consumptionCompareData,
-    } = hasProduction
+    } = showUntracked
       ? computeConsumptionData(summedData, compareSummedData)
       : { consumption: undefined, compareConsumption: undefined };
 
-    if (hasProduction) {
+    if (showUntracked) {
       this._untrackedIndex = datasets.length;
       const { dataset: untrackedData, datasetExtra: untrackedDataExtra } =
         this._processUntracked(
@@ -310,7 +310,7 @@ export class HuiEnergyDevicesDetailGraphCard
       datasets.push(...processedCompareData);
       datasetExtras.push(...processedCompareDataExtras);
 
-      if (hasProduction) {
+      if (showUntracked) {
         const {
           dataset: untrackedCompareData,
           datasetExtra: untrackedCompareDataExtra,

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
@@ -18,12 +18,15 @@ import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import memoizeOne from "memoize-one";
 import { getGraphColorByIndex } from "../../../../common/color/colors";
+import { getEnergyColor } from "./common/color";
 import { ChartDatasetExtra } from "../../../../components/chart/ha-chart-base";
 import "../../../../components/ha-card";
 import {
   DeviceConsumptionEnergyPreference,
   EnergyData,
   getEnergyDataCollection,
+  getSummedData,
+  computeConsumptionData,
 } from "../../../../data/energy";
 import {
   calculateStatisticSumGrowth,
@@ -71,6 +74,8 @@ export class HuiEnergyDevicesDetailGraphCard
     subscribe: false,
   })
   private _hiddenStats: string[] = [];
+
+  private _untrackedIndex?: number;
 
   protected hassSubscribeRequiredHostProps = ["_config"];
 
@@ -149,17 +154,22 @@ export class HuiEnergyDevicesDetailGraphCard
   }
 
   private _datasetHidden(ev) {
-    this._hiddenStats = [
-      ...this._hiddenStats,
-      this._data!.prefs.device_consumption[ev.detail.index].stat_consumption,
-    ];
+    const hiddenEntity =
+      ev.detail.index === this._untrackedIndex
+        ? "untracked"
+        : this._data!.prefs.device_consumption[ev.detail.index]
+            .stat_consumption;
+    this._hiddenStats = [...this._hiddenStats, hiddenEntity];
   }
 
   private _datasetUnhidden(ev) {
+    const hiddenEntity =
+      ev.detail.index === this._untrackedIndex
+        ? "untracked"
+        : this._data!.prefs.device_consumption[ev.detail.index]
+            .stat_consumption;
     this._hiddenStats = this._hiddenStats.filter(
-      (stat) =>
-        stat !==
-        this._data!.prefs.device_consumption[ev.detail.index].stat_consumption
+      (stat) => stat !== hiddenEntity
     );
   }
 
@@ -240,6 +250,23 @@ export class HuiEnergyDevicesDetailGraphCard
 
     datasetExtras.push(...processedDataExtras);
 
+    const { summedData, compareSummedData } = getSummedData(energyData);
+    const {
+      consumption: consumptionData,
+      compareConsumption: consumptionCompareData,
+    } = computeConsumptionData(summedData, compareSummedData);
+
+    this._untrackedIndex = datasets.length;
+    const { dataset: untrackedData, datasetExtra: untrackedDataExtra } =
+      this._processUntracked(
+        computedStyle,
+        processedData,
+        consumptionData,
+        false
+      );
+    datasets.push(untrackedData);
+    datasetExtras.push(untrackedDataExtra);
+
     if (compareData) {
       // Add empty dataset to align the bars
       datasets.push({
@@ -272,6 +299,18 @@ export class HuiEnergyDevicesDetailGraphCard
 
       datasets.push(...processedCompareData);
       datasetExtras.push(...processedCompareDataExtras);
+
+      const {
+        dataset: untrackedCompareData,
+        datasetExtra: untrackedCompareDataExtra,
+      } = this._processUntracked(
+        computedStyle,
+        processedCompareData,
+        consumptionCompareData,
+        true
+      );
+      datasets.push(untrackedCompareData);
+      datasetExtras.push(untrackedCompareDataExtra);
     }
 
     this._start = energyData.start;
@@ -284,6 +323,57 @@ export class HuiEnergyDevicesDetailGraphCard
       datasets,
     };
     this._chartDatasetExtra = datasetExtras;
+  }
+
+  private _processUntracked(
+    computedStyle: CSSStyleDeclaration,
+    processedData,
+    consumptionData,
+    compare: boolean
+  ): { dataset; datasetExtra } {
+    const totalDeviceConsumption: { [start: number]: number } = {};
+
+    processedData.forEach((device) => {
+      device.data.forEach((datapoint) => {
+        totalDeviceConsumption[datapoint.x] =
+          (totalDeviceConsumption[datapoint.x] || 0) + datapoint.y;
+      });
+    });
+
+    const untrackedConsumption: { x: number; y: number }[] = [];
+    Object.keys(consumptionData.total).forEach((time) => {
+      untrackedConsumption.push({
+        x: Number(time),
+        y: consumptionData.total[time] - (totalDeviceConsumption[time] || 0),
+      });
+    });
+    const dataset = {
+      label: this.hass.localize("ui.panel.energy.charts.untracked_consumption"),
+      hidden: this._hiddenStats.includes("untracked"),
+      borderColor: getEnergyColor(
+        computedStyle,
+        this.hass.themes.darkMode,
+        false,
+        compare,
+        "--state-unavailable-color"
+      ),
+      backgroundColor: getEnergyColor(
+        computedStyle,
+        this.hass.themes.darkMode,
+        true,
+        compare,
+        "--state-unavailable-color"
+      ),
+      data: untrackedConsumption,
+      order: 1 + this._untrackedIndex!,
+      stack: "devices",
+      pointStyle: compare ? false : "circle",
+      xAxisID: compare ? "xAxisCompare" : undefined,
+    };
+    const datasetExtra = {
+      show_legend: !compare,
+    };
+    return { dataset, datasetExtra };
   }
 
   private _processDataSet(

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
@@ -251,21 +251,31 @@ export class HuiEnergyDevicesDetailGraphCard
     datasetExtras.push(...processedDataExtras);
 
     const { summedData, compareSummedData } = getSummedData(energyData);
+
+    const hasProduction =
+      "from_grid" in summedData ||
+      "solar" in summedData ||
+      "from_battery" in summedData;
+
     const {
       consumption: consumptionData,
       compareConsumption: consumptionCompareData,
-    } = computeConsumptionData(summedData, compareSummedData);
+    } = hasProduction
+      ? computeConsumptionData(summedData, compareSummedData)
+      : { consumption: undefined, compareConsumption: undefined };
 
-    this._untrackedIndex = datasets.length;
-    const { dataset: untrackedData, datasetExtra: untrackedDataExtra } =
-      this._processUntracked(
-        computedStyle,
-        processedData,
-        consumptionData,
-        false
-      );
-    datasets.push(untrackedData);
-    datasetExtras.push(untrackedDataExtra);
+    if (hasProduction) {
+      this._untrackedIndex = datasets.length;
+      const { dataset: untrackedData, datasetExtra: untrackedDataExtra } =
+        this._processUntracked(
+          computedStyle,
+          processedData,
+          consumptionData,
+          false
+        );
+      datasets.push(untrackedData);
+      datasetExtras.push(untrackedDataExtra);
+    }
 
     if (compareData) {
       // Add empty dataset to align the bars
@@ -300,17 +310,19 @@ export class HuiEnergyDevicesDetailGraphCard
       datasets.push(...processedCompareData);
       datasetExtras.push(...processedCompareDataExtras);
 
-      const {
-        dataset: untrackedCompareData,
-        datasetExtra: untrackedCompareDataExtra,
-      } = this._processUntracked(
-        computedStyle,
-        processedCompareData,
-        consumptionCompareData,
-        true
-      );
-      datasets.push(untrackedCompareData);
-      datasetExtras.push(untrackedCompareDataExtra);
+      if (hasProduction) {
+        const {
+          dataset: untrackedCompareData,
+          datasetExtra: untrackedCompareDataExtra,
+        } = this._processUntracked(
+          computedStyle,
+          processedCompareData,
+          consumptionCompareData,
+          true
+        );
+        datasets.push(untrackedCompareData);
+        datasetExtras.push(untrackedCompareDataExtra);
+      }
     }
 
     this._start = energyData.start;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7145,7 +7145,8 @@
         "charts": {
           "stat_house_energy_meter": "Total energy consumption",
           "solar": "Solar",
-          "by_device": "Consumption by device"
+          "by_device": "Consumption by device",
+          "untracked_consumption": "Untracked consumption"
         },
         "cards": {
           "energy_usage_graph_title": "Energy usage",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Add a bar on the detail devices graph showing the "untracked consumption", which is the difference between the sum of all known device consumptions, and the computed total house consumption. I believe I've often seen requests for this, and it's not necessarily easy to template/calculate on your own. 

![image](https://github.com/user-attachments/assets/6fb12518-2889-488c-88c5-e7e6a7bf1fd0)

If we like this could probably add the same to the other invididual device card, but haven't looked at that yet. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://community.home-assistant.io/t/energy-dashboard-stacked-device-consumption/367087
https://community.home-assistant.io/t/track-untracked-energy-consumption/514041
https://community.home-assistant.io/t/improve-template-to-sum-untracked-electricity-use/480637
https://community.home-assistant.io/t/template-sum-energy-monitors/426637


- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced functions for aggregating and computing energy consumption data, enhancing data handling and visualization capabilities.
	- Added support for visualizing untracked energy consumption data in the energy devices detail graph card.
	- New translation entry for "Untracked consumption" to improve user interface clarity.

- **Bug Fixes**
	- Improved logic for managing hidden statistics in energy data visualization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->