### PR TITLE
 Always show backup location retention settings

### DIFF
--- a/src/panels/config/backup/ha-config-backup-location.ts
+++ b/src/panels/config/backup/ha-config-backup-location.ts
@@ -118,19 +118,17 @@ class HaConfigBackupDetails extends LitElement {
                             </p>
                           </div>
                         `
-                      : this.config?.agents[this.agentId]
-                        ? html`<ha-backup-config-retention
-                            location-specific
-                            .headline=${this.hass.localize(
-                              `ui.panel.config.backup.location.retention_for_${isLocalAgent(this.agentId) ? "this_system" : "location"}`,
-                              { location: agentName }
-                            )}
-                            .hass=${this.hass}
-                            .retention=${this.config?.agents[this.agentId]
-                              ?.retention}
-                            @value-changed=${this._retentionChanged}
-                          ></ha-backup-config-retention>`
-                        : nothing}
+                      : html`<ha-backup-config-retention
+                          location-specific
+                          .headline=${this.hass.localize(
+                            `ui.panel.config.backup.location.retention_for_${isLocalAgent(this.agentId) ? "this_system" : "location"}`,
+                            { location: agentName }
+                          )}
+                          .hass=${this.hass}
+                          .retention=${this.config?.agents[this.agentId]
+                            ?.retention}
+                          @value-changed=${this._retentionChanged}
+                        ></ha-backup-config-retention>`}
                   </ha-card>
                   <ha-card>
                     <div class="card-header">


### PR DESCRIPTION
## Proposed change
Always show the backup location retention settings unless if it is in the config or not. Assuming you have never changed the encryption of the location, the backup agent would not be present in the `agents` array and thus the retention settings wont display.

So show the settings always. When the agent is not in the array, the dropdown would default to use global options, which is the default in core as well. When the user sets now the retention to custom stuff, the agents array would get populated.

https://github.com/home-assistant/core/pull/143997 fixed a issue where the encryption got disabled unintentionally when frontend only sent the `retention`. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #25255
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
