### PR TITLE
Make "text-transform: none" in mwc-tab-bar

### DIFF
--- a/src/panels/lovelace/editor/badge-editor/hui-badge-element-editor.ts
+++ b/src/panels/lovelace/editor/badge-editor/hui-badge-element-editor.ts
@@ -92,7 +92,7 @@ export class HuiBadgeElementEditor extends HuiTypedElementEditor<LovelaceBadgeCo
       HuiTypedElementEditor.styles,
       css`
         mwc-tab-bar {
-          text-transform: uppercase;
+          --mdc-typography-button-text-transform: none;
           margin-bottom: 16px;
           border-bottom: 1px solid var(--divider-color);
         }

--- a/src/panels/lovelace/editor/badge-editor/hui-dialog-create-badge.ts
+++ b/src/panels/lovelace/editor/badge-editor/hui-dialog-create-badge.ts
@@ -209,6 +209,9 @@ export class HuiCreateDialogBadge
             height: calc(100vh - 158px);
           }
         }
+        mwc-tab-bar {
+          --mdc-typography-button-text-transform: none;
+        }
       `,
     ];
   }

--- a/src/panels/lovelace/editor/card-editor/hui-card-element-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-element-editor.ts
@@ -121,7 +121,7 @@ export class HuiCardElementEditor extends HuiTypedElementEditor<LovelaceCardConf
   static override styles = [
     css`
       mwc-tab-bar {
-        text-transform: uppercase;
+        --mdc-typography-button-text-transform: none;
         margin-bottom: 16px;
         border-bottom: 1px solid var(--divider-color);
       }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
@@ -228,6 +228,9 @@ export class HuiCreateDialogCard
             height: calc(100vh - 158px);
           }
         }
+        mwc-tab-bar {
+          --mdc-typography-button-text-transform: none;
+        }
       `,
     ];
   }

--- a/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
@@ -276,7 +276,7 @@ export class HuiDialogEditSection
         }
         mwc-tab-bar {
           color: var(--primary-text-color);
-          text-transform: uppercase;
+          --mdc-typography-button-text-transform: none;
           padding: 0 20px;
         }
         @media all and (min-width: 600px) {

--- a/src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts
@@ -645,7 +645,7 @@ export class HuiDialogEditView extends LitElement {
         }
         mwc-tab-bar {
           color: var(--primary-text-color);
-          text-transform: uppercase;
+          --mdc-typography-button-text-transform: none;
           padding: 0 20px;
         }
         ha-button.warning {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

After changing to shoelace tabs, labels in tabs (hui-root, devtools, stacks) became not "uppercased".
But on dialogs they are still "uppercase".
This PR makes them not "uppercased".
Although the look is not nice:
- labels are small;
- not easy readable.

![433432877-56f1195a-d4cd-41bb-ba31-873138f4d5c6](https://github.com/user-attachments/assets/0b3ebf26-0929-4e40-a3ec-69b813277967)

So, please tell me what shall I do to make it better.
In fact, we still can leave labels "uppercased", not a big deal).

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
