### PR TITLE
Fix fullscreen yaml editor (transparency background)

### DIFF
--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -559,9 +559,9 @@ export class HaCodeEditor extends ReactiveElement {
       right: 8px;
       z-index: 1;
       color: var(--secondary-text-color);
-      background-color: var(--card-background-color);
+      background-color: var(--secondary-background-color);
       border-radius: 50%;
-      opacity: 0.6;
+      opacity: 0.9;
       transition: opacity 0.2s;
       --mdc-icon-button-size: 32px;
       --mdc-icon-size: 18px;
@@ -591,7 +591,7 @@ export class HaCodeEditor extends ReactiveElement {
       z-index: 9999 !important;
       background-color: var(
         --code-editor-background-color,
-        var(--mdc-text-field-fill-color, whitesmoke)
+        var(--card-background-color)
       ) !important;
       margin: 0 !important;
       padding-top: var(--safe-area-inset-top) !important;

--- a/src/resources/codemirror.ts
+++ b/src/resources/codemirror.ts
@@ -51,7 +51,7 @@ export const haTheme = EditorView.theme({
   "&": {
     color: "var(--primary-text-color)",
     backgroundColor:
-      "var(--code-editor-background-color, var(--mdc-text-field-fill-color, whitesmoke))",
+      "var(--code-editor-background-color, var(--card-background-color))",
     borderRadius:
       "var(--mdc-shape-small, 4px) var(--mdc-shape-small, 4px) 0px 0px",
     caretColor: "var(--secondary-text-color)",


### PR DESCRIPTION
## Proposed change
Fixes https://github.com/home-assistant/frontend/issues/25977 by not using any transparent colors. 
(It's color swapped, the button is the same as the gutter, and the background the same as the card. )

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
