### PR TITLE
Fix stack editor bugs

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
@@ -219,7 +219,7 @@ export class HuiStackCardEditor
   }
 
   private _getKey(cards: LovelaceCardConfig[], index: number): string {
-    const key = `${index}${cards.length}`;
+    const key = `${index}-${cards.length}`;
     if (!this._keys.has(key)) {
       this._keys.set(key, Math.random().toString());
     }

--- a/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
@@ -219,7 +219,7 @@ export class HuiStackCardEditor
   }
 
   private _getKey(cards: LovelaceCardConfig[], index: number): string {
-    const key = `${cards[index].type}${index}${cards.length}`;
+    const key = `${index}${cards.length}`;
     if (!this._keys.has(key)) {
       this._keys.set(key, Math.random().toString());
     }
@@ -234,7 +234,7 @@ export class HuiStackCardEditor
   }
 
   protected _handleSelectedCard(ev) {
-    this._setMode(true);
+    this._GUImode = true;
     this._guiModeAvailable = true;
     this._selectedCard = parseInt(ev.detail.name, 10);
   }
@@ -315,13 +315,6 @@ export class HuiStackCardEditor
 
   protected _toggleMode(): void {
     this._cardEditorEl?.toggleMode();
-  }
-
-  protected _setMode(value: boolean): void {
-    this._GUImode = value;
-    if (this._cardEditorEl) {
-      this._cardEditorEl!.GUImode = value;
-    }
   }
 
   protected _valueChanged(ev: CustomEvent): void {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Fix two issues in stack card:

1. Since the tabs changed, something is messed up in how new cards are initialized in yaml mode. Any card without a visual editor now creates in a broken state where no editor _or_ yaml editor is shown. This was fixed by removing the attempt to force the sub-element into gui mode anytime a tab was selected. We already destroy and recreate the editor when a new tab is selected, and that will automatically recreate itself into gui mode (if available), so I don't think we need to do that anymore.

2. Third attempt at fixing the keyed() function after #24065 and #24530. I noticed that currently if you create a manual card, you cannot type a "type" in the yaml editor nicely, because the editor is keyed on card type, so anytime you type a single letter to change the type it resets the editor, which is not good. I actually don't think it's necessary to key on the card type, the element editor already handles this internally when its type is changed. The initial bugs I was trying to fix were all when switching between cards of the _same_ type. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #25491
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
