### PR TITLE
Grid empty square fix

### DIFF
--- a/src/panels/lovelace/cards/hui-grid-card.ts
+++ b/src/panels/lovelace/cards/hui-grid-card.ts
@@ -84,14 +84,13 @@ class HuiGridCard extends HuiStackCard<GridCardConfig> {
         :host([square]) #root {
           grid-auto-rows: 1fr;
         }
-        :host([square]) #root::before {
+        :host([square]) #root:not(.empty)::before {
           content: "";
           width: 0;
           padding-bottom: 100%;
           grid-row: 1 / 1;
           grid-column: 1 / 1;
         }
-
         :host([square]) #root > *:not([hidden]) {
           display: block;
           grid-row: 1 / 1;

--- a/src/panels/lovelace/cards/hui-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-stack-card.ts
@@ -1,5 +1,6 @@
 import { LitElement, css, html, nothing } from "lit";
 import { property, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
 import { computeRTLDirection } from "../../../common/util/compute_rtl";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
 import type { HomeAssistant } from "../../../types";
@@ -7,7 +8,6 @@ import type { LovelaceCard, LovelaceCardEditor } from "../types";
 import "./hui-card";
 import type { HuiCard } from "./hui-card";
 import type { StackCardConfig } from "./types";
-import { classMap } from "lit/directives/class-map";
 
 export abstract class HuiStackCard<T extends StackCardConfig = StackCardConfig>
   extends LitElement

--- a/src/panels/lovelace/cards/hui-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-stack-card.ts
@@ -89,7 +89,7 @@ export abstract class HuiStackCard<T extends StackCardConfig = StackCardConfig>
       <div
         id="root"
         class=${classMap({
-          "empty": !this._cards,
+          empty: !this._cards,
         })}
         dir=${this.hass ? computeRTLDirection(this.hass) : "ltr"}
       >

--- a/src/panels/lovelace/cards/hui-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-stack-card.ts
@@ -7,6 +7,7 @@ import type { LovelaceCard, LovelaceCardEditor } from "../types";
 import "./hui-card";
 import type { HuiCard } from "./hui-card";
 import type { StackCardConfig } from "./types";
+import { classMap } from "lit/directives/class-map";
 
 export abstract class HuiStackCard<T extends StackCardConfig = StackCardConfig>
   extends LitElement
@@ -85,7 +86,13 @@ export abstract class HuiStackCard<T extends StackCardConfig = StackCardConfig>
       ${this._config.title
         ? html`<h1 class="card-header">${this._config.title}</h1>`
         : ""}
-      <div id="root" dir=${this.hass ? computeRTLDirection(this.hass) : "ltr"}>
+      <div
+        id="root"
+        class=${classMap({
+          "empty": !this._cards,
+        })}
+        dir=${this.hass ? computeRTLDirection(this.hass) : "ltr"}
+      >
         ${this._cards}
       </div>
     `;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

These are 2 grid cards without child cards:
-- with `square: true`
-- with `square: false`

![image](https://github.com/user-attachments/assets/a104b204-0d7a-4abc-a132-e0026d66b0a4)

A square form is implemented with `:before` pseudoclass for a `#root` element.

Another example with a grid card without child cards & with  defined `title`:

![image](https://github.com/user-attachments/assets/6c6093fd-7b30-472e-a884-8833d2f8ef4f)

Although grid cards are supposed to HAVE child cards - some users use an empty grid card as a "dummy card" to fill a gap inside another grid card, [see example here](https://github.com/home-assistant/frontend/issues/24369). With `square: true` set it may cause "imperfections" described above & in [mentioned issue](https://github.com/home-assistant/frontend/issues/24369).

This fix adds `empty` class to a `#root` element if no child cards are added.
In grid card, if `square: true` & `empty` class added - then a `:before` pseudoclass is not added.



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/frontend/issues/24369
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
