### PR TITLE
Hide devices without subentry box when not needed

### DIFF
--- a/src/panels/config/integrations/ha-config-entry-row.ts
+++ b/src/panels/config/integrations/ha-config-entry-row.ts
@@ -405,47 +405,54 @@ class HaConfigEntryRow extends LitElement {
       </ha-md-list-item>
       ${this._expanded
         ? subEntries.length
-          ? html`<ha-md-list class="devices">
-                <ha-md-list-item @click=${this._toggleOwnDevices} type="button">
-                  <ha-icon-button
-                    class="expand-button"
-                    .path=${this._devicesExpanded
-                      ? mdiChevronDown
-                      : mdiChevronUp}
-                    slot="start"
-                  >
-                  </ha-icon-button>
-                  ${this.hass.localize(
-                    "ui.panel.config.integrations.config_entry.devices_without_subentry"
-                  )}
-                </ha-md-list-item>
-                ${this._devicesExpanded
-                  ? ownDevices.map(
-                      (device) =>
-                        html`<ha-config-entry-device-row
-                          .hass=${this.hass}
-                          .narrow=${this.narrow}
-                          .entry=${item}
-                          .device=${device}
-                          .entities=${entities}
-                        ></ha-config-entry-device-row>`
-                    )
-                  : nothing}
-              </ha-md-list>
-              ${subEntries.map(
-                (subEntry) => html`
-                  <ha-config-sub-entry-row
-                    .hass=${this.hass}
-                    .narrow=${this.narrow}
-                    .manifest=${this.manifest}
-                    .diagnosticHandler=${this.diagnosticHandler}
-                    .entities=${this.entities}
-                    .entry=${item}
-                    .subEntry=${subEntry}
-                    data-entry-id=${item.entry_id}
-                  ></ha-config-sub-entry-row>
+          ? html` ${ownDevices.length
+              ? html`
+                  <ha-md-list class="devices">
+                    <ha-md-list-item
+                      @click=${this._toggleOwnDevices}
+                      type="button"
+                    >
+                      <ha-icon-button
+                        class="expand-button"
+                        .path=${this._devicesExpanded
+                          ? mdiChevronDown
+                          : mdiChevronUp}
+                        slot="start"
+                      >
+                      </ha-icon-button>
+                      ${this.hass.localize(
+                        "ui.panel.config.integrations.config_entry.devices_without_subentry"
+                      )}
+                    </ha-md-list-item>
+                    ${this._devicesExpanded
+                      ? ownDevices.map(
+                          (device) =>
+                            html`<ha-config-entry-device-row
+                              .hass=${this.hass}
+                              .narrow=${this.narrow}
+                              .entry=${item}
+                              .device=${device}
+                              .entities=${entities}
+                            ></ha-config-entry-device-row>`
+                        )
+                      : nothing}
+                  </ha-md-list>
                 `
-              )}`
+              : nothing}
+            ${subEntries.map(
+              (subEntry) => html`
+                <ha-config-sub-entry-row
+                  .hass=${this.hass}
+                  .narrow=${this.narrow}
+                  .manifest=${this.manifest}
+                  .diagnosticHandler=${this.diagnosticHandler}
+                  .entities=${this.entities}
+                  .entry=${item}
+                  .subEntry=${subEntry}
+                  data-entry-id=${item.entry_id}
+                ></ha-config-sub-entry-row>
+              `
+            )}`
           : html`
               ${ownDevices.map(
                 (device) =>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When rendering subentries, don't render the "devices without subentry" box unless there are any devices.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
