### PR TITLE
Fix script rename name placeholder

### DIFF
--- a/src/panels/config/automation/automation-rename-dialog/dialog-automation-rename.ts
+++ b/src/panels/config/automation/automation-rename-dialog/dialog-automation-rename.ts
@@ -41,7 +41,9 @@ class DialogAutomationRename extends LitElement implements HassDialog {
     this._newIcon = "icon" in params.config ? params.config.icon : undefined;
     this._newName =
       params.config.alias ||
-      this.hass.localize("ui.panel.config.automation.editor.default_name");
+      this.hass.localize(
+        `ui.panel.config.${this._params.domain}.editor.default_name`
+      );
     this._newDescription = params.config.description || "";
   }
 
@@ -83,7 +85,7 @@ class DialogAutomationRename extends LitElement implements HassDialog {
           dialogInitialFocus
           .value=${this._newName}
           .placeholder=${this.hass.localize(
-            "ui.panel.config.automation.editor.default_name"
+            `ui.panel.config.${this._params.domain}.editor.default_name`
           )}
           .label=${this.hass.localize(
             "ui.panel.config.automation.editor.alias"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
- in the script rename dialog, set the name placeholder to "New Script", it was "New Automation" which is confusing for the user.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
