### PR TITLE
Allow href="data:..." in config flow step description

### DIFF
--- a/src/components/ha-markdown-element.ts
+++ b/src/components/ha-markdown-element.ts
@@ -26,6 +26,9 @@ class HaMarkdownElement extends ReactiveElement {
 
   @property({ attribute: "allow-svg", type: Boolean }) public allowSvg = false;
 
+  @property({ attribute: "allow-data-url", type: Boolean })
+  public allowDataUrl = false;
+
   @property({ type: Boolean }) public breaks = false;
 
   @property({ type: Boolean, attribute: "lazy-images" }) public lazyImages =
@@ -66,6 +69,7 @@ class HaMarkdownElement extends ReactiveElement {
     return hash({
       content: this.content,
       allowSvg: this.allowSvg,
+      allowDataUrl: this.allowDataUrl,
       breaks: this.breaks,
     });
   }
@@ -79,6 +83,7 @@ class HaMarkdownElement extends ReactiveElement {
       },
       {
         allowSvg: this.allowSvg,
+        allowDataUrl: this.allowDataUrl,
       }
     );
 

--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -8,6 +8,9 @@ export class HaMarkdown extends LitElement {
 
   @property({ attribute: "allow-svg", type: Boolean }) public allowSvg = false;
 
+  @property({ attribute: "allow-data-url", type: Boolean })
+  public allowDataUrl = false;
+
   @property({ type: Boolean }) public breaks = false;
 
   @property({ type: Boolean, attribute: "lazy-images" }) public lazyImages =
@@ -23,6 +26,7 @@ export class HaMarkdown extends LitElement {
     return html`<ha-markdown-element
       .content=${this.content}
       .allowSvg=${this.allowSvg}
+      .allowDataUrl=${this.allowDataUrl}
       .breaks=${this.breaks}
       .lazyImages=${this.lazyImages}
       .cache=${this.cache}

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -73,7 +73,12 @@ export const showConfigFlowDialog = (
       );
       return description
         ? html`
-            <ha-markdown allow-svg breaks .content=${description}></ha-markdown>
+            <ha-markdown
+              allow-data-url
+              allow-svg
+              breaks
+              .content=${description}
+            ></ha-markdown>
           `
         : "";
     },

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -74,7 +74,7 @@ export const showConfigFlowDialog = (
       return description
         ? html`
             <ha-markdown
-              allow-data-url
+              .allowDataUrl=${step.handler === "zwave_js"}
               allow-svg
               breaks
               .content=${description}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The XSS filter normally strips such href values but we need this for the ZWaveJS migration. In case of a failed restore we want to allow downloading of the backup data.
Right now it is allowed for the description of all FORM type config flow steps. We could limit this to only Zwave flows but I don't know if we should. This is data from core components so I don't see the need for strict sanitization.

Core PR: https://github.com/home-assistant/core/pull/145434

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/zwave-js/backlog/issues/56
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
