### PR TITLE
Fix script more-info when entity_id != unique_id

### DIFF
--- a/src/dialogs/more-info/controls/more-info-script.ts
+++ b/src/dialogs/more-info/controls/more-info-script.ts
@@ -155,7 +155,7 @@ class MoreInfoScript extends LitElement {
         this._scriptData = {
           action:
             this.entry?.entity_id === newState.entity_id
-              ? this.entry.unique_id
+              ? `script.${this.entry.unique_id}`
               : newState.entity_id,
           data: {},
         };

--- a/src/dialogs/more-info/controls/more-info-script.ts
+++ b/src/dialogs/more-info/controls/more-info-script.ts
@@ -21,12 +21,15 @@ import { isUnavailableState } from "../../../data/entity";
 import { computeObjectId } from "../../../common/entity/compute_object_id";
 import { listenMediaQuery } from "../../../common/dom/media_query";
 import "../components/ha-more-info-state-header";
+import { ExtEntityRegistryEntry } from "../../../data/entity_registry";
 
 @customElement("more-info-script")
 class MoreInfoScript extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public stateObj?: ScriptEntity;
+
+  @property({ attribute: false }) public entry?: ExtEntityRegistryEntry;
 
   @state() private _scriptData: Record<string, any> = {};
 
@@ -59,8 +62,9 @@ class MoreInfoScript extends LitElement {
     const stateObj = this.stateObj;
 
     const fields =
-      this.hass.services.script[computeObjectId(this.stateObj.entity_id)]
-        ?.fields;
+      this.hass.services.script[
+        this.entry?.unique_id || computeObjectId(this.stateObj.entity_id)
+      ]?.fields;
 
     const hasFields = fields && Object.keys(fields).length > 0;
 
@@ -138,17 +142,31 @@ class MoreInfoScript extends LitElement {
   protected override willUpdate(changedProperties: PropertyValues): void {
     super.willUpdate(changedProperties);
 
-    if (!changedProperties.has("stateObj")) {
-      return;
+    if (changedProperties.has("stateObj")) {
+      const oldState = changedProperties.get("stateObj") as
+        | HassEntity
+        | undefined;
+      const newState = this.stateObj;
+
+      if (
+        newState &&
+        (!oldState || oldState.entity_id !== newState.entity_id)
+      ) {
+        this._scriptData = {
+          action:
+            this.entry?.entity_id === newState.entity_id
+              ? this.entry.unique_id
+              : newState.entity_id,
+          data: {},
+        };
+      }
     }
 
-    const oldState = changedProperties.get("stateObj") as
-      | HassEntity
-      | undefined;
-    const newState = this.stateObj;
-
-    if (newState && (!oldState || oldState.entity_id !== newState.entity_id)) {
-      this._scriptData = { action: newState.entity_id, data: {} };
+    if (this.entry?.unique_id && changedProperties.has("entry")) {
+      const action = `script.${this.entry?.unique_id}`;
+      if (this._scriptData?.action !== action) {
+        this._scriptData = { ...this._scriptData, action };
+      }
     }
   }
 
@@ -161,7 +179,7 @@ class MoreInfoScript extends LitElement {
     ev.stopPropagation();
     this.hass.callService(
       "script",
-      computeObjectId(this.stateObj!.entity_id),
+      this.entry?.unique_id || computeObjectId(this.stateObj!.entity_id),
       this._scriptData.data
     );
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
The script more-info dialog for an entity sometimes does not currently work as it is trying to call the script service based on the entity_id instead of the unique_id.

They are typically the same, but can differ if a script entity is renamed, as the unique_id is not renamed.

We need to get the unique_id from the Entity Registry to know the name of the service to call.

I wasn't 100% sure if scripts will always have a unique_id, so I left the fallback to entity_id if it didn't exist, not sure if that's helpful or not.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #21600
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property to enhance the script's ability to reference additional entity registry information.
	- Improved logic for handling script actions based on the state of the entry, enhancing responsiveness and functionality.

- **Bug Fixes**
	- Resolved issues with script data updates to ensure accuracy when the state object changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->