### PR TITLE
Use query params instead of path for media browser navigate ids

### DIFF
--- a/src/panels/media-browser/ha-panel-media-browser.ts
+++ b/src/panels/media-browser/ha-panel-media-browser.ts
@@ -45,14 +45,37 @@ import type { BarMediaPlayer } from "./ha-bar-media-player";
 import { showWebBrowserPlayMediaDialog } from "./show-media-player-dialog";
 
 const createMediaPanelUrl = (entityId: string, items: MediaPlayerItemId[]) => {
-  let path = `/media-browser/${entityId}`;
-  for (const item of items.slice(1)) {
-    path +=
-      "/" +
-      encodeURIComponent(`${item.media_content_type},${item.media_content_id}`);
+  const path = `/media-browser/${entityId}`;
+  if (items.length <= 1) {
+    return path;
   }
-  return path;
+  const navigateIds = items
+    .slice(1)
+    .map((item) =>
+      encodeURIComponent(`${item.media_content_type},${item.media_content_id}`)
+    );
+  const urlparams = new URLSearchParams();
+  urlparams.set("ids", navigateIds.join(","));
+  return path + "?" + urlparams.toString();
 };
+
+const decodeNavigateIds = (
+  navigateIdsEncoded: string[]
+): MediaPlayerItemId[] => [
+  {
+    media_content_id: undefined,
+    media_content_type: undefined,
+  },
+  ...navigateIdsEncoded.map((navigateId) => {
+    const decoded = decodeURIComponent(navigateId);
+    // Don't use split because media_content_id could contain commas
+    const delimiter = decoded.indexOf(",");
+    return {
+      media_content_type: decoded.substring(0, delimiter),
+      media_content_id: decoded.substring(delimiter + 1),
+    };
+  }),
+];
 
 @customElement("ha-panel-media-browser")
 class PanelMediaBrowser extends LitElement {
@@ -211,9 +234,19 @@ class PanelMediaBrowser extends LitElement {
       return;
     }
 
-    const [routePlayer, ...navigateIdsEncoded] = this.route.path
-      .substring(1)
-      .split("/");
+    const [routePlayer, ...paths] = this.route.path.substring(1).split("/");
+
+    const navigateIdsEncoded =
+      new URLSearchParams(location.search).get("ids")?.split(",") || [];
+
+    // Backwards compatibility with old URLs
+    if (navigateIdsEncoded.length === 0 && paths.length > 0) {
+      const navigateIds = decodeNavigateIds(paths);
+      navigate(createMediaPanelUrl(this._entityId, navigateIds), {
+        replace: true,
+      });
+      return;
+    }
 
     if (routePlayer !== this._entityId) {
       // Detect if picked player doesn't exist (anymore)
@@ -236,21 +269,7 @@ class PanelMediaBrowser extends LitElement {
       this._entityId = routePlayer;
     }
 
-    this._navigateIds = [
-      {
-        media_content_type: undefined,
-        media_content_id: undefined,
-      },
-      ...navigateIdsEncoded.map((navigateId) => {
-        const decoded = decodeURIComponent(navigateId);
-        // Don't use split because media_content_id could contain commas
-        const delimiter = decoded.indexOf(",");
-        return {
-          media_content_type: decoded.substring(0, delimiter),
-          media_content_id: decoded.substring(delimiter + 1),
-        };
-      }),
-    ];
+    this._navigateIds = decodeNavigateIds(navigateIdsEncoded);
     this._currentItem = undefined;
   }
 
@@ -258,6 +277,7 @@ class PanelMediaBrowser extends LitElement {
     navigate(
       createMediaPanelUrl(this._entityId, this._navigateIds.slice(0, -1))
     );
+    this.requestUpdate("route");
   }
 
   private _mediaBrowsed(ev: { detail: HASSDomEvents["media-browsed"] }) {
@@ -269,6 +289,7 @@ class PanelMediaBrowser extends LitElement {
     navigate(createMediaPanelUrl(this._entityId, ev.detail.ids), {
       replace: ev.detail.replace,
     });
+    this.requestUpdate("route");
   }
 
   private async _mediaPicked(


### PR DESCRIPTION
## Proposed change

Use query params instead of path for media browser navigate ids to avoid encoded character in the path because it has issues with mobile apps (https://github.com/home-assistant/frontend/issues/25471)

Before

```
/media-browser/browser/app%2Cmedia-source%3A%2F%2Fradio_browser/music%2Cmedia-source%3A%2F%2Fradio_browser%2Fpopular
```

After

```
/media-browser/browser?ids=app%252Cmedia-source%253A%252F%252Fradio_browser%2Cmusic%252Cmedia-source%253A%252F%252Fradio_browser%252Fpopular
```

A backward compatibility has been added to not break previous url format (e.g. bookmarks)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/25471
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
