### PR TITLE
Make duration input clearable

### DIFF
--- a/src/components/ha-duration-input.ts
+++ b/src/components/ha-duration-input.ts
@@ -43,6 +43,7 @@ class HaDurationInput extends LitElement {
         .label=${this.label}
         .helper=${this.helper}
         .required=${this.required}
+        .clearable=${!this.required && this.data !== undefined}
         .autoValidate=${this.required}
         .disabled=${this.disabled}
         errorMessage="Required"
@@ -67,50 +68,79 @@ class HaDurationInput extends LitElement {
   }
 
   private get _days() {
-    return this.data?.days ? Number(this.data.days) : 0;
+    return this.data?.days
+      ? Number(this.data.days)
+      : this.required || this.data
+        ? 0
+        : NaN;
   }
 
   private get _hours() {
-    return this.data?.hours ? Number(this.data.hours) : 0;
+    return this.data?.hours
+      ? Number(this.data.hours)
+      : this.required || this.data
+        ? 0
+        : NaN;
   }
 
   private get _minutes() {
-    return this.data?.minutes ? Number(this.data.minutes) : 0;
+    return this.data?.minutes
+      ? Number(this.data.minutes)
+      : this.required || this.data
+        ? 0
+        : NaN;
   }
 
   private get _seconds() {
-    return this.data?.seconds ? Number(this.data.seconds) : 0;
+    return this.data?.seconds
+      ? Number(this.data.seconds)
+      : this.required || this.data
+        ? 0
+        : NaN;
   }
 
   private get _milliseconds() {
-    return this.data?.milliseconds ? Number(this.data.milliseconds) : 0;
+    return this.data?.milliseconds
+      ? Number(this.data.milliseconds)
+      : this.required || this.data
+        ? 0
+        : NaN;
   }
 
-  private _durationChanged(ev: CustomEvent<{ value: TimeChangedEvent }>) {
+  private _durationChanged(ev: CustomEvent<{ value?: TimeChangedEvent }>) {
     ev.stopPropagation();
-    const value = { ...ev.detail.value };
+    const value = ev.detail.value ? { ...ev.detail.value } : undefined;
 
-    if (!this.enableMillisecond && !value.milliseconds) {
-      // @ts-ignore
-      delete value.milliseconds;
-    } else if (value.milliseconds > 999) {
-      value.seconds += Math.floor(value.milliseconds / 1000);
-      value.milliseconds %= 1000;
-    }
+    if (value) {
+      value.hours ||= 0;
+      value.minutes ||= 0;
+      value.seconds ||= 0;
 
-    if (value.seconds > 59) {
-      value.minutes += Math.floor(value.seconds / 60);
-      value.seconds %= 60;
-    }
+      if ("days" in value) value.days ||= 0;
+      if ("milliseconds" in value) value.milliseconds ||= 0;
 
-    if (value.minutes > 59) {
-      value.hours += Math.floor(value.minutes / 60);
-      value.minutes %= 60;
-    }
+      if (!this.enableMillisecond && !value.milliseconds) {
+        // @ts-ignore
+        delete value.milliseconds;
+      } else if (value.milliseconds > 999) {
+        value.seconds += Math.floor(value.milliseconds / 1000);
+        value.milliseconds %= 1000;
+      }
 
-    if (this.enableDay && value.hours > 24) {
-      value.days = (value.days ?? 0) + Math.floor(value.hours / 24);
-      value.hours %= 24;
+      if (value.seconds > 59) {
+        value.minutes += Math.floor(value.seconds / 60);
+        value.seconds %= 60;
+      }
+
+      if (value.minutes > 59) {
+        value.hours += Math.floor(value.minutes / 60);
+        value.minutes %= 60;
+      }
+
+      if (this.enableDay && value.hours > 24) {
+        value.days = (value.days ?? 0) + Math.floor(value.hours / 24);
+        value.hours %= 24;
+      }
     }
 
     fireEvent(this, "value-changed", {

--- a/src/panels/config/automation/action/types/ha-automation-action-delay.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-delay.ts
@@ -49,6 +49,7 @@ export class HaDelayAction extends LitElement implements ActionElement {
       .disabled=${this.disabled}
       .data=${this._timeData}
       enableMillisecond
+      required
       @value-changed=${this._valueChanged}
     ></ha-duration-input>`;
   }

--- a/src/panels/config/automation/action/types/ha-automation-action-wait_for_trigger.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-wait_for_trigger.ts
@@ -67,9 +67,6 @@ export class HaWaitForTriggerAction
   private _timeoutChanged(ev: CustomEvent<{ value: TimeChangedEvent }>): void {
     ev.stopPropagation();
     const value = ev.detail.value;
-    if (!value) {
-      return;
-    }
     fireEvent(this, "value-changed", {
       value: { ...this.action, timeout: value },
     });

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-calendar.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-calendar.ts
@@ -46,7 +46,7 @@ export class HaCalendarTrigger extends LitElement implements TriggerElement {
             ],
           ],
         },
-        { name: "offset", selector: { duration: {} } },
+        { name: "offset", required: true, selector: { duration: {} } },
         {
           name: "offset_type",
           type: "select",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

In the same style as #18590, make duration fields clearable as well. There are some cases where once a duration value is created, it needs to be removed.

E.g. for history_stats, without this I cannot remove the duration setting in options, so there is no way to fix this if I don't want it anymore:

![image](https://github.com/user-attachments/assets/17064ea8-4ce2-4647-ab9e-edb051eb629c)


With this change, optional duration selectors are now initialized to look blank instead of being filled with 0's:

![image](https://github.com/user-attachments/assets/cf5fb18e-d4ac-417f-96c0-45707bbf1666)



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #19360
- This PR is related to issue or discussion: https://github.com/home-assistant/core/issues/109586 https://github.com/home-assistant/core/pull/115830
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
