### PR TITLE
Use primary config entry for device

### DIFF
--- a/gallery/src/pages/components/ha-form.ts
+++ b/gallery/src/pages/components/ha-form.ts
@@ -64,6 +64,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     labels: [],
     created_at: 0,
     modified_at: 0,
+    primary_config_entry: null,
   },
   {
     area_id: "backyard",
@@ -86,6 +87,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     labels: [],
     created_at: 0,
     modified_at: 0,
+    primary_config_entry: null,
   },
   {
     area_id: null,
@@ -108,6 +110,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     labels: [],
     created_at: 0,
     modified_at: 0,
+    primary_config_entry: null,
   },
 ];
 

--- a/gallery/src/pages/components/ha-selector.ts
+++ b/gallery/src/pages/components/ha-selector.ts
@@ -64,6 +64,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     labels: [],
     created_at: 0,
     modified_at: 0,
+    primary_config_entry: null,
   },
   {
     area_id: "backyard",
@@ -86,6 +87,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     labels: [],
     created_at: 0,
     modified_at: 0,
+    primary_config_entry: null,
   },
   {
     area_id: null,
@@ -108,6 +110,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     labels: [],
     created_at: 0,
     modified_at: 0,
+    primary_config_entry: null,
   },
 ];
 

--- a/gallery/src/pages/misc/integration-card.ts
+++ b/gallery/src/pages/misc/integration-card.ts
@@ -232,6 +232,7 @@ const createDeviceRegistryEntries = (
     labels: [],
     created_at: 0,
     modified_at: 0,
+    primary_config_entry: null,
   },
 ];
 

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -1,6 +1,6 @@
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { HomeAssistant } from "../types";
-import type { IntegrationManifest, IntegrationType } from "./integration";
+import type { IntegrationType } from "./integration";
 
 export interface ConfigEntry {
   entry_id: string;
@@ -149,20 +149,19 @@ export const enableConfigEntry = (hass: HomeAssistant, configEntryId: string) =>
 
 export const sortConfigEntries = (
   configEntries: ConfigEntry[],
-  manifestLookup: { [domain: string]: IntegrationManifest }
+  primaryConfigEntry: string | null
 ): ConfigEntry[] => {
-  const sortedConfigEntries = [...configEntries];
-
-  const getScore = (entry: ConfigEntry) => {
-    const manifest = manifestLookup[entry.domain] as
-      | IntegrationManifest
-      | undefined;
-    const isHelper = manifest?.integration_type === "helper";
-    return isHelper ? -1 : 1;
-  };
-
-  const configEntriesCompare = (a: ConfigEntry, b: ConfigEntry) =>
-    getScore(b) - getScore(a);
-
-  return sortedConfigEntries.sort(configEntriesCompare);
+  if (!primaryConfigEntry) {
+    return configEntries;
+  }
+  const primaryEntry = configEntries.find(
+    (e) => e.entry_id === primaryConfigEntry
+  );
+  if (!primaryEntry) {
+    return configEntries;
+  }
+  const otherEntries = configEntries.filter(
+    (e) => e.entry_id !== primaryConfigEntry
+  );
+  return [primaryEntry, ...otherEntries];
 };

--- a/src/data/device_registry.ts
+++ b/src/data/device_registry.ts
@@ -33,6 +33,7 @@ export interface DeviceRegistryEntry extends RegistryEntry {
   entry_type: "service" | null;
   disabled_by: "user" | "integration" | "config_entry" | null;
   configuration_url: string | null;
+  primary_config_entry: string | null;
 }
 
 export interface DeviceEntityDisplayLookup {

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -153,7 +153,7 @@ export class HaConfigDevicePage extends LitElement {
         .filter((entId) => entId in entryLookup)
         .map((entry) => entryLookup[entry]);
 
-      return sortConfigEntries(deviceEntries, manifestLookup);
+      return sortConfigEntries(deviceEntries, device.primary_config_entry);
     }
   );
 

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -388,7 +388,7 @@ export class HaConfigDeviceDashboard extends SubscribeMixin(LitElement) {
           device.config_entries
             .filter((entId) => entId in entryLookup)
             .map((entId) => entryLookup[entId]),
-          manifestLookup
+          device.primary_config_entry
         );
 
         const labels = labelReg && device?.labels;


### PR DESCRIPTION
## Proposed change

Use primary config entry for device instead of checking if it's an helper

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a prioritization system for configuration entries based on a designated primary entry, enhancing the organization of config entries.
	- Added a new property for device registry entries to represent a primary configuration entry, improving device management capabilities.

- **Bug Fixes**
	- Updated logic for processing device configuration entries to utilize the primary configuration entry, ensuring more accurate data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->