### PR TITLE
Dont attempt to add devices to disabled zwave config

### DIFF
--- a/src/common/integrations/protocolIntegrationPicked.ts
+++ b/src/common/integrations/protocolIntegrationPicked.ts
@@ -34,9 +34,11 @@ export const protocolIntegrationPicked = async (
   if (domain === "zwave_js") {
     const entries = options?.config_entry
       ? undefined
-      : await getConfigEntries(hass, {
-          domain,
-        });
+      : (
+          await getConfigEntries(hass, {
+            domain,
+          })
+        ).filter((e) => !e.disabled_by);
 
     if (
       !isComponentLoaded(hass, "zwave_js") ||
@@ -81,9 +83,11 @@ export const protocolIntegrationPicked = async (
   } else if (domain === "zha") {
     const entries = options?.config_entry
       ? undefined
-      : await getConfigEntries(hass, {
-          domain,
-        });
+      : (
+          await getConfigEntries(hass, {
+            domain,
+          })
+        ).filter((e) => !e.disabled_by);
 
     if (
       !isComponentLoaded(hass, "zha") ||
@@ -129,9 +133,11 @@ export const protocolIntegrationPicked = async (
   } else if (domain === "matter") {
     const entries = options?.config_entry
       ? undefined
-      : await getConfigEntries(hass, {
-          domain,
-        });
+      : (
+          await getConfigEntries(hass, {
+            domain,
+          })
+        ).filter((e) => !e.disabled_by);
     if (
       !isComponentLoaded(hass, domain) ||
       (!options?.config_entry && !entries?.length)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

On my install clicking "Add a z-wave device" from integrations or devices page would always hang and generate an error.

It is because this button attempts to add the device to the first config entry for zwave_js integrations. But I have two zwave_js integration config entries, the first one I disabled when I migrated from an old coordinator, and a second config entry for my new coordinator.

We should instead try to add device to the first _enabled_ config entry (or raise a complaint if there are no enabled). 

I added the same filter for zha and matter as it seemed sensical to do so, but I did not test those flows. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
