### PR TITLE
Fix matter device actions

### DIFF
--- a/src/panels/config/devices/device-detail/integration-elements/matter/device-actions.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/matter/device-actions.ts
@@ -17,6 +17,30 @@ import type { DeviceAction } from "../../../ha-config-device-page";
 import { showMatterManageFabricsDialog } from "../../../../integrations/integration-panels/matter/show-dialog-matter-manage-fabrics";
 import { navigate } from "../../../../../../common/navigate";
 
+export const getMatterDeviceDefaultActions = (
+  el: HTMLElement,
+  hass: HomeAssistant,
+  device: DeviceRegistryEntry
+): DeviceAction[] => {
+  if (device.via_device_id !== null) {
+    // only show device actions for top level nodes (so not bridged)
+    return [];
+  }
+
+  const actions: DeviceAction[] = [];
+
+  actions.push({
+    label: hass.localize("ui.panel.config.matter.device_actions.ping_device"),
+    icon: mdiChatQuestion,
+    action: () =>
+      showMatterPingNodeDialog(el, {
+        device_id: device.id,
+      }),
+  });
+
+  return actions;
+};
+
 export const getMatterDeviceActions = async (
   el: HTMLElement,
   hass: HomeAssistant,
@@ -74,15 +98,6 @@ export const getMatterDeviceActions = async (
       action: () => navigate("/config/thread"),
     });
   }
-
-  actions.push({
-    label: hass.localize("ui.panel.config.matter.device_actions.ping_device"),
-    icon: mdiChatQuestion,
-    action: () =>
-      showMatterPingNodeDialog(el, {
-        device_id: device.id,
-      }),
-  });
 
   return actions;
 };

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -1125,24 +1125,14 @@ export class HaConfigDevicePage extends LitElement {
         device
       );
       deviceActions.push(...defaultActions);
-      this._loadMatterDeviceActions(matter, device);
+
+      // load matter device actions async to avoid an UI with 0 actions when the matter integration needs very long to get node diagnostics
+      matter.getMatterDeviceActions(this, this.hass, device).then((actions) => {
+        this._deviceActions = [...actions, ...(this._deviceActions || [])];
+      });
     }
 
     this._deviceActions = deviceActions;
-  }
-
-  // load matter device actions async to avoid an UI with 0 actions when the matter integration needs very long to get node diagnostics
-  private async _loadMatterDeviceActions(
-    matter: typeof import("./device-detail/integration-elements/matter/device-actions"),
-    device: DeviceRegistryEntry
-  ): Promise<void> {
-    const actions = await matter.getMatterDeviceActions(
-      this,
-      this.hass,
-      device
-    );
-
-    this._deviceActions = [...actions, ...(this._deviceActions || [])];
   }
 
   private async _getDeviceAlerts() {

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -1133,7 +1133,7 @@ export class HaConfigDevicePage extends LitElement {
 
   // load matter device actions async to avoid an UI with 0 actions when the matter integration needs very long to get node diagnostics
   private async _loadMatterDeviceActions(
-    matter: typeof import("/home/wendelin/nabucasa/home-assistant/frontend/src/panels/config/devices/device-detail/integration-elements/matter/device-actions"),
+    matter: typeof import("./device-detail/integration-elements/matter/device-actions"),
     device: DeviceRegistryEntry
   ): Promise<void> {
     const actions = await matter.getMatterDeviceActions(

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -1119,15 +1119,30 @@ export class HaConfigDevicePage extends LitElement {
       const matter = await import(
         "./device-detail/integration-elements/matter/device-actions"
       );
-      const actions = await matter.getMatterDeviceActions(
+      const defaultActions = matter.getMatterDeviceDefaultActions(
         this,
         this.hass,
         device
       );
-      deviceActions.push(...actions);
+      deviceActions.push(...defaultActions);
+      this._loadMatterDeviceActions(matter, device);
     }
 
     this._deviceActions = deviceActions;
+  }
+
+  // load matter device actions async to avoid an UI with 0 actions when the matter integration needs very long to get node diagnostics
+  private async _loadMatterDeviceActions(
+    matter: typeof import("/home/wendelin/nabucasa/home-assistant/frontend/src/panels/config/devices/device-detail/integration-elements/matter/device-actions"),
+    device: DeviceRegistryEntry
+  ): Promise<void> {
+    const actions = await matter.getMatterDeviceActions(
+      this,
+      this.hass,
+      device
+    );
+
+    this._deviceActions = [...actions, ...(this._deviceActions || [])];
   }
 
   private async _getDeviceAlerts() {


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
When a matter device is in an unkown state (for example when it is unplugged) the matter integration takes very long till endless to provide the node diagnostics for the frontend. There can be a state where the matter integration is still getting all diagnostics, but you are able to ping the device successfully.

- Add default matter device actions (ping action) that doesn't rely on the result of node diagnostics
- load node diagnostics in background and update the device actions when they are available.

Default only:
![image](https://github.com/user-attachments/assets/374b64a9-281c-4d23-ae1e-962252307089)


With node diagnostics loaded:
![image](https://github.com/user-attachments/assets/ddd5e1f9-176d-4b46-8125-66dbbb34b25c)



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
