### PR TITLE
Don't allow view URL to be a number

### DIFF
--- a/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
@@ -29,6 +29,7 @@ declare global {
 }
 
 const VALID_PATH_REGEX = /^[a-zA-Z0-9_-]+$/;
+const INTEGER_REGEX = /^[0-9]+$/;
 
 @customElement("hui-view-editor")
 export class HuiViewEditor extends LitElement {
@@ -165,14 +166,21 @@ export class HuiViewEditor extends LitElement {
       delete config.top_margin;
     }
 
+    const slugifyTitle = (title: string | undefined) => {
+      const slug = slugify(title || "", "-");
+      if (INTEGER_REGEX.test(slug)) {
+        return `view-${slug}`;
+      }
+      return slug;
+    };
+
     if (
       this.isNew &&
       !this._suggestedPath &&
       this._config.path === config.path &&
-      (!this._config.path ||
-        config.path === slugify(this._config.title || "", "-"))
+      (!this._config.path || config.path === slugifyTitle(this._config.title))
     ) {
-      config.path = slugify(config.title || "", "-");
+      config.path = slugifyTitle(config.title);
     }
 
     let valid = true;
@@ -180,6 +188,9 @@ export class HuiViewEditor extends LitElement {
     if (config.path && !VALID_PATH_REGEX.test(config.path)) {
       valid = false;
       this._error = { path: "error_invalid_path" };
+    } else if (config.path && INTEGER_REGEX.test(config.path)) {
+      valid = false;
+      this._error = { path: "error_number" };
     }
 
     fireEvent(this, "view-config-changed", { valid, config });

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7035,6 +7035,7 @@
             "saving_failed": "Saving failed",
             "error_same_url": "You cannot save a view with the same URL as a different existing view.",
             "error_invalid_path": "URL contains invalid/reserved characters. Please enter a simple string only for the path of this view.",
+            "error_number": "URL may not be a number.",
             "move_to_dashboard": "Move to dashboard"
           },
           "edit_view_header": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Don't allow the URL path of a view to be a positive integer, as this breaks the navigation.
If user enters a number for the title (which is fine), e.g. "5", slugify that as "view-5" instead as the suggested path. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #25913
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
