### PR TITLE
Fallback to formatjs pt for brazilian pt

### DIFF
--- a/build-scripts/gulp/locale-data.js
+++ b/build-scripts/gulp/locale-data.js
@@ -24,8 +24,11 @@ const convertToJSON = async (
 ) => {
   let localeData;
   try {
+    // use "pt" for "pt-BR", because "pt-BR" is unsupported by @formatjs
+    const language = lang !== "pt-BR" ? lang : "pt";
+
     localeData = await readFile(
-      join(formatjsDir, pkg, subDir, `${lang}.js`),
+      join(formatjsDir, pkg, subDir, `${language}.js`),
       "utf-8"
     );
   } catch (e) {

--- a/build-scripts/gulp/locale-data.js
+++ b/build-scripts/gulp/locale-data.js
@@ -25,7 +25,7 @@ const convertToJSON = async (
   let localeData;
   try {
     // use "pt" for "pt-BR", because "pt-BR" is unsupported by @formatjs
-    const language = lang !== "pt-BR" ? lang : "pt";
+    const language = lang === "pt-BR" ? "pt" : lang;
 
     localeData = await readFile(
       join(formatjsDir, pkg, subDir, `${language}.js`),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
- Gulp task "create-locale-data" use lang `pt` for brazilian Portuguese, because it is not provided by formatjs
  - see: https://github.com/formatjs/formatjs/issues/2237


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
