### PR TITLE
Handle predefined options in Z-Wave config panel

### DIFF
--- a/src/components/ha-combo-box.ts
+++ b/src/components/ha-combo-box.ts
@@ -205,7 +205,7 @@ export class HaComboBox extends LitElement {
               role="button"
               tabindex="-1"
               aria-label=${ifDefined(this.hass?.localize("ui.common.clear"))}
-              class="clear-button"
+              class=${`clear-button ${this.label ? "" : "no-label"}`}
               .path=${mdiClose}
               @click=${this._clearValue}
             ></ha-svg-icon>`
@@ -215,7 +215,7 @@ export class HaComboBox extends LitElement {
           tabindex="-1"
           aria-label=${ifDefined(this.label)}
           aria-expanded=${this.opened ? "true" : "false"}
-          class="toggle-button"
+          class=${`toggle-button ${this.label ? "" : "no-label"}`}
           .path=${this.opened ? mdiMenuUp : mdiMenuDown}
           ?disabled=${this.disabled}
           @click=${this._toggleOpen}
@@ -397,6 +397,9 @@ export class HaComboBox extends LitElement {
       color: var(--disabled-text-color);
       pointer-events: none;
     }
+    .toggle-button.no-label {
+      top: -3px;
+    }
     .clear-button {
       --mdc-icon-size: 20px;
       top: -7px;
@@ -404,6 +407,9 @@ export class HaComboBox extends LitElement {
       inset-inline-start: initial;
       inset-inline-end: 36px;
       direction: var(--direction);
+    }
+    .clear-button.no-label {
+      top: 0;
     }
     ha-input-helper-text {
       margin-top: 4px;

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -10,6 +10,7 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { computeDeviceNameDisplay } from "../../../../../common/entity/compute_device_name";
 import { groupBy } from "../../../../../common/util/group-by";
@@ -335,9 +336,7 @@ class ZWaveJSNodeConfig extends LitElement {
             .value=${item.value?.toString()}
             allow-custom-value
             hide-clear-icon
-            .items=${Object.entries(item.metadata.states).map(
-              ([value, label]) => ({ value, label: `${value} - ${label}` })
-            )}
+            .items=${this._getComboBoxOptions(item.metadata.states)}
             .disabled=${!item.metadata.writeable}
             .invalid=${result?.status === "error"}
             .placeholder=${item.metadata.unit}
@@ -475,6 +474,13 @@ class ZWaveJSNodeConfig extends LitElement {
     this._setResult(ev.target.key, undefined);
     this._updateConfigParameter(ev.target, value);
   }
+
+  private _getComboBoxOptions = memoizeOne((states: Record<string, string>) =>
+    Object.entries(states).map(([value, label]) => ({
+      value,
+      label: `${value} - ${label}`,
+    }))
+  );
 
   private _getComboBoxValueChangedCallback(
     id: string,

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -295,9 +295,10 @@ class ZWaveJSNodeConfig extends LitElement {
               ? this.hass.localize(
                   item.metadata.default === 1 ? "ui.common.yes" : "ui.common.no"
                 )
-              : item.configuration_value_type === "enumerated"
-                ? item.metadata.states[item.metadata.default] ||
-                  item.metadata.default
+              : item.metadata.states?.[item.metadata.default]
+                ? item.configuration_value_type === "manual_entry"
+                  ? `${item.metadata.default} - ${item.metadata.states[item.metadata.default]}`
+                  : item.metadata.states[item.metadata.default]
                 : item.metadata.default
           }`
         : "";
@@ -335,7 +336,7 @@ class ZWaveJSNodeConfig extends LitElement {
             allow-custom-value
             hide-clear-icon
             .items=${Object.entries(item.metadata.states).map(
-              ([value, label]) => ({ value, label })
+              ([value, label]) => ({ value, label: `${value} - ${label}` })
             )}
             .disabled=${!item.metadata.writeable}
             .invalid=${result?.status === "error"}

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -232,7 +232,9 @@ class ZWaveJSNodeConfig extends LitElement {
   ): TemplateResult {
     const result = this._results[id];
 
-    const isTypeBoolean = item.configuration_value_type === "boolean" || this._isEnumeratedBool(item);
+    const isTypeBoolean =
+      item.configuration_value_type === "boolean" ||
+      this._isEnumeratedBool(item);
 
     const labelAndDescription = html`
       <span slot="prefix" class="prefix">

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -338,6 +338,7 @@ class ZWaveJSNodeConfig extends LitElement {
               ([value, label]) => ({ value, label })
             )}
             .disabled=${!item.metadata.writeable}
+            .invalid=${result?.status === "error"}
             .placeholder=${item.metadata.unit}
             .helper=${`${this.hass.localize("ui.panel.config.zwave_js.node_config.between_min_max", { min: item.metadata.min, max: item.metadata.max })}${defaultLabel ? `, ${defaultLabel}` : ""}`}
             @value-changed=${this._getComboBoxValueChangedCallback(id, item)}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6061,6 +6061,7 @@
             "parameter_is_read_only": "This parameter is read-only.",
             "between_min_max": "Between {min} and {max}",
             "error_not_in_range": "Value must be between {min} and {max}",
+            "error_not_numeric": "Value must be a number",
             "error_required": "{entity} is required",
             "error_device_not_found": "Device not found",
             "set_param_accepted": "The parameter has been updated.",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
~~Show a select if there are predefined options and the possible values are less than 100. There are still some params that have a range of 0-255 and predefined labels for 0 and 255 but I don't see how we can handle those without a new UI component~~

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/backlog/issues/59
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
