### PR TITLE
Support templates in action target

### DIFF
--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -276,6 +276,16 @@ export class HaServiceControl extends LitElement {
 
   private _getTargetedEntities = memoizeOne((target, value) => {
     const targetSelector = target ? { target } : { target: {} };
+    if (
+      hasTemplate(value?.target) ||
+      hasTemplate(value?.data?.entity_id) ||
+      hasTemplate(value?.data?.device_id) ||
+      hasTemplate(value?.data?.area_id) ||
+      hasTemplate(value?.data?.floor_id) ||
+      hasTemplate(value?.data?.label_id)
+    ) {
+      return null;
+    }
     const targetEntities =
       ensureArray(
         value?.target?.entity_id || value?.data?.entity_id
@@ -349,8 +359,11 @@ export class HaServiceControl extends LitElement {
 
   private _filterField(
     filter: ExtHassService["fields"][number]["filter"],
-    targetEntities: string[]
+    targetEntities: string[] | null
   ) {
+    if (targetEntities === null) {
+      return true; // Target is a template, show all fields
+    }
     if (!targetEntities.length) {
       return false;
     }
@@ -386,8 +399,21 @@ export class HaServiceControl extends LitElement {
   }
 
   private _targetSelector = memoizeOne(
-    (targetSelector: TargetSelector | null | undefined) =>
-      targetSelector ? { target: { ...targetSelector } } : { target: {} }
+    (targetSelector: TargetSelector | null | undefined, value) => {
+      if (!value || (typeof value === "object" && !Object.keys(value).length)) {
+        delete this._stickySelector.target;
+      } else if (hasTemplate(value)) {
+        if (typeof value === "string") {
+          this._stickySelector.target = { template: null };
+        } else {
+          this._stickySelector.target = { object: null };
+        }
+      }
+      return (
+        this._stickySelector.target ??
+        (targetSelector ? { target: { ...targetSelector } } : { target: {} })
+      );
+    }
   );
 
   protected render() {
@@ -482,7 +508,8 @@ export class HaServiceControl extends LitElement {
           ><ha-selector
             .hass=${this.hass}
             .selector=${this._targetSelector(
-              serviceData.target as TargetSelector
+              serviceData.target as TargetSelector,
+              this._value?.target
             )}
             .disabled=${this.disabled}
             @value-changed=${this._targetChanged}
@@ -575,7 +602,7 @@ export class HaServiceControl extends LitElement {
 
   private _hasFilteredFields(
     dataFields: ExtHassService["fields"],
-    targetEntities: string[]
+    targetEntities: string[] | null
   ) {
     return dataFields.some(
       (dataField) =>
@@ -588,7 +615,7 @@ export class HaServiceControl extends LitElement {
     hasOptional: boolean,
     domain: string | undefined,
     serviceName: string | undefined,
-    targetEntities: string[]
+    targetEntities: string[] | null
   ) => {
     if (
       dataField.filter &&
@@ -822,6 +849,10 @@ export class HaServiceControl extends LitElement {
 
   private _targetChanged(ev: CustomEvent) {
     ev.stopPropagation();
+    if (ev.detail.isValid === false) {
+      // Don't clear an object selector that returns invalid YAML
+      return;
+    }
     const newValue = ev.detail.value;
     if (this._value?.target === newValue) {
       return;

--- a/src/data/script.ts
+++ b/src/data/script.ts
@@ -14,6 +14,7 @@ import {
   literal,
   is,
   boolean,
+  refine,
 } from "superstruct";
 import { arrayLiteralIncludes } from "../common/array/literal-includes";
 import { navigate } from "../common/navigate";
@@ -29,6 +30,7 @@ import { migrateAutomationTrigger } from "./automation";
 import type { BlueprintInput } from "./blueprint";
 import { computeObjectId } from "../common/entity/compute_object_id";
 import { createSearchParam } from "../common/url/search-params";
+import { hasTemplate } from "../common/string/has-template";
 
 export const MODES = ["single", "restart", "queued", "parallel"] as const;
 export const MODES_MAX = ["queued", "parallel"] as const;
@@ -54,7 +56,12 @@ export const serviceActionStruct: Describe<ServiceAction> = assign(
     action: optional(string()),
     service_template: optional(string()),
     entity_id: optional(string()),
-    target: optional(targetStruct),
+    target: optional(
+      union([
+        targetStruct,
+        refine(string(), "has_template", (val) => hasTemplate(val)),
+      ])
+    ),
     data: optional(object()),
     response_variable: optional(string()),
     metadata: optional(object()),
@@ -125,7 +132,7 @@ export interface ServiceAction extends BaseAction {
   action?: string;
   service_template?: string;
   entity_id?: string;
-  target?: HassServiceTarget;
+  target?: HassServiceTarget | string;
   data?: Record<string, unknown>;
   response_variable?: string;
   metadata?: Record<string, unknown>;

--- a/src/data/script.ts
+++ b/src/data/script.ts
@@ -50,7 +50,7 @@ export const targetStruct = object({
   label_id: optional(union([string(), array(string())])),
 });
 
-export const serviceActionStruct: Describe<ServiceAction> = assign(
+export const serviceActionStruct: Describe<ServiceActionWithTemplate> = assign(
   baseActionStruct,
   object({
     action: optional(string()),
@@ -132,11 +132,17 @@ export interface ServiceAction extends BaseAction {
   action?: string;
   service_template?: string;
   entity_id?: string;
-  target?: HassServiceTarget | string;
+  target?: HassServiceTarget;
   data?: Record<string, unknown>;
   response_variable?: string;
   metadata?: Record<string, unknown>;
 }
+
+type ServiceActionWithTemplate = ServiceAction & {
+  target?: HassServiceTarget | string;
+};
+
+export type { ServiceActionWithTemplate };
 
 export interface DeviceAction extends BaseAction {
   type: string;

--- a/src/panels/config/automation/action/types/ha-automation-action-service.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-service.ts
@@ -42,7 +42,7 @@ export class HaServiceAction extends LitElement implements ActionElement {
     if (
       this.action &&
       Object.entries(this.action).some(
-        ([key, val]) => key !== "data" && hasTemplate(val)
+        ([key, val]) => !["data", "target"].includes(key) && hasTemplate(val)
       )
     ) {
       fireEvent(

--- a/src/panels/developer-tools/action/developer-tools-action.ts
+++ b/src/panels/developer-tools/action/developer-tools-action.ts
@@ -535,7 +535,7 @@ class HaPanelDevAction extends LitElement {
     if (
       this._serviceData &&
       Object.entries(this._serviceData).some(
-        ([key, val]) => key !== "data" && hasTemplate(val)
+        ([key, val]) => !["data", "target"].includes(key) && hasTemplate(val)
       )
     ) {
       this._yamlMode = true;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Support templates in visual editor for action target field. We currently support it for all subfields of `data`, but not for target until now. 

There is sometimes a bit of jankiness where messing with the selector will kick the user out of visual editor and back to yaml mode due to superstruct validation, but I didn't come up with a great solution that doesn't undesirably weaken the validation for other cases not involving templates. 

E.g. in the example screenshot, if you add the key `area_id:` to the object selector you'll be temporarily kicked out of visual editor because the struct validator asserts that area_id cannot be null. We could add to the validator that area_id is allowed to be null, but I don't know if we want that. Or if you're editing the target template, and you remove the template identifier "{{", you'll be kicked out of visual mode because the superstruct asserts that if target is a string it must be a template. 

I think that's not too bad of a tradeoff to support this though, it would be a fairly rare occurence to be making edits like that. 

![image](https://github.com/user-attachments/assets/a8570e97-648c-4e5e-acc3-8999ed2e91c0)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #25639
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
