### PR TITLE
Add more config option to heading entity element

### DIFF
--- a/src/panels/lovelace/cards/heading/hui-heading-entity.ts
+++ b/src/panels/lovelace/cards/heading/hui-heading-entity.ts
@@ -24,6 +24,7 @@ import {
   attachConditionMediaQueriesListeners,
   checkConditionsMet,
 } from "../../common/validate-condition";
+import { DEFAULT_CONFIG } from "../../editor/heading-entity/hui-heading-entity-editor";
 import type { HeadingEntityConfig } from "../types";
 
 @customElement("hui-heading-entity")
@@ -54,6 +55,7 @@ export class HuiHeadingEntity extends LitElement {
           : configOrString;
 
       return {
+        ...DEFAULT_CONFIG,
         tap_action: {
           action: "none",
         },
@@ -133,16 +135,24 @@ export class HuiHeadingEntity extends LitElement {
         role=${ifDefined(actionable ? "button" : undefined)}
         tabindex=${ifDefined(actionable ? "0" : undefined)}
       >
-        <ha-state-icon
-          .hass=${this.hass}
-          .icon=${config.icon}
-          .stateObj=${stateObj}
-        ></ha-state-icon>
-        <state-display
-          .hass=${this.hass}
-          .stateObj=${stateObj}
-          .content=${config.content || "state"}
-        ></state-display>
+        ${config.show_icon
+          ? html`
+              <ha-state-icon
+                .hass=${this.hass}
+                .icon=${config.icon}
+                .stateObj=${stateObj}
+              ></ha-state-icon>
+            `
+          : nothing}
+        ${config.show_state
+          ? html`
+              <state-display
+                .hass=${this.hass}
+                .stateObj=${stateObj}
+                .content=${config.state_content}
+              ></state-display>
+            `
+          : nothing}
       </div>
     `;
   }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -505,8 +505,10 @@ export interface TileCardConfig extends LovelaceCardConfig {
 
 export interface HeadingEntityConfig {
   entity: string;
-  content?: string | string[];
+  state_content?: string | string[];
   icon?: string;
+  show_state?: boolean;
+  show_icon?: boolean;
   tap_action?: ActionConfig;
   visibility?: Condition[];
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6007,9 +6007,15 @@
               },
               "entities": "Entities",
               "entity_config": {
-                "content": "Content",
                 "visibility": "Visibility",
-                "visibility_explanation": "The entity will be shown when ALL conditions below are fulfilled. If no conditions are set, the entity will always be shown."
+                "visibility_explanation": "The entity will be shown when ALL conditions below are fulfilled. If no conditions are set, the entity will always be shown.",
+                "appearance": "Appearance",
+                "state_content": "State content",
+                "displayed_elements": "[%key:ui::panel::lovelace::editor::badge::entity::displayed_elements%]",
+                "displayed_elements_options": {
+                  "icon": "[%key:ui::panel::lovelace::editor::badge::entity::displayed_elements_options::icon%]",
+                  "state": "[%key:ui::panel::lovelace::editor::badge::entity::displayed_elements_options::state%]"
+                }
               },
               "default_heading": "Kitchen"
             },


### PR DESCRIPTION
## Proposed change

Add show_state and show_icon option to heading entities

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced default configuration for the `HuiHeadingEntity` component, enhancing flexibility in display options.
	- Added new properties for controlling visibility of state and icons in heading entities.

- **Documentation**
	- Updated translation files to reflect new configuration options and removed outdated keys. 

These changes improve user customization and control over how heading entities are displayed in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->