### PR TITLE
Add "copy to clipboard" button to Entity picker

### DIFF
--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -121,6 +121,9 @@ export class HaEntityPicker extends LitElement {
   @property({ attribute: false })
   public entityFilter?: HaEntityPickerEntityFilterFunc;
 
+  @property({ attribute: "hide-copy-icon", type: Boolean })
+  public hideCopyIcon = false;
+
   @property({ attribute: "hide-clear-icon", type: Boolean })
   public hideClearIcon = false;
 
@@ -408,6 +411,7 @@ export class HaEntityPicker extends LitElement {
         .rowRenderer=${this._rowRenderer}
         .getItems=${this._getItems}
         .getAdditionalItems=${this._getAdditionalItems}
+        .hideCopyIcon=${this.hideCopyIcon}
         .hideClearIcon=${this.hideClearIcon}
         .searchFn=${this._searchFn}
         .valueRenderer=${this._valueRenderer}

--- a/src/components/ha-generic-picker.ts
+++ b/src/components/ha-generic-picker.ts
@@ -43,6 +43,9 @@ export class HaGenericPicker extends LitElement {
   @property({ type: String, attribute: "search-label" })
   public searchLabel?: string;
 
+  @property({ attribute: "hide-copy-icon", type: Boolean })
+  public hideCopyIcon = true; 
+
   @property({ attribute: "hide-clear-icon", type: Boolean })
   public hideClearIcon = false;
 
@@ -79,6 +82,7 @@ export class HaGenericPicker extends LitElement {
         ${!this._opened
           ? html`
               <ha-picker-field
+                .hass=${this.hass}
                 type="button"
                 compact
                 aria-label=${ifDefined(this.label)}
@@ -88,6 +92,7 @@ export class HaGenericPicker extends LitElement {
                 .value=${this.value}
                 .required=${this.required}
                 .disabled=${this.disabled}
+                .hideCopyIcon=${this.hideCopyIcon}
                 .hideClearIcon=${this.hideClearIcon}
                 .valueRenderer=${this.valueRenderer}
               >

--- a/src/components/ha-generic-picker.ts
+++ b/src/components/ha-generic-picker.ts
@@ -44,7 +44,7 @@ export class HaGenericPicker extends LitElement {
   public searchLabel?: string;
 
   @property({ attribute: "hide-copy-icon", type: Boolean })
-  public hideCopyIcon = true; 
+  public hideCopyIcon = true;
 
   @property({ attribute: "hide-clear-icon", type: Boolean })
   public hideClearIcon = false;

--- a/src/components/ha-picker-field.ts
+++ b/src/components/ha-picker-field.ts
@@ -169,7 +169,8 @@ export class HaPickerField extends LitElement {
           background-color: var(--mdc-theme-primary);
         }
 
-        .copy, .clear {
+        .copy,
+        .clear {
           margin: 0 -8px;
           --mdc-icon-button-size: 32px;
           --mdc-icon-size: 20px;

--- a/src/panels/developer-tools/state/developer-tools-state.ts
+++ b/src/panels/developer-tools/state/developer-tools-state.ts
@@ -131,6 +131,7 @@ class HaPanelDevState extends LitElement {
               @value-changed=${this._entityIdChanged}
               allow-custom-entity
               show-entity-id
+              hide-copy-icon
             ></ha-entity-picker>
             ${this._entityId
               ? html`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

A "copy to clipboard" button is added to `ha-entity-picker`.
In fact, it is added to `ha-generic-picker` & `ha-picker-field` (not shown by default).
Also, not shown (not added at all) for an expanded combobox since currently a content is empty when expanded.
Also, not shown in "Dev tools -> Set State" since it already has own "copy" button.


![image](https://github.com/user-attachments/assets/643e1f96-f872-4bd4-86c1-c3edb4408031)

![image](https://github.com/user-attachments/assets/d68c9df0-4b26-4d8b-afcf-359cc08f2b85)

![image](https://github.com/user-attachments/assets/8c06ac5c-35a1-458f-86af-1b23f3aca267)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
