### PR TITLE
Revert display_precision override for duration format

### DIFF
--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -71,8 +71,7 @@ export const computeStateDisplayFromEntityAttributes = (
     if (
       attributes.device_class === "duration" &&
       attributes.unit_of_measurement &&
-      UNIT_TO_MILLISECOND_CONVERT[attributes.unit_of_measurement] &&
-      entity?.display_precision === undefined
+      UNIT_TO_MILLISECOND_CONVERT[attributes.unit_of_measurement]
     ) {
       try {
         return formatDuration(state, attributes.unit_of_measurement);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
I unfortunately suggest to remove the feature I added back in https://github.com/home-assistant/frontend/pull/19396, to allow the entity precision selection to override the special duration formatter.

The intention was to allow users to use the display_precision selector for duration entities to optionally render with the requested precision and given unit. 

However this doesn't work quite right for entities which have a _suggested_ display precision from the integration. While those entities still have default display precision in their entity registry settings, the way we fetch `EntityRegistryDisplayEntry` cause display_precision and suggested_display_precision to be merged in the DisplayEntry. Meaning that those entities appear to the frontend to always have a set display precision, and so there is no way for these entities to "deselect" this and get back the default duration format. The only way to remedy this would be to fetch both values when getting DisplayEntries, and that seems too heavy just for this usage.

This specifically impacts any new entities created by history_stats in the UI, since those all get a suggested display precision, and thus the standard duration format is not usable for those entities without merging this PR. 

I'm still not completely happy with how we display duration entities in all cases, but perhaps I'll start a discussion to see if this can be improved in a different way. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/123961 fixes https://github.com/home-assistant/frontend/issues/21478
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced duration display formatting by simplifying logic, allowing better handling of entity attributes related to duration.
  
- **Bug Fixes**
  - Resolved inconsistencies in duration display by removing unnecessary condition checks that could prevent proper formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->