### PR TITLE
Put number selector label above the input

### DIFF
--- a/src/components/ha-selector/ha-selector-number.ts
+++ b/src/components/ha-selector/ha-selector-number.ts
@@ -1,4 +1,11 @@
-import { css, CSSResultGroup, html, LitElement, PropertyValues } from "lit";
+import {
+  css,
+  CSSResultGroup,
+  html,
+  LitElement,
+  nothing,
+  PropertyValues,
+} from "lit";
 import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { fireEvent } from "../../common/dom/fire_event";
@@ -60,12 +67,10 @@ export class HaNumberSelector extends LitElement {
     }
 
     return html`
+      ${this.label ? html`${this.label}${this.required ? "*" : ""}` : nothing}
       <div class="input">
         ${!isBox
           ? html`
-              ${this.label
-                ? html`${this.label}${this.required ? "*" : ""}`
-                : ""}
               <ha-slider
                 labeled
                 .min=${this.selector.number!.min}
@@ -75,10 +80,11 @@ export class HaNumberSelector extends LitElement {
                 .disabled=${this.disabled}
                 .required=${this.required}
                 @change=${this._handleSliderChange}
+                .ticks=${this.selector.number?.slider_ticks}
               >
               </ha-slider>
             `
-          : ""}
+          : nothing}
         <ha-textfield
           .inputMode=${this.selector.number?.step === "any" ||
           (this.selector.number?.step ?? 1) % 1 !== 0
@@ -105,7 +111,7 @@ export class HaNumberSelector extends LitElement {
       </div>
       ${!isBox && this.helper
         ? html`<ha-input-helper-text>${this.helper}</ha-input-helper-text>`
-        : ""}
+        : nothing}
     `;
   }
 
@@ -141,6 +147,9 @@ export class HaNumberSelector extends LitElement {
       }
       ha-slider {
         flex: 1;
+        margin-right: 16px;
+        margin-inline-end: 16px;
+        margin-inline-start: 0;
       }
       ha-textfield {
         --ha-textfield-input-width: 40px;

--- a/src/components/ha-slider.ts
+++ b/src/components/ha-slider.ts
@@ -20,6 +20,7 @@ export class HaSlider extends MdSlider {
         --md-sys-color-on-surface: var(--primary-text-color);
         --md-slider-handle-width: 14px;
         --md-slider-handle-height: 14px;
+        --md-slider-state-layer-size: 24px;
         min-width: 100px;
         min-inline-size: 100px;
         width: 200px;

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -323,6 +323,7 @@ export interface NumberSelector {
     step?: number | "any";
     mode?: "box" | "slider";
     unit_of_measurement?: string;
+    slider_ticks?: boolean;
   } | null;
 }
 

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -36,6 +36,7 @@ export class HuiDialogEditSection extends LitElement {
             number: {
               min: 1,
               max: maxColumns,
+              slider_ticks: true,
             },
           },
         },

--- a/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
@@ -77,6 +77,7 @@ export class HuiViewEditor extends LitElement {
                     min: 1,
                     max: 10,
                     mode: "slider",
+                    slider_ticks: true,
                   },
                 },
               },


### PR DESCRIPTION
## Proposed change

Keep label at the top for slider because label can be very long in some language and it's consistent with other field. That's also a Material design 3 guideline : https://m3.material.io/components/sliders/accessibility#bd0b6c2a-3b7e-4d52-b4a3-9fea0cdfb570

I also added an option to show ticks on the slider.

### Before

![CleanShot 2024-08-29 at 15 57 33](https://github.com/user-attachments/assets/af9c347f-927e-4e49-9e19-951b9b94bbe5)

### After

![CleanShot 2024-08-29 at 15 56 59](https://github.com/user-attachments/assets/c217e981-060d-4922-82c1-47208b4927bd)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `HaNumberSelector` component with improved rendering logic and styling.
	- Introduced a new property `slider_ticks` to the `NumberSelector` interface, allowing users to specify tick marks on sliders.
	- Added a new CSS variable for better customization of the `HaSlider` component's visual representation.

- **Improvements**
	- Streamlined label rendering in the `HaNumberSelector` for cleaner output.
	- Improved usability of sliders by providing visual cues with tick marks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->