### PR TITLE
Update entity naming in entity picker

### DIFF
--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -497,32 +497,32 @@ export class HaEntityPicker extends LitElement {
     const target = ev.target as HaComboBox;
     const filterString = ev.detail.value.trim().toLowerCase() as string;
 
-    const index = this._fuseIndex(this.items);
-
     const minLength = 2;
 
-    const options: IFuseOptions<EntityPickerItem> = {
-      isCaseSensitive: false,
-      threshold: 0.3,
-      ignoreDiacritics: true,
-      minMatchCharLength: minLength,
-    };
+    const searchTerms = (filterString.split(" ") ?? []).filter(
+      (term) => term.length >= minLength
+    );
 
-    const fuse = new Fuse(this.items, options, index);
+    if (searchTerms.length > 0) {
+      const index = this._fuseIndex(this.items);
 
-    const searchString = (
-      filterString.match(/("[^"]*?"|[^"\s]+)+(?=\s*|\s*$)/g) ?? []
-    ).filter((term) => term.length >= minLength);
+      const options: IFuseOptions<EntityPickerItem> = {
+        isCaseSensitive: false,
+        threshold: 0.3,
+        ignoreDiacritics: true,
+        minMatchCharLength: minLength,
+      };
 
-    const results = fuse.search({
-      $and: searchString.map((term) => ({
-        $or: this._fuseKeys.map((key) => ({ [key]: term })),
-      })),
-    });
-
-    target.filteredItems = searchString.length
-      ? results.map((result) => result.item)
-      : this.items;
+      const fuse = new Fuse(this.items, options, index);
+      const results = fuse.search({
+        $and: searchTerms.map((term) => ({
+          $or: this._fuseKeys.map((key) => ({ [key]: term })),
+        })),
+      });
+      target.filteredItems = results.map((result) => result.item);
+    } else {
+      target.filteredItems = this.items;
+    }
   }
 
   private _setValue(value: string | undefined) {

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -137,6 +137,11 @@ export class HaEntityPicker extends LitElement {
 
   private _states: HassEntityWithCachedName[] = [];
 
+  protected firstUpdated(changedProperties: PropertyValues): void {
+    super.firstUpdated(changedProperties);
+    this.hass.loadBackendTranslation("title");
+  }
+
   private _rowRenderer: ComboBoxLitRenderer<HassEntityWithCachedName> = (
     item
   ) => html`

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -158,8 +158,11 @@ export class HaEntityPicker extends LitElement {
     this.hass.loadBackendTranslation("title");
   }
 
-  private _rowRenderer: ComboBoxLitRenderer<EntityPickerItem> = (item) => html`
-    <ha-combo-box-item type="button" compact>
+  private _rowRenderer: ComboBoxLitRenderer<EntityPickerItem> = (
+    item,
+    { index }
+  ) => html`
+    <ha-combo-box-item type="button" compact .borderTop=${index !== 0}>
       ${item.icon_path
         ? html`<ha-svg-icon slot="start" .path=${item.icon_path}></ha-svg-icon>`
         : html`

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -145,14 +145,12 @@ export class HaEntityPicker extends LitElement {
   private _rowRenderer: ComboBoxLitRenderer<HassEntityWithCachedName> = (
     item
   ) => html`
-    <ha-combo-box-item type="button">
-      ${html`
-        <state-badge
-          slot="start"
-          .stateObj=${item}
-          .hass=${this.hass}
-        ></state-badge>
-      `}
+    <ha-combo-box-item type="button" compact>
+      <state-badge
+        slot="start"
+        .stateObj=${item}
+        .hass=${this.hass}
+      ></state-badge>
       <span slot="headline">${item.primary} </span>
       ${item.secondary
         ? html`<span slot="supporting-text">${item.secondary}</span>`

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -57,6 +57,22 @@ export type HaEntityPickerEntityFilterFunc = (entity: HassEntity) => boolean;
 
 const CREATE_ID = "___create-new-entity___";
 
+const DOMAIN_STYLE = styleMap({
+  fontSize: "12px",
+  fontWeight: "400",
+  lineHeight: "18px",
+  alignSelf: "flex-end",
+  maxWidth: "30%",
+  textOverflow: "ellipsis",
+  overflow: "hidden",
+  whiteSpace: "nowrap",
+});
+
+const ENTITY_ID_STYLE = styleMap({
+  fontFamily: "var(--code-font-family, monospace)",
+  fontSize: "11px",
+});
+
 @customElement("ha-entity-picker")
 export class HaEntityPicker extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -178,29 +194,12 @@ export class HaEntityPicker extends LitElement {
         ? html`<span slot="supporting-text">${item.secondary}</span>`
         : nothing}
       ${item.entity_id && item.show_entity_id
-        ? html`<span
-            slot="supporting-text"
-            style=${styleMap({
-              fontFamily: "var(--code-font-family, monospace)",
-              fontSize: "11px",
-            })}
+        ? html`<span slot="supporting-text" style=${ENTITY_ID_STYLE}
             >${item.entity_id}</span
           >`
         : nothing}
       ${item.translated_domain && !item.show_entity_id
-        ? html`<div
-            slot="trailing-supporting-text"
-            style=${styleMap({
-              fontSize: "12px",
-              fontWeight: "400",
-              lineHeight: "18px",
-              alignSelf: "flex-end",
-              maxWidth: "30%",
-              textOverflow: "ellipsis",
-              overflow: "hidden",
-              whiteSpace: "nowrap",
-            })}
-          >
+        ? html`<div slot="trailing-supporting-text" style=${DOMAIN_STYLE}>
             ${item.translated_domain}
           </div>`
         : nothing}

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -167,7 +167,7 @@ export class HaEntityPicker extends LitElement {
 
   private _initialItems = false;
 
-  private items: EntityPickerItem[] = [];
+  private _items: EntityPickerItem[] = [];
 
   protected firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
@@ -406,7 +406,7 @@ export class HaEntityPicker extends LitElement {
 
   public willUpdate(changedProps: PropertyValues) {
     if (!this._initialItems || (changedProps.has("_opened") && this._opened)) {
-      this.items = this._getItems(
+      this._items = this._getItems(
         this._opened,
         this.hass,
         this.includeDomains,
@@ -419,7 +419,7 @@ export class HaEntityPicker extends LitElement {
         this.createDomains
       );
       if (this._initialItems) {
-        this.comboBox.filteredItems = this.items;
+        this.comboBox.filteredItems = this._items;
       }
       this._initialItems = true;
     }
@@ -441,7 +441,7 @@ export class HaEntityPicker extends LitElement {
           : this.label}
         .helper=${this.helper}
         .allowCustomValue=${this.allowCustomEntity}
-        .filteredItems=${this.items}
+        .filteredItems=${this._items}
         .renderer=${this._rowRenderer}
         .required=${this.required}
         .disabled=${this.disabled}
@@ -506,7 +506,7 @@ export class HaEntityPicker extends LitElement {
     );
 
     if (searchTerms.length > 0) {
-      const index = this._fuseIndex(this.items);
+      const index = this._fuseIndex(this._items);
 
       const options: IFuseOptions<EntityPickerItem> = {
         isCaseSensitive: false,
@@ -515,7 +515,7 @@ export class HaEntityPicker extends LitElement {
         minMatchCharLength: minLength,
       };
 
-      const fuse = new Fuse(this.items, options, index);
+      const fuse = new Fuse(this._items, options, index);
       const results = fuse.search({
         $and: searchTerms.map((term) => ({
           $or: this._fuseKeys.map((key) => ({ [key]: term })),
@@ -523,7 +523,7 @@ export class HaEntityPicker extends LitElement {
       });
       target.filteredItems = results.map((result) => result.item);
     } else {
-      target.filteredItems = this.items;
+      target.filteredItems = this._items;
     }
   }
 

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -303,7 +303,7 @@ export class HaEntityPicker extends LitElement {
           const primary = entityName || deviceName || entityId;
           const secondary = [areaName, entityName ? deviceName : undefined]
             .filter(Boolean)
-            .join(isRTL ? " < " : " > ");
+            .join(isRTL ? " ◂ " : " ▸ ");
 
           const translatedDomain = domainToName(
             this.hass.localize,

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -166,10 +166,10 @@ export class HaEntityPicker extends LitElement {
         ? html`<div
             slot="trailing-supporting-text"
             style=${styleMap({
-              fontFamily: "var(--code-font-family, monospace)",
-              fontSize: "11px",
+              fontSize: "12px",
+              fontWeight: "400",
+              lineHeight: "18px",
               alignSelf: "flex-end",
-              marginBottom: "2px",
               maxWidth: "30%",
               textOverflow: "ellipsis",
               overflow: "hidden",
@@ -302,6 +302,11 @@ export class HaEntityPicker extends LitElement {
             .filter(Boolean)
             .join(isRTL ? " < " : " > ");
 
+          const translatedDomain = domainToName(
+            this.hass.localize,
+            computeDomain(entityId)
+          );
+
           return {
             ...hass!.states[entityId],
             primary: primary,
@@ -309,7 +314,7 @@ export class HaEntityPicker extends LitElement {
               secondary ||
               this.hass.localize("ui.components.device-picker.no_area"),
             label: friendlyName,
-            domain: computeDomain(entityId),
+            domain: translatedDomain,
             sortingLabel: [deviceName, entityName].filter(Boolean).join("-"),
             strings: [
               entityId,

--- a/src/components/ha-combo-box-item.ts
+++ b/src/components/ha-combo-box-item.ts
@@ -9,16 +9,12 @@ export class HaComboBoxItem extends HaMdListItem {
     css`
       :host {
         --md-list-item-two-line-container-height: 64px;
-        --md-list-item-leading-space: 12px;
-        --md-list-item-trailing-space: 12px;
       }
       md-item {
-        gap: 8px;
         border-bottom: 1px solid var(--divider-color);
       }
       [slot="start"] {
         --paper-item-icon-color: var(--secondary-text-color);
-        min-width: 40px;
       }
       [slot="headline"] {
         line-height: 22px;
@@ -29,6 +25,10 @@ export class HaComboBoxItem extends HaMdListItem {
         line-height: 18px;
         font-size: 12px;
         white-space: nowrap;
+      }
+      ::slotted(state-badge) {
+        width: 32px;
+        height: 32px;
       }
     `,
   ];

--- a/src/components/ha-combo-box-item.ts
+++ b/src/components/ha-combo-box-item.ts
@@ -1,17 +1,20 @@
 import { css } from "lit";
-import { customElement } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import { HaMdListItem } from "./ha-md-list-item";
 
 @customElement("ha-combo-box-item")
 export class HaComboBoxItem extends HaMdListItem {
+  @property({ type: Boolean, reflect: true, attribute: "border-top" })
+  public borderTop = false;
+
   static override styles = [
     ...super.styles,
     css`
       :host {
         --md-list-item-two-line-container-height: 64px;
       }
-      md-item {
-        border-bottom: 1px solid var(--divider-color);
+      :host([border-top]) md-item {
+        border-top: 1px solid var(--divider-color);
       }
       [slot="start"] {
         --paper-item-icon-color: var(--secondary-text-color);

--- a/src/components/ha-combo-box-item.ts
+++ b/src/components/ha-combo-box-item.ts
@@ -18,19 +18,17 @@ export class HaComboBoxItem extends HaMdListItem {
       }
       [slot="start"] {
         --paper-item-icon-color: var(--secondary-text-color);
-        width: 40px;
-      }
-      [slot="headline"],
-      [slot="supporting-text"] {
-        white-space: nowrap;
+        min-width: 40px;
       }
       [slot="headline"] {
         line-height: 22px;
         font-size: 14px;
+        white-space: nowrap;
       }
       [slot="supporting-text"] {
         line-height: 18px;
         font-size: 12px;
+        white-space: nowrap;
       }
     `,
   ];

--- a/src/components/ha-combo-box-item.ts
+++ b/src/components/ha-combo-box-item.ts
@@ -1,0 +1,34 @@
+import { css } from "lit";
+import { customElement } from "lit/decorators";
+import { HaMdListItem } from "./ha-md-list-item";
+
+@customElement("ha-combo-box-item")
+export class HaComboBoxItem extends HaMdListItem {
+  static override styles = [
+    ...super.styles,
+    css`
+      :host {
+        --md-list-item-two-line-container-height: 64px;
+        --md-list-item-leading-space: 12px;
+        --md-list-item-trailing-space: 12px;
+      }
+      md-item {
+        gap: 8px;
+      }
+      [slot="start"] {
+        --paper-item-icon-color: var(--secondary-text-color);
+        width: 40px;
+      }
+      [slot="headline"],
+      [slot="supporting-text"] {
+        white-space: nowrap;
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-combo-box-item": HaComboBoxItem;
+  }
+}

--- a/src/components/ha-combo-box-item.ts
+++ b/src/components/ha-combo-box-item.ts
@@ -14,6 +14,7 @@ export class HaComboBoxItem extends HaMdListItem {
       }
       md-item {
         gap: 8px;
+        border-bottom: 1px solid var(--divider-color);
       }
       [slot="start"] {
         --paper-item-icon-color: var(--secondary-text-color);
@@ -22,6 +23,14 @@ export class HaComboBoxItem extends HaMdListItem {
       [slot="headline"],
       [slot="supporting-text"] {
         white-space: nowrap;
+      }
+      [slot="headline"] {
+        line-height: 22px;
+        font-size: 14px;
+      }
+      [slot="supporting-text"] {
+        line-height: 18px;
+        font-size: 12px;
       }
     `,
   ];

--- a/src/data/frontend.ts
+++ b/src/data/frontend.ts
@@ -3,6 +3,7 @@ import { getOptimisticCollection } from "./collection";
 
 export interface CoreFrontendUserData {
   showAdvanced?: boolean;
+  showEntityIdPicker?: boolean;
 }
 
 declare global {

--- a/src/panels/profile/ha-entity-id-picker-row.ts
+++ b/src/panels/profile/ha-entity-id-picker-row.ts
@@ -1,0 +1,53 @@
+import type { TemplateResult } from "lit";
+import { css, html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import "../../components/ha-card";
+import "../../components/ha-settings-row";
+import "../../components/ha-switch";
+import type { CoreFrontendUserData } from "../../data/frontend";
+import { getOptimisticFrontendUserDataCollection } from "../../data/frontend";
+import type { HomeAssistant } from "../../types";
+
+@customElement("ha-entity-id-picker-row")
+class EntityIdPickerRow extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ type: Boolean }) public narrow = false;
+
+  @property({ attribute: false }) public coreUserData?: CoreFrontendUserData;
+
+  protected render(): TemplateResult {
+    return html`
+      <ha-settings-row .narrow=${this.narrow}>
+        <span slot="heading"> Display entity IDs in picker </span>
+        <span slot="description">
+          Shows the full entity IDs when selecting items
+        </span>
+        <ha-switch
+          .checked=${this.coreUserData && this.coreUserData.showEntityIdPicker}
+          .disabled=${this.coreUserData === undefined}
+          @change=${this._advancedToggled}
+        ></ha-switch>
+      </ha-settings-row>
+    `;
+  }
+
+  private async _advancedToggled(ev) {
+    getOptimisticFrontendUserDataCollection(this.hass.connection, "core").save({
+      ...this.coreUserData,
+      showEntityIdPicker: ev.currentTarget.checked,
+    });
+  }
+
+  static styles = css`
+    a {
+      color: var(--primary-color);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-entity-id-picker-row": EntityIdPickerRow;
+  }
+}

--- a/src/panels/profile/ha-entity-id-picker-row.ts
+++ b/src/panels/profile/ha-entity-id-picker-row.ts
@@ -19,20 +19,22 @@ class EntityIdPickerRow extends LitElement {
   protected render(): TemplateResult {
     return html`
       <ha-settings-row .narrow=${this.narrow}>
-        <span slot="heading"> Display entity IDs in picker </span>
+        <span slot="heading">
+          ${this.hass.localize("ui.panel.profile.entity_id_picker.title")}</span
+        >
         <span slot="description">
-          Shows the full entity IDs when selecting items
+          ${this.hass.localize("ui.panel.profile.entity_id_picker.description")}
         </span>
         <ha-switch
           .checked=${this.coreUserData && this.coreUserData.showEntityIdPicker}
           .disabled=${this.coreUserData === undefined}
-          @change=${this._advancedToggled}
+          @change=${this._toggled}
         ></ha-switch>
       </ha-settings-row>
     `;
   }
 
-  private async _advancedToggled(ev) {
+  private async _toggled(ev) {
     getOptimisticFrontendUserDataCollection(this.hass.connection, "core").save({
       ...this.coreUserData,
       showEntityIdPicker: ev.currentTarget.checked,

--- a/src/panels/profile/ha-profile-section-general.ts
+++ b/src/panels/profile/ha-profile-section-general.ts
@@ -16,6 +16,7 @@ import { haStyle } from "../../resources/styles";
 import type { HomeAssistant, Route } from "../../types";
 import "./ha-advanced-mode-row";
 import "./ha-enable-shortcuts-row";
+import "./ha-entity-id-picker-row";
 import "./ha-force-narrow-row";
 import "./ha-pick-dashboard-row";
 import "./ha-pick-first-weekday-row";
@@ -154,6 +155,15 @@ class HaProfileSectionGeneral extends LitElement {
                     .narrow=${this.narrow}
                     .coreUserData=${this._coreUserData}
                   ></ha-advanced-mode-row>
+                `
+              : ""}
+            ${this.hass.user!.is_admin
+              ? html`
+                  <ha-entity-id-picker-row
+                    .hass=${this.hass}
+                    .narrow=${this.narrow}
+                    .coreUserData=${this._coreUserData}
+                  ></ha-entity-id-picker-row>
                 `
               : ""}
           </ha-card>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7845,6 +7845,10 @@
           "description": "Unlocks advanced features.",
           "link_promo": "Learn more"
         },
+        "entity_id_picker": {
+          "title": "Display entity IDs in picker",
+          "description": "Shows the full entity IDs when selecting entities with a picker."
+        },
         "refresh_tokens": {
           "header": "Refresh tokens",
           "description": "Each refresh token represents a login session. Refresh tokens will be automatically deleted when you log out. Unused refresh tokens will be automatically deleted after 90 days. The following refresh tokens are currently active for your account.",


### PR DESCRIPTION
## Proposed change

Display entity name, device name, domain and area in the device picker.
When a entity is selected, the label is still the friendly_name. Only row items are changed.
The items are sorting by device name and entity name so the entity are grouped by device.

![CleanShot 2025-04-15 at 18 15 30](https://github.com/user-attachments/assets/d7190e93-3c57-490c-a97a-ce8c2a9938fc)

The entity ID not displayed because it's technical and it should not be needed for most users as more context has been added. However, you can still display it by enabling it with a dedicated setting in the profile.

![CleanShot 2025-04-15 at 18 16 18](https://github.com/user-attachments/assets/13b2aa3d-a4c2-4fc0-981f-f7ad3a2e68eb)

It will end up with this result : the domain is removed and the entity is displayed in a third line.

![CleanShot 2025-04-15 at 18 15 56](https://github.com/user-attachments/assets/88b01278-5062-4cab-ab11-ef59d4cabc52)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
