### PR TITLE
Use constant for Home Assistant bluetooth node in graph

### DIFF
--- a/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
@@ -32,6 +32,9 @@ import { throttle } from "../../../../../common/util/throttle";
 
 const UPDATE_THROTTLE_TIME = 10000;
 
+const CORE_SOURCE_ID = "ha";
+const CORE_SOURCE_LABEL = "Home Assistant";
+
 @customElement("bluetooth-network-visualization")
 export class BluetoothNetworkVisualization extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -130,7 +133,7 @@ export class BluetoothNetworkVisualization extends LitElement {
     ): NetworkData => {
       const categories = [
         {
-          name: this.hass.localize("ui.panel.config.bluetooth.core"),
+          name: CORE_SOURCE_LABEL,
           symbol: "roundRect",
           itemStyle: {
             color: colorVariables["primary-color"],
@@ -160,8 +163,8 @@ export class BluetoothNetworkVisualization extends LitElement {
       ];
       const nodes: NetworkNode[] = [
         {
-          id: "ha",
-          name: this.hass.localize("ui.panel.config.bluetooth.core"),
+          id: CORE_SOURCE_ID,
+          name: CORE_SOURCE_LABEL,
           category: 0,
           value: 4,
           symbol: "roundRect",
@@ -183,7 +186,7 @@ export class BluetoothNetworkVisualization extends LitElement {
           polarDistance: 0.25,
         });
         links.push({
-          source: "ha",
+          source: CORE_SOURCE_ID,
           target: scanner.source,
           value: 0,
           symbol: "none",
@@ -234,8 +237,8 @@ export class BluetoothNetworkVisualization extends LitElement {
   );
 
   private _getBluetoothDeviceName(id: string): string {
-    if (id === "ha") {
-      return this.hass.localize("ui.panel.config.bluetooth.core");
+    if (id === CORE_SOURCE_ID) {
+      return CORE_SOURCE_LABEL;
     }
     if (this._sourceDevices[id]) {
       return (
@@ -262,7 +265,7 @@ export class BluetoothNetworkVisualization extends LitElement {
       const sourceName = this._getBluetoothDeviceName(source);
       const targetName = this._getBluetoothDeviceName(target);
       tooltipText = `${sourceName} → ${targetName}`;
-      if (source !== "ha") {
+      if (source !== CORE_SOURCE_ID) {
         tooltipText += ` <b>${this.hass.localize("ui.panel.config.bluetooth.rssi")}:</b> ${value}`;
       }
     } else {


### PR DESCRIPTION
## Proposed change

Use constant for Home Assistant bluetooth node in graph because "Home Assistant" should not be translated.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
