### PR TITLE
Add 'for' duration to lovelace state visibility condition

### DIFF
--- a/src/common/datetime/duration_to_seconds.ts
+++ b/src/common/datetime/duration_to_seconds.ts
@@ -1,4 +1,26 @@
+import type { HaDurationData } from "../../components/ha-duration-input";
+
 export default function durationToSeconds(duration: string): number {
   const parts = duration.split(":").map(Number);
   return parts[0] * 3600 + parts[1] * 60 + parts[2];
+}
+
+export function HaDurationData_to_milliseconds(
+  duration: HaDurationData | undefined
+): number | undefined {
+  if (duration) {
+    const days = duration.days || 0;
+    let hours = duration.hours || 0;
+    let minutes = duration.minutes || 0;
+    let seconds = duration.seconds || 0;
+    let milliseconds = duration.milliseconds || 0;
+
+    hours += days * 24;
+    minutes += hours * 60;
+    seconds += minutes * 60;
+    milliseconds += seconds * 1000;
+
+    return milliseconds;
+  }
+  return undefined;
 }

--- a/src/common/datetime/duration_to_seconds.ts
+++ b/src/common/datetime/duration_to_seconds.ts
@@ -5,7 +5,7 @@ export default function durationToSeconds(duration: string): number {
   return parts[0] * 3600 + parts[1] * 60 + parts[2];
 }
 
-export function HaDurationData_to_milliseconds(
+export function HaDurationDataToMilliseconds(
   duration: HaDurationData | undefined
 ): number | undefined {
   if (duration) {

--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -8,7 +8,7 @@ import { getUserPerson } from "../../../data/person";
 import type { HomeAssistant } from "../../../types";
 import { createDurationData } from "../../../common/datetime/create_duration_data";
 import type { HaDurationData } from "../../../components/ha-duration-input";
-import { HaDurationData_to_milliseconds } from "../../../common/datetime/duration_to_seconds";
+import { HaDurationDataToMilliseconds } from "../../../common/datetime/duration_to_seconds";
 
 export type Condition =
   | LocationCondition
@@ -96,7 +96,7 @@ function checkStateCondition(
       ? hass.states[condition.entity].state
       : UNKNOWN;
   let value = condition.state ?? condition.state_not;
-  const state_last_changed =
+  const stateLastChanged =
     condition.entity && hass.states[condition.entity]
       ? hass.states[condition.entity].last_changed
       : UNKNOWN;
@@ -116,21 +116,21 @@ function checkStateCondition(
   }
 
   const forDuration =
-    HaDurationData_to_milliseconds(createDurationData(condition.for)) || 0;
+    HaDurationDataToMilliseconds(createDurationData(condition.for)) || 0;
 
-  const numericStateLastChanged = new Date(state_last_changed).getTime();
+  const numericStateLastChanged = new Date(stateLastChanged).getTime();
   if (isNaN(numericStateLastChanged)) {
     return false;
   }
   const numericFor = numericStateLastChanged + forDuration;
 
   const now = new Date().getTime();
-  const last_changed_condition =
+  const lastChangedCondition =
     condition.for == null || isNaN(numericFor) || now > numericFor;
 
   return condition.state != null
-    ? ensureArray(value).includes(state) && last_changed_condition
-    : !ensureArray(value).includes(state) && last_changed_condition;
+    ? ensureArray(value).includes(state) && lastChangedCondition
+    : !ensureArray(value).includes(state) && lastChangedCondition;
 }
 
 function checkStateNumericCondition(

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-state.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-state.ts
@@ -2,7 +2,16 @@ import type { PropertyValues } from "lit";
 import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
-import { assert, literal, object, optional, string } from "superstruct";
+import {
+  assert,
+  literal,
+  object,
+  optional,
+  string,
+  number,
+  union,
+} from "superstruct";
+import { forDictStruct } from "../../../../config/automation/structs";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
 import "../../../../../components/ha-form/ha-form";
@@ -12,12 +21,14 @@ import type {
 } from "../../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../../types";
 import type { StateCondition } from "../../../common/validate-condition";
+import type { HaDurationData } from "../../../../../components/ha-duration-input";
 
 const stateConditionStruct = object({
   condition: literal("state"),
   entity: optional(string()),
   state: optional(string()),
   state_not: optional(string()),
+  for: optional(union([number(), string(), forDictStruct])),
 });
 
 interface StateConditionData {
@@ -25,6 +36,7 @@ interface StateConditionData {
   entity?: string;
   invert: "true" | "false";
   state?: string | string[];
+  for?: number | string | HaDurationData;
 }
 
 @customElement("ha-card-condition-state")
@@ -94,6 +106,12 @@ export class HaCardConditionState extends LitElement {
                 filter_entity: "entity",
               },
             },
+            {
+              name: "for",
+              selector: {
+                duration: {},
+              },
+            },
           ],
         },
       ] as const satisfies readonly HaFormSchema[]
@@ -146,6 +164,10 @@ export class HaCardConditionState extends LitElement {
       case "state":
         return this.hass.localize(
           "ui.components.entity.entity-state-picker.state"
+        );
+      case "for":
+        return this.hass.localize(
+          "ui.panel.lovelace.editor.condition-editor.condition.state.for"
         );
       default:
         return "";

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7416,7 +7416,8 @@
               "state": {
                 "label": "Entity state",
                 "state_equal": "State is equal to",
-                "state_not_equal": "State is not equal to"
+                "state_not_equal": "State is not equal to",
+                "for": "For"
               },
               "location": {
                 "label": "Location",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This is an alternative implementation of this PR: https://github.com/home-assistant/frontend/pull/25864.

In that PR, I added a new condition called 'Last Entity Change', which would allow the user to specify a 'within' and 'after' duration, which would show a card based on the last changed time of an entity (either 'within' a certain duration since a change; or 'after' some duration since a change).

Thanks to the comments of @karwosts , they suggested this could be implemented to more closely follow how the automation interface works.

To do this, this PR adds a 'For' duration to the State visibility condition.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: entity
entity: light.kitchen_floor_lamp_light
visibility:
  - condition: not
    conditions:
      - condition: state
        entity: light.kitchen_floor_lamp_light
        for:
          hours: 0
          minutes: 0
          seconds: 10
        state:
          - "on"
          - "off"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Demo:
![last_state_change_demo_with_not](https://github.com/user-attachments/assets/0867e0fd-8c3d-4155-9413-68a90581c164)


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

Some help with letting me know where to add tests would be much appreciated :)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
