### PR TITLE
Improve message when no discovery data is found

### DIFF
--- a/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-advertisement-monitor.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-advertisement-monitor.ts
@@ -210,6 +210,9 @@ export class BluetoothAdvertisementMonitorPanel extends LitElement {
         .route=${this.route}
         .columns=${this._columns(this.hass.localize)}
         .data=${this._dataWithNamedSourceAndIds(this._data)}
+        .noDataText=${this.hass.localize(
+          "ui.panel.config.bluetooth.no_advertisements_found"
+        )}
         @row-click=${this._handleRowClicked}
         .initialGroupColumn=${this._activeGrouping}
         .initialCollapsedGroups=${this._activeCollapsed}

--- a/src/panels/config/integrations/integration-panels/dhcp/dhcp-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/dhcp/dhcp-config-panel.ts
@@ -96,6 +96,9 @@ export class DHCPConfigPanel extends SubscribeMixin(LitElement) {
         .route=${this.route}
         .columns=${this._columns(this.hass.localize)}
         .data=${this._dataWithIds(this._data)}
+        .noDataText=${this.hass.localize(
+          "ui.panel.config.dhcp.no_devices_found"
+        )}
         filter=${this._macAddress || ""}
       ></hass-tabs-subpage-data-table>
     `;

--- a/src/panels/config/integrations/integration-panels/ssdp/ssdp-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/ssdp/ssdp-config-panel.ts
@@ -105,6 +105,9 @@ export class SSDPConfigPanel extends SubscribeMixin(LitElement) {
         @grouping-changed=${this._handleGroupingChanged}
         @collapsed-changed=${this._handleCollapseChanged}
         .data=${this._dataWithIds(this._data)}
+        .noDataText=${this.hass.localize(
+          "ui.panel.config.ssdp.no_devices_found"
+        )}
         @row-click=${this._handleRowClicked}
         clickable
       ></hass-tabs-subpage-data-table>

--- a/src/panels/config/integrations/integration-panels/zeroconf/zeroconf-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/zeroconf/zeroconf-config-panel.ts
@@ -112,6 +112,9 @@ export class ZeroconfConfigPanel extends SubscribeMixin(LitElement) {
         @grouping-changed=${this._handleGroupingChanged}
         @collapsed-changed=${this._handleCollapseChanged}
         .data=${this._dataWithIds(this._data)}
+        .noDataText=${this.hass.localize(
+          "ui.panel.config.zeroconf.no_devices_found"
+        )}
         @row-click=${this._handleRowClicked}
         clickable
       ></hass-tabs-subpage-data-table>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5530,7 +5530,7 @@
           "mac_address": "MAC Address",
           "hostname": "Hostname",
           "ip_address": "IP Address",
-          "no_devices_found": "No matching DHCP discoveries found"
+          "no_devices_found": "No matching DHCP discoveries found; The device may not have made a DHCP request recently"
         },
         "thread": {
           "other_networks": "Other networks",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5530,7 +5530,7 @@
           "mac_address": "MAC Address",
           "hostname": "Hostname",
           "ip_address": "IP Address",
-          "no_devices_found": "No matching DHCP discoveries found; The device may not have made a DHCP request recently"
+          "no_devices_found": "No matching DHCP discoveries found; Devices may not have made a DHCP request recently"
         },
         "thread": {
           "other_networks": "Other networks",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5508,6 +5508,7 @@
           "connection_monitor": "Connection monitor",
           "used_connection_slot_allocations": "Used connection slot allocations",
           "no_connections": "No active connections",
+          "no_advertisements_found": "No matching Bluetooth advertisements found",
           "no_connection_slot_allocations": "No connection slot allocations information available",
           "no_active_connection_support": "This adapter does not support making active (GATT) connections.",
           "address": "Address",
@@ -5528,7 +5529,8 @@
           "title": "DHCP discovery",
           "mac_address": "MAC Address",
           "hostname": "Hostname",
-          "ip_address": "IP Address"
+          "ip_address": "IP Address",
+          "no_devices_found": "No matching DHCP discoveries found"
         },
         "thread": {
           "other_networks": "Other networks",
@@ -5577,7 +5579,8 @@
           "ssdp_headers": "SSDP Headers",
           "upnp": "Universal Plug and Play (UPnP)",
           "discovery_information": "Discovery information",
-          "copy_to_clipboard": "Copy to clipboard"
+          "copy_to_clipboard": "Copy to clipboard",
+          "no_devices_found": "No matching SSDP/UPnP discoveries found"
         },
         "zeroconf": {
           "name": "Name",
@@ -5586,7 +5589,8 @@
           "ip_addresses": "IP Addresses",
           "properties": "Properties",
           "discovery_information": "Discovery information",
-          "copy_to_clipboard": "Copy to clipboard"
+          "copy_to_clipboard": "Copy to clipboard",
+          "no_devices_found": "No matching Zeroconf discoveries found"
         },
         "zha": {
           "common": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5530,7 +5530,7 @@
           "mac_address": "MAC Address",
           "hostname": "Hostname",
           "ip_address": "IP Address",
-          "no_devices_found": "No matching DHCP discoveries found; Devices may not have made a DHCP request recently"
+          "no_devices_found": "No recent DHCP requests found; no matching discoveries detected"
         },
         "thread": {
           "other_networks": "Other networks",


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
It was pointed out its a bit confusing when a device has not been discovered yet for the discovery/network browser panels as we only said there was no data. Give the user a better hint as to why there is no data.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
