### PR TITLE
Add Mobile team and design has codeowner of the theme colors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,6 @@
 # Part of the frontend that mobile developper should review
 src/external_app/ @bgoncal @TimoPtr
 test/external_app/ @bgoncal @TimoPtr
+
+# Part of the frontend that mobile developper and designer should review
+src/resources/theme/color/ @bgoncal @marcinbauer85 @TimoPtr

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@ src/external_app/ @bgoncal @TimoPtr
 test/external_app/ @bgoncal @TimoPtr
 
 # Part of the frontend that mobile developper and designer should review
-src/resources/theme/color/ @bgoncal @marcinbauer85 @TimoPtr
+src/resources/theme/color/ @bgoncal @marcinbauer85 @TimoPtr @wendevlin


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Since we are sharing the same colors between the mobile applications and the frontend and Figma is not keeping history. In order to be notify of a Color change we should use the frontend as a source of truth. By making us codeowners we would be notified of any changes on the color so we can also if needed make the changes.

This will avoid using simple messages to notify of a change. I can already give an example where the Neutral colors were updated and I was not aware until I discuss with @marcinbauer85. We also spot a small typo in the core color and it would be nice that Bruno is aware of the fix when he gets back.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests