### PR TITLE
Fix warnings raised when migrating incomplete automation configuration

### DIFF
--- a/src/data/script.ts
+++ b/src/data/script.ts
@@ -415,7 +415,7 @@ export const migrateAutomationAction = (
     return action.map(migrateAutomationAction) as Action[];
   }
 
-  if ("service" in action) {
+  if (typeof action === "object" && action !== null && "service" in action) {
     if (!("action" in action)) {
       action.action = action.service;
     }
@@ -423,7 +423,7 @@ export const migrateAutomationAction = (
   }
 
   // legacy scene (scene: scene_name)
-  if ("scene" in action) {
+  if (typeof action === "object" && action !== null && "scene" in action) {
     action.action = "scene.turn_on";
     action.target = {
       entity_id: action.scene,
@@ -431,7 +431,7 @@ export const migrateAutomationAction = (
     delete action.scene;
   }
 
-  if ("sequence" in action) {
+  if (typeof action === "object" && action !== null && "sequence" in action) {
     for (const sequenceAction of (action as SequenceAction).sequence) {
       migrateAutomationAction(sequenceAction);
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


Fixes the following console errors while typing automations in the YAML editor of the UI:

```
script.ts:418 Uncaught TypeError: Cannot use 'in' operator to search for 'service' in action
      at migrateAutomationAction (script.ts:418:1)
      at Array.map (<anonymous>)
      at migrateAutomationAction (script.ts:415:1)
      at migrateAutomationConfig (automation.ts:420:1)
      at normalizeAutomationConfig (automation.ts:377:1)
      at HaAutomationEditor._yamlChanged (ha-automation-editor.ts:752:1)
      at fireEvent (fire_event.ts:75:1)
      at HaYamlEditor._onChange (ha-yaml-editor.ts:170:1)
```

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
