### PR TITLE
Add severity level to dialog automation mode

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -13,6 +13,7 @@ import { createSearchParam } from "../common/url/search-params";
 
 export const AUTOMATION_DEFAULT_MODE: (typeof MODES)[number] = "single";
 export const AUTOMATION_DEFAULT_MAX = 10;
+export const AUTOMATION_DEFAULT_MAX_EXCEEDED: AutomationConfigMaxExceeded = "warning";
 
 export interface AutomationEntity extends HassEntityBase {
   attributes: HassEntityAttributeBase & {
@@ -40,18 +41,20 @@ export interface ManualAutomationConfig {
   action?: Action | Action[];
   mode?: (typeof MODES)[number];
   max?: number;
-  max_exceeded?:
-    | "silent"
-    | "critical"
-    | "fatal"
-    | "error"
-    | "warning"
-    | "warn"
-    | "info"
-    | "debug"
-    | "notset";
+  max_exceeded?: AutomationConfigMaxExceeded;
   variables?: Record<string, unknown>;
 }
+
+export type AutomationConfigMaxExceeded = "silent"
+  | "critical"
+  | "fatal"
+  | "error"
+  | "warning"
+  | "warn"
+  | "info"
+  | "debug"
+  | "notset";
+export const automationConfigMaxExceededOptions = ["silent", "critical", "fatal", "error", "warning", "info", "debug"];
 
 export interface BlueprintAutomationConfig extends ManualAutomationConfig {
   use_blueprint: { path: string; input?: BlueprintInput };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3707,6 +3707,7 @@
               "queued": "Queue length",
               "parallel": "Max number of parallel runs"
             },
+            "max_exceeded": "Max exceeded severity level",
             "edit_yaml": "Edit in YAML",
             "edit_ui": "Edit in visual editor",
             "copy_to_clipboard": "Copy to clipboard",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add a severity level select in the dialog to change the automation mode.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
