### PR TITLE
Do not show AI suggestion button when no inputs in save dialog

### DIFF
--- a/src/panels/config/automation/automation-save-dialog/dialog-automation-save.ts
+++ b/src/panels/config/automation/automation-save-dialog/dialog-automation-save.ts
@@ -260,12 +260,14 @@ class DialogAutomationSave extends LitElement implements HassDialog {
             .path=${mdiClose}
           ></ha-icon-button>
           <span slot="title">${this._params.title || title}</span>
-          <ha-suggest-with-ai-button
-            slot="actionItems"
-            .hass=${this.hass}
-            .generateTask=${this._generateTask}
-            @suggestion=${this._handleSuggestion}
-          ></ha-suggest-with-ai-button>
+          ${this._params.hideInputs
+            ? nothing
+            : html` <ha-suggest-with-ai-button
+                slot="actionItems"
+                .hass=${this.hass}
+                .generateTask=${this._generateTask}
+                @suggestion=${this._handleSuggestion}
+              ></ha-suggest-with-ai-button>`}
         </ha-dialog-header>
         ${this._error
           ? html`<ha-alert alert-type="error"


### PR DESCRIPTION
## Proposed change
Currently the AI suggestion button would also appear when leaving a existing automation/script dirty:

| <img width="541" height="300" alt="image" src="https://github.com/user-attachments/assets/2ca82c5a-3371-44de-8b08-f0f226ffac44" /> |
| :-: |

The suggestion wont work here as the dialog does not have any inputs, so only show it when we have inputs in this dialog:

| <img width="531" height="411" alt="image" src="https://github.com/user-attachments/assets/ca8bc65c-9d29-4aa7-a884-768b3aaa659b" /> | <img width="526" height="301" alt="image" src="https://github.com/user-attachments/assets/aaf0205c-9156-4f03-a2f3-3ef92a53f713" /> |
| :-: | :-: |

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
