### PR TITLE
Fix duplicated requests in statistics-graph

### DIFF
--- a/src/panels/lovelace/cards/hui-statistics-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-statistics-graph-card.ts
@@ -97,8 +97,8 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
     }
     if (this._config?.energy_date_selection) {
       this._subscribeEnergy();
-    } else {
-      this._setFetchStatisticsTimer();
+    } else if (this._interval === undefined) {
+      this._setFetchStatisticsTimer(true);
     }
   }
 
@@ -213,9 +213,7 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
       changedProps.has("_config") &&
       oldConfig?.entities !== this._config.entities
     ) {
-      this._getStatisticsMetaData(this._entities).then(() => {
-        this._setFetchStatisticsTimer();
-      });
+      this._setFetchStatisticsTimer(true);
       return;
     }
 
@@ -230,10 +228,14 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
     }
   }
 
-  private _setFetchStatisticsTimer() {
-    this._getStatistics();
-    // statistics are created every hour
+  private async _setFetchStatisticsTimer(fetchMetadata = false) {
     clearInterval(this._interval);
+    this._interval = 0; // block concurrent calls
+    if (fetchMetadata) {
+      await this._getStatisticsMetaData(this._entities);
+    }
+    await this._getStatistics();
+    // statistics are created every hour
     if (!this._config?.energy_date_selection) {
       this._interval = window.setInterval(
         () => this._getStatistics(),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Statistics graph was `this._setFetchStatisticsTimer` twice in Masonry view because on `connectedCallback` was called after `willUpdate`.
This should improve home-assistant/core#146799 but I'm not sure it was the root problem

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
