### PR TITLE
Keyboard accessible panel sorting

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -52,6 +52,7 @@ import "./user/ha-user-badge";
 import "./ha-md-list";
 import "./ha-md-list-item";
 import type { HaMdListItem } from "./ha-md-list-item";
+import { showPromptDialog } from "../dialogs/generic/show-dialog-box";
 
 const SHOW_AFTER_SPACER = ["config", "developer-tools"];
 
@@ -422,8 +423,12 @@ class HaSidebar extends SubscribeMixin(LitElement) {
     `;
   }
 
-  private _renderPanels(panels: PanelInfo[], selectedPanel: string) {
-    return panels.map((panel) =>
+  private _renderPanels(
+    panels: PanelInfo[],
+    selectedPanel: string,
+    orderable = false
+  ) {
+    return panels.map((panel, idx) =>
       this._renderPanel(
         panel.url_path,
         panel.url_path === this.hass.defaultPanel
@@ -435,7 +440,8 @@ class HaSidebar extends SubscribeMixin(LitElement) {
           : panel.url_path in PANEL_ICONS
             ? PANEL_ICONS[panel.url_path]
             : undefined,
-        selectedPanel
+        selectedPanel,
+        orderable ? idx : null
       )
     );
   }
@@ -445,7 +451,8 @@ class HaSidebar extends SubscribeMixin(LitElement) {
     title: string | null,
     icon: string | null | undefined,
     iconPath: string | null | undefined,
-    selectedPanel: string
+    selectedPanel: string,
+    index: number | null
   ) {
     return urlPath === "config"
       ? this._renderConfiguration(title, selectedPanel)
@@ -461,8 +468,20 @@ class HaSidebar extends SubscribeMixin(LitElement) {
               ? html`<ha-svg-icon slot="start" .path=${iconPath}></ha-svg-icon>`
               : html`<ha-icon slot="start" .icon=${icon}></ha-icon>`}
             <span class="item-text" slot="headline">${title}</span>
-            ${this.editMode
+            ${index != null
               ? html`<ha-icon-button
+                  @click=${this._changePosition}
+                  .label=${this.hass!.localize("ui.sidebar.change_position")}
+                  class="hide-panel"
+                  slot="end"
+                  .index=${index}
+                  .title=${title}
+                >
+                  <div class="position-badge">${index + 1}</div>
+                </ha-icon-button>`
+              : nothing}
+            ${this.editMode
+              ? html` <ha-icon-button
                   .label=${this.hass.localize("ui.sidebar.hide_panel")}
                   .path=${mdiClose}
                   class="hide-panel"
@@ -478,7 +497,10 @@ class HaSidebar extends SubscribeMixin(LitElement) {
   private _panelMoved(ev: CustomEvent) {
     ev.stopPropagation();
     const { oldIndex, newIndex } = ev.detail;
+    this._panelMove(oldIndex, newIndex);
+  }
 
+  private _panelMove(oldIndex: number, newIndex: number) {
     const [beforeSpacer] = computePanels(
       this.hass.panels,
       this.hass.defaultPanel,
@@ -497,7 +519,7 @@ class HaSidebar extends SubscribeMixin(LitElement) {
   private _renderPanelsEdit(beforeSpacer: PanelInfo[], selectedPanel: string) {
     return html`
       <ha-sortable .disabled=${!this.editMode} @item-moved=${this._panelMoved}
-        ><div>${this._renderPanels(beforeSpacer, selectedPanel)}</div>
+        ><div>${this._renderPanels(beforeSpacer, selectedPanel, true)}</div>
       </ha-sortable>
       ${this._renderSpacer()}${this._renderHiddenPanels()}
     `;
@@ -686,6 +708,28 @@ class HaSidebar extends SubscribeMixin(LitElement) {
 
   private _closeEditMode() {
     fireEvent(this, "hass-edit-sidebar", { editMode: false });
+  }
+
+  private async _changePosition(ev): Promise<void> {
+    ev.preventDefault();
+    const oldIndex = (ev.currentTarget as any).index as number;
+    const name = ((ev.currentTarget as any).title as string) || "";
+
+    const positionString = await showPromptDialog(this, {
+      title: this.hass!.localize("ui.sidebar.change_position"),
+      text: this.hass!.localize("ui.sidebar.change_position_dialog_text", {
+        name,
+      }),
+      inputType: "number",
+      inputMin: "1",
+      placeholder: String(oldIndex + 1),
+    });
+
+    if (!positionString) return;
+    const position = parseInt(positionString);
+    if (isNaN(position)) return;
+    const newIndex = Math.max(0, position - 1);
+    this._panelMove(oldIndex, newIndex);
   }
 
   private async _hidePanel(ev: Event) {
@@ -938,7 +982,7 @@ class HaSidebar extends SubscribeMixin(LitElement) {
 
         ha-md-list-item .item-text {
           display: none;
-          max-width: calc(100% - 56px);
+          max-width: 100%;
           font-weight: 500;
           font-size: 14px;
         }
@@ -967,6 +1011,19 @@ class HaSidebar extends SubscribeMixin(LitElement) {
           background-color: var(--accent-color);
           padding: 2px 6px;
           color: var(--text-accent-color, var(--text-primary-color));
+        }
+
+        .position-badge {
+          display: block;
+          width: 24px;
+          line-height: 24px;
+          box-sizing: border-box;
+          border-radius: 50%;
+          font-weight: 500;
+          text-align: center;
+          font-size: 14px;
+          background-color: var(--app-header-edit-background-color, #455a64);
+          color: var(--app-header-edit-text-color, white);
         }
 
         ha-svg-icon + .badge {

--- a/src/resources/ha-sidebar-edit-style.ts
+++ b/src/resources/ha-sidebar-edit-style.ts
@@ -58,7 +58,7 @@ export const sidebarEditStyle = css`
   }
 
   :host([expanded]) .hide-panel {
-    display: block;
+    display: inline-block;
   }
 
   :host([expanded]) .show-panel {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2016,7 +2016,9 @@
       "sidebar_toggle": "Sidebar toggle",
       "done": "Done",
       "hide_panel": "Hide panel",
-      "show_panel": "Show panel"
+      "show_panel": "Show panel",
+      "change_position": "Change panel position",
+      "change_position_dialog_text": "What position do you want to move your ''{name}'' panel to?"
     },
     "panel": {
       "my": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Add a button for non-mouse users to reorder the dashboards. Similar to the masonry move button.

![image](https://github.com/user-attachments/assets/157bc98d-9bd7-45dc-8f0e-908f17ca04ba)

![image](https://github.com/user-attachments/assets/e69b30e0-4189-44ef-94bb-8a0a29675147)



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://community.home-assistant.io/t/wth-why-can-t-i-reorder-sidebar-menu-items-using-a-keyboard-and-screen-reader/803087
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
