### PR TITLE
Set sidebar title to location name

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -377,7 +377,9 @@ class HaSidebar extends SubscribeMixin(LitElement) {
         ? html`<mwc-button outlined @click=${this._closeEditMode}>
             ${this.hass.localize("ui.sidebar.done")}
           </mwc-button>`
-        : html`<div class="title">Home Assistant</div>`}
+        : html`<div class="title">
+            ${this.hass.config.location_name ?? "Home Assistant"}
+          </div>`}
     </div>`;
   }
 


### PR DESCRIPTION
## Proposed change
Set the sidebar title to the `location_name` configuration value. If no name is present, it defaults back to "Home Assistant". As someone with multiple HA installations, I find this very helpful to quickly differentiate which instance I'm looking at in the UI. I've been using a HACS add-on for this, but having first-class support feels useful.


## Type of change
- [x] New feature (thank you!)

## Example configuration
N/A - this default configuration will work.

## Additional information

- This PR is related to issue or discussion:
    - https://community.home-assistant.io/t/changing-sidebar-title-and-favicon/653807
    - https://community.home-assistant.io/t/favicon-change-the-favicon-or-title-of-your-home-assistant-interface/131662
- Link to documentation pull request:
    - TODO(@sethvargo): Write documentation after maintainers agree on this approach

An alternative approach I considered was to introduce a new configuration parameter for the sidebar title, but that felt unnecessary since most of the time the value will be the location_name of the HA instance.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

    - **⚠️ HELP** - I could not find any existing test files or test cases for the sidebar. I'm not sure how/where to write them.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
    - TODO(@sethvargo): Write documentation after maintainers agree on this approach

[docs-repository]: https://github.com/home-assistant/home-assistant.io