### PR TITLE
Move edit mode actions next to section block

### DIFF
--- a/src/panels/lovelace/sections/hui-grid-section.ts
+++ b/src/panels/lovelace/sections/hui-grid-section.ts
@@ -203,6 +203,7 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
         .container.edit-mode {
           padding: 8px;
           border-radius: var(--ha-card-border-radius, 12px);
+          border-start-end-radius: 0px;
           border: 2px dashed var(--divider-color);
           min-height: var(--row-height);
         }

--- a/src/panels/lovelace/sections/hui-grid-section.ts
+++ b/src/panels/lovelace/sections/hui-grid-section.ts
@@ -62,20 +62,6 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
     const editMode = Boolean(this.lovelace?.editMode && !this.isStrategy);
 
     return html`
-      ${this._config.title || this.lovelace?.editMode
-        ? html`
-            <h2
-              class="title ${classMap({
-                placeholder: !this._config.title,
-              })}"
-            >
-              ${this._config.title ||
-              this.hass.localize(
-                "ui.panel.lovelace.editor.section.unnamed_section"
-              )}
-            </h2>
-          `
-        : nothing}
       <ha-sortable
         .disabled=${!editMode}
         @item-moved=${this._cardMoved}

--- a/src/panels/lovelace/sections/hui-grid-section.ts
+++ b/src/panels/lovelace/sections/hui-grid-section.ts
@@ -194,29 +194,6 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
           min-height: var(--row-height);
         }
 
-        .title {
-          color: var(--primary-text-color);
-          font-size: 20px;
-          font-weight: normal;
-          margin: 0px;
-          letter-spacing: 0.1px;
-          line-height: 32px;
-          text-align: var(--ha-view-sections-title-text-align, start);
-          min-height: 32px;
-          display: block;
-          height: var(--row-height);
-          box-sizing: border-box;
-          padding: 0 10px 10px;
-          display: flex;
-          flex-direction: column;
-          justify-content: flex-end;
-        }
-
-        .title.placeholder {
-          color: var(--secondary-text-color);
-          font-style: italic;
-        }
-
         .card {
           border-radius: var(--ha-card-border-radius, 12px);
           position: relative;

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -177,26 +177,24 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
                 >
                   ${editMode
                     ? html`
-                        <div class="section-overlay">
-                          <div class="section-actions">
-                            <ha-svg-icon
-                              aria-hidden="true"
-                              class="handle"
-                              .path=${mdiArrowAll}
-                            ></ha-svg-icon>
-                            <ha-icon-button
-                              .label=${this.hass.localize("ui.common.edit")}
-                              @click=${this._editSection}
-                              .index=${idx}
-                              .path=${mdiPencil}
-                            ></ha-icon-button>
-                            <ha-icon-button
-                              .label=${this.hass.localize("ui.common.delete")}
-                              @click=${this._deleteSection}
-                              .index=${idx}
-                              .path=${mdiDelete}
-                            ></ha-icon-button>
-                          </div>
+                        <div class="section-actions">
+                          <ha-svg-icon
+                            aria-hidden="true"
+                            class="handle"
+                            .path=${mdiArrowAll}
+                          ></ha-svg-icon>
+                          <ha-icon-button
+                            .label=${this.hass.localize("ui.common.edit")}
+                            @click=${this._editSection}
+                            .index=${idx}
+                            .path=${mdiPencil}
+                          ></ha-icon-button>
+                          <ha-icon-button
+                            .label=${this.hass.localize("ui.common.delete")}
+                            @click=${this._deleteSection}
+                            .index=${idx}
+                            .path=${mdiDelete}
+                          ></ha-icon-button>
                         </div>
                       `
                     : nothing}
@@ -348,7 +346,8 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
 
       .section-actions {
         position: absolute;
-        top: 0;
+        height: 36px;
+        top: calc(var(--row-height) + var(--row-gap) - 36px + 2px);
         right: 0;
         inset-inline-end: 0;
         inset-inline-start: initial;
@@ -358,7 +357,8 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
         justify-content: center;
         transition: opacity 0.2s ease-in-out;
         background-color: rgba(var(--rgb-card-background-color), 0.3);
-        border-radius: 18px;
+        border-top-left-radius: 18px;
+        border-top-right-radius: 18px;
         background: var(--secondary-background-color);
         --mdc-icon-button-size: 36px;
         --mdc-icon-size: 20px;

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -175,30 +175,53 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
                     "--column-span": columnSpan,
                   })}
                 >
-                  ${editMode
-                    ? html`
-                        <div class="section-actions">
-                          <ha-svg-icon
-                            aria-hidden="true"
-                            class="handle"
-                            .path=${mdiArrowAll}
-                          ></ha-svg-icon>
-                          <ha-icon-button
-                            .label=${this.hass.localize("ui.common.edit")}
-                            @click=${this._editSection}
-                            .index=${idx}
-                            .path=${mdiPencil}
-                          ></ha-icon-button>
-                          <ha-icon-button
-                            .label=${this.hass.localize("ui.common.delete")}
-                            @click=${this._deleteSection}
-                            .index=${idx}
-                            .path=${mdiDelete}
-                          ></ha-icon-button>
-                        </div>
-                      `
-                    : nothing}
-                  ${section}
+                    ${
+                      sectionConfig?.title || this.lovelace?.editMode
+                        ? html`
+                            <div class="section-header">
+                              <h2
+                                class="section-title ${classMap({
+                                  placeholder: !sectionConfig?.title,
+                                })}"
+                              >
+                                ${sectionConfig?.title ||
+                                this.hass.localize(
+                                  "ui.panel.lovelace.editor.section.unnamed_section"
+                                )}
+                              </h2>
+                              ${editMode
+                                ? html`
+                                    <div class="section-actions">
+                                      <ha-svg-icon
+                                        aria-hidden="true"
+                                        class="handle"
+                                        .path=${mdiArrowAll}
+                                      ></ha-svg-icon>
+                                      <ha-icon-button
+                                        .label=${this.hass.localize(
+                                          "ui.common.edit"
+                                        )}
+                                        @click=${this._editSection}
+                                        .index=${idx}
+                                        .path=${mdiPencil}
+                                      ></ha-icon-button>
+                                      <ha-icon-button
+                                        .label=${this.hass.localize(
+                                          "ui.common.delete"
+                                        )}
+                                        @click=${this._deleteSection}
+                                        .index=${idx}
+                                        .path=${mdiDelete}
+                                      ></ha-icon-button>
+                                    </div>
+                                  `
+                                : nothing}
+                            </div>
+                          `
+                        : nothing
+                    }
+                    ${section}
+                  </div>
                 </div>
               `;
             }
@@ -344,27 +367,6 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
         }
       }
 
-      .section-actions {
-        position: absolute;
-        height: 36px;
-        top: calc(var(--row-height) + var(--row-gap) - 36px + 2px);
-        right: 0;
-        inset-inline-end: 0;
-        inset-inline-start: initial;
-        opacity: 1;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        transition: opacity 0.2s ease-in-out;
-        background-color: rgba(var(--rgb-card-background-color), 0.3);
-        border-top-left-radius: 18px;
-        border-top-right-radius: 18px;
-        background: var(--secondary-background-color);
-        --mdc-icon-button-size: 36px;
-        --mdc-icon-size: 20px;
-        color: var(--primary-text-color);
-      }
-
       .handle {
         cursor: grab;
         padding: 8px;
@@ -395,6 +397,55 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
         display: block;
         margin: 16px 8px;
         text-align: center;
+      }
+
+      .section-header {
+        position: relative;
+        height: var(--row-height);
+        margin-bottom: var(--row-gap);
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+      }
+
+      .section-title {
+        color: var(--primary-text-color);
+        font-size: 20px;
+        font-weight: normal;
+        margin: 0px;
+        letter-spacing: 0.1px;
+        line-height: 32px;
+        text-align: var(--ha-view-sections-title-text-align, start);
+        min-height: 32px;
+        box-sizing: border-box;
+        padding: 0 10px 10px;
+      }
+
+      .section-title.placeholder {
+        color: var(--secondary-text-color);
+        font-style: italic;
+      }
+
+      .section-actions {
+        position: absolute;
+        height: 36px;
+        bottom: calc(-1 * var(--row-gap) - 2px);
+        right: 0;
+        inset-inline-end: 0;
+        inset-inline-start: initial;
+        opacity: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: opacity 0.2s ease-in-out;
+        background-color: rgba(var(--rgb-card-background-color), 0.3);
+        border-radius: var(--ha-card-border-radius, 12px);
+        border-bottom-left-radius: 0px;
+        border-bottom-right-radius: 0px;
+        background: var(--secondary-background-color);
+        --mdc-icon-button-size: 36px;
+        --mdc-icon-size: 20px;
+        color: var(--primary-text-color);
       }
     `;
   }


### PR DESCRIPTION
## Proposed change

Move edit mode actions next to section block. Title has also been moved outside the grid section.

### Before 

![CleanShot 2024-09-02 at 11 41 27](https://github.com/user-attachments/assets/bd217bd9-86c4-4d7a-881d-e49bb896638a)

### After

![CleanShot 2024-09-02 at 11 41 45](https://github.com/user-attachments/assets/1b51fb51-c80e-49ac-87a0-f674d8f78cea)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual styling of the Grid Section component in edit mode with sharper corner edges.
	- Improved layout of section actions for better responsiveness and readability.
	- Simplified rendering logic for the Grid Section by removing the title display when not provided.

- **Style**
	- Adjusted CSS properties for better positioning and refined border radius for improved aesthetics.
	- Introduced a new section header for better semantic structure and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->