### PR TITLE
Short-format negative and small numbers in energy-distribution-card

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -1114,12 +1114,16 @@ export const formatConsumptionShort = (
   if (!consumption) {
     return `0 ${unit}`;
   }
-  const units = ["kWh", "MWh", "GWh", "TWh"];
+  const units = ["Wh", "kWh", "MWh", "GWh", "TWh"];
   let pickedUnit = unit;
   let val = consumption;
   let unitIndex = units.findIndex((u) => u === unit);
   if (unitIndex >= 0) {
-    while (val >= 1000 && unitIndex < units.length - 1) {
+    while (Math.abs(val) < 1 && unitIndex > 0) {
+      val *= 1000;
+      unitIndex--;
+    }
+    while (Math.abs(val) >= 1000 && unitIndex < units.length - 1) {
       val /= 1000;
       unitIndex++;
     }
@@ -1127,7 +1131,8 @@ export const formatConsumptionShort = (
   }
   return (
     formatNumber(val, hass.locale, {
-      maximumFractionDigits: val < 10 ? 2 : val < 100 ? 1 : 0,
+      maximumFractionDigits:
+        Math.abs(val) < 10 ? 2 : Math.abs(val) < 100 ? 1 : 0,
     }) +
     " " +
     pickedUnit

--- a/test/data/energy.test.ts
+++ b/test/data/energy.test.ts
@@ -68,15 +68,18 @@ describe("Energy Short Format Test", () => {
   };
 
   const hass = { locale: defaultLocale } as HomeAssistant;
-  it("Formats", () => {
+  it("No Unit conversion", () => {
+    assert.strictEqual(formatConsumptionShort(hass, 0, "Wh"), "0 Wh");
     assert.strictEqual(formatConsumptionShort(hass, 0, "kWh"), "0 kWh");
     assert.strictEqual(formatConsumptionShort(hass, 0, "GWh"), "0 GWh");
     assert.strictEqual(formatConsumptionShort(hass, 0, "gal"), "0 gal");
 
     assert.strictEqual(
-      formatConsumptionShort(hass, 0.12345, "kWh"),
-      "0.12 kWh"
+      formatConsumptionShort(hass, 10000.12345, "gal"),
+      "10,000 gal"
     );
+
+    assert.strictEqual(formatConsumptionShort(hass, 1.2345, "kWh"), "1.23 kWh");
     assert.strictEqual(
       formatConsumptionShort(hass, 10.12345, "kWh"),
       "10.1 kWh"
@@ -85,6 +88,10 @@ describe("Energy Short Format Test", () => {
       formatConsumptionShort(hass, 500.12345, "kWh"),
       "500 kWh"
     );
+
+    assert.strictEqual(formatConsumptionShort(hass, 10.01, "kWh"), "10 kWh");
+  });
+  it("Upward Unit conversion", () => {
     assert.strictEqual(
       formatConsumptionShort(hass, 1512.34567, "kWh"),
       "1.51 MWh"
@@ -105,23 +112,31 @@ describe("Energy Short Format Test", () => {
       formatConsumptionShort(hass, 15123456789.9, "kWh"),
       "15.1 TWh"
     );
-
     assert.strictEqual(
       formatConsumptionShort(hass, 15123456789000.9, "kWh"),
       "15,123 TWh"
     );
-
-    assert.strictEqual(formatConsumptionShort(hass, 1000.1, "GWh"), "1 TWh");
-
+  });
+  it("Downward Unit conversion", () => {
+    assert.strictEqual(formatConsumptionShort(hass, 0.00012, "kWh"), "0.12 Wh");
+    assert.strictEqual(formatConsumptionShort(hass, 0.12345, "kWh"), "123 Wh");
     assert.strictEqual(
-      formatConsumptionShort(hass, 10000.12345, "gal"),
-      "10,000 gal"
+      formatConsumptionShort(hass, 0.00001234, "TWh"),
+      "12.3 MWh"
     );
-
-    // Don't really modify negative numbers, but make sure it's something sane.
+  });
+  it("Negativ Consumption", () => {
+    assert.strictEqual(
+      formatConsumptionShort(hass, -500.123, "kWh"),
+      "-500 kWh"
+    );
     assert.strictEqual(
       formatConsumptionShort(hass, -1234.56, "kWh"),
-      "-1,234.56 kWh"
+      "-1.23 MWh"
+    );
+    assert.strictEqual(
+      formatConsumptionShort(hass, -0.001234, "kWh"),
+      "-1.23 Wh"
     );
   });
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Shorten small numbers in energy-distribution-card by using smaller or larger units.
Small numbers like 0,03 kWh have low precision and become unnecessarily large.
![Proposed Formatting](https://github.com/user-attachments/assets/cf4ff45e-e9c5-4bdb-9db1-a181aaa34388)
![Current Formatting](https://github.com/user-attachments/assets/cc69ac97-e1a2-471e-9f03-00f544357670)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #25861
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
