### PR TITLE
Fix period boundaries in Energy dashboard

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -30,6 +30,7 @@ import { fetchStatistics, getStatisticMetadata } from "./recorder";
 import { calcDateRange } from "../common/datetime/calc_date_range";
 import type { DateRange } from "../common/datetime/calc_date_range";
 import { formatNumber } from "../common/number/format_number";
+import { firstWeekdayIndex } from "../common/datetime/first_weekday";
 
 const energyCollectionKeys: (string | undefined)[] = [];
 
@@ -679,7 +680,14 @@ export const getEnergyDataCollection = (
   const period =
     preferredPeriod === "today" && hour === "0" ? "yesterday" : preferredPeriod;
 
-  [collection.start, collection.end] = calcDateRange(hass, period);
+  const [start, end] = calcDateRange(hass, period);
+  const weekStartsOn = firstWeekdayIndex(hass.locale);
+  collection.start = calcDate(start, startOfDay, hass.locale, hass.config, {
+    weekStartsOn,
+  });
+  collection.end = calcDate(end, endOfDay, hass.locale, hass.config, {
+    weekStartsOn,
+  });
 
   const scheduleUpdatePeriod = () => {
     collection._updatePeriodTimeout = window.setTimeout(

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -30,7 +30,6 @@ import { fetchStatistics, getStatisticMetadata } from "./recorder";
 import { calcDateRange } from "../common/datetime/calc_date_range";
 import type { DateRange } from "../common/datetime/calc_date_range";
 import { formatNumber } from "../common/number/format_number";
-import { firstWeekdayIndex } from "../common/datetime/first_weekday";
 
 const energyCollectionKeys: (string | undefined)[] = [];
 
@@ -681,13 +680,8 @@ export const getEnergyDataCollection = (
     preferredPeriod === "today" && hour === "0" ? "yesterday" : preferredPeriod;
 
   const [start, end] = calcDateRange(hass, period);
-  const weekStartsOn = firstWeekdayIndex(hass.locale);
-  collection.start = calcDate(start, startOfDay, hass.locale, hass.config, {
-    weekStartsOn,
-  });
-  collection.end = calcDate(end, endOfDay, hass.locale, hass.config, {
-    weekStartsOn,
-  });
+  collection.start = calcDate(start, startOfDay, hass.locale, hass.config);
+  collection.end = calcDate(end, endOfDay, hass.locale, hass.config);
 
   const scheduleUpdatePeriod = () => {
     collection._updatePeriodTimeout = window.setTimeout(

--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -10,6 +10,8 @@ import {
   addYears,
   addMonths,
   addHours,
+  startOfDay,
+  addDays,
 } from "date-fns";
 import type {
   BarSeriesOption,
@@ -281,6 +283,10 @@ export function getCompareTransform(start: Date, compareStart?: Date) {
     start.getTime() === startOfMonth(start).getTime()
   ) {
     return (ts: Date) => addMonths(ts, compareMonthDiff);
+  }
+  const compareDayDiff = differenceInDays(start, compareStart);
+  if (compareDayDiff !== 0 && start.getTime() === startOfDay(start).getTime()) {
+    return (ts: Date) => addDays(ts, compareDayDiff);
   }
   const compareOffset = start.getTime() - compareStart.getTime();
   return (ts: Date) => addMilliseconds(ts, compareOffset);

--- a/src/panels/lovelace/components/hui-energy-period-selector.ts
+++ b/src/panels/lovelace/components/hui-energy-period-selector.ts
@@ -297,24 +297,17 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
   }
 
   private _dateRangeChanged(ev) {
-    const weekStartsOn = firstWeekdayIndex(this.hass.locale);
     this._startDate = calcDate(
       ev.detail.value.startDate,
       startOfDay,
       this.hass.locale,
-      this.hass.config,
-      {
-        weekStartsOn,
-      }
+      this.hass.config
     );
     this._endDate = calcDate(
       ev.detail.value.endDate,
       endOfDay,
       this.hass.locale,
-      this.hass.config,
-      {
-        weekStartsOn,
-      }
+      this.hass.config
     );
 
     this._updateCollectionPeriod();


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Start & end datetimes were set differently in `hui-energy-period-selector` and when loaded in `energy.ts` leading to inconsistent behaviour.

Also included a fix for DST bug I discovered when comparing arbitrary periods (ex. last 30 days) that include a DST change.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #25551
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
