### PR TITLE
Handle visibility changes in camera players

### DIFF
--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -59,6 +59,19 @@ class HaHLSPlayer extends LitElement {
 
   private static streamCount = 0;
 
+  private _handleVisibilityChange = () => {
+    if (document.hidden) {
+      // eslint-disable-next-line no-console
+      console.log("Player is hidden");
+      this._cleanUp();
+    } else {
+      // eslint-disable-next-line no-console
+      console.log("Player is visible");
+      this._resetError();
+      this._startHls();
+    }
+  };
+
   public connectedCallback() {
     super.connectedCallback();
     HaHLSPlayer.streamCount += 1;
@@ -66,10 +79,15 @@ class HaHLSPlayer extends LitElement {
       this._resetError();
       this._startHls();
     }
+    document.addEventListener("visibilitychange", this._handleVisibilityChange);
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
+    document.removeEventListener(
+      "visibilitychange",
+      this._handleVisibilityChange
+    );
     HaHLSPlayer.streamCount -= 1;
     this._cleanUp();
   }

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -61,12 +61,8 @@ class HaHLSPlayer extends LitElement {
 
   private _handleVisibilityChange = () => {
     if (document.hidden) {
-      // eslint-disable-next-line no-console
-      console.log("Player is hidden");
       this._cleanUp();
     } else {
-      // eslint-disable-next-line no-console
-      console.log("Player is visible");
       this._resetError();
       this._startHls();
     }

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -61,6 +61,18 @@ class HaWebRtcPlayer extends LitElement {
 
   private _candidatesList: RTCIceCandidate[] = [];
 
+  private _handleVisibilityChange = () => {
+    if (document.hidden) {
+      // eslint-disable-next-line no-console
+      console.log("Player is hidden");
+      this._cleanUp();
+    } else {
+      // eslint-disable-next-line no-console
+      console.log("Player is visible");
+      this._startWebRtc();
+    }
+  };
+
   protected override render(): TemplateResult {
     if (this._error) {
       return html`<ha-alert alert-type="error">${this._error}</ha-alert>`;
@@ -88,10 +100,15 @@ class HaWebRtcPlayer extends LitElement {
     if (this.hasUpdated && this.entityid) {
       this._startWebRtc();
     }
+    document.addEventListener("visibilitychange", this._handleVisibilityChange);
   }
 
   public override disconnectedCallback() {
     super.disconnectedCallback();
+    document.removeEventListener(
+      "visibilitychange",
+      this._handleVisibilityChange
+    );
     this._cleanUp();
   }
 

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -63,12 +63,8 @@ class HaWebRtcPlayer extends LitElement {
 
   private _handleVisibilityChange = () => {
     if (document.hidden) {
-      // eslint-disable-next-line no-console
-      console.log("Player is hidden");
       this._cleanUp();
     } else {
-      // eslint-disable-next-line no-console
-      console.log("Player is visible");
       this._startWebRtc();
     }
   };


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR listens to visibility changes to cleanup the stream, and start it again when the element is visible again.

This has two benefits:
- On the Android app (have not tested iOS), the stream is stoped when the app goes to the background, while currently it keeps streaming in the background. So this fixes https://github.com/home-assistant/android/issues/979.
- Pauses streams when the browser tab is not visible, which is important for battery cameras.

This affects both when viewing the stream directly or when using "live" in picture cards.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
