### PR TITLE
Clock card timezone entity support

### DIFF
--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -54,14 +54,17 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
 
     let zone: string | undefined = this._config.time_zone;
 
-    if (zone?.startsWith("sensor.") || zone?.startsWith("input_text.")) {
+    if (
+      zone?.startsWith("sensor.") || 
+      zone?.startsWith("input_text.")
+    ) {
       const entity = this.hass.states[zone];
       zone = entity?.state;
     }
 
     return safeResolveTimeZone(
       zone ?? this.hass.config.time_zone,
-      this.hass.config.time_zone,
+      this.hass.config.time_zone
     );
   }
 

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -12,7 +12,6 @@ import type {
 import type { ClockCardConfig } from "./types";
 import { useAmPm } from "../../../common/datetime/use_am_pm";
 import { resolveTimeZone } from "../../../common/datetime/resolve-time-zone";
-import type { TimeZone } from "../../../common/datetime/resolve-time-zone";
 
 const INTERVAL = 1000;
 
@@ -74,8 +73,8 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
     }
     
     timeZone = resolveTimeZone(
-      (timeZone ?? this.hass.config?.time_zone) as unknown as TimeZone,
-      this.hass.config?.time_zone as TimeZone
+      timeZone ?? this.hass.config?.time_zone as any,
+      this.hass.config?.time_zone as any
     );
     
     this._dateTimeFormat = new Intl.DateTimeFormat(this.hass.locale.language, {

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -60,6 +60,18 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
       locale = { ...locale, time_format: this._config.time_format };
     }
 
+    let timeZone = string | undefined;
+
+    if (
+      this._config.time_zone?.startsWith("sensor.") ||
+      this._config.time_zone?.startsWith("input_text.")
+    ) {
+      const entity = this.hass.states[this._config.time_zone];
+      timeZone = entity?.state;
+    } else {
+      timeZone = this._config.time_zone;
+    }
+
     this._dateTimeFormat = new Intl.DateTimeFormat(this.hass.locale.language, {
       hour: "2-digit",
       minute: "2-digit",

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -60,8 +60,8 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
       locale = { ...locale, time_format: this._config.time_format };
     }
 
-    let timeZone = string | undefined;
-
+    let timeZone: string | undefined;
+    
     if (
       this._config.time_zone?.startsWith("sensor.") ||
       this._config.time_zone?.startsWith("input_text.")
@@ -71,15 +71,15 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
     } else {
       timeZone = this._config.time_zone;
     }
+    
+    timeZone = resolveTimeZone(timeZone, this.hass.config?.time_zone);
 
     this._dateTimeFormat = new Intl.DateTimeFormat(this.hass.locale.language, {
       hour: "2-digit",
       minute: "2-digit",
       second: "2-digit",
       hourCycle: useAmPm(locale) ? "h12" : "h23",
-      timeZone:
-        this._config?.time_zone ||
-        resolveTimeZone(locale.time_zone, this.hass.config?.time_zone),
+      timeZone,
     });
 
     this._tick();

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -54,7 +54,10 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
   
     let zone: string | undefined = this._config.time_zone;
   
-    if (zone?.startsWith("sensor.") || zone?.startsWith("input_text.")) {
+    if (
+      zone?.startsWith("sensor.") || 
+      zone?.startsWith("input_text.")
+    ) {
       const entity = this.hass.states[zone];
       zone = entity?.state;
     }

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -73,8 +73,8 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
     }
     
     timeZone = resolveTimeZone(
-      timeZone ?? this.hass.config?.time_zone,
-      this.hass.config?.time_zone
+      (timeZone ?? this.hass.config?.time_zone) as unknown as TimeZone,
+      this.hass.config?.time_zone as TimeZone
     );
     
     this._dateTimeFormat = new Intl.DateTimeFormat(this.hass.locale.language, {

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -72,8 +72,11 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
       timeZone = this._config.time_zone;
     }
     
-    timeZone = resolveTimeZone(timeZone, this.hass.config?.time_zone);
-
+    timeZone = resolveTimeZone(
+      timeZone ?? this.hass.config?.time_zone,
+      this.hass.config?.time_zone
+    );
+    
     this._dateTimeFormat = new Intl.DateTimeFormat(this.hass.locale.language, {
       hour: "2-digit",
       minute: "2-digit",

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -17,7 +17,7 @@ const INTERVAL = 1000;
 
 const safeResolveTimeZone = resolveTimeZone as unknown as (
   zone: string,
-  fallback: string
+  fallback: string,
 ) => string;
 
 @customElement("hui-clock-card")
@@ -51,20 +51,17 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
     if (!this._config || !this.hass) {
       return this.hass?.config?.time_zone ?? "UTC";
     }
-  
+
     let zone: string | undefined = this._config.time_zone;
-  
-    if (
-      zone?.startsWith("sensor.") || 
-      zone?.startsWith("input_text.")
-    ) {
+
+    if (zone?.startsWith("sensor.") || zone?.startsWith("input_text.")) {
       const entity = this.hass.states[zone];
       zone = entity?.state;
     }
-  
+
     return safeResolveTimeZone(
       zone ?? this.hass.config.time_zone,
-      this.hass.config.time_zone
+      this.hass.config.time_zone,
     );
   }
 
@@ -87,7 +84,7 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
     }
 
     const timeZone = this._getTimeZoneFromConfig();
-    
+
     this._dateTimeFormat = new Intl.DateTimeFormat(this.hass.locale.language, {
       hour: "2-digit",
       minute: "2-digit",

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -12,6 +12,7 @@ import type {
 import type { ClockCardConfig } from "./types";
 import { useAmPm } from "../../../common/datetime/use_am_pm";
 import { resolveTimeZone } from "../../../common/datetime/resolve-time-zone";
+import type { TimeZone } from "../../../common/datetime/resolve-time-zone";
 
 const INTERVAL = 1000;
 

--- a/src/panels/lovelace/cards/hui-clock-card.ts
+++ b/src/panels/lovelace/cards/hui-clock-card.ts
@@ -47,14 +47,7 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
 
   @state() private _timeAmPm?: string;
 
-  private _tickInterval?: undefined | number;
-
-  public setConfig(config: ClockCardConfig): void {
-    this._config = config;
-    this._initDate();
-  }
-
-  private getTimeZoneFromConfig(): string {
+  private _getTimeZoneFromConfig(): string {
     if (!this._config || !this.hass) {
       return this.hass?.config?.time_zone ?? "UTC";
     }
@@ -72,6 +65,13 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
     );
   }
 
+  private _tickInterval?: undefined | number;
+
+  public setConfig(config: ClockCardConfig): void {
+    this._config = config;
+    this._initDate();
+  }
+
   private _initDate() {
     if (!this._config || !this.hass) {
       return;
@@ -83,7 +83,7 @@ export class HuiClockCard extends LitElement implements LovelaceCard {
       locale = { ...locale, time_format: this._config.time_format };
     }
 
-    const timeZone = this.getTimeZoneFromConfig();
+    const timeZone = this._getTimeZoneFromConfig();
     
     this._dateTimeFormat = new Intl.DateTimeFormat(this.hass.locale.language, {
       hour: "2-digit",

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -369,7 +369,6 @@ export interface MarkdownCardConfig extends LovelaceCardConfig {
 
 export interface ClockCardConfig extends LovelaceCardConfig {
   type: "clock";
-  entity?: string;
   title?: string;
   clock_size?: "small" | "medium" | "large";
   show_seconds?: boolean | undefined;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -369,6 +369,7 @@ export interface MarkdownCardConfig extends LovelaceCardConfig {
 
 export interface ClockCardConfig extends LovelaceCardConfig {
   type: "clock";
+  entity?: string;
   title?: string;
   clock_size?: "small" | "medium" | "large";
   show_seconds?: boolean | undefined;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
I added the option to either manual put a time zone (`Europe/Amsterdam`) or put an entity_id (`sensor.timezone_user_a`). The state of this sensor would need to be the correct format.
This way, the clock card is a little bit more dynamic.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: clock
clock_size: medium
time_zone: sensor.timezone_user_a
title: John 
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]
needs: https://github.com/home-assistant/home-assistant.io/pull/40099

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
