### PR TITLE
Fix old safari but for relative time

### DIFF
--- a/src/components/ha-relative-time.ts
+++ b/src/components/ha-relative-time.ts
@@ -59,10 +59,10 @@ class HaRelativeTime extends ReactiveElement {
     if (!this.datetime) {
       this.innerHTML = this.hass.localize("ui.components.relative_time.never");
     } else {
-      let date: Date = this.datetime as Date;
-      if (typeof this.datetime === "string") {
-        date = parseISO(this.datetime);
-      }
+      const date =
+        typeof this.datetime === "string"
+          ? parseISO(this.datetime)
+          : this.datetime;
 
       const relTime = relativeTime(date, this.hass.locale);
       this.innerHTML = this.capitalize

--- a/src/components/ha-relative-time.ts
+++ b/src/components/ha-relative-time.ts
@@ -1,4 +1,5 @@
 import { PropertyValues, ReactiveElement } from "lit";
+import { parseISO } from "date-fns";
 import { customElement, property } from "lit/decorators";
 import { relativeTime } from "../common/datetime/relative_time";
 import { capitalizeFirstLetter } from "../common/string/capitalize-first-letter";
@@ -58,7 +59,12 @@ class HaRelativeTime extends ReactiveElement {
     if (!this.datetime) {
       this.innerHTML = this.hass.localize("ui.components.relative_time.never");
     } else {
-      const relTime = relativeTime(new Date(this.datetime), this.hass.locale);
+      let date: Date = this.datetime as Date;
+      if (typeof this.datetime === "string") {
+        date = parseISO(this.datetime);
+      }
+
+      const relTime = relativeTime(date, this.hass.locale);
       this.innerHTML = this.capitalize
         ? capitalizeFirstLetter(relTime)
         : relTime;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Older Safari browser (<= iOS 15) havn't been able to show the ha-relative-time because of a browser bug.
A datetime string needs to be `"2024-10-21T15:27:00"` but we provide it as `"2024-10-21 15:27:00"`. `date-fns.parseISO` fix this issue for us.


## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
