### PR TITLE
add floor column to datatable in config devices page

### DIFF
--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -426,10 +426,14 @@ export class HaConfigDeviceDashboard extends SubscribeMixin(LitElement) {
         );
 
         let floorName = "—";
-        if (device.area_id && areas[device.area_id]?.floor_id) {
+        if (
+          device.area_id &&
+          areas[device.area_id]?.floor_id &&
+          this.hass.floors
+        ) {
           const floorId = areas[device.area_id].floor_id;
-          if (floorId && this.hass.floors && this.hass.floors[floorId]) {
-            floorName = computeFloorName(this.hass.floors[floorId]);
+          if (this.hass.floors[floorId!]) {
+            floorName = computeFloorName(this.hass.floors[floorId!]);
           }
         }
 

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -19,6 +19,7 @@ import { formatShortDateTime } from "../../../common/datetime/format_date_time";
 import { storage } from "../../../common/decorators/storage";
 import type { HASSDomEvent } from "../../../common/dom/fire_event";
 import { computeDeviceNameDisplay } from "../../../common/entity/compute_device_name";
+import { computeFloorName } from "../../../common/entity/compute_floor_name";
 import { computeStateDomain } from "../../../common/entity/compute_state_domain";
 import {
   PROTOCOL_INTEGRATIONS,
@@ -424,6 +425,14 @@ export class HaConfigDeviceDashboard extends SubscribeMixin(LitElement) {
           (lbl) => labelReg!.find((label) => label.label_id === lbl)!
         );
 
+        let floorName = "—";
+        if (device.area_id && areas[device.area_id]?.floor_id) {
+          const floorId = areas[device.area_id].floor_id;
+          if (floorId && this.hass.floors && this.hass.floors[floorId]) {
+            floorName = computeFloorName(this.hass.floors[floorId]);
+          }
+        }
+
         return {
           ...device,
           name: computeDeviceNameDisplay(
@@ -441,6 +450,7 @@ export class HaConfigDeviceDashboard extends SubscribeMixin(LitElement) {
             device.area_id && areas[device.area_id]
               ? areas[device.area_id].name
               : "—",
+          floor: floorName,
           integration: deviceEntries.length
             ? deviceEntries
                 .map(
@@ -523,6 +533,14 @@ export class HaConfigDeviceDashboard extends SubscribeMixin(LitElement) {
         filterable: true,
         groupable: true,
         minWidth: "120px",
+      },
+      floor: {
+        title: localize("ui.panel.config.devices.data_table.floor"),
+        sortable: true,
+        filterable: true,
+        groupable: true,
+        minWidth: "120px",
+        defaultHidden: true,
       },
       integration: {
         title: localize("ui.panel.config.devices.data_table.integration"),

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5138,6 +5138,7 @@
             "manufacturer": "Manufacturer",
             "model": "Model",
             "area": "Area",
+            "floor": "Floor",
             "integration": "Integration",
             "battery": "Battery",
             "disabled_by": "Disabled",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR adds a `floor` column to the config devices table, displaying the floor value for each listed device.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: Idea was mentioned in a comment here: [#25979](https://github.com/home-assistant/frontend/issues/25979#issuecomment-3021502193)
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
