### PR TITLE
Render energy-water in the display unit of the sources

### DIFF
--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -108,6 +108,8 @@ export interface StatisticsValidationResultMeanTypeChanged {
   };
 }
 
+export const VOLUME_UNITS = ["L", "gal", "ft³", "m³", "CCF"] as const;
+
 export interface StatisticsUnitConfiguration {
   energy?: "Wh" | "kWh" | "MWh" | "GJ";
   power?: "W" | "kW";
@@ -122,7 +124,7 @@ export interface StatisticsUnitConfiguration {
     | "psi"
     | "mmHg";
   temperature?: "°C" | "°F" | "K";
-  volume?: "L" | "gal" | "ft³" | "m³";
+  volume?: (typeof VOLUME_UNITS)[number];
 }
 
 const _statisticTypes = [

--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -25,7 +25,6 @@ import {
   computeConsumptionData,
   getEnergyDataCollection,
   getEnergyGasUnit,
-  getEnergyWaterUnit,
   getSummedData,
 } from "../../data/energy";
 import { fileDownload } from "../../util/file_download";
@@ -158,7 +157,6 @@ class PanelEnergy extends LitElement {
       energyData.prefs,
       energyData.state.statsMetadata
     );
-    const waterUnit = getEnergyWaterUnit(this.hass);
     const electricUnit = "kWh";
 
     const energy_sources = energyData.prefs.energy_sources;
@@ -335,7 +333,7 @@ class PanelEnergy extends LitElement {
     printCategory(
       "water_consumption",
       water_consumptions,
-      waterUnit,
+      energyData.state.waterUnit,
       "water_consumption_cost",
       water_consumptions_cost
     );

--- a/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
@@ -24,7 +24,6 @@ import {
   energySourcesByType,
   getEnergyDataCollection,
   getEnergyGasUnit,
-  getEnergyWaterUnit,
   formatConsumptionShort,
   getSummedData,
   computeConsumptionData,
@@ -373,7 +372,7 @@ class HuiEnergyDistrubutionCard
                           ${formatConsumptionShort(
                             this.hass,
                             waterUsage,
-                            getEnergyWaterUnit(this.hass)
+                            this._data.waterUnit
                           )}
                         </div>
                         <svg width="80" height="30">
@@ -603,7 +602,7 @@ class HuiEnergyDistrubutionCard
                         ${formatConsumptionShort(
                           this.hass,
                           waterUsage,
-                          getEnergyWaterUnit(this.hass)
+                          this._data.waterUnit
                         )}
                       </div>
                       <span class="label"

--- a/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
@@ -14,7 +14,6 @@ import {
   energySourcesByType,
   getEnergyDataCollection,
   getEnergyGasUnit,
-  getEnergyWaterUnit,
 } from "../../../../data/energy";
 import {
   calculateStatisticSumGrowth,
@@ -140,7 +139,7 @@ export class HuiEnergySourcesTableCard
       this._data.statsMetadata
     );
 
-    const waterUnit = getEnergyWaterUnit(this.hass);
+    const waterUnit = this._data.waterUnit;
 
     const compare = this._data.statsCompare !== undefined;
 

--- a/src/panels/lovelace/cards/energy/hui-energy-water-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-water-graph-card.ts
@@ -13,10 +13,7 @@ import type {
   EnergyData,
   WaterSourceTypeEnergyPreference,
 } from "../../../../data/energy";
-import {
-  getEnergyDataCollection,
-  getEnergyWaterUnit,
-} from "../../../../data/energy";
+import { getEnergyDataCollection } from "../../../../data/energy";
 import type { Statistics, StatisticsMetaData } from "../../../../data/recorder";
 import { getStatisticLabel } from "../../../../data/recorder";
 import type { FrontendLocaleData } from "../../../../data/translation";
@@ -163,7 +160,7 @@ export class HuiEnergyWaterGraphCard
         (source) => source.type === "water"
       ) as WaterSourceTypeEnergyPreference[];
 
-    this._unit = getEnergyWaterUnit(this.hass);
+    this._unit = energyData.waterUnit;
 
     const datasets: BarSeriesOption[] = [];
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Instead of hardcoding the unit of display for energy panel for water based on the system units, allow the user to indirectly choose his display unit by matching the display unit of the source.

If there are multiple source statistics that do not have the same display unit, we fall back to the previous default. But if they are all the same, we can use that as the statistics unit. 

The system default may not be ideal for users, based on how they interpret their energy usage. For example my water is billed in CCF, so forcing it to display in gallons is a bit confusing, as typically in my region water consumption is not counted/billed in gallons. For many metric users, their usage may be billed in cubic meters instead of liters. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #23318 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
