### PR TITLE
Fix dialog box callback order

### DIFF
--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -149,11 +149,10 @@ class DialogBox extends LitElement {
 
   private _dialogClosed() {
     if (!this._closeState) {
+      fireEvent(this, "dialog-closed", { dialog: this.localName });
       this._cancel();
     }
-    if (!this._params) {
-      return;
-    }
+    this._closeState = undefined;
     this._params = undefined;
   }
 

--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -129,20 +129,21 @@ class DialogBox extends LitElement {
   }
 
   private _dismiss(): void {
-    this._cancel();
     this._closeState = "canceled";
     this._closeDialog();
+    this._cancel();
   }
 
   private _confirm(): void {
+    this._closeState = "confirmed";
+    this._closeDialog();
     if (this._params!.confirm) {
       this._params!.confirm(this._textField?.value);
     }
-    this._closeState = "confirmed";
-    this._closeDialog();
   }
 
   private _closeDialog() {
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
     this._dialog?.close();
   }
 
@@ -154,7 +155,6 @@ class DialogBox extends LitElement {
       return;
     }
     this._params = undefined;
-    fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
   static get styles(): CSSResultGroup {


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The `dialog-closed` event was fired after the callbacks for cancel or confirm where called, causing issues with history modification.

Now the `dialog-closed` event is fired before the callbacks, so it works as before again.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/22091
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
