### PR TITLE
Cleanup some selectors firing double value-changed events

### DIFF
--- a/src/components/ha-selector/ha-selector-color-temp.ts
+++ b/src/components/ha-selector/ha-selector-color-temp.ts
@@ -95,6 +95,7 @@ export class HaColorTempSelector extends LitElement {
   );
 
   private _valueChanged(ev: CustomEvent) {
+    ev.stopPropagation();
     fireEvent(this, "value-changed", {
       value: Number((ev.detail as any).value),
     });

--- a/src/components/ha-selector/ha-selector-object.ts
+++ b/src/components/ha-selector/ha-selector-object.ts
@@ -279,6 +279,7 @@ export class HaObjectSelector extends LitElement {
   }
 
   private _handleChange(ev) {
+    ev.stopPropagation();
     this._valueChangedFromChild = true;
     const value = ev.target.value;
     if (!ev.target.isValid) {

--- a/src/components/ha-selector/ha-selector-template.ts
+++ b/src/components/ha-selector/ha-selector-template.ts
@@ -71,6 +71,7 @@ export class HaTemplateSelector extends LitElement {
   }
 
   private _handleChange(ev) {
+    ev.stopPropagation();
     let value = ev.target.value;
     if (this.value === value) {
       return;

--- a/src/components/ha-selector/ha-selector-text.ts
+++ b/src/components/ha-selector/ha-selector-text.ts
@@ -111,6 +111,7 @@ export class HaTextSelector extends LitElement {
   }
 
   private _handleChange(ev) {
+    ev.stopPropagation();
     let value = ev.detail?.value ?? ev.target.value;
     if (this.value === value) {
       return;

--- a/src/components/ha-selector/ha-selector-ui-action.ts
+++ b/src/components/ha-selector/ha-selector-ui-action.ts
@@ -33,6 +33,7 @@ export class HaSelectorUiAction extends LitElement {
   }
 
   private _valueChanged(ev: CustomEvent) {
+    ev.stopPropagation();
     fireEvent(this, "value-changed", { value: ev.detail.value });
   }
 }

--- a/src/components/ha-selector/ha-selector-ui-color.ts
+++ b/src/components/ha-selector/ha-selector-ui-color.ts
@@ -33,6 +33,7 @@ export class HaSelectorUiColor extends LitElement {
   }
 
   private _valueChanged(ev: CustomEvent) {
+    ev.stopPropagation();
     fireEvent(this, "value-changed", { value: ev.detail.value });
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
While debugging some other code, noticed these selectors are intercepting bubbling/composed events, and re-firing new modified versions of the event without stopping the original event, which also bubbles alongside of it.

This cause every change in the selector to bubble up two value-changed events for every change, which I don't think is intended. Sometimes these selectors nest inside of each other, which then again doubles the original event to 4 events. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
