### PR TITLE
Fix height for horizontal-stack-card

### DIFF
--- a/src/panels/lovelace/cards/hui-horizontal-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-horizontal-stack-card.ts
@@ -27,7 +27,6 @@ export class HuiHorizontalStackCard extends HuiStackCard {
       css`
         #root {
           display: flex;
-          height: 100%;
           gap: var(--horizontal-stack-card-gap, var(--stack-card-gap, 8px));
         }
         #root > hui-card {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

There is an old issue with `horizontal-stack` on a Panel view (at least I reproduced it on 2023.7.x).
And it is only observed in Panel view.
Consider this code:
```
type: horizontal-stack
cards:
  - type: history-graph
    entities:
      - entity: sun.sun
  - type: picture
    image: https://demo.home-assistant.io/stub_config/t-shirt-promo.png
```
![image](https://github.com/user-attachments/assets/d578ac15-c2e8-47ed-9c10-f0d371b1b44b)

Both cards occupy a full height - and imho this happens due to `height: 100%`.
This style seems to be added in https://github.com/home-assistant/frontend/pull/7177.

With removed style:
![image](https://github.com/user-attachments/assets/e84642c4-528b-4f2a-855a-f6010c3f9c39)

One more example - when `horizontal-stack` overflows to a next card below:
```
type: vertical-stack
cards:
  - type: horizontal-stack
    title: xxx
    cards:
      - type: entity
        entity: sun.sun
      - type: entity
        entity: sun.sun
  - type: entity
    entity: sun.sun
```
![image](https://github.com/user-attachments/assets/ac42f9b1-c678-47db-87d4-f0926d2a8d19)

After the fix:
![image](https://github.com/user-attachments/assets/f918fc4e-9766-4066-8d0c-edcd1e72c3d3)



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/frontend/issues/18972
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
