### PR TITLE
add returning lawn mower state

### DIFF
--- a/src/common/entity/get_states.ts
+++ b/src/common/entity/get_states.ts
@@ -26,7 +26,7 @@ export const FIXED_DOMAIN_STATES = {
   humidifier: ["on", "off"],
   input_boolean: ["on", "off"],
   input_button: [],
-  lawn_mower: ["error", "paused", "mowing", "docked"],
+  lawn_mower: ["error", "paused", "mowing", "returning", "docked"],
   light: ["on", "off"],
   lock: [
     "jammed",

--- a/src/components/ha-lawn_mower-action-button.ts
+++ b/src/components/ha-lawn_mower-action-button.ts
@@ -28,6 +28,11 @@ const LAWN_MOWER_ACTIONS: Partial<
     service: "start_mowing",
     feature: LawnMowerEntityFeature.START_MOWING,
   },
+  returning: {
+    action: "pause",
+    service: "pause",
+    feature: LawnMowerEntityFeature.PAUSE,
+  },
   paused: {
     action: "resume_mowing",
     service: "start_mowing",

--- a/src/data/lawn_mower.ts
+++ b/src/data/lawn_mower.ts
@@ -4,7 +4,12 @@ import {
 } from "home-assistant-js-websocket";
 import { UNAVAILABLE } from "./entity";
 
-export type LawnMowerEntityState = "paused" | "mowing" | "docked" | "error";
+export type LawnMowerEntityState =
+  | "paused"
+  | "mowing"
+  | "returning"
+  | "docked"
+  | "error";
 
 export const enum LawnMowerEntityFeature {
   START_MOWING = 1,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -170,6 +170,7 @@
         "actions": {
           "resume_mowing": "Resume mowing",
           "start_mowing": "Start mowing",
+          "pause": "Pause",
           "dock": "Return to dock"
         }
       },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
add returning lawn mower state
see -> https://github.com/home-assistant/architecture/discussions/1123

core: https://github.com/home-assistant/core/pull/124261

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added a "returning" state to the lawn mower entity, enhancing its operational capabilities.
    - Introduced a "pause" action for the lawn mower, allowing for finer control over its operation.
    - Added a new translation for the "pause" action to improve user experience.

- **Bug Fixes**
    - N/A

- **Documentation**
    - N/A

- **Refactor**
    - N/A

- **Style**
    - N/A

- **Tests**
    - N/A

- **Chores**
    - N/A

- **Revert**
    - N/A

<!-- end of auto-generated comment: release notes by coderabbit.ai -->