### PR TITLE
Add advanced yaml only row_span option for sections

### DIFF
--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -6,6 +6,7 @@ export interface LovelaceBaseSectionConfig {
   title?: string;
   visibility?: Condition[];
   column_span?: number;
+  row_span?: number;
 }
 
 export interface LovelaceSectionConfig extends LovelaceBaseSectionConfig {

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -163,6 +163,8 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
                 maxColumnCount
               );
 
+              const rowSpan = sectionConfig?.row_span || 1;
+
               (section as any).itemPath = [idx];
 
               return html`
@@ -170,6 +172,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
                   class="section"
                   style=${styleMap({
                     "--column-span": columnSpan,
+                    "--row-span": rowSpan,
                   })}
                 >
                   ${editMode
@@ -308,6 +311,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
       .section {
         border-radius: var(--ha-card-border-radius, 12px);
         grid-column: span var(--column-span);
+        grid-row: span var(--row-span);
       }
 
       .section:not(:has(> *:not([hidden]))) {


### PR DESCRIPTION
## Proposed change

Proof of concept for row span to allow section to span multiple row for layout flexibility.
 For now, yaml only feature because it's very advanced and it can be difficult to build a good dashboard using it. 
It can be useful for a potential revamp of the energy dashboard or other graph oriented dashboard.

Needs product decision before merge it.

![CleanShot 2024-08-29 at 14 24 18](https://github.com/user-attachments/assets/28ca93ed-216e-4a3c-bdb4-a08beb034e57)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional property, `row_span`, for enhanced section configuration in the Lovelace UI.
	- Improved layout capabilities allowing sections to span multiple rows, providing greater flexibility in UI customization.

- **Bug Fixes**
	- Updated CSS to accommodate new row spanning functionality, enhancing the responsiveness of the layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->