### PR TITLE
Fix: Show delete button in portrait mode on iPad when selecting backups (#25111)

### DIFF
--- a/src/panels/config/backup/ha-config-backup-backups.ts
+++ b/src/panels/config/backup/ha-config-backup-backups.ts
@@ -414,25 +414,13 @@ class HaConfigBackupBackups extends SubscribeMixin(LitElement) {
         </div>
 
         <div slot="selection-bar">
-          ${!this.narrow
-            ? html`
-                <ha-button @click=${this._deleteSelected} class="warning">
-                  ${this.hass.localize(
-                    "ui.panel.config.backup.backups.delete_selected"
-                  )}
-                </ha-button>
-              `
-            : html`
-                <ha-icon-button
-                  .label=${this.hass.localize(
-                    "ui.panel.config.backup.backups.delete_selected"
-                  )}
-                  .path=${mdiDelete}
-                  class="warning"
-                  @click=${this._deleteSelected}
-                ></ha-icon-button>
-              `}
+          <ha-button @click=${this._deleteSelected} class="warning">
+            ${this.hass.localize(
+              "ui.panel.config.backup.backups.delete_selected"
+            )}
+          </ha-button>
         </div>
+
 
         <ha-filter-states
           .hass=${this.hass}


### PR DESCRIPTION
## Breaking change

<!-- Not a breaking change, so remove this section -->

## Proposed change

When selecting multiple backups on iPad or iPhone in portrait mode, the "Delete" button would not appear. This change updates the toolbar to always render the delete button regardless of the device orientation.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Example configuration

<!-- No configuration needed -->

## Additional information

- This PR fixes or closes issue: fixes #25111

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
