### PR TITLE
Repaired hard coded link in supervisor-error-screen.ts

### DIFF
--- a/src/layouts/supervisor-error-screen.ts
+++ b/src/layouts/supervisor-error-screen.ts
@@ -43,7 +43,7 @@ class SupervisorErrorScreen extends LitElement {
               <li>
                 <a
                   class="supervisor_error-link"
-                  href="http://homeassistant.local:4357"
+                  .href=${`http://${location.hostname}:4357`}
                   target="_blank"
                   rel="noreferrer"
                 >
@@ -52,7 +52,7 @@ class SupervisorErrorScreen extends LitElement {
               </li>
               <li>${this.hass.localize("ui.errors.supervisor.reboot")}</li>
               <li>
-                <a href="/config/info" target="_parent">
+                <a href="/config/logs" target="_parent">
                   ${this.hass.localize("ui.errors.supervisor.system_health")}
                 </a>
               </li>


### PR DESCRIPTION
Changed hardcoded url to use current hostname instead of "homeassistant.local" which assumes the user has not changed their hostname. Also provided a more useful link for system health.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
My supervisor is dead right now (I'll figure out why shortly I'm sure) and I encountered this error page.  One of its recommendations is to check the observer, but as seen in this screenshot, it assumes I still have the default hostname in place.  As I maintain several different instances of home assistance in my family, I give them unique hostnames to prevent session contamination, meaning this hardcoded link would never load.
![Screenshot 2025-03-04 at 10 56 40](https://github.com/user-attachments/assets/0507268a-b1bb-48df-bd1c-ace1e2132caa)

I've changed this to use the current hostname, with the port number applied after it.  This obviously won't work in some cases, such as Nabu Casa tunnel URLs, but it's still an improvement worth pursuing I believe, and if anyone could direct me on how to retrieve the configured `internal_url` that could improve it further.

I also noticed that the suggestion to "Check the system health" linked to an about page that I assume once upon a time did show some basic health information about the instance but now only shows things like version numbers etc.  I've tweaked this url too to point at the logs page instead.  I'm not sure if we want to update the text of the link, but I'm not sure where the localisation files are and think it's still close enough to not have to create the work for all those who would have to contribute new translations if we did.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

### _Sorry, I don't have a proper environment set up to test this, so would appreciate someone taking the time to check it._

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
