### PR TITLE
Allow picture card to serve media images

### DIFF
--- a/src/data/media_source.ts
+++ b/src/data/media_source.ts
@@ -24,6 +24,9 @@ export const browseLocalMediaPlayer = (
     media_content_id: mediaContentId,
   });
 
+export const isMediaSourceContentId = (mediaId: string) =>
+  mediaId.startsWith("media-source://");
+
 export const isLocalMediaSourceContentId = (mediaId: string) =>
   mediaId.startsWith("media-source://media_source");
 

--- a/src/panels/lovelace/cards/hui-picture-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-card.ts
@@ -41,7 +41,7 @@ export class HuiPictureCard extends LitElement implements LovelaceCard {
 
   @state() private _config?: PictureCardConfig;
 
-  @state() private _resolvedImage?: string | null;
+  @state() private _resolvedImage?: string;
 
   public getCardSize(): number {
     return 5;
@@ -93,19 +93,17 @@ export class HuiPictureCard extends LitElement implements LovelaceCard {
       changedProps.has("_config") &&
       changedProps.get("_config")?.image !== this._config?.image;
 
-    if (imageChanged) {
-      this._resolvedImage = this._config?.image;
-    }
-
     if (
       (firstHass || imageChanged) &&
       typeof this._config?.image === "string" &&
       isMediaSourceContentId(this._config.image)
     ) {
-      this._resolvedImage = null;
+      this._resolvedImage = undefined;
       resolveMediaSource(this.hass, this._config?.image).then((result) => {
         this._resolvedImage = result.url;
       });
+    } else if (imageChanged) {
+      this._resolvedImage = this._config?.image;
     }
   }
 
@@ -145,7 +143,7 @@ export class HuiPictureCard extends LitElement implements LovelaceCard {
       }
     }
 
-    let image: string | null | undefined = this._resolvedImage;
+    let image: string | undefined = this._resolvedImage;
     if (this._config.image_entity) {
       const domain: string = computeDomain(this._config.image_entity);
       switch (domain) {
@@ -160,7 +158,7 @@ export class HuiPictureCard extends LitElement implements LovelaceCard {
       }
     }
 
-    if (image === null) {
+    if (image === undefined) {
       // Bail if we're waiting for our image to be resolved from the media-source.
       return nothing;
     }

--- a/src/panels/lovelace/cards/hui-picture-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-card.ts
@@ -18,6 +18,10 @@ import { createEntityNotFoundWarning } from "../components/hui-warning";
 import type { LovelaceCard, LovelaceCardEditor } from "../types";
 import type { PictureCardConfig } from "./types";
 import type { PersonEntity } from "../../../data/person";
+import {
+  isMediaSourceContentId,
+  resolveMediaSource,
+} from "../../../data/media_source";
 
 @customElement("hui-picture-card")
 export class HuiPictureCard extends LitElement implements LovelaceCard {
@@ -37,6 +41,8 @@ export class HuiPictureCard extends LitElement implements LovelaceCard {
 
   @state() private _config?: PictureCardConfig;
 
+  @state() private _resolvedImage?: string | null;
+
   public getCardSize(): number {
     return 5;
   }
@@ -53,7 +59,11 @@ export class HuiPictureCard extends LitElement implements LovelaceCard {
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
-    if (!this._config || hasConfigChanged(this, changedProps)) {
+    if (
+      !this._config ||
+      hasConfigChanged(this, changedProps) ||
+      changedProps.has("_resolvedImage")
+    ) {
       return true;
     }
     if (this._config.image_entity && changedProps.has("hass")) {
@@ -68,6 +78,35 @@ export class HuiPictureCard extends LitElement implements LovelaceCard {
     }
 
     return false;
+  }
+
+  protected willUpdate(changedProps: PropertyValues) {
+    super.willUpdate(changedProps);
+
+    if (!this._config || !this.hass) {
+      return;
+    }
+
+    const firstHass =
+      changedProps.has("hass") && changedProps.get("hass") === undefined;
+    const imageChanged =
+      changedProps.has("_config") &&
+      changedProps.get("_config")?.image !== this._config?.image;
+
+    if (imageChanged) {
+      this._resolvedImage = this._config?.image;
+    }
+
+    if (
+      (firstHass || imageChanged) &&
+      typeof this._config?.image === "string" &&
+      isMediaSourceContentId(this._config.image)
+    ) {
+      this._resolvedImage = null;
+      resolveMediaSource(this.hass, this._config?.image).then((result) => {
+        this._resolvedImage = result.url;
+      });
+    }
   }
 
   protected updated(changedProps: PropertyValues): void {
@@ -106,7 +145,7 @@ export class HuiPictureCard extends LitElement implements LovelaceCard {
       }
     }
 
-    let image: string | undefined = this._config.image;
+    let image: string | null | undefined = this._resolvedImage;
     if (this._config.image_entity) {
       const domain: string = computeDomain(this._config.image_entity);
       switch (domain) {
@@ -119,6 +158,11 @@ export class HuiPictureCard extends LitElement implements LovelaceCard {
           }
           break;
       }
+    }
+
+    if (image === null) {
+      // Bail if we're waiting for our image to be resolved from the media-source.
+      return nothing;
     }
 
     return html`


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Allow picture card to serve image paths in the form of:

```
type: picture
image: media-source://media_source/local/test.jpg
```

It just needs an extra step to resolve the authentication signature from the media_source API. 

This is pretty barebones at the moment, and I would eventually plan to do more, including:
- Work out a visual editor for this with a media browser
- Add similar logic to `<hui-image>` (for picture-entity, picture-elements, etc)
- Maybe convert hui-picture-card to use hui-image?

But I don't see that any of those tasks necessarily need to be blocking. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://community.home-assistant.io/t/wth-bundled-cards-cannot-access-media-source/804323
https://community.home-assistant.io/t/wth-i-cant-add-a-picture-from-media/815130
https://community.home-assistant.io/t/show-a-picture-in-a-seperate-dashboard-from-media-foldername/914133
https://community.home-assistant.io/t/use-picture-from-media-in-dashboard/904393/8
https://community.home-assistant.io/t/possibility-to-add-image-from-media-browser-on-picture-card/314201/10

- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
