### PR TITLE
Add has-fab to hass-tabs-subpage

### DIFF
--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -3,15 +3,15 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, eventOptions, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import memoizeOne from "memoize-one";
+import { canShowPage } from "../common/config/can_show_page";
 import { restoreScroll } from "../common/decorators/restore-scroll";
 import type { LocalizeFunc } from "../common/translations/localize";
 import "../components/ha-icon-button-arrow-prev";
 import "../components/ha-menu-button";
 import "../components/ha-svg-icon";
 import "../components/ha-tab";
-import type { HomeAssistant, Route } from "../types";
 import { haStyleScrollbar } from "../resources/styles";
-import { canShowPage } from "../common/config/can_show_page";
+import type { HomeAssistant, Route } from "../types";
 
 export interface PageNavigation {
   path: string;
@@ -51,6 +51,12 @@ class HassTabsSubpage extends LitElement {
   public isWide = false;
 
   @property({ type: Boolean }) public pane = false;
+
+  /**
+   * Do we need to add padding for a fab.
+   * @type {Boolean}
+   */
+  @property({ type: Boolean, attribute: "has-fab" }) public hasFab = false;
 
   @state() private _activeTab?: PageNavigation;
 
@@ -178,6 +184,7 @@ class HassTabsSubpage extends LitElement {
           @scroll=${this._saveScrollPos}
         >
           <slot></slot>
+          ${this.hasFab ? html`<div class="fab-bottom-space"></div>` : nothing}
         </div>
       </div>
       <div id="fab" class=${classMap({ tabs: showTabs })}>
@@ -334,6 +341,14 @@ class HassTabsSubpage extends LitElement {
           height: calc(
             100% - 2 * var(--header-height) - env(safe-area-inset-bottom)
           );
+        }
+
+        .content .fab-bottom-space {
+          height: calc(64px + env(safe-area-inset-bottom));
+        }
+
+        :host([narrow]) .content.tabs .fab-bottom-space {
+          height: calc(80px + env(safe-area-inset-bottom));
         }
 
         #fab {

--- a/src/panels/config/areas/ha-config-areas-dashboard.ts
+++ b/src/panels/config/areas/ha-config-areas-dashboard.ts
@@ -148,6 +148,7 @@ export class HaConfigAreasDashboard extends LitElement {
         back-path="/config"
         .tabs=${configSections.areas}
         .route=${this.route}
+        has-fab
       >
         <ha-icon-button
           slot="toolbar-icon"

--- a/src/panels/config/integrations/ha-config-integrations-dashboard.ts
+++ b/src/panels/config/integrations/ha-config-integrations-dashboard.ts
@@ -447,6 +447,7 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
         back-path="/config"
         .route=${this.route}
         .tabs=${configSections.devices}
+        has-fab
       >
         ${this.narrow
           ? html`
@@ -983,9 +984,6 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
           grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
           grid-gap: 8px 8px;
           padding: 8px 16px 16px;
-        }
-        .container:last-of-type {
-          margin-bottom: 64px;
         }
         .empty-message {
           margin: auto;

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -1,48 +1,48 @@
 import "@material/mwc-button/mwc-button";
 import {
+  mdiAlertCircle,
+  mdiCheckCircle,
   mdiFolderMultipleOutline,
   mdiLan,
   mdiNetwork,
-  mdiPlus,
   mdiPencil,
-  mdiCheckCircle,
-  mdiAlertCircle,
+  mdiPlus,
 } from "@mdi/js";
 import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import type { ConfigEntry } from "../../../../../data/config_entries";
-import { getConfigEntries } from "../../../../../data/config_entries";
+import "../../../../../components/buttons/ha-progress-button";
+import "../../../../../components/ha-alert";
 import "../../../../../components/ha-card";
 import "../../../../../components/ha-fab";
-import "../../../../../components/ha-icon-button";
-import { fileDownload } from "../../../../../util/file_download";
-import "../../../../../components/ha-icon-next";
-import "../../../../../layouts/hass-tabs-subpage";
-import type { PageNavigation } from "../../../../../layouts/hass-tabs-subpage";
-import { showOptionsFlowDialog } from "../../../../../dialogs/config-flow/show-dialog-options-flow";
-import { haStyle } from "../../../../../resources/styles";
-import type { HomeAssistant, Route } from "../../../../../types";
-import "../../../ha-config-section";
 import "../../../../../components/ha-form/ha-form";
-import "../../../../../components/buttons/ha-progress-button";
+import "../../../../../components/ha-icon-button";
+import "../../../../../components/ha-icon-next";
 import "../../../../../components/ha-settings-row";
 import "../../../../../components/ha-svg-icon";
-import "../../../../../components/ha-alert";
-import { showZHAChangeChannelDialog } from "./show-dialog-zha-change-channel";
+import type { ConfigEntry } from "../../../../../data/config_entries";
+import { getConfigEntries } from "../../../../../data/config_entries";
 import type {
   ZHAConfiguration,
-  ZHANetworkSettings,
   ZHANetworkBackupAndMetadata,
+  ZHANetworkSettings,
 } from "../../../../../data/zha";
 import {
-  fetchZHAConfiguration,
-  updateZHAConfiguration,
-  fetchZHANetworkSettings,
   createZHANetworkBackup,
   fetchDevices,
+  fetchZHAConfiguration,
+  fetchZHANetworkSettings,
+  updateZHAConfiguration,
 } from "../../../../../data/zha";
+import { showOptionsFlowDialog } from "../../../../../dialogs/config-flow/show-dialog-options-flow";
 import { showAlertDialog } from "../../../../../dialogs/generic/show-dialog-box";
+import "../../../../../layouts/hass-tabs-subpage";
+import type { PageNavigation } from "../../../../../layouts/hass-tabs-subpage";
+import { haStyle } from "../../../../../resources/styles";
+import type { HomeAssistant, Route } from "../../../../../types";
+import { fileDownload } from "../../../../../util/file_download";
+import "../../../ha-config-section";
+import { showZHAChangeChannelDialog } from "./show-dialog-zha-change-channel";
 
 const MULTIPROTOCOL_ADDON_URL = "socket://core-silabs-multiprotocol:9999";
 
@@ -108,6 +108,7 @@ class ZHAConfigDashboard extends LitElement {
         .route=${this.route}
         .tabs=${zhaTabs}
         back-path="/config/integrations"
+        has-fab
       >
         <ha-card class="content network-status">
           ${this._error

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -43,6 +43,7 @@ import {
   subscribeZwaveControllerStatistics,
   subscribeZwaveNVMBackup,
 } from "../../../../../data/zwave_js";
+import { showConfigFlowDialog } from "../../../../../dialogs/config-flow/show-dialog-config-flow";
 import { showAlertDialog } from "../../../../../dialogs/generic/show-dialog-box";
 import "../../../../../layouts/hass-tabs-subpage";
 import { SubscribeMixin } from "../../../../../mixins/subscribe-mixin";
@@ -53,7 +54,6 @@ import { showZWaveJSAddNodeDialog } from "./add-node/show-dialog-zwave_js-add-no
 import { showZWaveJSRebuildNetworkRoutesDialog } from "./show-dialog-zwave_js-rebuild-network-routes";
 import { showZWaveJSRemoveNodeDialog } from "./show-dialog-zwave_js-remove-node";
 import { configTabs } from "./zwave_js-config-router";
-import { showConfigFlowDialog } from "../../../../../dialogs/config-flow/show-dialog-config-flow";
 
 @customElement("zwave_js-config-dashboard")
 class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
@@ -142,6 +142,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
         .narrow=${this.narrow}
         .route=${this.route}
         .tabs=${configTabs}
+        has-fab
       >
         <ha-icon-button
           slot="toolbar-icon"

--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -65,6 +65,7 @@ export class HaConfigPerson extends LitElement {
         .route=${this.route}
         back-path="/config"
         .tabs=${configSections.persons}
+        has-fab
       >
         <ha-config-section .isWide=${this.isWide}>
           <span slot="header"

--- a/src/panels/config/zone/ha-config-zone.ts
+++ b/src/panels/config/zone/ha-config-zone.ts
@@ -238,6 +238,7 @@ export class HaConfigZone extends SubscribeMixin(LitElement) {
           ? undefined
           : "/config"}
         .tabs=${configSections.areas}
+        has-fab
       >
         ${this.narrow
           ? html`
@@ -580,9 +581,6 @@ export class HaConfigZone extends SubscribeMixin(LitElement) {
       width: 250px;
       min-height: 100%;
       box-sizing: border-box;
-    }
-    ha-card {
-      margin-bottom: 100px;
     }
     ha-tooltip {
       display: block;


### PR DESCRIPTION
## Proposed change
- introduce  `has-fab` prop in `hass-tabs-subpage` to avoid buttons that cannot be pressed because of the fab (mostly on mobile)

![image](https://github.com/user-attachments/assets/099dccbb-2f3a-46a0-9b54-9f1a6a509eae)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
