### PR TITLE
Add entity filter section strategy

### DIFF
--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -5,6 +5,7 @@ import type { LovelaceStrategyConfig } from "./strategy";
 export interface LovelaceBaseSectionConfig {
   visibility?: Condition[];
   column_span?: number;
+  hidden?: boolean;
   row_span?: number;
   /**
    * @deprecated Use heading card instead.

--- a/src/panels/lovelace/sections/hui-grid-section.ts
+++ b/src/panels/lovelace/sections/hui-grid-section.ts
@@ -80,7 +80,7 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
 
     const cardsConfig = this._config?.cards ?? [];
 
-    const editMode = Boolean(this.lovelace?.editMode && !this.isStrategy);
+    const editMode = Boolean(this.lovelace?.editMode);
 
     const sortableOptions = this.importOnly
       ? IMPORT_MODE_CARD_SORTABLE_OPTIONS
@@ -88,7 +88,7 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
 
     return html`
       <ha-sortable
-        .disabled=${!editMode}
+        .disabled=${!(editMode && !this.isStrategy)}
         @drag-start=${this._dragStart}
         @drag-end=${this._dragEnd}
         draggable-selector=".card"
@@ -103,6 +103,7 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
           class="container ${classMap({
             "edit-mode": editMode,
             "import-only": this.importOnly,
+            "is-strategy": this.isStrategy,
           })}"
         >
           ${repeat(
@@ -133,7 +134,7 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
                   })}"
                   .sortableData=${cardPath}
                 >
-                  ${editMode
+                  ${editMode && !this.isStrategy
                     ? html`
                         <hui-card-edit-mode
                           .hass=${this.hass}
@@ -151,7 +152,7 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
               `;
             }
           )}
-          ${editMode && !this.importOnly
+          ${editMode && !this.importOnly && !this.isStrategy
             ? html`
                 <button
                   class="add"
@@ -244,6 +245,10 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
           border-start-end-radius: 0;
           border: 2px dashed var(--divider-color);
           min-height: var(--row-height);
+        }
+
+        .container.edit-mode.is-strategy {
+          border-style: solid;
         }
 
         .container.import-only {

--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -55,6 +55,8 @@ export class HuiSection extends ReactiveElement {
 
   @state() private _cards: HuiCard[] = [];
 
+  @state() private _config?: LovelaceSectionConfig;
+
   private _layoutElementType?: string;
 
   private _layoutElement?: LovelaceSectionElement;
@@ -195,6 +197,8 @@ export class HuiSection extends ReactiveElement {
       type: sectionConfig.type || DEFAULT_SECTION_LAYOUT,
     };
 
+    this._config = sectionConfig;
+
     // Create a new layout element if necessary.
     let addLayoutElement = false;
 
@@ -223,14 +227,16 @@ export class HuiSection extends ReactiveElement {
   }
 
   private _updateElement(forceVisible?: boolean) {
-    if (!this._layoutElement) {
+    if (!this._layoutElement || !this._config) {
       return;
     }
+
     const visible =
       forceVisible ||
       this.preview ||
-      !this.config.visibility ||
-      checkConditionsMet(this.config.visibility, this.hass);
+      (!this._config.hidden &&
+        (!this.config.visibility ||
+          checkConditionsMet(this.config.visibility, this.hass)));
 
     if (this.hidden !== !visible) {
       this.style.setProperty("display", visible ? "" : "none");

--- a/src/panels/lovelace/strategies/entities-filter/entities-filter-section-strategy.ts
+++ b/src/panels/lovelace/strategies/entities-filter/entities-filter-section-strategy.ts
@@ -1,0 +1,143 @@
+import { ReactiveElement } from "lit";
+import { customElement } from "lit/decorators";
+import {
+  generateEntityFilter,
+  type EntityFilter,
+} from "../../../../common/entity/entity_filter";
+import type { TileCardConfig, HeadingCardConfig } from "../../cards/types";
+import type { HomeAssistant } from "../../../../types";
+import type { LovelaceSectionConfig } from "../../../../data/lovelace/config/section";
+import type { LovelaceCardConfig } from "../../../../data/lovelace/config/card";
+import { ensureArray } from "../../../../common/array/ensure-array";
+
+interface EntityFilterConfig {
+  title?: string;
+  icon?: string;
+  filter?: EntityFilter | EntityFilter[];
+  include_entities?: string[];
+  exclude_entities?: string[];
+  order?: string[];
+}
+
+export type EntitiesFilterSectionStrategyConfig = EntityFilterConfig & {
+  type: "entities-filter";
+  groups?: EntityFilterConfig[];
+};
+
+const getEntities = (hass: HomeAssistant, config: EntityFilterConfig) => {
+  let entitiesIds =
+    config.filter || config.exclude_entities ? Object.keys(hass.states) : [];
+
+  if (config.exclude_entities) {
+    entitiesIds = entitiesIds.filter(
+      (entityId) => !config.exclude_entities!.includes(entityId)
+    );
+  }
+
+  if (config.filter) {
+    const filters = ensureArray(config.filter);
+    const entityFilters = filters.map((filter) =>
+      generateEntityFilter(hass, filter)
+    );
+
+    entitiesIds = entitiesIds.filter((entityId) =>
+      entityFilters.some((filter) => filter(entityId))
+    );
+  }
+
+  if (config.include_entities) {
+    entitiesIds.push(...config.include_entities);
+  }
+
+  if (config.order) {
+    entitiesIds.sort((a, b) => {
+      const aIndex = config.order!.indexOf(a);
+      const bIndex = config.order!.indexOf(b);
+      if (aIndex === -1 && bIndex === -1) return 0;
+      if (aIndex === -1) return 1;
+      if (bIndex === -1) return -1;
+      return aIndex - bIndex;
+    });
+  }
+
+  return entitiesIds;
+};
+
+@customElement("entities-filter-section-strategy")
+export class EntitiesFilterSectionStrategy extends ReactiveElement {
+  static async generate(
+    config: EntitiesFilterSectionStrategyConfig,
+    hass: HomeAssistant
+  ): Promise<LovelaceSectionConfig> {
+    const cards: LovelaceCardConfig[] = [];
+    let isEmpty = true;
+
+    if (config.title) {
+      const headingCard: HeadingCardConfig = {
+        type: "heading",
+        heading: config.title,
+        heading_style: "title",
+        icon: config.icon,
+      };
+      cards.push(headingCard);
+    }
+
+    const entities = getEntities(hass, config);
+
+    if (entities.length > 0) {
+      isEmpty = false;
+      for (const entityId of entities) {
+        const tileCard: TileCardConfig = {
+          type: "tile",
+          entity: entityId,
+        };
+        cards.push(tileCard);
+      }
+    }
+
+    if (config.groups) {
+      for (const group of config.groups) {
+        const groupEntities = getEntities(hass, group);
+
+        if (groupEntities.length > 0) {
+          isEmpty = false;
+          if (group.title) {
+            cards.push({
+              type: "heading",
+              heading: group.title,
+              heading_style: "subtitle",
+              icon: group.icon,
+            });
+          }
+
+          for (const entityId of groupEntities) {
+            const tileCard: TileCardConfig = {
+              type: "tile",
+              entity: entityId,
+            };
+            cards.push(tileCard);
+          }
+        }
+      }
+    }
+
+    if (isEmpty) {
+      cards.push({
+        type: "markdown",
+        content: "No entities found.",
+      });
+    }
+
+    return {
+      type: "grid",
+      cards: cards,
+      hidden: isEmpty,
+    };
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "entities-filter-section-strategy": EntitiesFilterSectionStrategy;
+  }
+}

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -35,7 +35,10 @@ const STRATEGIES: Record<LovelaceStrategyConfigType, Record<string, any>> = {
     area: () => import("./area/area-view-strategy"),
     areas: () => import("./areas/areas-view-strategy"),
   },
-  section: {},
+  section: {
+    "entities-filter": () =>
+      import("./entities-filter/entities-filter-section-strategy"),
+  },
 };
 
 export type LovelaceStrategyConfigType = "dashboard" | "view" | "section";


### PR DESCRIPTION
## Proposed change

The `entity-filter` strategy allows to create section using tile cards and filtered rules.

**Content**

- one tile card per entities matching the filter. 
- groups separated using the `heading` card with the `subtitle` style.

**Parameters**

All parameters are optional

```yaml
# Configuration
title: string # Title display at the top of the section
icon: string # Icon display display a the top of the section
filter: object|list # See filter rules
include_entities: list # List of entities to include (even if they don't match the filter)
exclude_entities: list # List of entities to exclude
group: list # See group

# Group
title: string # Title display at the top of the group
icon: string # Icon display display a the top of the group
filter: object|list # See filter rules
include_entities: list # List of entities to include (even if they don't match the filter)
exclude_entities: list # List of entities to exclude

# Filter rules
domain: string|list # Only include entities from certain entity domains
device_class: string|list # Only include entities with certain entity device class
device: string|list # Only include entities from certain device
area: string|list # Only include entities from certain areas
floor: string|list # Only include entities from certain floors
label: string|list # Only include entities with certain labels
entity_category: string|list # Only include entities with certain entity categories (none, configuration, diagnostic)
hidden_platform: string|list # If you want to hide entities from certains platform (e.g, mobile_app)


```
**Examples**

![CleanShot 2025-03-10 at 14 27 22](https://github.com/user-attachments/assets/e419e30f-800f-4d65-907a-e230a74ef682)

```yaml
strategy:
  type: entities-filter
  title: Climate
  icon: mdi:home-thermometer
  groups:
    - title: Thermostat and humidifier
      icon: mdi:thermostat
      filter:
        domain: 
          - climate
          - humidifier
        area: living_room
        entity_category: none
    - title: Shutters
      icon: mdi:window-shutter
      filter:
        domain: cover
        device_class:
          - shutters
        area: living_room
        entity_category: none
```

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
