### PR TITLE
Add range support to icon translations

### DIFF
--- a/src/common/entity/state_icon.ts
+++ b/src/common/entity/state_icon.ts
@@ -2,7 +2,6 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import { computeStateDomain } from "./compute_state_domain";
 import { updateIcon } from "./update_icon";
 import { deviceTrackerIcon } from "./device_tracker_icon";
-import { batteryIcon } from "./battery_icon";
 
 export const stateIcon = (
   stateObj: HassEntity,
@@ -10,16 +9,9 @@ export const stateIcon = (
 ): string | undefined => {
   const domain = computeStateDomain(stateObj);
   const compareState = state ?? stateObj.state;
-  const dc = stateObj.attributes.device_class;
   switch (domain) {
     case "update":
       return updateIcon(stateObj, compareState);
-
-    case "sensor":
-      if (dc === "battery") {
-        return batteryIcon(stateObj, compareState);
-      }
-      break;
 
     case "device_tracker":
       return deviceTrackerIcon(stateObj, compareState);

--- a/src/data/icons.ts
+++ b/src/data/icons.ts
@@ -346,22 +346,18 @@ const getIconFromTranslations = (
     return undefined;
   }
 
-  let icon: string | undefined;
 
   // First check for exact state match
   if (state && translations.state?.[state]) {
-    icon = translations.state[state];
+    return translations.state[state];
   }
   // Then check for range-based icons if we have a numeric state
-  else if (state !== undefined && translations.range && !isNaN(Number(state))) {
-    icon = getIconFromRange(Number(state), translations.range);
+  if (state !== undefined && translations.range && !isNaN(Number(state))) {
+    return getIconFromRange(Number(state), translations.range);
   }
   // Fallback to default icon
-  if (!icon) {
-    icon = translations.default;
-  }
+  return translations.default;
 
-  return icon;
 };
 
 export const entityIcon = async (

--- a/src/data/icons.ts
+++ b/src/data/icons.ts
@@ -346,7 +346,6 @@ const getIconFromTranslations = (
     return undefined;
   }
 
-
   // First check for exact state match
   if (state && translations.state?.[state]) {
     return translations.state[state];
@@ -357,7 +356,6 @@ const getIconFromTranslations = (
   }
   // Fallback to default icon
   return translations.default;
-
 };
 
 export const entityIcon = async (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add range support to icon translations, meaning we can now provide icons based on the numeric state through the icons translation files.

Implements the proposal from architectural discussion: https://github.com/home-assistant/architecture/discussions/1190

Backend change: https://github.com/home-assistant/core/pull/145340

This PR add support for the state icon lookup in the translations + cleans up the custom logic used for battery sensors state icons.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
