### PR TITLE
Add template option to time_zone

### DIFF
--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -271,11 +271,13 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
   private async _tryDisconnect(): Promise<void> {
     if (this._unsubRenderTemplate) {
       this._unsubRenderTemplate.then((unsub) => unsub()).catch(() => {});
+      // ignore
       this._unsubRenderTemplate = undefined;
     }
 
     if (this._unsubTimeZoneTemplate) {
       this._unsubTimeZoneTemplate.then((unsub) => unsub()).catch(() => {});
+      // ignore
       this._unsubTimeZoneTemplate = undefined;
     }
 

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -270,14 +270,16 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
 
   private async _tryDisconnect(): Promise<void> {
     if (this._unsubRenderTemplate) {
-      this._unsubRenderTemplate.then((unsub) => unsub()).catch(() => {});
-      // ignore
+      this._unsubRenderTemplate.then((unsub) => unsub()).catch(() => {
+        //ignore
+      });
       this._unsubRenderTemplate = undefined;
     }
 
     if (this._unsubTimeZoneTemplate) {
-      this._unsubTimeZoneTemplate.then((unsub) => unsub()).catch(() => {});
-      // ignore
+      this._unsubTimeZoneTemplate.then((unsub) => unsub()).catch(() => {
+        //ignore
+      });
       this._unsubTimeZoneTemplate = undefined;
     }
 

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -223,7 +223,6 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
 
     await this._tryDisconnect();
 
-    // Subscribe to content template
     if (this._config.content?.includes("{{")) {
       this._unsubRenderTemplate = subscribeRenderTemplate(
         this.hass.connection,
@@ -248,14 +247,13 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
       );
     }
 
-    // Subscribe to time_zone template
     if (this._config.time_zone?.includes("{{")) {
       this._unsubTimeZoneTemplate = subscribeRenderTemplate(
         this.hass.connection,
         (result) => {
           if (!("error" in result)) {
             this._resolvedTimeZone = result.result;
-            this._initDate(); // reapply formatting
+            this._initDate(); 
           }
         },
         {

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -40,10 +40,6 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
   @state() private _config?: ClockCardConfig;
 
   @state() private _dateTimeFormat?: Intl.DateTimeFormat;
-
-  @state() private _error?: string;
-
-  @state() private _errorLevel?: "ERROR" | "WARNING";
   
   @state() private _resolvedTimeZone?: string;
 
@@ -228,8 +224,6 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
         this.hass.connection,
         (result) => {
           if ("error" in result) {
-            this._error = result.error;
-            this._errorLevel = result.level;
             return;
           }
           this._templateResult = result;
@@ -242,7 +236,6 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
             user: this.hass.user?.name,
           },
           strict: true,
-          report_errors: this.preview,
         }
       );
     }
@@ -282,9 +275,6 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
       });
       this._unsubTimeZoneTemplate = undefined;
     }
-
-    this._error = undefined;
-    this._errorLevel = undefined;
   }
 
   protected render() {

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -44,10 +44,10 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
   @state() private _error?: string;
 
   @state() private _errorLevel?: "ERROR" | "WARNING";
+  
+  @state() private _resolvedTimeZone?: string;
 
   @state() private _templateResult?: RenderTemplateResult;
-
-  @state() private _resolvedTimeZone?: string;
 
   @state() private _timeHour?: string;
 
@@ -57,11 +57,11 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
 
   @state() private _timeAmPm?: string;
 
+  private _tickInterval?: undefined | number;
+
   private _unsubRenderTemplate?: Promise<UnsubscribeFunc>;
 
   private _unsubTimeZoneTemplate?: Promise<UnsubscribeFunc>;
-
-  private _tickInterval?: undefined | number;
 
   public setConfig(config: ClockCardConfig): void {
     this._config = config;

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -271,14 +271,14 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
   private async _tryDisconnect(): Promise<void> {
     if (this._unsubRenderTemplate) {
       this._unsubRenderTemplate.then((unsub) => unsub()).catch(() => {
-        //ignore
+        // ignore
       });
       this._unsubRenderTemplate = undefined;
     }
 
     if (this._unsubTimeZoneTemplate) {
       this._unsubTimeZoneTemplate.then((unsub) => unsub()).catch(() => {
-        //ignore
+        // ignore
       });
       this._unsubTimeZoneTemplate = undefined;
     }

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -312,7 +312,98 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
   }
 
   static styles = css`
-    /* [Same styles as before] */
+    ha-card {
+      height: 100%;
+    }
+    .time-wrapper {
+      display: flex;
+      height: calc(100% - 12px);
+      align-items: center;
+      flex-direction: column;
+      justify-content: center;
+      padding: 6px 8px;
+      row-gap: 6px;
+    }
+    .time-wrapper.size-medium,
+    .time-wrapper.size-large {
+      height: calc(100% - 32px);
+      padding: 16px;
+      row-gap: 12px;
+    }
+    .time-title {
+      color: var(--primary-text-color);
+      font-size: var(--ha-font-size-m);
+      font-weight: var(--ha-font-weight-normal);
+      line-height: var(--ha-line-height-condensed);
+      overflow: hidden;
+      text-align: center;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      width: 100%;
+    }
+    .time-wrapper.size-medium .time-title {
+      font-size: var(--ha-font-size-l);
+      line-height: var(--ha-line-height-condensed);
+    }
+    .time-wrapper.size-large .time-title {
+      font-size: var(--ha-font-size-2xl);
+      line-height: var(--ha-line-height-condensed);
+    }
+    .time-parts {
+      align-items: center;
+      display: grid;
+      grid-template-areas:
+        "hour minute second"
+        "hour minute am-pm";
+      font-size: 2rem;
+      font-weight: var(--ha-font-weight-medium);
+      line-height: 0.8;
+      direction: ltr;
+    }
+    .time-title + .time-parts {
+      font-size: 1.5rem;
+    }
+    .time-wrapper.size-medium .time-parts {
+      font-size: 3rem;
+    }
+    .time-wrapper.size-large .time-parts {
+      font-size: 4rem;
+    }
+    .time-wrapper.size-medium .time-parts .time-part.second,
+    .time-wrapper.size-medium .time-parts .time-part.am-pm {
+      font-size: var(--ha-font-size-l);
+      margin-left: 6px;
+    }
+    .time-wrapper.size-large .time-parts .time-part.second,
+    .time-wrapper.size-large .time-parts .time-part.am-pm {
+      font-size: var(--ha-font-size-2xl);
+      margin-left: 8px;
+    }
+    .time-parts .time-part.hour {
+      grid-area: hour;
+    }
+    .time-parts .time-part.minute {
+      grid-area: minute;
+    }
+    .time-parts .time-part.second {
+      grid-area: second;
+      line-height: 0.9;
+      opacity: 0.4;
+    }
+    .time-parts .time-part.am-pm {
+      grid-area: am-pm;
+      line-height: 0.9;
+      opacity: 0.6;
+    }
+    .time-parts .time-part.second,
+    .time-parts .time-part.am-pm {
+      font-size: var(--ha-font-size-xs);
+      margin-left: 4px;
+    }
+    .time-parts .time-part.hour:after {
+      content: ":";
+      margin: 0 2px;
+    }
   `;
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Added the option to use templates in the configuration of the clock card.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: clock
clock_size: medium
time_zone: "{{ states('sensor.time_zone_user_a') }}"
title: London 💂
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.
_2x // ignore in catch block_

If user exposed functionality or configuration variables are added/changed:

- [-] Documentation added/updated for [www.home-assistant.io][docs-repository]
_Will do that later when approved_

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
