### PR TITLE
Add 'Not' to lovelace visibility conditions

### DIFF
--- a/src/panels/lovelace/common/icon-condition.ts
+++ b/src/panels/lovelace/common/icon-condition.ts
@@ -2,6 +2,7 @@ import {
   mdiAccount,
   mdiAmpersand,
   mdiGateOr,
+  mdiNotEqualVariant,
   mdiNumeric,
   mdiResponsive,
   mdiStateMachine,
@@ -14,5 +15,6 @@ export const ICON_CONDITION: Record<Condition["condition"], string> = {
   screen: mdiResponsive,
   user: mdiAccount,
   and: mdiAmpersand,
+  not: mdiNotEqualVariant,
   or: mdiGateOr,
 };

--- a/src/panels/lovelace/editor/conditions/ha-card-conditions-editor.ts
+++ b/src/panels/lovelace/editor/conditions/ha-card-conditions-editor.ts
@@ -18,6 +18,7 @@ import "./ha-card-condition-editor";
 import type { HaCardConditionEditor } from "./ha-card-condition-editor";
 import type { LovelaceConditionEditorConstructor } from "./types";
 import "./types/ha-card-condition-and";
+import "./types/ha-card-condition-not";
 import "./types/ha-card-condition-numeric_state";
 import "./types/ha-card-condition-or";
 import "./types/ha-card-condition-screen";
@@ -30,6 +31,7 @@ const UI_CONDITION = [
   "screen",
   "user",
   "and",
+  "not",
   "or",
 ] as const satisfies readonly Condition["condition"][];
 

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-not.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-not.ts
@@ -1,0 +1,62 @@
+import { html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import { any, array, assert, literal, object, optional } from "superstruct";
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import "../../../../../components/ha-form/ha-form";
+import type { HomeAssistant } from "../../../../../types";
+import type {
+  NotCondition,
+  Condition,
+  StateCondition,
+} from "../../../common/validate-condition";
+import "../ha-card-conditions-editor";
+
+const notConditionStruct = object({
+  condition: literal("not"),
+  conditions: optional(array(any())),
+});
+
+@customElement("ha-card-condition-not")
+export class HaCardConditionNot extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public condition!: NotCondition;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  public static get defaultConfig(): NotCondition {
+    return { condition: "not", conditions: [] };
+  }
+
+  protected static validateUIConfig(condition: StateCondition) {
+    return assert(condition, notConditionStruct);
+  }
+
+  protected render() {
+    return html`
+      <ha-card-conditions-editor
+        nested
+        .hass=${this.hass}
+        .conditions=${this.condition.conditions}
+        @value-changed=${this._valueChanged}
+      >
+      </ha-card-conditions-editor>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const conditions = ev.detail.value as Condition[];
+    const condition = {
+      ...this.condition,
+      conditions,
+    };
+    fireEvent(this, "value-changed", { value: condition });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-card-condition-not": HaCardConditionNot;
+  }
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7233,6 +7233,9 @@
               "or": {
                 "label": "Or"
               },
+              "not": {
+                "label": "Not"
+              },
               "and": {
                 "label": "And"
               }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add a 'Not' condition to the lovelace visibility conditions.

This is split from this PR: https://github.com/home-assistant/frontend/pull/26094


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
show_name: true
show_icon: true
type: button
entity: light.bathroom
visibility:
  - condition: not
    conditions:
      - condition: state
        entity: light.bathroom
        state: "on"
name: Show when off
```

<img width="1039" height="738" alt="image" src="https://github.com/user-attachments/assets/05d584aa-13e7-4915-a9fd-7f39e0d055a0" />


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://community.home-assistant.io/t/wth-why-isnt-there-a-not-operator-for-conditional-cards/810127
- Link to documentation pull request: Will put in one soon

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
