### PR TITLE
Devtools statistics - new style, multi-select, & multi-delete

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -204,6 +204,29 @@ export class HaDataTable extends LitElement {
     this._checkedRowsChanged();
   }
 
+  public select(ids: string[], clear?: boolean): void {
+    if (clear) {
+      this._checkedRows = [];
+    }
+    ids.forEach((id) => {
+      const row = this._filteredData.find((data) => data[this.id] === id);
+      if (row?.selectable !== false && !this._checkedRows.includes(id)) {
+        this._checkedRows.push(id);
+      }
+    });
+    this._checkedRowsChanged();
+  }
+
+  public unselect(ids: string[]): void {
+    ids.forEach((id) => {
+      const index = this._checkedRows.indexOf(id);
+      if (index > -1) {
+        this._checkedRows.splice(index, 1);
+      }
+    });
+    this._checkedRowsChanged();
+  }
+
   public connectedCallback() {
     super.connectedCallback();
     if (this._filteredData.length) {

--- a/src/panels/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/developer-tools/statistics/developer-tools-statistics.ts
@@ -11,6 +11,7 @@ import "../../../components/data-table/ha-data-table";
 import type { DataTableColumnContainer } from "../../../components/data-table/ha-data-table";
 import { subscribeEntityRegistry } from "../../../data/entity_registry";
 import {
+  clearStatistics,
   getStatisticIds,
   StatisticsMetaData,
   StatisticsValidationResult,
@@ -19,6 +20,7 @@ import {
 import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import { haStyle } from "../../../resources/styles";
 import { HomeAssistant } from "../../../types";
+import { showAlertDialog, showConfirmationDialog } from "../../lovelace/custom-card-helpers";
 import { fixStatisticsIssue } from "./fix-statistics";
 import { showStatisticsAdjustSumDialog } from "./show-dialog-statistics-adjust-sum";
 
@@ -122,7 +124,11 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
           localize("ui.panel.developer-tools.tabs.statistics.no_issue")}`,
       },
       fix: {
-        title: "",
+        title: html`<mwc-button @click=${this._fixAllAutofixableIssues}>
+          ${localize(
+            "ui.panel.developer-tools.tabs.statistics.fix_issue.fix_all"
+          )}
+        </mwc-button>`,
         label: this.hass.localize(
           "ui.panel.developer-tools.tabs.statistics.fix_issue.fix"
         ),
@@ -253,7 +259,53 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
     });
   }
 
-  private _fixIssue = async (ev) => {
+  private _fixAllAutofixableIssues = async () => {
+    const validationResults = await validateStatistics(this.hass);
+    const autoFixable = new Set(["no_state", "unsupported_state_class"]);
+    const autoFixableIds = Object.entries(validationResults)
+      .filter(([, issues]) =>
+        issues.some((issue) => autoFixable.has(issue.type))
+      )
+      .map(([statistic_id]) => statistic_id);
+
+    if (autoFixableIds.length <= 0) {
+      showAlertDialog(this, {
+        title: this.hass.localize(
+          "ui.panel.developer-tools.tabs.statistics.fix_issue.auto_fix.title"
+        ),
+        text: this.hass.localize(
+          "ui.panel.developer-tools.tabs.statistics.fix_issue.auto_fix.info_text_not_available"
+        ),
+      });
+      return;
+    }
+
+    showConfirmationDialog(this, {
+      title: this.hass.localize(
+        "ui.panel.developer-tools.tabs.statistics.fix_issue.auto_fix.title"
+      ),
+      text: html`${this.hass.localize(
+          "ui.panel.developer-tools.tabs.statistics.fix_issue.auto_fix.info_text_1"
+        )}<br /><br />${this.hass.localize(
+          "ui.panel.developer-tools.tabs.statistics.fix_issue.auto_fix.info_text_2",
+          { statistic_count: autoFixableIds.length }
+        )}<br /><br />${this.hass.localize(
+          "ui.panel.developer-tools.tabs.statistics.fix_issue.auto_fix.info_text_3"
+        )}<br /><br />
+        ${autoFixableIds.map((i) => i).join(", ")}`,
+      confirmText: this.hass.localize("ui.common.delete"),
+      destructive: true,
+      confirm: async () => {
+        await clearStatistics(this.hass, autoFixableIds);
+        autoFixableIds.forEach((statistic_id) =>
+          this._deletedStatistics.add(statistic_id)
+        );
+        this._validateStatistics();
+      },
+    });
+  };
+
+  private async _fixIssue = (ev) => {
     const issues = (ev.currentTarget.data as StatisticsValidationResult[]).sort(
       (itemA, itemB) =>
         (FIX_ISSUES_ORDER[itemA.type] ?? 99) -

--- a/src/panels/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/developer-tools/statistics/developer-tools-statistics.ts
@@ -28,10 +28,10 @@ import type {
   SortingDirection,
 } from "../../../components/data-table/ha-data-table";
 import { showDataTableSettingsDialog } from "../../../components/data-table/show-dialog-data-table-settings";
-import "../../../components/ha-button-menu-new";
+import "../../../components/ha-md-button-menu";
 import "../../../components/ha-dialog";
 import { HaMenu } from "../../../components/ha-menu";
-import "../../../components/ha-menu-item";
+import "../../../components/ha-md-menu-item";
 import "../../../components/search-input-outlined";
 import { subscribeEntityRegistry } from "../../../data/entity_registry";
 import {
@@ -61,11 +61,6 @@ const FIXABLE_ISSUES = [
   "entity_no_longer_recorded",
   "unsupported_state_class",
   "units_changed",
-];
-const SELECTABLE_ISSUES = [
-  "no_state",
-  "entity_no_longer_recorded",
-  "unsupported_state_class",
 ];
 
 type StatisticData = StatisticsMetaData & {
@@ -260,7 +255,7 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
     const searchBar = html`<search-input-outlined
       .hass=${this.hass}
       .filter=${this.filter}
-      s
+      @value-changed=${this._handleSearchChange}
     >
     </search-input-outlined>`;
 
@@ -320,7 +315,7 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
                     "ui.components.subpage-data-table.exit_selection_mode"
                   )}
                 ></ha-icon-button>
-                <ha-button-menu-new positioning="absolute">
+                <ha-md-button-menu positioning="absolute">
                   <ha-assist-chip
                     .label=${localize(
                       "ui.components.subpage-data-table.select"
@@ -336,20 +331,26 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
                       .path=${mdiMenuDown}
                     ></ha-svg-icon
                   ></ha-assist-chip>
-                  <ha-menu-item .value=${undefined} @click=${this._selectAll}>
+                  <ha-md-menu-item
+                    .value=${undefined}
+                    @click=${this._selectAll}
+                  >
                     <div slot="headline">
                       ${localize("ui.components.subpage-data-table.select_all")}
                     </div>
-                  </ha-menu-item>
-                  <ha-menu-item .value=${undefined} @click=${this._selectNone}>
+                  </ha-md-menu-item>
+                  <ha-md-menu-item
+                    .value=${undefined}
+                    @click=${this._selectNone}
+                  >
                     <div slot="headline">
                       ${localize(
                         "ui.components.subpage-data-table.select_none"
                       )}
                     </div>
-                  </ha-menu-item>
+                  </ha-md-menu-item>
                   <md-divider role="separator" tabindex="-1"></md-divider>
-                  <ha-menu-item
+                  <ha-md-menu-item
                     .value=${undefined}
                     @click=${this._disableSelectMode}
                   >
@@ -358,8 +359,8 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
                         "ui.components.subpage-data-table.close_select_mode"
                       )}
                     </div>
-                  </ha-menu-item>
-                </ha-button-menu-new>
+                  </ha-md-menu-item>
+                </ha-md-button-menu>
                 <p>
                   ${localize("ui.components.subpage-data-table.selected", {
                     selected: this._selected?.length || "0",
@@ -371,9 +372,9 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
               </div>
               <ha-assist-chip
                 .label=${localize(
-                  "ui.panel.developer-tools.tabs.statistics.fix_issue.fix_selected"
+                  "ui.panel.developer-tools.tabs.statistics.clear_selected"
                 )}
-                @click=${this._fixSelectedIssues}
+                @click=${this._clearSelected}
               >
               </ha-assist-chip>
             </div>`
@@ -431,27 +432,27 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
         ${Object.entries(columns).map(([id, column]) =>
           column.groupable
             ? html`
-                <ha-menu-item
+                <ha-md-menu-item
                   .value=${id}
                   @click=${this._handleGroupBy}
                   .selected=${id === this._groupColumn}
                   class=${classMap({ selected: id === this._groupColumn })}
                 >
                   ${column.title || column.label}
-                </ha-menu-item>
+                </ha-md-menu-item>
               `
             : nothing
         )}
-        <ha-menu-item
+        <ha-md-menu-item
           .value=${undefined}
           @click=${this._handleGroupBy}
           .selected=${this._groupColumn === undefined}
           class=${classMap({ selected: this._groupColumn === undefined })}
         >
           ${localize("ui.components.subpage-data-table.dont_group_by")}
-        </ha-menu-item>
+        </ha-md-menu-item>
         <md-divider role="separator" tabindex="-1"></md-divider>
-        <ha-menu-item
+        <ha-md-menu-item
           @click=${this._collapseAllGroups}
           .disabled=${this._groupColumn === undefined}
         >
@@ -460,8 +461,8 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
             .path=${mdiUnfoldLessHorizontal}
           ></ha-svg-icon>
           ${localize("ui.components.subpage-data-table.collapse_all_groups")}
-        </ha-menu-item>
-        <ha-menu-item
+        </ha-md-menu-item>
+        <ha-md-menu-item
           @click=${this._expandAllGroups}
           .disabled=${this._groupColumn === undefined}
         >
@@ -470,13 +471,13 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
             .path=${mdiUnfoldMoreHorizontal}
           ></ha-svg-icon>
           ${localize("ui.components.subpage-data-table.expand_all_groups")}
-        </ha-menu-item>
+        </ha-md-menu-item>
       </ha-menu>
       <ha-menu anchor="sort-by-anchor" id="sort-by-menu" positioning="fixed">
         ${Object.entries(columns).map(([id, column]) =>
           column.sortable
             ? html`
-                <ha-menu-item
+                <ha-md-menu-item
                   .value=${id}
                   @click=${this._handleSortBy}
                   keep-open
@@ -494,12 +495,19 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
                       `
                     : nothing}
                   ${column.title || column.label}
-                </ha-menu-item>
+                </ha-md-menu-item>
               `
             : nothing
         )}
       </ha-menu>
     `;
+  }
+
+  private _handleSearchChange(ev: CustomEvent) {
+    if (this.filter === ev.detail.value) {
+      return;
+    }
+    this.filter = ev.detail.value;
   }
 
   private _handleSelectionChanged(
@@ -620,10 +628,6 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
           ...statistic,
           state: this.hass.states[statistic.statistic_id],
           issues: issues[statistic.statistic_id],
-          selectable:
-            issues[statistic.statistic_id]?.some((issue) =>
-              SELECTABLE_ISSUES.includes(issue.type)
-            ) || false,
         };
       });
 
@@ -638,10 +642,6 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
           source: "",
           state: this.hass.states[statisticId],
           issues: issues[statisticId],
-          selectable:
-            issues[statisticId]?.some((issue) =>
-              SELECTABLE_ISSUES.includes(issue.type)
-            ) || false,
           has_mean: false,
           has_sum: false,
           unit_class: null,
@@ -650,7 +650,7 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
     });
   }
 
-  private _fixSelectedIssues = async () => {
+  private _clearSelected = async () => {
     if (!this._selected?.length) {
       return;
     }
@@ -659,15 +659,13 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
 
     await showConfirmationDialog(this, {
       title: this.hass.localize(
-        "ui.panel.developer-tools.tabs.statistics.fix_issue.auto_fix.title"
+        "ui.panel.developer-tools.tabs.statistics.multi_clear.title"
       ),
       text: html`${this.hass.localize(
-          "ui.panel.developer-tools.tabs.statistics.fix_issue.auto_fix.info_text_1"
-        )}<br /><br />${this.hass.localize(
-          "ui.panel.developer-tools.tabs.statistics.fix_issue.auto_fix.info_text_2",
+          "ui.panel.developer-tools.tabs.statistics.multi_clear.info_text_1",
           { statistic_count: deletableIds.length }
         )}<br /><br />${this.hass.localize(
-          "ui.panel.developer-tools.tabs.statistics.fix_issue.auto_fix.info_text_3"
+          "ui.panel.developer-tools.tabs.statistics.multi_clear.info_text_2"
         )}<br /><br />
         ${deletableIds.map((i) => i).join(", ")}`,
       confirmText: this.hass.localize("ui.common.delete"),
@@ -680,7 +678,7 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
     });
   };
 
-  private async _fixIssue = (ev) => {
+  private _fixIssue = async (ev) => {
     const issues = (ev.currentTarget.data as StatisticsValidationResult[]).sort(
       (itemA, itemB) =>
         (FIX_ISSUES_ORDER[itemA.type] ?? 99) -

--- a/src/panels/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/developer-tools/statistics/developer-tools-statistics.ts
@@ -673,7 +673,7 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
       confirm: async () => {
         await clearStatistics(this.hass, deletableIds);
         this._validateStatistics();
-        this._selected = [];
+        this._dataTable.clearSelection();
       },
     });
   };

--- a/src/panels/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/developer-tools/statistics/developer-tools-statistics.ts
@@ -705,19 +705,11 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
           height: 100%;
           --data-table-border-width: 0;
         }
-        :host(:not([narrow])) ha-data-table,
-        .pane {
+        :host(:not([narrow])) ha-data-table {
           height: calc(100vh - 1px - var(--header-height));
           display: block;
         }
 
-        .pane-content {
-          height: calc(
-            100vh - 1px - var(--header-height) - var(--header-height)
-          );
-          display: flex;
-          flex-direction: column;
-        }
         :host([narrow]) {
           --expansion-panel-summary-padding: 0 16px;
         }
@@ -741,51 +733,6 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
           display: flex;
           align-items: center;
           color: var(--secondary-text-color);
-        }
-        .badge {
-          min-width: 20px;
-          box-sizing: border-box;
-          border-radius: 50%;
-          font-weight: 400;
-          background-color: var(--primary-color);
-          line-height: 20px;
-          text-align: center;
-          padding: 0px 4px;
-          color: var(--text-primary-color);
-          position: absolute;
-          right: 0;
-          inset-inline-end: 0;
-          inset-inline-start: initial;
-          top: 4px;
-          font-size: 0.65em;
-        }
-        .center {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          text-align: center;
-          box-sizing: border-box;
-          height: 100%;
-          width: 100%;
-          padding: 16px;
-        }
-
-        .badge {
-          position: absolute;
-          top: -4px;
-          right: -4px;
-          inset-inline-end: -4px;
-          inset-inline-start: initial;
-          min-width: 16px;
-          box-sizing: border-box;
-          border-radius: 50%;
-          font-weight: 400;
-          font-size: 11px;
-          background-color: var(--primary-color);
-          line-height: 16px;
-          text-align: center;
-          padding: 0px 2px;
-          color: var(--text-primary-color);
         }
 
         .narrow-header-row {
@@ -843,21 +790,6 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
           --md-assist-chip-trailing-space: 8px;
         }
 
-        .pane {
-          border-right: 1px solid var(--divider-color);
-          border-inline-end: 1px solid var(--divider-color);
-          border-inline-start: initial;
-          box-sizing: border-box;
-          display: flex;
-          flex: 0 0 var(--sidepane-width, 250px);
-          width: var(--sidepane-width, 250px);
-          flex-direction: column;
-          position: relative;
-        }
-        .pane .ha-scrollbar {
-          flex: 1;
-        }
-
         ha-dialog {
           --mdc-dialog-min-width: calc(
             100vw - env(safe-area-inset-right) - env(safe-area-inset-left)
@@ -870,12 +802,6 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
           --vertical-align-dialog: flex-end;
           --ha-dialog-border-radius: 0;
           --dialog-content-padding: 0;
-        }
-
-        .filter-dialog-content {
-          height: calc(100vh - 1px - 61px - var(--header-height));
-          display: flex;
-          flex-direction: column;
         }
 
         #sort-by-anchor,

--- a/src/panels/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/developer-tools/statistics/developer-tools-statistics.ts
@@ -341,6 +341,16 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
                   </ha-md-menu-item>
                   <ha-md-menu-item
                     .value=${undefined}
+                    @click=${this._selectAllIssues}
+                  >
+                    <div slot="headline">
+                      ${localize(
+                        "ui.panel.developer-tools.tabs.statistics.data_table.select_all_issues"
+                      )}
+                    </div>
+                  </ha-md-menu-item>
+                  <ha-md-menu-item
+                    .value=${undefined}
                     @click=${this._selectNone}
                   >
                     <div slot="headline">
@@ -576,6 +586,15 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
 
   private _selectNone() {
     this._dataTable.clearSelection();
+  }
+
+  private _selectAllIssues() {
+    this._dataTable.select(
+      this._data
+        .filter((statistic) => statistic.issues)
+        .map((statistic) => statistic.statistic_id),
+      true
+    );
   }
 
   private _showStatisticsAdjustSumDialog(ev) {

--- a/src/panels/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/developer-tools/statistics/developer-tools-statistics.ts
@@ -372,8 +372,9 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
               </div>
               <ha-assist-chip
                 .label=${localize(
-                  "ui.panel.developer-tools.tabs.statistics.clear_selected"
+                  "ui.panel.developer-tools.tabs.statistics.delete_selected"
                 )}
+                .disabled=${!this._selected?.length}
                 @click=${this._clearSelected}
               >
               </ha-assist-chip>
@@ -659,15 +660,12 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
 
     await showConfirmationDialog(this, {
       title: this.hass.localize(
-        "ui.panel.developer-tools.tabs.statistics.multi_clear.title"
+        "ui.panel.developer-tools.tabs.statistics.multi_delete.title"
       ),
       text: html`${this.hass.localize(
-          "ui.panel.developer-tools.tabs.statistics.multi_clear.info_text_1",
-          { statistic_count: deletableIds.length }
-        )}<br /><br />${this.hass.localize(
-          "ui.panel.developer-tools.tabs.statistics.multi_clear.info_text_2"
-        )}<br /><br />
-        ${deletableIds.map((i) => i).join(", ")}`,
+        "ui.panel.developer-tools.tabs.statistics.multi_delete.info_text",
+        { statistic_count: deletableIds.length }
+      )}`,
       confirmText: this.hass.localize("ui.common.delete"),
       destructive: true,
       confirm: async () => {

--- a/src/panels/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/developer-tools/statistics/developer-tools-statistics.ts
@@ -84,7 +84,7 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
 
   @state() private filter = "";
 
-  @state() private _selected?;
+  @state() private _selected: string[] = [];
 
   @state() private groupOrder?: string[];
 
@@ -373,7 +373,7 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
                 </ha-md-button-menu>
                 <p>
                   ${localize("ui.components.subpage-data-table.selected", {
-                    selected: this._selected?.length || "0",
+                    selected: this._selected.length,
                   })}
                 </p>
               </div>
@@ -384,7 +384,7 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
                 .label=${localize(
                   "ui.panel.developer-tools.tabs.statistics.delete_selected"
                 )}
-                .disabled=${!this._selected?.length}
+                .disabled=${!this._selected.length}
                 @click=${this._clearSelected}
               >
               </ha-assist-chip>
@@ -671,7 +671,7 @@ class HaPanelDevStatistics extends SubscribeMixin(LitElement) {
   }
 
   private _clearSelected = async () => {
-    if (!this._selected?.length) {
+    if (!this._selected.length) {
       return;
     }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6971,6 +6971,14 @@
               "clearing_failed": "Clearing the statistics failed",
               "clearing_timeout_title": "Clearing not done yet",
               "clearing_timeout_text": "The clearing of the statistics took longer than expected, it might take longer for the issue to disappear.",
+              "fix_all": "Fix all",
+              "auto_fix": {
+                "title": "Fix all auto-fixable issues",
+                "info_text_not_available": "There are no auto-fixable issues, no action will be taken.",
+                "info_text_1": "This will delete long term statistics of all entities that either have an unsupported state class or have no state.",
+                "info_text_2": "Do you want to permanently delete {statistic_count} long term statistics from your database?",
+                "info_text_3": "The following statistics will be deleted:"
+              },
               "no_support": {
                 "title": "Fix issue",
                 "info_text_1": "Fixing this issue is not supported yet."

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1191,7 +1191,9 @@
           "skip": "Skip",
           "clear_skipped": "Clear skipped",
           "install": "Install",
-          "create_backup": "Create backup before updating"
+          "create_backup": "Create backup before updating",
+          "auto_update_enabled_title": "Can not skip version",
+          "auto_update_enabled_text": "Automatic updates for this item have been enabled; skipping it is, therefore, unavailable. You can either install this update now or wait for Home Assistant to do it automatically."
         },
         "updater": {
           "title": "Update instructions"
@@ -7036,6 +7038,7 @@
             },
             "adjust_sum": "Adjust sum",
             "data_table": {
+              "select_all_issues": "Select all with issues",
               "name": "Name",
               "statistic_id": "Statistic id",
               "statistics_unit": "Statistics unit",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6972,10 +6972,11 @@
               "clearing_timeout_title": "Clearing not done yet",
               "clearing_timeout_text": "The clearing of the statistics took longer than expected, it might take longer for the issue to disappear.",
               "fix_all": "Fix all",
+              "info": "Info",
+              "fix_selected": "Fix selected issues",
               "auto_fix": {
-                "title": "Fix all auto-fixable issues",
-                "info_text_not_available": "There are no auto-fixable issues, no action will be taken.",
-                "info_text_1": "This will delete long term statistics of all entities that either have an unsupported state class or have no state.",
+                "title": "Fix selected issues",
+                "info_text_1": "You may delete long term statistics of all entities that either are unrecorded, have an unsupported state class, or have no state.",
                 "info_text_2": "Do you want to permanently delete {statistic_count} long term statistics from your database?",
                 "info_text_3": "The following statistics will be deleted:"
               },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6966,6 +6966,12 @@
               "entity_no_longer_recorded": "This entity is no longer being recorded.",
               "no_state": "There is no state available for this entity."
             },
+            "clear_selected": "Clear selected statistics",
+            "multi_clear": {
+              "title": "Clear selected statistics",
+              "info_text_1": "Do you want to permanently delete {statistic_count} long term statistics from your database?",
+              "info_text_2": "The following statistics will be deleted:"
+            },
             "fix_issue": {
               "fix": "Fix issue",
               "clearing_failed": "Clearing the statistics failed",
@@ -6973,13 +6979,6 @@
               "clearing_timeout_text": "The clearing of the statistics took longer than expected, it might take longer for the issue to disappear.",
               "fix_all": "Fix all",
               "info": "Info",
-              "fix_selected": "Fix selected issues",
-              "auto_fix": {
-                "title": "Fix selected issues",
-                "info_text_1": "You may delete long term statistics of all entities that either are unrecorded, have an unsupported state class, or have no state.",
-                "info_text_2": "Do you want to permanently delete {statistic_count} long term statistics from your database?",
-                "info_text_3": "The following statistics will be deleted:"
-              },
               "no_support": {
                 "title": "Fix issue",
                 "info_text_1": "Fixing this issue is not supported yet."

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6966,11 +6966,10 @@
               "entity_no_longer_recorded": "This entity is no longer being recorded.",
               "no_state": "There is no state available for this entity."
             },
-            "clear_selected": "Clear selected statistics",
-            "multi_clear": {
-              "title": "Clear selected statistics",
-              "info_text_1": "Do you want to permanently delete {statistic_count} long term statistics from your database?",
-              "info_text_2": "The following statistics will be deleted:"
+            "delete_selected": "Delete selected statistics",
+            "multi_delete": {
+              "title": "Delete selected statistics",
+              "info_text": "Do you want to permanently delete the long term statistics {statistic_count, plural,\n  one {of this entity}\n  other {of {statistic_count} entities}\n} from your database?"
             },
             "fix_issue": {
               "fix": "Fix issue",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1191,9 +1191,7 @@
           "skip": "Skip",
           "clear_skipped": "Clear skipped",
           "install": "Install",
-          "create_backup": "Create backup before updating",
-          "auto_update_enabled_title": "Can not skip version",
-          "auto_update_enabled_text": "Automatic updates for this item have been enabled; skipping it is, therefore, unavailable. You can either install this update now or wait for Home Assistant to do it automatically."
+          "create_backup": "Create backup before updating"
         },
         "updater": {
           "title": "Update instructions"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Following from the discussions of https://github.com/home-assistant/frontend/pull/20389 I tried to implement multi-select & bulk-issue fixing for developer tools/statistics. 

The existing table was getting a bit rough and buggy, not working gracefully in narrow mode, so also decided to try to pickup some of the new data tables enhancements. It seems to work well, though I had to do an ugly amount of copy-pasting, given that there was no way I could see to leverage the existing code in hass-tabs-subpage-data-table. Tried looking to see if developer tools could use a hass-tabs style setup instead of paper tabs, but hass-tabs-subpage can't cleanly fit all of our devtools tabs, so just kept with the existing paper tabs and tried to hack in the table features. 

Now table supports sorting, grouping, customizing columns, multi-select, and bulk issue fixing (for all types except units_changed which I haven't decided what to do with yet). But those are probably less common type of issues so I don't think it's a big loss. 

Looked at getting filters as well, but the existing multi-pane structure was too complex to replicate and not worth the effort so I punted on that. I don't think it's needed yet.

![image](https://github.com/user-attachments/assets/42570071-7ca9-4eae-9592-a690cce48fbd)









## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced statistics panel with improved sorting and grouping functionalities.
  - Added new icons for better visual representation of actions.
  - Introduced selection mode for bulk actions on statistics.
  - New UI components, including a search input and assist chips for enhanced interactivity.

- **Bug Fixes**
  - Improved handling of issues related to statistics with new categorization constants.

- **Documentation**
  - Updated translations to provide better user guidance on fixing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->