### PR TITLE
 Fix for "Increase generic entity row touch target (4): iOS troubles

### DIFF
--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -200,8 +200,6 @@ export class HuiGenericEntityRow extends LitElement {
       padding-inline-start: 16px;
       padding-inline-end: 8px;
       flex: 1 1 30%;
-      min-height: 40px;
-      align-content: center;
     }
     .info,
     .info > * {
@@ -235,8 +233,6 @@ export class HuiGenericEntityRow extends LitElement {
     }
     .value {
       direction: ltr;
-      min-height: 40px;
-      align-content: center;
     }
   `;
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This whole story:
FR https://github.com/home-assistant/frontend/issues/18461 -> fix https://github.com/home-assistant/frontend/pull/23894 -> issue https://github.com/home-assistant/frontend/issues/23948 -> fix https://github.com/home-assistant/frontend/pull/23953 -> issue https://github.com/home-assistant/frontend/issues/23971 -> fix https://github.com/home-assistant/frontend/pull/23973 -> issue https://github.com/home-assistant/frontend/issues/24009 -> fix https://github.com/home-assistant/frontend/pull/24002

ended up with a fixed look (colored areas are "active"):
![image](https://github.com/user-attachments/assets/6428f440-c08b-4bdc-acac-df1e75be3ecb)

Same nice look in Chrome & FF in Win10x64.

But there is an issue https://github.com/home-assistant/frontend/issues/24214 in iOS Companion App & Mac.
I see it in iOS 15.7.x & Mac 10.15.x - both Safari and Chrome.
Names & states are not vertically aligned.
![image](https://github.com/user-attachments/assets/3a29544a-f504-4a3f-ae64-b410afcaf575)

After unsuccessful attempts to fix this behaviour in iOS - I think that REVERTING to the old structure (at least for `height`) is the best option.
Now it looks like
![image](https://github.com/user-attachments/assets/4dc0d570-168a-41cc-940b-3f7e7b9fcff3)
Active areas became smaller - as they were before 2025.2. 
Imho not a big deal if compared with consequences.



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/frontend/issues/24214
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
