### PR TITLE
Theming: Search box - outlined field

### DIFF
--- a/src/components/ha-outlined-text-field.ts
+++ b/src/components/ha-outlined-text-field.ts
@@ -19,21 +19,60 @@ export class HaOutlinedTextField extends OutlinedTextField {
         --md-sys-color-primary: var(--primary-text-color);
         --md-outlined-text-field-input-text-color: var(--primary-text-color);
         --md-sys-color-on-surface-variant: var(--secondary-text-color);
-        --md-outlined-field-outline-color: var(--outline-color);
-        --md-outlined-field-focus-outline-color: var(--primary-color);
-        --md-outlined-field-hover-outline-color: var(--outline-hover-color);
+        --md-outlined-field-outline-color: var(
+          --md-outlined-field-outline-color,
+          var(--outline-color)
+        );
+        --md-outlined-field-focus-outline-color: var(
+          --md-outlined-field-focus-outline-color,
+          var(--primary-color)
+        );
+        --md-outlined-field-hover-outline-color: var(
+          --md-outlined-field-hover-outline-color,
+          var(--outline-hover-color)
+        );
       }
       :host([dense]) {
-        --md-outlined-field-top-space: 5.5px;
-        --md-outlined-field-bottom-space: 5.5px;
-        --md-outlined-field-container-shape-start-start: 10px;
-        --md-outlined-field-container-shape-start-end: 10px;
-        --md-outlined-field-container-shape-end-end: 10px;
-        --md-outlined-field-container-shape-end-start: 10px;
-        --md-outlined-field-focus-outline-width: 1px;
-        --md-outlined-field-with-leading-content-leading-space: 8px;
-        --md-outlined-field-with-trailing-content-trailing-space: 8px;
-        --md-outlined-field-content-space: 8px;
+        --md-outlined-field-top-space: var(
+          --md-outlined-field-top-space,
+          5.5px
+        );
+        --md-outlined-field-bottom-space: var(
+          --md-outlined-field-bottom-space,
+          5.5px
+        );
+        --md-outlined-field-container-shape-start-start: var(
+          --md-outlined-field-container-shape-start-start,
+          10px
+        );
+        --md-outlined-field-container-shape-start-end: var(
+          --md-outlined-field-container-shape-start-end,
+          10px
+        );
+        --md-outlined-field-container-shape-end-end: var(
+          --md-outlined-field-container-shape-end-end,
+          10px
+        );
+        --md-outlined-field-container-shape-end-start: var(
+          --md-outlined-field-container-shape-end-start,
+          10px
+        );
+        --md-outlined-field-focus-outline-width: var(
+          --md-outlined-field-focus-outline-width,
+          1px
+        );
+        --md-outlined-field-with-leading-content-leading-space: var(
+          --md-outlined-field-with-leading-content-leading-space,
+          8px
+        );
+        --md-outlined-field-with-trailing-content-trailing-space: var(
+          --md-outlined-field-with-trailing-content-trailing-space,
+          8px
+        );
+        --md-outlined-field-content-space: var(
+          --md-outlined-field-content-space,
+          8px
+        );
         --mdc-icon-size: var(--md-input-chip-icon-size, 18px);
       }
       .input {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

It is currently not possible to customize the shape and style of search fields. This pull request attempts to resolve this issue by adding an additional variable layer. For example row:
```
--md-outlined-field-container-shape-start-start: 10px;
```
becomes:
```
--md-outlined-field-container-shape-start-start: var(--md-outlined-field-container-shape-start-start, 10px);
```

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
  md-outlined-text-field-outline-color: transparent
  md-outlined-field-container-shape-start-start: 4px
  md-outlined-field-container-shape-start-end: 4px
  md-outlined-field-container-shape-end-end: 4px
  md-outlined-field-container-shape-end-start: 4px
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
