### PR TITLE
Fix some instability in ha-selector-object

### DIFF
--- a/src/components/ha-selector/ha-selector-object.ts
+++ b/src/components/ha-selector/ha-selector-object.ts
@@ -15,6 +15,7 @@ import "../ha-md-list-item";
 import "../ha-sortable";
 import "../ha-yaml-editor";
 import type { HaYamlEditor } from "../ha-yaml-editor";
+import { deepEqual } from "../../common/util/deep-equal";
 
 @customElement("ha-selector-object")
 export class HaObjectSelector extends LitElement {
@@ -271,7 +272,8 @@ export class HaObjectSelector extends LitElement {
     if (
       changedProps.has("value") &&
       !this._valueChangedFromChild &&
-      this._yamlEditor
+      this._yamlEditor &&
+      !deepEqual(this.value, changedProps.get("value"))
     ) {
       this._yamlEditor.setValue(this.value);
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When ha-yaml-editor fires two back to back value-changed events that are different objects, but are otherwise deep-equal, the card editor stack will first do an update cycle with the newer second value, but then eventually do another update cycle with the first object (as the ultimate card config will ignore the second change as it sees them as deep-equal). 

Then when the final update cycle happens in ha-yaml-editor, it sees the value changed in changedProps and causes the yaml editor to reset unwantedly, which leads to jarring changes interrupting the ability to type. 

This PR skips the yamlEditor set when the old and new value are both deep-equal. 

As an alternative, it _might_ be possible to remove the entire `valueChangedFromChild` option and _never_ call setValue on the yaml editor after firstUpdated (as I think that original bug I added that for _might_ have been fixed in a different way, but I'm not entirely sure). 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #26284 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
