### PR TITLE
Fix onboarding with 0 found integrations

### DIFF
--- a/src/onboarding/onboarding-integrations.ts
+++ b/src/onboarding/onboarding-integrations.ts
@@ -121,8 +121,16 @@ class OnboardingIntegrations extends SubscribeMixin(LitElement) {
     if (domains.length === 0) {
       return html`
         <div class="all-set-icon">🎉</div>
-        <h1>All set!</h1>
-        <p>Let’s start your private smart home adventure.</p>
+        <h1>
+          ${this.onboardingLocalize(
+            "ui.panel.page-onboarding.integration.all_set"
+          )}
+        </h1>
+        <p>
+          ${this.onboardingLocalize(
+            "ui.panel.page-onboarding.integration.lets_start"
+          )}
+        </p>
         <div class="footer">
           <mwc-button unelevated @click=${this._finish}>
             ${this.onboardingLocalize(

--- a/src/onboarding/onboarding-integrations.ts
+++ b/src/onboarding/onboarding-integrations.ts
@@ -1,4 +1,3 @@
-import "@material/mwc-button/mwc-button";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import {
   CSSResultGroup,
@@ -13,6 +12,7 @@ import { isComponentLoaded } from "../common/config/is_component_loaded";
 import { fireEvent } from "../common/dom/fire_event";
 import { stringCompare } from "../common/string/compare";
 import { LocalizeFunc } from "../common/translations/localize";
+import "../components/ha-button";
 import { ConfigEntry, subscribeConfigEntries } from "../data/config_entries";
 import { subscribeConfigFlowInProgress } from "../data/config_flow";
 import { domainToName } from "../data/integration";
@@ -118,7 +118,7 @@ class OnboardingIntegrations extends SubscribeMixin(LitElement) {
     const foundIntegrations = domains.length;
 
     // there is a possibility that the user has no integrations
-    if (domains.length === 0) {
+    if (foundIntegrations === 0) {
       return html`
         <div class="all-set-icon">🎉</div>
         <h1>
@@ -132,11 +132,11 @@ class OnboardingIntegrations extends SubscribeMixin(LitElement) {
           )}
         </p>
         <div class="footer">
-          <mwc-button unelevated @click=${this._finish}>
+          <ha-button unelevated @click=${this._finish}>
             ${this.onboardingLocalize(
               "ui.panel.page-onboarding.integration.finish"
             )}
-          </mwc-button>
+          </ha-button>
         </div>
       `;
     }
@@ -173,11 +173,11 @@ class OnboardingIntegrations extends SubscribeMixin(LitElement) {
           : nothing}
       </div>
       <div class="footer">
-        <mwc-button unelevated @click=${this._finish}>
+        <ha-button unelevated @click=${this._finish}>
           ${this.onboardingLocalize(
             "ui.panel.page-onboarding.integration.finish"
           )}
-        </mwc-button>
+        </ha-button>
       </div>
     `;
   }

--- a/src/onboarding/onboarding-integrations.ts
+++ b/src/onboarding/onboarding-integrations.ts
@@ -117,6 +117,22 @@ class OnboardingIntegrations extends SubscribeMixin(LitElement) {
 
     const foundIntegrations = domains.length;
 
+    // there is a possibility that the user has no integrations
+    if (domains.length === 0) {
+      return html`
+        <div class="all-set-icon">🎉</div>
+        <h1>All set!</h1>
+        <p>Let’s start your private smart home adventure.</p>
+        <div class="footer">
+          <mwc-button unelevated @click=${this._finish}>
+            ${this.onboardingLocalize(
+              "ui.panel.page-onboarding.integration.finish"
+            )}
+          </mwc-button>
+        </div>
+      `;
+    }
+
     if (domains.length > 12) {
       domains = domains.slice(0, 11);
     }
@@ -192,6 +208,10 @@ class OnboardingIntegrations extends SubscribeMixin(LitElement) {
           justify-content: center;
           align-items: center;
           height: 100%;
+        }
+        .all-set-icon {
+          font-size: 64px;
+          text-align: center;
         }
       `,
     ];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7090,7 +7090,9 @@
           "header": "We found compatible devices!",
           "intro": "These are found on your local network. Some are already added, others may need extra configuration.",
           "more_integrations": "+{count} more",
-          "finish": "Finish"
+          "finish": "Finish",
+          "all_set": "All set!",
+          "lets_start": "Let’s start your private smart home adventure."
         },
         "analytics": {
           "header": "Help us help you",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
If at the Home Assistant onboarding process 0 (additional to the standard ones like: sun, radio browser,...) integrations are found, show an "All set" screen instead of the integrations screen.

![image](https://github.com/user-attachments/assets/7f4e8cea-3910-42d6-aa15-7e07b10a1bb7)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced celebratory messaging for users completing the onboarding process without integrations, enhancing user feedback.
	- Added new translation strings to improve the interface for device integration, making it more welcoming.

- **Style**
	- Implemented a new CSS class for styling the celebratory icon in the onboarding component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->