### PR TITLE
Use ha-dialog-header for data-entry-flow

### DIFF
--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -1,17 +1,20 @@
 import { mdiClose, mdiHelpCircle } from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
-import type { CSSResultGroup, PropertyValues } from "lit";
+import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
 import type { HASSDomEvent } from "../../common/dom/fire_event";
 import { fireEvent } from "../../common/dom/fire_event";
 import "../../components/ha-dialog";
+import "../../components/ha-dialog-header";
 import "../../components/ha-icon-button";
 import type { DataEntryFlowStep } from "../../data/data_entry_flow";
 import {
   subscribeDataEntryFlowProgress,
   subscribeDataEntryFlowProgressed,
 } from "../../data/data_entry_flow";
+import type { DeviceRegistryEntry } from "../../data/device_registry";
 import { haStyleDialog } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import { documentationUrl } from "../../util/documentation-url";
@@ -171,6 +174,92 @@ class DataEntryFlowDialog extends LitElement {
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
+  private _devices = memoizeOne(
+    (
+      showDevices: boolean,
+      devices: DeviceRegistryEntry[],
+      entry_id?: string
+    ) =>
+      showDevices && entry_id
+        ? devices.filter((device) => device.config_entries.includes(entry_id))
+        : []
+  );
+
+  private _getDialogTitle(): string {
+    if (this._loading || !this._step || !this._params) {
+      return "";
+    }
+
+    switch (this._step.type) {
+      case "form":
+        return this._params.flowConfig.renderShowFormStepHeader(
+          this.hass,
+          this._step
+        );
+      case "abort":
+        return this._params.flowConfig.renderAbortHeader
+          ? this._params.flowConfig.renderAbortHeader(this.hass, this._step)
+          : this.hass.localize(
+              `component.${this._params.domain ?? this._step.handler}.title`
+            );
+      case "progress":
+        return this._params.flowConfig.renderShowFormProgressHeader(
+          this.hass,
+          this._step
+        );
+      case "menu":
+        return this._params.flowConfig.renderMenuHeader(this.hass, this._step);
+      case "create_entry": {
+        const devicesLength = this._devices(
+          this._params.flowConfig.showDevices,
+          Object.values(this.hass.devices),
+          this._step.result?.entry_id
+        ).length;
+        return this.hass.localize(
+          `ui.panel.config.integrations.config_flow.${
+            devicesLength ? "device_created" : "success"
+          }`,
+          {
+            number: devicesLength,
+          }
+        );
+      }
+      default:
+        return "";
+    }
+  }
+
+  private _getDialogSubtitle(): string | TemplateResult | undefined {
+    if (this._loading || !this._step || !this._params) {
+      return "";
+    }
+
+    switch (this._step.type) {
+      case "form":
+        return this._params.flowConfig.renderShowFormStepSubheader?.(
+          this.hass,
+          this._step
+        );
+      case "abort":
+        return this._params.flowConfig.renderAbortSubheader?.(
+          this.hass,
+          this._step
+        );
+      case "progress":
+        return this._params.flowConfig.renderShowFormProgressSubheader?.(
+          this.hass,
+          this._step
+        );
+      case "menu":
+        return this._params.flowConfig.renderMenuSubheader?.(
+          this.hass,
+          this._step
+        );
+      default:
+        return "";
+    }
+  }
+
   protected render() {
     if (!this._params) {
       return nothing;
@@ -187,6 +276,9 @@ class DataEntryFlowDialog extends LitElement {
         this._params.manifest?.is_built_in) ||
       !!this._params.manifest?.documentation;
 
+    const dialogTitle = this._getDialogTitle();
+    const dialogSubtitle = this._getDialogSubtitle();
+
     return html`
       <ha-dialog
         open
@@ -194,7 +286,50 @@ class DataEntryFlowDialog extends LitElement {
         scrimClickAction
         escapeKeyAction
         hideActions
+        .heading=${dialogTitle}
       >
+        <ha-dialog-header slot="heading">
+          <ha-icon-button
+            .label=${this.hass.localize("ui.common.close")}
+            .path=${mdiClose}
+            dialogAction="close"
+            slot="navigationIcon"
+          ></ha-icon-button>
+
+          <div
+            slot="title"
+            class="dialog-title${this._step?.type === "form" ? " form" : ""}"
+            title=${dialogTitle}
+          >
+            ${dialogTitle}
+          </div>
+
+          ${dialogSubtitle
+            ? html` <div slot="subtitle">${dialogSubtitle}</div>`
+            : nothing}
+          ${showDocumentationLink && !this._loading && this._step
+            ? html`
+                <a
+                  slot="actionItems"
+                  class="help"
+                  href=${this._params.manifest!.is_built_in
+                    ? documentationUrl(
+                        this.hass,
+                        `/integrations/${this._params.manifest!.domain}`
+                      )
+                    : this._params.manifest!.documentation}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  <ha-icon-button
+                    .label=${this.hass.localize("ui.common.help")}
+                    .path=${mdiHelpCircle}
+                  >
+                  </ha-icon-button
+                ></a>
+              `
+            : nothing}
+        </ha-dialog-header>
         <div>
           ${this._loading || this._step === null
             ? html`
@@ -211,40 +346,12 @@ class DataEntryFlowDialog extends LitElement {
                 // to reset the element.
                 nothing
               : html`
-                  <div class="dialog-actions">
-                    ${showDocumentationLink
-                      ? html`
-                          <a
-                            href=${this._params.manifest!.is_built_in
-                              ? documentationUrl(
-                                  this.hass,
-                                  `/integrations/${this._params.manifest!.domain}`
-                                )
-                              : this._params.manifest!.documentation}
-                            target="_blank"
-                            rel="noreferrer noopener"
-                          >
-                            <ha-icon-button
-                              .label=${this.hass.localize("ui.common.help")}
-                              .path=${mdiHelpCircle}
-                            >
-                            </ha-icon-button
-                          ></a>
-                        `
-                      : nothing}
-                    <ha-icon-button
-                      .label=${this.hass.localize("ui.common.close")}
-                      .path=${mdiClose}
-                      dialogAction="close"
-                    ></ha-icon-button>
-                  </div>
                   ${this._step.type === "form"
                     ? html`
                         <step-flow-form
                           .flowConfig=${this._params.flowConfig}
                           .step=${this._step}
                           .hass=${this.hass}
-                          .increasePaddingEnd=${showDocumentationLink}
                         ></step-flow-form>
                       `
                     : this._step.type === "external"
@@ -253,7 +360,6 @@ class DataEntryFlowDialog extends LitElement {
                             .flowConfig=${this._params.flowConfig}
                             .step=${this._step}
                             .hass=${this.hass}
-                            .increasePaddingEnd=${showDocumentationLink}
                           ></step-flow-external>
                         `
                       : this._step.type === "abort"
@@ -265,7 +371,6 @@ class DataEntryFlowDialog extends LitElement {
                               .handler=${this._step.handler}
                               .domain=${this._params.domain ??
                               this._step.handler}
-                              .increasePaddingEnd=${showDocumentationLink}
                             ></step-flow-abort>
                           `
                         : this._step.type === "progress"
@@ -275,7 +380,6 @@ class DataEntryFlowDialog extends LitElement {
                                 .step=${this._step}
                                 .hass=${this.hass}
                                 .progress=${this._progress}
-                                .increasePaddingEnd=${showDocumentationLink}
                               ></step-flow-progress>
                             `
                           : this._step.type === "menu"
@@ -284,7 +388,6 @@ class DataEntryFlowDialog extends LitElement {
                                   .flowConfig=${this._params.flowConfig}
                                   .step=${this._step}
                                   .hass=${this.hass}
-                                  .increasePaddingEnd=${showDocumentationLink}
                                 ></step-flow-menu>
                               `
                             : html`
@@ -294,7 +397,11 @@ class DataEntryFlowDialog extends LitElement {
                                   .hass=${this.hass}
                                   .navigateToResult=${this._params
                                     .navigateToResult ?? false}
-                                  .increasePaddingEnd=${showDocumentationLink}
+                                  .devices=${this._devices(
+                                    this._params.flowConfig.showDevices,
+                                    Object.values(this.hass.devices),
+                                    this._step.result?.entry_id
+                                  )}
                                 ></step-flow-create-entry>
                               `}
                 `}
@@ -384,16 +491,14 @@ class DataEntryFlowDialog extends LitElement {
         ha-dialog {
           --dialog-content-padding: 0;
         }
-        .dialog-actions {
-          padding: 16px;
-          position: absolute;
-          top: 0;
-          right: 0;
-          inset-inline-start: initial;
-          inset-inline-end: 0px;
-          direction: var(--direction);
+        .dialog-title {
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
-        .dialog-actions > * {
+        .dialog-title.form {
+          white-space: pre-wrap;
+        }
+        .help {
           color: var(--secondary-text-color);
         }
       `,

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -496,7 +496,7 @@ class DataEntryFlowDialog extends LitElement {
           text-overflow: ellipsis;
         }
         .dialog-title.form {
-          white-space: pre-wrap;
+          white-space: normal;
         }
         .help {
           color: var(--secondary-text-color);

--- a/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
@@ -31,10 +31,12 @@ export interface FlowConfig {
 
   deleteFlow(hass: HomeAssistant, flowId: string): Promise<unknown>;
 
-  renderAbortHeader?(
+  renderAbortHeader?(hass: HomeAssistant, step: DataEntryFlowStepAbort): string;
+
+  renderAbortSubheader?(
     hass: HomeAssistant,
     step: DataEntryFlowStepAbort
-  ): TemplateResult | string;
+  ): string | TemplateResult;
 
   renderAbortDescription(
     hass: HomeAssistant,
@@ -42,6 +44,11 @@ export interface FlowConfig {
   ): TemplateResult | string;
 
   renderShowFormStepHeader(
+    hass: HomeAssistant,
+    step: DataEntryFlowStepForm
+  ): string;
+
+  renderShowFormStepSubheader?(
     hass: HomeAssistant,
     step: DataEntryFlowStepForm
   ): string | TemplateResult;
@@ -100,6 +107,11 @@ export interface FlowConfig {
   renderShowFormProgressHeader(
     hass: HomeAssistant,
     step: DataEntryFlowStepProgress
+  ): string;
+
+  renderShowFormProgressSubheader?(
+    hass: HomeAssistant,
+    step: DataEntryFlowStepProgress
   ): string | TemplateResult;
 
   renderShowFormProgressDescription(
@@ -107,7 +119,9 @@ export interface FlowConfig {
     step: DataEntryFlowStepProgress
   ): TemplateResult | "";
 
-  renderMenuHeader(
+  renderMenuHeader(hass: HomeAssistant, step: DataEntryFlowStepMenu): string;
+
+  renderMenuSubheader?(
     hass: HomeAssistant,
     step: DataEntryFlowStepMenu
   ): string | TemplateResult;

--- a/src/dialogs/config-flow/step-flow-abort.ts
+++ b/src/dialogs/config-flow/step-flow-abort.ts
@@ -22,9 +22,6 @@ class StepFlowAbort extends LitElement {
 
   @property({ attribute: false }) public handler!: string;
 
-  @property({ type: Boolean, attribute: "increase-padding-end" })
-  public increasePaddingEnd = false;
-
   protected firstUpdated(changed: PropertyValues) {
     super.firstUpdated(changed);
     if (this.step.reason === "missing_credentials") {
@@ -37,11 +34,6 @@ class StepFlowAbort extends LitElement {
       return nothing;
     }
     return html`
-      <h2 class=${this.increasePaddingEnd ? "end-space" : ""}>
-        ${this.params.flowConfig.renderAbortHeader
-          ? this.params.flowConfig.renderAbortHeader(this.hass, this.step)
-          : this.hass.localize(`component.${this.domain}.title`)}
-      </h2>
       <div class="content">
         ${this.params.flowConfig.renderAbortDescription(this.hass, this.step)}
       </div>

--- a/src/dialogs/config-flow/step-flow-external.ts
+++ b/src/dialogs/config-flow/step-flow-external.ts
@@ -15,16 +15,10 @@ class StepFlowExternal extends LitElement {
 
   @property({ attribute: false }) public step!: DataEntryFlowStepExternal;
 
-  @property({ type: Boolean, attribute: "increase-padding-end" })
-  public increasePaddingEnd = false;
-
   protected render(): TemplateResult {
     const localize = this.hass.localize;
 
     return html`
-      <h2 class=${this.increasePaddingEnd ? "end-space" : ""}>
-        ${this.flowConfig.renderExternalStepHeader(this.hass, this.step)}
-      </h2>
       <div class="content">
         ${this.flowConfig.renderExternalStepDescription(this.hass, this.step)}
         <div class="open-button">
@@ -55,9 +49,6 @@ class StepFlowExternal extends LitElement {
         }
         .open-button a {
           text-decoration: none;
-        }
-        h2.end-space {
-          padding-inline-end: 72px;
         }
       `,
     ];

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -6,18 +6,18 @@ import { dynamicElement } from "../../common/dom/dynamic-element-directive";
 import { fireEvent } from "../../common/dom/fire_event";
 import { isNavigationClick } from "../../common/dom/is-navigation-click";
 import "../../components/ha-alert";
-import "../../components/ha-spinner";
 import { computeInitialHaFormData } from "../../components/ha-form/compute-initial-ha-form-data";
 import "../../components/ha-form/ha-form";
 import type { HaFormSchema } from "../../components/ha-form/types";
 import "../../components/ha-markdown";
+import "../../components/ha-spinner";
 import { autocompleteLoginFields } from "../../data/auth";
 import type { DataEntryFlowStepForm } from "../../data/data_entry_flow";
+import { previewModule } from "../../data/preview";
+import { haStyle } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import type { FlowConfig } from "./show-dialog-data-entry-flow";
 import { configFlowContentStyles } from "./styles";
-import { haStyle } from "../../resources/styles";
-import { previewModule } from "../../data/preview";
 
 @customElement("step-flow-form")
 class StepFlowForm extends LitElement {
@@ -26,9 +26,6 @@ class StepFlowForm extends LitElement {
   @property({ attribute: false }) public step!: DataEntryFlowStepForm;
 
   @property({ attribute: false }) public hass!: HomeAssistant;
-
-  @property({ type: Boolean, attribute: "increase-padding-end" })
-  public increasePaddingEnd = false;
 
   @state() private _loading = false;
 
@@ -46,9 +43,6 @@ class StepFlowForm extends LitElement {
     const stepData = this._stepDataProcessed;
 
     return html`
-      <h2 class=${this.increasePaddingEnd ? "end-space" : ""}>
-        ${this.flowConfig.renderShowFormStepHeader(this.hass, this.step)}
-      </h2>
       <div class="content" @click=${this._clickHandler}>
         ${this.flowConfig.renderShowFormStepDescription(this.hass, this.step)}
         ${this._errorMsg
@@ -280,9 +274,6 @@ class StepFlowForm extends LitElement {
         ha-form {
           margin-top: 24px;
           display: block;
-        }
-        h2 {
-          word-break: break-word;
         }
       `,
     ];

--- a/src/dialogs/config-flow/step-flow-menu.ts
+++ b/src/dialogs/config-flow/step-flow-menu.ts
@@ -17,9 +17,6 @@ class StepFlowMenu extends LitElement {
 
   @property({ attribute: false }) public step!: DataEntryFlowStepMenu;
 
-  @property({ type: Boolean, attribute: "increase-padding-end" })
-  public increasePaddingEnd = false;
-
   protected render(): TemplateResult {
     let options: string[];
     let translations: Record<string, string>;
@@ -45,9 +42,6 @@ class StepFlowMenu extends LitElement {
     );
 
     return html`
-      <h2 class=${this.increasePaddingEnd ? "end-space" : ""}>
-        ${this.flowConfig.renderMenuHeader(this.hass, this.step)}
-      </h2>
       ${description ? html`<div class="content">${description}</div>` : ""}
       <div class="options">
         ${options.map(

--- a/src/dialogs/config-flow/step-flow-progress.ts
+++ b/src/dialogs/config-flow/step-flow-progress.ts
@@ -2,13 +2,13 @@ import "@material/mwc-button";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
+import { blankBeforePercent } from "../../common/translations/blank_before_percent";
 import "../../components/ha-progress-ring";
 import "../../components/ha-spinner";
 import type { DataEntryFlowStepProgress } from "../../data/data_entry_flow";
 import type { HomeAssistant } from "../../types";
 import type { FlowConfig } from "./show-dialog-data-entry-flow";
 import { configFlowContentStyles } from "./styles";
-import { blankBeforePercent } from "../../common/translations/blank_before_percent";
 
 @customElement("step-flow-progress")
 class StepFlowProgress extends LitElement {
@@ -24,14 +24,8 @@ class StepFlowProgress extends LitElement {
   @property({ type: Number })
   public progress?: number;
 
-  @property({ type: Boolean, attribute: "increase-padding-end" })
-  public increasePaddingEnd = false;
-
   protected render(): TemplateResult {
     return html`
-      <h2 class=${this.increasePaddingEnd ? "end-space" : ""}>
-        ${this.flowConfig.renderShowFormProgressHeader(this.hass, this.step)}
-      </h2>
       <div class="content">
         ${this.progress
           ? html`

--- a/src/dialogs/config-flow/styles.ts
+++ b/src/dialogs/config-flow/styles.ts
@@ -25,9 +25,6 @@ export const configFlowContentStyles = css`
     text-transform: var(--mdc-typography-headline6-text-transform, inherit);
     box-sizing: border-box;
   }
-  h2.end-space {
-    padding-inline-end: 72px;
-  }
 
   .content,
   .preview {

--- a/src/panels/config/repairs/show-dialog-repair-flow.ts
+++ b/src/panels/config/repairs/show-dialog-repair-flow.ts
@@ -1,7 +1,6 @@
 import { html, nothing } from "lit";
 import type { DataEntryFlowStep } from "../../../data/data_entry_flow";
 import { domainToName } from "../../../data/integration";
-import "./dialog-repairs-issue-subtitle";
 import type { RepairsIssue } from "../../../data/repairs";
 import {
   createRepairsFlow,
@@ -14,6 +13,7 @@ import {
   showFlowDialog,
 } from "../../../dialogs/config-flow/show-dialog-data-entry-flow";
 import type { HomeAssistant } from "../../../types";
+import "./dialog-repairs-issue-subtitle";
 
 const mergePlaceholders = (issue: RepairsIssue, step: DataEntryFlowStep) =>
   step.description_placeholders && issue.translation_placeholders
@@ -68,8 +68,11 @@ export const showRepairsFlowDialog = (
       deleteFlow: deleteRepairsFlow,
 
       renderAbortHeader(hass) {
+        return hass.localize("ui.dialogs.repair_flow.form.header");
+      },
+
+      renderAbortSubheader(hass) {
         return html`
-          ${hass.localize("ui.dialogs.repair_flow.form.header")}
           <dialog-repairs-issue-subtitle
             .hass=${hass}
             .issue=${issue}
@@ -98,13 +101,18 @@ export const showRepairsFlowDialog = (
       },
 
       renderShowFormStepHeader(hass, step) {
-        return html`
-          ${hass.localize(
+        return (
+          hass.localize(
             `component.${issue.domain}.issues.${
               issue.translation_key || issue.issue_id
             }.fix_flow.step.${step.step_id}.title`,
             mergePlaceholders(issue, step)
-          ) || hass.localize("ui.dialogs.repair_flow.form.header")}
+          ) || hass.localize("ui.dialogs.repair_flow.form.header")
+        );
+      },
+
+      renderShowFormStepSubheader(hass) {
+        return html`
           <dialog-repairs-issue-subtitle
             .hass=${hass}
             .issue=${issue}
@@ -196,13 +204,18 @@ export const showRepairsFlowDialog = (
       },
 
       renderShowFormProgressHeader(hass, step) {
-        return html`
-          ${hass.localize(
+        return (
+          hass.localize(
             `component.${issue.domain}.issues.step.${
               issue.translation_key || issue.issue_id
             }.fix_flow.${step.step_id}.title`,
             mergePlaceholders(issue, step)
-          ) || hass.localize(`component.${issue.domain}.title`)}
+          ) || hass.localize(`component.${issue.domain}.title`)
+        );
+      },
+
+      renderShowFormProgressSubheader(hass) {
+        return html`
           <dialog-repairs-issue-subtitle
             .hass=${hass}
             .issue=${issue}
@@ -229,13 +242,18 @@ export const showRepairsFlowDialog = (
       },
 
       renderMenuHeader(hass, step) {
-        return html`
-          ${hass.localize(
+        return (
+          hass.localize(
             `component.${issue.domain}.issues.${
               issue.translation_key || issue.issue_id
             }.fix_flow.step.${step.step_id}.title`,
             mergePlaceholders(issue, step)
-          ) || hass.localize(`component.${issue.domain}.title`)}
+          ) || hass.localize(`component.${issue.domain}.title`)
+        );
+      },
+
+      renderMenuSubheader(hass) {
+        return html`
           <dialog-repairs-issue-subtitle
             .hass=${hass}
             .issue=${issue}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5340,7 +5340,7 @@
           },
           "config_flow": {
             "success": "Success",
-            "assign_area": "Assign {number, plural,\n  one {device}\n  other {devices}\n} to area",
+            "device_created": "{number, plural,\n  one {Device}\n  other {Devices}\n} created",
             "device_name": "Device name",
             "aborted": "Aborted",
             "close": "Close",


### PR DESCRIPTION
## Proposed change
- use `ha-dialog-header` for `dialog-data-entry-flow` steps

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
