### PR TITLE
New solar-consumed-gauge algorithm

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -1123,17 +1123,16 @@ export const calculateSolarConsumedGauge = (
   hasBattery: boolean,
   data: EnergySumData
 ): number | undefined => {
+  if (!data.total.solar) {
+    return undefined;
+  }
   const { consumption, compareConsumption: _ } = computeConsumptionData(
     data,
     undefined
   );
   if (!hasBattery) {
     const solarProduction = data.total.solar;
-    const hasSolarProduction = !!solarProduction;
-    if (hasSolarProduction) {
-      return (consumption.total.used_solar / solarProduction) * 100;
-    }
-    return undefined;
+    return (consumption.total.used_solar / solarProduction) * 100;
   }
 
   let solarConsumed = 0;

--- a/src/panels/lovelace/cards/energy/hui-energy-solar-consumed-gauge-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-solar-consumed-gauge-card.ts
@@ -9,6 +9,7 @@ import "../../../../components/ha-gauge";
 import "../../../../components/ha-svg-icon";
 import type { EnergyData } from "../../../../data/energy";
 import {
+  calculateSolarConsumedGauge,
   getEnergyDataCollection,
   getSummedData,
 } from "../../../../data/energy";
@@ -78,18 +79,12 @@ class HuiEnergySolarGaugeCard
       return nothing;
     }
 
-    const totalSolarProduction = summedData.total.solar;
-
     const productionReturnedToGrid = summedData.total.to_grid ?? null;
 
     let value: number | undefined;
-
-    if (productionReturnedToGrid !== null && totalSolarProduction) {
-      const consumedSolar = Math.max(
-        0,
-        totalSolarProduction - productionReturnedToGrid
-      );
-      value = (consumedSolar / totalSolarProduction) * 100;
+    if (productionReturnedToGrid !== null) {
+      const hasBattery = !!summedData.to_battery || !!summedData.from_battery;
+      value = calculateSolarConsumedGauge(hasBattery, summedData);
     }
 
     return html`
@@ -125,7 +120,7 @@ class HuiEnergySolarGaugeCard
                 )}
               </div>
             `
-          : totalSolarProduction === 0
+          : productionReturnedToGrid !== null
             ? this.hass.localize(
                 "ui.panel.lovelace.cards.energy.solar_consumed_gauge.not_produced_solar_energy"
               )

--- a/test/data/energy.test.ts
+++ b/test/data/energy.test.ts
@@ -513,6 +513,13 @@ describe("Self-consumed solar gauge tests", () => {
     const hasBattery = false;
     assert.deepEqual(
       calculateSolarConsumedGauge(hasBattery, {
+        total: {},
+        timestamps: [0],
+      }),
+      undefined
+    );
+    assert.deepEqual(
+      calculateSolarConsumedGauge(hasBattery, {
         solar: {
           "0": 0,
         },
@@ -576,12 +583,17 @@ describe("Self-consumed solar gauge tests", () => {
     const hasBattery = true;
     assert.deepEqual(
       calculateSolarConsumedGauge(hasBattery, {
+        total: {},
+        timestamps: [0],
+      }),
+      undefined
+    );
+    assert.deepEqual(
+      calculateSolarConsumedGauge(hasBattery, {
         solar: {
           "0": 0,
         },
-        total: {
-          solar: 0,
-        },
+        total: {},
         timestamps: [0],
       }),
       undefined
@@ -608,10 +620,7 @@ describe("Self-consumed solar gauge tests", () => {
         to_grid: {
           "1": 1,
         },
-        total: {
-          solar: 4,
-          to_grid: 1,
-        },
+        total: {},
         timestamps: [0, 1],
       }),
       75
@@ -633,64 +642,71 @@ describe("Self-consumed solar gauge tests", () => {
           "2": 1,
           "3": 1,
         },
-        total: {
-          solar: 1,
-          to_grid: 4,
-          from_battery: 4,
-        },
+        total: {},
         timestamps: [0, 1, 2, 3, 10],
       }),
       // As the battery is discharged from unknown source, it does not affect solar production number.
       100
     );
+    assert.deepEqual(
+      calculateSolarConsumedGauge(hasBattery, {
+        solar: {
+          "0": 10,
+        },
+        to_battery: {
+          "0": 10,
+        },
+        to_grid: {
+          "1": 3,
+          "3": 1,
+        },
+        from_battery: {
+          "1": 3,
+          "2": 2,
+          "3": 2,
+          "4": 3,
+          "5": 100, // Unknown source, not counted
+        },
+        total: {},
+        timestamps: [0, 1, 2, 3, 4, 5],
+      }),
+      // As the battery is discharged from unknown source, it does not affect solar production number.
+      60
+    );
   });
   it("complex battery/solar/grid", () => {
     const hasBattery = true;
-    const solar = {
-      "1": 6,
-      "2": 0,
-      "3": 7,
-    };
-    const to_battery = {
-      "1": 5,
-      "2": 5,
-      "3": 7,
-    };
-    const to_grid = {
-      "0": 5,
-      "10": 1,
-      "11": 1,
-      "12": 5,
-      "13": 3,
-    };
-    const from_grid = {
-      "2": 5,
-    };
-    const from_battery = {
-      "0": 5,
-      "10": 3,
-      "11": 4,
-      "12": 5,
-      "13": 5,
-    };
+
     const value = calculateSolarConsumedGauge(hasBattery, {
-      solar,
-      to_battery,
-      to_grid,
-      from_grid,
-      from_battery,
+      solar: {
+        "1": 6,
+        "2": 0,
+        "3": 7,
+      },
+      to_battery: {
+        "1": 5,
+        "2": 5,
+        "3": 7,
+      },
+      to_grid: {
+        "0": 5,
+        "10": 1,
+        "11": 1,
+        "12": 5,
+        "13": 3,
+      },
+      from_grid: {
+        "2": 5,
+      },
+      from_battery: {
+        "0": 5,
+        "10": 3,
+        "11": 4,
+        "12": 5,
+        "13": 5,
+      },
       total: {
-        solar: Object.values(solar).reduce((acc, val) => acc + val, 0),
-        to_battery: Object.values(to_battery).reduce(
-          (acc, val) => acc + val,
-          0
-        ),
-        to_grid: Object.values(to_grid).reduce((acc, val) => acc + val, 0),
-        from_grid: Object.values(from_grid).reduce((acc, val) => acc + val, 0),
-        from_battery: Object.values(from_battery).reduce(
-          (acc, val) => acc + val,
-          0
-        ),
+        // Total is don't care when hasBattery, only hourly values are used
       },
       timestamps: [0, 1, 2, 3, 10, 11, 12, 13],
     });
@@ -709,31 +725,25 @@ describe("Self-consumed solar gauge tests", () => {
 
   it("complex battery/solar/grid #2", () => {
     const hasBattery = true;
-    const solar = {
-      "0": 100,
-      "2": 100,
-    };
-    const to_battery = {
-      "0": 100,
-      "1": 100,
-      "2": 100,
-    };
-    const to_grid = {
-      "10": 50,
-    };
-    const from_grid = {
-      "1": 100,
-    };
-
-    const from_battery = {
-      "10": 300,
-    };
     const value = calculateSolarConsumedGauge(hasBattery, {
-      solar,
-      to_battery,
-      to_grid,
-      from_grid,
-      from_battery,
+      solar: {
+        "0": 100,
+        "2": 100,
+      },
+      to_battery: {
+        "0": 100,
+        "1": 100,
+        "2": 100,
+      },
+      to_grid: {
+        "10": 50,
+      },
+      from_grid: {
+        "1": 100,
+      },
+      from_battery: {
+        "10": 300,
+      },
       total: {
         solar: 200,
         to_battery: 300,

--- a/test/data/energy.test.ts
+++ b/test/data/energy.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   computeConsumptionSingle,
   formatConsumptionShort,
+  calculateSolarConsumedGauge,
 } from "../../src/data/energy";
 import type { HomeAssistant } from "../../src/types";
 
@@ -503,6 +504,250 @@ describe("Energy Usage Calculation Tests", () => {
         solar_to_grid: 1,
         used_total: 0,
       }
+    );
+  });
+});
+
+describe("Self-consumed solar gauge tests", () => {
+  it("no battery", () => {
+    const hasBattery = false;
+    assert.deepEqual(
+      calculateSolarConsumedGauge(hasBattery, {
+        solar: {
+          "0": 0,
+        },
+        total: {
+          solar: 0,
+        },
+        timestamps: [0],
+      }),
+      undefined
+    );
+    assert.deepEqual(
+      calculateSolarConsumedGauge(hasBattery, {
+        solar: {
+          "0": 1,
+          "1": 3,
+        },
+        total: {
+          solar: 4,
+        },
+        timestamps: [0, 1],
+      }),
+      100
+    );
+    assert.deepEqual(
+      calculateSolarConsumedGauge(hasBattery, {
+        solar: {
+          "0": 1,
+          "1": 3,
+        },
+        to_grid: {
+          "1": 1,
+        },
+        total: {
+          solar: 4,
+          to_grid: 1,
+        },
+        timestamps: [0, 1],
+      }),
+      75
+    );
+    assert.deepEqual(
+      calculateSolarConsumedGauge(hasBattery, {
+        solar: {
+          "0": 1,
+          "1": 3,
+        },
+        to_grid: {
+          "0": 1,
+          "1": 3,
+        },
+        total: {
+          solar: 4,
+          to_grid: 4,
+        },
+        timestamps: [0, 1],
+      }),
+      0
+    );
+  });
+  it("with battery", () => {
+    const hasBattery = true;
+    assert.deepEqual(
+      calculateSolarConsumedGauge(hasBattery, {
+        solar: {
+          "0": 0,
+        },
+        total: {
+          solar: 0,
+        },
+        timestamps: [0],
+      }),
+      undefined
+    );
+    assert.deepEqual(
+      calculateSolarConsumedGauge(hasBattery, {
+        solar: {
+          "0": 1,
+          "1": 3,
+        },
+        total: {
+          solar: 4,
+        },
+        timestamps: [0, 1],
+      }),
+      100
+    );
+    assert.deepEqual(
+      calculateSolarConsumedGauge(hasBattery, {
+        solar: {
+          "0": 1,
+          "1": 3,
+        },
+        to_grid: {
+          "1": 1,
+        },
+        total: {
+          solar: 4,
+          to_grid: 1,
+        },
+        timestamps: [0, 1],
+      }),
+      75
+    );
+    assert.deepEqual(
+      calculateSolarConsumedGauge(hasBattery, {
+        solar: {
+          "10": 1,
+        },
+        to_grid: {
+          "0": 1,
+          "1": 1,
+          "2": 1,
+          "3": 1,
+        },
+        from_battery: {
+          "0": 1,
+          "1": 1,
+          "2": 1,
+          "3": 1,
+        },
+        total: {
+          solar: 1,
+          to_grid: 4,
+          from_battery: 4,
+        },
+        timestamps: [0, 1, 2, 3, 10],
+      }),
+      // As the battery is discharged from unknown source, it does not affect solar production number.
+      100
+    );
+  });
+  it("complex battery/solar/grid", () => {
+    const hasBattery = true;
+    const solar = {
+      "1": 6,
+      "2": 0,
+      "3": 7,
+    };
+    const to_battery = {
+      "1": 5,
+      "2": 5,
+      "3": 7,
+    };
+    const to_grid = {
+      "0": 5,
+      "10": 1,
+      "11": 1,
+      "12": 5,
+      "13": 3,
+    };
+    const from_grid = {
+      "2": 5,
+    };
+    const from_battery = {
+      "0": 5,
+      "10": 3,
+      "11": 4,
+      "12": 5,
+      "13": 5,
+    };
+    const value = calculateSolarConsumedGauge(hasBattery, {
+      solar,
+      to_battery,
+      to_grid,
+      from_grid,
+      from_battery,
+      total: {
+        solar: Object.values(solar).reduce((acc, val) => acc + val, 0),
+        to_battery: Object.values(to_battery).reduce(
+          (acc, val) => acc + val,
+          0
+        ),
+        to_grid: Object.values(to_grid).reduce((acc, val) => acc + val, 0),
+        from_grid: Object.values(from_grid).reduce((acc, val) => acc + val, 0),
+        from_battery: Object.values(from_battery).reduce(
+          (acc, val) => acc + val,
+          0
+        ),
+      },
+      timestamps: [0, 1, 2, 3, 10, 11, 12, 13],
+    });
+    // "1"  - consumed 1 solar, 5 sent to battery
+    // "10" - consumed 2/3 of solar energy stored in battery
+    // "11" - consumed 3/4 of solar energy stored in battery
+    // "12" - skipped as this is energy from grid, not counted
+    // "13" - consumed 2/5 of solar energy stored in battery
+    const expectedNumerator = 1 + 2 + 3 + 0 + 2; // 8
+    const expectedDenominator = 1 + 3 + 4 + 0 + 5; // 13
+    assert.equal(
+      Math.round(value!),
+      Math.round((expectedNumerator / expectedDenominator) * 100)
+    );
+  });
+
+  it("complex battery/solar/grid #2", () => {
+    const hasBattery = true;
+    const solar = {
+      "0": 100,
+      "2": 100,
+    };
+    const to_battery = {
+      "0": 100,
+      "1": 100,
+      "2": 100,
+    };
+    const to_grid = {
+      "10": 50,
+    };
+    const from_grid = {
+      "1": 100,
+    };
+
+    const from_battery = {
+      "10": 300,
+    };
+    const value = calculateSolarConsumedGauge(hasBattery, {
+      solar,
+      to_battery,
+      to_grid,
+      from_grid,
+      from_battery,
+      total: {
+        solar: 200,
+        to_battery: 300,
+        to_grid: 50,
+        from_grid: 100,
+        from_battery: 300,
+      },
+      timestamps: [0, 1, 2, 10],
+    });
+    const expectedNumerator = 200 - 50;
+    const expectedDenominator = 200; // ignoring 100 from grid
+    assert.equal(
+      Math.round(value!),
+      Math.round((expectedNumerator / expectedDenominator) * 100)
     );
   });
 });

--- a/test/data/energy.test.ts
+++ b/test/data/energy.test.ts
@@ -593,7 +593,9 @@ describe("Self-consumed solar gauge tests", () => {
         solar: {
           "0": 0,
         },
-        total: {},
+        total: {
+          solar: 0,
+        },
         timestamps: [0],
       }),
       undefined
@@ -620,7 +622,9 @@ describe("Self-consumed solar gauge tests", () => {
         to_grid: {
           "1": 1,
         },
-        total: {},
+        total: {
+          solar: 4,
+        },
         timestamps: [0, 1],
       }),
       75
@@ -642,7 +646,9 @@ describe("Self-consumed solar gauge tests", () => {
           "2": 1,
           "3": 1,
         },
-        total: {},
+        total: {
+          solar: 1,
+        },
         timestamps: [0, 1, 2, 3, 10],
       }),
       // As the battery is discharged from unknown source, it does not affect solar production number.
@@ -667,7 +673,9 @@ describe("Self-consumed solar gauge tests", () => {
           "4": 3,
           "5": 100, // Unknown source, not counted
         },
-        total: {},
+        total: {
+          solar: 10,
+        },
         timestamps: [0, 1, 2, 3, 4, 5],
       }),
       // As the battery is discharged from unknown source, it does not affect solar production number.
@@ -706,7 +714,8 @@ describe("Self-consumed solar gauge tests", () => {
         "13": 5,
       },
       total: {
-        // Total is don't care when hasBattery, only hourly values are used
+        // Total is mostly don't care when hasBattery, only hourly values are used
+        solar: 13,
       },
       timestamps: [0, 1, 2, 3, 10, 11, 12, 13],
     });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The current "Self consumed solar energy" card doesn't really work correctly for users with batteries, so I took a shot at trying to rewrite an algorithm that might better represent that usecase. 

One problem with the current card is that any day you return more energy to the grid than your solar panels produced, it just says you have consumed 0% of your solar. 

So if you discharge 10kWh from battery to grid in the morning, and then in the afternoon your solar panel produces 5kWh, and you self-consume all 5 kWh, the self consumed gauge says 0% was self consumed, which is pretty clearly not consistent with the other visualizations saying that you consumed 5 kWh of solar. 

For battery users, I attempt to rewrite this like the following:

- Each hour of the day, track solar->consumption and solar->grid in a running total.
- Each hour of the day, track solar->battery and grid->battery, modelling a sort of "stack" in the battery counting the amount of energy it was charged with from both types of source.
- When we remove energy from the battery, look at the top of the energy stack and if that energy in the battery was solar sourced, count that as solar consumption if it is consumed, and count it as solar energy going to grid if it goes to grid.
- If we remove energy from the battery, and that energy was charged from the grid, ignore that outflow for the solar calculation. 
- If we are taking more energy out of the battery than we have put into it during this window, just omit that from the calculation, as we can't assume if it was solar energy or grid energy. 

With this new algorithm, the problematic case above now reports 100% self-consumed energy, as you have produced 5 kWh and consumed all of it. The early morning battery discharge is not a factor during this window, since that energy wasn't produced during this period. 

Added some testcases trying to model various scenarios. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
