### PR TITLE
Fix loading behavior when manually typing card type

### DIFF
--- a/src/panels/lovelace/editor/hui-element-editor.ts
+++ b/src/panels/lovelace/editor/hui-element-editor.ts
@@ -82,6 +82,8 @@ export abstract class HuiElementEditor<
 
   @query("ha-yaml-editor") _yamlEditor?: HaYamlEditor;
 
+  private _loadCount = 0;
+
   public get value(): T | undefined {
     return this._config;
   }
@@ -411,7 +413,7 @@ export abstract class HuiElementEditor<
     if (!this.value) {
       return;
     }
-
+    const loadNum = ++this._loadCount;
     try {
       this._errors = undefined;
       this._warnings = undefined;
@@ -435,6 +437,9 @@ export abstract class HuiElementEditor<
         this.GUImode = false;
       }
     } catch (err: any) {
+      if (loadNum !== this._loadCount) {
+        return;
+      }
       if (err instanceof GUISupportError) {
         this._warnings = err.warnings ?? [err.message];
         this._errors = err.errors || undefined;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Improve the behavior of manual card editor. 

Imagine adding a manual card, and you want to add a custom:foobar-card. So you type that in the yaml editor. 

With each keystroke, we fire off a new attempt to load the card
So as you type, we fire off 5 attemps to load a card in parallel:

- custom:foobar-
- custom:foobar-c
- custom:foobar-ca
- custom:foobar-car
- custom:foobar-card

The final one hits and loads quickly, because it is available, and the editor is correctly displayed. But if you type fast we are still awaiting the loading of the first 4 attempts. As they start to timeout, your working editor now starts showing a series of errors, which trickle in over the next few seconds:

- "Error: foobar- doesn't exist"
- "Error: foobar-c doesn't exist"
and finally
- "Error: foobar-car doesn't exist"

The last message is the final load to complete, and now this is stale error is stuck on the screen, even though you had already successfully loaded the card that you want. 

We can just discard whichever errors are not associated with the most recent load attempt. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
