### PR TITLE
Fix logbook keeps loading

### DIFF
--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -1,4 +1,4 @@
-import type { HassEntity } from "home-assistant-js-websocket";
+import type { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
 import {
   BINARY_STATE_OFF,
   BINARY_STATE_ON,
@@ -119,7 +119,7 @@ export const subscribeLogbook = (
   endDate: string,
   entityIds?: string[],
   deviceIds?: string[]
-): Promise<() => Promise<void>> => {
+): Promise<UnsubscribeFunc> => {
   // If all specified filters are empty lists, we can return an empty list.
   if (
     (entityIds || deviceIds) &&

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -140,7 +140,7 @@ export class HaLogbook extends LitElement {
     this._throttleGetLogbookEntries.cancel();
     this._updateTraceContexts.cancel();
     this._updateUsers.cancel();
-    await this._unsubscribe(true);
+    this._unsubscribe(true);
 
     this._liveUpdatesEnabled = true;
 
@@ -215,7 +215,7 @@ export class HaLogbook extends LitElement {
    * - we are about to resubscribe
    * - the entity is not being tracked in the logbook
    *   and will not return results ever
-   * - the requested start time in the future
+   * - the requested start time is in the future
    *
    * In cases where no events are expected, we set this._logbookEntries
    * to an empty list to show a no results message.

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -224,16 +224,10 @@ export class HaLogbook extends LitElement {
    */
   private _unsubscribe(loading: boolean): void {
     if (this._unsubLogbook) {
-      try {
-        this._unsubLogbook.then((unsub) => unsub());
-      } catch (err: any) {
-        // eslint-disable-next-line
-        console.error("Error unsubscribing:", err);
-      } finally {
-        this._unsubLogbook = undefined;
-        this._logbookEntries = loading ? undefined : [];
-        this._pendingStreamMessages = [];
-      }
+      this._unsubLogbook.then((unsub) => unsub());
+      this._unsubLogbook = undefined;
+      this._logbookEntries = loading ? undefined : [];
+      this._pendingStreamMessages = [];
     }
   }
 
@@ -282,6 +276,7 @@ export class HaLogbook extends LitElement {
     if (this._unsubLogbook) {
       return;
     }
+
     try {
       this._unsubLogbook = subscribeLogbook(
         this.hass,
@@ -293,6 +288,7 @@ export class HaLogbook extends LitElement {
         this.entityIds,
         this.deviceIds
       );
+      await this._unsubLogbook;
     } catch (err: any) {
       this._unsubLogbook = undefined;
       this._error = err;


### PR DESCRIPTION
## Proposed change
2 bug fixes for https://github.com/home-assistant/frontend/issues/24212 introduced after https://github.com/home-assistant/frontend/pull/23853. It's a bit the logic how it is handled that makes it hard to not break anything here along the line. 

So, some sensors are continuous, and there's a short circuit in the backend that will provide an empty event straight away after subscription. But the event and the subscription are message wise sent together. 
First bug appears that the event is pushed through before the subscription is finalized, and the event is being throw away for being too early according to the comment. I've added the promise to a temporary variable to ensure we know that events that come with the subscription are not being handled as too "early". The subscription promise will resolve shortly after. 
Second bug appears on unsubscribing (whenever you change entities for example). The unsubscribe has already happened and the subscription is gone. Giving an error and failing to clean the UI state, resulting in the need to hard refresh. 

The demo integration provides a "number.temperature_setting", which you can add on the logbook page. 
* Go to the logbook page
* Add the "number.temperature_setting" => First bug
* Remove the "number.temperature_setting" => Second bug

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/24212
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
