### PR TITLE
Change duration input to ha-time-input component

### DIFF
--- a/src/panels/config/helpers/forms/ha-timer-form.ts
+++ b/src/panels/config/helpers/forms/ha-timer-form.ts
@@ -5,19 +5,19 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-checkbox";
 import "../../../../components/ha-formfield";
 import "../../../../components/ha-icon-picker";
-import "../../../../components/ha-time-input";
+import "../../../../components/ha-duration-input";
 import "../../../../components/ha-textfield";
 import type { DurationDict, Timer } from "../../../../data/timer";
 import { haStyle } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
+import { createDurationData } from "../../../../common/datetime/create_duration_data";
+import type { HaDurationData } from "../../../../components/ha-duration-input";
 
 @customElement("ha-timer-form")
 class HaTimerForm extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ type: Boolean }) public new = false;
-
-  @property({ attribute: "enable-second", type: Boolean }) enableSecond = true;
 
   private _item?: Timer;
 
@@ -26,6 +26,8 @@ class HaTimerForm extends LitElement {
   @state() private _icon!: string;
 
   @state() private _duration!: string | number | DurationDict;
+
+  @state() private _duration_data!: HaDurationData | undefined;
 
   @state() private _restore!: boolean;
 
@@ -42,6 +44,8 @@ class HaTimerForm extends LitElement {
       this._duration = "00:00:00";
       this._restore = false;
     }
+
+    this._duration_data = createDurationData(this._duration);
   }
 
   public focus() {
@@ -82,14 +86,11 @@ class HaTimerForm extends LitElement {
             "ui.dialogs.helper_settings.generic.icon"
           )}
         ></ha-icon-picker>
-        <ha-time-input
-           .configValue=${"duration"}
-           .value=${this._duration}
-           .locale=${this.hass.locale}
-           clearable
-           .enableSecond=${this.enableSecond}
-           @value-changed=${this._valueChanged}
-         ></ha-time-input>
+        <ha-duration-input
+          .configValue=${"duration"}
+          .data=${this._duration_data}
+          @value-changed=${this._valueChanged}
+        ></ha-duration-input>
         <ha-formfield
           .label=${this.hass.localize(
             "ui.dialogs.helper_settings.timer.restore"
@@ -141,7 +142,7 @@ class HaTimerForm extends LitElement {
         .form {
           color: var(--primary-text-color);
         }
-        ha-textfield, 
+        ha-textfield,
         ha-time-input {
           display: block;
           margin: 8px 0;

--- a/src/panels/config/helpers/forms/ha-timer-form.ts
+++ b/src/panels/config/helpers/forms/ha-timer-form.ts
@@ -5,6 +5,7 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-checkbox";
 import "../../../../components/ha-formfield";
 import "../../../../components/ha-icon-picker";
+import "../../../../components/ha-time-input";
 import "../../../../components/ha-textfield";
 import type { DurationDict, Timer } from "../../../../data/timer";
 import { haStyle } from "../../../../resources/styles";
@@ -15,6 +16,8 @@ class HaTimerForm extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ type: Boolean }) public new = false;
+
+  @property({ attribute: "enable-second", type: Boolean }) enableSecond = true;
 
   private _item?: Timer;
 
@@ -79,14 +82,14 @@ class HaTimerForm extends LitElement {
             "ui.dialogs.helper_settings.generic.icon"
           )}
         ></ha-icon-picker>
-        <ha-textfield
-          .configValue=${"duration"}
-          .value=${this._duration}
-          @input=${this._valueChanged}
-          .label=${this.hass.localize(
-            "ui.dialogs.helper_settings.timer.duration"
-          )}
-        ></ha-textfield>
+        <ha-time-input
+           .configValue=${"duration"}
+           .value=${this._duration}
+           .locale=${this.hass.locale}
+           clearable
+           .enableSecond=${this.enableSecond}
+           @value-changed=${this._valueChanged}
+         ></ha-time-input>
         <ha-formfield
           .label=${this.hass.localize(
             "ui.dialogs.helper_settings.timer.restore"
@@ -138,7 +141,8 @@ class HaTimerForm extends LitElement {
         .form {
           color: var(--primary-text-color);
         }
-        ha-textfield {
+        ha-textfield, 
+        ha-time-input {
           display: block;
           margin: 8px 0;
         }

--- a/src/panels/config/helpers/forms/ha-timer-form.ts
+++ b/src/panels/config/helpers/forms/ha-timer-form.ts
@@ -12,6 +12,7 @@ import { haStyle } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import { createDurationData } from "../../../../common/datetime/create_duration_data";
 import type { HaDurationData } from "../../../../components/ha-duration-input";
+import type { ForDict } from "../../../../data/automation";
 
 @customElement("ha-timer-form")
 class HaTimerForm extends LitElement {
@@ -45,7 +46,7 @@ class HaTimerForm extends LitElement {
       this._restore = false;
     }
 
-    this._duration_data = createDurationData(this._duration);
+    this._setDurationData();
   }
 
   public focus() {
@@ -135,6 +136,25 @@ class HaTimerForm extends LitElement {
     });
   }
 
+  private _setDurationData() {
+    let durationInput: string | number | ForDict;
+
+    if (typeof this._duration === "object" && this._duration !== null) {
+      const d = this._duration as DurationDict;
+      durationInput = {
+        hours: typeof d.hours === "string" ? parseFloat(d.hours) : d.hours,
+        minutes:
+          typeof d.minutes === "string" ? parseFloat(d.minutes) : d.minutes,
+        seconds:
+          typeof d.seconds === "string" ? parseFloat(d.seconds) : d.seconds,
+      };
+    } else {
+      durationInput = this._duration;
+    }
+
+    this._duration_data = createDurationData(durationInput);
+  }
+
   static get styles(): CSSResultGroup {
     return [
       haStyle,
@@ -143,7 +163,7 @@ class HaTimerForm extends LitElement {
           color: var(--primary-text-color);
         }
         ha-textfield,
-        ha-time-input {
+        ha-duration-input {
           display: block;
           margin: 8px 0;
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Changed the duration input field from a standard `textfield` to `ha-time-input` to improve the user interface and provide a more intuitive input method for time durations.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Change brought to attention by [@wendevlin](https://github.com/wendevlin)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
