### PR TITLE
Fix automation drag&drop loses item

### DIFF
--- a/src/panels/config/automation/action/ha-automation-action.ts
+++ b/src/panels/config/automation/action/ha-automation-action.ts
@@ -235,7 +235,7 @@ export default class HaAutomationAction extends LitElement {
   private async _actionAdded(ev: CustomEvent): Promise<void> {
     ev.stopPropagation();
     const { index, data } = ev.detail;
-    const actions = [
+    let actions = [
       ...this.actions.slice(0, index),
       data,
       ...this.actions.slice(index),
@@ -243,7 +243,15 @@ export default class HaAutomationAction extends LitElement {
     // Add action locally to avoid UI jump
     this.actions = actions;
     await nextRender();
-    fireEvent(this, "value-changed", { value: this.actions });
+    if (this.actions !== actions) {
+      // Ensure action is added even after update
+      actions = [
+        ...this.actions.slice(0, index),
+        data,
+        ...this.actions.slice(index),
+      ];
+    }
+    fireEvent(this, "value-changed", { value: actions });
   }
 
   private async _actionRemoved(ev: CustomEvent): Promise<void> {

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -258,7 +258,7 @@ export default class HaAutomationCondition extends LitElement {
   private async _conditionAdded(ev: CustomEvent): Promise<void> {
     ev.stopPropagation();
     const { index, data } = ev.detail;
-    const conditions = [
+    let conditions = [
       ...this.conditions.slice(0, index),
       data,
       ...this.conditions.slice(index),
@@ -266,7 +266,15 @@ export default class HaAutomationCondition extends LitElement {
     // Add condition locally to avoid UI jump
     this.conditions = conditions;
     await nextRender();
-    fireEvent(this, "value-changed", { value: this.conditions });
+    if (this.conditions !== conditions) {
+      // Ensure condition is added even after update
+      conditions = [
+        ...this.conditions.slice(0, index),
+        data,
+        ...this.conditions.slice(index),
+      ];
+    }
+    fireEvent(this, "value-changed", { value: conditions });
   }
 
   private async _conditionRemoved(ev: CustomEvent): Promise<void> {

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -220,7 +220,7 @@ export default class HaAutomationTrigger extends LitElement {
   private async _triggerAdded(ev: CustomEvent): Promise<void> {
     ev.stopPropagation();
     const { index, data } = ev.detail;
-    const triggers = [
+    let triggers = [
       ...this.triggers.slice(0, index),
       data,
       ...this.triggers.slice(index),
@@ -228,7 +228,15 @@ export default class HaAutomationTrigger extends LitElement {
     // Add trigger locally to avoid UI jump
     this.triggers = triggers;
     await nextRender();
-    fireEvent(this, "value-changed", { value: this.triggers });
+    if (this.triggers !== triggers) {
+      // Ensure trigger is added even after update
+      triggers = [
+        ...this.triggers.slice(0, index),
+        data,
+        ...this.triggers.slice(index),
+      ];
+    }
+    fireEvent(this, "value-changed", { value: triggers });
   }
 
   private async _triggerRemoved(ev: CustomEvent): Promise<void> {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Due to rare race condition, in automation drag and drop an item will sometimes disappear after drop.

More detail about exactly why this happens is described in https://github.com/home-assistant/frontend/issues/23171#issuecomment-2968340200

I believe we need to protect against the case while we are waiting for nextRender, this.actions might be reset back to the previous value, and we need to make sure we don't lose the new item.

A similar type of logic/guard seems to have been already added to `_actionRemoved` function (see just below _actionAdded) when it was originally developed, not sure why it was treated differently and the same was not provided for `_actionAdded`. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #23171
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
