### PR TITLE
Don't use the word column in section view

### DIFF
--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -2,7 +2,6 @@ import { LitElement, html } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { LocalizeFunc } from "../../../../common/translations/localize";
 import {
   HaFormSchema,
   SchemaUnion,
@@ -25,7 +24,7 @@ export class HuiDialogEditSection extends LitElement {
   @property({ attribute: false }) public viewConfig!: LovelaceViewConfig;
 
   private _schema = memoizeOne(
-    (localize: LocalizeFunc, maxColumns: number) =>
+    (maxColumns: number) =>
       [
         {
           name: "title",
@@ -37,9 +36,6 @@ export class HuiDialogEditSection extends LitElement {
             number: {
               min: 1,
               max: maxColumns,
-              unit_of_measurement: localize(
-                `ui.panel.lovelace.editor.edit_section.settings.column_span_unit`
-              ),
             },
           },
         },
@@ -52,10 +48,7 @@ export class HuiDialogEditSection extends LitElement {
       column_span: this.config.column_span || 1,
     };
 
-    const schema = this._schema(
-      this.hass.localize,
-      this.viewConfig.max_columns || 4
-    );
+    const schema = this._schema(this.viewConfig.max_columns || 4);
 
     return html`
       <ha-form

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5549,7 +5549,7 @@
               "sections": "Sections (experimental)"
             },
             "subview": "Subview",
-            "max_columns": "Max number of columns",
+            "max_columns": "Max number of sections wide",
             "subview_helper": "Subviews don't appear in tabs and have a back button.",
             "edit_ui": "Edit in visual editor",
             "edit_yaml": "Edit in YAML",
@@ -5665,9 +5665,8 @@
             "settings": {
               "title": "Title",
               "title_helper": "The title will appear at the top of section. Leave empty to hide the title.",
-              "column_span": "Size",
-              "column_span_unit": "columns",
-              "column_span_helper": "The size may be smaller if less columns are displayed (e.g. on mobile devices)."
+              "column_span": "Width",
+              "column_span_helper": "Larger sections will be made smaller to fit the display. (e.g. on mobile devices)"
             },
             "visibility": {
               "explanation": "The section will be shown when ALL conditions below are fulfilled. If no conditions are set, the section will always be shown."


### PR DESCRIPTION
## Proposed change

Wording change

![CleanShot 2024-08-29 at 15 31 16](https://github.com/user-attachments/assets/cc98e044-6a1b-4381-bf97-f8af0aba842e)

![CleanShot 2024-08-29 at 15 31 27](https://github.com/user-attachments/assets/671512e7-74b8-4113-a10a-69543e5c99af)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated user interface terminology for better clarity, changing "Max number of columns" to "Max number of sections wide" and "Size" to "Width."
	- Enhanced helper text for "column_span" to explain resizing behavior on mobile devices.

- **Bug Fixes**
	- Simplified method calls in the section editor by removing unnecessary localization parameters, potentially improving performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->