### PR TITLE
Support external step for login flow

### DIFF
--- a/src/auth/ha-auth-external.ts
+++ b/src/auth/ha-auth-external.ts
@@ -22,21 +22,14 @@ export class HaAuthExternal extends HaForm {
       <div class="content">
         ${this.localize("ui.panel.page-authorize.external.description")}
         ${this.blocked
-          ? html` <ha-alert alert-type="error">
+          ? html`<ha-alert alert-type="error">
               ${this.localize("ui.panel.page-authorize.external.popup_blocked")}
             </ha-alert>`
           : ""}
         <div class="open-button">
-          <a
-            href=${this.step.url}
-            target="_blank"
-            rel="opener"
-            @click=${this._openExternalStep}
-          >
-            <mwc-button raised>
-              ${this.localize("ui.panel.page-authorize.external.open_site")}
-            </mwc-button>
-          </a>
+          <mwc-button raised @click=${this._openExternalStep}>
+            ${this.localize("ui.panel.page-authorize.external.open_site")}
+          </mwc-button>
         </div>
       </div>
     `;

--- a/src/auth/ha-auth-external.ts
+++ b/src/auth/ha-auth-external.ts
@@ -32,9 +32,13 @@ export class HaAuthExternal extends HaForm {
 
   protected firstUpdated(changedProps) {
     super.firstUpdated(changedProps);
-    window.open(this.step.url);
+    const source = window.open(this.step.url);
     window.addEventListener("message", async (message: MessageEvent) => {
-      if (message.data.type === "externalCallback") {
+      if (
+        message.origin === window.location.origin &&
+        message.source === source &&
+        message.data.type === "externalCallback"
+      ) {
         fireEvent(this, "step-finished");
       }
     });

--- a/src/auth/ha-auth-external.ts
+++ b/src/auth/ha-auth-external.ts
@@ -1,14 +1,14 @@
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html } from "lit";
 import { customElement, property } from "lit/decorators";
-import type { DataEntryFlowStepExternal } from "../../data/data_entry_flow";
+import type { DataEntryFlowStepExternal } from "../data/data_entry_flow";
 import { fireEvent } from "../common/dom/fire_event";
 import type { LocalizeFunc } from "../common/translations/localize";
 import { HaForm } from "../components/ha-form/ha-form";
 
 @customElement("ha-auth-external")
 export class HaAuthExternal extends HaForm {
-  @property({ attribute: false }) public localize?: LocalizeFunc;
+  @property({ attribute: false }) public localize!: LocalizeFunc;
 
   @property({ attribute: false }) public stepTitle?: string;
 

--- a/src/auth/ha-auth-external.ts
+++ b/src/auth/ha-auth-external.ts
@@ -1,0 +1,65 @@
+import type { CSSResultGroup, TemplateResult } from "lit";
+import { css, html } from "lit";
+import { customElement, property } from "lit/decorators";
+import type { DataEntryFlowStepExternal } from "../../data/data_entry_flow";
+import { fireEvent } from "../common/dom/fire_event";
+import type { LocalizeFunc } from "../common/translations/localize";
+import { HaForm } from "../components/ha-form/ha-form";
+
+@customElement("ha-auth-external")
+export class HaAuthExternal extends HaForm {
+  @property({ attribute: false }) public localize?: LocalizeFunc;
+
+  @property({ attribute: false }) public stepTitle?: string;
+
+  @property({ attribute: false }) public step!: DataEntryFlowStepExternal;
+
+  protected render(): TemplateResult {
+    return html`
+      <h2>${this.stepTitle}</h2>
+      <div class="content">
+        ${this.localize("ui.panel.page-authorize.external.description")}
+        <div class="open-button">
+          <a href=${this.step.url} target="_blank" rel="opener">
+            <mwc-button raised>
+              ${this.localize("ui.panel.page-authorize.external.open_site")}
+            </mwc-button>
+          </a>
+        </div>
+      </div>
+    `;
+  }
+
+  protected firstUpdated(changedProps) {
+    super.firstUpdated(changedProps);
+    window.open(this.step.url);
+    window.addEventListener("message", async (message: MessageEvent) => {
+      if (message.data.type === "externalCallback") {
+        fireEvent(this, "step-finished");
+      }
+    });
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      css`
+        .open-button {
+          text-align: center;
+          padding: 24px 0;
+        }
+        .open-button a {
+          text-decoration: none;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-auth-external": HaAuthExternal;
+  }
+  interface HASSDomEvents {
+    "step-finished": undefined;
+  }
+}

--- a/src/auth/ha-auth-flow.ts
+++ b/src/auth/ha-auth-flow.ts
@@ -373,8 +373,10 @@ export class HaAuthFlow extends LitElement {
     this._providerChanged(this.authProvider);
   }
 
-  private async _handleSubmit(ev: Event) {
-    ev.preventDefault();
+  private async _handleSubmit(ev?: Event) {
+    if (ev) {
+      ev.preventDefault();
+    }
     if (this.step == null) {
       return;
     }
@@ -418,8 +420,8 @@ export class HaAuthFlow extends LitElement {
     }
   }
 
-  private _externalStepFinished(ev: CustomEvent) {
-    this._handleSubmit(ev);
+  private _externalStepFinished(_ev: CustomEvent) {
+    this._handleSubmit();
   }
 }
 

--- a/src/auth/ha-auth-flow.ts
+++ b/src/auth/ha-auth-flow.ts
@@ -272,7 +272,7 @@ export class HaAuthFlow extends LitElement {
     if (step.type === "external") {
       return nothing;
     }
-    return html` <div class="action">
+    return html`<div class="action">
       <mwc-button
         raised
         @click=${this._handleSubmit}

--- a/src/auth/ha-auth-flow.ts
+++ b/src/auth/ha-auth-flow.ts
@@ -260,7 +260,7 @@ export class HaAuthFlow extends LitElement {
         return html`<ha-auth-external
           .localize=${this.localize}
           .step=${this.step!}
-          .title=${this.authProvider.name}
+          .title=${this.authProvider!.name}
           @step-finished=${this._externalStepFinished}
         ></ha-auth-external>`;
       default:

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7144,6 +7144,10 @@
               }
             }
           }
+        },
+        "external": {
+          "description": "This step requires you to visit an external website to be completed.",
+          "open_site": "Open website"
         }
       },
       "page-demo": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7147,7 +7147,8 @@
         },
         "external": {
           "description": "This step requires you to visit an external website to be completed.",
-          "open_site": "Open website"
+          "open_site": "Open website",
+          "popup_blocked": "Could not open external website because a popup was blocked. Please allow to continue."
         }
       },
       "page-demo": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Support external step for login flow for use by authentication providers for custom components. This is an update on https://github.com/home-assistant/frontend/pull/14471 that addresses some of the PR feedback, and is also simpler, reusing more of the existing login flow and is based on the config flow external steps.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:


https://github.com/user-attachments/assets/771fde0a-92e2-427e-9465-bb496a405864



## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
