### PR TITLE
Support any custom type of consumption for Energy Dashboard

### DIFF
--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -39,6 +39,7 @@ export interface Statistic {
 
 export interface StatisticsMetaData {
   statistics_unit_of_measurement: string | null;
+  display_unit_of_measurement?: string | null;
   statistic_id: string;
   source: string;
   name?: string | null;

--- a/src/panels/config/energy/components/ha-energy-generic-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-generic-settings.ts
@@ -1,0 +1,227 @@
+import "@material/mwc-button/mwc-button";
+import { mdiDelete, mdiPlus, mdiPencil } from "@mdi/js";
+import { CSSResultGroup, html, LitElement, nothing, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-card";
+import "../../../../components/ha-icon-button";
+import {
+  EnergyPreferences,
+  EnergyPreferencesValidation,
+  EnergyValidationIssue,
+  saveEnergyPreferences,
+  GenericSourceTypeEnergyPreference,
+} from "../../../../data/energy";
+import {
+  StatisticsMetaData,
+  getStatisticLabel,
+} from "../../../../data/recorder";
+import {
+  showAlertDialog,
+  showConfirmationDialog,
+} from "../../../../dialogs/generic/show-dialog-box";
+import { capitalizeFirstLetter } from "../../../../common/string/capitalize-first-letter";
+import { haStyle } from "../../../../resources/styles";
+import { HomeAssistant } from "../../../../types";
+import { showEnergySettingsGenericDialog } from "../dialogs/show-dialogs-energy";
+import "./ha-energy-validation-result";
+import { energyCardStyles } from "./styles";
+
+@customElement("ha-energy-generic-settings")
+export class EnergyGenericSettings extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property() public energyType!: string;
+
+  @property({ attribute: false })
+  public preferences!: EnergyPreferences;
+
+  @property({ attribute: false })
+  public statsMetadata?: Record<string, StatisticsMetaData>;
+
+  @property({ attribute: false })
+  public validationResult?: EnergyPreferencesValidation;
+
+  private unit?: string | null;
+
+  private unitClass?: string | null;
+
+  protected render(): TemplateResult {
+    const genericSources: GenericSourceTypeEnergyPreference[] = [];
+    const genericValidation: EnergyValidationIssue[][] = [];
+
+    this.preferences.energy_sources.forEach((source, idx) => {
+      if (source.type !== "custom" || source.custom_type !== this.energyType) {
+        return;
+      }
+      genericSources.push(source);
+
+      if (this.validationResult) {
+        genericValidation.push(this.validationResult.energy_sources[idx]);
+      }
+    });
+
+    this.unitClass =
+      this.statsMetadata?.[genericSources[0]?.stat_energy_from]?.unit_class;
+    if (!this.unitClass) {
+      this.unit =
+        this.statsMetadata?.[
+          genericSources[0]?.stat_energy_from
+        ]?.statistics_unit_of_measurement;
+    } else {
+      this.unit = undefined;
+    }
+
+    return html`
+      <ha-card outlined>
+        <h1 class="card-header">
+          ${capitalizeFirstLetter(this.energyType.replaceAll("_", " "))}
+        </h1>
+
+        <div class="card-content">
+          <p>
+            ${this.hass.localize("ui.panel.config.energy.generic.sub", {
+              type: this.energyType.replaceAll("_", " "),
+            })}
+          </p>
+          ${genericValidation.map(
+            (result) => html`
+              <ha-energy-validation-result
+                .hass=${this.hass}
+                .issues=${result}
+              ></ha-energy-validation-result>
+            `
+          )}
+          <h3>
+            ${capitalizeFirstLetter(this.energyType.replaceAll("_", " "))}
+          </h3>
+          ${genericSources.map((source) => {
+            const entityState = this.hass.states[source.stat_energy_from];
+            return html`
+              <div class="row" .source=${source}>
+                ${entityState?.attributes.icon
+                  ? html`<ha-icon
+                      .icon=${entityState.attributes.icon}
+                    ></ha-icon>`
+                  : nothing}
+                <span class="content"
+                  >${getStatisticLabel(
+                    this.hass,
+                    source.stat_energy_from,
+                    this.statsMetadata?.[source.stat_energy_from]
+                  )}</span
+                >
+                <ha-icon-button
+                  .label=${this.hass.localize(
+                    "ui.panel.config.energy.generic.edit_generic_source",
+                    { type: this.energyType.replaceAll("_", " ") }
+                  )}
+                  @click=${this._editSource}
+                  .path=${mdiPencil}
+                ></ha-icon-button>
+                <ha-icon-button
+                  .label=${this.hass.localize(
+                    "ui.panel.config.energy.generic.delete_generic_source",
+                    { type: this.energyType.replaceAll("_", " ") }
+                  )}
+                  @click=${this._deleteSource}
+                  .path=${mdiDelete}
+                ></ha-icon-button>
+              </div>
+            `;
+          })}
+          <div class="row border-bottom">
+            <ha-svg-icon .path=${mdiPlus}></ha-svg-icon>
+            <mwc-button @click=${this._addSource}
+              >${this.hass.localize(
+                "ui.panel.config.energy.generic.add_generic_source",
+                { type: this.energyType.replaceAll("_", " ") }
+              )}</mwc-button
+            >
+          </div>
+        </div>
+      </ha-card>
+    `;
+  }
+
+  private _addSource() {
+    showEnergySettingsGenericDialog(this, {
+      generic_sources: this.preferences.energy_sources.filter(
+        (src) => src.type === "custom" && src.custom_type === this.energyType
+      ) as GenericSourceTypeEnergyPreference[],
+      energyType: this.energyType,
+      unit: this.unit,
+      unitClass: this.unitClass,
+      saveCallback: async (source) => {
+        delete source.unit_of_measurement;
+        await this._savePreferences({
+          ...this.preferences,
+          energy_sources: this.preferences.energy_sources.concat(source),
+        });
+      },
+    });
+  }
+
+  private _editSource(ev) {
+    const origSource: GenericSourceTypeEnergyPreference =
+      ev.currentTarget.closest(".row").source;
+    const generic_sources = this.preferences.energy_sources.filter(
+      (src) => src.type === "custom" && src.custom_type === this.energyType
+    ) as GenericSourceTypeEnergyPreference[];
+    showEnergySettingsGenericDialog(this, {
+      source: { ...origSource },
+      metadata: this.statsMetadata?.[origSource.stat_energy_from],
+      energyType: this.energyType,
+      unit: generic_sources.length === 1 ? undefined : this.unit,
+      unitClass: generic_sources.length === 1 ? undefined : this.unitClass,
+      generic_sources,
+      saveCallback: async (newSource) => {
+        await this._savePreferences({
+          ...this.preferences,
+          energy_sources: this.preferences.energy_sources.map((src) =>
+            src === origSource ? newSource : src
+          ),
+        });
+      },
+    });
+  }
+
+  private async _deleteSource(ev) {
+    const sourceToDelete: GenericSourceTypeEnergyPreference =
+      ev.currentTarget.closest(".row").source;
+
+    if (
+      !(await showConfirmationDialog(this, {
+        title: this.hass.localize("ui.panel.config.energy.delete_source"),
+      }))
+    ) {
+      return;
+    }
+
+    try {
+      await this._savePreferences({
+        ...this.preferences,
+        energy_sources: this.preferences.energy_sources.filter(
+          (source) => source !== sourceToDelete
+        ),
+      });
+    } catch (err: any) {
+      showAlertDialog(this, { title: `Failed to save config: ${err.message}` });
+    }
+  }
+
+  private async _savePreferences(preferences: EnergyPreferences) {
+    const result = await saveEnergyPreferences(this.hass, preferences);
+    fireEvent(this, "value-changed", { value: result });
+  }
+
+  static get styles(): CSSResultGroup {
+    return [haStyle, energyCardStyles];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-energy-generic-settings": EnergyGenericSettings;
+  }
+}

--- a/src/panels/config/energy/components/ha-energy-new-generic-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-new-generic-settings.ts
@@ -1,0 +1,74 @@
+import "@material/mwc-button/mwc-button";
+import { mdiPlus } from "@mdi/js";
+import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-card";
+import "../../../../components/ha-icon-button";
+import {
+  EnergyPreferences,
+  saveEnergyPreferences,
+  GenericSourceTypeEnergyPreference,
+} from "../../../../data/energy";
+
+import { haStyle } from "../../../../resources/styles";
+import { HomeAssistant } from "../../../../types";
+import { showEnergySettingsGenericDialog } from "../dialogs/show-dialogs-energy";
+import "./ha-energy-validation-result";
+import { energyCardStyles } from "./styles";
+
+@customElement("ha-energy-new-generic-settings")
+export class EnergyNewGenericSettings extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false })
+  public preferences!: EnergyPreferences;
+
+  protected render(): TemplateResult {
+    return html`
+      <ha-card outlined>
+        <h1 class="card-header">
+          ${this.hass.localize("ui.panel.config.energy.generic.new_title")}
+        </h1>
+        <div class="card-content">
+          <div class="row border-bottom">
+            <ha-svg-icon .path=${mdiPlus}></ha-svg-icon>
+            <mwc-button @click=${this._addType}
+              >${this.hass.localize(
+                "ui.panel.config.energy.generic.new_type_button"
+              )}</mwc-button
+            >
+          </div>
+        </div>
+      </ha-card>
+    `;
+  }
+
+  private _addType() {
+    showEnergySettingsGenericDialog(this, {
+      generic_sources: [] as GenericSourceTypeEnergyPreference[],
+      saveCallback: async (source) => {
+        delete source.unit_of_measurement;
+        await this._savePreferences({
+          ...this.preferences,
+          energy_sources: this.preferences.energy_sources.concat(source),
+        });
+      },
+    });
+  }
+
+  private async _savePreferences(preferences: EnergyPreferences) {
+    const result = await saveEnergyPreferences(this.hass, preferences);
+    fireEvent(this, "value-changed", { value: result });
+  }
+
+  static get styles(): CSSResultGroup {
+    return [haStyle, energyCardStyles];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-energy-new-generic-settings": EnergyNewGenericSettings;
+  }
+}

--- a/src/panels/config/energy/dialogs/dialog-energy-generic-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-generic-settings.ts
@@ -1,0 +1,367 @@
+import "@material/mwc-button/mwc-button";
+import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/entity/ha-entity-picker";
+import "../../../../components/entity/ha-statistic-picker";
+import "../../../../components/ha-dialog";
+import "../../../../components/ha-formfield";
+import "../../../../components/ha-radio";
+import type { HaRadio } from "../../../../components/ha-radio";
+import type { HaTextField } from "../../../../components/ha-textfield";
+import "../../../../components/ha-textfield";
+import {
+  emptyGenericEnergyPreference,
+  GenericSourceTypeEnergyPreference,
+  energyStatisticHelpUrl,
+} from "../../../../data/energy";
+import {
+  getDisplayUnit,
+  getStatisticMetadata,
+  isExternalStatistic,
+} from "../../../../data/recorder";
+import { HassDialog } from "../../../../dialogs/make-dialog-manager";
+import { haStyle, haStyleDialog } from "../../../../resources/styles";
+import { HomeAssistant } from "../../../../types";
+import { EnergySettingsGenericDialogParams } from "./show-dialogs-energy";
+import { slugify } from "../../../../common/string/slugify";
+
+@customElement("dialog-energy-generic-settings")
+export class DialogEnergyGenericSettings
+  extends LitElement
+  implements HassDialog<EnergySettingsGenericDialogParams>
+{
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _params?: EnergySettingsGenericDialogParams;
+
+  @state() private _source?: GenericSourceTypeEnergyPreference;
+
+  @state() private _costs?: "no-costs" | "number" | "entity" | "statistic";
+
+  @state() private _pickedDisplayUnit?: string | null;
+
+  @state() private _error?: string;
+
+  private _excludeList?: string[];
+
+  private _fixedType = false;
+
+  public async showDialog(
+    params: EnergySettingsGenericDialogParams
+  ): Promise<void> {
+    this._params = params;
+    this._source = params.source
+      ? { ...params.source }
+      : emptyGenericEnergyPreference();
+    this._pickedDisplayUnit = getDisplayUnit(
+      this.hass,
+      params.source?.stat_energy_from,
+      params.metadata
+    );
+    this._costs = this._source.entity_energy_price
+      ? "entity"
+      : this._source.number_energy_price
+        ? "number"
+        : this._source.stat_cost
+          ? "statistic"
+          : "no-costs";
+    this._excludeList = this._params.generic_sources
+      .map((entry) => entry.stat_energy_from)
+      .filter((id) => id !== this._source?.stat_energy_from);
+
+    this._fixedType = !!this._params.energyType;
+    this._source.custom_type = this._params.energyType || "";
+  }
+
+  public closeDialog(): void {
+    this._params = undefined;
+    this._source = undefined;
+    this._error = undefined;
+    this._pickedDisplayUnit = undefined;
+    this._excludeList = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render() {
+    if (!this._params || !this._source) {
+      return nothing;
+    }
+
+    const unitPrice = this._pickedDisplayUnit
+      ? `${this.hass.config.currency}/${this._pickedDisplayUnit}`
+      : undefined;
+
+    const externalSource =
+      this._source.stat_energy_from &&
+      isExternalStatistic(this._source.stat_energy_from);
+
+    return html`
+      <ha-dialog
+        open
+        .heading=${html` ${this.hass.localize(
+          "ui.panel.config.energy.generic.dialog.header"
+        )}`}
+        @closed=${this.closeDialog}
+      >
+        ${this._error ? html`<p class="error">${this._error}</p>` : ""}
+        <div>
+          <p>
+            ${this.hass.localize(
+              "ui.panel.config.energy.generic.dialog.paragraph"
+            )}
+          </p>
+
+          ${!this._fixedType
+            ? html`<p>
+                ${this.hass.localize(
+                  "ui.panel.config.energy.generic.dialog.pick_type"
+                )}
+              </p>`
+            : nothing}
+          <ha-textfield
+            .label=${"Energy Type"}
+            .value=${this._source.custom_type}
+            .disabled=${this._fixedType}
+            @change=${this._energyTypeChanged}
+          ></ha-textfield>
+
+          <p>
+            ${this.hass.localize(
+              "ui.panel.config.energy.generic.dialog.entity_para",
+              {
+                type: this._params.energyType,
+                unit: this._params.unitClass || this._params.unit,
+              }
+            )}
+          </p>
+        </div>
+
+        <ha-statistic-picker
+          .hass=${this.hass}
+          .helpMissingEntityUrl=${energyStatisticHelpUrl}
+          .value=${this._source.stat_energy_from}
+          .label=${this.hass.localize(
+            "ui.panel.config.energy.generic.dialog.generic_usage"
+          )}
+          .includeStatisticsUnitOfMeasurement=${this._params.unit}
+          .includeUnitClass=${this._params.unitClass}
+          .excludeStatistics=${this._excludeList}
+          @value-changed=${this._statisticChanged}
+          dialogInitialFocus
+        ></ha-statistic-picker>
+
+        <p>
+          ${this.hass.localize(
+            "ui.panel.config.energy.generic.dialog.cost_para"
+          )}
+        </p>
+
+        <ha-formfield
+          .label=${this.hass.localize(
+            "ui.panel.config.energy.generic.dialog.no_cost"
+          )}
+        >
+          <ha-radio
+            value="no-costs"
+            name="costs"
+            .checked=${this._costs === "no-costs"}
+            @change=${this._handleCostChanged}
+          ></ha-radio>
+        </ha-formfield>
+        <ha-formfield
+          .label=${this.hass.localize(
+            "ui.panel.config.energy.generic.dialog.cost_stat"
+          )}
+        >
+          <ha-radio
+            value="statistic"
+            name="costs"
+            .checked=${this._costs === "statistic"}
+            @change=${this._handleCostChanged}
+          ></ha-radio>
+        </ha-formfield>
+        ${this._costs === "statistic"
+          ? html`<ha-statistic-picker
+              class="price-options"
+              .hass=${this.hass}
+              statistic-types="sum"
+              .value=${this._source.stat_cost}
+              .label=${`${this.hass.localize(
+                "ui.panel.config.energy.generic.dialog.cost_stat_input"
+              )} (${this.hass.config.currency})`}
+              @value-changed=${this._priceStatChanged}
+            ></ha-statistic-picker>`
+          : ""}
+        <ha-formfield
+          .label=${this.hass.localize(
+            "ui.panel.config.energy.generic.dialog.cost_entity"
+          )}
+        >
+          <ha-radio
+            value="entity"
+            name="costs"
+            .checked=${this._costs === "entity"}
+            .disabled=${externalSource}
+            @change=${this._handleCostChanged}
+          ></ha-radio>
+        </ha-formfield>
+        ${this._costs === "entity"
+          ? html`<ha-entity-picker
+              class="price-options"
+              .hass=${this.hass}
+              include-domains='["sensor", "input_number"]'
+              .value=${this._source.entity_energy_price}
+              .label=${`${this.hass.localize(
+                "ui.panel.config.energy.generic.dialog.cost_entity_input"
+              )}${unitPrice ? ` (${unitPrice})` : ""}`}
+              @value-changed=${this._priceEntityChanged}
+            ></ha-entity-picker>`
+          : ""}
+        <ha-formfield
+          .label=${this.hass.localize(
+            "ui.panel.config.energy.generic.dialog.cost_number"
+          )}
+        >
+          <ha-radio
+            value="number"
+            name="costs"
+            .checked=${this._costs === "number"}
+            .disabled=${externalSource}
+            @change=${this._handleCostChanged}
+          ></ha-radio>
+        </ha-formfield>
+        ${this._costs === "number"
+          ? html`<ha-textfield
+              .label=${`${this.hass.localize(
+                "ui.panel.config.energy.generic.dialog.cost_number_input"
+              )} (${unitPrice})`}
+              class="price-options"
+              step="any"
+              type="number"
+              .value=${this._source.number_energy_price}
+              @change=${this._numberPriceChanged}
+              .suffix=${unitPrice}
+            >
+            </ha-textfield>`
+          : ""}
+
+        <mwc-button @click=${this.closeDialog} slot="secondaryAction">
+          ${this.hass.localize("ui.common.cancel")}
+        </mwc-button>
+        <mwc-button
+          @click=${this._save}
+          .disabled=${!this._source.stat_energy_from}
+          slot="primaryAction"
+        >
+          ${this.hass.localize("ui.common.save")}
+        </mwc-button>
+      </ha-dialog>
+    `;
+  }
+
+  private _handleCostChanged(ev: CustomEvent) {
+    const input = ev.currentTarget as HaRadio;
+    this._costs = input.value as any;
+  }
+
+  private _numberPriceChanged(ev) {
+    this._source = {
+      ...this._source!,
+      number_energy_price: Number(ev.target.value),
+      entity_energy_price: null,
+      stat_cost: null,
+    };
+  }
+
+  private _priceStatChanged(ev: CustomEvent) {
+    this._source = {
+      ...this._source!,
+      entity_energy_price: null,
+      number_energy_price: null,
+      stat_cost: ev.detail.value,
+    };
+  }
+
+  private _priceEntityChanged(ev: CustomEvent) {
+    this._source = {
+      ...this._source!,
+      entity_energy_price: ev.detail.value,
+      number_energy_price: null,
+      stat_cost: null,
+    };
+  }
+
+  private async _statisticChanged(ev: CustomEvent<{ value: string }>) {
+    if (ev.detail.value) {
+      const metadata = await getStatisticMetadata(this.hass, [ev.detail.value]);
+      this._pickedDisplayUnit = getDisplayUnit(
+        this.hass,
+        ev.detail.value,
+        metadata[0]
+      );
+    } else {
+      this._pickedDisplayUnit = undefined;
+    }
+    if (isExternalStatistic(ev.detail.value) && this._costs !== "statistic") {
+      this._costs = "no-costs";
+    }
+    this._source = {
+      ...this._source!,
+      stat_energy_from: ev.detail.value,
+    };
+  }
+
+  private _energyTypeChanged(ev: CustomEvent) {
+    this._source!.custom_type = (ev.currentTarget as HaTextField).value;
+  }
+
+  private async _save() {
+    const type = slugify(this._source!.custom_type);
+    if (!type) {
+      this._error = "Must define an energy type";
+      return;
+    }
+    this._source!.custom_type = type;
+
+    try {
+      if (this._costs === "no-costs") {
+        this._source!.entity_energy_price = null;
+        this._source!.number_energy_price = null;
+        this._source!.stat_cost = null;
+      }
+      await this._params!.saveCallback(this._source!);
+      this.closeDialog();
+    } catch (err: any) {
+      this._error = err.message;
+    }
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      haStyleDialog,
+      css`
+        ha-dialog {
+          --mdc-dialog-max-width: 430px;
+        }
+        ha-formfield {
+          display: block;
+        }
+        .price-options {
+          display: block;
+          padding-left: 52px;
+          padding-inline-start: 52px;
+          padding-inline-end: initial;
+          margin-top: -8px;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-energy-generic-settings": DialogEnergyGenericSettings;
+  }
+}

--- a/src/panels/config/energy/dialogs/show-dialogs-energy.ts
+++ b/src/panels/config/energy/dialogs/show-dialogs-energy.ts
@@ -10,6 +10,7 @@ import {
   GridSourceTypeEnergyPreference,
   SolarSourceTypeEnergyPreference,
   WaterSourceTypeEnergyPreference,
+  GenericSourceTypeEnergyPreference,
 } from "../../../../data/energy";
 import { StatisticsMetaData } from "../../../../data/recorder";
 
@@ -69,6 +70,16 @@ export interface EnergySettingsWaterDialogParams {
   saveCallback: (source: WaterSourceTypeEnergyPreference) => Promise<void>;
 }
 
+export interface EnergySettingsGenericDialogParams {
+  source?: GenericSourceTypeEnergyPreference;
+  metadata?: StatisticsMetaData;
+  energyType?: string;
+  unit?: string | null;
+  unitClass?: string | null;
+  generic_sources: GenericSourceTypeEnergyPreference[];
+  saveCallback: (source: GenericSourceTypeEnergyPreference) => Promise<void>;
+}
+
 export interface EnergySettingsDeviceDialogParams {
   device?: DeviceConsumptionEnergyPreference;
   device_consumptions: DeviceConsumptionEnergyPreference[];
@@ -126,6 +137,17 @@ export const showEnergySettingsWaterDialog = (
   fireEvent(element, "show-dialog", {
     dialogTag: "dialog-energy-water-settings",
     dialogImport: () => import("./dialog-energy-water-settings"),
+    dialogParams: dialogParams,
+  });
+};
+
+export const showEnergySettingsGenericDialog = (
+  element: HTMLElement,
+  dialogParams: EnergySettingsGenericDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-energy-generic-settings",
+    dialogImport: () => import("./dialog-energy-generic-settings"),
     dialogParams: dialogParams,
   });
 };

--- a/src/panels/config/energy/ha-config-energy.ts
+++ b/src/panels/config/energy/ha-config-energy.ts
@@ -9,6 +9,7 @@ import {
   getEnergyInfo,
   getEnergyPreferences,
   getReferencedStatisticIds,
+  getGenericEnergyTypes,
 } from "../../../data/energy";
 import {
   getStatisticMetadata,
@@ -25,6 +26,8 @@ import "./components/ha-energy-solar-settings";
 import "./components/ha-energy-battery-settings";
 import "./components/ha-energy-gas-settings";
 import "./components/ha-energy-water-settings";
+import "./components/ha-energy-generic-settings";
+import "./components/ha-energy-new-generic-settings";
 
 const INITIAL_CONFIG: EnergyPreferences = {
   energy_sources: [],
@@ -131,6 +134,22 @@ class HaConfigEnergy extends LitElement {
             .validationResult=${this._validationResult}
             @value-changed=${this._prefsChanged}
           ></ha-energy-device-settings>
+          ${getGenericEnergyTypes(this._preferences!).map(
+            (type) =>
+              html`<ha-energy-generic-settings
+                .hass=${this.hass}
+                .energyType=${type}
+                .preferences=${this._preferences!}
+                .statsMetadata=${this._statsMetadata}
+                .validationResult=${this._validationResult}
+                @value-changed=${this._prefsChanged}
+              ></ha-energy-generic-settings>`
+          )}
+          <ha-energy-new-generic-settings
+            .hass=${this.hass}
+            .preferences=${this._preferences!}
+            @value-changed=${this._prefsChanged}
+          ></ha-energy-new-generic-settings>
         </div>
       </hass-subpage>
     `;

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -3,11 +3,13 @@ import { customElement } from "lit/decorators";
 import {
   EnergyPreferences,
   getEnergyPreferences,
+  getGenericEnergyTypes,
   GridSourceTypeEnergyPreference,
 } from "../../../data/energy";
 import { HomeAssistant } from "../../../types";
 import { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import { LovelaceStrategyConfig } from "../../../data/lovelace/config/strategy";
+import { capitalizeFirstLetter } from "../../../common/string/capitalize-first-letter";
 
 const setupWizard = async (): Promise<LovelaceViewConfig> => {
   await import("../cards/energy-setup-wizard-card");
@@ -109,6 +111,15 @@ export class EnergyViewStrategy extends ReactiveElement {
         collection_key: "energy_dashboard",
       });
     }
+
+    getGenericEnergyTypes(prefs).forEach((type) => {
+      view.cards!.push({
+        title: capitalizeFirstLetter(type.replaceAll("_", " ")),
+        type: "energy-generic-graph",
+        energyType: type,
+        collection_key: "energy_dashboard",
+      });
+    });
 
     // Only include if we have a grid.
     if (hasGrid) {

--- a/src/panels/lovelace/cards/energy/common/color.ts
+++ b/src/panels/lovelace/cards/energy/common/color.ts
@@ -27,9 +27,9 @@ export function getEnergyColor(
 
   if (themeColor.length === 0) {
     // If we don't have a defined color, pick a graph color derived from the hash of the key name.
-    // eslint-disable-next-line no-bitwise
     const hashCode = propertyName
       .split("")
+      // eslint-disable-next-line no-bitwise
       .reduce((a, b) => ((a << 5) - a + b.charCodeAt(0)) | 0, 0);
     themeColor = getGraphColorByIndex(Math.abs(hashCode), computedStyles);
   }

--- a/src/panels/lovelace/cards/energy/common/color.ts
+++ b/src/panels/lovelace/cards/energy/common/color.ts
@@ -6,6 +6,7 @@ import {
   theme2hex,
 } from "../../../../../common/color/convert-color";
 import { labBrighten, labDarken } from "../../../../../common/color/lab";
+import { getGraphColorByIndex } from "../../../../../common/color/colors";
 
 export function getEnergyColor(
   computedStyles: CSSStyleDeclaration,
@@ -19,10 +20,19 @@ export function getEnergyColor(
     .getPropertyValue(propertyName + "-" + idx)
     .trim();
 
-  const themeColor =
+  let themeColor =
     themeIdxColor.length > 0
       ? themeIdxColor
       : computedStyles.getPropertyValue(propertyName).trim();
+
+  if (themeColor.length === 0) {
+    // If we don't have a defined color, pick a graph color derived from the hash of the key name.
+    // eslint-disable-next-line no-bitwise
+    const hashCode = propertyName
+      .split("")
+      .reduce((a, b) => ((a << 5) - a + b.charCodeAt(0)) | 0, 0);
+    themeColor = getGraphColorByIndex(Math.abs(hashCode), computedStyles);
+  }
 
   let hexColor = theme2hex(themeColor);
 

--- a/src/panels/lovelace/cards/energy/hui-energy-generic-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-generic-graph-card.ts
@@ -1,0 +1,356 @@
+import {
+  ChartData,
+  ChartDataset,
+  ChartOptions,
+  ScatterDataPoint,
+} from "chart.js";
+import { endOfToday, isToday, startOfToday } from "date-fns";
+import { HassConfig, UnsubscribeFunc } from "home-assistant-js-websocket";
+import {
+  css,
+  CSSResultGroup,
+  html,
+  LitElement,
+  nothing,
+  PropertyValues,
+} from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
+import memoizeOne from "memoize-one";
+import { getEnergyColor } from "./common/color";
+import { formatNumber } from "../../../../common/number/format_number";
+import "../../../../components/chart/ha-chart-base";
+import "../../../../components/ha-card";
+import {
+  EnergyData,
+  getEnergyDataCollection,
+  GenericSourceTypeEnergyPreference,
+} from "../../../../data/energy";
+import {
+  getStatisticLabel,
+  Statistics,
+  StatisticsMetaData,
+} from "../../../../data/recorder";
+import { FrontendLocaleData } from "../../../../data/translation";
+import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
+import { HomeAssistant } from "../../../../types";
+import { LovelaceCard } from "../../types";
+import { EnergyGenericGraphCardConfig } from "../types";
+import { hasConfigChanged } from "../../common/has-changed";
+import { getCommonOptions } from "./common/energy-chart-options";
+
+@customElement("hui-energy-generic-graph-card")
+export class HuiEnergyGenericGraphCard
+  extends SubscribeMixin(LitElement)
+  implements LovelaceCard
+{
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _config?: EnergyGenericGraphCardConfig;
+
+  @state() private _chartData: ChartData = {
+    datasets: [],
+  };
+
+  @state() private _start = startOfToday();
+
+  @state() private _end = endOfToday();
+
+  @state() private _compareStart?: Date;
+
+  @state() private _compareEnd?: Date;
+
+  @state() private _unit?: string;
+
+  protected hassSubscribeRequiredHostProps = ["_config"];
+
+  public hassSubscribe(): UnsubscribeFunc[] {
+    return [
+      getEnergyDataCollection(this.hass, {
+        key: this._config?.collection_key,
+      }).subscribe((data) => this._getStatistics(data)),
+    ];
+  }
+
+  public getCardSize(): Promise<number> | number {
+    return 3;
+  }
+
+  public setConfig(config: EnergyGenericGraphCardConfig): void {
+    this._config = config;
+  }
+
+  protected shouldUpdate(changedProps: PropertyValues): boolean {
+    return (
+      hasConfigChanged(this, changedProps) ||
+      changedProps.size > 1 ||
+      !changedProps.has("hass")
+    );
+  }
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    return html`
+      <ha-card>
+        ${this._config.title
+          ? html`<h1 class="card-header">${this._config.title}</h1>`
+          : ""}
+        <div
+          class="content ${classMap({
+            "has-header": !!this._config.title,
+          })}"
+        >
+          <ha-chart-base
+            .hass=${this.hass}
+            .data=${this._chartData}
+            .options=${this._createOptions(
+              this._start,
+              this._end,
+              this.hass.locale,
+              this.hass.config,
+              this._unit,
+              this._compareStart,
+              this._compareEnd
+            )}
+            chart-type="bar"
+          ></ha-chart-base>
+          ${!this._chartData.datasets.length
+            ? html`<div class="no-data">
+                ${isToday(this._start)
+                  ? this.hass.localize("ui.panel.lovelace.cards.energy.no_data")
+                  : this.hass.localize(
+                      "ui.panel.lovelace.cards.energy.no_data_period"
+                    )}
+              </div>`
+            : ""}
+        </div>
+      </ha-card>
+    `;
+  }
+
+  private _createOptions = memoizeOne(
+    (
+      start: Date,
+      end: Date,
+      locale: FrontendLocaleData,
+      config: HassConfig,
+      unit?: string,
+      compareStart?: Date,
+      compareEnd?: Date
+    ): ChartOptions => {
+      const commonOptions = getCommonOptions(
+        start,
+        end,
+        locale,
+        config,
+        unit,
+        compareStart,
+        compareEnd
+      );
+      const options: ChartOptions = {
+        ...commonOptions,
+        plugins: {
+          ...commonOptions.plugins,
+          tooltip: {
+            ...commonOptions.plugins!.tooltip,
+            callbacks: {
+              ...commonOptions.plugins!.tooltip!.callbacks,
+              footer: (contexts) => {
+                if (contexts.length < 2) {
+                  return [];
+                }
+                let total = 0;
+                for (const context of contexts) {
+                  total += (context.dataset.data[context.dataIndex] as any).y;
+                }
+                if (total === 0) {
+                  return [];
+                }
+                return [
+                  this.hass.localize(
+                    "ui.panel.lovelace.cards.energy.energy_generic_graph.total_consumed",
+                    { num: formatNumber(total, locale), unit }
+                  ),
+                ];
+              },
+            },
+          },
+        },
+      };
+      return options;
+    }
+  );
+
+  private async _getStatistics(energyData: EnergyData): Promise<void> {
+    const genericSources: GenericSourceTypeEnergyPreference[] =
+      energyData.prefs.energy_sources.filter(
+        (source) =>
+          source.type === "custom" &&
+          source.custom_type === this._config!.energyType
+      ) as GenericSourceTypeEnergyPreference[];
+
+    this._unit =
+      energyData.statsMetadata[genericSources[0].stat_energy_from]
+        .display_unit_of_measurement || "";
+
+    const datasets: ChartDataset<"bar", ScatterDataPoint[]>[] = [];
+
+    const computedStyles = getComputedStyle(this);
+
+    datasets.push(
+      ...this._processDataSet(
+        energyData.stats,
+        energyData.statsMetadata,
+        genericSources,
+        computedStyles
+      )
+    );
+
+    if (energyData.statsCompare) {
+      // Add empty dataset to align the bars
+      datasets.push({
+        order: 0,
+        data: [],
+      });
+      datasets.push({
+        order: 999,
+        data: [],
+        xAxisID: "xAxisCompare",
+      });
+
+      datasets.push(
+        ...this._processDataSet(
+          energyData.statsCompare,
+          energyData.statsMetadata,
+          genericSources,
+          computedStyles,
+          true
+        )
+      );
+    }
+
+    this._start = energyData.start;
+    this._end = energyData.end || endOfToday();
+
+    this._compareStart = energyData.startCompare;
+    this._compareEnd = energyData.endCompare;
+
+    this._chartData = {
+      datasets,
+    };
+  }
+
+  private _processDataSet(
+    statistics: Statistics,
+    statisticsMetaData: Record<string, StatisticsMetaData>,
+    genericSources: GenericSourceTypeEnergyPreference[],
+    computedStyles: CSSStyleDeclaration,
+    compare = false
+  ) {
+    const data: ChartDataset<"bar", ScatterDataPoint[]>[] = [];
+
+    genericSources.forEach((source, idx) => {
+      let prevStart: number | null = null;
+
+      const genericConsumptionData: ScatterDataPoint[] = [];
+
+      // Process generic consumption data.
+      if (source.stat_energy_from in statistics) {
+        const stats = statistics[source.stat_energy_from];
+        let end;
+
+        for (const point of stats) {
+          if (point.change === null || point.change === undefined) {
+            continue;
+          }
+          if (prevStart === point.start) {
+            continue;
+          }
+          const date = new Date(point.start);
+          genericConsumptionData.push({
+            x: date.getTime(),
+            y: point.change,
+          });
+          prevStart = point.start;
+          end = point.end;
+        }
+        if (genericConsumptionData.length === 1) {
+          genericConsumptionData.push({
+            x: end,
+            y: 0,
+          });
+        }
+      }
+
+      data.push({
+        label: getStatisticLabel(
+          this.hass,
+          source.stat_energy_from,
+          statisticsMetaData[source.stat_energy_from]
+        ),
+        borderColor: getEnergyColor(
+          computedStyles,
+          this.hass.themes.darkMode,
+          false,
+          compare,
+          `--energy-${this._config!.energyType}-color`,
+          idx
+        ),
+        backgroundColor: getEnergyColor(
+          computedStyles,
+          this.hass.themes.darkMode,
+          true,
+          compare,
+          `--energy-${this._config!.energyType}-color`,
+          idx
+        ),
+        data: genericConsumptionData,
+        order: 1,
+        stack: this._config!.energyType,
+        xAxisID: compare ? "xAxisCompare" : undefined,
+      });
+    });
+    return data;
+  }
+
+  static get styles(): CSSResultGroup {
+    return css`
+      ha-card {
+        height: 100%;
+      }
+      .card-header {
+        padding-bottom: 0;
+      }
+      .content {
+        padding: 16px;
+      }
+      .has-header {
+        padding-top: 0;
+      }
+      .no-data {
+        position: absolute;
+        height: 100%;
+        top: 0;
+        left: 0;
+        right: 0;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 20%;
+        margin-left: 32px;
+        margin-inline-start: 32px;
+        margin-inline-end: initial;
+        box-sizing: border-box;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-energy-generic-graph-card": HuiEnergyGenericGraphCard;
+  }
+}

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -150,6 +150,12 @@ export interface EnergyWaterGraphCardConfig extends EnergyCardBaseConfig {
   title?: string;
 }
 
+export interface EnergyGenericGraphCardConfig extends EnergyCardBaseConfig {
+  type: "energy-generic-graph";
+  title?: string;
+  energyType: string;
+}
+
 export interface EnergyDevicesGraphCardConfig extends EnergyCardBaseConfig {
   type: "energy-devices-graph";
   title?: string;

--- a/src/panels/lovelace/create-element/create-card-element.ts
+++ b/src/panels/lovelace/create-element/create-card-element.ts
@@ -51,6 +51,8 @@ const LAZY_LOAD_TYPES = {
   "energy-gas-graph": () => import("../cards/energy/hui-energy-gas-graph-card"),
   "energy-water-graph": () =>
     import("../cards/energy/hui-energy-water-graph-card"),
+  "energy-generic-graph": () =>
+    import("../cards/energy/hui-energy-generic-graph-card"),
   "energy-grid-neutrality-gauge": () =>
     import("../cards/energy/hui-energy-grid-neutrality-gauge-card"),
   "energy-solar-consumed-gauge": () =>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2297,6 +2297,30 @@
               "water_usage": "Water usage"
             }
           },
+          "generic": {
+            "new_title": "Custom energy",
+            "new_type_button": "Add new energy type",
+            "sub": "Let Home Assistant monitor your {type}.",
+            "edit_generic_source": "Edit {type} source",
+            "delete_generic_source": "Delete {type} source",
+            "add_generic_source": "Add {type} source",
+            "dialog": {
+              "header": "Configure generic consumption",
+              "pick_type": "Enter a key that defines this type of consumption, e.g. 'oil', 'hot water', or another label of your choice.",
+              "paragraph": "Monitor consumption for a custom category.",
+              "entity_para": "Pick a sensor which measures consumption for {type, select, \n undefined {this type} \n other {{type}}\n }{unit, select, \n undefined {} \n other { in units of {unit}}\n }.",
+              "cost_para": "Select how Home Assistant should keep track of the costs of the consumption.",
+              "no_cost": "[%key:ui::panel::config::energy::grid::flow_dialog::from::no_cost%]",
+              "cost_stat": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_stat%]",
+              "cost_stat_input": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_stat_input%]",
+              "cost_entity": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_entity%]",
+              "cost_entity_input": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_entity_input%]",
+              "cost_number": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_number%]",
+              "cost_number_input": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_number%]",
+              "generic_usage": "Generic usage"
+            }
+          },
+
           "device_consumption": {
             "title": "Individual devices",
             "sub": "Tracking the energy usage of individual devices allows Home Assistant to break down your energy usage by device.",
@@ -5382,6 +5406,7 @@
               "gas_total": "Gas total",
               "solar_total": "Solar total",
               "water_total": "Water total",
+              "generic_total": "{type} total",
               "source": "Source",
               "energy": "Energy",
               "cost": "Cost",
@@ -5397,6 +5422,9 @@
             },
             "energy_gas_graph": {
               "total_consumed": "Total consumed {num} {unit}"
+            },
+            "energy_generic_graph": {
+              "total_consumed": "[%key:ui::panel::lovelace::cards::energy::energy_gas_graph::total_consumed%]"
             },
             "energy_water_graph": {
               "total_consumed": "[%key:ui::panel::lovelace::cards::energy::energy_gas_graph::total_consumed%]"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Was exploring what it would look like if we let users define any generic type of consumption they wish to track in energy dashboard, as it is often requested to support various kinds of utilities that we don't currently support. Currently the best they can do is to shoehorn it into the "gas" tracker with fake units and a fake title, which isn't a great experience (especially if they also have gas to track). This may also have other interesting usecases such as adding cost tracking to individual devices, or adding groupings to subsets of different energy sensors, possibly other uses I haven't thought of yet.

Came up with something like the following. Still maybe a little work to do to make sure units/conversions/prices are handled correctly, but would be good to know if this looks like something we would be interested in approving.

Config dashboard:
![image](https://github.com/user-attachments/assets/d3758226-98d3-4304-a2df-a232113481e3)

Dialog:
![image](https://github.com/user-attachments/assets/7849d901-abec-46ed-983b-109541e0cc0c)

Graphs:
![image](https://github.com/user-attachments/assets/23957a40-3ad5-4ff6-b7c1-d6918efbfde7)

Table:
![image](https://github.com/user-attachments/assets/394b342c-8973-4670-b18b-c50d517154f2)



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://community.home-assistant.io/t/add-support-for-heat-pumps-in-the-energy-dashboard/405399
https://community.home-assistant.io/t/change-the-name-of-gas-on-the-energy-dashboard/462432
https://community.home-assistant.io/t/custom-consumptions-for-energy-dashboard-wood-pellets-water-oil/405326
https://community.home-assistant.io/t/energy-adding-pellets-and-wood-to-gaz-and-electricity/335031
https://community.home-assistant.io/t/energy-card-oil-consumption-in-addition-to-gas-consumption/604364
https://community.home-assistant.io/t/energy-dashboard-names-customisable/426570
https://community.home-assistant.io/t/energy-dashboard-change-gas-into-heating/391647
https://community.home-assistant.io/t/energy-dashboard-add-oil-usage-in-addition-to-gas/471084
https://community.home-assistant.io/t/energy-dashboard-wood-pellets-consumption/376702
https://community.home-assistant.io/t/energy-dashboard-add-electric-car-consumption/340161
https://community.home-assistant.io/t/having-diffrent-sources-for-heating-in-energy-dashboard/486957
https://community.home-assistant.io/t/energy-management-allow-oil-in-addition-to-gas/333984
https://community.home-assistant.io/t/energy-wood-pellets-wood-chips-oil/505299
https://community.home-assistant.io/t/split-energy-to-track-ev-and-heating-consumption/487314
https://community.home-assistant.io/t/support-heat-pumps-in-energy-dashboard/650033
https://github.com/home-assistant/frontend/discussions/12992
https://github.com/home-assistant/frontend/discussions/15918
https://github.com/home-assistant/frontend/discussions/14345

- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced support for custom energy sources, enhancing energy management capabilities.
	- Added new components for managing and displaying energy settings, including dialogs and settings cards.
	- Implemented a new graph card for visualizing energy consumption data.
	- Enhanced the energy settings interface with new user-friendly components for adding and editing energy types.

- **Bug Fixes**
	- Improved error handling and validation for energy settings dialogs.

- **Documentation**
	- Updated translations to include new entries for custom energy types and related interactions.

- **Refactor**
	- Streamlined rendering logic for energy sources in table format, improving maintainability.
	- Improved color assignment logic for energy visualizations, enhancing robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->