### PR TITLE
Improve warnings for insecure zwavejs inclusion

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
@@ -518,9 +518,7 @@ class DialogZWaveJSAddNode extends LitElement {
                                               ${this.hass.localize(
                                                 "ui.panel.config.zwave_js.add_node.added_insecurely_text"
                                               )}
-                                              ${typeof this
-                                                ._lowSecurityReason !==
-                                              "undefined"
+                                              ${!isNaN(this._lowSecurityReason)
                                                 ? html`<p>
                                                     ${this.hass.localize(
                                                       `ui.panel.config.zwave_js.add_node.low_security_reason.${this._lowSecurityReason}`

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
@@ -80,6 +80,8 @@ class DialogZWaveJSAddNode extends LitElement {
 
   @state() private _lowSecurity = false;
 
+  @state() private _lowSecurityReason?: number;
+
   @state() private _supportsSmartStart?: boolean;
 
   private _addNodeTimeoutHandle?: number;
@@ -406,6 +408,26 @@ class DialogZWaveJSAddNode extends LitElement {
                                         )}</b
                                       >
                                     </p>
+                                    ${this._lowSecurity
+                                      ? html`<ha-alert
+                                          alert-type="warning"
+                                          title=${this.hass.localize(
+                                            "ui.panel.config.zwave_js.add_node.adding_insecurely"
+                                          )}
+                                        >
+                                          ${this.hass.localize(
+                                            "ui.panel.config.zwave_js.add_node.added_insecurely_text"
+                                          )}
+                                          ${typeof this._lowSecurityReason !==
+                                          "undefined"
+                                            ? html`<p>
+                                                ${this.hass.localize(
+                                                  `ui.panel.config.zwave_js.add_node.low_security_reason.${this._lowSecurityReason}`
+                                                )}
+                                              </p>`
+                                            : ""}
+                                        </ha-alert>`
+                                      : ""}
                                     ${this._stages
                                       ? html` <div class="stages">
                                           ${this._stages.map(
@@ -489,12 +511,22 @@ class DialogZWaveJSAddNode extends LitElement {
                                         ${this._lowSecurity
                                           ? html`<ha-alert
                                               alert-type="warning"
-                                              title="The device was added insecurely"
+                                              title=${this.hass.localize(
+                                                "ui.panel.config.zwave_js.add_node.added_insecurely"
+                                              )}
                                             >
-                                              There was an error during secure
-                                              inclusion. You can try again by
-                                              excluding the device and adding it
-                                              again.
+                                              ${this.hass.localize(
+                                                "ui.panel.config.zwave_js.add_node.added_insecurely_text"
+                                              )}
+                                              ${typeof this
+                                                ._lowSecurityReason !==
+                                              "undefined"
+                                                ? html`<p>
+                                                    ${this.hass.localize(
+                                                      `ui.panel.config.zwave_js.add_node.low_security_reason.${this._lowSecurityReason}`
+                                                    )}
+                                                  </p>`
+                                                : ""}
                                             </ha-alert>`
                                           : ""}
                                         <a
@@ -790,6 +822,7 @@ class DialogZWaveJSAddNode extends LitElement {
         if (message.event === "node added") {
           this._status = "interviewing";
           this._lowSecurity = message.node.low_security;
+          this._lowSecurityReason = message.node.low_security_reason;
         }
 
         if (message.event === "interview completed") {
@@ -953,6 +986,10 @@ class DialogZWaveJSAddNode extends LitElement {
           margin-right: 20px;
           margin-inline-end: 20px;
           margin-inline-start: initial;
+        }
+
+        .status {
+          flex: 1;
         }
       `,
     ];

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
@@ -524,7 +524,7 @@ class DialogZWaveJSAddNode extends LitElement {
                                                       `ui.panel.config.zwave_js.add_node.low_security_reason.${this._lowSecurityReason}`
                                                     )}
                                                   </p>`
-                                                : ""}
+                                                : nothing}
                                             </ha-alert>`
                                           : ""}
                                         <a

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
@@ -518,7 +518,9 @@ class DialogZWaveJSAddNode extends LitElement {
                                               ${this.hass.localize(
                                                 "ui.panel.config.zwave_js.add_node.added_insecurely_text"
                                               )}
-                                              ${!isNaN(this._lowSecurityReason)
+                                              ${typeof this
+                                                ._lowSecurityReason !==
+                                              "undefined"
                                                 ? html`<p>
                                                     ${this.hass.localize(
                                                       `ui.panel.config.zwave_js.add_node.low_security_reason.${this._lowSecurityReason}`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4966,7 +4966,21 @@
             "view_device": "View Device",
             "interview_started": "The device is being interviewed. This may take some time.",
             "interview_failed": "The device interview failed. Additional information may be available in the logs.",
-            "waiting_for_device": "Communicating with the device. Please wait."
+            "waiting_for_device": "Communicating with the device. Please wait.",
+            "adding_insecurely": "The device is being added insecurely",
+            "added_insecurely": "The device was added insecurely",
+            "added_insecurely_text": "There was an error during secure inclusion. You can try again by excluding the device and adding it again.",
+            "low_security_reason": {
+              "0": "Security bootstrapping was canceled by the user.",
+              "1": "The required security keys were not configured in the driver.",
+              "2": "No Security S2 user callbacks (or provisioning info) were provided to grant security classes and/or validate the DSK.",
+              "3": "An expected message was not received within the corresponding timeout.",
+              "4": "There was no possible match in encryption parameters between the controller and the node.",
+              "5": "Security bootstrapping was canceled by the included node.",
+              "6": "The PIN was incorrect, so the included node could not decode the key exchange commands.",
+              "7": "There was a mismatch in security keys between the controller and the node.",
+              "8": "Unknown error occurred."
+            }
           },
           "provisioned": {
             "dsk": "DSK",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Better warnings when adding a device. Also show the warning earlier to address https://github.com/home-assistant/core/issues/117636

Related core PR: https://github.com/home-assistant/core/pull/128896

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/117636
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
