### PR TITLE
Fix height & scroll in hui-dialog-create-card

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
@@ -58,6 +58,8 @@ export class HuiCardPicker extends LitElement {
 
   @state() private _filter = "";
 
+  private _prevFilter = "";
+
   private _unusedEntities?: string[];
 
   private _usedEntities?: string[];
@@ -253,9 +255,12 @@ export class HuiCardPicker extends LitElement {
 
   protected updated(changedProps) {
     super.updated(changedProps);
-    const div = this.parentElement!.shadowRoot!.getElementById("content");
-    if (div) {
-      div.scrollTo({ behavior: "auto", top: 0 });
+    if (this._prevFilter !== this._filter) {
+      this._prevFilter = this._filter;
+      const div = this.parentElement!.shadowRoot!.getElementById("content");
+      if (div) {
+        div.scrollTo({ behavior: "auto", top: 0 });
+      }
     }
   }
 

--- a/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
@@ -4,7 +4,6 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
-import { styleMap } from "lit/directives/style-map";
 import { until } from "lit/directives/until";
 import memoizeOne from "memoize-one";
 import { storage } from "../../../../common/decorators/storage";
@@ -58,10 +57,6 @@ export class HuiCardPicker extends LitElement {
   public cardPicked?: (cardConf: LovelaceCardConfig) => void;
 
   @state() private _filter = "";
-
-  @state() private _width?: number;
-
-  @state() private _height?: number;
 
   private _unusedEntities?: string[];
 
@@ -146,13 +141,7 @@ export class HuiCardPicker extends LitElement {
           "ui.panel.lovelace.editor.edit_card.search_cards"
         )}
       ></search-input>
-      <div
-        id="content"
-        style=${styleMap({
-          width: this._width ? `${this._width}px` : "auto",
-          height: this._height ? `${this._height}px` : "auto",
-        })}
-      >
+      <div id="content">
         ${this._filter
           ? html`<div class="cards-container">
               ${this._filterCards(this._cards, this._filter).map(
@@ -352,30 +341,7 @@ export class HuiCardPicker extends LitElement {
   }
 
   private _handleSearchChange(ev: CustomEvent) {
-    const value = ev.detail.value;
-
-    if (!value) {
-      // Reset when we no longer filter
-      this._width = undefined;
-      this._height = undefined;
-    } else if (!this._width || !this._height) {
-      // Save height and width so the dialog doesn't jump while searching
-      const div = this.shadowRoot!.getElementById("content");
-      if (div && !this._width) {
-        const width = div.clientWidth;
-        if (width) {
-          this._width = width;
-        }
-      }
-      if (div && !this._height) {
-        const height = div.clientHeight;
-        if (height) {
-          this._height = height;
-        }
-      }
-    }
-
-    this._filter = value;
+    this._filter = ev.detail.value;
   }
 
   private _cardPicked(ev: Event): void {

--- a/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
@@ -58,8 +58,6 @@ export class HuiCardPicker extends LitElement {
 
   @state() private _filter = "";
 
-  private _prevFilter = "";
-
   private _unusedEntities?: string[];
 
   private _usedEntities?: string[];
@@ -255,8 +253,7 @@ export class HuiCardPicker extends LitElement {
 
   protected updated(changedProps) {
     super.updated(changedProps);
-    if (this._prevFilter !== this._filter) {
-      this._prevFilter = this._filter;
+    if (changedProps.has("_filter")) {
       const div = this.parentElement!.shadowRoot!.getElementById("content");
       if (div) {
         div.scrollTo({ behavior: "auto", top: 0 });

--- a/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
@@ -251,6 +251,14 @@ export class HuiCardPicker extends LitElement {
     this._loadCards();
   }
 
+  protected updated(changedProps) {
+    super.updated(changedProps);
+    const div = this.parentElement!.shadowRoot!.getElementById("content");
+    if (div) {
+      div.scrollTo({ behavior: "auto", top: 0 });
+    }
+  }
+
   private _loadCards() {
     let cards: Card[] = coreCards.map((card: Card) => ({
       name: this.hass!.localize(

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
@@ -194,6 +194,8 @@ export class HuiCreateDialogCard
         @media all and (min-width: 850px) {
           ha-dialog {
             --mdc-dialog-min-width: 845px;
+            --mdc-dialog-min-height: calc(100vh - 72px);
+            --mdc-dialog-max-height: calc(100vh - 72px);
           }
         }
 
@@ -216,7 +218,7 @@ export class HuiCreateDialogCard
 
         hui-card-picker {
           --card-picker-search-shape: 0;
-          --card-picker-search-margin: -2px -24px 0;
+          --card-picker-search-margin: 0 -24px 0;
         }
         hui-entity-picker-table {
           display: block;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Currently a list of cards has a height which is kept same after filtering (to prevent "jumping" while searching).
But it may cause this look - a list is too huge & filtered cards are not shown, you need to scroll (steps to reproduce described in https://github.com/home-assistant/frontend/issues/25041):

![image](https://github.com/user-attachments/assets/4aaef728-b8ee-46c5-8874-2299c033d622)

After this PR:

![image](https://github.com/user-attachments/assets/e4d00327-b662-40b5-bd85-8dada905ac66)

A constant height is provided by `--mdc-dialog-min/max-height` vars.

Also, had to fix `--card-picker-search-margin` variable, otherwise a negative margin causes a not needed vert. scrollbar (observed in Chrome & Edge, not observed in FF).
With this change, a tiny portion of scrolled cards may be seen through a gap between a dialog's header and a "search" field on some devices (observed on iPad). Imho not a big deal if compared to a not needed scrollbar.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/25041
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
