### PR TITLE
Do not display no areas in entity pickers

### DIFF
--- a/src/components/entity/ha-entity-combo-box.ts
+++ b/src/components/entity/ha-entity-combo-box.ts
@@ -314,9 +314,7 @@ export class HaEntityComboBox extends LitElement {
             ...hass!.states[entityId],
             label: "",
             primary: primary,
-            secondary:
-              secondary ||
-              this.hass.localize("ui.components.device-picker.no_area"),
+            secondary: secondary,
             translated_domain: translatedDomain,
             sorting_label: [deviceName, entityName].filter(Boolean).join("-"),
             entity_name: entityName || deviceName,

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -162,10 +162,7 @@ export class HaEntityPicker extends LitElement {
         slot="start"
       ></state-badge>
       <span slot="headline">${primary}</span>
-      <span slot="supporting-text">
-        ${secondary ||
-        this.hass.localize("ui.components.device-picker.no_area")}
-      </span>
+      <span slot="supporting-text">${secondary}</span>
       ${showClearIcon
         ? html`<ha-icon-button
             class="clear"

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -358,6 +358,7 @@ export class QuickBar extends LitElement {
   private _renderDeviceItem(item: DeviceItem, index?: number) {
     return html`
       <ha-md-list-item
+        class="two-line"
         .item=${item}
         index=${ifDefined(index)}
         tabindex="0"
@@ -376,6 +377,7 @@ export class QuickBar extends LitElement {
 
     return html`
       <ha-md-list-item
+        class=${showEntityId ? "three-line" : "two-line"}
         .item=${item}
         index=${ifDefined(index)}
         tabindex="0"
@@ -621,9 +623,7 @@ export class QuickBar extends LitElement {
 
         const entityItem = {
           primaryText: primary,
-          altText:
-            secondary ||
-            this.hass.localize("ui.components.device-picker.no_area"),
+          altText: secondary,
           icon: html`
             <ha-state-icon
               .hass=${this.hass}
@@ -1019,6 +1019,23 @@ export class QuickBar extends LitElement {
 
         ha-md-list-item {
           width: 100%;
+        }
+
+        /* Fixed height for items because we are use virtualizer */
+        ha-md-list-item.two-line {
+          --md-list-item-one-line-container-height: 64px;
+          --md-list-item-two-line-container-height: 64px;
+          --md-list-item-top-space: 8px;
+          --md-list-item-bottom-space: 8px;
+        }
+
+        ha-md-list-item.three-line {
+          width: 100%;
+          --md-list-item-one-line-container-height: 72px;
+          --md-list-item-two-line-container-height: 72px;
+          --md-list-item-three-line-container-height: 72px;
+          --md-list-item-top-space: 8px;
+          --md-list-item-bottom-space: 8px;
         }
 
         ha-tip {


### PR DESCRIPTION
## Proposed change

Do not display no areas in entity pickers because it makes no sense for some technical entities or domain (zone, device tracker, person, etc...)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
