### PR TITLE
Add view in More Info to show entities within a group

### DIFF
--- a/src/dialogs/more-info/ha-more-info-group.ts
+++ b/src/dialogs/more-info/ha-more-info-group.ts
@@ -1,0 +1,83 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { css, html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import { computeDomain } from "../../common/entity/compute_domain";
+import type { ExtEntityRegistryEntry } from "../../data/entity_registry";
+import type { HomeAssistant } from "../../types";
+import { computeShowNewMoreInfo, DOMAINS_FULL_HEIGHT_MORE_INFO } from "./const";
+import "./ha-more-info-history";
+import "./ha-more-info-logbook";
+import "./more-info-group-content";
+
+@customElement("ha-more-info-group")
+export class MoreInfoGroup extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public entityId!: string;
+
+  @property({ attribute: false }) public entry?: ExtEntityRegistryEntry | null;
+
+  @property({ attribute: false }) public editMode?: boolean;
+
+  protected render() {
+    const entityId = this.entityId;
+    const stateObj = this.hass.states[entityId] as HassEntity | undefined;
+    const domain = computeDomain(entityId);
+    const isNewMoreInfo = stateObj && computeShowNewMoreInfo(stateObj);
+    const isFullHeight =
+      isNewMoreInfo || DOMAINS_FULL_HEIGHT_MORE_INFO.includes(domain);
+
+    return html`
+      <div class="container" data-domain=${domain}>
+        <div class="content">
+          <more-info-group-content
+            ?full-height=${isFullHeight}
+            .stateObj=${stateObj}
+            .hass=${this.hass}
+            .entry=${this.entry}
+            .editMode=${this.editMode}
+          ></more-info-group-content>
+        </div>
+      </div>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+    }
+    .container {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+    }
+
+    .content {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      padding: 24px;
+      padding-bottom: max(var(--safe-area-inset-bottom), 24px);
+    }
+
+    more-info-group-content {
+      position: relative;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      justify-content: center;
+      row-gap: 16px;
+    }
+
+    more-info-group-content[full-height] {
+      flex: 1;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-more-info-group": MoreInfoGroup;
+  }
+}

--- a/src/dialogs/more-info/more-info-group-content.ts
+++ b/src/dialogs/more-info/more-info-group-content.ts
@@ -1,0 +1,133 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+import type { ExtEntityRegistryEntry } from "../../data/entity_registry";
+import { importMoreInfoControl } from "../../panels/lovelace/custom-card-helpers";
+import type { HomeAssistant } from "../../types";
+import { stateMoreInfoType } from "./state_more_info_control";
+import { dynamicElement } from "../../common/dom/dynamic-element-directive";
+import { computeStateName } from "../../common/entity/compute_state_name";
+import { stripPrefixFromEntityName } from "../../common/entity/strip_prefix_from_entity_name";
+
+interface RenderItem {
+  stateObj: HassEntity;
+  type: string | undefined;
+}
+@customElement("more-info-group-content")
+class MoreInfoGroupContent extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public stateObj?: HassEntity;
+
+  @property({ attribute: false }) public entry?: ExtEntityRegistryEntry | null;
+
+  @property({ attribute: false }) public editMode?: boolean;
+
+  protected render() {
+    const items = this._getRenderItems();
+    if (items.length === 0) return nothing;
+
+    return items.map((item) => {
+      if (!item.type) return nothing;
+      return html`
+        <div class="group-item">
+          <div class="header-title">
+            ${this._formattedFriendlyName(item.stateObj)}
+          </div>
+          ${dynamicElement(item.type, {
+            hass: this.hass,
+            stateObj: item.stateObj,
+            entry: this.entry,
+            editMode: this.editMode,
+          })}
+        </div>
+      `;
+    });
+  }
+
+  private _formattedFriendlyName(stateObj: HassEntity): string {
+    const parentName = computeStateName(this.stateObj!);
+    const currentName = computeStateName(stateObj);
+
+    return stripPrefixFromEntityName(currentName, parentName) || currentName;
+  }
+
+  private _getRenderItems(): RenderItem[] {
+    const moreInfoType = (t: string): string | undefined =>
+      t === "hidden" ? undefined : `more-info-${t}`;
+
+    if (!this.stateObj || !this.hass) return [];
+
+    if (
+      this.stateObj.attributes &&
+      "custom_ui_more_info" in this.stateObj.attributes
+    ) {
+      return [
+        {
+          stateObj: this.stateObj,
+          type: this.stateObj.attributes.custom_ui_more_info,
+        },
+      ];
+    }
+
+    const type = stateMoreInfoType(this.stateObj);
+    importMoreInfoControl(type);
+
+    const renderItems: RenderItem[] = [];
+    if (
+      this.stateObj.attributes &&
+      "entity_id" in this.stateObj.attributes &&
+      "length" in this.stateObj.attributes.entity_id &&
+      this.stateObj.attributes.entity_id.length > 1
+    ) {
+      this.stateObj.attributes.entity_id.forEach((entityId: string) => {
+        if (!entityId) return;
+
+        const stateObj = this.hass!.states[entityId] as HassEntity | undefined;
+        if (!stateObj) return;
+
+        const newType = stateMoreInfoType(stateObj);
+        importMoreInfoControl(newType);
+
+        renderItems.push({
+          stateObj: stateObj,
+          type: moreInfoType(newType),
+        });
+      });
+    }
+
+    return renderItems;
+  }
+
+  static styles = css`
+    .group-item {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .header-title {
+      font-size: var(--ha-font-size-xl);
+      line-height: var(--ha-line-height-condensed);
+      font-weight: var(--ha-font-weight-normal);
+      text-align: center;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin: 0 16px 4px;
+      padding: 2px 6px;
+      background-color: var(--secondary-background-color);
+      border-radius: 6px;
+    }
+
+    @media all and (max-width: 450px), all and (max-height: 500px) {
+      .header-title {
+        font-size: var(--ha-font-size-3xl);
+      }
+    }
+  `;
+}
+declare global {
+  interface HTMLElementTagNameMap {
+    "more-info-group-content": MoreInfoGroupContent;
+  }
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1293,6 +1293,7 @@
         "info": "Information",
         "related": "Related",
         "history": "History",
+        "group": "Group",
         "logbook": "Logbook",
         "device_info": "Device info",
         "last_changed": "Last changed",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This proposed change adds an icon to the More Info dialog (see screenshots) that allows you to show and control all the entities within that group. It shows them in a grid pattern using the existing more info controls.

This seems very useful for entities that are controlled simultaneously _most_ of the time, but not all the time. It also helps to simplify dashboards, especially for tablets. Instead of having to have every shade have a tile, one group can be created, and every entity within it can be 2 taps away from being controlled.

Looking forward to feedback and suggestions on everything from code to UI style.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
No additional configuration necessary. Though I was considering adding something to allow this option to be turned on/off for each group. But given how minimal the icon is, it seemed unnecessary.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15192
- This PR is related to issue or discussion: #15192
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.
  > There doesn't seem to be any tests in this area of the code. What should I do?

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
  > Documentation seems unnecessary. Let me know if I'm wrong.
<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io

<img width="608" alt="image" src="https://github.com/user-attachments/assets/da7fe1b2-b232-42fe-9deb-98250eff1b33" />
<img width="1088" alt="image" src="https://github.com/user-attachments/assets/c5d41f40-ef33-4f15-a1dc-f5be6759ccb8" />
<img width="606" alt="image" src="https://github.com/user-attachments/assets/aa6ddeb6-eec8-44df-a7ff-81bf37b8f1c4" />
<img width="1084" alt="image" src="https://github.com/user-attachments/assets/2c876a7f-4175-4480-a5e6-79fdf5756485" />
