### PR TITLE
Add color option to heading entities

### DIFF
--- a/src/components/ha-color-picker.ts
+++ b/src/components/ha-color-picker.ts
@@ -26,8 +26,8 @@ export class HaColorPicker extends LitElement {
   @property({ type: Boolean, attribute: "include_state" })
   public includeState = false;
 
-  @property({ type: Boolean, attribute: "include_uncolored" })
-  public includeUncolored = false;
+  @property({ type: Boolean, attribute: "include_none" })
+  public includeNone = false;
 
   @property({ type: Boolean }) public disabled = false;
 
@@ -58,7 +58,7 @@ export class HaColorPicker extends LitElement {
         ${value
           ? html`
               <span slot="icon">
-                ${value === "uncolored"
+                ${value === "none"
                   ? html`
                       <ha-svg-icon path=${mdiInvertColorsOff}></ha-svg-icon>
                     `
@@ -68,11 +68,11 @@ export class HaColorPicker extends LitElement {
               </span>
             `
           : nothing}
-        ${this.includeUncolored
+        ${this.includeNone
           ? html`
-              <ha-list-item value="uncolored" graphic="icon">
-                ${this.hass.localize("ui.components.color-picker.uncolored")}
-                ${this.defaultColor === "uncolored"
+              <ha-list-item value="none" graphic="icon">
+                ${this.hass.localize("ui.components.color-picker.none")}
+                ${this.defaultColor === "none"
                   ? ` (${this.hass.localize("ui.components.color-picker.default")})`
                   : nothing}
                 <ha-svg-icon

--- a/src/components/ha-color-picker.ts
+++ b/src/components/ha-color-picker.ts
@@ -1,14 +1,14 @@
-import "@material/mwc-list/mwc-list-item";
+import { mdiInvertColorsOff, mdiPalette } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import { computeCssColor, THEME_COLORS } from "../common/color/compute-color";
 import { fireEvent } from "../common/dom/fire_event";
 import { stopPropagation } from "../common/dom/stop_propagation";
-import "./ha-select";
-import "./ha-list-item";
-import { HomeAssistant } from "../types";
 import { LocalizeKeys } from "../common/translations/localize";
+import { HomeAssistant } from "../types";
+import "./ha-list-item";
+import "./ha-select";
 
 @customElement("ha-color-picker")
 export class HaColorPicker extends LitElement {
@@ -20,43 +20,78 @@ export class HaColorPicker extends LitElement {
 
   @property() public value?: string;
 
-  @property({ type: Boolean }) public defaultColor = false;
+  @property({ type: String, attribute: "default_color" })
+  public defaultColor?: string;
+
+  @property({ type: Boolean, attribute: "include_state" })
+  public includeState = false;
+
+  @property({ type: Boolean, attribute: "include_uncolored" })
+  public includeUncolored = false;
 
   @property({ type: Boolean }) public disabled = false;
 
   _valueSelected(ev) {
     const value = ev.target.value;
-    if (value) {
-      fireEvent(this, "value-changed", {
-        value: value !== "default" ? value : undefined,
-      });
-    }
+    this.value = value === this.defaultColor ? undefined : value;
+    fireEvent(this, "value-changed", {
+      value: this.value,
+    });
   }
 
   render() {
+    const value = this.value || this.defaultColor;
+
     return html`
       <ha-select
-        .icon=${Boolean(this.value)}
+        .icon=${Boolean(value)}
         .label=${this.label}
-        .value=${this.value || "default"}
+        .value=${value}
         .helper=${this.helper}
         .disabled=${this.disabled}
         @closed=${stopPropagation}
         @selected=${this._valueSelected}
         fixedMenuPosition
         naturalMenuWidth
+        .clearable=${!this.defaultColor}
       >
-        ${this.value
+        ${value
           ? html`
               <span slot="icon">
-                ${this.renderColorCircle(this.value || "grey")}
+                ${value === "uncolored"
+                  ? html`
+                      <ha-svg-icon path=${mdiInvertColorsOff}></ha-svg-icon>
+                    `
+                  : value === "state"
+                    ? html`<ha-svg-icon path=${mdiPalette}></ha-svg-icon>`
+                    : this.renderColorCircle(value || "grey")}
               </span>
             `
           : nothing}
-        ${this.defaultColor
-          ? html` <ha-list-item value="default">
-              ${this.hass.localize(`ui.components.color-picker.default_color`)}
-            </ha-list-item>`
+        ${this.includeUncolored
+          ? html`
+              <ha-list-item value="uncolored" graphic="icon">
+                ${this.hass.localize("ui.components.color-picker.uncolored")}
+                ${this.defaultColor === "uncolored"
+                  ? ` (${this.hass.localize("ui.components.color-picker.default")})`
+                  : nothing}
+                <ha-svg-icon
+                  slot="graphic"
+                  path=${mdiInvertColorsOff}
+                ></ha-svg-icon>
+              </ha-list-item>
+            `
+          : nothing}
+        ${this.includeState
+          ? html`
+              <ha-list-item value="state" graphic="icon">
+                ${this.hass.localize("ui.components.color-picker.state")}
+                ${this.defaultColor === "state"
+                  ? ` (${this.hass.localize("ui.components.color-picker.default")})`
+                  : nothing}
+                <ha-svg-icon slot="graphic" path=${mdiPalette}></ha-svg-icon>
+              </ha-list-item>
+            `
           : nothing}
         ${Array.from(THEME_COLORS).map(
           (color) => html`
@@ -64,6 +99,9 @@ export class HaColorPicker extends LitElement {
               ${this.hass.localize(
                 `ui.components.color-picker.colors.${color}` as LocalizeKeys
               ) || color}
+              ${this.defaultColor === color
+                ? ` (${this.hass.localize("ui.components.color-picker.default")})`
+                : nothing}
               <span slot="graphic">${this.renderColorCircle(color)}</span>
             </ha-list-item>
           `
@@ -87,10 +125,11 @@ export class HaColorPicker extends LitElement {
     return css`
       .circle-color {
         display: block;
-        background-color: var(--circle-color);
+        background-color: var(--circle-color, var(--divider-color));
         border-radius: 10px;
         width: 20px;
         height: 20px;
+        box-sizing: border-box;
       }
       ha-select {
         width: 100%;

--- a/src/components/ha-selector/ha-selector-ui-color.ts
+++ b/src/components/ha-selector/ha-selector-ui-color.ts
@@ -24,7 +24,7 @@ export class HaSelectorUiColor extends LitElement {
         .hass=${this.hass}
         .value=${this.value}
         .helper=${this.helper}
-        .includeUncolored=${this.selector.ui_color?.include_uncolored}
+        .includeNone=${this.selector.ui_color?.include_none}
         .includeState=${this.selector.ui_color?.include_state}
         .defaultColor=${this.selector.ui_color?.default_color}
         @value-changed=${this._valueChanged}

--- a/src/components/ha-selector/ha-selector-ui-color.ts
+++ b/src/components/ha-selector/ha-selector-ui-color.ts
@@ -24,6 +24,8 @@ export class HaSelectorUiColor extends LitElement {
         .hass=${this.hass}
         .value=${this.value}
         .helper=${this.helper}
+        .includeUncolored=${this.selector.ui_color?.include_uncolored}
+        .includeState=${this.selector.ui_color?.include_state}
         .defaultColor=${this.selector.ui_color?.default_color}
         @value-changed=${this._valueChanged}
       ></ha-color-picker>

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -456,7 +456,7 @@ export interface UiColorSelector {
   // eslint-disable-next-line @typescript-eslint/ban-types
   ui_color: {
     default_color?: string;
-    include_uncolored?: boolean;
+    include_none?: boolean;
     include_state?: boolean;
   } | null;
 }

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -454,7 +454,11 @@ export interface UiActionSelector {
 
 export interface UiColorSelector {
   // eslint-disable-next-line @typescript-eslint/ban-types
-  ui_color: { default_color?: boolean } | null;
+  ui_color: {
+    default_color?: string;
+    include_uncolored?: boolean;
+    include_state?: boolean;
+  } | null;
 }
 
 export interface UiStateContentSelector {

--- a/src/panels/lovelace/cards/heading/hui-heading-entity.ts
+++ b/src/panels/lovelace/cards/heading/hui-heading-entity.ts
@@ -231,6 +231,7 @@ export class HuiHeadingEntity extends LitElement {
         line-height: 20px; /* 142.857% */
         letter-spacing: 0.1px;
         --mdc-icon-size: 14px;
+        --state-inactive-color: initial;
       }
       .entity ha-state-icon {
         --ha-icon-display: block;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -509,6 +509,7 @@ export interface HeadingEntityConfig {
   icon?: string;
   show_state?: boolean;
   show_icon?: boolean;
+  color?: string;
   tap_action?: ActionConfig;
   visibility?: Condition[];
 }

--- a/src/panels/lovelace/editor/config-elements/hui-entity-badge-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entity-badge-editor.ts
@@ -205,7 +205,7 @@ export class HuiEntityBadgeEditor
         .data=${data}
         .schema=${schema}
         .computeLabel=${this._computeLabelCallback}
-        .computeHelpText=${this._computeHelperCallback}
+        .computeHelper=${this._computeHelperCallback}
         @value-changed=${this._valueChanged}
       ></ha-form>
     `;

--- a/src/panels/lovelace/editor/config-elements/hui-entity-badge-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entity-badge-editor.ts
@@ -92,7 +92,9 @@ export class HuiEntityBadgeEditor
                 {
                   name: "color",
                   selector: {
-                    ui_color: { default_color: true },
+                    ui_color: {
+                      include_state: true,
+                    },
                   },
                 },
                 {

--- a/src/panels/lovelace/editor/config-elements/hui-entity-badge-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entity-badge-editor.ts
@@ -205,6 +205,7 @@ export class HuiEntityBadgeEditor
         .data=${data}
         .schema=${schema}
         .computeLabel=${this._computeLabelCallback}
+        .computeHelpText=${this._computeHelperCallback}
         @value-changed=${this._valueChanged}
       ></ha-form>
     `;
@@ -249,6 +250,19 @@ export class HuiEntityBadgeEditor
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.generic.${schema.name}`
         );
+    }
+  };
+
+  private _computeHelperCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
+    switch (schema.name) {
+      case "color":
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.badge.entity.${schema.name}_helper`
+        );
+      default:
+        return undefined;
     }
   };
 

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -208,6 +208,7 @@ export class HuiTileCardEditor
         .data=${data}
         .schema=${schema}
         .computeLabel=${this._computeLabelCallback}
+        .computeHelper=${this._computeHelperCallback}
         @value-changed=${this._valueChanged}
       ></ha-form>
       <ha-expansion-panel outlined>
@@ -329,6 +330,19 @@ export class HuiTileCardEditor
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.generic.${schema.name}`
         );
+    }
+  };
+
+  private _computeHelperCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
+    switch (schema.name) {
+      case "color":
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.tile.${schema.name}_helper`
+        );
+      default:
+        return undefined;
     }
   };
 

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -95,7 +95,10 @@ export class HuiTileCardEditor
                 {
                   name: "color",
                   selector: {
-                    ui_color: { default_color: true },
+                    ui_color: {
+                      default_color: "state",
+                      include_state: true,
+                    },
                   },
                 },
                 {

--- a/src/panels/lovelace/editor/heading-entity/hui-heading-entity-editor.ts
+++ b/src/panels/lovelace/editor/heading-entity/hui-heading-entity-editor.ts
@@ -39,6 +39,7 @@ const entityConfigStruct = object({
   state_content: optional(union([string(), array(string())])),
   show_state: optional(boolean()),
   show_icon: optional(boolean()),
+  color: optional(string()),
   tap_action: optional(actionConfigStruct),
   visibility: optional(array(any())),
 });
@@ -80,9 +81,25 @@ export class HuiHeadingEntityEditor
           iconPath: mdiPalette,
           schema: [
             {
-              name: "icon",
-              selector: { icon: {} },
-              context: { icon_entity: "entity" },
+              name: "",
+              type: "grid",
+              schema: [
+                {
+                  name: "icon",
+                  selector: { icon: {} },
+                  context: { icon_entity: "entity" },
+                },
+                {
+                  name: "color",
+                  selector: {
+                    ui_color: {
+                      default_color: "uncolored",
+                      include_state: true,
+                      include_uncolored: true,
+                    },
+                  },
+                },
+              ],
             },
             {
               name: "displayed_elements",

--- a/src/panels/lovelace/editor/heading-entity/hui-heading-entity-editor.ts
+++ b/src/panels/lovelace/editor/heading-entity/hui-heading-entity-editor.ts
@@ -93,9 +93,9 @@ export class HuiHeadingEntityEditor
                   name: "color",
                   selector: {
                     ui_color: {
-                      default_color: "uncolored",
+                      default_color: "none",
                       include_state: true,
-                      include_uncolored: true,
+                      include_none: true,
                     },
                   },
                 },

--- a/src/panels/lovelace/editor/heading-entity/hui-heading-entity-editor.ts
+++ b/src/panels/lovelace/editor/heading-entity/hui-heading-entity-editor.ts
@@ -176,6 +176,7 @@ export class HuiHeadingEntityEditor
         .data=${data}
         .schema=${schema}
         .computeLabel=${this._computeLabelCallback}
+        .computeHelper=${this._computeHelperCallback}
         @value-changed=${this._valueChanged}
       ></ha-form>
       <ha-expansion-panel outlined>
@@ -245,6 +246,7 @@ export class HuiHeadingEntityEditor
       case "state_content":
       case "displayed_elements":
       case "appearance":
+      case "color":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.heading.entity_config.${schema.name}`
         );
@@ -252,6 +254,19 @@ export class HuiHeadingEntityEditor
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.generic.${schema.name}`
         );
+    }
+  };
+
+  private _computeHelperCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
+    switch (schema.name) {
+      case "color":
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.heading.entity_config.${schema.name}_helper`
+        );
+      default:
+        return undefined;
     }
   };
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6105,7 +6105,7 @@
               "name": "Tile",
               "description": "The tile card gives you a quick overview of your entity. The card allow you to toggle the entity, show the more info dialog or custom actions.",
               "color": "Color",
-              "color_helper": "Applied when the entity state is active (e.g. on, open, detected)",
+              "color_helper": "Inactive state (e.g. off, closed) will not be colored.",
               "icon_tap_action": "Icon tap behavior",
               "interactions": "Interactions",
               "appearance": "Appearance",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -701,7 +701,7 @@
       "color-picker": {
         "default": "default",
         "state": "State color",
-        "uncolored": "Uncolored",
+        "none": "No color",
         "colors": {
           "primary": "Primary",
           "accent": "Accent",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -699,7 +699,9 @@
         "unsupported_format": "Unsupported format, please choose a JPEG, PNG, or GIF image."
       },
       "color-picker": {
-        "default_color": "Default color (state)",
+        "default": "default",
+        "state": "State color",
+        "uncolored": "Uncolored",
         "colors": {
           "primary": "Primary",
           "accent": "Accent",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6009,6 +6009,8 @@
               },
               "entities": "Entities",
               "entity_config": {
+                "color": "[%key:ui::panel::lovelace::editor::card::tile::color%]",
+                "color_helper": "[%key:ui::panel::lovelace::editor::card::tile::color_helper%]",
                 "visibility": "Visibility",
                 "visibility_explanation": "The entity will be shown when ALL conditions below are fulfilled. If no conditions are set, the entity will always be shown.",
                 "appearance": "Appearance",
@@ -6103,6 +6105,7 @@
               "name": "Tile",
               "description": "The tile card gives you a quick overview of your entity. The card allow you to toggle the entity, show the more info dialog or custom actions.",
               "color": "Color",
+              "color_helper": "Applied when the entity state is active (e.g. on, open, detected)",
               "icon_tap_action": "Icon tap behavior",
               "interactions": "Interactions",
               "appearance": "Appearance",
@@ -6142,7 +6145,8 @@
             "entity": {
               "name": "Entity",
               "description": "The Entity badge gives you a quick overview of your entity.",
-              "color": "Color",
+              "color": "[%key:ui::panel::lovelace::editor::card::tile::color%]",
+              "color_helper": "[%key:ui::panel::lovelace::editor::card::tile::color_helper%]",
               "interactions": "Interactions",
               "appearance": "Appearance",
               "show_entity_picture": "Show entity picture",


### PR DESCRIPTION
## Proposed change

### Color editor

![CleanShot 2024-09-24 at 17 41 16](https://github.com/user-attachments/assets/32231d3d-748a-47c2-82b1-aff401ffa388)

![CleanShot 2024-09-24 at 18 04 20](https://github.com/user-attachments/assets/b31b91e9-f731-4105-abaf-6418a093e9b1)

### Colored icons

![CleanShot 2024-09-24 at 14 25 24](https://github.com/user-attachments/assets/9075e6b6-6773-4d58-8ede-3d0447c5f6aa)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced `HaColorPicker` component with new properties for better customization: `includeState` and `includeNone`.
  - Introduced dynamic color handling in entity headings based on state and attributes.
  - Added color configuration options in entity editors, including an "appearance" section for better user experience.

- **Bug Fixes**
  - Improved rendering logic for color selections, ensuring accurate display of state and uncolored options.

- **Documentation**
  - Updated translations for clarity in color selection and entity configuration terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->