### PR TITLE
Fix disabled color in dark mode in production

### DIFF
--- a/src/common/style/derived-css-vars.ts
+++ b/src/common/style/derived-css-vars.ts
@@ -9,7 +9,9 @@ const _extractCssVars = (
   cssString.split(";").forEach((rawLine) => {
     const line = rawLine.substring(rawLine.indexOf("--")).trim();
     if (line.startsWith("--") && condition(line)) {
-      const [name, value] = line.split(":").map((part) => part.trim());
+      const [name, value] = line
+        .split(":")
+        .map((part) => part.replaceAll("}", "").trim());
       variables[name.substring(2, name.length)] = value;
     }
   });
@@ -25,7 +27,10 @@ export const extractVar = (css: CSSResult, varName: string) => {
   }
 
   const endIndex = cssString.indexOf(";", startIndex + search.length);
-  return cssString.substring(startIndex + search.length, endIndex).trim();
+  return cssString
+    .substring(startIndex + search.length, endIndex)
+    .replaceAll("}", "")
+    .trim();
 };
 
 export const extractVars = (css: CSSResult) => {


### PR DESCRIPTION
## Proposed change

When minified, the last `;` was removed in css causing the disabled color to be `#464646}` instead of `#464646`

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
