### PR TITLE
Don't hide location entities that are "home" in the MapViewStrategy

### DIFF
--- a/src/panels/lovelace/strategies/map/map-view-strategy.ts
+++ b/src/panels/lovelace/strategies/map/map-view-strategy.ts
@@ -14,7 +14,6 @@ const getMapEntities = (hass: HomeAssistant) => {
   const locationEntities: string[] = [];
   Object.values(hass.states).forEach((entity) => {
     if (
-      entity.state === "home" ||
       !("latitude" in entity.attributes) ||
       !("longitude" in entity.attributes)
     ) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

I've discovered that the `MapViewStrategy` that populates the default `map` dashboard filters any entity that is "home" no matter if it has geolocation data. Checking the history, I can see that this is how it always worked:
https://github.com/home-assistant/frontend/blame/7542c03dbbfd64e20dbc061ab6d271d4aec8a76a/src/panels/map/ha-panel-map.ts#L61-L87

I'd like to challenge that, because to me, it is very confusing.

I first thought that maybe my android companion app was misconfigured, because even though I enabled my location, I just couldn't see anything. There was simply no feedback excluding maybe the devtools where my `person` entity suddenly gained `latitude`/`longitude` attributes.
I was considering that maybe I'm supposed to "Take Control" of the Map dashboard, however that also seemed wrong so I started digging and eventually found that filter.

Another inconsistency about this filter is that the `person` marker will show up while in any other configured zone (e.g. `work`, `school`, etc.) but not while `home`.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue) - arguably a UX bugfix but might also just be an opinion
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Default config

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes N/A
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
