### PR TITLE
Capitalise ha-relative-time in state-display

### DIFF
--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -99,6 +99,7 @@ class StateDisplay extends LitElement {
         <ha-relative-time
           .hass=${this.hass}
           .datetime=${stateObj.last_changed}
+          capitalize
         ></ha-relative-time>
       `;
     }
@@ -108,6 +109,7 @@ class StateDisplay extends LitElement {
         <ha-relative-time
           .hass=${this.hass}
           .datetime=${stateObj.last_updated}
+          capitalize
         ></ha-relative-time>
       `;
     }
@@ -116,6 +118,7 @@ class StateDisplay extends LitElement {
         <ha-relative-time
           .hass=${this.hass}
           .datetime=${stateObj.attributes.last_triggered}
+          capitalize
         ></ha-relative-time>
       `;
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR corrects inconsistent capitalisation for relative time displays. Currently capitalisation is applied to `ha-relative-time` when displayed in the `state-info` component, but not in the `state-display` component. Capitalisation _is_ applied for `hui-timestamp-display` in `state-display`, however. 

This PR applies capitalisation for `ha-relative-time` from `state-display`, removing this inconsistency.



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #21948

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] ~~Tests have been added to verify that the new code works.~~ N/A


<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `capitalize` attribute to the `<ha-relative-time>` component for improved visual presentation of time-related data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->