### PR TITLE
Add 'state' option for secondary entity info on Entities card

### DIFF
--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -73,6 +73,7 @@ export interface EntitiesCardEntityConfig extends EntityConfig {
     | "last-triggered"
     | "last-updated"
     | "position"
+    | "state"
     | "tilt-position"
     | "brightness";
   action_name?: string;

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -17,6 +17,7 @@ import { handleAction } from "../common/handle-action";
 import { hasAction, hasAnyAction } from "../common/has-action";
 import { createEntityNotFoundWarning } from "./hui-warning";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
+import { computeStateDisplay } from "../../../common/entity/compute_state_display";
 
 @customElement("hui-generic-entity-row")
 export class HuiGenericEntityRow extends LitElement {
@@ -146,7 +147,16 @@ export class HuiGenericEntityRow extends LitElement {
                                           100
                                       )}
                                       %`
-                                    : nothing)}
+                                    : this.config.secondary_info === "state"
+                                      ? html`${computeStateDisplay(
+                                          this.hass.localize,
+                                          stateObj,
+                                          this.hass.locale,
+                                          [],
+                                          this.hass.config,
+                                          this.hass.entities
+                                        )}`
+                                      : nothing)}
                     </div>
                   `
                 : nothing}

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -17,7 +17,6 @@ import { handleAction } from "../common/handle-action";
 import { hasAction, hasAnyAction } from "../common/has-action";
 import { createEntityNotFoundWarning } from "./hui-warning";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
-import { computeStateDisplay } from "../../../common/entity/compute_state_display";
 
 @customElement("hui-generic-entity-row")
 export class HuiGenericEntityRow extends LitElement {
@@ -148,13 +147,8 @@ export class HuiGenericEntityRow extends LitElement {
                                       )}
                                       %`
                                     : this.config.secondary_info === "state"
-                                      ? html`${computeStateDisplay(
-                                          this.hass.localize,
-                                          stateObj,
-                                          this.hass.locale,
-                                          [],
-                                          this.hass.config,
-                                          this.hass.entities
+                                      ? html`${this.hass.formatEntityState(
+                                          stateObj
                                         )}`
                                       : nothing)}
                     </div>

--- a/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
@@ -19,6 +19,7 @@ const SECONDARY_INFO_VALUES = {
   "last-updated": {},
   "last-triggered": { domains: ["automation", "script"] },
   position: { domains: ["cover"] },
+  state: {},
   "tilt-position": { domains: ["cover"] },
   brightness: { domains: ["light"] },
 };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7303,7 +7303,8 @@
                 "position": "Position",
                 "tilt-position": "Tilt position",
                 "brightness": "Brightness",
-                "last-updated": "Last updated"
+                "last-updated": "Last updated",
+                "state": "State"
               },
               "entity_row": {
                 "divider": "Divider",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This change adds "state" as an option when selecting secondary entity info to display in the `entities` card. While it might seem redundant, some entity rows show controls as the primary entity info, and in that case there is no way to directly view the entity state. The most common example I can think of (and the specific problem I ran into) is a garage door opener (cover):

<img width="492" height="57" alt="image" src="https://github.com/user-attachments/assets/f7771a85-275c-4113-a948-48d0f9986407" />

It is not visually easy to parse whether the door is up or down (granted, if I look a bit closer at the icon or the state of the buttons I can figure it out). With the state displayed in the secondary info area, it is very easy to see:
<img width="493" height="58" alt="image" src="https://github.com/user-attachments/assets/a841155e-fbdb-407c-b76a-5bb4c2f4df21" />

I also find it useful for locks, and for number inputs in the new Sections layout (if the section is narrow, the state is not displayed).

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Frontend YAML configuration example:
```yaml
title: Garage
type: entities
entities:
  - entity: cover.garage_door
    secondary_info: state
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I found a request for this in the HA forums: https://community.home-assistant.io/t/secondary-info-on-a-cover-entity-row/690657

I'm open to narrowing the scope of the `state` option to just certain domains, but I think it's nice to have as an option for everything.

I'm not 100% sure about the parameters to `computeStateDisplay` (mostly the numeric device classes parameter), so please let me know if something doesn't look right.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
