### PR TITLE
Add inline features position for tile card

### DIFF
--- a/src/panels/lovelace/card-features/hui-card-features.ts
+++ b/src/panels/lovelace/card-features/hui-card-features.ts
@@ -20,40 +20,31 @@ export class HuiCardFeatures extends LitElement {
       return nothing;
     }
     return html`
-      <div class="container">
-        ${this.features.map(
-          (feature) => html`
-            <hui-card-feature
-              .hass=${this.hass}
-              .stateObj=${this.stateObj}
-              .color=${this.color}
-              .feature=${feature}
-            ></hui-card-feature>
-          `
-        )}
-      </div>
+      ${this.features.map(
+        (feature) => html`
+          <hui-card-feature
+            .hass=${this.hass}
+            .stateObj=${this.stateObj}
+            .color=${this.color}
+            .feature=${feature}
+          ></hui-card-feature>
+        `
+      )}
     `;
   }
 
   static styles = css`
     :host {
       --feature-color: var(--state-icon-color);
-      --feature-padding: 12px;
       --feature-height: 42px;
       --feature-border-radius: 12px;
       --feature-button-spacing: 12px;
       position: relative;
       width: 100%;
-    }
-    .container {
-      position: relative;
       display: flex;
       flex-direction: column;
-      padding: var(--feature-padding);
-      padding-top: 0px;
-      gap: var(--feature-padding);
+      gap: 12px;
       width: 100%;
-      height: 100%;
       box-sizing: border-box;
       justify-content: space-evenly;
     }

--- a/src/panels/lovelace/cards/hui-humidifier-card.ts
+++ b/src/panels/lovelace/cards/hui-humidifier-card.ts
@@ -256,6 +256,7 @@ export class HuiHumidifierCard extends LitElement implements LovelaceCard {
     hui-card-features {
       width: 100%;
       flex: none;
+      padding: 0 12px 12px 12px;
     }
   `;
 }

--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -248,6 +248,7 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
     hui-card-features {
       width: 100%;
       flex: none;
+      padding: 0 12px 12px 12px;
     }
   `;
 }

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -408,9 +408,6 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     .container.horizontal {
       flex-direction: row;
     }
-    .container.horizontal .content {
-      flex: 1;
-    }
 
     .content {
       position: relative;
@@ -423,6 +420,11 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       pointer-events: none;
       gap: 10px;
     }
+
+    .container.horizontal .content {
+      width: 50%;
+    }
+
     .vertical {
       flex-direction: column;
       text-align: center;
@@ -456,7 +458,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       padding: 0 12px 12px 12px;
     }
     .container.horizontal hui-card-features {
-      flex: 1;
+      width: 50%;
       --feature-height: 36px;
       padding: 10px;
       padding-inline-start: 0;

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -106,7 +106,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     return (
       1 +
       (this._config?.vertical ? 1 : 0) +
-      (featuresPosition === "bottom" ? featuresCount : 0)
+      (featuresPosition === "inline" ? 0 : featuresCount)
     );
   }
 
@@ -116,12 +116,14 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     let rows = 1;
     const featurePosition = this._config && this._featurePosition(this._config);
     const featuresCount = this._config?.features?.length || 0;
-    if (featuresCount && featurePosition === "bottom") {
-      rows += featuresCount;
+    if (featuresCount) {
+      if (featurePosition === "inline") {
+        min_columns = 12;
+      } else {
+        rows += featuresCount;
+      }
     }
-    if (featuresCount && featurePosition === "side") {
-      min_columns = 12;
-    }
+
     if (this._config?.vertical) {
       rows++;
       min_columns = 3;
@@ -229,7 +231,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     const features = config.features || [];
     const featurePosition = this._featurePosition(config);
 
-    if (featurePosition === "side") {
+    if (featurePosition === "inline") {
       return features.slice(0, 1);
     }
     return features;
@@ -292,7 +294,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     const features = this._displayedFeatures(this._config);
 
     const containerOrientationClass =
-      featurePosition === "side" ? "horizontal" : "";
+      featurePosition === "inline" ? "horizontal" : "";
 
     return html`
       <ha-card style=${styleMap(style)} class=${classMap({ active })}>

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -533,6 +533,7 @@ export interface TileCardConfig extends LovelaceCardConfig {
   icon_hold_action?: ActionConfig;
   icon_double_tap_action?: ActionConfig;
   features?: LovelaceCardFeatureConfig[];
+  features_position?: "bottom" | "side";
 }
 
 export interface HeadingCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -533,7 +533,7 @@ export interface TileCardConfig extends LovelaceCardConfig {
   icon_hold_action?: ActionConfig;
   icon_double_tap_action?: ActionConfig;
   features?: LovelaceCardFeatureConfig[];
-  features_position?: "bottom" | "side";
+  features_position?: "bottom" | "inline";
 }
 
 export interface HeadingCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -16,6 +16,7 @@ import {
 } from "superstruct";
 import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-expansion-panel";
 import "../../../../components/ha-form/ha-form";
 import type {
@@ -110,7 +111,7 @@ export class HuiTileCardEditor
   }
 
   private _featuresSchema = memoizeOne(
-    () =>
+    (localize: LocalizeFunc) =>
       [
         {
           name: "features_position",
@@ -118,17 +119,12 @@ export class HuiTileCardEditor
           selector: {
             select: {
               mode: "dropdown",
-
-              options: [
-                {
-                  label: "At the bottom",
-                  value: "bottom",
-                },
-                {
-                  label: "On the side",
-                  value: "side",
-                },
-              ],
+              options: ["bottom", "side"].map((value) => ({
+                label: localize(
+                  `ui.panel.lovelace.editor.card.tile.features_position_options.${value}`
+                ),
+                value,
+              })),
             },
           },
         },
@@ -256,7 +252,7 @@ export class HuiTileCardEditor
       this._displayActions
     );
 
-    const featureSchema = this._featuresSchema();
+    const featureSchema = this._featuresSchema(this.hass.localize);
 
     const data = { ...this._config };
 
@@ -294,14 +290,17 @@ export class HuiTileCardEditor
           ${this._config.vertical
             ? html`
                 <p class="info">
-                  This options is ignored when vertical layout is selected.
+                  ${this.hass!.localize(
+                    "ui.panel.lovelace.editor.card.tile.features_position_vertical_info"
+                  )}
                 </p>
               `
             : this._config.features_position === "side"
               ? html`
                   <p class="info">
-                    Only the first feature will be displayed when side position
-                    is selected.
+                    ${this.hass!.localize(
+                      "ui.panel.lovelace.editor.card.tile.features_position_side_limitation_info"
+                    )}
                   </p>
                 `
               : nothing}
@@ -402,11 +401,10 @@ export class HuiTileCardEditor
       case "state_content":
       case "appearance":
       case "interactions":
+      case "features_position":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.tile.${schema.name}`
         );
-      case "features_position":
-        return "Features position";
       default:
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.generic.${schema.name}`

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -56,7 +56,7 @@ const cardConfigStruct = assign(
     icon_hold_action: optional(actionConfigStruct),
     icon_double_tap_action: optional(actionConfigStruct),
     features: optional(array(any())),
-    features_position: optional(enums(["bottom", "side"])),
+    features_position: optional(enums(["bottom", "inline"])),
   })
 );
 
@@ -119,7 +119,7 @@ export class HuiTileCardEditor
           selector: {
             select: {
               mode: "dropdown",
-              options: ["bottom", "side"].map((value) => ({
+              options: ["bottom", "inline"].map((value) => ({
                 label: localize(
                   `ui.panel.lovelace.editor.card.tile.features_position_options.${value}`
                 ),
@@ -295,11 +295,11 @@ export class HuiTileCardEditor
                   )}
                 </p>
               `
-            : this._config.features_position === "side"
+            : this._config.features_position === "inline"
               ? html`
                   <p class="info">
                     ${this.hass!.localize(
-                      "ui.panel.lovelace.editor.card.tile.features_position_side_limitation_info"
+                      "ui.panel.lovelace.editor.card.tile.features_position_inline_limitation_info"
                     )}
                   </p>
                 `

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7128,10 +7128,10 @@
               "features_position": "Features position",
               "features_position_options": {
                 "bottom": "At the bottom",
-                "side": "On the side"
+                "inline": "Inline"
               },
               "features_position_vertical_info": "This option is ignored when vertical layout is selected.",
-              "features_position_side_limitation_info": "Only the first feature is displayed when side position is selected."
+              "features_position_inline_limitation_info": "Only the first feature is displayed when side position is selected."
             },
             "vertical-stack": {
               "name": "Vertical stack",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7124,7 +7124,14 @@
               "show_entity_picture": "Show entity picture",
               "vertical": "Vertical",
               "hide_state": "Hide state",
-              "state_content": "State content"
+              "state_content": "State content",
+              "features_position": "Features position",
+              "features_position_options": {
+                "bottom": "At the bottom",
+                "side": "On the side"
+              },
+              "features_position_vertical_info": "This option is ignored when vertical layout is selected.",
+              "features_position_side_limitation_info": "Only the first feature is displayed when side position is selected."
             },
             "vertical-stack": {
               "name": "Vertical stack",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7119,10 +7119,8 @@
               "icon_tap_action": "Icon tap behavior",
               "icon_hold_action": "Icon hold behavior",
               "icon_double_tap_action": "Icon double tap behavior",
-              "interactions": "Interactions",
               "appearance": "Appearance",
               "show_entity_picture": "Show entity picture",
-              "vertical": "Vertical",
               "hide_state": "Hide state",
               "state_content": "State content",
               "features_position": "Features position",
@@ -7130,8 +7128,11 @@
                 "bottom": "At the bottom",
                 "inline": "Inline"
               },
-              "features_position_vertical_info": "This option is ignored when vertical layout is selected.",
-              "features_position_inline_limitation_info": "Only the first feature is displayed when side position is selected."
+              "content_layout": "Content layout",
+              "content_layout_options": {
+                "horizontal": "Horizontal",
+                "vertical": "Vertical"
+              }
             },
             "vertical-stack": {
               "name": "Vertical stack",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7125,7 +7125,7 @@
               "state_content": "State content",
               "features_position": "Features position",
               "features_position_options": {
-                "bottom": "At the bottom",
+                "bottom": "Bottom",
                 "inline": "Inline"
               },
               "content_layout": "Content layout",


### PR DESCRIPTION
## Proposed change

Add features position for tile card. It can be set either to `side` or `bottom`. Default is bottom.
It has some limitation because of the design of the card : 
1. If the content layout is set to `vertical`, the `side` position of the features is ignored because of the card structure.
2. Only the first feature is displayed when using `side` position because of the card structure.

Based on Figma [Tile card improvements](https://www.figma.com/design/6gSXJvdU1VkN7WoQdycqMA/PDX-1891-Tile-card-improvements-%2B-%E2%80%9CTrend-Chart%E2%80%9D-feature?node-id=4219-38704&t=DKpoIVDM1c42Cxks-4).

### Card examples

![CleanShot 2025-02-12 at 14 40 18](https://github.com/user-attachments/assets/9354bc0c-f8ea-41b1-acaa-110e6d8f4b2e)

### Card editor

![CleanShot 2025-02-14 at 12 55 07](https://github.com/user-attachments/assets/6634a36e-672e-4cbd-b561-6a9d5578e4cd)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37515

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
