### PR TITLE
Revert "Add Mobile team and design has codeowner of the theme colors"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,3 @@
 # Part of the frontend that mobile developper should review
 src/external_app/ @bgoncal @TimoPtr
 test/external_app/ @bgoncal @TimoPtr
-
-# Part of the frontend that mobile developper and designer should review
-src/resources/theme/color/ @bgoncal @marcinbauer85 @TimoPtr @wendevlin


### PR DESCRIPTION
Reverts home-assistant/frontend#26428 because we need to discuss it what approach fits best.