### PR TITLE
Add 'focus' option to geo_location_sources for map card

### DIFF
--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -298,6 +298,11 @@ export interface LogbookCardConfig extends LovelaceCardConfig {
   theme?: string;
 }
 
+interface GeoLocationSourceConfig {
+  source: string;
+  focus?: boolean;
+}
+
 export interface MapCardConfig extends LovelaceCardConfig {
   type: "map";
   title?: string;
@@ -307,7 +312,7 @@ export interface MapCardConfig extends LovelaceCardConfig {
   default_zoom?: number;
   entities?: Array<EntityConfig | string>;
   hours_to_show?: number;
-  geo_location_sources?: string[];
+  geo_location_sources?: Array<GeoLocationSourceConfig | string>;
   dark_mode?: boolean;
   theme_mode?: ThemeMode;
 }

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -42,6 +42,14 @@ export const mapEntitiesConfigStruct = union([
   string(),
 ]);
 
+const geoSourcesConfigStruct = union([
+  object({
+    source: string(),
+    focus: optional(boolean()),
+  }),
+  string(),
+]);
+
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
   object({
@@ -51,7 +59,7 @@ const cardConfigStruct = assign(
     dark_mode: optional(boolean()),
     entities: array(mapEntitiesConfigStruct),
     hours_to_show: optional(number()),
-    geo_location_sources: optional(array(string())),
+    geo_location_sources: optional(array(geoSourcesConfigStruct)),
     auto_fit: optional(boolean()),
     theme_mode: optional(string()),
   })
@@ -135,8 +143,12 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
       : [];
   }
 
+  private _geoSourcesStrings = memoizeOne((sources): string[] | undefined =>
+    sources?.map((s) => (typeof s === "string" ? s : s.source))
+  );
+
   get _geo_location_sources(): string[] {
-    return (this._config!.geo_location_sources as string[]) || [];
+    return this._geoSourcesStrings(this._config!.geo_location_sources) || [];
   }
 
   protected render() {
@@ -201,9 +213,16 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
       this._config = { ...this._config };
       delete this._config.geo_location_sources;
     } else {
+      const newSources = value.map(
+        (newSource) =>
+          this._config!.geo_location_sources?.find(
+            (oldSource) =>
+              typeof oldSource === "object" && oldSource.source === newSource
+          ) || newSource
+      );
       this._config = {
         ...this._config,
-        geo_location_sources: value,
+        geo_location_sources: newSources,
       };
     }
     fireEvent(this, "config-changed", { config: this._config });

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -136,7 +136,7 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
   }
 
   get _geo_location_sources(): string[] {
-    return this._config!.geo_location_sources || [];
+    return (this._config!.geo_location_sources as string[]) || [];
   }
 
   protected render() {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Map card entities have the `focus` option to exclude them from the auto-fit boundary, but geo_location_sources have no such option (so the fitBounds always wraps the entirety of all geo_location entities). 

This PR adds the same `focus` option to geo_location_sources. As it is somewhat advanced (and not trivial to create UI for), the use of this option locks the card to yaml-only. 

~~Can document on approval.~~

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://community.home-assistant.io/t/map-card-force-the-home-as-the-center/786623/2
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35454

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
