### PR TITLE
Improve Wifi configuration UI

### DIFF
--- a/src/data/hassio/network.ts
+++ b/src/data/hassio/network.ts
@@ -17,7 +17,7 @@ export interface NetworkInterface {
   ipv4?: Partial<IpConfiguration>;
   ipv6?: Partial<IpConfiguration>;
   type: "ethernet" | "wireless" | "vlan";
-  wifi?: Partial<WifiConfiguration>;
+  wifi?: Partial<WifiConfiguration> | null;
 }
 
 interface DockerNetwork {
@@ -27,7 +27,7 @@ interface DockerNetwork {
   interface: string;
 }
 
-interface AccessPoint {
+export interface AccessPoint {
   mode: "infrastructure" | "mesh" | "adhoc" | "ap";
   ssid: string;
   mac: string;

--- a/src/panels/config/network/supervisor-network.ts
+++ b/src/panels/config/network/supervisor-network.ts
@@ -267,7 +267,7 @@ export class HassioNetwork extends LitElement {
             : this.hass.localize("ui.common.save")}
         </ha-button>
         <ha-button @click=${this._clear}>
-          ${this.hass.localize("ui.common.clear")}
+          ${this.hass.localize("ui.panel.config.network.supervisor.reset")}
         </ha-button>
       </div>`;
   }
@@ -588,7 +588,9 @@ export class HassioNetwork extends LitElement {
   private async _clear() {
     await this._fetchNetworkInfo();
     this._interface!.ipv4!.method = "auto";
+    this._interface!.ipv4!.nameservers = [];
     this._interface!.ipv6!.method = "auto";
+    this._interface!.ipv6!.nameservers = [];
     // removing the connection will disable the interface
     // this is the only way to forget the wifi network right now
     this._interface!.wifi = null;

--- a/src/panels/config/network/supervisor-network.ts
+++ b/src/panels/config/network/supervisor-network.ts
@@ -613,10 +613,6 @@ export class HassioNetwork extends LitElement {
     }
     this._curTabIndex = ev.detail.index;
     this._interface = { ...this._interfaces[ev.detail.index] };
-    // mock
-    if (this._interface?.wifi) {
-      // this._interface!.wifi!.ssid = undefined;
-    }
   }
 
   private _handleRadioValueChanged(ev: Event): void {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5241,6 +5241,7 @@
             "custom_dns": "Custom",
             "unsaved": "You have unsaved changes, these will get lost if you change tabs, do you want to continue?",
             "failed_to_change": "Failed to change network settings",
+            "waiting_for_ssid": "Please select a Wi-Fi network first",
             "hostname": {
               "title": "Host name",
               "description": "The name your instance will have on your network",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5222,6 +5222,7 @@
             "title": "Configure network interfaces",
             "connected_to": "Connected to {ssid}",
             "scan_ap": "Search networks",
+            "reset": "Reset configuration",
             "signal_strength": "Signal strength",
             "open": "Open",
             "wep": "WEP",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5221,7 +5221,7 @@
           "supervisor": {
             "title": "Configure network interfaces",
             "connected_to": "Connected to {ssid}",
-            "scan_ap": "Scan for access points",
+            "scan_ap": "Search networks",
             "signal_strength": "Signal strength",
             "open": "Open",
             "wep": "WEP",
@@ -5241,7 +5241,6 @@
             "custom_dns": "Custom",
             "unsaved": "You have unsaved changes, these will get lost if you change tabs, do you want to continue?",
             "failed_to_change": "Failed to change network settings",
-            "waiting_for_ssid": "Please select a Wi-Fi network first",
             "hostname": {
               "title": "Host name",
               "description": "The name your instance will have on your network",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
- Disable IP configuration until wifi network is selected
- Deduplicate wifi networks by name and show only the one with the strongest signal
- Reload IP configuration after save to show current IP
- Add clear button that resets the form to defaults and removes the wifi network. Essentially allowing to forget a network

![image](https://github.com/user-attachments/assets/2f3f2d01-dc1b-410f-a5b9-8a8e8891812f)



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
