### PR TITLE
Allow to move card from other view to section view

### DIFF
--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -30,7 +30,7 @@ import { LovelaceCardConfig } from "../../../data/lovelace/config/card";
 import { saveConfig } from "../../../data/lovelace/config/types";
 import {
   isStrategyView,
-  LovelaceViewConfig,
+  type LovelaceViewConfig,
 } from "../../../data/lovelace/config/view";
 import {
   showAlertDialog,

--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -50,7 +50,7 @@ import {
 } from "../editor/config-util";
 import {
   LovelaceCardPath,
-  LovelaceContainerPath,
+  type LovelaceContainerPath,
   findLovelaceItems,
   getLovelaceContainerPath,
   parseLovelaceCardPath,
@@ -380,7 +380,7 @@ export class HuiCardOptions extends LitElement {
 
         let toPath: LovelaceContainerPath = [viewIndex];
 
-        // If the view is a section view and has no i"mported cards" section, adds a default section.
+        // If the view is a section view and has no "imported cards" section, adds a default section.
         if (isSectionsView) {
           const importedCardHeading = fromView.title
             ? this.hass!.localize(
@@ -391,15 +391,16 @@ export class HuiCardOptions extends LitElement {
                 "ui.panel.lovelace.editor.section.imported_card_section_title_default"
               );
 
-          let sectionIndex =
-            toView.sections?.findIndex(
-              (s) =>
-                "cards" in s &&
-                s.cards?.some(
-                  (c) =>
-                    c.type === "heading" && c.heading === importedCardHeading
-                )
-            ) ?? -1;
+          let sectionIndex = toView.sections
+            ? toView.sections.findIndex(
+                (s) =>
+                  "cards" in s &&
+                  s.cards?.some(
+                    (c) =>
+                      c.type === "heading" && c.heading === importedCardHeading
+                  )
+              )
+            : -1;
           if (sectionIndex === -1) {
             const newSection: LovelaceSectionConfig = {
               type: "grid",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5710,7 +5710,9 @@
             "add_badge": "Add badge",
             "add_card": "[%key:ui::panel::lovelace::editor::edit_card::add%]",
             "create_section": "Create section",
-            "default_section_title": "New section"
+            "default_section_title": "New section",
+            "imported_card_section_title_view": "Imported cards from ''{view_title}'' view",
+            "imported_card_section_title_default": "Imported cards from another view"
           },
           "delete_section": {
             "title": "Delete section",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5691,8 +5691,8 @@
           },
           "move_card": {
             "header": "Choose a view to move the card to",
-            "error_title": "Impossible to move the card",
-            "error_text_section": "Moving a card to a section view is not supported yet. Use copy/cut/paste instead."
+            "strategy_error_title": "Impossible to move the card",
+            "strategy_error_text_strategy": "Moving a card to a strategy view is not supported."
           },
           "change_position": {
             "title": "Change card position",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5692,7 +5692,7 @@
           "move_card": {
             "header": "Choose a view to move the card to",
             "strategy_error_title": "Impossible to move the card",
-            "strategy_error_text_strategy": "Moving a card to a strategy view is not supported."
+            "strategy_error_text_strategy": "Moving a card to an auto generated view is not supported."
           },
           "change_position": {
             "title": "Change card position",


### PR DESCRIPTION
## Proposed change

Allow to move card to a "sections" view. It will create a new section with dedicated title. 

![CleanShot 2024-10-22 at 17 43 05](https://github.com/user-attachments/assets/241d82c9-2cae-46be-b7d7-41c37cb4371c)

The heading of the section is used to know if we need to create another section or use the existing one when moving.

I first tested to add metadata to the section config but it wasn't a good solution as the user can reuse the section in the dashboard. That will end up with adding moved card to this reused section. 

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
