### PR TITLE
Update styling on Template dev-tools

### DIFF
--- a/src/panels/developer-tools/template/developer-tools-template.ts
+++ b/src/panels/developer-tools/template/developer-tools-template.ts
@@ -129,137 +129,135 @@ class HaPanelDevTemplate extends LitElement {
           horizontal: !this.narrow,
         })}"
       >
-        <div class="edit-pane">
-          <ha-card
-            header=${this.hass.localize(
-              "ui.panel.developer-tools.tabs.templates.editor"
-            )}
-          >
-            <div class="card-content">
-              <ha-code-editor
-                mode="jinja2"
-                .hass=${this.hass}
-                .value=${this._template}
-                .error=${this._error}
-                autofocus
-                autocomplete-entities
-                autocomplete-icons
-                @value-changed=${this._templateChanged}
-                dir="ltr"
-              ></ha-code-editor>
-            </div>
-            <div class="card-actions">
-              <mwc-button @click=${this._restoreDemo}>
-                ${this.hass.localize(
-                  "ui.panel.developer-tools.tabs.templates.reset"
-                )}
-              </mwc-button>
-              <mwc-button @click=${this._clear}>
-                ${this.hass.localize("ui.common.clear")}
-              </mwc-button>
-            </div>
-          </ha-card>
-        </div>
+        <ha-card
+          class="edit-pane"
+          header=${this.hass.localize(
+            "ui.panel.developer-tools.tabs.templates.editor"
+          )}
+        >
+          <div class="card-content">
+            <ha-code-editor
+              mode="jinja2"
+              .hass=${this.hass}
+              .value=${this._template}
+              .error=${this._error}
+              autofocus
+              autocomplete-entities
+              autocomplete-icons
+              @value-changed=${this._templateChanged}
+              dir="ltr"
+            ></ha-code-editor>
+          </div>
+          <div class="card-actions">
+            <mwc-button @click=${this._restoreDemo}>
+              ${this.hass.localize(
+                "ui.panel.developer-tools.tabs.templates.reset"
+              )}
+            </mwc-button>
+            <mwc-button @click=${this._clear}>
+              ${this.hass.localize("ui.common.clear")}
+            </mwc-button>
+          </div>
+        </ha-card>
 
-        <div class="render-pane">
-          <ha-card
-            header=${this.hass.localize(
-              "ui.panel.developer-tools.tabs.templates.result"
-            )}
-          >
-            <div class="card-content">
-              ${this._rendering
-                ? html`<ha-circular-progress
-                    class="render-spinner"
-                    indeterminate
-                    size="small"
-                  ></ha-circular-progress>`
-                : ""}
-              ${this._error
-                ? html`<ha-alert
-                    alert-type=${this._errorLevel?.toLowerCase() || "error"}
-                    >${this._error}</ha-alert
-                  >`
-                : nothing}
-              ${this._templateResult
-                ? html`${this.hass.localize(
-                      "ui.panel.developer-tools.tabs.templates.result_type"
-                    )}:
-                    ${resultType}
-                    <!-- prettier-ignore -->
-                    <pre class="rendered ${classMap({
-                      [resultType]: resultType,
-                    })}"
+        <ha-card
+          class="render-pane"
+          header=${this.hass.localize(
+            "ui.panel.developer-tools.tabs.templates.result"
+          )}
+        >
+          <div class="card-content">
+            ${this._rendering
+              ? html`<ha-circular-progress
+                  class="render-spinner"
+                  indeterminate
+                  size="small"
+                ></ha-circular-progress>`
+              : ""}
+            ${this._error
+              ? html`<ha-alert
+                  alert-type=${this._errorLevel?.toLowerCase() || "error"}
+                  >${this._error}</ha-alert
+                >`
+              : nothing}
+            ${this._templateResult
+              ? html`${this.hass.localize(
+                    "ui.panel.developer-tools.tabs.templates.result_type"
+                  )}:
+                  ${resultType}
+                  <!-- prettier-ignore -->
+                  <pre class="rendered ${classMap({
+                    [resultType]: resultType,
+                  })}"
                   >${type === "object"
-                      ? JSON.stringify(this._templateResult.result, null, 2)
-                      : this._templateResult.result}</pre>
-                    ${this._templateResult.listeners.time
+                    ? JSON.stringify(this._templateResult.result, null, 2)
+                    : this._templateResult.result}</pre>
+                  ${this._templateResult.listeners.time
+                    ? html`
+                        <p>
+                          ${this.hass.localize(
+                            "ui.panel.developer-tools.tabs.templates.time"
+                          )}
+                        </p>
+                      `
+                    : ""}
+                  ${!this._templateResult.listeners
+                    ? nothing
+                    : this._templateResult.listeners.all
                       ? html`
-                          <p>
+                          <p class="all_listeners">
                             ${this.hass.localize(
-                              "ui.panel.developer-tools.tabs.templates.time"
+                              "ui.panel.developer-tools.tabs.templates.all_listeners"
                             )}
                           </p>
                         `
-                      : ""}
-                    ${!this._templateResult.listeners
-                      ? nothing
-                      : this._templateResult.listeners.all
+                      : this._templateResult.listeners.domains.length ||
+                          this._templateResult.listeners.entities.length
                         ? html`
-                            <p class="all_listeners">
+                            <p>
                               ${this.hass.localize(
-                                "ui.panel.developer-tools.tabs.templates.all_listeners"
+                                "ui.panel.developer-tools.tabs.templates.listeners"
                               )}
                             </p>
+                            <ul>
+                              ${this._templateResult.listeners.domains
+                                .sort()
+                                .map(
+                                  (domain) => html`
+                                    <li>
+                                      <b
+                                        >${this.hass.localize(
+                                          "ui.panel.developer-tools.tabs.templates.domain"
+                                        )}</b
+                                      >: ${domain}
+                                    </li>
+                                  `
+                                )}
+                              ${this._templateResult.listeners.entities
+                                .sort()
+                                .map(
+                                  (entity_id) => html`
+                                    <li>
+                                      <b
+                                        >${this.hass.localize(
+                                          "ui.panel.developer-tools.tabs.templates.entity"
+                                        )}</b
+                                      >: ${entity_id}
+                                    </li>
+                                  `
+                                )}
+                            </ul>
                           `
-                        : this._templateResult.listeners.domains.length ||
-                            this._templateResult.listeners.entities.length
-                          ? html`
-                              <p>
-                                ${this.hass.localize(
-                                  "ui.panel.developer-tools.tabs.templates.listeners"
-                                )}
-                              </p>
-                              <ul>
-                                ${this._templateResult.listeners.domains
-                                  .sort()
-                                  .map(
-                                    (domain) => html`
-                                      <li>
-                                        <b
-                                          >${this.hass.localize(
-                                            "ui.panel.developer-tools.tabs.templates.domain"
-                                          )}</b
-                                        >: ${domain}
-                                      </li>
-                                    `
-                                  )}
-                                ${this._templateResult.listeners.entities
-                                  .sort()
-                                  .map(
-                                    (entity_id) => html`
-                                      <li>
-                                        <b
-                                          >${this.hass.localize(
-                                            "ui.panel.developer-tools.tabs.templates.entity"
-                                          )}</b
-                                        >: ${entity_id}
-                                      </li>
-                                    `
-                                  )}
-                              </ul>
-                            `
-                          : !this._templateResult.listeners.time
-                            ? html`<span class="all_listeners">
-                                ${this.hass.localize(
-                                  "ui.panel.developer-tools.tabs.templates.no_listeners"
-                                )}
-                              </span>`
-                            : nothing}`
-                : nothing}
-            </div>
-          </ha-card>
-        </div>
+                        : !this._templateResult.listeners.time
+                          ? html`<span class="all_listeners">
+                              ${this.hass.localize(
+                                "ui.panel.developer-tools.tabs.templates.no_listeners"
+                              )}
+                            </span>`
+                          : nothing}`
+              : nothing}
+          </div>
+        </ha-card>
       </div>
     `;
   }

--- a/src/panels/developer-tools/template/developer-tools-template.ts
+++ b/src/panels/developer-tools/template/developer-tools-template.ts
@@ -88,13 +88,8 @@ class HaPanelDevTemplate extends LitElement {
           : "dict"
         : type;
     return html`
-      <div
-        class="content ${classMap({
-          layout: !this.narrow,
-          horizontal: !this.narrow,
-        })}"
-      >
-        <div class="edit-pane">
+      <div class="content">
+        <div class="description">
           <p>
             ${this.hass.localize(
               "ui.panel.developer-tools.tabs.templates.description"
@@ -126,122 +121,144 @@ class HaPanelDevTemplate extends LitElement {
               >
             </li>
           </ul>
-          <p>
-            ${this.hass.localize(
+        </div>
+      </div>
+      <div
+        class="content ${classMap({
+          layout: !this.narrow,
+          horizontal: !this.narrow,
+        })}"
+      >
+        <div class="edit-pane">
+          <ha-card
+            header=${this.hass.localize(
               "ui.panel.developer-tools.tabs.templates.editor"
             )}
-          </p>
-          <ha-code-editor
-            mode="jinja2"
-            .hass=${this.hass}
-            .value=${this._template}
-            .error=${this._error}
-            autofocus
-            autocomplete-entities
-            autocomplete-icons
-            @value-changed=${this._templateChanged}
-            dir="ltr"
-          ></ha-code-editor>
-          <mwc-button @click=${this._restoreDemo}>
-            ${this.hass.localize(
-              "ui.panel.developer-tools.tabs.templates.reset"
-            )}
-          </mwc-button>
-          <mwc-button @click=${this._clear}>
-            ${this.hass.localize("ui.common.clear")}
-          </mwc-button>
+          >
+            <div class="card-content">
+              <ha-code-editor
+                mode="jinja2"
+                .hass=${this.hass}
+                .value=${this._template}
+                .error=${this._error}
+                autofocus
+                autocomplete-entities
+                autocomplete-icons
+                @value-changed=${this._templateChanged}
+                dir="ltr"
+              ></ha-code-editor>
+            </div>
+            <div class="card-actions">
+              <mwc-button @click=${this._restoreDemo}>
+                ${this.hass.localize(
+                  "ui.panel.developer-tools.tabs.templates.reset"
+                )}
+              </mwc-button>
+              <mwc-button @click=${this._clear}>
+                ${this.hass.localize("ui.common.clear")}
+              </mwc-button>
+            </div>
+          </ha-card>
         </div>
 
         <div class="render-pane">
-          ${this._rendering
-            ? html`<ha-circular-progress
-                class="render-spinner"
-                indeterminate
-                size="small"
-              ></ha-circular-progress>`
-            : ""}
-          ${this._error
-            ? html`<ha-alert
-                alert-type=${this._errorLevel?.toLowerCase() || "error"}
-                >${this._error}</ha-alert
-              >`
-            : nothing}
-          ${this._templateResult
-            ? html`${this.hass.localize(
-                  "ui.panel.developer-tools.tabs.templates.result_type"
-                )}:
-                ${resultType}
-                <!-- prettier-ignore -->
-                <pre class="rendered ${classMap({
-                  [resultType]: resultType,
-                })}"
-                >${type === "object"
-                  ? JSON.stringify(this._templateResult.result, null, 2)
-                  : this._templateResult.result}</pre>
-                ${this._templateResult.listeners.time
-                  ? html`
-                      <p>
-                        ${this.hass.localize(
-                          "ui.panel.developer-tools.tabs.templates.time"
-                        )}
-                      </p>
-                    `
-                  : ""}
-                ${!this._templateResult.listeners
-                  ? nothing
-                  : this._templateResult.listeners.all
-                    ? html`
-                        <p class="all_listeners">
-                          ${this.hass.localize(
-                            "ui.panel.developer-tools.tabs.templates.all_listeners"
-                          )}
-                        </p>
-                      `
-                    : this._templateResult.listeners.domains.length ||
-                        this._templateResult.listeners.entities.length
+          <ha-card
+            header=${this.hass.localize(
+              "ui.panel.developer-tools.tabs.templates.result"
+            )}
+          >
+            <div class="card-content">
+              ${this._rendering
+                ? html`<ha-circular-progress
+                    class="render-spinner"
+                    indeterminate
+                    size="small"
+                  ></ha-circular-progress>`
+                : ""}
+              ${this._error
+                ? html`<ha-alert
+                    alert-type=${this._errorLevel?.toLowerCase() || "error"}
+                    >${this._error}</ha-alert
+                  >`
+                : nothing}
+              ${this._templateResult
+                ? html`${this.hass.localize(
+                      "ui.panel.developer-tools.tabs.templates.result_type"
+                    )}:
+                    ${resultType}
+                    <!-- prettier-ignore -->
+                    <pre class="rendered ${classMap({
+                      [resultType]: resultType,
+                    })}"
+                  >${type === "object"
+                      ? JSON.stringify(this._templateResult.result, null, 2)
+                      : this._templateResult.result}</pre>
+                    ${this._templateResult.listeners.time
                       ? html`
                           <p>
                             ${this.hass.localize(
-                              "ui.panel.developer-tools.tabs.templates.listeners"
+                              "ui.panel.developer-tools.tabs.templates.time"
                             )}
                           </p>
-                          <ul>
-                            ${this._templateResult.listeners.domains
-                              .sort()
-                              .map(
-                                (domain) => html`
-                                  <li>
-                                    <b
-                                      >${this.hass.localize(
-                                        "ui.panel.developer-tools.tabs.templates.domain"
-                                      )}</b
-                                    >: ${domain}
-                                  </li>
-                                `
-                              )}
-                            ${this._templateResult.listeners.entities
-                              .sort()
-                              .map(
-                                (entity_id) => html`
-                                  <li>
-                                    <b
-                                      >${this.hass.localize(
-                                        "ui.panel.developer-tools.tabs.templates.entity"
-                                      )}</b
-                                    >: ${entity_id}
-                                  </li>
-                                `
-                              )}
-                          </ul>
                         `
-                      : !this._templateResult.listeners.time
-                        ? html`<span class="all_listeners">
-                            ${this.hass.localize(
-                              "ui.panel.developer-tools.tabs.templates.no_listeners"
-                            )}
-                          </span>`
-                        : nothing}`
-            : nothing}
+                      : ""}
+                    ${!this._templateResult.listeners
+                      ? nothing
+                      : this._templateResult.listeners.all
+                        ? html`
+                            <p class="all_listeners">
+                              ${this.hass.localize(
+                                "ui.panel.developer-tools.tabs.templates.all_listeners"
+                              )}
+                            </p>
+                          `
+                        : this._templateResult.listeners.domains.length ||
+                            this._templateResult.listeners.entities.length
+                          ? html`
+                              <p>
+                                ${this.hass.localize(
+                                  "ui.panel.developer-tools.tabs.templates.listeners"
+                                )}
+                              </p>
+                              <ul>
+                                ${this._templateResult.listeners.domains
+                                  .sort()
+                                  .map(
+                                    (domain) => html`
+                                      <li>
+                                        <b
+                                          >${this.hass.localize(
+                                            "ui.panel.developer-tools.tabs.templates.domain"
+                                          )}</b
+                                        >: ${domain}
+                                      </li>
+                                    `
+                                  )}
+                                ${this._templateResult.listeners.entities
+                                  .sort()
+                                  .map(
+                                    (entity_id) => html`
+                                      <li>
+                                        <b
+                                          >${this.hass.localize(
+                                            "ui.panel.developer-tools.tabs.templates.entity"
+                                          )}</b
+                                        >: ${entity_id}
+                                      </li>
+                                    `
+                                  )}
+                              </ul>
+                            `
+                          : !this._templateResult.listeners.time
+                            ? html`<span class="all_listeners">
+                                ${this.hass.localize(
+                                  "ui.panel.developer-tools.tabs.templates.no_listeners"
+                                )}
+                              </span>`
+                            : nothing}`
+                : nothing}
+            </div>
+          </ha-card>
         </div>
       </div>
     `;
@@ -258,6 +275,7 @@ class HaPanelDevTemplate extends LitElement {
         }
 
         .content {
+          gap: 16px;
           padding: 16px;
           padding: max(16px, env(safe-area-inset-top))
             max(16px, env(safe-area-inset-right))
@@ -265,10 +283,11 @@ class HaPanelDevTemplate extends LitElement {
             max(16px, env(safe-area-inset-left));
         }
 
+        ha-card {
+          margin-bottom: 16px;
+        }
+
         .edit-pane {
-          margin-right: 16px;
-          margin-inline-start: initial;
-          margin-inline-end: 16px;
           direction: var(--direction);
         }
 
@@ -278,12 +297,6 @@ class HaPanelDevTemplate extends LitElement {
 
         .horizontal .edit-pane {
           max-width: 50%;
-        }
-
-        .render-pane {
-          position: relative;
-          max-width: 50%;
-          flex: 1;
         }
 
         .render-spinner {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6857,6 +6857,7 @@
             "title": "Template",
             "description": "Templates are rendered using the Jinja2 template engine with some Home Assistant specific extensions.",
             "editor": "Template editor",
+            "result": "Result",
             "reset": "Reset to demo template",
             "confirm_reset": "Do you want to reset your current template back to the demo template?",
             "confirm_clear": "Do you want to clear your current template?",


### PR DESCRIPTION
## Proposed change
Adjustments to the styling of the Templates dev-tools page. Wrapping the editor and result sections in `ha-card` to bring it more in-line with current frontend design.

Before pic (blue theme) and after pic (red theme)
![image](https://github.com/user-attachments/assets/afe63d05-f43d-43b3-b759-f0ef2a34d03f)
![image](https://github.com/user-attachments/assets/7d66b9ea-911c-4a39-809d-2240f71f47a4)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Improved layout and visual presentation of the developer tools panel, enhancing user experience.
  - Added localization support with a new translation for "Result" in the user interface.

- **Bug Fixes**
  - Simplified HTML structure and improved organization of components to enhance clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->