### PR TITLE
Add cover controls to area card and improve areas dashboard

### DIFF
--- a/src/common/entity/group_entities.ts
+++ b/src/common/entity/group_entities.ts
@@ -1,0 +1,68 @@
+import { callService, type HassEntity } from "home-assistant-js-websocket";
+import { computeStateDomain } from "./compute_state_domain";
+import { isUnavailableState, UNAVAILABLE } from "../../data/entity";
+import type { HomeAssistant } from "../../types";
+
+export const computeGroupEntitiesState = (states: HassEntity[]): string => {
+  if (!states.length) {
+    return UNAVAILABLE;
+  }
+
+  const validState = states.filter((stateObj) => isUnavailableState(stateObj));
+
+  if (!validState) {
+    return UNAVAILABLE;
+  }
+
+  // Use the first state to determine the domain
+  // This assumes all states in the group have the same domain
+  const domain = computeStateDomain(states[0]);
+
+  if (domain === "cover") {
+    for (const s of ["opening", "closing", "open"]) {
+      if (states.some((stateObj) => stateObj.state === s)) {
+        return s;
+      }
+    }
+    return "closed";
+  }
+
+  if (states.some((stateObj) => stateObj.state === "on")) {
+    return "on";
+  }
+  return "off";
+};
+
+export const toggleGroupEntities = (
+  hass: HomeAssistant,
+  states: HassEntity[]
+) => {
+  if (!states.length) {
+    return;
+  }
+
+  // Use the first state to determine the domain
+  // This assumes all states in the group have the same domain
+  const domain = computeStateDomain(states[0]);
+
+  const state = computeGroupEntitiesState(states);
+
+  const isOn = state === "on" || state === "open";
+
+  let service = isOn ? "turn_off" : "turn_on";
+  if (domain === "cover") {
+    if (state === "opening" || state === "closing") {
+      // If the cover is opening or closing, we toggle it to stop it
+      service = "stop_cover";
+    } else {
+      // For covers, we use the open/close service
+      service = isOn ? "close_cover" : "open_cover";
+    }
+  }
+
+  const entitiesIds = states.map((stateObj) => stateObj.entity_id);
+
+  callService(hass.connection, domain, service, {
+    entity_id: entitiesIds,
+  });
+};

--- a/src/common/entity/state_color.ts
+++ b/src/common/entity/state_color.ts
@@ -64,15 +64,27 @@ export const domainStateColorProperties = (
   const compareState = state !== undefined ? state : stateObj.state;
   const active = stateActive(stateObj, state);
 
+  return domainColorProperties(
+    domain,
+    stateObj.attributes.device_class,
+    compareState,
+    active
+  );
+};
+
+export const domainColorProperties = (
+  domain: string,
+  deviceClass: string | undefined,
+  state: string,
+  active: boolean
+) => {
   const properties: string[] = [];
 
-  const stateKey = slugify(compareState, "_");
+  const stateKey = slugify(state, "_");
   const activeKey = active ? "active" : "inactive";
 
-  const dc = stateObj.attributes.device_class;
-
-  if (dc) {
-    properties.push(`--state-${domain}-${dc}-${stateKey}-color`);
+  if (deviceClass) {
+    properties.push(`--state-${domain}-${deviceClass}-${stateKey}-color`);
   }
 
   properties.push(

--- a/src/components/ha-control-button-group.ts
+++ b/src/components/ha-control-button-group.ts
@@ -7,9 +7,6 @@ export class HaControlButtonGroup extends LitElement {
   @property({ type: Boolean, reflect: true })
   public vertical = false;
 
-  @property({ attribute: "no-fill", type: Boolean, reflect: true })
-  public noFill = false;
-
   protected render(): TemplateResult {
     return html`
       <div class="container">

--- a/src/components/ha-control-button-group.ts
+++ b/src/components/ha-control-button-group.ts
@@ -7,6 +7,9 @@ export class HaControlButtonGroup extends LitElement {
   @property({ type: Boolean, reflect: true })
   public vertical = false;
 
+  @property({ attribute: "no-fill", type: Boolean, reflect: true })
+  public noFill = false;
+
   protected render(): TemplateResult {
     return html`
       <div class="container">
@@ -26,6 +29,7 @@ export class HaControlButtonGroup extends LitElement {
     .container {
       display: flex;
       flex-direction: row;
+      justify-content: var(--control-button-group-alignment, start);
       width: 100%;
       height: 100%;
     }

--- a/src/components/ha-domain-icon.ts
+++ b/src/components/ha-domain-icon.ts
@@ -18,6 +18,8 @@ export class HaDomainIcon extends LitElement {
 
   @property({ attribute: false }) public deviceClass?: string;
 
+  @property({ attribute: false }) public state?: string;
+
   @property() public icon?: string;
 
   @property({ attribute: "brand-fallback", type: Boolean })
@@ -36,14 +38,17 @@ export class HaDomainIcon extends LitElement {
       return this._renderFallback();
     }
 
-    const icon = domainIcon(this.hass, this.domain, this.deviceClass).then(
-      (icn) => {
-        if (icn) {
-          return html`<ha-icon .icon=${icn}></ha-icon>`;
-        }
-        return this._renderFallback();
+    const icon = domainIcon(
+      this.hass,
+      this.domain,
+      this.deviceClass,
+      this.state
+    ).then((icn) => {
+      if (icn) {
+        return html`<ha-icon .icon=${icn}></ha-icon>`;
       }
-    );
+      return this._renderFallback();
+    });
 
     return html`${until(icon)}`;
   }

--- a/src/data/icons.ts
+++ b/src/data/icons.ts
@@ -504,14 +504,25 @@ export const serviceSectionIcon = async (
 export const domainIcon = async (
   hass: HomeAssistant,
   domain: string,
-  deviceClass?: string
+  deviceClass?: string,
+  state?: string
 ): Promise<string | undefined> => {
   const entityComponentIcons = await getComponentIcons(hass, domain);
   if (entityComponentIcons) {
     const translations =
       (deviceClass && entityComponentIcons[deviceClass]) ||
       entityComponentIcons._;
-    return translations?.default;
+    // First check for exact state match
+    if (state && translations.state?.[state]) {
+      return translations.state[state];
+    }
+    // Then check for range-based icons if we have a numeric state
+    if (state !== undefined && translations.range && !isNaN(Number(state))) {
+      return getIconFromRange(Number(state), translations.range);
+    }
+    // Fallback to default icon
+    return translations.default;
   }
+
   return undefined;
 };

--- a/src/panels/lovelace/card-features/common/card-feature-styles.ts
+++ b/src/panels/lovelace/card-features/common/card-feature-styles.ts
@@ -25,6 +25,9 @@ export const cardFeatureStyles = css`
     flex-basis: 20px;
     --control-button-padding: 0px;
   }
+  ha-control-button-group[no-fill] > ha-control-button {
+    max-width: 48px;
+  }
   ha-control-button {
     --control-button-focus-color: var(--feature-color);
   }

--- a/src/panels/lovelace/card-features/common/card-feature-styles.ts
+++ b/src/panels/lovelace/card-features/common/card-feature-styles.ts
@@ -25,7 +25,7 @@ export const cardFeatureStyles = css`
     flex-basis: 20px;
     --control-button-padding: 0px;
   }
-  ha-control-button-group[no-fill] > ha-control-button {
+  ha-control-button-group[no-stretch] > ha-control-button {
     max-width: 48px;
   }
   ha-control-button {

--- a/src/panels/lovelace/card-features/hui-area-controls-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-area-controls-card-feature.ts
@@ -231,8 +231,13 @@ class HuiAreaControlsCardFeature
             return stateActive(stateObj);
           });
 
+          const label = this.hass!.localize(
+            `ui.card_features.area_controls.${control}.${active ? "off" : "on"}`
+          );
           return html`
             <ha-control-button
+              .title=${label}
+              aria-label=${label}
               class=${active ? "active" : ""}
               .control=${control}
               @click=${this._handleButtonTap}

--- a/src/panels/lovelace/card-features/hui-area-controls-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-area-controls-card-feature.ts
@@ -1,4 +1,11 @@
-import { mdiFan, mdiLightbulb, mdiToggleSwitch } from "@mdi/js";
+import {
+  mdiFan,
+  mdiFanOff,
+  mdiLightbulb,
+  mdiLightbulbOff,
+  mdiToggleSwitch,
+  mdiToggleSwitchOff,
+} from "@mdi/js";
 import { callService, type HassEntity } from "home-assistant-js-websocket";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
@@ -23,7 +30,8 @@ import type {
 import { AREA_CONTROLS } from "./types";
 
 interface AreaControlsButton {
-  iconPath: string;
+  onIconPath: string;
+  offIconPath: string;
   onService: string;
   offService: string;
   filter: EntityFilter;
@@ -31,7 +39,8 @@ interface AreaControlsButton {
 
 export const AREA_CONTROLS_BUTTONS: Record<AreaControl, AreaControlsButton> = {
   light: {
-    iconPath: mdiLightbulb,
+    onIconPath: mdiLightbulb,
+    offIconPath: mdiLightbulbOff,
     filter: {
       domain: "light",
     },
@@ -39,7 +48,8 @@ export const AREA_CONTROLS_BUTTONS: Record<AreaControl, AreaControlsButton> = {
     offService: "light.turn_off",
   },
   fan: {
-    iconPath: mdiFan,
+    onIconPath: mdiFan,
+    offIconPath: mdiFanOff,
     filter: {
       domain: "fan",
     },
@@ -47,7 +57,8 @@ export const AREA_CONTROLS_BUTTONS: Record<AreaControl, AreaControlsButton> = {
     offService: "fan.turn_off",
   },
   switch: {
-    iconPath: mdiToggleSwitch,
+    onIconPath: mdiToggleSwitch,
+    offIconPath: mdiToggleSwitchOff,
     filter: {
       domain: "switch",
     },
@@ -226,7 +237,9 @@ class HuiAreaControlsCardFeature
               .control=${control}
               @click=${this._handleButtonTap}
             >
-              <ha-svg-icon .path=${button.iconPath}></ha-svg-icon>
+              <ha-svg-icon
+                .path=${active ? button.onIconPath : button.offIconPath}
+              ></ha-svg-icon>
             </ha-control-button>
           `;
         })}

--- a/src/panels/lovelace/card-features/hui-area-controls-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-area-controls-card-feature.ts
@@ -228,7 +228,7 @@ class HuiAreaControlsCardFeature
     }
 
     return html`
-      <ha-control-button-group .noFill=${this.position === "inline"}>
+      <ha-control-button-group ?no-stretch=${this.position === "inline"}>
         ${displayControls.map((control) => {
           const button = AREA_CONTROLS_BUTTONS[control];
 

--- a/src/panels/lovelace/card-features/hui-area-controls-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-area-controls-card-feature.ts
@@ -1,15 +1,8 @@
-import {
-  mdiFan,
-  mdiFanOff,
-  mdiLightbulb,
-  mdiLightbulbOff,
-  mdiToggleSwitch,
-  mdiToggleSwitchOff,
-} from "@mdi/js";
 import { callService, type HassEntity } from "home-assistant-js-websocket";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
+import { ensureArray } from "../../../common/array/ensure-array";
 import {
   generateEntityFilter,
   type EntityFilter,
@@ -30,17 +23,27 @@ import type {
 import { AREA_CONTROLS } from "./types";
 
 interface AreaControlsButton {
-  onIconPath: string;
-  offIconPath: string;
+  offIcon?: string;
+  onIcon?: string;
   onService: string;
   offService: string;
   filter: EntityFilter;
 }
 
+const coverButton = (deviceClass) => ({
+  filter: {
+    domain: "cover",
+    device_class: deviceClass,
+  },
+  onService: "cover.open_cover",
+  offService: "cover.close_cover",
+});
+
 export const AREA_CONTROLS_BUTTONS: Record<AreaControl, AreaControlsButton> = {
   light: {
-    onIconPath: mdiLightbulb,
-    offIconPath: mdiLightbulbOff,
+    // Overrides the icons for lights
+    offIcon: "mdi:lightbulb-off",
+    onIcon: "mdi:lightbulb",
     filter: {
       domain: "light",
     },
@@ -48,8 +51,6 @@ export const AREA_CONTROLS_BUTTONS: Record<AreaControl, AreaControlsButton> = {
     offService: "light.turn_off",
   },
   fan: {
-    onIconPath: mdiFan,
-    offIconPath: mdiFanOff,
     filter: {
       domain: "fan",
     },
@@ -57,14 +58,22 @@ export const AREA_CONTROLS_BUTTONS: Record<AreaControl, AreaControlsButton> = {
     offService: "fan.turn_off",
   },
   switch: {
-    onIconPath: mdiToggleSwitch,
-    offIconPath: mdiToggleSwitchOff,
     filter: {
       domain: "switch",
     },
     onService: "switch.turn_on",
     offService: "switch.turn_off",
   },
+  "cover-awning": coverButton("awning"),
+  "cover-blind": coverButton("blind"),
+  "cover-curtain": coverButton("curtain"),
+  "cover-damper": coverButton("damper"),
+  "cover-door": coverButton("door"),
+  "cover-garage": coverButton("garage"),
+  "cover-gate": coverButton("gate"),
+  "cover-shade": coverButton("shade"),
+  "cover-shutter": coverButton("shutter"),
+  "cover-window": coverButton("window"),
 };
 
 export const supportsAreaControlsCardFeature = (
@@ -97,6 +106,20 @@ export const getAreaControlEntities = (
     },
     {} as Record<AreaControl, string[]>
   );
+
+const getFilterDomain = (filter: EntityFilter): string | undefined => {
+  if (filter.domain) {
+    return ensureArray(filter.domain)[0];
+  }
+  return undefined;
+};
+
+const getFilterDeviceClass = (filter: EntityFilter): string | undefined => {
+  if (filter.device_class) {
+    return ensureArray(filter.device_class)[0];
+  }
+  return undefined;
+};
 
 @customElement("hui-area-controls-card-feature")
 class HuiAreaControlsCardFeature
@@ -211,13 +234,17 @@ class HuiAreaControlsCardFeature
       (control) => controlEntities[control].length > 0
     );
 
-    if (!supportedControls.length) {
+    const displayControls = this._config.controls
+      ? supportedControls
+      : supportedControls.slice(0, 4);
+
+    if (!displayControls.length) {
       return nothing;
     }
 
     return html`
       <ha-control-button-group>
-        ${supportedControls.map((control) => {
+        ${displayControls.map((control) => {
           const button = AREA_CONTROLS_BUTTONS[control];
 
           const entities = controlEntities[control];
@@ -234,6 +261,12 @@ class HuiAreaControlsCardFeature
           const label = this.hass!.localize(
             `ui.card_features.area_controls.${control}.${active ? "off" : "on"}`
           );
+
+          const icon = active ? button.onIcon : button.offIcon;
+
+          const domain = getFilterDomain(button.filter);
+          const deviceClass = getFilterDeviceClass(button.filter);
+
           return html`
             <ha-control-button
               .title=${label}
@@ -242,9 +275,19 @@ class HuiAreaControlsCardFeature
               .control=${control}
               @click=${this._handleButtonTap}
             >
-              <ha-svg-icon
-                .path=${active ? button.onIconPath : button.offIconPath}
-              ></ha-svg-icon>
+              <ha-domain-icon
+                .hass=${this.hass}
+                .icon=${icon}
+                .domain=${domain}
+                .deviceClass=${deviceClass}
+                .state=${active
+                  ? domain === "cover"
+                    ? "open"
+                    : "on"
+                  : domain === "cover"
+                    ? "closed"
+                    : "off"}
+              ></ha-domain-icon>
             </ha-control-button>
           `;
         })}

--- a/src/panels/lovelace/card-features/hui-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-card-feature.ts
@@ -7,6 +7,7 @@ import type { LovelaceCardFeature } from "../types";
 import type {
   LovelaceCardFeatureConfig,
   LovelaceCardFeatureContext,
+  LovelaceCardFeaturePosition,
 } from "./types";
 
 @customElement("hui-card-feature")
@@ -18,6 +19,9 @@ export class HuiCardFeature extends LitElement {
   @property({ attribute: false }) public feature?: LovelaceCardFeatureConfig;
 
   @property({ attribute: false }) public color?: string;
+
+  @property({ attribute: false })
+  public position?: LovelaceCardFeaturePosition;
 
   private _element?: LovelaceCardFeature | HuiErrorCard;
 
@@ -41,6 +45,7 @@ export class HuiCardFeature extends LitElement {
       element.hass = this.hass;
       element.context = this.context;
       element.color = this.color;
+      element.position = this.position;
       // Backwards compatibility from custom card features
       if (this.context.entity_id) {
         const stateObj = this.hass.states[this.context.entity_id];

--- a/src/panels/lovelace/card-features/hui-card-features.ts
+++ b/src/panels/lovelace/card-features/hui-card-features.ts
@@ -5,6 +5,7 @@ import "./hui-card-feature";
 import type {
   LovelaceCardFeatureConfig,
   LovelaceCardFeatureContext,
+  LovelaceCardFeaturePosition,
 } from "./types";
 
 @customElement("hui-card-features")
@@ -16,6 +17,9 @@ export class HuiCardFeatures extends LitElement {
   @property({ attribute: false }) public features?: LovelaceCardFeatureConfig[];
 
   @property({ attribute: false }) public color?: string;
+
+  @property({ attribute: false })
+  public position?: LovelaceCardFeaturePosition;
 
   protected render() {
     if (!this.features) {
@@ -29,6 +33,7 @@ export class HuiCardFeatures extends LitElement {
             .context=${this.context}
             .color=${this.color}
             .feature=${feature}
+            .position=${this.position}
           ></hui-card-feature>
         `
       )}

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -158,7 +158,21 @@ export interface UpdateActionsCardFeatureConfig {
   backup?: "yes" | "no" | "ask";
 }
 
-export const AREA_CONTROLS = ["light", "fan", "switch"] as const;
+export const AREA_CONTROLS = [
+  "light",
+  "fan",
+  "cover-shutter",
+  "cover-blind",
+  "cover-curtain",
+  "cover-shade",
+  "cover-awning",
+  "cover-garage",
+  "cover-gate",
+  "cover-door",
+  "cover-window",
+  "cover-damper",
+  "switch",
+] as const;
 
 export type AreaControl = (typeof AREA_CONTROLS)[number];
 

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -182,6 +182,8 @@ export interface AreaControlsCardFeatureConfig {
   exclude_entities?: string[];
 }
 
+export type LovelaceCardFeaturePosition = "bottom" | "inline";
+
 export type LovelaceCardFeatureConfig =
   | AlarmModesCardFeatureConfig
   | ClimateFanModesCardFeatureConfig

--- a/src/panels/lovelace/cards/hui-area-card.ts
+++ b/src/panels/lovelace/cards/hui-area-card.ts
@@ -514,6 +514,7 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
                   .context=${this._featureContext}
                   .color=${this._config.color}
                   .features=${features}
+                  .position=${featurePosition}
                 ></hui-card-features>
               `
             : nothing}

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -9,7 +9,10 @@ import type {
   ThemeMode,
   TranslationDict,
 } from "../../../types";
-import type { LovelaceCardFeatureConfig } from "../card-features/types";
+import type {
+  LovelaceCardFeatureConfig,
+  LovelaceCardFeaturePosition,
+} from "../card-features/types";
 import type { LegacyStateFilter } from "../common/evaluate-filter";
 import type { Condition, LegacyCondition } from "../common/validate-condition";
 import type { HuiImage } from "../components/hui-image";
@@ -113,7 +116,7 @@ export interface AreaCardConfig extends LovelaceCardConfig {
   sensor_classes?: string[];
   alert_classes?: string[];
   features?: LovelaceCardFeatureConfig[];
-  features_position?: "bottom" | "inline";
+  features_position?: LovelaceCardFeaturePosition;
 }
 
 export interface ButtonCardConfig extends LovelaceCardConfig {
@@ -564,7 +567,7 @@ export interface TileCardConfig extends LovelaceCardConfig {
   icon_hold_action?: ActionConfig;
   icon_double_tap_action?: ActionConfig;
   features?: LovelaceCardFeatureConfig[];
-  features_position?: "bottom" | "inline";
+  features_position?: LovelaceCardFeaturePosition;
 }
 
 export interface HeadingCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-area-controls-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-area-controls-card-feature-editor.ts
@@ -148,7 +148,7 @@ export class HuiAreaControlsCardFeatureEditor
         this.hass!.entities,
         this.hass!.devices,
         this.hass!.areas
-      ).concat();
+      ).slice(0, 4); // Default to first 4 compatible controls
     }
 
     if (!customize_controls && config.controls) {

--- a/src/panels/lovelace/editor/config-elements/hui-area-controls-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-area-controls-card-feature-editor.ts
@@ -9,7 +9,10 @@ import type {
   SchemaUnion,
 } from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
-import { getAreaControlEntities } from "../../card-features/hui-area-controls-card-feature";
+import {
+  getAreaControlEntities,
+  MAX_DEFAULT_AREA_CONTROLS,
+} from "../../card-features/hui-area-controls-card-feature";
 import {
   AREA_CONTROLS,
   type AreaControl,
@@ -72,7 +75,7 @@ export class HuiAreaControlsCardFeatureEditor
       ] as const satisfies readonly HaFormSchema[]
   );
 
-  private _compatibleControls = memoizeOne(
+  private _supportedControls = memoizeOne(
     (
       areaId: string,
       // needed to update memoized function when entities, devices or areas change
@@ -99,14 +102,14 @@ export class HuiAreaControlsCardFeatureEditor
       return nothing;
     }
 
-    const compatibleControls = this._compatibleControls(
+    const supportedControls = this._supportedControls(
       this.context.area_id,
       this.hass.entities,
       this.hass.devices,
       this.hass.areas
     );
 
-    if (compatibleControls.length === 0) {
+    if (supportedControls.length === 0) {
       return html`
         <ha-alert alert-type="warning">
           ${this.hass.localize(
@@ -124,7 +127,7 @@ export class HuiAreaControlsCardFeatureEditor
     const schema = this._schema(
       this.hass.localize,
       data.customize_controls,
-      compatibleControls
+      supportedControls
     );
 
     return html`
@@ -143,12 +146,12 @@ export class HuiAreaControlsCardFeatureEditor
       .value as AreaControlsCardFeatureData;
 
     if (customize_controls && !config.controls) {
-      config.controls = this._compatibleControls(
+      config.controls = this._supportedControls(
         this.context!.area_id!,
         this.hass!.entities,
         this.hass!.devices,
         this.hass!.areas
-      ).slice(0, 4); // Default to first 4 compatible controls
+      ).slice(0, MAX_DEFAULT_AREA_CONTROLS); // Limit to max default controls
     }
 
     if (!customize_controls && config.controls) {

--- a/src/panels/lovelace/strategies/areas/areas-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/areas/areas-overview-view-strategy.ts
@@ -6,7 +6,7 @@ import type { LovelaceSectionConfig } from "../../../../data/lovelace/config/sec
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
 import { getAreaControlEntities } from "../../card-features/hui-area-controls-card-feature";
-import type { AreaControl } from "../../card-features/types";
+import { AREA_CONTROLS, type AreaControl } from "../../card-features/types";
 import type { AreaCardConfig, HeadingCardConfig } from "../../cards/types";
 import type { EntitiesDisplay } from "./area-view-strategy";
 import { computeAreaPath, getAreas } from "./helpers/areas-strategy-helper";
@@ -77,7 +77,9 @@ export class AreasOverviewViewStrategy extends ReactiveElement {
             .map((display) => display.hidden || [])
             .flat();
 
-          const controls: AreaControl[] = ["light", "fan"];
+          const controls: AreaControl[] = AREA_CONTROLS.filter(
+            (a) => a !== "switch" // Exclude switches control for areas as we don't know what the switches control
+          );
           const controlEntities = getAreaControlEntities(
             controls,
             area.area_id,
@@ -112,6 +114,11 @@ export class AreasOverviewViewStrategy extends ReactiveElement {
                   },
                 ]
               : [],
+            grid_options: {
+              rows: 1,
+              columns: 12,
+            },
+            features_position: "inline",
             navigation_path: path,
           };
         });

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -13,6 +13,7 @@ import type { Constructor, HomeAssistant } from "../../types";
 import type {
   LovelaceCardFeatureConfig,
   LovelaceCardFeatureContext,
+  LovelaceCardFeaturePosition,
 } from "./card-features/types";
 import type { LovelaceElement, LovelaceElementConfig } from "./elements/types";
 import type { LovelaceRow, LovelaceRowConfig } from "./entity-rows/types";
@@ -179,6 +180,7 @@ export interface LovelaceCardFeature extends HTMLElement {
   context?: LovelaceCardFeatureContext;
   setConfig(config: LovelaceCardFeatureConfig);
   color?: string;
+  position?: LovelaceCardFeaturePosition;
 }
 
 export interface LovelaceCardFeatureConstructor

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -325,6 +325,22 @@
         "low": "Low"
       }
     },
+    "card_features": {
+      "area_controls": {
+        "light": {
+          "on": "Turn on area lights",
+          "off": "Turn off area lights"
+        },
+        "fan": {
+          "on": "Turn on area fans",
+          "off": "Turn off area fans"
+        },
+        "switch": {
+          "on": "Turn on area switches",
+          "off": "Turn off area switches"
+        }
+      }
+    },
     "common": {
       "and": "and",
       "continue": "Continue",
@@ -383,6 +399,7 @@
       "markdown": "Markdown",
       "suggest_ai": "Suggest with AI"
     },
+
     "components": {
       "selectors": {
         "media": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -338,6 +338,46 @@
         "switch": {
           "on": "Turn on area switches",
           "off": "Turn off area switches"
+        },
+        "cover-awning": {
+          "on": "Open area awnings",
+          "off": "Close area awnings"
+        },
+        "cover-blind": {
+          "on": "Open area blinds",
+          "off": "Close area blinds"
+        },
+        "cover-curtain": {
+          "on": "Open area curtains",
+          "off": "Close area curtains"
+        },
+        "cover-damper": {
+          "on": "Open area dampers",
+          "off": "Close area dampers"
+        },
+        "cover-door": {
+          "on": "Open area doors",
+          "off": "Close area doors"
+        },
+        "cover-garage": {
+          "on": "Open garage door",
+          "off": "Close garage door"
+        },
+        "cover-gate": {
+          "on": "Open area gates",
+          "off": "Close area gates"
+        },
+        "cover-shade": {
+          "on": "Open area shades",
+          "off": "Close area shades"
+        },
+        "cover-shutter": {
+          "on": "Open area shutters",
+          "off": "Close area shutters"
+        },
+        "cover-window": {
+          "on": "Open area windows",
+          "off": "Close area windows"
         }
       }
     },
@@ -7874,7 +7914,17 @@
                 "controls_options": {
                   "light": "Lights",
                   "fan": "Fans",
-                  "switch": "Switches"
+                  "switch": "Switches",
+                  "cover-awning": "Awnings",
+                  "cover-blind": "Blinds",
+                  "cover-curtain": "Curtains",
+                  "cover-damper": "Dampers",
+                  "cover-door": "Doors",
+                  "cover-garage": "Garage doors",
+                  "cover-gate": "Gates",
+                  "cover-shade": "Shades",
+                  "cover-shutter": "Shutters",
+                  "cover-window": "Windows"
                 },
                 "no_compatible_controls": "No compatible controls available for this area"
               }


### PR DESCRIPTION
## Proposed change

Add cover controls to area card. As the cover domain is big, the controls are split by device classes. Different typecover must be controlled separately. (You may not want to open the garage door when you open the shutters).

These new controls are available for area-controls feature : 
- `cover-shutter`
- `cover-blind`
- `cover-curtain`
- `cover-shade`
- `cover-awning`
- `cover-garage`
- `cover-gate`
- `cover-door`
- `cover-window`
- `cover-damper`

Other changes : 
- the button are not full width anymore when the position of the feature is set to `inline`
- the buttons new use the domain and device class color
- the cover feature is used in the areas dashboard
- the areas dashboard now use `inline` features

### Card feature

![CleanShot 2025-06-25 at 10 37 27](https://github.com/user-attachments/assets/73c621f3-f375-450e-9c57-5fda4b3b152c)

![CleanShot 2025-06-25 at 10 39 19](https://github.com/user-attachments/assets/f8c3e4bb-b187-43e8-a84f-654c2c0aaaee)

### Editor 

![CleanShot 2025-06-24 at 11 07 59](https://github.com/user-attachments/assets/0bd8efe2-c48d-4441-8d74-475c0225d1d6)

### Areas dashboard

![CleanShot 2025-06-25 at 10 42 46](https://github.com/user-attachments/assets/639307d3-17e0-4445-9fd1-d4ddb895c17c)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
