### PR TITLE
Add area, device, floor and formatted state to template editor completions

### DIFF
--- a/src/components/ha-code-editor-completion-items.ts
+++ b/src/components/ha-code-editor-completion-items.ts
@@ -42,10 +42,10 @@ export class HaCodeEditorCompletionItems extends LitElement {
     }
 
     pre {
-      margin: 0 0.2em;
-      padding: 0.2em 0.2em;
+      margin: 0 3px;
+      padding: 3px;
       background-color: var(--markdown-code-background-color, none);
-      border-radius: 3px;
+      border-radius: var(--ha-border-radius-sm, 4px);
       line-height: var(--ha-line-height-condensed);
     }
   `;

--- a/src/components/ha-code-editor-completion-items.ts
+++ b/src/components/ha-code-editor-completion-items.ts
@@ -31,10 +31,14 @@ export class HaCodeEditorCompletionItems extends LitElement {
       grid-template-columns: auto 1fr;
       gap: 6px;
       white-space: pre-wrap;
+      flex-wrap: nowrap;
     }
 
     span {
       display: flex;
+      align-items: center;
+      flex-flow: wrap;
+      word-wrap: break-word;
     }
 
     pre {

--- a/src/components/ha-code-editor-completion-items.ts
+++ b/src/components/ha-code-editor-completion-items.ts
@@ -1,0 +1,54 @@
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+
+export interface CompletionItem {
+  label: string;
+  value: string;
+  subValue?: string;
+}
+
+@customElement("ha-code-editor-completion-items")
+export class HaCodeEditorCompletionItems extends LitElement {
+  @property({ attribute: false }) public items: CompletionItem[] = [];
+
+  render() {
+    return this.items.map(
+      (item) => html`
+        <span><strong>${item.label}</strong>:</span>
+        <span
+          >${item.value}${item.subValue && item.subValue.length > 0
+            ? // prettier-ignore
+              html` (<pre>${item.subValue}</pre>)`
+            : nothing}</span
+        >
+      `
+    );
+  }
+
+  static styles = css`
+    :host {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 6px;
+      white-space: pre-wrap;
+    }
+
+    span {
+      display: flex;
+    }
+
+    pre {
+      margin: 0 0.2em;
+      padding: 0.2em 0.2em;
+      background-color: var(--markdown-code-background-color, none);
+      border-radius: 3px;
+      line-height: var(--ha-line-height-condensed);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-code-editor-completion-items": HaCodeEditorCompletionItems;
+  }
+}

--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -10,7 +10,7 @@ import type { EditorView, KeyBinding, ViewUpdate } from "@codemirror/view";
 import { mdiArrowExpand, mdiArrowCollapse } from "@mdi/js";
 import type { HassEntities } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
-import { css, ReactiveElement, html, render } from "lit";
+import { css, ReactiveElement, html, render, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../common/dom/fire_event";
@@ -332,26 +332,41 @@ export class HaCodeEditor extends ReactiveElement {
     const completionInfo = document.createElement("div");
     completionInfo.classList.add("completion-info");
 
+    const renderItem = (label: string, value: string) => html`
+      <span><strong>${label}:</strong></span>
+      <span>${value}</span>
+    `;
+
     render(
       html`
-        <span
-          ><strong
-            >${this.hass!.localize(
-              "ui.components.entity.entity-state-picker.state"
-            )}:</strong
-          ></span
-        >
-        <span>${this.hass!.states[key].state}</span>
-
-        <span
-          ><strong
-            >${this.hass!.localize("ui.components.area-picker.area")}:</strong
-          ></span
-        >
-        <span
-          >${context.area?.name ??
-          this.hass!.localize("ui.components.device-picker.no_area")}</span
-        >
+        ${renderItem(
+          this.hass!.localize("ui.components.entity.entity-state-picker.state"),
+          this.hass!.states[key].state
+        )}
+        ${context.device?.name
+          ? html`
+              ${renderItem(
+                this.hass!.localize("ui.components.device-picker.device"),
+                context.device.name
+              )}
+            `
+          : nothing}
+        ${context.floor?.name
+          ? html`
+              ${renderItem(
+                this.hass!.localize("ui.components.floor-picker.floor"),
+                context.floor.name
+              )}
+            `
+          : nothing}
+        ${context.area?.name
+          ? html`
+              ${renderItem(
+                this.hass!.localize("ui.components.area-picker.area"),
+                context.area.name
+              )}
+            `
+          : nothing}
       `,
       completionInfo
     );

--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -343,11 +343,28 @@ export class HaCodeEditor extends ReactiveElement {
 
           render(
             html`
-              <span><strong>State:</strong></span>
+              <span
+                ><strong
+                  >${this.hass!.localize(
+                    "ui.panel.config.automation.picker.state"
+                  )}:</strong
+                ></span
+              >
               <span>${states[key].state}</span>
 
-              <span><strong>Area:</strong></span>
-              <span>${context.area?.name ?? "Not found"}</span>
+              <span
+                ><strong
+                  >${this.hass!.localize(
+                    "ui.panel.config.integrations.config_entry.area"
+                  )}:</strong
+                ></span
+              >
+              <span
+                >${context.area?.name ??
+                this.hass!.localize(
+                  "ui.panel.config.integrations.config_entry.no_area"
+                )}</span
+              >
             `,
             containerElement
           );

--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -335,13 +335,19 @@ export class HaCodeEditor extends ReactiveElement {
     const completionInfo = document.createElement("div");
     completionInfo.classList.add("completion-info");
 
+    const formattedState = this.hass!.formatEntityState(this.hass!.states[key]);
+
     const completionItems: CompletionItem[] = [
       {
         label: this.hass!.localize(
           "ui.components.entity.entity-state-picker.state"
         ),
-        value: this.hass!.formatEntityState(this.hass!.states[key]),
-        subValue: this.hass!.states[key].state,
+        value: formattedState,
+        subValue:
+          // If the state exactly matches the formatted state, don't show the raw state
+          this.hass!.states[key].state === formattedState
+            ? undefined
+            : this.hass!.states[key].state,
       },
     ];
 

--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -682,6 +682,14 @@ export class HaCodeEditor extends ReactiveElement {
       gap: 3px;
       padding: 8px;
     }
+
+    /* Hide completion info on narrow screens */
+    @media (max-width: 600px) {
+      .cm-completionInfo,
+      .completion-info {
+        display: none;
+      }
+    }
   `;
 }
 

--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -17,6 +17,7 @@ import { fireEvent } from "../common/dom/fire_event";
 import { stopPropagation } from "../common/dom/stop_propagation";
 import { getEntityContext } from "../common/entity/context/get_entity_context";
 import type { HomeAssistant } from "../types";
+import type { LocalizeKeys } from "../common/translations/localize";
 import "./ha-icon";
 import "./ha-icon-button";
 
@@ -39,6 +40,30 @@ const renderIcon = (completion: Completion) => {
   icon.icon = completion.label;
   return icon;
 };
+
+const renderItem = (label: string, value: string) => html`
+  <span><strong>${label}:</strong></span>
+  <span>${value}</span>
+`;
+
+const CONTEXT_ITEMS: {
+  itemKey: "device" | "area" | "floor";
+  translationKey: LocalizeKeys;
+}[] = [
+  {
+    itemKey: "device",
+    translationKey: "ui.components.device-picker.device",
+  },
+  {
+    itemKey: "area",
+    translationKey: "ui.components.area-picker.area",
+  },
+  {
+    itemKey: "floor",
+    translationKey: "ui.components.floor-picker.floor",
+  },
+] as const;
+
 @customElement("ha-code-editor")
 export class HaCodeEditor extends ReactiveElement {
   public codemirror?: EditorView;
@@ -332,41 +357,22 @@ export class HaCodeEditor extends ReactiveElement {
     const completionInfo = document.createElement("div");
     completionInfo.classList.add("completion-info");
 
-    const renderItem = (label: string, value: string) => html`
-      <span><strong>${label}:</strong></span>
-      <span>${value}</span>
-    `;
-
     render(
       html`
         ${renderItem(
           this.hass!.localize("ui.components.entity.entity-state-picker.state"),
           this.hass!.states[key].state
         )}
-        ${context.device?.name
-          ? html`
-              ${renderItem(
-                this.hass!.localize("ui.components.device-picker.device"),
-                context.device.name
-              )}
-            `
-          : nothing}
-        ${context.floor?.name
-          ? html`
-              ${renderItem(
-                this.hass!.localize("ui.components.floor-picker.floor"),
-                context.floor.name
-              )}
-            `
-          : nothing}
-        ${context.area?.name
-          ? html`
-              ${renderItem(
-                this.hass!.localize("ui.components.area-picker.area"),
-                context.area.name
-              )}
-            `
-          : nothing}
+        ${CONTEXT_ITEMS.map(({ itemKey, translationKey }) =>
+          context[itemKey]?.name
+            ? html`
+                ${renderItem(
+                  this.hass!.localize(translationKey),
+                  context[itemKey].name
+                )}
+              `
+            : nothing
+        )}
       `,
       completionInfo
     );

--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -338,8 +338,8 @@ export class HaCodeEditor extends ReactiveElement {
         label: key,
         detail: states[key].attributes.friendly_name,
         info: (_completion: Completion) => {
-          const containerElement = document.createElement("div");
-          containerElement.classList.add("completion-info");
+          const completionInfo = document.createElement("div");
+          completionInfo.classList.add("completion-info");
 
           render(
             html`
@@ -366,10 +366,10 @@ export class HaCodeEditor extends ReactiveElement {
                 )}</span
               >
             `,
-            containerElement
+            completionInfo
           );
 
-          return containerElement;
+          return completionInfo;
         },
       };
     });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Adds context to entity auto completion popup. Also localizes the labels and values

**Entity with full context**:

<img width="1138" height="486" alt="image" src="https://github.com/user-attachments/assets/71fb771d-a05d-4d3e-b1fc-30614fcc8d7e" />

**Entity without area/floor + identical formatted and raw state**:

<img width="1786" height="601" alt="image" src="https://github.com/user-attachments/assets/c790d726-7fe8-4eb8-ad1e-80e51f6240cf" />

**No device/area/floor**:

<img width="1324" height="460" alt="image" src="https://github.com/user-attachments/assets/e0fddba0-2f2c-49ad-9110-03a1c21a7ec6" />

**Mobile**:

Completion info is now hidden on small devices / mobile

<img width="535" height="993" alt="image" src="https://github.com/user-attachments/assets/3e95e265-444c-487f-9990-05c1f26d5d6f" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
