### PR TITLE
Update media-player.ts to display artist name as backup secondary title

### DIFF
--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -245,7 +245,7 @@ export const computeMediaDescription = (
       secondaryTitle = stateObj.attributes.media_artist!;
       break;
     case "playlist":
-      secondaryTitle = stateObj.attributes.media_playlist!;
+      secondaryTitle = stateObj.attributes.media_playlist || stateObj.attributes.media_artist!;
       break;
     case "tvshow":
       secondaryTitle = stateObj.attributes.media_series_title!;

--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -245,7 +245,8 @@ export const computeMediaDescription = (
       secondaryTitle = stateObj.attributes.media_artist!;
       break;
     case "playlist":
-      secondaryTitle = stateObj.attributes.media_playlist || stateObj.attributes.media_artist!;
+      secondaryTitle =
+        stateObj.attributes.media_playlist || stateObj.attributes.media_artist!;
       break;
     case "tvshow":
       secondaryTitle = stateObj.attributes.media_series_title!;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When the media control card plays media content type `music`, the title of the song and the artist name are displayed.

But when it plays media content type `playlist`, the playlist is used as the secondary title.

Squeezebox (and perhaps other) media player integrations don't have a concept of the title of the currently playing playlist; it is just the list of tracks queued up in the player. So there is nothing stored in the `media_playlist` attribute.

If `media_artist` is used as the fallback value for this, the media control card will look the same whether playing a single track or a playlist. This seems to match the user expectation: https://github.com/home-assistant/core/issues/126007

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the assignment logic for the media description to ensure `secondaryTitle` is always defined for playlists, enhancing user experience.

- **New Features**
	- Introduced a fallback mechanism for displaying the secondary title, providing a more reliable media description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->