### PR TITLE
Improve explanation of 'Ping a Matter device' dialog

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6376,7 +6376,7 @@
           },
           "ping_node": {
             "title": "Ping a Matter device",
-            "introduction": "Perform a (server-side) ping on your Matter device on all its (known) IP-addresses.",
+            "introduction": "This performs a (server-side) ping of your Matter device on all its (known) IP addresses.",
             "battery_device_warning": "Note that especially for battery powered devices this can take a while. You may need to wake up battery powered devices before starting the pinging to speed up the process. Refer to your device's manual for instructions on how to wake the device.",
             "start_ping": "Start ping",
             "in_progress": "The device is being pinged. This may take some time.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6377,7 +6377,7 @@
           "ping_node": {
             "title": "Ping a Matter device",
             "introduction": "This performs a (server-side) ping of your Matter device on all its (known) IP addresses.",
-            "battery_device_warning": "Note that especially for battery-powered devices this can take a while. You may need to wake up battery powered devices before starting the pinging to speed up the process. Refer to your device's manual for instructions on how to wake the device.",
+            "battery_device_warning": "Note that especially for battery-powered devices this can take a while. You may need to wake up battery-powered devices before starting the pinging to speed up the process. Refer to your device's manual for instructions on how to wake the device.",
             "start_ping": "Start ping",
             "in_progress": "The device is being pinged. This may take some time.",
             "ping_failed": "The device ping failed. Additional information may be available in the logs.",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Currently the 'Ping a Matter device' dialog looks like this:

![Screenshot 2025-06-19 11 26 24](https://github.com/user-attachments/assets/2f09e5d9-edae-4349-969b-eea184ad188f)

"Perform a … ping" can be misunderstood as telling the user to do something outside of Home Assistant while it is meant to explain what is happening next. This commit fixes this along with two more issues in that sentence:

- change to more descriptive wording using third-person singular
- replace first "on" with "of" to clarify (currently "on" contradicts "server-side")
- remove the wrong hyphen in "IP-addresses"

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
