### PR TITLE
Don't show members for legacy groups

### DIFF
--- a/src/dialogs/more-info/more-info-content.ts
+++ b/src/dialogs/more-info/more-info-content.ts
@@ -3,6 +3,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { dynamicElement } from "../../common/dom/dynamic-element-directive";
+import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import "../../components/ha-badge";
 import type { ExtEntityRegistryEntry } from "../../data/entity_registry";
 import type { TileCardConfig } from "../../panels/lovelace/cards/types";
@@ -45,8 +46,7 @@ class MoreInfoContent extends LitElement {
         entry: this.entry,
         editMode: this.editMode,
       })}
-      ${this.stateObj.attributes.entity_id &&
-      this.stateObj.attributes.entity_id.length
+      ${this._showEntityMembers(this.stateObj)
         ? html`
             <hui-section
               .hass=${this.hass}
@@ -58,6 +58,19 @@ class MoreInfoContent extends LitElement {
           `
         : nothing}
     `;
+  }
+
+  private _showEntityMembers(stateObj: HassEntity): boolean {
+    if (computeStateDomain(stateObj) === "group") {
+      // Don't show entity members for legacy groups as they already show
+      // the members in their more info dialog.
+      return false;
+    }
+    return (
+      stateObj.attributes &&
+      stateObj.attributes.entity_id &&
+      Array.isArray(stateObj.attributes.entity_id)
+    );
   }
 
   private _entitiesSectionConfig = memoizeOne((entityIds: string[]) => ({


### PR DESCRIPTION
## Proposed change

Don't show members for legacy groups. 
I preferred to keep the old design for legacy groups because it's legacy and I didn't wanted to break the workflow of some people using the legacy group.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
