### PR TITLE
Periodically refresh alerts on the device page

### DIFF
--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -136,7 +136,7 @@ export class HaConfigDevicePage extends LitElement {
 
   @state() private _deviceAlerts?: DeviceAlert[];
 
-  private _deviceAlertsTimeout?: NodeJS.Timeout;
+  private _deviceAlertsTimeout?: number;
 
   @state()
   @consume({ context: fullEntitiesContext, subscribe: true })

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -136,7 +136,7 @@ export class HaConfigDevicePage extends LitElement {
 
   @state() private _deviceAlerts?: DeviceAlert[];
 
-  private _deviceAlertsTimeout?: number;
+  private _deviceAlertsTimeout?: NodeJS.Timeout;
 
   @state()
   @consume({ context: fullEntitiesContext, subscribe: true })

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -136,7 +136,7 @@ export class HaConfigDevicePage extends LitElement {
 
   @state() private _deviceAlerts?: DeviceAlert[];
 
-  private _deviceAlertsTimeout?: NodeJS.Timeout;
+  private _deviceAlertsTimeout?: number;
 
   @state()
   @consume({ context: fullEntitiesContext, subscribe: true })
@@ -1163,7 +1163,7 @@ export class HaConfigDevicePage extends LitElement {
 
     if (deviceAlerts.length) {
       this._deviceAlerts = deviceAlerts;
-      this._deviceAlertsTimeout = setTimeout(
+      this._deviceAlertsTimeout = window.setTimeout(
         () => this._getDeviceAlerts(),
         DEVICE_ALERTS_INTERVAL
       );

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -107,6 +107,8 @@ export interface DeviceAlert {
   text: string;
 }
 
+const DEVICE_ALERTS_INTERVAL = 30000;
+
 @customElement("ha-config-device-page")
 export class HaConfigDevicePage extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -133,6 +135,8 @@ export class HaConfigDevicePage extends LitElement {
   @state() private _deviceActions?: DeviceAction[];
 
   @state() private _deviceAlerts?: DeviceAlert[];
+
+  private _deviceAlertsTimeout?: NodeJS.Timeout;
 
   @state()
   @consume({ context: fullEntitiesContext, subscribe: true })
@@ -280,6 +284,7 @@ export class HaConfigDevicePage extends LitElement {
     this._getDiagnosticButtons(this._diagnosticDownloadLinks);
     this._getDeleteActions();
     this._getDeviceActions();
+    clearTimeout(this._deviceAlertsTimeout);
     this._getDeviceAlerts();
   }
 
@@ -293,6 +298,11 @@ export class HaConfigDevicePage extends LitElement {
     if (changedProps.has("deviceId")) {
       this._findRelated();
     }
+  }
+
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    clearTimeout(this._deviceAlertsTimeout);
   }
 
   protected render() {
@@ -1153,6 +1163,10 @@ export class HaConfigDevicePage extends LitElement {
 
     if (deviceAlerts.length) {
       this._deviceAlerts = deviceAlerts;
+      this._deviceAlertsTimeout = setTimeout(
+        () => this._getDeviceAlerts(),
+        DEVICE_ALERTS_INTERVAL
+      );
     }
   }
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
These alerts are currently only used by ZWaveJS and some of them are temporary so they need to be cleared at some point. We could do this with events but it may require specific events for each alert and changes to the alert type to indicate wether it is temporary. A simple polling is good enough for now IMO.
I added the polling timeout only if there are alerts found. It could be done in the upper if that is only for zwavejs but since no other integration uses this, the effect is the same.

Period set to 30s for now. The "interviewing" zwave alert will probably be cleared within a couple of seconds so a shorter interval will be better for that specific case. But I don't want to spam core too much.

Currently this is needed for only for 2 cases:
- smart start pre-provisioned device
- smart start just added device that hasn't finished interviewing yet
- 
But it will also run for zwavejs devices that have alerts about bad firmware versions or other warnings

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/backlog/issues/60
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
