### PR TITLE
fix(#17820): prevent event propagation to browser history when clicki…

### DIFF
--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -168,7 +168,7 @@ export class HuiGenericEntityRow extends LitElement {
             class="text-content value ${classMap({
               pointer,
             })}"
-            @action=${this._handleAction}
+            @action=${this._handleValueAction}
             .actionHandler=${actionHandler({
               hasHold: hasAction(this.config!.hold_action),
               hasDoubleClick: hasAction(this.config!.double_tap_action),
@@ -191,6 +191,18 @@ export class HuiGenericEntityRow extends LitElement {
 
   private _handleAction(ev: ActionHandlerEvent) {
     handleAction(this, this.hass!, this.config!, ev.detail.action!);
+  }
+
+  // To stop unwanted event propagation, only handle the action
+  // if it originated from the value div or its direct state child
+  private _handleValueAction(ev: ActionHandlerEvent) {
+    ev.stopPropagation();
+    if (
+      ev.target === ev.currentTarget ||
+      ev.target === this.shadowRoot?.querySelector(".state")
+    ) {
+      this._handleAction(ev);
+    }
   }
 
   static get styles(): CSSResultGroup {


### PR DESCRIPTION
This is a partial fix to bug #17820 which pushes 4 items to the browser history when clicking on the state object in the lovelace GUI. 

It's only a partial fix because in my local (very limited) testing this change appears to reduces this number from 4 to 2.

As it is a small change, I wanted to raise this PR to get some early feedback as I am not a frontend webdev, but it is such a hot-button topic that so many users are complaining about, and from my investigations it looked like it should be a pretty simple issue to fix so I wanted to give it a try.

I think I can complete the fix so that only a single item is pushed to the browser history, but it would be nice to have some feedback from some proper frontend webdevs.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The fix partially prevents duplicate history entries by adding a new `_handleValueAction` method that checks if the action event originated directly from the value div or its immediate state child div. Event propagation is also stopped to prevent any potential bubbling that could trigger multiple history updates.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
None

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17820 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
