### PR TITLE
Add support for media players to the controls of area cards.

### DIFF
--- a/src/common/entity/group_entities.ts
+++ b/src/common/entity/group_entities.ts
@@ -27,6 +27,14 @@ export const computeGroupEntitiesState = (states: HassEntity[]): string => {
     return "closed";
   }
 
+  if (domain === "media_player") {
+    if (states.some((stateObj) => stateObj.state === "playing")) {
+      return "playing";
+    }
+
+    return "standby";
+  }
+
   if (states.some((stateObj) => stateObj.state === "on")) {
     return "on";
   }
@@ -47,7 +55,7 @@ export const toggleGroupEntities = (
 
   const state = computeGroupEntitiesState(states);
 
-  const isOn = state === "on" || state === "open";
+  const isOn = state === "on" || state === "open" || state === "playing";
 
   let service = isOn ? "turn_off" : "turn_on";
   if (domain === "cover") {
@@ -58,6 +66,8 @@ export const toggleGroupEntities = (
       // For covers, we use the open/close service
       service = isOn ? "close_cover" : "open_cover";
     }
+  } else if (domain === "media_player") {
+    service = isOn ? "media_pause" : "media_play";
   }
 
   const entitiesIds = states.map((stateObj) => stateObj.entity_id);

--- a/src/panels/lovelace/card-features/hui-area-controls-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-area-controls-card-feature.ts
@@ -66,6 +66,14 @@ export const AREA_CONTROLS_BUTTONS: Record<AreaControl, AreaControlsButton> = {
       domain: "switch",
     },
   },
+  "media-player": {
+    // Overrides the icons for media players
+    offIcon: "mdi:speaker-off",
+    onIcon: "mdi:speaker",
+    filter: {
+      domain: "media_player",
+    },
+  },
   "cover-blind": coverButton("blind"),
   "cover-curtain": coverButton("curtain"),
   "cover-damper": coverButton("damper"),

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -172,6 +172,7 @@ export const AREA_CONTROLS = [
   "cover-window",
   "cover-damper",
   "switch",
+  "media-player",
 ] as const;
 
 export type AreaControl = (typeof AREA_CONTROLS)[number];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -339,6 +339,10 @@
           "on": "Turn on area switches",
           "off": "Turn off area switches"
         },
+        "media-player": {
+          "on": "Turn on area media players",
+          "off": "Turn off area media players"
+        },
         "cover-awning": {
           "on": "Open area awnings",
           "off": "Close area awnings"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

It is possible that this is a breaking change. I do not have the required context to make that judgement.

My concern would be that the schema of the card would've changed.

## Proposed change

Add support for media players (at least speakers) to the controls of area cards.

<img width="268" alt="image" src="https://github.com/user-attachments/assets/dea425bf-835b-4f1a-bd32-26e869538524" />

<img width="271" alt="image" src="https://github.com/user-attachments/assets/b22cc7c2-fb38-4a10-941f-ee107b1aee5a" />


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

N/A

## Additional information

N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
