### PR TITLE
allow previews in config_subentries_flow

### DIFF
--- a/src/data/preview.ts
+++ b/src/data/preview.ts
@@ -13,7 +13,7 @@ export const subscribePreviewGeneric = (
   hass: HomeAssistant,
   domain: string,
   flow_id: string,
-  flow_type: "config_flow" | "options_flow",
+  flow_type: "config_flow" | "options_flow" | "config_subentries_flow",
   user_input: Record<string, any>,
   callback: (preview: GenericPreview) => void
 ): Promise<UnsubscribeFunc> =>

--- a/src/dialogs/config-flow/previews/flow-preview-generic.ts
+++ b/src/dialogs/config-flow/previews/flow-preview-generic.ts
@@ -82,7 +82,11 @@ export class FlowPreviewGeneric extends LitElement {
       (await this._unsub)();
       this._unsub = undefined;
     }
-    if (this.flowType !== "config_flow" && this.flowType !== "options_flow") {
+    if (
+      this.flowType !== "config_flow" &&
+      this.flowType !== "options_flow" &&
+      this.flowType !== "config_subentries_flow"
+    ) {
       return;
     }
     this._error = undefined;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The current frontend doesn't support previews during Config Subentry Flow due to a hard stop in verifying  flow type. This PR adds `config_subentries_flow` as an allowable flow type in  the generic config flow preview.  

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

This is not configuration specific but I have developed an custom integration that's in it's infancy but has config subentry flows with preview.  This is available at [PDF Scrape](https://github.com/iluvdata/pdf_scrape).

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #25860 
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
