### PR TITLE
Use finishes_at in timer remaining calculation

### DIFF
--- a/src/data/timer.ts
+++ b/src/data/timer.ts
@@ -72,8 +72,8 @@ export const timerTimeRemaining = (
 
   if (stateObj.state === "active") {
     const now = new Date().getTime();
-    const madeActive = new Date(stateObj.last_changed).getTime();
-    timeRemaining = Math.max(timeRemaining - (now - madeActive) / 1000, 0);
+    const finishes = new Date(stateObj.attributes.finishes_at);
+    timeRemaining = Math.max((finishes - now) / 1000, 0);
   }
 
   return timeRemaining;

--- a/src/data/timer.ts
+++ b/src/data/timer.ts
@@ -72,7 +72,7 @@ export const timerTimeRemaining = (
 
   if (stateObj.state === "active") {
     const now = new Date().getTime();
-    const finishes = new Date(stateObj.attributes.finishes_at);
+    const finishes = new Date(stateObj.attributes.finishes_at).getTime();
     timeRemaining = Math.max((finishes - now) / 1000, 0);
   }
 

--- a/test/common/entity/timer_time_remaining_test.ts
+++ b/test/common/entity/timer_time_remaining_test.ts
@@ -42,8 +42,8 @@ describe("timerTimeRemaining", () => {
           state: "active",
           attributes: {
             remaining: "0:01:05",
+            finishes_at: "2018-01-17T16:16:17+00:00",
           },
-          last_changed: "2018-01-17T16:15:12Z",
         } as any),
         47
       );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Modify the timer remaining time calculation, which currently breaks if timers/yaml are reloaded.

Reloading yaml cause all active timers to update their last_changed to the time of the reload, but core does not update the remaining time. 

So if you have a 10 minute timer, its active, and 3 minutes in yaml is reloaded, the last_changed will update to now, meaning the frontend timer will start counting down from 10:00 again, even though there's only 7 minutes left in the timer. 

Not clear if that's a core bug or not? But regardless if we use `finishes_at` attribute instead of `remaining`, I think we avoid the problem. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22154
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
