### PR TITLE
Fix/dhcp config network sort

### DIFF
--- a/src/common/string/compare.ts
+++ b/src/common/string/compare.ts
@@ -1,4 +1,5 @@
 import memoizeOne from "memoize-one";
+import { isIPAddress } from "./is_ip_address";
 
 const collator = memoizeOne(
   (language: string | undefined) => new Intl.Collator(language)
@@ -33,20 +34,17 @@ export const stringCompare = (
   return fallbackStringCompare(a, b);
 };
 
-export const ipv4Compare = (a: string, b: string) => {
-  const num1 = Number(
-    a
-      .split(".")
-      .map((num) => num.padStart(3, "0"))
-      .join("")
-  );
-  const num2 = Number(
-    b
-      .split(".")
-      .map((num) => num.padStart(3, "0"))
-      .join("")
-  );
-  return num1 - num2;
+export const ipCompare = (a: string, b: string) => {
+  const aIsIpV4 = isIPAddress(a);
+  const bIsIpV4 = isIPAddress(b);
+
+  if (aIsIpV4 && bIsIpV4) {
+    return ipv4Compare(a, b);
+  }
+  if (!aIsIpV4 && !bIsIpV4) {
+    return ipV6Compare(a, b);
+  }
+  return aIsIpV4 ? -1 : 1;
 };
 
 export const caseInsensitiveStringCompare = (
@@ -80,3 +78,42 @@ export const orderCompare = (order: string[]) => (a: string, b: string) => {
 
   return idxA - idxB;
 };
+
+function ipv4Compare(a: string, b: string) {
+  const num1 = Number(
+    a
+      .split(".")
+      .map((num) => num.padStart(3, "0"))
+      .join("")
+  );
+  const num2 = Number(
+    b
+      .split(".")
+      .map((num) => num.padStart(3, "0"))
+      .join("")
+  );
+  return num1 - num2;
+}
+
+function ipV6Compare(a: string, b: string) {
+  const ipv6a = normalizeIPv6(a)
+    .split(":")
+    .map((part) => part.padStart(4, "0"))
+    .join("");
+  const ipv6b = normalizeIPv6(b)
+    .split(":")
+    .map((part) => part.padStart(4, "0"))
+    .join("");
+
+  return ipv6a.localeCompare(ipv6b);
+}
+
+function normalizeIPv6(ip) {
+  const parts = ip.split("::");
+  const head = parts[0].split(":");
+  const tail = parts[1] ? parts[1].split(":") : [];
+  const totalParts = 8;
+  const missing = totalParts - (head.length + tail.length);
+  const zeros = new Array(missing).fill("0");
+  return [...head, ...zeros, ...tail].join(":");
+}

--- a/src/common/string/compare.ts
+++ b/src/common/string/compare.ts
@@ -33,6 +33,22 @@ export const stringCompare = (
   return fallbackStringCompare(a, b);
 };
 
+export const ipCompare = (a: string, b: string) => {
+   const num1 = Number(
+     a
+       .split(".")
+       .map((num) => `000${num}`.slice(-3))
+       .join("")
+   );
+   const num2 = Number(
+     b
+       .split(".")
+       .map((num) => `000${num}`.slice(-3))
+       .join("")
+   );
+   return num1 - num2;
+ };
+
 export const caseInsensitiveStringCompare = (
   a: string,
   b: string,

--- a/src/common/string/compare.ts
+++ b/src/common/string/compare.ts
@@ -33,7 +33,7 @@ export const stringCompare = (
   return fallbackStringCompare(a, b);
 };
 
-export const ipCompare = (a: string, b: string) => {
+export const ipv4Compare = (a: string, b: string) => {
   const num1 = Number(
     a
       .split(".")

--- a/src/common/string/compare.ts
+++ b/src/common/string/compare.ts
@@ -34,20 +34,20 @@ export const stringCompare = (
 };
 
 export const ipCompare = (a: string, b: string) => {
-   const num1 = Number(
-     a
-       .split(".")
-       .map((num) => `000${num}`.slice(-3))
-       .join("")
-   );
-   const num2 = Number(
-     b
-       .split(".")
-       .map((num) => `000${num}`.slice(-3))
-       .join("")
-   );
-   return num1 - num2;
- };
+  const num1 = Number(
+    a
+      .split(".")
+      .map((num) => num.padStart(3, "0"))
+      .join("")
+  );
+  const num2 = Number(
+    b
+      .split(".")
+      .map((num) => num.padStart(3, "0"))
+      .join("")
+  );
+  return num1 - num2;
+};
 
 export const caseInsensitiveStringCompare = (
   a: string,

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -72,7 +72,7 @@ export interface DataTableColumnData<T = any> extends DataTableSortColumnData {
   label?: TemplateResult | string;
   type?:
     | "numeric"
-    | "ip"
+    | "ipv4"
     | "icon"
     | "icon-button"
     | "overflow"

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -72,7 +72,7 @@ export interface DataTableColumnData<T = any> extends DataTableSortColumnData {
   label?: TemplateResult | string;
   type?:
     | "numeric"
-    | "ipv4"
+    | "ip"
     | "icon"
     | "icon-button"
     | "overflow"

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -72,6 +72,7 @@ export interface DataTableColumnData<T = any> extends DataTableSortColumnData {
   label?: TemplateResult | string;
   type?:
     | "numeric"
+    | "ip"
     | "icon"
     | "icon-button"
     | "overflow"

--- a/src/components/data-table/sort-filter-worker.ts
+++ b/src/components/data-table/sort-filter-worker.ts
@@ -1,5 +1,5 @@
 import { expose } from "comlink";
-import { stringCompare, ipv4Compare } from "../../common/string/compare";
+import { stringCompare, ipCompare } from "../../common/string/compare";
 import { stripDiacritics } from "../../common/string/strip-diacritics";
 import type {
   ClonedDataTableColumnData,
@@ -57,8 +57,8 @@ const sortData = (
     if (column.type === "numeric") {
       valA = isNaN(valA) ? undefined : Number(valA);
       valB = isNaN(valB) ? undefined : Number(valB);
-    } else if (column.type === "ipv4") {
-      return sort * ipv4Compare(valA, valB);
+    } else if (column.type === "ip") {
+      return sort * ipCompare(valA, valB);
     } else if (typeof valA === "string" && typeof valB === "string") {
       return sort * stringCompare(valA, valB, language);
     }

--- a/src/components/data-table/sort-filter-worker.ts
+++ b/src/components/data-table/sort-filter-worker.ts
@@ -1,5 +1,5 @@
 import { expose } from "comlink";
-import { stringCompare } from "../../common/string/compare";
+import { stringCompare, ipCompare } from "../../common/string/compare";
 import { stripDiacritics } from "../../common/string/strip-diacritics";
 import type {
   ClonedDataTableColumnData,
@@ -57,7 +57,9 @@ const sortData = (
     if (column.type === "numeric") {
       valA = isNaN(valA) ? undefined : Number(valA);
       valB = isNaN(valB) ? undefined : Number(valB);
-    } else if (typeof valA === "string" && typeof valB === "string") {
+    } else if (column.type === "ip") {
+       return sort * ipCompare(valA, valB);
+     } else if (typeof valA === "string" && typeof valB === "string") {
       return sort * stringCompare(valA, valB, language);
     }
 

--- a/src/components/data-table/sort-filter-worker.ts
+++ b/src/components/data-table/sort-filter-worker.ts
@@ -1,5 +1,5 @@
 import { expose } from "comlink";
-import { stringCompare, ipCompare } from "../../common/string/compare";
+import { stringCompare, ipv4Compare } from "../../common/string/compare";
 import { stripDiacritics } from "../../common/string/strip-diacritics";
 import type {
   ClonedDataTableColumnData,
@@ -57,9 +57,9 @@ const sortData = (
     if (column.type === "numeric") {
       valA = isNaN(valA) ? undefined : Number(valA);
       valB = isNaN(valB) ? undefined : Number(valB);
-    } else if (column.type === "ip") {
-       return sort * ipCompare(valA, valB);
-     } else if (typeof valA === "string" && typeof valB === "string") {
+    } else if (column.type === "ipv4") {
+      return sort * ipv4Compare(valA, valB);
+    } else if (typeof valA === "string" && typeof valB === "string") {
       return sort * stringCompare(valA, valB, language);
     }
 

--- a/src/panels/config/integrations/integration-panels/dhcp/dhcp-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/dhcp/dhcp-config-panel.ts
@@ -60,6 +60,7 @@ export class DHCPConfigPanel extends SubscribeMixin(LitElement) {
           title: localize("ui.panel.config.dhcp.ip_address"),
           filterable: true,
           sortable: true,
+          type: "ip",
         },
       };
 

--- a/src/panels/config/integrations/integration-panels/dhcp/dhcp-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/dhcp/dhcp-config-panel.ts
@@ -60,7 +60,7 @@ export class DHCPConfigPanel extends SubscribeMixin(LitElement) {
           title: localize("ui.panel.config.dhcp.ip_address"),
           filterable: true,
           sortable: true,
-          type: "ipv4",
+          type: "ip",
         },
       };
 

--- a/src/panels/config/integrations/integration-panels/dhcp/dhcp-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/dhcp/dhcp-config-panel.ts
@@ -60,7 +60,7 @@ export class DHCPConfigPanel extends SubscribeMixin(LitElement) {
           title: localize("ui.panel.config.dhcp.ip_address"),
           filterable: true,
           sortable: true,
-          type: "ip",
+          type: "ipv4",
         },
       };
 

--- a/test/common/string/compare_ip.test.ts
+++ b/test/common/string/compare_ip.test.ts
@@ -1,0 +1,34 @@
+import { assert, describe, it } from "vitest";
+import { ipCompare } from "../../../src/common/string/compare";
+import { isIPAddress } from "../../../src/common/string/is_ip_address";
+
+describe("compareIpAdresses", () => {
+  const ipAddresses: string[] = [
+    "192.168.1.1",
+    "10.0.0.1",
+    "fe80::85d:e82c:9446:7995",
+    "192.168.0.1",
+    "fe80::85d:e82c:9446:7994",
+    "::ffff:192.168.1.1",
+    "1050:0000:0000:0000:0005:0600:300c:326b",
+  ];
+  const expected: string[] = [
+    "10.0.0.1",
+    "192.168.0.1",
+    "192.168.1.1",
+    "::ffff:192.168.1.1",
+    "1050:0000:0000:0000:0005:0600:300c:326b",
+    "fe80::85d:e82c:9446:7994",
+    "fe80::85d:e82c:9446:7995",
+  ];
+
+  const sorted = [...ipAddresses].sort(ipCompare);
+
+  it("Detects ipv4 addresses", () => {
+    assert.isTrue(isIPAddress("192.168.0.1"));
+  });
+
+  it("Compares ipv4 and ipv6 addresses", () => {
+    assert.deepEqual(sorted, expected);
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR improves the sorting of IP addresses in the DHCP settings data table. Previously, IP addresses were sorted as strings, which led to incorrect order (e.g., `192.168.1.100` appearing before `192.168.1.2`). This fix applies proper numeric sorting for IP addresses, providing a more intuitive and correct display order.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes [#25490](https://github.com/home-assistant/frontend/issues/25490)
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
