### PR TITLE
Change date-time formatting to respect user date format preference

### DIFF
--- a/src/common/datetime/format_date.ts
+++ b/src/common/datetime/format_date.ts
@@ -9,7 +9,29 @@ export const formatDateWeekdayDay = (
   dateObj: Date,
   locale: FrontendLocaleData,
   config: HassConfig
-) => formatDateWeekdayDayMem(locale, config.time_zone).format(dateObj);
+) => {
+  const formatter = formatDateWeekdayDayMem(locale, config.time_zone);
+
+  if (
+    locale.date_format === DateFormat.language ||
+    locale.date_format === DateFormat.system
+  ) {
+    return formatter.format(dateObj);
+  }
+
+  const parts = formatter.formatToParts(dateObj);
+  const day = parts.find((part) => part.type === "day")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const weekday = parts.find((part) => part.type === "weekday")?.value;
+
+  const formats = {
+    [DateFormat.DMY]: `${weekday}, ${day} ${month}`,
+    [DateFormat.MDY]: `${weekday}, ${month} ${day}`,
+    [DateFormat.YMD]: `${weekday}, ${month} ${day}`,
+  };
+
+  return formats[locale.date_format];
+};
 
 const formatDateWeekdayDayMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
@@ -26,7 +48,29 @@ export const formatDate = (
   dateObj: Date,
   locale: FrontendLocaleData,
   config: HassConfig
-) => formatDateMem(locale, config.time_zone).format(dateObj);
+) => {
+  const formatter = formatDateMem(locale, config.time_zone);
+
+  if (
+    locale.date_format === DateFormat.language ||
+    locale.date_format === DateFormat.system
+  ) {
+    return formatter.format(dateObj);
+  }
+
+  const parts = formatter.formatToParts(dateObj);
+  const day = parts.find((part) => part.type === "day")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const year = parts.find((part) => part.type === "year")?.value;
+
+  const formats = {
+    [DateFormat.DMY]: `${day} ${month}, ${year}`,
+    [DateFormat.MDY]: `${month} ${day}, ${year}`,
+    [DateFormat.YMD]: `${year}, ${month} ${day}`,
+  };
+
+  return formats[locale.date_format];
+};
 
 const formatDateMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
@@ -43,7 +87,29 @@ export const formatDateShort = (
   dateObj: Date,
   locale: FrontendLocaleData,
   config: HassConfig
-) => formatDateShortMem(locale, config.time_zone).format(dateObj);
+) => {
+  const formatter = formatDateShortMem(locale, config.time_zone);
+
+  if (
+    locale.date_format === DateFormat.language ||
+    locale.date_format === DateFormat.system
+  ) {
+    return formatter.format(dateObj);
+  }
+
+  const parts = formatter.formatToParts(dateObj);
+  const day = parts.find((part) => part.type === "day")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const year = parts.find((part) => part.type === "year")?.value;
+
+  const formats = {
+    [DateFormat.DMY]: `${day} ${month}, ${year}`,
+    [DateFormat.MDY]: `${month} ${day}, ${year}`,
+    [DateFormat.YMD]: `${year}, ${month} ${day}`,
+  };
+
+  return formats[locale.date_format];
+};
 
 const formatDateShortMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
@@ -124,7 +190,28 @@ export const formatDateVeryShort = (
   dateObj: Date,
   locale: FrontendLocaleData,
   config: HassConfig
-) => formatDateVeryShortMem(locale, config.time_zone).format(dateObj);
+) => {
+  const formatter = formatDateVeryShortMem(locale, config.time_zone);
+
+  if (
+    locale.date_format === DateFormat.language ||
+    locale.date_format === DateFormat.system
+  ) {
+    return formatter.format(dateObj);
+  }
+
+  const parts = formatter.formatToParts(dateObj);
+  const day = parts.find((part) => part.type === "day")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+
+  const formats = {
+    [DateFormat.DMY]: `${day} ${month}`,
+    [DateFormat.MDY]: `${month} ${day}`,
+    [DateFormat.YMD]: `${month} ${day}`,
+  };
+
+  return formats[locale.date_format];
+};
 
 const formatDateVeryShortMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
@@ -140,7 +227,28 @@ export const formatDateMonthYear = (
   dateObj: Date,
   locale: FrontendLocaleData,
   config: HassConfig
-) => formatDateMonthYearMem(locale, config.time_zone).format(dateObj);
+) => {
+  const formatter = formatDateMonthYearMem(locale, config.time_zone);
+
+  if (
+    locale.date_format === DateFormat.language ||
+    locale.date_format === DateFormat.system
+  ) {
+    return formatter.format(dateObj);
+  }
+
+  const parts = formatter.formatToParts(dateObj);
+  const month = parts.find((part) => part.type === "month")?.value;
+  const year = parts.find((part) => part.type === "year")?.value;
+
+  const formats = {
+    [DateFormat.DMY]: `${month} ${year}`,
+    [DateFormat.MDY]: `${month} ${year}`,
+    [DateFormat.YMD]: `${year} ${month}`,
+  };
+
+  return formats[locale.date_format];
+};
 
 const formatDateMonthYearMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>

--- a/src/common/datetime/format_date_time.ts
+++ b/src/common/datetime/format_date_time.ts
@@ -1,6 +1,6 @@
 import type { HassConfig } from "home-assistant-js-websocket";
 import memoizeOne from "memoize-one";
-import type { FrontendLocaleData } from "../../data/translation";
+import { DateFormat, type FrontendLocaleData } from "../../data/translation";
 import { formatDateNumeric } from "./format_date";
 import { formatTime } from "./format_time";
 import { resolveTimeZone } from "./resolve-time-zone";
@@ -11,7 +11,31 @@ export const formatDateTime = (
   dateObj: Date,
   locale: FrontendLocaleData,
   config: HassConfig
-) => formatDateTimeMem(locale, config.time_zone).format(dateObj);
+) => {
+  const formatter = formatDateTimeMem(locale, config.time_zone);
+
+  if (
+    locale.date_format === DateFormat.language ||
+    locale.date_format === DateFormat.system
+  ) {
+    return formatter.format(dateObj);
+  }
+
+  const parts = formatter.formatToParts(dateObj);
+  const day = parts.find((part) => part.type === "day")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const year = parts.find((part) => part.type === "year")?.value;
+  const hour = parts.find((part) => part.type === "hour")?.value;
+  const minute = parts.find((part) => part.type === "minute")?.value;
+
+  const formats = {
+    [DateFormat.DMY]: `${day} ${month}, ${year}, ${hour}:${minute}`,
+    [DateFormat.MDY]: `${month} ${day}, ${year}, ${hour}:${minute}`,
+    [DateFormat.YMD]: `${year}, ${month} ${day}, ${hour}:${minute}`,
+  };
+
+  return formats[locale.date_format];
+};
 
 const formatDateTimeMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
@@ -45,7 +69,31 @@ export const formatShortDateTimeWithYear = (
   dateObj: Date,
   locale: FrontendLocaleData,
   config: HassConfig
-) => formatShortDateTimeWithYearMem(locale, config.time_zone).format(dateObj);
+) => {
+  const formatter = formatShortDateTimeWithYearMem(locale, config.time_zone);
+
+  if (
+    locale.date_format === DateFormat.language ||
+    locale.date_format === DateFormat.system
+  ) {
+    return formatter.format(dateObj);
+  }
+
+  const parts = formatter.formatToParts(dateObj);
+  const day = parts.find((part) => part.type === "day")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const year = parts.find((part) => part.type === "year")?.value;
+  const hour = parts.find((part) => part.type === "hour")?.value;
+  const minute = parts.find((part) => part.type === "minute")?.value;
+
+  const formats = {
+    [DateFormat.DMY]: `${day} ${month}, ${year}, ${hour}:${minute}`,
+    [DateFormat.MDY]: `${month} ${day}, ${year}, ${hour}:${minute}`,
+    [DateFormat.YMD]: `${year}, ${month} ${day}, ${hour}:${minute}`,
+  };
+
+  return formats[locale.date_format];
+};
 
 const formatShortDateTimeWithYearMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
@@ -65,7 +113,30 @@ export const formatShortDateTime = (
   dateObj: Date,
   locale: FrontendLocaleData,
   config: HassConfig
-) => formatShortDateTimeMem(locale, config.time_zone).format(dateObj);
+) => {
+  const formatter = formatShortDateTimeMem(locale, config.time_zone);
+
+  if (
+    locale.date_format === DateFormat.language ||
+    locale.date_format === DateFormat.system
+  ) {
+    return formatter.format(dateObj);
+  }
+
+  const parts = formatter.formatToParts(dateObj);
+  const day = parts.find((part) => part.type === "day")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const hour = parts.find((part) => part.type === "hour")?.value;
+  const minute = parts.find((part) => part.type === "minute")?.value;
+
+  const formats = {
+    [DateFormat.DMY]: `${day} ${month}, ${hour}:${minute}`,
+    [DateFormat.MDY]: `${month} ${day}, ${hour}:${minute}`,
+    [DateFormat.YMD]: `${month} ${day}, ${hour}:${minute}`,
+  };
+
+  return formats[locale.date_format];
+};
 
 const formatShortDateTimeMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
@@ -96,7 +167,32 @@ export const formatDateTimeWithSeconds = (
   dateObj: Date,
   locale: FrontendLocaleData,
   config: HassConfig
-) => formatDateTimeWithSecondsMem(locale, config.time_zone).format(dateObj);
+) => {
+  const formatter = formatDateTimeWithSecondsMem(locale, config.time_zone);
+
+  if (
+    locale.date_format === DateFormat.language ||
+    locale.date_format === DateFormat.system
+  ) {
+    return formatter.format(dateObj);
+  }
+
+  const parts = formatter.formatToParts(dateObj);
+  const day = parts.find((part) => part.type === "day")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const year = parts.find((part) => part.type === "year")?.value;
+  const hour = parts.find((part) => part.type === "hour")?.value;
+  const minute = parts.find((part) => part.type === "minute")?.value;
+  const second = parts.find((part) => part.type === "second")?.value;
+
+  const formats = {
+    [DateFormat.DMY]: `${day} ${month}, ${year}, ${hour}:${minute}:${second}`,
+    [DateFormat.MDY]: `${month} ${day}, ${year}, ${hour}:${minute}:${second}`,
+    [DateFormat.YMD]: `${year}, ${month} ${day}, ${hour}:${minute}:${second}`,
+  };
+
+  return formats[locale.date_format];
+};
 
 const formatDateTimeWithSecondsMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Make non-numeric date formatting consistent with the user's date format preference.

Fixes #22900

As the issue describes, the user setting for date format is not adhered to in non-numeric date representations. Since the setting does not specify that it only applies to numeric representations, this seems unintended.

This change makes written representations also follow the preference by using `formatToParts` to construct the appropriate output strings, just like `formatDateNumeric` already did.

Setting in `/profile/general`:
![image](https://github.com/user-attachments/assets/257870eb-6e25-4b0c-84f5-57245fc490cd)

Result in a history graph:
![image](https://github.com/user-attachments/assets/b51b36a2-3629-4625-aab5-ffcaf061b876)


## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
In `/profile/general`, set "Language" to English and "Date format" to Year-Month-Day to see an example. 

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22900

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
