### PR TITLE
Set icon width of hassio content card to prevent content shift of title/description

### DIFF
--- a/hassio/src/components/hassio-card-content.ts
+++ b/hassio/src/components/hassio-card-content.ts
@@ -40,6 +40,7 @@ class HassioCardContent extends LitElement {
                 src=${this.iconImage}
                 .title=${this.iconTitle}
                 alt=${this.iconTitle ?? ""}
+                width="40"
               />
               <div></div>
             </div>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Just a small fix to prevent the content shift of the addon title and description when the icon loads.
Setting the width to 40 tells the HTML DOM that there will be an image and keep the space until the icon is loaded.
We can hardcode the width because it's also hardcoded in the CSS. I didn't set the height as there can be icons that have different aspect ratios (to prevent distortion).

Content shift I'm speaking of:
<video src="https://github.com/user-attachments/assets/095342ff-23af-49b2-a342-d47a841d86a8" controls="controls" style="max-width: 730px;">
</video>

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

⚠️ Unfortunately I couldn't test it as I have setup the frontend to connect to my production instance and I couldn't get the hassio/addon settings to load!
But it's such a small change, it shouldn't produce any problems. But I would be glad if someone who has the correct dev stup could test it...

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
