### PR TITLE
Fix "unavailable" state in Area card

### DIFF
--- a/src/panels/lovelace/cards/hui-area-card.ts
+++ b/src/panels/lovelace/cards/hui-area-card.ts
@@ -397,21 +397,20 @@ export class HuiAreaCard
             (entity) => entity.attributes.device_class === deviceClass
           )
         ) {
-          const value = areaEntity
+          let value = areaEntity
             ? this.hass.formatEntityState(areaEntity)
             : this._average(domain, deviceClass);
-          if (value) {
-            sensors.push(html`
-              <div class="sensor">
-                <ha-domain-icon
-                  .hass=${this.hass}
-                  .domain=${domain}
-                  .deviceClass=${deviceClass}
-                ></ha-domain-icon>
-                ${value}
-              </div>
-            `);
-          }
+          if (!value) value = "—";
+          sensors.push(html`
+            <div class="sensor">
+              <ha-domain-icon
+                .hass=${this.hass}
+                .domain=${domain}
+                .deviceClass=${deviceClass}
+              ></ha-domain-icon>
+              ${value}
+            </div>
+          `);
         }
       });
     });

--- a/src/panels/lovelace/cards/hui-area-card.ts
+++ b/src/panels/lovelace/cards/hui-area-card.ts
@@ -385,27 +385,33 @@ export class HuiAreaCard
             areaSensorEntityId = area.humidity_entity_id;
             break;
         }
-        const areaEntity = areaSensorEntityId
-          ? this.hass.states[areaSensorEntityId]
-          : undefined;
+        const areaEntity =
+          areaSensorEntityId &&
+          this.hass.states[areaSensorEntityId] &&
+          !isUnavailableState(this.hass.states[areaSensorEntityId].state)
+            ? this.hass.states[areaSensorEntityId]
+            : undefined;
         if (
           areaEntity ||
           entitiesByDomain[domain].some(
             (entity) => entity.attributes.device_class === deviceClass
           )
         ) {
-          sensors.push(html`
-            <div class="sensor">
-              <ha-domain-icon
-                .hass=${this.hass}
-                .domain=${domain}
-                .deviceClass=${deviceClass}
-              ></ha-domain-icon>
-              ${areaEntity
-                ? this.hass.formatEntityState(areaEntity)
-                : this._average(domain, deviceClass)}
-            </div>
-          `);
+          const value = areaEntity
+            ? this.hass.formatEntityState(areaEntity)
+            : this._average(domain, deviceClass);
+          if (value) {
+            sensors.push(html`
+              <div class="sensor">
+                <ha-domain-icon
+                  .hass=${this.hass}
+                  .domain=${domain}
+                  .deviceClass=${deviceClass}
+                ></ha-domain-icon>
+                ${value}
+              </div>
+            `);
+          }
         }
       });
     });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Fixed `unavailable` state for `areaEntity` & "averaged" entities.

When `areaEntity` = `unavailable` (temperature):
Before:
![image](https://github.com/user-attachments/assets/1365a356-60e8-4668-94cc-aa7fda76c316)

After:
![image](https://github.com/user-attachments/assets/deea68bf-4af6-4afc-86f8-6215d88e639c)

When all "averaged" entities are `unavailable` (humidity):
Before:
![image](https://github.com/user-attachments/assets/3b559d5a-6d24-440d-993b-a049ba792b3e)

After:
![image](https://github.com/user-attachments/assets/474bcdcb-6b18-475e-a7b3-ed04983db7ba)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/19755
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
