### PR TITLE
Make delete button red when removing todo item (#21466)

### DIFF
--- a/src/panels/todo/dialog-todo-item-editor.ts
+++ b/src/panels/todo/dialog-todo-item-editor.ts
@@ -364,6 +364,9 @@ class DialogTodoItemEditor extends LitElement {
         "ui.components.todo.item.confirm_delete.delete"
       ),
       text: this.hass.localize("ui.components.todo.item.confirm_delete.prompt"),
+      destructive: true,
+      confirmText: this.hass.localize("ui.common.delete"),
+      dismissText: this.hass.localize("ui.common.cancel"),
     });
     if (!confirm) {
       // Cancel


### PR DESCRIPTION
## Proposed change
When removing a todo item there is the confirmation dialog. I have changed the color of the condition button to red so it is consistent with the rest of the app.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration


```yaml

```

## Additional information

- This PR fixes or closes issue: fixes #21466
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced confirmation dialog for deleting a todo item with improved messaging and clarity.
	- Localized confirm and dismiss text for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->