### PR TITLE
Added select all checkbox to backup add-on picker

### DIFF
--- a/src/panels/config/backup/components/ha-backup-addons-picker.ts
+++ b/src/panels/config/backup/components/ha-backup-addons-picker.ts
@@ -1,4 +1,4 @@
-import { mdiPuzzle } from "@mdi/js";
+import { mdiPuzzle, mdiCheckboxMultipleMarked } from "@mdi/js";
 import { LitElement, css, html } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -38,8 +38,25 @@ export class HaBackupAddonsPicker extends LitElement {
   );
 
   protected render() {
+    const allSelected =
+      this.addons?.length > 0 && this.value?.length === this.addons.length;
     return html`
       <div class="items">
+        <ha-formfield>
+          <ha-backup-formfield-label
+            slot="label"
+            .label=${this.hass?.localize?.(
+              "ui.components.subpage-data-table.select_all"
+            ) ?? ""}
+            .iconPath=${mdiCheckboxMultipleMarked}
+          ></ha-backup-formfield-label>
+          <ha-checkbox
+            id="select-all"
+            .checked=${allSelected}
+            @change=${this._selectAllChanged}
+            .disabled=${this.disabled}
+          ></ha-checkbox>
+        </ha-formfield>
         ${this._addons(this.addons).map(
           (item) => html`
             <ha-formfield>
@@ -69,12 +86,25 @@ export class HaBackupAddonsPicker extends LitElement {
   private _checkboxChanged(ev: Event) {
     ev.stopPropagation();
     let value = this.value ?? [];
-
     const checkbox = ev.currentTarget as HaCheckbox;
     if (checkbox.checked) {
-      value.push(checkbox.id);
+      if (!value.includes(checkbox.id)) {
+        value = [...value, checkbox.id];
+      }
     } else {
       value = value.filter((id) => id !== checkbox.id);
+    }
+    fireEvent(this, "value-changed", { value });
+  }
+
+  private _selectAllChanged(ev: Event) {
+    ev.stopPropagation();
+    const checkbox = ev.currentTarget as HaCheckbox;
+    let value: string[];
+    if (checkbox.checked) {
+      value = this.addons.map((addon) => addon.slug);
+    } else {
+      value = [];
     }
     fireEvent(this, "value-changed", { value });
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<sup>btw, this is my first contribution to frontend, so let me know if I did anything wrong <3</sup>
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Adds a select all checkbox to the backup add-on picker

Example use case:

<img width="553" height="816" alt="image" src="https://github.com/user-attachments/assets/a6a8b6e6-f235-4284-9729-615700451b0c" />
<img width="502" height="832" alt="image" src="https://github.com/user-attachments/assets/cb7b9ea8-5683-4449-bbf5-e10765d14393" />
<img width="415" height="832" alt="image" src="https://github.com/user-attachments/assets/9d84dee8-b32c-4e5d-9f93-303330c037f1" />

This way you don't have to manually check all the checkboxes in the list except the one add-on

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
