### PR TITLE
Don't push a duplicate entry to select selector when filtering

### DIFF
--- a/src/components/ha-selector/ha-selector-select.ts
+++ b/src/components/ha-selector/ha-selector-select.ts
@@ -383,8 +383,13 @@ export class HaSelectSelector extends LitElement {
       return label.toLowerCase().includes(this._filter?.toLowerCase());
     });
 
-    if (this._filter && this.selector.select?.custom_value) {
-      filteredItems?.unshift({ label: this._filter, value: this._filter });
+    if (
+      this._filter &&
+      this.selector.select?.custom_value &&
+      filteredItems &&
+      !filteredItems.some((item) => (item.label || item.value) === this._filter)
+    ) {
+      filteredItems.unshift({ label: this._filter, value: this._filter });
     }
 
     this.comboBox.filteredItems = filteredItems;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
When typing a custom value into a `ha-select-selector`, if we type the same value as a predefined option, it will be shown duplicated, leading to some confusion why there are two identical options to choose from.

By skipping the push of the custom value to the filter list when it's already in the list, it looks a bit cleaner and doesn't make me pause to think about which identical option to pick. 

![image](https://github.com/user-attachments/assets/f1e7f00e-f8a7-4eaa-87e2-fadd21dc52f5)



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
