### PR TITLE
Adds throttler to config pages for state entity updates

### DIFF
--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -51,6 +51,7 @@ import { SubscribeMixin } from "../../mixins/subscribe-mixin";
 import { HomeAssistant, Route } from "../../types";
 import { subscribeLabelRegistry } from "../../data/label_registry";
 import { subscribeFloorRegistry } from "../../data/floor_registry";
+import { throttle } from "../../common/util/throttle";
 
 declare global {
   // for fire event
@@ -395,6 +396,10 @@ class HaPanelConfig extends SubscribeMixin(HassRouterPage) {
     initialValue: [],
   });
 
+  private _hassThrottler = throttle((el, hass) => {
+    el.hass = hass;
+  }, 1000);
+
   public hassSubscribe(): UnsubscribeFunc[] {
     return [
       subscribeEntityRegistry(this.hass.connection!, (entities) => {
@@ -641,7 +646,11 @@ class HaPanelConfig extends SubscribeMixin(HassRouterPage) {
       this.hass.dockedSidebar === "docked" ? this._wideSidebar : this._wide;
 
     el.route = this.routeTail;
-    el.hass = this.hass;
+    if (el.hass !== undefined) {
+      this._hassThrottler(el, this.hass);
+    } else {
+      el.hass = this.hass;
+    }
     el.showAdvanced = Boolean(this.hass.userData?.showAdvanced);
     el.isWide = isWide;
     el.narrow = this.narrow;


### PR DESCRIPTION
## Proposed change
Adds a throttler to throttle incoming state changes. This is only a problem for Home Assistant installations that do multiple state updates per second. I didn't add it everywhere hass is updated, as it needs further testing for edge cases and therefore also not for backport I guess. 

This problem, better described in the issue, started with the introduction of the new tables, since they do a lot more scripting work than before. Apparently, the entity page was already slower since a few releases, since the last release the helper page is added. It slows down to the fact that lit cannot keep up rendering the bottom children of the render tree, delaying until a moment allows to render it. On those entity and helper pages, it triggers the component to recalculate the shown items and filteredItems, probably the cause of pushing the pages to lag. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #21530 fixes #21001
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced performance for handling updates to the `hass` property, ensuring more responsive interaction with the component.
- **Bug Fixes**
	- Improved conditional logic for assigning the `hass` instance, reducing unnecessary updates and enhancing stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->