### PR TITLE
Hide hardware integrations in brand sub-menu

### DIFF
--- a/src/panels/config/integrations/ha-domain-integrations.ts
+++ b/src/panels/config/integrations/ha-domain-integrations.ts
@@ -138,6 +138,7 @@ class HaDomainIntegrations extends LitElement {
                 this.hass.locale.language
               );
             })
+            .filter(([, val]) => val.integration_type !== "hardware")
             .map(
               ([dom, val]) =>
                 html`<ha-integration-list-item

--- a/src/panels/config/integrations/ha-domain-integrations.ts
+++ b/src/panels/config/integrations/ha-domain-integrations.ts
@@ -125,6 +125,7 @@ class HaDomainIntegrations extends LitElement {
       "integrations" in this.integration &&
       this.integration.integrations
         ? Object.entries(this.integration.integrations)
+            .filter(([, val]) => val.integration_type !== "hardware")
             .sort((a, b) => {
               if (a[1].config_flow && !b[1].config_flow) {
                 return -1;
@@ -138,7 +139,6 @@ class HaDomainIntegrations extends LitElement {
                 this.hass.locale.language
               );
             })
-            .filter(([, val]) => val.integration_type !== "hardware")
             .map(
               ([dom, val]) =>
                 html`<ha-integration-list-item


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Hardware integrations were filtered from the main menu, but still showing in brand sub-menus. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #26239
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
