### PR TITLE
Show if a custom integration overwrites a core integration

### DIFF
--- a/src/data/integration.ts
+++ b/src/data/integration.ts
@@ -22,6 +22,7 @@ export type IntegrationType =
 
 export interface IntegrationManifest {
   is_built_in: boolean;
+  overwrites_built_in: boolean;
   domain: string;
   name: string;
   config_flow: boolean;

--- a/src/data/integration.ts
+++ b/src/data/integration.ts
@@ -22,7 +22,7 @@ export type IntegrationType =
 
 export interface IntegrationManifest {
   is_built_in: boolean;
-  overwrites_built_in: boolean;
+  overwrites_built_in?: boolean;
   domain: string;
   name: string;
   config_flow: boolean;

--- a/src/data/integrations.ts
+++ b/src/data/integrations.ts
@@ -11,6 +11,7 @@ export interface Integration {
   iot_class?: string;
   supported_by?: string;
   is_built_in?: boolean;
+  overwrites_built_in?: boolean;
   single_config_entry?: boolean;
 }
 
@@ -23,6 +24,7 @@ export interface Brand {
   integrations?: Integrations;
   iot_standards?: IotStandards[];
   is_built_in?: boolean;
+  overwrites_built_in?: boolean;
 }
 
 export interface Brands {

--- a/src/panels/config/integrations/dialog-add-integration.ts
+++ b/src/panels/config/integrations/dialog-add-integration.ts
@@ -69,6 +69,7 @@ export interface IntegrationListItem {
   supported_by?: string;
   cloud?: boolean;
   is_built_in?: boolean;
+  overwrites_built_in?: boolean;
   is_add?: boolean;
   single_config_entry?: boolean;
 }
@@ -211,6 +212,7 @@ class AddIntegrationDialog extends LitElement {
             iot_standards: supportedIntegration.iot_standards,
             supported_by: integration.supported_by,
             is_built_in: supportedIntegration.is_built_in !== false,
+            overwrites_built_in: integration.overwrites_built_in,
             cloud: supportedIntegration.iot_class?.startsWith("cloud_"),
             single_config_entry: integration.single_config_entry,
           });
@@ -232,6 +234,7 @@ class AddIntegrationDialog extends LitElement {
               ? Object.keys(integration.integrations)
               : undefined,
             is_built_in: integration.is_built_in !== false,
+            overwrites_built_in: integration.overwrites_built_in,
           });
         } else if (filter && "integration_type" in integration) {
           // Integration without a config flow
@@ -240,6 +243,7 @@ class AddIntegrationDialog extends LitElement {
             name: integration.name || domainToName(localize, domain),
             config_flow: integration.config_flow,
             is_built_in: integration.is_built_in !== false,
+            overwrites_built_in: integration.overwrites_built_in,
             cloud: integration.iot_class?.startsWith("cloud_"),
           });
         }

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -1,10 +1,5 @@
 import "@lrnwebcomponents/simple-tooltip/simple-tooltip";
-import {
-  mdiCloud,
-  mdiFileCodeOutline,
-  mdiPackageVariant,
-  mdiFolderAlert,
-} from "@mdi/js";
+import { mdiCloud, mdiFileCodeOutline, mdiPackageVariant } from "@mdi/js";
 import {
   CSSResultGroup,
   LitElement,
@@ -161,28 +156,21 @@ export class HaIntegrationCard extends LitElement {
                 </a>`
               : html`<div class="spacer"></div>`}
         <div class="icons">
-          ${this.manifest && this.manifest.overwrites_built_in
-            ? html`<span class="icon overwrites">
-                <ha-svg-icon .path=${mdiFolderAlert}></ha-svg-icon>
-                <simple-tooltip
-                  animation-delay="0"
-                  .position=${computeRTL(this.hass) ? "right" : "left"}
-                  offset="4"
-                  >${this.hass.localize(
-                    "ui.panel.config.integrations.config_entry.custom_overwrites_core"
-                  )}</simple-tooltip
-                >
-              </span>`
-            : nothing}
           ${this.manifest && !this.manifest.is_built_in
-            ? html`<span class="icon custom">
+            ? html`<span
+                class="icon ${this.manifest.overwrites_built_in
+                  ? "overwrites"
+                  : "custom"}"
+              >
                 <ha-svg-icon .path=${mdiPackageVariant}></ha-svg-icon>
                 <simple-tooltip
                   animation-delay="0"
                   .position=${computeRTL(this.hass) ? "right" : "left"}
                   offset="4"
                   >${this.hass.localize(
-                    "ui.panel.config.integrations.config_entry.custom_integration"
+                    this.manifest.overwrites_built_in
+                      ? "ui.panel.config.integrations.config_entry.custom_overwrites_core"
+                      : "ui.panel.config.integrations.config_entry.custom_integration"
                   )}</simple-tooltip
                 >
               </span>`
@@ -372,9 +360,11 @@ export class HaIntegrationCard extends LitElement {
         .icon.cloud {
           background: var(--info-color);
         }
-        .icon.custom,
-        .icon.overwrites {
+        .icon.custom {
           background: var(--warning-color);
+        }
+        .icon.overwrites {
+          background: var(--error-color);
         }
         .icon.yaml {
           background: var(--label-badge-grey);

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -1,5 +1,10 @@
 import "@lrnwebcomponents/simple-tooltip/simple-tooltip";
-import { mdiCloud, mdiFileCodeOutline, mdiPackageVariant } from "@mdi/js";
+import {
+  mdiCloud,
+  mdiFileCodeOutline,
+  mdiPackageVariant,
+  mdiFolderAlert,
+} from "@mdi/js";
 import {
   CSSResultGroup,
   LitElement,
@@ -156,6 +161,19 @@ export class HaIntegrationCard extends LitElement {
                 </a>`
               : html`<div class="spacer"></div>`}
         <div class="icons">
+          ${this.manifest && this.manifest.overwrites_built_in
+            ? html`<span class="icon overwrites">
+                <ha-svg-icon .path=${mdiFolderAlert}></ha-svg-icon>
+                <simple-tooltip
+                  animation-delay="0"
+                  .position=${computeRTL(this.hass) ? "right" : "left"}
+                  offset="4"
+                  >${this.hass.localize(
+                    "ui.panel.config.integrations.config_entry.custom_overwrites_core"
+                  )}</simple-tooltip
+                >
+              </span>`
+            : nothing}
           ${this.manifest && !this.manifest.is_built_in
             ? html`<span class="icon custom">
                 <ha-svg-icon .path=${mdiPackageVariant}></ha-svg-icon>
@@ -354,7 +372,8 @@ export class HaIntegrationCard extends LitElement {
         .icon.cloud {
           background: var(--info-color);
         }
-        .icon.custom {
+        .icon.custom,
+        .icon.overwrites {
           background: var(--warning-color);
         }
         .icon.yaml {

--- a/src/panels/config/integrations/ha-integration-list-item.ts
+++ b/src/panels/config/integrations/ha-integration-list-item.ts
@@ -3,12 +3,7 @@ import {
   ListItemBase,
 } from "@material/mwc-list/mwc-list-item-base";
 import { styles } from "@material/mwc-list/mwc-list-item.css";
-import {
-  mdiCloudOutline,
-  mdiFolderAlert,
-  mdiOpenInNew,
-  mdiPackageVariant,
-} from "@mdi/js";
+import { mdiCloudOutline, mdiOpenInNew, mdiPackageVariant } from "@mdi/js";
 import { css, CSSResultGroup, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
@@ -90,17 +85,9 @@ export class HaIntegrationListItem extends ListItemBase {
             ><ha-svg-icon .path=${mdiPackageVariant}></ha-svg-icon
             ><simple-tooltip animation-delay="0" position="left"
               >${this.hass.localize(
-                "ui.panel.config.integrations.config_entry.custom_integration"
-              )}</simple-tooltip
-            ></span
-          >`
-        : ""}
-      ${this.integration.overwrites_built_in
-        ? html`<span
-            ><ha-svg-icon .path=${mdiFolderAlert}></ha-svg-icon
-            ><simple-tooltip animation-delay="0" position="left"
-              >${this.hass.localize(
-                "ui.panel.config.integrations.config_entry.custom_overwrites_core"
+                this.integration.overwrites_built_in
+                  ? "ui.panel.config.integrations.config_entry.custom_overwrites_core"
+                  : "ui.panel.config.integrations.config_entry.custom_integration"
               )}</simple-tooltip
             ></span
           >`

--- a/src/panels/config/integrations/ha-integration-list-item.ts
+++ b/src/panels/config/integrations/ha-integration-list-item.ts
@@ -3,7 +3,12 @@ import {
   ListItemBase,
 } from "@material/mwc-list/mwc-list-item-base";
 import { styles } from "@material/mwc-list/mwc-list-item.css";
-import { mdiCloudOutline, mdiOpenInNew, mdiPackageVariant } from "@mdi/js";
+import {
+  mdiCloudOutline,
+  mdiFolderAlert,
+  mdiOpenInNew,
+  mdiPackageVariant,
+} from "@mdi/js";
 import { css, CSSResultGroup, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
@@ -86,6 +91,16 @@ export class HaIntegrationListItem extends ListItemBase {
             ><simple-tooltip animation-delay="0" position="left"
               >${this.hass.localize(
                 "ui.panel.config.integrations.config_entry.custom_integration"
+              )}</simple-tooltip
+            ></span
+          >`
+        : ""}
+      ${this.integration.overwrites_built_in
+        ? html`<span
+            ><ha-svg-icon .path=${mdiFolderAlert}></ha-svg-icon
+            ><simple-tooltip animation-delay="0" position="left"
+              >${this.hass.localize(
+                "ui.panel.config.integrations.config_entry.custom_overwrites_core"
               )}</simple-tooltip
             ></span
           >`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4401,7 +4401,7 @@
               }
             },
             "custom_integration": "Custom integration",
-            "custom_overwrites_core": "Overwrites a core integration",
+            "custom_overwrites_core": "Custom integration that replaces a core component",
             "depends_on_cloud": "Depends on the cloud",
             "yaml_only": "Needs manual configuration",
             "no_config_flow": "This integration was not set up from the UI",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4401,6 +4401,7 @@
               }
             },
             "custom_integration": "Custom integration",
+            "custom_overwrites_core": "Overwrites a core integration",
             "depends_on_cloud": "Depends on the cloud",
             "yaml_only": "Needs manual configuration",
             "no_config_flow": "This integration was not set up from the UI",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Sometimes users override a core integration, without them knowing they do. This often results in unexpected behavior.
While it is part of the design of core to allow for overriding core integration, we should make the user more aware they actually are override a core integration.

~~I do need some input on the design. Ideally I would've replaced the custom component icon with the same + an exclamation mark, but there isn't such an icon in Material icons. So the options I see are:~~
- ~~Add a new icon. This is the current implementation in this PR~~
- ~~Change the icon from `package-variant` to something else but what?~~
- ~~Change the color of the icon to something more prominent. The icons in the selector for a new integrations don't have color though~~

The design decision was to change the color and tooltip
![image](https://github.com/user-attachments/assets/c4afb845-3242-494e-b076-ac345abc8ed1)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to backend PR: https://github.com/home-assistant/core/pull/127937

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
