### PR TITLE
Add attribute condition

### DIFF
--- a/src/panels/lovelace/editor/conditions/ha-card-conditions-editor.ts
+++ b/src/panels/lovelace/editor/conditions/ha-card-conditions-editor.ts
@@ -23,10 +23,12 @@ import "./types/ha-card-condition-or";
 import "./types/ha-card-condition-screen";
 import "./types/ha-card-condition-state";
 import "./types/ha-card-condition-user";
+import "./types/ha-card-condition-attribute";
 
 const UI_CONDITION = [
   "numeric_state",
   "state",
+  "attribute",
   "screen",
   "user",
   "and",

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-attribute.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-attribute.ts
@@ -1,0 +1,171 @@
+import type { PropertyValues } from "lit";
+import { html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { assert, literal, object, optional, string } from "superstruct";
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import type { LocalizeFunc } from "../../../../../common/translations/localize";
+import "../../../../../components/ha-form/ha-form";
+import type {
+  SchemaUnion,
+  HaFormSchema,
+} from "../../../../../components/ha-form/types";
+import type { HomeAssistant } from "../../../../../types";
+import type { AttributeCondition } from "../../../common/validate-condition";
+
+const attributeConditionStruct = object({
+  condition: literal("attribute"),
+  entity: optional(string()),
+  attribute: optional(string()),
+  attribute_value: optional(string()),
+  attribute_value_not: optional(string()),
+});
+
+interface AttributeConditionData {
+  condition: "attribute";
+  entity?: string;
+  attribute?: string;
+  invert: "true" | "false";
+  attribute_value?: string | string[];
+}
+
+@customElement("ha-card-condition-attribute")
+export class HaCardConditionAttribute extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public condition!: AttributeCondition;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  public static get defaultConfig(): AttributeCondition {
+    return {
+      condition: "attribute",
+      entity: "",
+      attribute: "",
+      attribute_value: "",
+    };
+  }
+
+  protected static validateUIConfig(condition: AttributeCondition) {
+    return assert(condition, attributeConditionStruct);
+  }
+
+  protected willUpdate(changedProperties: PropertyValues): void {
+    if (!changedProperties.has("condition")) {
+      return;
+    }
+    try {
+      assert(this.condition, attributeConditionStruct);
+    } catch (err: any) {
+      fireEvent(this, "ui-mode-not-available", err);
+    }
+  }
+
+  private _schema = memoizeOne(
+    (localize: LocalizeFunc) =>
+      [
+        { name: "entity", selector: { entity: {} } },
+        {
+          name: "attribute",
+          selector: { attribute: {} },
+          context: {
+            filter_entity: "entity",
+          },
+        },
+        {
+          name: "",
+          type: "grid",
+          schema: [
+            {
+              name: "invert",
+              required: true,
+              selector: {
+                select: {
+                  mode: "dropdown",
+                  options: [
+                    {
+                      label: localize(
+                        "ui.panel.lovelace.editor.condition-editor.condition.attribute.attribute_equal"
+                      ),
+                      value: "false",
+                    },
+                    {
+                      label: localize(
+                        "ui.panel.lovelace.editor.condition-editor.condition.attribute.attribute_not_equal"
+                      ),
+                      value: "true",
+                    },
+                  ],
+                },
+              },
+            },
+            {
+              name: "attribute_value",
+              selector: { text: {} },
+            },
+          ],
+        },
+      ] as const satisfies readonly HaFormSchema[]
+  );
+
+  protected render() {
+    const { attribute_value, attribute_value_not, ...content } = this.condition;
+
+    const data: AttributeConditionData = {
+      ...content,
+      entity: this.condition.entity,
+      attribute: this.condition.attribute,
+      invert: attribute_value_not !== undefined ? "true" : "false",
+      attribute_value: attribute_value_not ?? attribute_value,
+    };
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._schema(this.hass.localize)}
+        .disabled=${this.disabled}
+        @value-changed=${this._valueChanged}
+        .computeLabel=${this._computeLabelCallback}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const data = ev.detail.value as AttributeConditionData;
+
+    const { invert, attribute_value, condition: _, ...content } = data;
+
+    const condition: AttributeCondition = {
+      condition: "attribute",
+      ...content,
+      attribute_value: invert === "false" ? (attribute_value ?? "") : undefined,
+      attribute_value_not:
+        invert === "true" ? (attribute_value ?? "") : undefined,
+    };
+
+    fireEvent(this, "value-changed", { value: condition });
+  }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ): string => {
+    switch (schema.name) {
+      case "entity":
+        return this.hass.localize("ui.components.entity.entity-picker.entity");
+      case "attribute":
+        return this.hass.localize(
+          "ui.components.entity.entity-attribute-picker.attribute"
+        );
+      default:
+        return "";
+    }
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-card-condition-attribute": HaCardConditionAttribute;
+  }
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6812,6 +6812,11 @@
                 "state_equal": "State is equal to",
                 "state_not_equal": "State is not equal to"
               },
+              "attribute": {
+                "label": "Entity attribute",
+                "attribute_equal": "Attribute is equal to",
+                "attribute_not_equal": "Attribute is not equal to"
+              },
               "user": {
                 "label": "User"
               },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
New simple condition for attributes. Basically the same as the "Entity state" condition, just extended by attribute.  

Example config would look like:
```yaml
condition: attribute
entity: sun.sun
attribute: rising
attribute_value: "true"
```
<img width="300" alt="attribute-condition" src="https://github.com/user-attachments/assets/862a67d9-de77-434d-a1d6-d39c4adbe93e" />

The actual comparison is string based, the user is able to set the match/not match condition as a string (as in the other conditions, that string can be an entityId, resulting in the entity state to be used as compare value).
The attribute values are always treated as strings, too. e.g. `true` is `"true"`, `0` is`"0"`. This means if the actual attribute value is `true`(boolean) it will match when the user enters "true".

Values have to be an exact match so there is no option to use e.g. "above", "below" for numeric values. This would need an additional  new condition, similar to "Entity numeric state".

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/discussions/21550
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
