### PR TITLE
Light color temp picker: check light color temperature support from supported_color_modes

### DIFF
--- a/src/dialogs/more-info/components/lights/light-color-temp-picker.ts
+++ b/src/dialogs/more-info/components/lights/light-color-temp-picker.ts
@@ -24,6 +24,7 @@ import {
   LightColor,
   LightColorMode,
   LightEntity,
+  lightSupportsColorMode,
 } from "../../../../data/light";
 import { HomeAssistant } from "../../../../types";
 import { DOMAIN_ATTRIBUTES_UNITS } from "../../../../data/entity_attributes";
@@ -111,7 +112,7 @@ class LightColorTempPicker extends LitElement {
 
     if (stateObj.state === "on") {
       this._ctPickerValue =
-        stateObj.attributes.color_mode === LightColorMode.COLOR_TEMP
+        lightSupportsColorMode(stateObj, LightColorMode.COLOR_TEMP)
           ? stateObj.attributes.color_temp_kelvin
           : undefined;
     } else {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

HA supports lights having multiple color modes, for example RGBW+COLOR_TEMP for CCT led strips.
Light entities have two attributes:
- `supported_color_modes` which stores ALL supported color modes
- `color_mode` that stores the main color mode
For these kind of lights often `color_mode` does not equal to `COLOR_TEMP `, despite the light having color temperature support.

This PR changes how the support is checked: instead of checking the `color_mode` attribute checks the `supported_color_modes` one.

This (together with another PR to the core) fixes WLED CCT support for HA.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new utility function to determine light color mode support, enhancing flexibility in handling light color functionalities.

- **Refactor**
	- Improved maintainability of the light color temperature picker by encapsulating color mode logic in a new function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->