### PR TITLE
Add visibility condition for lovelace cards based on an entity's last changed time

### DIFF
--- a/src/common/datetime/duration_to_seconds.ts
+++ b/src/common/datetime/duration_to_seconds.ts
@@ -1,4 +1,26 @@
+import type { HaDurationData } from "../../components/ha-duration-input";
+
 export default function durationToSeconds(duration: string): number {
   const parts = duration.split(":").map(Number);
   return parts[0] * 3600 + parts[1] * 60 + parts[2];
+}
+
+export function HaDurationData_to_milliseconds(
+  duration: HaDurationData | undefined
+): number | undefined {
+  if (duration) {
+    const days = duration.days || 0;
+    let hours = duration.hours || 0;
+    let minutes = duration.minutes || 0;
+    let seconds = duration.seconds || 0;
+    let milliseconds = duration.milliseconds || 0;
+
+    hours += days * 24;
+    minutes += hours * 60;
+    seconds += minutes * 60;
+    milliseconds += seconds * 1000;
+
+    return milliseconds;
+  }
+  return undefined;
 }

--- a/src/panels/lovelace/common/icon-condition.ts
+++ b/src/panels/lovelace/common/icon-condition.ts
@@ -5,11 +5,13 @@ import {
   mdiNumeric,
   mdiResponsive,
   mdiStateMachine,
+  mdiTimelineClock,
 } from "@mdi/js";
 import type { Condition } from "./validate-condition";
 
 export const ICON_CONDITION: Record<Condition["condition"], string> = {
   numeric_state: mdiNumeric,
+  last_changed_state: mdiTimelineClock,
   state: mdiStateMachine,
   screen: mdiResponsive,
   user: mdiAccount,

--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -8,7 +8,7 @@ import { createDurationData } from "../../../common/datetime/create_duration_dat
 import type { HaDurationData } from "../../../components/ha-duration-input";
 
 export type Condition =
-  | LastUpdatedStateCondition
+  | LastChangedStateCondition
   | NumericStateCondition
   | StateCondition
   | ScreenCondition
@@ -27,8 +27,8 @@ interface BaseCondition {
   condition: string;
 }
 
-export interface LastUpdatedStateCondition extends BaseCondition {
-  condition: "last_updated_state";
+export interface LastChangedStateCondition extends BaseCondition {
+  condition: "last_changed_state";
   entity?: string;
   within?: HaDurationData;
   after?: HaDurationData;
@@ -142,8 +142,8 @@ function checkStateNumericCondition(
   );
 }
 
-function checkLastUpdatedStateCondition(
-  condition: LastUpdatedStateCondition,
+function checkLastChangedStateCondition(
+  condition: LastChangedStateCondition,
   hass: HomeAssistant
 ) {
   const state_last_changed = (
@@ -181,11 +181,11 @@ function checkLastUpdatedStateCondition(
     createDurationData(after)
   );
 
-  const numericLastUpdatedState = new Date(state_last_changed).getTime();
-  const numericWithin = numericLastUpdatedState + withinDuration;
-  const numericAfter = numericLastUpdatedState + afterDuration;
+  const numericLastChangedState = new Date(state_last_changed).getTime();
+  const numericWithin = numericLastChangedState + withinDuration;
+  const numericAfter = numericLastChangedState + afterDuration;
 
-  if (isNaN(numericLastUpdatedState)) {
+  if (isNaN(numericLastChangedState)) {
     return false;
   }
 
@@ -239,8 +239,8 @@ export function checkConditionsMet(
           return checkUserCondition(c, hass);
         case "numeric_state":
           return checkStateNumericCondition(c, hass);
-        case "last_updated_state":
-          return checkLastUpdatedStateCondition(c, hass);
+        case "last_changed_state":
+          return checkLastChangedStateCondition(c, hass);
         case "and":
           return checkAndCondition(c, hass);
         case "or":
@@ -274,7 +274,7 @@ export function extractConditionEntityIds(
       ) {
         entityIds.add(condition.below);
       }
-    } else if (condition.condition === "last_updated_state") {
+    } else if (condition.condition === "last_changed_state") {
       if (condition.entity) {
         entityIds.add(condition.entity);
       }
@@ -341,8 +341,8 @@ function validateNumericStateCondition(condition: NumericStateCondition) {
     (condition.above != null || condition.below != null)
   );
 }
-function validateLastUpdatedStateCondition(
-  condition: LastUpdatedStateCondition
+function validateLastChangedStateCondition(
+  condition: LastChangedStateCondition
 ) {
   return (
     condition.entity != null &&
@@ -366,8 +366,8 @@ export function validateConditionalConfig(
           return validateUserCondition(c);
         case "numeric_state":
           return validateNumericStateCondition(c);
-        case "last_updated_state":
-          return validateLastUpdatedStateCondition(c);
+        case "last_changed_state":
+          return validateLastChangedStateCondition(c);
         case "and":
           return validateAndCondition(c);
         case "or":
@@ -402,7 +402,7 @@ export function addEntityToCondition(
   if (
     condition.condition === "state" ||
     condition.condition === "numeric_state" ||
-    condition.condition === "last_updated_state"
+    condition.condition === "last_changed_state"
   ) {
     return {
       entity: entityId,

--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -150,6 +150,10 @@ function checkLastChangedStateCondition(
   const state_last_changed = (
     condition.entity ? hass.states[condition.entity] : undefined
   )?.last_changed;
+  if (state_last_changed === undefined) {
+    return false;
+  }
+
   const within = condition.within;
   const after = condition.after;
 

--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -6,6 +6,7 @@ import { UNKNOWN } from "../../../data/entity";
 import type { HomeAssistant } from "../../../types";
 import { createDurationData } from "../../../common/datetime/create_duration_data";
 import type { HaDurationData } from "../../../components/ha-duration-input";
+import { HaDurationData_to_milliseconds } from "../../../common/datetime/duration_to_seconds";
 
 export type Condition =
   | LastChangedStateCondition
@@ -152,34 +153,10 @@ function checkLastChangedStateCondition(
   const within = condition.within;
   const after = condition.after;
 
-  function HaDurationData_to_milliseconds(
-    duration: HaDurationData | undefined
-  ) {
-    // This function should not be here, and surely something like this already exists?
-    // If so, I can't find it :'(
-    if (duration) {
-      const days = duration.days || 0;
-      let hours = duration.hours || 0;
-      let minutes = duration.minutes || 0;
-      let seconds = duration.seconds || 0;
-      let milliseconds = duration.milliseconds || 0;
-
-      hours += days * 24;
-      minutes += hours * 60;
-      seconds += minutes * 60;
-      milliseconds += seconds * 1000;
-
-      return milliseconds;
-    }
-    return 0; // this also is probably not good
-  }
-
-  const withinDuration = HaDurationData_to_milliseconds(
-    createDurationData(within)
-  );
-  const afterDuration = HaDurationData_to_milliseconds(
-    createDurationData(after)
-  );
+  const withinDuration =
+    HaDurationData_to_milliseconds(createDurationData(within)) || 0;
+  const afterDuration =
+    HaDurationData_to_milliseconds(createDurationData(after)) || 0;
 
   const numericLastChangedState = new Date(state_last_changed).getTime();
   const numericWithin = numericLastChangedState + withinDuration;

--- a/src/panels/lovelace/editor/conditions/ha-card-conditions-editor.ts
+++ b/src/panels/lovelace/editor/conditions/ha-card-conditions-editor.ts
@@ -19,6 +19,7 @@ import type { HaCardConditionEditor } from "./ha-card-condition-editor";
 import type { LovelaceConditionEditorConstructor } from "./types";
 import "./types/ha-card-condition-and";
 import "./types/ha-card-condition-numeric_state";
+import "./types/ha-card-condition-last_updated_state";
 import "./types/ha-card-condition-or";
 import "./types/ha-card-condition-screen";
 import "./types/ha-card-condition-state";
@@ -26,6 +27,7 @@ import "./types/ha-card-condition-user";
 
 const UI_CONDITION = [
   "numeric_state",
+  "last_updated_state",
   "state",
   "screen",
   "user",

--- a/src/panels/lovelace/editor/conditions/ha-card-conditions-editor.ts
+++ b/src/panels/lovelace/editor/conditions/ha-card-conditions-editor.ts
@@ -19,7 +19,7 @@ import type { HaCardConditionEditor } from "./ha-card-condition-editor";
 import type { LovelaceConditionEditorConstructor } from "./types";
 import "./types/ha-card-condition-and";
 import "./types/ha-card-condition-numeric_state";
-import "./types/ha-card-condition-last_updated_state";
+import "./types/ha-card-condition-last_changed_state";
 import "./types/ha-card-condition-or";
 import "./types/ha-card-condition-screen";
 import "./types/ha-card-condition-state";
@@ -27,7 +27,7 @@ import "./types/ha-card-condition-user";
 
 const UI_CONDITION = [
   "numeric_state",
-  "last_updated_state",
+  "last_changed_state",
   "state",
   "screen",
   "user",

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-last_changed_state.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-last_changed_state.ts
@@ -72,15 +72,11 @@ export class HaCardConditionLastChangedState extends LitElement {
   );
 
   protected render() {
-    const stateObj = this.condition.entity
-      ? this.hass.states[this.condition.entity]
-      : undefined;
-
     return html`
       <ha-form
         .hass=${this.hass}
         .data=${this.condition}
-        .schema=${this._schema(stateObj)}
+        .schema=${this._schema()}
         .disabled=${this.disabled}
         @value-changed=${this._valueChanged}
         .computeLabel=${this._computeLabelCallback}

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-last_changed_state.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-last_changed_state.ts
@@ -19,31 +19,31 @@ import type {
 import { forDictStruct } from "../../../../config/automation/structs";
 import type { HomeAssistant } from "../../../../../types";
 import type {
-  LastUpdatedStateCondition,
+  LastChangedStateCondition,
   StateCondition,
 } from "../../../common/validate-condition";
 
-const lastUpdatedStateConditionStruct = object({
-  condition: literal("last_updated_state"),
+const lastChangededStateConditionStruct = object({
+  condition: literal("last_changed_state"),
   entity: optional(string()),
   within: optional(union([number(), string(), forDictStruct])),
   after: optional(union([number(), string(), forDictStruct])),
 });
 
-@customElement("ha-card-condition-last_updated_state")
-export class HaCardConditionLastUpdatedState extends LitElement {
+@customElement("ha-card-condition-last_changed_state")
+export class HaCardConditionLastChangedState extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property({ attribute: false }) public condition!: LastUpdatedStateCondition;
+  @property({ attribute: false }) public condition!: LastChangedStateCondition;
 
   @property({ type: Boolean }) public disabled = false;
 
-  public static get defaultConfig(): LastUpdatedStateCondition {
-    return { condition: "last_updated_state", entity: "" };
+  public static get defaultConfig(): LastChangedStateCondition {
+    return { condition: "last_changed_state", entity: "" };
   }
 
   protected static validateUIConfig(condition: StateCondition) {
-    return assert(condition, lastUpdatedStateConditionStruct);
+    return assert(condition, lastChangededStateConditionStruct);
   }
 
   private _schema = memoizeOne(
@@ -90,7 +90,7 @@ export class HaCardConditionLastUpdatedState extends LitElement {
 
   private _valueChanged(ev: CustomEvent): void {
     ev.stopPropagation();
-    const condition = ev.detail.value as LastUpdatedStateCondition;
+    const condition = ev.detail.value as LastChangedStateCondition;
     fireEvent(this, "value-changed", { value: condition });
   }
 
@@ -113,6 +113,6 @@ export class HaCardConditionLastUpdatedState extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "ha-card-condition-last_updated_state": HaCardConditionLastUpdatedState;
+    "ha-card-condition-last_changed_state": HaCardConditionLastChangedState;
   }
 }

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-last_changed_state.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-last_changed_state.ts
@@ -99,7 +99,7 @@ export class HaCardConditionLastChangedState extends LitElement {
       case "within":
       case "after":
         return this.hass.localize(
-          "ui.panel.config.automation.editor.triggers.type.state.for"
+          `ui.panel.lovelace.editor.condition-editor.condition.last_changed_state.${schema.name}`
         );
       default:
         return "";

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-last_updated_state.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-last_updated_state.ts
@@ -1,0 +1,118 @@
+import { html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import {
+  assert,
+  literal,
+  number,
+  object,
+  optional,
+  string,
+  union,
+} from "superstruct";
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import "../../../../../components/ha-form/ha-form";
+import type {
+  SchemaUnion,
+  HaFormSchema,
+} from "../../../../../components/ha-form/types";
+import { forDictStruct } from "../../../../config/automation/structs";
+import type { HomeAssistant } from "../../../../../types";
+import type {
+  LastUpdatedStateCondition,
+  StateCondition,
+} from "../../../common/validate-condition";
+
+const lastUpdatedStateConditionStruct = object({
+  condition: literal("last_updated_state"),
+  entity: optional(string()),
+  within: optional(union([number(), string(), forDictStruct])),
+  after: optional(union([number(), string(), forDictStruct])),
+});
+
+@customElement("ha-card-condition-last_updated_state")
+export class HaCardConditionLastUpdatedState extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public condition!: LastUpdatedStateCondition;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  public static get defaultConfig(): LastUpdatedStateCondition {
+    return { condition: "last_updated_state", entity: "" };
+  }
+
+  protected static validateUIConfig(condition: StateCondition) {
+    return assert(condition, lastUpdatedStateConditionStruct);
+  }
+
+  private _schema = memoizeOne(
+    () =>
+      [
+        { name: "entity", selector: { entity: {} } },
+        {
+          name: "",
+          type: "grid",
+          schema: [
+            {
+              name: "within",
+              selector: {
+                duration: {},
+              },
+            },
+            {
+              name: "after",
+              selector: {
+                duration: {},
+              },
+            },
+          ],
+        },
+      ] as const satisfies readonly HaFormSchema[]
+  );
+
+  protected render() {
+    const stateObj = this.condition.entity
+      ? this.hass.states[this.condition.entity]
+      : undefined;
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${this.condition}
+        .schema=${this._schema(stateObj)}
+        .disabled=${this.disabled}
+        @value-changed=${this._valueChanged}
+        .computeLabel=${this._computeLabelCallback}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const condition = ev.detail.value as LastUpdatedStateCondition;
+    fireEvent(this, "value-changed", { value: condition });
+  }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ): string => {
+    switch (schema.name) {
+      case "entity":
+        return this.hass.localize("ui.components.entity.entity-picker.entity");
+      case "within":
+      case "after":
+        return this.hass.localize(
+          "ui.panel.config.automation.editor.triggers.type.state.for"
+        );
+      default:
+        return "";
+    }
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-card-condition-last_updated_state": HaCardConditionLastUpdatedState;
+  }
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7200,6 +7200,9 @@
                 "above": "Above",
                 "below": "Below"
               },
+              "last_updated_state": {
+                "label": "Entity updated"
+              },
               "screen": {
                 "label": "Screen",
                 "breakpoints": "Screen sizes",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7201,7 +7201,9 @@
                 "below": "Below"
               },
               "last_changed_state": {
-                "label": "Last entity change"
+                "label": "Last entity change",
+                "within": "Within",
+                "after": "After"
               },
               "screen": {
                 "label": "Screen",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7200,8 +7200,8 @@
                 "above": "Above",
                 "below": "Below"
               },
-              "last_updated_state": {
-                "label": "Entity updated"
+              "last_changed_state": {
+                "label": "Last entity change"
               },
               "screen": {
                 "label": "Screen",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

**EDIT**: there is an alternative implementation done here: https://github.com/home-assistant/frontend/pull/26094 - it would be good to know which way is preferred! :)

This change adds a condition to lovelace cards, where you can decide if a card should be visible based on the time since the last change to an entity was made.

An example might be: I have a card show up on my dashboard when occupancy is detected at my front-door, showing a picture of who was there - but as soon as they leave, and the occupancy sensor is cleared, the picture immediately disappears.

This change allows me to set a visibility condition where I say display the picture for 5 minutes after the last update to the occupancy sensor.

I'm sure people will come up with other ideas too :).


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: entity
entity: light.kitchen_floor_lamp_light
visibility:
  - condition: last_changed_state
    entity: light.kitchen_floor_lamp_light
    within:
      hours: 0
      minutes: 1
      seconds: 25

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I'm not 100% sure where to put tests, a pointer would be much appreciated.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

## Demo:
![last_state_change_demo](https://github.com/user-attachments/assets/73de823f-2d49-45a0-8e72-af0d035c2709)


<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
