### PR TITLE
More error handling for preview flow

### DIFF
--- a/src/data/preview.ts
+++ b/src/data/preview.ts
@@ -6,6 +6,7 @@ const HAS_CUSTOM_PREVIEW = ["generic_camera", "template"];
 export interface GenericPreview {
   state: string;
   attributes: Record<string, any>;
+  error?: string;
 }
 
 export const subscribePreviewGeneric = (

--- a/src/dialogs/config-flow/previews/flow-preview-generic.ts
+++ b/src/dialogs/config-flow/previews/flow-preview-generic.ts
@@ -31,12 +31,12 @@ export class FlowPreviewGeneric extends LitElement {
 
   @state() protected _error?: string;
 
-  private _unsub?: Promise<UnsubscribeFunc | undefined>;
+  private _unsub?: Promise<UnsubscribeFunc>;
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
     if (this._unsub) {
-      this._unsub.then((unsub) => unsub?.());
+      this._unsub.then((unsub) => unsub());
       this._unsub = undefined;
     }
   }
@@ -79,7 +79,7 @@ export class FlowPreviewGeneric extends LitElement {
 
   private async _subscribePreview() {
     if (this._unsub) {
-      (await this._unsub)?.();
+      (await this._unsub)();
       this._unsub = undefined;
     }
     if (this.flowType !== "config_flow" && this.flowType !== "options_flow") {
@@ -94,11 +94,8 @@ export class FlowPreviewGeneric extends LitElement {
         this.flowType,
         this.stepData,
         this._setPreview
-      ).catch((err) => {
-        this._error = err.message;
-        this._preview = undefined;
-        return undefined;
-      });
+      );
+      await this._unsub;
       fireEvent(this, "set-flow-errors", { errors: {} });
     } catch (err: any) {
       if (typeof err.message === "string") {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Was working on a [preview_flow](https://github.com/home-assistant/core/pull/145721) and found that the error handling on frontend was lacking for the generic module. There didn't seem to be a way for a component to pass an error to the frontend, so I ended up adding two different ways. 

Firstly, add error handling if the initial preview flow is rejected. This could be because the options passed to the preview flow can be detected as illegal early, before the component setup starts. 

Secondly, after the preview flow starts and is successfully acked, add a way for component to signal that an error occured during a subscription update. This could be because of an error that is not detected when the flow is first setup, but is detected later during the components update cycle. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
