### PR TITLE
Fix use of numeric option for collator

### DIFF
--- a/src/common/string/compare.ts
+++ b/src/common/string/compare.ts
@@ -2,12 +2,13 @@ import memoizeOne from "memoize-one";
 import { isIPAddress } from "./is_ip_address";
 
 const collator = memoizeOne(
-  (language: string | undefined) => new Intl.Collator(language)
+  (language: string | undefined) =>
+    new Intl.Collator(language, { numeric: true })
 );
 
 const caseInsensitiveCollator = memoizeOne(
   (language: string | undefined) =>
-    new Intl.Collator(language, { sensitivity: "accent" })
+    new Intl.Collator(language, { sensitivity: "accent", numeric: true })
 );
 
 const fallbackStringCompare = (a: string, b: string) => {

--- a/test/common/string/sort.test.ts
+++ b/test/common/string/sort.test.ts
@@ -1,0 +1,51 @@
+import { assert, describe, it } from "vitest";
+
+import { stringCompare } from "../../../src/common/string/compare";
+
+describe("stringCompare", () => {
+  // Node only ships with English support for `Intl`, so we cannot test for other language collators.
+  it("Ensure natural order reutrned when numeric value is included", () => {
+    assert.strictEqual(stringCompare("Helper 2", "Helper 10"), -1);
+  });
+
+  it("Ensure prefixed numeric value is sorted naturally", () => {
+    assert.strictEqual(stringCompare("2 Helper", "10 Helper"), -1);
+  });
+
+  it("Ensure order has reversed alphabet is sorted", () => {
+    const reverseAlphabet = [
+      "z",
+      "y",
+      "x",
+      "w",
+      "v",
+      "u",
+      "t",
+      "d",
+      "c",
+      "b",
+      "a",
+    ];
+    assert.deepStrictEqual(
+      [...reverseAlphabet].sort(stringCompare),
+      [...reverseAlphabet].reverse()
+    );
+  });
+
+  it("Ensure natural order when using numbers", () => {
+    const testArray = [
+      "Helper 1",
+      "Helper 10",
+      "Helper 2",
+      "Helper 3",
+      "Helper 4",
+    ];
+    assert.deepStrictEqual([...testArray].sort(stringCompare), [
+      "Helper 1",
+      "Helper 2",
+      "Helper 3",
+      "Helper 4",
+      "Helper 10",
+    ]);
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Allow strings with numbers to be sorted in a more natural order (1, 2, 3, 10) instead of (1, 10, 2, 3). 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

I added helpers locally to verify the names were sorted in the order expected. If there is a better way through configuration - I'd love to hear about it.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #24791
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
