### PR TITLE
ZwaveJS: Resume adding a device if the page is refreshed

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
@@ -846,7 +846,11 @@ class DialogZWaveJSAddNode extends LitElement {
       undefined,
       undefined,
       dsk
-    );
+    ).catch((err) => {
+      this._error = err.message;
+      this._status = "failed";
+      return () => {};
+    });
     this._addNodeTimeoutHandle = window.setTimeout(() => {
       this._unsubscribe();
       this._status = "timed_out";

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
@@ -76,7 +76,7 @@ class DialogZWaveJSRemoveNode extends LitElement {
                 )}
               </mwc-button>
             `
-          : ``}
+          : nothing}
         ${this._status === "started"
           ? html`
               <div class="flex-container">
@@ -102,7 +102,7 @@ class DialogZWaveJSRemoveNode extends LitElement {
                 )}
               </mwc-button>
             `
-          : ``}
+          : nothing}
         ${this._status === "failed"
           ? html`
               <div class="flex-container">
@@ -120,14 +120,14 @@ class DialogZWaveJSRemoveNode extends LitElement {
                     ? html`<ha-alert alert-type="error">
                         ${this._error}
                       </ha-alert>`
-                    : ""}
+                    : nothing}
                 </div>
               </div>
               <mwc-button slot="primaryAction" @click=${this.closeDialog}>
                 ${this.hass.localize("ui.common.close")}
               </mwc-button>
             `
-          : ``}
+          : nothing}
         ${this._status === "finished"
           ? html`
               <div class="flex-container">
@@ -148,7 +148,7 @@ class DialogZWaveJSRemoveNode extends LitElement {
                 ${this.hass.localize("ui.common.close")}
               </mwc-button>
             `
-          : ``}
+          : nothing}
       </ha-dialog>
     `;
   }

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
@@ -2,6 +2,7 @@ import "@material/mwc-button/mwc-button";
 import { mdiCheckCircle, mdiCloseCircle } from "@mdi/js";
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-circular-progress";
 import { createCloseHeading } from "../../../../../components/ha-dialog";
@@ -25,9 +26,13 @@ class DialogZWaveJSRemoveNode extends LitElement {
 
   @state() private _node?: ZWaveJSRemovedNode;
 
+  @state() private _removedCallback?: () => void;
+
   private _removeNodeTimeoutHandle?: number;
 
-  private _subscribed?: Promise<() => Promise<void>>;
+  private _subscribed?: Promise<UnsubscribeFunc>;
+
+  @state() private _error?: string;
 
   public disconnectedCallback(): void {
     super.disconnectedCallback();
@@ -38,6 +43,10 @@ class DialogZWaveJSRemoveNode extends LitElement {
     params: ZWaveJSRemoveNodeDialogParams
   ): Promise<void> {
     this.entry_id = params.entry_id;
+    this._removedCallback = params.removedCallback;
+    if (params.skipConfirmation) {
+      this._startExclusion();
+    }
   }
 
   protected render() {
@@ -107,6 +116,11 @@ class DialogZWaveJSRemoveNode extends LitElement {
                       "ui.panel.config.zwave_js.remove_node.exclusion_failed"
                     )}
                   </p>
+                  ${this._error
+                    ? html`<ha-alert alert-type="error">
+                        ${this._error}
+                      </ha-alert>`
+                    : ""}
                 </div>
               </div>
               <mwc-button slot="primaryAction" @click=${this.closeDialog}>
@@ -143,13 +157,17 @@ class DialogZWaveJSRemoveNode extends LitElement {
     if (!this.hass) {
       return;
     }
-    this._subscribed = this.hass.connection.subscribeMessage(
-      (message) => this._handleMessage(message),
-      {
+    this._subscribed = this.hass.connection
+      .subscribeMessage((message) => this._handleMessage(message), {
         type: "zwave_js/remove_node",
         entry_id: this.entry_id,
-      }
-    );
+      })
+      .catch((err) => {
+        this._status = "failed";
+        this._error = err.message;
+        return () => {};
+      });
+    this._status = "started";
     this._removeNodeTimeoutHandle = window.setTimeout(
       () => this._unsubscribe(),
       120000
@@ -174,6 +192,9 @@ class DialogZWaveJSRemoveNode extends LitElement {
       this._status = "finished";
       this._node = message.node;
       this._unsubscribe();
+      if (this._removedCallback) {
+        this._removedCallback();
+      }
     }
   }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-remove-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-remove-node.ts
@@ -2,6 +2,8 @@ import { fireEvent } from "../../../../../common/dom/fire_event";
 
 export interface ZWaveJSRemoveNodeDialogParams {
   entry_id: string;
+  skipConfirmation?: boolean;
+  removedCallback?: () => void;
 }
 
 export const loadRemoveNodeDialog = () =>

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -79,19 +79,18 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
   @state()
   private _statistics?: ZWaveJSControllerStatisticsUpdatedMessage;
 
-  protected firstUpdated() {
+  protected async firstUpdated() {
     if (this.hass) {
-      this._fetchData().then(() => {
-        if (this._status === "connected") {
-          const inclusion_state = this._network?.controller.inclusion_state;
-          // show dialog if inclusion/exclusion is already in progress
-          if (inclusion_state === InclusionState.Including) {
-            this._addNodeClicked();
-          } else if (inclusion_state === InclusionState.Excluding) {
-            this._removeNodeClicked();
-          }
+      await this._fetchData();
+      if (this._status === "connected") {
+        const inclusion_state = this._network?.controller.inclusion_state;
+        // show dialog if inclusion/exclusion is already in progress
+        if (inclusion_state === InclusionState.Including) {
+          this._addNodeClicked();
+        } else if (inclusion_state === InclusionState.Excluding) {
+          this._removeNodeClicked();
         }
-      });
+      }
     }
   }
 
@@ -176,11 +175,11 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                                     `ui.panel.config.zwave_js.dashboard.not_ready`,
                                     { count: notReadyDevices }
                                   )})`
-                                : ""}
+                                : nothing}
                             </small>
                           </div>
                         `
-                      : ``}
+                      : nothing}
                   </div>
                 </div>
                 <div class="card-actions">
@@ -207,7 +206,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                           )}
                         </mwc-button></a
                       >`
-                    : ""}
+                    : nothing}
                 </div>
               </ha-card>
               <ha-card header="Diagnostics">
@@ -447,7 +446,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                 </div>
               </ha-card>
             `
-          : ``}
+          : nothing}
         <ha-fab
           slot="fab"
           .label=${this.hass.localize(
@@ -523,7 +522,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
             </mwc-button>
           </div>
         `
-      : ""}`;
+      : nothing}`;
   }
 
   private _handleBack(): void {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -36,8 +36,6 @@ import {
   fetchZwaveProvisioningEntries,
   InclusionState,
   setZwaveDataCollectionPreference,
-  stopZwaveExclusion,
-  stopZwaveInclusion,
   subscribeZwaveControllerStatistics,
   ZWaveJSClient,
   ZWaveJSControllerStatisticsUpdatedMessage,
@@ -83,7 +81,17 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
 
   protected firstUpdated() {
     if (this.hass) {
-      this._fetchData();
+      this._fetchData().then(() => {
+        if (this._status === "connected") {
+          const inclusion_state = this._network?.controller.inclusion_state;
+          // show dialog if inclusion/exclusion is already in progress
+          if (inclusion_state === InclusionState.Including) {
+            this._addNodeClicked();
+          } else if (inclusion_state === InclusionState.Excluding) {
+            this._removeNodeClicked();
+          }
+        }
+      });
     }
   }
 
@@ -126,31 +134,6 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
           .path=${mdiRefresh}
           .label=${this.hass!.localize("ui.common.refresh")}
         ></ha-icon-button>
-        ${this._network &&
-        this._status === "connected" &&
-        (this._network?.controller.inclusion_state ===
-          InclusionState.Including ||
-          this._network?.controller.inclusion_state ===
-            InclusionState.Excluding)
-          ? html`
-              <ha-alert alert-type="info">
-                ${this.hass.localize(
-                  `ui.panel.config.zwave_js.common.in_progress_inclusion_exclusion`
-                )}
-                <mwc-button
-                  slot="action"
-                  .label=${this.hass.localize(
-                    `ui.panel.config.zwave_js.common.cancel_inclusion_exclusion`
-                  )}
-                  @click=${this._network?.controller.inclusion_state ===
-                  InclusionState.Including
-                    ? this._cancelInclusion
-                    : this._cancelExclusion}
-                >
-                </mwc-button>
-              </ha-alert>
-            `
-          : ""}
         ${this._network
           ? html`
               <ha-card class="content network-status">
@@ -593,6 +576,9 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
   private async _removeNodeClicked() {
     showZWaveJSRemoveNodeDialog(this, {
       entry_id: this.configEntryId!,
+      skipConfirmation:
+        this._network?.controller.inclusion_state === InclusionState.Excluding,
+      removedCallback: () => this._fetchData(),
     });
   }
 
@@ -600,16 +586,6 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
     showZWaveJSRebuildNetworkRoutesDialog(this, {
       entry_id: this.configEntryId!,
     });
-  }
-
-  private async _cancelInclusion() {
-    stopZwaveInclusion(this.hass!, this.configEntryId!);
-    await this._fetchData();
-  }
-
-  private async _cancelExclusion() {
-    stopZwaveExclusion(this.hass!, this.configEntryId!);
-    await this._fetchData();
   }
 
   private _dataCollectionToggled(ev) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Auto show the add/remove device dialog if inclusion/exclusion is already in progress. Remove the "searching for devices" header and just show the dialog. This makes the process seamless when reopening/refreshing the page as the current header doesn't listen for status updates.
Starting the add/remove subscription again doesn't produce an error and adds listeners for the relevant events.
Also added some error handling that was missing and corrected the status flow.

Core PR https://github.com/home-assistant/core/pull/129081


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
