### PR TITLE
Exclude entities in controls for areas dashboard

### DIFF
--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -165,6 +165,7 @@ export type AreaControl = (typeof AREA_CONTROLS)[number];
 export interface AreaControlsCardFeatureConfig {
   type: "area-controls";
   controls?: AreaControl[];
+  exclude_entities?: string[];
 }
 
 export type LovelaceCardFeatureConfig =

--- a/src/panels/lovelace/strategies/areas/areas-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/areas/areas-overview-view-strategy.ts
@@ -71,11 +71,18 @@ export class AreasOverviewViewStrategy extends ReactiveElement {
         const areasCards = areasInFloors.map<AreaCardConfig>((area) => {
           const path = computeAreaPath(area.area_id);
 
+          const areaOptions = config.areas_options?.[area.area_id] || {};
+
+          const hiddenEntities = Object.values(areaOptions.groups_options || {})
+            .map((display) => display.hidden || [])
+            .flat();
+
           const controls: AreaControl[] = ["light", "fan"];
           const controlEntities = getAreaControlEntities(
             controls,
             area.area_id,
-            hass
+            hass,
+            hiddenEntities
           );
 
           const filteredControls = controls.filter(
@@ -101,6 +108,7 @@ export class AreasOverviewViewStrategy extends ReactiveElement {
                   {
                     type: "area-controls",
                     controls: filteredControls,
+                    exclude_entities: hiddenEntities,
                   },
                 ]
               : [],


### PR DESCRIPTION
## Proposed change

Exclude entities in controls for areas dashboard so areas controls in the area card controls the same entities displayed in the area view.

I also added a missing `entity_category: none` for the filter.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
