### PR TITLE
Improve robustness of automation editor description error handling

### DIFF
--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -68,9 +68,18 @@ export const describeTrigger = (
   hass: HomeAssistant,
   entityRegistry: EntityRegistryEntry[],
   ignoreAlias = false
-) => {
+): string => {
   try {
-    return tryDescribeTrigger(trigger, hass, entityRegistry, ignoreAlias);
+    const description = tryDescribeTrigger(
+      trigger,
+      hass,
+      entityRegistry,
+      ignoreAlias
+    );
+    if (typeof description !== "string") {
+      throw new Error(String(description));
+    }
+    return description;
   } catch (error: any) {
     // eslint-disable-next-line no-console
     console.error(error);
@@ -700,9 +709,18 @@ export const describeCondition = (
   hass: HomeAssistant,
   entityRegistry: EntityRegistryEntry[],
   ignoreAlias = false
-) => {
+): string => {
   try {
-    return tryDescribeCondition(condition, hass, entityRegistry, ignoreAlias);
+    const description = tryDescribeCondition(
+      condition,
+      hass,
+      entityRegistry,
+      ignoreAlias
+    );
+    if (typeof description !== "string") {
+      throw new Error(String(description));
+    }
+    return description;
   } catch (error: any) {
     // eslint-disable-next-line no-console
     console.error(error);

--- a/src/data/script_i18n.ts
+++ b/src/data/script_i18n.ts
@@ -50,7 +50,7 @@ export const describeAction = <T extends ActionType>(
   ignoreAlias = false
 ): string => {
   try {
-    return tryDescribeAction(
+    const description = tryDescribeAction(
       hass,
       entityRegistry,
       labelRegistry,
@@ -59,6 +59,10 @@ export const describeAction = <T extends ActionType>(
       actionType,
       ignoreAlias
     );
+    if (typeof description !== "string") {
+      throw new Error(String(description));
+    }
+    return description;
   } catch (error: any) {
     // eslint-disable-next-line no-console
     console.error(error);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Was a little surprised to find that the `hass.localize` function, while typed to return a string, does not actually guarantee to return a string, it can sometimes return other types (like array) without throwing an error. 

I'm not sure if that's a bug or intended. I looked at trying to throw inside localize function if it doesn't produce a string, but it seems that there may be some existing usecases for this that would break.

But in the case of automation editor descriptions, we definitely want to make sure that we really have a string, or else we will generate uncaught error and break the entire automation element. (see https://github.com/home-assistant/frontend/issues/21987)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling and type validation for `describeTrigger`, `describeCondition`, and `describeAction` functions to ensure they only return valid string descriptions, enhancing reliability and preventing runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->