### PR TITLE
Add stopPropagation to other state-cards

### DIFF
--- a/src/state-summary/state-card-input_number.ts
+++ b/src/state-summary/state-card-input_number.ts
@@ -2,6 +2,7 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
+import { stopPropagation } from "../common/dom/stop_propagation";
 import { debounce } from "../common/util/debounce";
 import "../components/entity/state-info";
 import "../components/ha-slider";
@@ -63,6 +64,7 @@ class StateCardInputNumber extends LitElement {
                 .max=${Number(this.stateObj.attributes.max)}
                 .value=${this.stateObj.state}
                 @change=${this._selectedValueChanged}
+                @click=${stopPropagation}
               ></ha-slider>
               <span class="state">
                 ${this.hass.formatEntityState(this.stateObj)}
@@ -81,6 +83,7 @@ class StateCardInputNumber extends LitElement {
                 .suffix=${this.stateObj.attributes.unit_of_measurement || ""}
                 type="number"
                 @change=${this._selectedValueChanged}
+                @click=${stopPropagation}
               >
               </ha-textfield>
             </div>

--- a/src/state-summary/state-card-number.ts
+++ b/src/state-summary/state-card-number.ts
@@ -2,13 +2,14 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
+import { stopPropagation } from "../common/dom/stop_propagation";
+import { debounce } from "../common/util/debounce";
 import "../components/entity/state-info";
 import "../components/ha-slider";
 import "../components/ha-textfield";
-import type { HomeAssistant } from "../types";
-import { haStyle } from "../resources/styles";
 import { isUnavailableState } from "../data/entity";
-import { debounce } from "../common/util/debounce";
+import { haStyle } from "../resources/styles";
+import type { HomeAssistant } from "../types";
 
 @customElement("state-card-number")
 class StateCardNumber extends LitElement {
@@ -66,6 +67,7 @@ class StateCardNumber extends LitElement {
                 .max=${Number(this.stateObj.attributes.max)}
                 .value=${this.stateObj.state}
                 @change=${this._selectedValueChanged}
+                @click=${stopPropagation}
               >
               </ha-slider>
               <span class="state">
@@ -84,6 +86,7 @@ class StateCardNumber extends LitElement {
               .suffix=${this.stateObj.attributes.unit_of_measurement || ""}
               type="number"
               @change=${this._selectedValueChanged}
+              @click=${stopPropagation}
             >
             </ha-textfield>
           </div>`}

--- a/src/state-summary/state-card-select.ts
+++ b/src/state-summary/state-card-select.ts
@@ -29,6 +29,7 @@ class StateCardSelect extends LitElement {
         fixedMenuPosition
         @selected=${this._selectedOptionChanged}
         @closed=${stopPropagation}
+        @click=${stopPropagation}
       >
         ${this.stateObj.attributes.options.map(
           (option) => html`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Similar to all the other state-cards, we will not propagate the click events up.  This can cause odd behavior in divs wrapping these controls which listen to click events.  These makes all the state-cards act consistently.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

You would need a custom card to test that propagation is no longer happening.
```yaml
- type: custom:device-card
  device_id: 75376456755137575411dd1b1c39567f
- type: custom:device-card
  device_id: 04cb8c479a6a122b15d8759e3927dd83
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/homeassistant-extras/device-card/issues/23
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] ~~Tests have been added to verify that the new code works.~~

If user exposed functionality or configuration variables are added/changed:

- [ ] ~~Documentation added/updated for [www.home-assistant.io][docs-repository]~~

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
