### PR TITLE
Dev tools -> yaml: use "pre" instead of "span" for "validate-log"

### DIFF
--- a/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
+++ b/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
@@ -120,8 +120,8 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.errors"
                             )}
                           >
-                            <span class="validate-log"
-                              >${this._validateResult.errors}</span
+                            <pre class="validate-log"
+                              >${this._validateResult.errors}</pre
                             >
                           </ha-alert>`
                         : ""
@@ -134,8 +134,8 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.warnings"
                             )}
                           >
-                            <span class="validate-log"
-                              >${this._validateResult.warnings}</span
+                            <pre class="validate-log"
+                              >${this._validateResult.warnings}</pre
                             >
                           </ha-alert>`
                         : ""
@@ -246,6 +246,7 @@ export class DeveloperYamlConfig extends LitElement {
         .validate-log {
           white-space: pre-wrap;
           direction: ltr;
+          margin: 0 !important;
         }
 
         .content {

--- a/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
+++ b/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
@@ -120,7 +120,9 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.errors"
                             )}
                           >
-                            <pre class="validate-log">${this._validateResult.errors}</pre>
+                            <pre class="validate-log">
+                              ${this._validateResult.errors}</pre
+                            >
                           </ha-alert>`
                         : ""
                     }
@@ -132,7 +134,9 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.warnings"
                             )}
                           >
-                            <pre class="validate-log">${this._validateResult.warnings}</pre>
+                            <pre class="validate-log">
+                              ${this._validateResult.warnings}</pre
+                            >
                           </ha-alert>`
                         : ""
                     }

--- a/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
+++ b/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
@@ -120,9 +120,7 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.errors"
                             )}
                           >
-                            <pre class="validate-log">
-                              ${this._validateResult.errors}</pre
-                            >
+                            <pre class="validate-log">${this._validateResult.errors}</pre>
                           </ha-alert>`
                         : ""
                     }
@@ -134,9 +132,7 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.warnings"
                             )}
                           >
-                            <pre class="validate-log">
-                              ${this._validateResult.warnings}</pre
-                            >
+                            <pre class="validate-log">${this._validateResult.warnings}</pre>
                           </ha-alert>`
                         : ""
                     }

--- a/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
+++ b/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
@@ -120,9 +120,7 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.errors"
                             )}
                           >
-                            <pre class="validate-log"
-                              >${this._validateResult.errors}</pre
-                            >
+                            <pre class="validate-log">${this._validateResult.errors}</pre>
                           </ha-alert>`
                         : ""
                     }
@@ -134,9 +132,7 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.warnings"
                             )}
                           >
-                            <pre class="validate-log"
-                              >${this._validateResult.warnings}</pre
-                            >
+                            <pre class="validate-log">${this._validateResult.warnings}</pre>
                           </ha-alert>`
                         : ""
                     }

--- a/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
+++ b/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
@@ -120,6 +120,7 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.errors"
                             )}
                           >
+                            <!-- prettier-ignore -->
                             <pre class="validate-log">${this._validateResult
                               .errors}</pre>
                           </ha-alert>`
@@ -133,6 +134,7 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.warnings"
                             )}
                           >
+                            <!-- prettier-ignore -->
                             <pre class="validate-log">${this._validateResult
                               .warnings}</pre>
                           </ha-alert>`

--- a/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
+++ b/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
@@ -120,8 +120,8 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.errors"
                             )}
                           >
-                            <pre class="validate-log">${this._validateResult.errors}<
-                            /pre>
+                            <pre class="validate-log">${this._validateResult.
+                                                        errors}</pre>
                           </ha-alert>`
                         : ""
                     }
@@ -133,8 +133,8 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.warnings"
                             )}
                           >
-                            <pre class="validate-log">${this._validateResult.warnings}<
-                            /pre>
+                            <pre class="validate-log">${this._validateResult.
+                                                        warnings}</pre>
                           </ha-alert>`
                         : ""
                     }

--- a/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
+++ b/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
@@ -120,7 +120,8 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.errors"
                             )}
                           >
-                            <pre class="validate-log">${this._validateResult.errors}</pre>
+                            <pre class="validate-log">${this._validateResult.errors}<
+                            /pre>
                           </ha-alert>`
                         : ""
                     }
@@ -132,7 +133,8 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.warnings"
                             )}
                           >
-                            <pre class="validate-log">${this._validateResult.warnings}</pre>
+                            <pre class="validate-log">${this._validateResult.warnings}<
+                            /pre>
                           </ha-alert>`
                         : ""
                     }

--- a/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
+++ b/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
@@ -246,7 +246,7 @@ export class DeveloperYamlConfig extends LitElement {
         .validate-log {
           white-space: pre-wrap;
           direction: ltr;
-          margin: 0 !important;
+          margin: 0;
         }
 
         .content {

--- a/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
+++ b/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
@@ -120,8 +120,8 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.errors"
                             )}
                           >
-                            <pre class="validate-log">${this._validateResult.
-                                                        errors}</pre>
+                            <!-- prettier-ignore -->
+                            <pre class="validate-log">${this._validateResult.errors}</pre>
                           </ha-alert>`
                         : ""
                     }
@@ -133,8 +133,8 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.warnings"
                             )}
                           >
-                            <pre class="validate-log">${this._validateResult.
-                                                        warnings}</pre>
+                            <!-- prettier-ignore -->
+                            <pre class="validate-log">${this._validateResult.warnings}</pre>
                           </ha-alert>`
                         : ""
                     }

--- a/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
+++ b/src/panels/developer-tools/yaml_configuration/developer-yaml-config.ts
@@ -120,8 +120,8 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.errors"
                             )}
                           >
-                            <!-- prettier-ignore -->
-                            <pre class="validate-log">${this._validateResult.errors}</pre>
+                            <pre class="validate-log">${this._validateResult
+                              .errors}</pre>
                           </ha-alert>`
                         : ""
                     }
@@ -133,8 +133,8 @@ export class DeveloperYamlConfig extends LitElement {
                               "ui.panel.developer-tools.tabs.yaml.section.validation.warnings"
                             )}
                           >
-                            <!-- prettier-ignore -->
-                            <pre class="validate-log">${this._validateResult.warnings}</pre>
+                            <pre class="validate-log">${this._validateResult
+                              .warnings}</pre>
                           </ha-alert>`
                         : ""
                     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Before:
![изображение](https://github.com/user-attachments/assets/7252bcca-a8a0-48f3-88df-1e5b59ce70c2)

After:
![изображение](https://github.com/user-attachments/assets/70e9f507-988e-4ff1-8b55-1927ac138aaa)

My subjective opinion is that using a monospace font for Logs (and this is a small log) containing technical stuff is better than using a proportional font.

Also, there is one more practical outcome - fixing an issue.
It is not possible to select this text in FF:
![изображение](https://github.com/user-attachments/assets/6acfc43b-8739-47d7-90fe-ce33aec8a8f9)
But it is possible in Chrome 134.0.6998.89, MS Edge 134.0.3124.72 (Official build) (64-bit).
Just a guess (I am not a css pro) that FF does not like a multiline span.
As a workaround, I considered to set `-moz-user-select: all` for `.validate-log`.
But in the end proposed a different way.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/24720
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
