### PR TITLE
Add hold_action to Tile card's visual config editor

### DIFF
--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -96,6 +96,9 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       icon_tap_action: {
         action: getEntityDefaultTileIconAction(config.entity),
       },
+      hold_action: {
+        action: "more-info",
+      },
       ...config,
     };
   }

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -96,9 +96,6 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       icon_tap_action: {
         action: getEntityDefaultTileIconAction(config.entity),
       },
-      hold_action: {
-        action: "more-info",
-      },
       ...config,
     };
   }

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -50,6 +50,7 @@ const cardConfigStruct = assign(
     vertical: optional(boolean()),
     tap_action: optional(actionConfigStruct),
     icon_tap_action: optional(actionConfigStruct),
+    hold_action: optional(actionConfigStruct),
     features: optional(array(any())),
   })
 );
@@ -154,6 +155,14 @@ export class HuiTileCardEditor
                   default_action: entityId
                     ? getEntityDefaultTileIconAction(entityId)
                     : "more-info",
+                },
+              },
+            },
+            {
+              name: "hold_action",
+              selector: {
+                ui_action: {
+                  default_action: "more-info",
                 },
               },
             },

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -162,7 +162,7 @@ export class HuiTileCardEditor
               name: "hold_action",
               selector: {
                 ui_action: {
-                  default_action: "more-info",
+                  default_action: "none",
                 },
               },
             },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This change adds the `hold_action` config option to the visual editor for the tile card.

As someone who uses a lot of tiles, I almost always set both `tap_action` and `icon_tap_action` to `toggle`, so it makes a lot of sense to use `hold_action` for `more-info`.

Since there is only visual editor support for `tap_action` and `icon_tap_action`, it becomes fairly cumbersome and annoying to have to drop an element into YAML mode just to add a `hold_action`, since it removes the very capable dynamic configuration of the tile card.

As I'm fairly certain that I'm not the only one who makes extensive use of the `hold_action`, I feel it would make sense to include the it in the visual editor.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: tile
entity: light.ceiling_light
tap_action:
  action: toggle
hold_action:
  action: more-info
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional `hold_action` property in the tile card editor, allowing users to define actions triggered by holding a tile.
	- Added a schema entry for `hold_action`, enhancing the user interface for action configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->