### PR TITLE
Use issue placeholders in issue repair flow, show break warning in re…

### DIFF
--- a/src/panels/config/repairs/show-dialog-repair-flow.ts
+++ b/src/panels/config/repairs/show-dialog-repair-flow.ts
@@ -1,16 +1,34 @@
 import { html } from "lit";
+import { DataEntryFlowStep } from "../../../data/data_entry_flow";
 import { domainToName } from "../../../data/integration";
 import {
+  RepairsIssue,
   createRepairsFlow,
   deleteRepairsFlow,
   fetchRepairsFlow,
   handleRepairsFlowStep,
-  RepairsIssue,
 } from "../../../data/repairs";
 import {
   loadDataEntryFlowDialog,
   showFlowDialog,
 } from "../../../dialogs/config-flow/show-dialog-data-entry-flow";
+import { HomeAssistant } from "../../../types";
+
+const mergePlaceholders = (issue: RepairsIssue, step: DataEntryFlowStep) =>
+  step.description_placeholders && issue.translation_placeholders
+    ? { ...issue.translation_placeholders, ...step.description_placeholders }
+    : step.description_placeholders || issue.translation_placeholders;
+
+const renderIssueDescription = (hass: HomeAssistant, issue: RepairsIssue) =>
+  issue.breaks_in_ha_version
+    ? html`
+        <ha-alert alert-type="warning">
+          ${hass.localize("ui.panel.config.repairs.dialog.breaks_in_version", {
+            version: issue.breaks_in_ha_version,
+          })} </ha-alert
+        ><br />
+      `
+    : "";
 
 export const loadRepairFlowDialog = loadDataEntryFlowDialog;
 
@@ -53,10 +71,11 @@ export const showRepairsFlowDialog = (
           `component.${issue.domain}.issues.${
             issue.translation_key || issue.issue_id
           }.fix_flow.abort.${step.reason}`,
-          step.description_placeholders
+          mergePlaceholders(issue, step)
         );
 
-        return description
+        return html`${renderIssueDescription(hass, issue)}
+        ${description
           ? html`
               <ha-markdown
                 breaks
@@ -64,7 +83,7 @@ export const showRepairsFlowDialog = (
                 .content=${description}
               ></ha-markdown>
             `
-          : step.reason;
+          : step.reason}`;
       },
 
       renderShowFormStepHeader(hass, step) {
@@ -73,7 +92,7 @@ export const showRepairsFlowDialog = (
             `component.${issue.domain}.issues.${
               issue.translation_key || issue.issue_id
             }.fix_flow.step.${step.step_id}.title`,
-            step.description_placeholders
+            mergePlaceholders(issue, step)
           ) || hass.localize("ui.dialogs.repair_flow.form.header")
         );
       },
@@ -83,9 +102,10 @@ export const showRepairsFlowDialog = (
           `component.${issue.domain}.issues.${
             issue.translation_key || issue.issue_id
           }.fix_flow.step.${step.step_id}.description`,
-          step.description_placeholders
+          mergePlaceholders(issue, step)
         );
-        return description
+        return html`${renderIssueDescription(hass, issue)}
+        ${description
           ? html`
               <ha-markdown
                 allowsvg
@@ -93,7 +113,7 @@ export const showRepairsFlowDialog = (
                 .content=${description}
               ></ha-markdown>
             `
-          : "";
+          : ""}`;
       },
 
       renderShowFormStepFieldLabel(hass, step, field, options) {
@@ -101,7 +121,7 @@ export const showRepairsFlowDialog = (
           `component.${issue.domain}.issues.${
             issue.translation_key || issue.issue_id
           }.fix_flow.step.${step.step_id}.${options?.prefix ? `section.${options.prefix[0]}.` : ""}data.${field.name}`,
-          step.description_placeholders
+          mergePlaceholders(issue, step)
         );
       },
 
@@ -110,11 +130,12 @@ export const showRepairsFlowDialog = (
           `component.${issue.domain}.issues.${
             issue.translation_key || issue.issue_id
           }.fix_flow.step.${step.step_id}.${options?.prefix ? `section.${options.prefix[0]}.` : ""}data_description.${field.name}`,
-          step.description_placeholders
+          mergePlaceholders(issue, step)
         );
-        return description
+        return html`${renderIssueDescription(hass, issue)}
+        ${description
           ? html`<ha-markdown breaks .content=${description}></ha-markdown>`
-          : "";
+          : ""}`;
       },
 
       renderShowFormStepFieldError(hass, step, error) {
@@ -122,7 +143,7 @@ export const showRepairsFlowDialog = (
           `component.${issue.domain}.issues.${
             issue.translation_key || issue.issue_id
           }.fix_flow.error.${error}`,
-          step.description_placeholders
+          mergePlaceholders(issue, step)
         );
       },
 
@@ -165,7 +186,7 @@ export const showRepairsFlowDialog = (
             `component.${issue.domain}.issues.step.${
               issue.translation_key || issue.issue_id
             }.fix_flow.${step.step_id}.title`,
-            step.description_placeholders
+            mergePlaceholders(issue, step)
           ) || hass.localize(`component.${issue.domain}.title`)
         );
       },
@@ -175,9 +196,9 @@ export const showRepairsFlowDialog = (
           `component.${issue.domain}.issues.${
             issue.translation_key || issue.issue_id
           }.fix_flow.progress.${step.progress_action}`,
-          step.description_placeholders
+          mergePlaceholders(issue, step)
         );
-        return description
+        return html`${renderIssueDescription(hass, issue)}${description
           ? html`
               <ha-markdown
                 allowsvg
@@ -185,7 +206,7 @@ export const showRepairsFlowDialog = (
                 .content=${description}
               ></ha-markdown>
             `
-          : "";
+          : ""}`;
       },
 
       renderMenuHeader(hass, step) {
@@ -194,7 +215,7 @@ export const showRepairsFlowDialog = (
             `component.${issue.domain}.issues.${
               issue.translation_key || issue.issue_id
             }.fix_flow.step.${step.step_id}.title`,
-            step.description_placeholders
+            mergePlaceholders(issue, step)
           ) || hass.localize(`component.${issue.domain}.title`)
         );
       },
@@ -204,9 +225,10 @@ export const showRepairsFlowDialog = (
           `component.${issue.domain}.issues.${
             issue.translation_key || issue.issue_id
           }.fix_flow.step.${step.step_id}.description`,
-          step.description_placeholders
+          mergePlaceholders(issue, step)
         );
-        return description
+        return html`${renderIssueDescription(hass, issue)}
+        ${description
           ? html`
               <ha-markdown
                 allowsvg
@@ -214,7 +236,7 @@ export const showRepairsFlowDialog = (
                 .content=${description}
               ></ha-markdown>
             `
-          : "";
+          : ""}`;
       },
 
       renderMenuOption(hass, step, option) {
@@ -222,7 +244,7 @@ export const showRepairsFlowDialog = (
           `component.${issue.domain}.issues.${
             issue.translation_key || issue.issue_id
           }.fix_flow.step.${step.step_id}.menu_options.${option}`,
-          step.description_placeholders
+          mergePlaceholders(issue, step)
         );
       },
 


### PR DESCRIPTION
…pair flow


## Proposed change

Show the warning when the issue will break something also in the repair flow, was previously only shown when the issue could not be repaired.

Adds the repair translation placeholders to the flow, so they can also be used. The flow placeholders will win.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced repair flow dialogs for improved clarity.
	- Introduced contextual warning alerts for compatibility issues based on Home Assistant versions.
- **Bug Fixes**
	- Improved merging and rendering of issue descriptions and placeholders for a more user-friendly experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->