### PR TITLE
Update `ha-spinner` component to webawesome

### DIFF
--- a/src/components/ha-spinner.ts
+++ b/src/components/ha-spinner.ts
@@ -1,8 +1,9 @@
-import Spinner from "@shoelace-style/shoelace/dist/components/spinner/spinner.component";
-import spinnerStyles from "@shoelace-style/shoelace/dist/components/spinner/spinner.styles";
-import type { PropertyValues } from "lit";
+import Spinner from "@awesome.me/webawesome/dist/components/spinner/spinner";
+import type { CSSResultGroup, PropertyValues } from "lit";
 import { css } from "lit";
 import { customElement, property } from "lit/decorators";
+
+import { StateSet } from "../resources/polyfills/stateset";
 
 @customElement("ha-spinner")
 export class HaSpinner extends Spinner {
@@ -32,21 +33,31 @@ export class HaSpinner extends Spinner {
     }
   }
 
-  static override styles = [
-    spinnerStyles,
-    css`
-      :host {
-        --indicator-color: var(
-          --ha-spinner-indicator-color,
-          var(--primary-color)
-        );
-        --track-color: var(--ha-spinner-divider-color, var(--divider-color));
-        --track-width: 4px;
-        --speed: 3.5s;
-        font-size: var(--ha-spinner-size, 48px);
-      }
-    `,
-  ];
+  attachInternals() {
+    const internals = super.attachInternals();
+    Object.defineProperty(internals, "states", {
+      value: new StateSet(this, internals.states),
+    });
+    return internals;
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      Spinner.styles,
+      css`
+        :host {
+          --indicator-color: var(
+            --ha-spinner-indicator-color,
+            var(--primary-color)
+          );
+          --track-color: var(--ha-spinner-divider-color, var(--divider-color));
+          --track-width: 4px;
+          --speed: 3.5s;
+          font-size: var(--ha-spinner-size, 48px);
+        }
+      `,
+    ];
+  }
 }
 
 declare global {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Swaps out to the web awesome component for `ha-spinner` 

### Testing

Not much difference in the styling, the spinner is less rounded by default. 

Tested on:
- Card to test sizes and themes below
- Initial HA frontend loading spinner
- Navigation between config pages
- Logbook
- History
- Media

**Large**:

https://github.com/user-attachments/assets/274e2913-1dda-4240-9e9b-85057aefb834

**Large (Dark theme)**:

https://github.com/user-attachments/assets/ce06a58b-810f-4309-ab3f-214614ebf5a6

**Medium**:

https://github.com/user-attachments/assets/a5d1f5b6-ad19-441b-9dd6-0cf6f3faa999

**Small**:

https://github.com/user-attachments/assets/33a608c8-e7d6-4d0c-b9ff-947cba9687d0

**Tiny**:

https://github.com/user-attachments/assets/6cc868f1-65e7-45f7-9cdc-b062a12d873d

**Default**:

https://github.com/user-attachments/assets/a2e21097-2568-4758-b0e8-f0714c12e714

**Themed (Changed primary color)**:

https://github.com/user-attachments/assets/e2b7bb55-566a-4d6f-a643-dda1c0b1688b

**Themed (Catpuccin Mocha)**:

https://github.com/user-attachments/assets/b2c66cb5-2ad5-4430-a28e-be540daf97d2

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #26456 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
