### PR TITLE
Pause map autofit when user initiates pan/zoom

### DIFF
--- a/src/components/map/ha-map.ts
+++ b/src/components/map/ha-map.ts
@@ -93,8 +93,6 @@ export class HaMap extends ReactiveElement {
 
   @state() private _loaded = false;
 
-  @state() private _pauseAutoFit = false;
-
   public leafletMap?: Map;
 
   private Leaflet?: LeafletModuleType;
@@ -116,6 +114,8 @@ export class HaMap extends ReactiveElement {
   private _clickCount = 0;
 
   private _isProgrammaticFit = false;
+
+  private _pauseAutoFit = false;
 
   public connectedCallback(): void {
     super.connectedCallback();

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -239,7 +239,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
               )}
               .path=${mdiImageFilterCenterFocus}
               style=${isDarkMode ? "color:#ffffff" : "color:#000000"}
-              @click=${this._fitMap}
+              @click=${this._resetFocus}
               tabindex="0"
             ></ha-icon-button>
           </div>
@@ -389,8 +389,8 @@ class HuiMapCard extends LitElement implements LovelaceCard {
         : (root.style.paddingBottom = "100%");
   }
 
-  private _fitMap() {
-    this._map?.fitMap();
+  private _resetFocus() {
+    this._map?.fitMap({ unpause_autofit: true });
   }
 
   private _toggleClusterMarkers() {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
If user pans/zooms the map, pause the autofit algorithm until the next time the map reconnects, or when the user hits the "Reset Focus" button. This prevents user fighting with frequently moving entity which keeps yanking the map view away from where they're trying to go.

Unfortunately leaflet does not provide a clean way to do this, so this is a bit of a kludge, and it may not be 100% perfect. But it seems pretty good for me at the moment. 

I had considered if it might be a good idea to change the reset focus icon when the autofit is enabled but temporarily paused, but I wasn't sure. Maybe focus-auto? 
![image](https://github.com/user-attachments/assets/b461b0f1-fb2b-48f3-a15f-9871b1ea3b9c)

Or maybe just hide the reset focus button when auto-fit is enabled and not paused, since it should do nothing in that case, then it will appear anytime the pause is active. 


In action:
![map-autofit](https://github.com/user-attachments/assets/32d3724e-e390-4297-bbfc-586c34e9bf65)



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #16666 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
