### PR TITLE
Fix integration configure on failed setup

### DIFF
--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -772,9 +772,9 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
           : ""}
       </div>
       ${item.disabled_by === "user"
-        ? html`<mwc-button unelevated slot="end" @click=${this._handleEnable}>
+        ? html`<ha-button unelevated slot="end" @click=${this._handleEnable}>
             ${this.hass.localize("ui.common.enable")}
-          </mwc-button>`
+          </ha-button>`
         : configPanel &&
             (item.domain !== "matter" ||
               isDevVersion(this.hass.config.version)) &&
@@ -782,19 +782,19 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
           ? html`<a
               slot="end"
               href=${`/${configPanel}?config_entry=${item.entry_id}`}
-              ><mwc-button>
+              ><ha-button>
                 ${this.hass.localize(
                   "ui.panel.config.integrations.config_entry.configure"
                 )}
-              </mwc-button></a
+              </ha-button></a
             >`
           : item.supports_options
             ? html`
-                <mwc-button slot="end" @click=${this._showOptions}>
+                <ha-button slot="end" @click=${this._showOptions}>
                   ${this.hass.localize(
                     "ui.panel.config.integrations.config_entry.configure"
                   )}
-                </mwc-button>
+                </ha-button>
               `
             : ""}
       <ha-md-button-menu positioning="popover" slot="end">

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -776,7 +776,9 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
             ${this.hass.localize("ui.common.enable")}
           </mwc-button>`
         : configPanel &&
-            (item.domain !== "matter" || isDevVersion(this.hass.config.version))
+            (item.domain !== "matter" ||
+              isDevVersion(this.hass.config.version)) &&
+            !stateText
           ? html`<a
               slot="end"
               href=${`/${configPanel}?config_entry=${item.entry_id}`}
@@ -786,7 +788,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                 )}
               </mwc-button></a
             >`
-          : item.supports_options && !stateText
+          : item.supports_options
             ? html`
                 <mwc-button slot="end" @click=${this._showOptions}>
                   ${this.hass.localize(
@@ -801,14 +803,6 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
           .label=${this.hass.localize("ui.common.menu")}
           .path=${mdiDotsVertical}
         ></ha-icon-button>
-        ${item.supports_options && stateText
-          ? html`<ha-md-menu-item @click=${this._showOptions}>
-              <ha-svg-icon slot="start" .path=${mdiCog}></ha-svg-icon>
-              ${this.hass.localize(
-                "ui.panel.config.integrations.config_entry.configure"
-              )}
-            </ha-md-menu-item>`
-          : ""}
         ${item.disabled_by && devices.length
           ? html`
               <ha-md-menu-item


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
If an integration failed to setup and has a config panel, show the options instead of the config panel when click configure

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
