### PR TITLE
Fix an infinite loop in automation numeric_state

### DIFF
--- a/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
@@ -60,6 +60,18 @@ export default class HaNumericStateCondition extends LitElement {
     return true;
   }
 
+  private _data = memoizeOne(
+    (
+      inputAboveIsEntity: boolean,
+      inputBelowIsEntity: boolean,
+      condition: NumericStateCondition
+    ) => ({
+      mode_above: inputAboveIsEntity ? "input" : "value",
+      mode_below: inputBelowIsEntity ? "input" : "value",
+      ...condition,
+    })
+  );
+
   private _schema = memoizeOne(
     (
       localize: LocalizeFunc,
@@ -233,31 +245,33 @@ export default class HaNumericStateCondition extends LitElement {
       ] as const
   );
 
-  public render() {
-    const inputAboveIsEntity =
+  public willUpdate() {
+    this._inputAboveIsEntity =
       this._inputAboveIsEntity ??
       (typeof this.condition.above === "string" &&
         ((this.condition.above as string).startsWith("input_number.") ||
           (this.condition.above as string).startsWith("number.") ||
           (this.condition.above as string).startsWith("sensor.")));
-    const inputBelowIsEntity =
+    this._inputBelowIsEntity =
       this._inputBelowIsEntity ??
       (typeof this.condition.below === "string" &&
         ((this.condition.below as string).startsWith("input_number.") ||
           (this.condition.below as string).startsWith("number.") ||
           (this.condition.below as string).startsWith("sensor.")));
+  }
 
+  public render() {
     const schema = this._schema(
       this.hass.localize,
-      inputAboveIsEntity,
-      inputBelowIsEntity
+      this._inputAboveIsEntity,
+      this._inputBelowIsEntity
     );
 
-    const data = {
-      mode_above: inputAboveIsEntity ? "input" : "value",
-      mode_below: inputBelowIsEntity ? "input" : "value",
-      ...this.condition,
-    };
+    const data = this._data(
+      this._inputAboveIsEntity!,
+      this._inputBelowIsEntity!,
+      this.condition
+    );
 
     return html`
       <ha-form


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Address issues from #22403

As best I can tell what was happening was (on changing template field from empty to e.g. `a`)
 - On change of template field, valueChanged was called for the first time
 - inputAbove and inputBelow mode variables changed from `undefined` to `true/false` in `valueChanged`, as well as firing a `valueChanged` event with the new template condition.
 - the change in the input mode variables triggered a local update due to change in `@state`.
 - on this update from `@state` change, `template` field is still undefined because the valueChanged event hasn't propogated up and back down yet.
 - because we rerender the form with template as undefined, the codemirror block fires this as a valueChanged, this time with template as `""`. This seems unique to codemirror/template blocks, and is not how e.g. a text field behaves. not sure if that's an issue. 
 - numeric_state condition gets a second valueChanged event, this time with template as `""`, and fires another value-changed with template as `""`.
 - Now from a single change in template,  we have fired two events, first one with `template: a`, and second one with `template: ""`. 
 - These two events propogate back down as two condition changes, and just spin in an infinite loop changing the template field from "" -> "a" -> "" -> "a".
 
 
 This is mitigated by setting the inputMode variables to true/false before the first time valueChanged event is received, so they don't trigger updates from unrelated change in other fields. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22403
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
