### PR TITLE
Restore screen readers support on pickers

### DIFF
--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -317,6 +317,7 @@ export class HaEntityPicker extends LitElement {
         const secondary = [areaName, entityName ? deviceName : undefined]
           .filter(Boolean)
           .join(isRTL ? " ◂ " : " ▸ ");
+        const a11yLabel = [deviceName, entityName].filter(Boolean).join(" - ");
 
         return {
           id: entityId,
@@ -332,6 +333,7 @@ export class HaEntityPicker extends LitElement {
             friendlyName,
             entityId,
           ].filter(Boolean) as string[],
+          a11y_label: a11yLabel,
           stateObj: stateObj,
         };
       });

--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -267,6 +267,7 @@ export class HaStatisticPicker extends LitElement {
         const secondary = [areaName, entityName ? deviceName : undefined]
           .filter(Boolean)
           .join(isRTL ? " ◂ " : " ▸ ");
+        const a11yLabel = [deviceName, entityName].filter(Boolean).join(" - ");
 
         const sortingPrefix = `${TYPE_ORDER.indexOf("entity")}`;
         output.push({
@@ -274,6 +275,7 @@ export class HaStatisticPicker extends LitElement {
           statistic_id: id,
           primary,
           secondary,
+          a11y_label: a11yLabel,
           stateObj: stateObj,
           type: "entity",
           sorting_label: [sortingPrefix, deviceName, entityName].join("_"),

--- a/src/components/ha-combo-box-textfield.ts
+++ b/src/components/ha-combo-box-textfield.ts
@@ -1,0 +1,24 @@
+import type { PropertyValues } from "lit";
+import { customElement, property } from "lit/decorators";
+import { HaTextField } from "./ha-textfield";
+
+@customElement("ha-combo-box-textfield")
+export class HaComboBoxTextField extends HaTextField {
+  @property({ type: Boolean, attribute: "disable-set-value" })
+  public disableSetValue = false;
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+    if (changedProps.has("value")) {
+      if (this.disableSetValue) {
+        this.value = changedProps.get("value") as string;
+      }
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-combo-box-textfield": HaComboBoxTextField;
+  }
+}

--- a/src/components/ha-combo-box.ts
+++ b/src/components/ha-combo-box.ts
@@ -116,7 +116,7 @@ export class HaComboBox extends LitElement {
 
   @query("ha-combo-box-textfield", true) private _inputElement!: HaTextField;
 
-  @state({ type: Boolean }) public disableSetValue = false;
+  @state({ type: Boolean }) private _disableSetValue = false;
 
   private _overlayMutationObserver?: MutationObserver;
 
@@ -197,7 +197,7 @@ export class HaComboBox extends LitElement {
           .invalid=${this.invalid}
           .helper=${this.helper}
           helperPersistent
-          .disableSetValue=${this.disableSetValue}
+          .disableSetValue=${this._disableSetValue}
         >
           <slot name="icon" slot="leadingIcon"></slot>
         </ha-combo-box-textfield>
@@ -261,10 +261,10 @@ export class HaComboBox extends LitElement {
       if (opened) {
         // Wait 100ms to be sure vaddin-combo-box-light already tried to set the value
         setTimeout(() => {
-          this.disableSetValue = false;
+          this._disableSetValue = false;
         }, 100);
       } else {
-        this.disableSetValue = true;
+        this._disableSetValue = true;
       }
     }
 

--- a/src/components/ha-combo-box.ts
+++ b/src/components/ha-combo-box.ts
@@ -12,11 +12,12 @@ import type {
 import { registerStyles } from "@vaadin/vaadin-themable-mixin/register-styles";
 import type { TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
-import { customElement, property, query } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
 import { fireEvent } from "../common/dom/fire_event";
 import type { HomeAssistant } from "../types";
 import "./ha-combo-box-item";
+import "./ha-combo-box-textfield";
 import "./ha-icon-button";
 import "./ha-textfield";
 import type { HaTextField } from "./ha-textfield";
@@ -108,9 +109,14 @@ export class HaComboBox extends LitElement {
   @property({ type: Boolean, attribute: "hide-clear-icon" })
   public hideClearIcon = false;
 
+  @property({ type: Boolean, attribute: "clear-initial-value" })
+  public clearInitialValue = false;
+
   @query("vaadin-combo-box-light", true) private _comboBox!: ComboBoxLight;
 
-  @query("ha-textfield", true) private _inputElement!: HaTextField;
+  @query("ha-combo-box-textfield", true) private _inputElement!: HaTextField;
+
+  @state({ type: Boolean }) public disableSetValue = false;
 
   private _overlayMutationObserver?: MutationObserver;
 
@@ -171,7 +177,7 @@ export class HaComboBox extends LitElement {
         @value-changed=${this._valueChanged}
         attr-for-value="value"
       >
-        <ha-textfield
+        <ha-combo-box-textfield
           label=${ifDefined(this.label)}
           placeholder=${ifDefined(this.placeholder)}
           ?disabled=${this.disabled}
@@ -191,9 +197,10 @@ export class HaComboBox extends LitElement {
           .invalid=${this.invalid}
           .helper=${this.helper}
           helperPersistent
+          .disableSetValue=${this.disableSetValue}
         >
           <slot name="icon" slot="leadingIcon"></slot>
-        </ha-textfield>
+        </ha-combo-box-textfield>
         ${this.value && !this.hideClearIcon
           ? html`<ha-svg-icon
               role="button"
@@ -248,6 +255,18 @@ export class HaComboBox extends LitElement {
       this.opened = opened;
       fireEvent(this, "opened-changed", { value: ev.detail.value });
     }, 0);
+
+    if (this.clearInitialValue) {
+      this.setTextFieldValue("");
+      if (opened) {
+        // Wait 100ms to be sure vaddin-combo-box-light already tried to set the value
+        setTimeout(() => {
+          this.disableSetValue = false;
+        }, 100);
+      } else {
+        this.disableSetValue = true;
+      }
+    }
 
     if (opened) {
       const overlay = document.querySelector<HTMLElement>(
@@ -342,10 +361,10 @@ export class HaComboBox extends LitElement {
       position: relative;
       --vaadin-combo-box-overlay-max-height: calc(45vh - 56px);
     }
-    ha-textfield {
+    ha-combo-box-textfield {
       width: 100%;
     }
-    ha-textfield > ha-icon-button {
+    ha-combo-box-textfield > ha-icon-button {
       --mdc-icon-button-size: 24px;
       padding: 2px;
       color: var(--secondary-text-color);

--- a/src/components/ha-generic-picker.ts
+++ b/src/components/ha-generic-picker.ts
@@ -2,6 +2,7 @@ import type { ComboBoxLitRenderer } from "@vaadin/combo-box/lit";
 import type { ComboBoxLightOpenedChangedEvent } from "@vaadin/combo-box/vaadin-combo-box-light";
 import { css, html, LitElement, nothing, type CSSResultGroup } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
+import { ifDefined } from "lit/directives/if-defined";
 import { fireEvent } from "../common/dom/fire_event";
 import type { HomeAssistant } from "../types";
 import "./ha-combo-box-item";
@@ -74,6 +75,7 @@ export class HaGenericPicker extends LitElement {
               <ha-picker-field
                 type="button"
                 compact
+                aria-label=${ifDefined(this.label)}
                 @click=${this.open}
                 @clear=${this._clear}
                 .placeholder=${this.placeholder}

--- a/src/components/ha-picker-combo-box.ts
+++ b/src/components/ha-picker-combo-box.ts
@@ -18,6 +18,7 @@ import "./ha-icon";
 export interface PickerComboBoxItem {
   id: string;
   primary: string;
+  a11y_label?: string;
   secondary?: string;
   search_labels?: string[];
   sorting_label?: string;
@@ -27,7 +28,7 @@ export interface PickerComboBoxItem {
 
 // Hack to force empty label to always display empty value by default in the search field
 export interface PickerComboBoxItemWithLabel extends PickerComboBoxItem {
-  label: "";
+  a11y_label: string;
 }
 
 const NO_MATCHING_ITEMS_FOUND_ID = "___no_matching_items_found___";
@@ -109,7 +110,7 @@ export class HaPickerComboBox extends LitElement {
       id: NO_MATCHING_ITEMS_FOUND_ID,
       primary: label || localize("ui.components.combo-box.no_match"),
       icon_path: mdiMagnify,
-      label: "",
+      a11y_label: label || localize("ui.components.combo-box.no_match"),
     })
   );
 
@@ -118,7 +119,7 @@ export class HaPickerComboBox extends LitElement {
 
     return items.map<PickerComboBoxItemWithLabel>((item) => ({
       ...item,
-      label: "",
+      a11y_label: item.a11y_label || item.primary,
     }));
   };
 
@@ -128,7 +129,7 @@ export class HaPickerComboBox extends LitElement {
     const sortedItems = items
       .map<PickerComboBoxItemWithLabel>((item) => ({
         ...item,
-        label: "",
+        a11y_label: item.a11y_label || item.primary,
       }))
       .sort((entityA, entityB) =>
         caseInsensitiveStringCompare(
@@ -175,7 +176,8 @@ export class HaPickerComboBox extends LitElement {
       <ha-combo-box
         item-id-path="id"
         item-value-path="id"
-        item-label-path="label"
+        item-label-path="a11y_label"
+        clear-initial-value
         .hass=${this.hass}
         .value=${this._value}
         .label=${this.label}


### PR DESCRIPTION
## Proposed change

Since last release, we use the picker textfield as a search instead of a combobox. By clearing the label, we removed the accessibility for screen reader.
This PR restore it. It's very hacky because the vaddin component we use it not designed to be used like that. 

We must consider to rebuild the pickers ourself using `combobox` area role in future update

That PR is quick fix to improve accessibility even if it's not perfect.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
