### PR TITLE
Handle disabled ZWave provisionning entries

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -439,6 +439,7 @@ export interface ZwaveJSProvisioningEntry {
   dsk: string;
   securityClasses: SecurityClass[];
   nodeId?: number;
+  status: ProvisioningEntryStatus;
   [prop: string]: any;
 }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -37,6 +37,7 @@ import {
   fetchZwaveNetworkStatus,
   fetchZwaveProvisioningEntries,
   InclusionState,
+  ProvisioningEntryStatus,
   restoreZwaveNVM,
   setZwaveDataCollectionPreference,
   subscribeS2Inclusion,
@@ -134,7 +135,10 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
       return this._renderErrorScreen();
     }
     const provisioningDevices =
-      this._provisioningEntries?.filter((entry) => !entry.nodeId).length ?? 0;
+      this._provisioningEntries?.filter(
+        (entry) =>
+          !entry.nodeId && entry.status === ProvisioningEntryStatus.Active
+      ).length ?? 0;
     const notReadyDevices =
       (this._network?.controller.nodes.filter((node) => !node.ready).length ??
         0) + provisioningDevices;

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-provisioned.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-provisioned.ts
@@ -6,6 +6,7 @@ import type { DataTableColumnContainer } from "../../../../../components/data-ta
 import type { ZwaveJSProvisioningEntry } from "../../../../../data/zwave_js";
 import {
   fetchZwaveProvisioningEntries,
+  ProvisioningEntryStatus,
   SecurityClass,
   unprovisionZwaveSmartStartNode,
 } from "../../../../../data/zwave_js";
@@ -67,6 +68,14 @@ class ZWaveJSProvisioned extends LitElement {
                   .path=${mdiCloseCircleOutline}
                 ></ha-svg-icon>
               `,
+      },
+      active: {
+        title: localize("ui.panel.config.zwave_js.provisioned.active"),
+        type: "icon",
+        template: (entry) =>
+          entry.status === ProvisioningEntryStatus.Active
+            ? html`<ha-svg-icon .path=${mdiCheckCircle}></ha-svg-icon>`
+            : html`<ha-svg-icon .path=${mdiCloseCircleOutline}></ha-svg-icon>`,
       },
       dsk: {
         main: true,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6194,7 +6194,8 @@
             "included": "Included",
             "not_included": "Not Included",
             "confirm_unprovision_title": "Remove device?",
-            "confirm_unprovision_text": "{name} will be permanently removed from Home Assistant and your Z-Wave network."
+            "confirm_unprovision_text": "{name} will be permanently removed from Home Assistant and your Z-Wave network.",
+            "active": "Active"
           },
           "security_classes": {
             "None": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6192,7 +6192,7 @@
             "security_classes": "Security classes",
             "unprovision": "Unprovision",
             "included": "Included",
-            "not_included": "Not Included",
+            "not_included": "Not included",
             "confirm_unprovision_title": "Remove device?",
             "confirm_unprovision_text": "{name} will be permanently removed from Home Assistant and your Z-Wave network.",
             "active": "Active"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Take the status into account when showing device count. Also show status in the data table.
The icons are not great but better than not showing it at all.
<img width="2180" height="324" alt="image" src="https://github.com/user-attachments/assets/a45856f6-d8f1-4dc4-90e9-2375e3fdabdc" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/zwave-js/backlog/issues/11
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
