### PR TITLE
Disable energy distribution animation if `prefers-reduced-motion` is set

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
@@ -47,6 +47,8 @@ class HuiEnergyDistrubutionCard
 
   @state() private _data?: EnergyData;
 
+  @state() private _animate = true;
+
   protected hassSubscribeRequiredHostProps = ["_config"];
 
   public setConfig(config: EnergyDistributionCardConfig): void {
@@ -65,6 +67,12 @@ class HuiEnergyDistrubutionCard
 
   public getCardSize(): Promise<number> | number {
     return 3;
+  }
+
+  protected firstUpdated() {
+    if (matchMedia("(prefers-reduced-motion)").matches) {
+      this._animate = false;
+    }
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
@@ -349,7 +357,7 @@ class HuiEnergyDistrubutionCard
                       </div>
                       <svg width="80" height="30">
                         <path d="M40 0 v30" id="gas" />
-                        ${gasUsage
+                        ${gasUsage && this._animate
                           ? svg`<circle
                     r="1"
                     class="gas"
@@ -382,7 +390,7 @@ class HuiEnergyDistrubutionCard
                         </div>
                         <svg width="80" height="30">
                           <path d="M40 0 v30" id="water" />
-                          ${waterUsage
+                          ${waterUsage && this._animate
                             ? svg`<circle
                 r="1"
                 class="water"
@@ -577,7 +585,7 @@ class HuiEnergyDistrubutionCard
                   ? html`<div class="circle-container water bottom">
                       <svg width="80" height="30">
                         <path d="M40 30 v-30" id="water" />
-                        ${waterUsage
+                        ${waterUsage && this._animate
                           ? svg`<circle
                     r="1"
                     class="water"
@@ -671,7 +679,7 @@ class HuiEnergyDistrubutionCard
                 d="M0,${hasBattery ? 50 : hasSolarProduction ? 56 : 53} H100"
                 vector-effect="non-scaling-stroke"
               ></path>
-              ${returnedToGrid && hasSolarProduction
+              ${returnedToGrid && hasSolarProduction && this._animate
                 ? svg`<circle
                     r="1"
                     class="return"
@@ -690,7 +698,7 @@ class HuiEnergyDistrubutionCard
                     </animateMotion>
                   </circle>`
                 : ""}
-              ${solarConsumption
+              ${solarConsumption && this._animate
                 ? svg`<circle
                     r="1"
                     class="solar"
@@ -705,7 +713,7 @@ class HuiEnergyDistrubutionCard
                     </animateMotion>
                   </circle>`
                 : ""}
-              ${gridConsumption
+              ${gridConsumption && this._animate
                 ? svg`<circle
                     r="1"
                     class="grid"
@@ -720,7 +728,7 @@ class HuiEnergyDistrubutionCard
                     </animateMotion>
                   </circle>`
                 : ""}
-              ${solarToBattery
+              ${solarToBattery && this._animate
                 ? svg`<circle
                     r="1"
                     class="battery-solar"
@@ -735,7 +743,7 @@ class HuiEnergyDistrubutionCard
                     </animateMotion>
                   </circle>`
                 : ""}
-              ${batteryConsumption
+              ${batteryConsumption && this._animate
                 ? svg`<circle
                     r="1"
                     class="battery-house"
@@ -750,7 +758,7 @@ class HuiEnergyDistrubutionCard
                     </animateMotion>
                   </circle>`
                 : ""}
-              ${batteryFromGrid
+              ${batteryFromGrid && this._animate
                 ? svg`<circle
                     r="1"
                     class="battery-from-grid"
@@ -766,7 +774,7 @@ class HuiEnergyDistrubutionCard
                     </animateMotion>
                   </circle>`
                 : ""}
-              ${batteryToGrid
+              ${batteryToGrid && this._animate
                 ? svg`<circle
                     r="1"
                     class="battery-to-grid"

--- a/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
@@ -69,12 +69,6 @@ class HuiEnergyDistrubutionCard
     return 3;
   }
 
-  protected firstUpdated() {
-    if (matchMedia("(prefers-reduced-motion)").matches) {
-      this._animate = false;
-    }
-  }
-
   protected shouldUpdate(changedProps: PropertyValues): boolean {
     return (
       hasConfigChanged(this, changedProps) ||
@@ -84,6 +78,12 @@ class HuiEnergyDistrubutionCard
         this.hass.states[this._data.co2SignalEntity] !==
           changedProps.get("hass").states[this._data.co2SignalEntity])
     );
+  }
+
+  protected willUpdate() {
+    if (!this.hasUpdated && matchMedia("(prefers-reduced-motion)").matches) {
+      this._animate = false;
+    }
   }
 
   protected render() {
@@ -1044,16 +1044,20 @@ class HuiEnergyDistrubutionCard
       border-width: 2px;
     }
     .circle svg circle {
-      animation: rotate-in 0.6s ease-in;
-      transition:
-        stroke-dashoffset 0.4s,
-        stroke-dasharray 0.4s;
       fill: none;
     }
-    @keyframes rotate-in {
-      from {
-        stroke-dashoffset: 238.76104;
-        stroke-dasharray: 238.76104;
+    @media not (prefers-reduced-motion) {
+      .circle svg circle {
+        animation: rotate-in 0.6s ease-in;
+        transition:
+          stroke-dashoffset 0.4s,
+          stroke-dasharray 0.4s;
+      }
+      @keyframes rotate-in {
+        from {
+          stroke-dashoffset: 238.76104;
+          stroke-dasharray: 238.76104;
+        }
       }
     }
     .card-actions a {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Remove the animated moving dots on energy distribution if `prefers-reduced-motion` is set. 

I believe these are kind of unnecessary to convey the information (and happen to consume high cpu). 

I can't decide if this is an accessibility issue, but seems like it might qualify. Might also be good for users who want it on a slower or low-power dashboard.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://github.com/home-assistant/frontend/issues/13816
https://github.com/home-assistant/frontend/issues/17941
https://github.com/home-assistant/frontend/issues/24575
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
