### PR TITLE
Render energy-gas in the display unit of the sources

### DIFF
--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -24,7 +24,6 @@ import type {
 import {
   computeConsumptionData,
   getEnergyDataCollection,
-  getEnergyGasUnit,
   getSummedData,
 } from "../../data/energy";
 import { fileDownload } from "../../util/file_download";
@@ -152,11 +151,7 @@ class PanelEnergy extends LitElement {
       return;
     }
 
-    const gasUnit = getEnergyGasUnit(
-      this.hass,
-      energyData.prefs,
-      energyData.state.statsMetadata
-    );
+    const gasUnit = energyData.state.gasUnit;
     const electricUnit = "kWh";
 
     const energy_sources = energyData.prefs.energy_sources;

--- a/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
@@ -23,7 +23,6 @@ import type { EnergyData } from "../../../../data/energy";
 import {
   energySourcesByType,
   getEnergyDataCollection,
-  getEnergyGasUnit,
   formatConsumptionShort,
   getSummedData,
   computeConsumptionData,
@@ -334,11 +333,7 @@ class HuiEnergyDistrubutionCard
                         ${formatConsumptionShort(
                           this.hass,
                           gasUsage,
-                          getEnergyGasUnit(
-                            this.hass,
-                            prefs,
-                            this._data.statsMetadata
-                          )
+                          this._data.gasUnit
                         )}
                       </div>
                       <svg width="80" height="30">

--- a/src/panels/lovelace/cards/energy/hui-energy-gas-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-gas-graph-card.ts
@@ -14,10 +14,7 @@ import type {
   EnergyData,
   GasSourceTypeEnergyPreference,
 } from "../../../../data/energy";
-import {
-  getEnergyDataCollection,
-  getEnergyGasUnit,
-} from "../../../../data/energy";
+import { getEnergyDataCollection } from "../../../../data/energy";
 import type { Statistics, StatisticsMetaData } from "../../../../data/recorder";
 import { getStatisticLabel } from "../../../../data/recorder";
 import type { FrontendLocaleData } from "../../../../data/translation";
@@ -163,11 +160,7 @@ export class HuiEnergyGasGraphCard
         (source) => source.type === "gas"
       ) as GasSourceTypeEnergyPreference[];
 
-    this._unit = getEnergyGasUnit(
-      this.hass,
-      energyData.prefs,
-      energyData.statsMetadata
-    );
+    this._unit = energyData.gasUnit;
 
     const datasets: BarSeriesOption[] = [];
 

--- a/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
@@ -13,7 +13,6 @@ import type { EnergyData } from "../../../../data/energy";
 import {
   energySourcesByType,
   getEnergyDataCollection,
-  getEnergyGasUnit,
 } from "../../../../data/energy";
 import {
   calculateStatisticSumGrowth,
@@ -133,11 +132,7 @@ export class HuiEnergySourcesTableCard
           flow.stat_cost || flow.entity_energy_price || flow.number_energy_price
       );
 
-    const gasUnit = getEnergyGasUnit(
-      this.hass,
-      this._data.prefs,
-      this._data.statsMetadata
-    );
+    const gasUnit = this._data.gasUnit;
 
     const waterUnit = this._data.waterUnit;
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Same as https://github.com/home-assistant/frontend/pull/26141 but for gas.

Slightly different in that this only applies to volumetric gas. Energy based gas is still fixed to unit "kWh", as I wasn't sure if it was desirable to keep this in the same unit as the electric sources. But we can change that further if desired, if there is desire to present it in GJ or something like that. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
