### PR TITLE
Improve performance of Helpers config page

### DIFF
--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -74,6 +74,7 @@ import type {
   UpdateEntityRegistryEntryResult,
 } from "../../../data/entity_registry";
 import {
+  entityRegistryByEntityId,
   subscribeEntityRegistry,
   updateEntityRegistryEntry,
 } from "../../../data/entity_registry";
@@ -520,9 +521,8 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
             : true
         )
         .map((item) => {
-          const entityRegEntry = entityReg.find(
-            (reg) => reg.entity_id === item.entity_id
-          );
+          const entityRegEntry =
+            entityRegistryByEntityId(entityReg)[item.entity_id];
           const labels = labelReg && entityRegEntry?.labels;
           const category = entityRegEntry?.categories.helpers;
           return {
@@ -547,7 +547,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
   private _labelsForEntity(entityId: string): string[] {
     return (
       this.hass.entities[entityId]?.labels ||
-      this._entityReg.find((e) => e.entity_id === entityId)?.labels ||
+      entityRegistryByEntityId(this._entityReg)[entityId]?.labels ||
       []
     );
   }
@@ -885,9 +885,9 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
         const labelItems = new Set<string>();
         this._stateItems
           .filter((stateItem) =>
-            this._entityReg
-              .find((reg) => reg.entity_id === stateItem.entity_id)
-              ?.labels.some((lbl) => filter.includes(lbl))
+            entityRegistryByEntityId(this._entityReg)[
+              stateItem.entity_id
+            ]?.labels.some((lbl) => filter.includes(lbl))
           )
           .forEach((stateItem) => labelItems.add(stateItem.entity_id));
         (this._disabledEntityEntries || [])
@@ -913,9 +913,8 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
           .filter(
             (stateItem) =>
               filter[0] ===
-              this._entityReg.find(
-                (reg) => reg.entity_id === stateItem.entity_id
-              )?.categories.helpers
+              entityRegistryByEntityId(this._entityReg)[stateItem.entity_id]
+                ?.categories.helpers
           )
           .forEach((stateItem) => categoryItems.add(stateItem.entity_id));
         (this._disabledEntityEntries || [])
@@ -943,9 +942,9 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
   }
 
   private _editCategory(helper: any) {
-    const entityReg = this._entityReg.find(
-      (reg) => reg.entity_id === helper.entity_id
-    );
+    const entityReg = entityRegistryByEntityId(this._entityReg)[
+      helper.entity_id
+    ];
     if (!entityReg) {
       showAlertDialog(this, {
         title: this.hass.localize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Fixes #21530. Using `find()` to interate the entities registry to find an entity is inefficient with a large number of entities. The submitter of #21530 had similar issue with custom element `auto-entities`. A similar fix for `auto-entities` provided for a solution. Like this fix, the improvment in performance is subjective to local setup, hardware etc.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Add substantial amount of helper entities. Attached below is an `input_button` file with 20,000 helper buttons which can be placed in .storage (remove .txt).

[input_button.txt](https://github.com/user-attachments/files/21206351/input_button.txt)

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #21530
- This PR is related to issue or discussion:
- Link to documentation pull request:

Two videos below. One before changes, one after changes.

Before

https://github.com/user-attachments/assets/6b6fcf3b-2130-4f3c-b1c6-c9835128799c

After

https://github.com/user-attachments/assets/fb9f301e-bba4-4f9b-b46f-ff75717be905

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
