### PR TITLE
Add default value to zwave config params

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -252,6 +252,7 @@ export interface ZWaveJSNodeConfigParamMetadata {
   type: string;
   unit: string;
   states: { [key: number]: string };
+  default: any;
 }
 
 export interface ZWaveJSSetConfigParamData {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -24,7 +24,6 @@ import "../../../../../components/ha-icon-next";
 import "../../../../../components/ha-select";
 import "../../../../../components/ha-settings-row";
 import "../../../../../components/ha-svg-icon";
-import "../../../../../components/ha-switch";
 import "../../../../../components/ha-textfield";
 import "../../../../../components/ha-selector/ha-selector-boolean";
 import { computeDeviceName } from "../../../../../data/device_registry";

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -261,10 +261,7 @@ class ZWaveJSNodeConfig extends LitElement {
         : "";
 
     // Numeric entries with a min value of 0 and max of 1 are considered boolean
-    if (
-      item.configuration_value_type === "boolean" ||
-      this._isEnumeratedBool(item)
-    ) {
+    if (isTypeBoolean) {
       return html`
         ${labelAndDescription}
         <div class="switch">

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4902,7 +4902,8 @@
             "set_param_queued": "The parameter change has been queued, and will be updated when the device wakes up.",
             "set_param_error": "An error occurred.",
             "parameter": "Parameter",
-            "bitmask": "Bitmask"
+            "bitmask": "Bitmask",
+            "default": "Default"
           },
           "network_status": {
             "connected": "Connected",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PRs adds In the zwave device configuration for each parameter the default value, to inform the user what was initially configured.

![2024-09-16_09-17](https://github.com/user-attachments/assets/529fd591-75de-45e0-b29c-c8f7890d6b1b)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue or discussion:  [zwave-js/certification-backlog#40](https://github.com/zwave-js/certification-backlog/issues/40)
- This PR needs the backend PR merged: https://github.com/home-assistant/core/pull/125343

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `default` property for configuration parameters, allowing for sensible initial states.
	- Added a new `ha-selector-boolean` component for better handling of boolean configuration options.
	- Enhanced helper text for configuration fields to provide clearer context.

- **Translations**
	- Added translation for the term "Default" to improve localization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->