### PR TITLE
Add light card feature to pick hue

### DIFF
--- a/src/panels/lovelace/card-features/hui-light-color-hue-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-light-color-hue-card-feature.ts
@@ -7,6 +7,7 @@ import { UNAVAILABLE } from "../../../data/entity";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { LightColorMode, lightSupportsColorMode } from "../../../data/light";
 import { stateActive } from "../../../common/entity/state_active";
+import "../../../components/ha-control-slider";
 import type { LovelaceCardFeature } from "../types";
 import type { LightColorHueCardFeatureConfig } from "./types";
 import type { HomeAssistant } from "../../../types";

--- a/src/panels/lovelace/card-features/hui-light-color-hue-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-light-color-hue-card-feature.ts
@@ -1,0 +1,127 @@
+import { customElement, property, state } from "lit/decorators";
+import { html, LitElement, nothing } from "lit";
+import memoizeOne from "memoize-one";
+import { styleMap } from "lit/directives/style-map";
+import type { HassEntity } from "home-assistant-js-websocket";
+import { UNAVAILABLE } from "../../../data/entity";
+import { computeDomain } from "../../../common/entity/compute_domain";
+import { LightColorMode, lightSupportsColorMode } from "../../../data/light";
+import { stateActive } from "../../../common/entity/state_active";
+import type { LovelaceCardFeature } from "../types";
+import type { LightColorHueCardFeatureConfig } from "./types";
+import type { HomeAssistant } from "../../../types";
+import { hsv2rgb, rgb2hsv } from "../../../common/color/convert-color";
+
+export const supportsLightColorHueCardFeature = (stateObj: HassEntity) => {
+  const domain = computeDomain(stateObj.entity_id);
+  return (
+    domain === "light" &&
+    (lightSupportsColorMode(stateObj, LightColorMode.XY) ||
+      lightSupportsColorMode(stateObj, LightColorMode.XY) ||
+      lightSupportsColorMode(stateObj, LightColorMode.RGB) ||
+      lightSupportsColorMode(stateObj, LightColorMode.RGBW) ||
+      lightSupportsColorMode(stateObj, LightColorMode.RGBWW))
+  );
+};
+
+@customElement("hui-light-color-hue-card-feature")
+class HuiLightColorHueCardFeature
+  extends LitElement
+  implements LovelaceCardFeature
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public stateObj?: HassEntity;
+
+  @state() private _config?: LightColorHueCardFeatureConfig;
+
+  static getStubConfig(): LightColorHueCardFeatureConfig {
+    return {
+      type: "light-color-hue",
+    };
+  }
+
+  public setConfig(config: LightColorHueCardFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  protected render() {
+    if (
+      !this._config ||
+      !this.hass ||
+      !this.stateObj ||
+      !supportsLightColorHueCardFeature(this.stateObj)
+    ) {
+      return nothing;
+    }
+
+    // Convert to hue
+    const rgbColor = this.stateObj.attributes.rgb_color || [255, 255, 255];
+    const [hue] = rgb2hsv(rgbColor);
+
+    const gradient = this._generateColorGradient();
+
+    return html`
+      <ha-control-slider
+        .value=${hue}
+        mode="cursor"
+        .showHandle=${stateActive(this.stateObj)}
+        .disabled=${this.stateObj!.state === UNAVAILABLE}
+        @value-changed=${this._valueChanged}
+        .label=${this.hass.localize("ui.card.light.color")}
+        .min=${0}
+        .max=${360}
+        .step=${1}
+        style=${styleMap({
+          "--control-slider-background": gradient,
+        })}
+      >
+      </ha-control-slider>
+    `;
+  }
+
+  private _generateColorGradient = memoizeOne(() => {
+    const colors = [
+      "rgb(255, 0, 0)", // Red (0°)
+      "rgb(255, 127, 0)", // Orange (30°)
+      "rgb(255, 255, 0)", // Yellow (60°)
+      "rgb(127, 255, 0)", // Yellow-Green (90°)
+      "rgb(0, 255, 0)", // Green (120°)
+      "rgb(0, 255, 127)", // Green-Cyan (150°)
+      "rgb(0, 255, 255)", // Cyan (180°)
+      "rgb(0, 127, 255)", // Cyan-Blue (210°)
+      "rgb(0, 0, 255)", // Blue (240°)
+      "rgb(127, 0, 255)", // Blue-Magenta (270°)
+      "rgb(255, 0, 255)", // Magenta (300°)
+      "rgb(255, 0, 127)", // Magenta-Red (330°)
+      "rgb(255, 0, 0)", // Red (360°)
+    ];
+    return `linear-gradient(to right, ${colors.join(", ")})`;
+  });
+
+  private _valueChanged(ev: CustomEvent) {
+    ev.stopPropagation();
+    const hue = ev.detail.value;
+
+    // Keeps full saturation and brightness
+    const [r, g, b] = hsv2rgb([hue, 1, 1]);
+
+    this.hass!.callService("light", "turn_on", {
+      entity_id: this.stateObj!.entity_id,
+      rgb_color: [
+        Math.round(r * 255),
+        Math.round(g * 255),
+        Math.round(b * 255),
+      ],
+    });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-light-color-hue-card-feature": HuiLightColorHueCardFeature;
+  }
+}

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -26,6 +26,10 @@ export interface LightColorTempCardFeatureConfig {
   type: "light-color-temp";
 }
 
+export interface LightColorHueCardFeatureConfig {
+  type: "light-color-hue";
+}
+
 export interface LockCommandsCardFeatureConfig {
   type: "lock-commands";
 }
@@ -177,6 +181,7 @@ export type LovelaceCardFeatureConfig =
   | LawnMowerCommandsCardFeatureConfig
   | LightBrightnessCardFeatureConfig
   | LightColorTempCardFeatureConfig
+  | LightColorHueCardFeatureConfig
   | LockCommandsCardFeatureConfig
   | LockOpenDoorCardFeatureConfig
   | MediaPlayerVolumeSliderCardFeatureConfig

--- a/src/panels/lovelace/create-element/create-card-feature-element.ts
+++ b/src/panels/lovelace/create-element/create-card-feature-element.ts
@@ -15,6 +15,7 @@ import "../card-features/hui-humidifier-modes-card-feature";
 import "../card-features/hui-humidifier-toggle-card-feature";
 import "../card-features/hui-lawn-mower-commands-card-feature";
 import "../card-features/hui-light-brightness-card-feature";
+import "../card-features/hui-light-color-hue-card-feature";
 import "../card-features/hui-light-color-temp-card-feature";
 import "../card-features/hui-lock-commands-card-feature";
 import "../card-features/hui-lock-open-door-card-feature";
@@ -53,6 +54,7 @@ const TYPES = new Set<LovelaceCardFeatureConfig["type"]>([
   "lawn-mower-commands",
   "light-brightness",
   "light-color-temp",
+  "light-color-hue",
   "lock-commands",
   "lock-open-door",
   "media-player-volume-slider",

--- a/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
@@ -35,6 +35,7 @@ import { supportsHumidifierModesCardFeature } from "../../card-features/hui-humi
 import { supportsHumidifierToggleCardFeature } from "../../card-features/hui-humidifier-toggle-card-feature";
 import { supportsLawnMowerCommandCardFeature } from "../../card-features/hui-lawn-mower-commands-card-feature";
 import { supportsLightBrightnessCardFeature } from "../../card-features/hui-light-brightness-card-feature";
+import { supportsLightColorHueCardFeature } from "../../card-features/hui-light-color-hue-card-feature";
 import { supportsLightColorTempCardFeature } from "../../card-features/hui-light-color-temp-card-feature";
 import { supportsLockCommandsCardFeature } from "../../card-features/hui-lock-commands-card-feature";
 import { supportsLockOpenDoorCardFeature } from "../../card-features/hui-lock-open-door-card-feature";
@@ -72,6 +73,7 @@ const UI_FEATURE_TYPES = [
   "lawn-mower-commands",
   "light-brightness",
   "light-color-temp",
+  "light-color-hue",
   "lock-commands",
   "lock-open-door",
   "media-player-volume-slider",
@@ -128,6 +130,7 @@ const SUPPORTS_FEATURE_TYPES: Record<
   "lawn-mower-commands": supportsLawnMowerCommandCardFeature,
   "light-brightness": supportsLightBrightnessCardFeature,
   "light-color-temp": supportsLightColorTempCardFeature,
+  "light-color-hue": supportsLightColorHueCardFeature,
   "lock-commands": supportsLockCommandsCardFeature,
   "lock-open-door": supportsLockOpenDoorCardFeature,
   "media-player-volume-slider": supportsMediaPlayerVolumeSliderCardFeature,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -181,6 +181,7 @@
       },
       "light": {
         "brightness": "Brightness",
+        "color": "Color",
         "color_temperature": "Color temperature",
         "white_value": "White brightness",
         "color_brightness": "Color brightness",
@@ -7645,6 +7646,9 @@
               },
               "light-color-temp": {
                 "label": "Light color temperature"
+              },
+              "light-color-hue": {
+                "label": "Light color hue"
               },
               "lock-commands": {
                 "label": "Lock commands"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

While editing my dashboard I noticed that I couldn't add a color slider in a Card Tile for my lights that support different colors. The only way to change the color was to open the "More info" dialog, click the color wheel button and then pick the color. 

This new feature makes it possible to pick a color directly from the dashboard and requires less clicks, this is useful in case you want to change colors to more than one light fixture.

This is obviously more limited than a color wheel as you can only pick the hue with a linear selector, though I think it's a good tradeoff.

This is a video showing how it works.

[!](https://github.com/user-attachments/assets/82ec18d8-6261-46eb-8532-8bb93d49da45)

The annoying thing is that the slider is always shown even when the light is off, I couldn't figure out why though.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

This is a Tile Card configuration that will show the color picker feature:

```yaml
features:
  - type: light-color-temp
  - type: light-brightness
  - type: light-color-hue
type: tile
entity: light.<your_colored_light_entity>
features_position: bottom
vertical: false
grid_options:
  columns: 6
  rows: 3
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I couldn't find any prior discussion about this issue. 
Since it was quite easy to implement I took the initiative and didn't open any issue to discuss it.

Also this is my first contribution to the project.

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/39206

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
