### PR TITLE
Improve accessibility for people with red-green colourblindness

### DIFF
--- a/hassio/src/addon-view/info/hassio-addon-info.ts
+++ b/hassio/src/addon-view/info/hassio-addon-info.ts
@@ -2,7 +2,8 @@ import "@material/mwc-button";
 import {
   mdiCheckCircle,
   mdiChip,
-  mdiCircle,
+  mdiPlayCircle,
+  mdiCircleOffOutline,
   mdiCursorDefaultClickOutline,
   mdiDocker,
   mdiExclamationThick,
@@ -198,7 +199,7 @@ class HassioAddonInfo extends LitElement {
                               "dashboard.addon_running"
                             )}
                             class="running"
-                            .path=${mdiCircle}
+                            .path=${mdiPlayCircle}
                           ></ha-svg-icon>
                         `
                       : html`
@@ -207,7 +208,7 @@ class HassioAddonInfo extends LitElement {
                               "dashboard.addon_stopped"
                             )}
                             class="stopped"
-                            .path=${mdiCircle}
+                            .path=${mdiCircleOffOutline}
                           ></ha-svg-icon>
                         `}
                   `


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The icon used to communicate whether an addon is running or not is currently just a circle, and we rely on colour to communicate its status. This PR changes that, and makes the icon change when the addon starts/stops. This makes it easier for people with red-green colourblindness (like myself) to see at a glance, the status of the addon.

|         | Running                                                                                   | Not Running                                                                               |
|---------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
| Current | ![image](https://github.com/user-attachments/assets/29310d2e-a58d-4268-a1f8-e9d4b03bb434) | ![image](https://github.com/user-attachments/assets/bacc7251-05e4-4f55-a6ff-07ffe82c60ce) |
| This PR | ![image](https://github.com/user-attachments/assets/3c86b199-eec2-40e5-99c2-551492e208d4) | ![image](https://github.com/user-attachments/assets/fa18ec1c-b4ca-48a7-a805-aed028dcc78f) |

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

> *I am unsure how to get an instance of my PR running, if someone could point me to the right documentation, I will gladly run tests, though nothing should have changed functionally*

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
