### PR TITLE
Handle falsy value in ha-yaml-editor (object selector)

### DIFF
--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -805,7 +805,8 @@ export class HaServiceControl extends LitElement {
     const value = ev.detail.value;
     if (
       this._value?.data?.[key] === value ||
-      (!this._value?.data?.[key] && (value === "" || value === undefined))
+      ((!this._value?.data || !(key in this._value.data)) &&
+        (value === "" || value === undefined))
     ) {
       return;
     }

--- a/src/components/ha-yaml-editor.ts
+++ b/src/components/ha-yaml-editor.ts
@@ -59,14 +59,13 @@ export class HaYamlEditor extends LitElement {
 
   public setValue(value): void {
     try {
-      this._yaml =
-        value && !isEmpty(value)
-          ? dump(value, {
-              schema: this.yamlSchema,
-              quotingType: '"',
-              noRefs: true,
-            })
-          : "";
+      this._yaml = !isEmpty(value)
+        ? dump(value, {
+            schema: this.yamlSchema,
+            quotingType: '"',
+            noRefs: true,
+          })
+        : "";
     } catch (err: any) {
       // eslint-disable-next-line no-console
       console.error(err, value);
@@ -75,7 +74,7 @@ export class HaYamlEditor extends LitElement {
   }
 
   protected firstUpdated(): void {
-    if (this.defaultValue) {
+    if (this.defaultValue !== undefined) {
       this.setValue(this.defaultValue);
     }
   }

--- a/src/components/ha-yaml-editor.ts
+++ b/src/components/ha-yaml-editor.ts
@@ -18,7 +18,7 @@ import type { HaCodeEditor } from "./ha-code-editor";
 import "./ha-button";
 
 const isEmpty = (obj: Record<string, unknown>): boolean => {
-  if (typeof obj !== "object") {
+  if (typeof obj !== "object" || obj === null) {
     return false;
   }
   for (const key in obj) {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When the `ha-yaml-editor` was loaded with falsy data, it would show no data.
Eg. in an object selector, when data was explicitly `0` or `false`.
With this change it shows the data if it isn't explicitly `undefined`.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

This is a demo of the object selector handling falsy values before this change. (persistent notification just as example action that has an object selector and is available on every installation).

https://github.com/user-attachments/assets/ab2b567e-1680-4acf-bb2d-c2ab44e06005



## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22062 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
