### PR TITLE
Fix typo in Neutral80 color

### DIFF
--- a/src/resources/theme/color/core.globals.ts
+++ b/src/resources/theme/color/core.globals.ts
@@ -32,7 +32,7 @@ export const coreColorStyles = css`
     --ha-color-neutral-50: #7a7a7a;
     --ha-color-neutral-60: #989898;
     --ha-color-neutral-70: #b1b1b1;
-    --ha-color-neutral-80: #b1b1b1;
+    --ha-color-neutral-80: #cccccc;
     --ha-color-neutral-90: #e6e6e6;
     --ha-color-neutral-95: #f3f3f3;
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The Neutral80 color has been updated since a typo has been introduced in Figma (it was the same as Neutral70). This PR this the value with the corrected one.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests