### PR TITLE
Show accurate state of show_header_toggle in entities card editor

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -24,6 +24,29 @@ import type {
 } from "../types";
 import type { EntitiesCardConfig } from "./types";
 
+export const computeShowHeaderToggle = <
+  T extends EntityConfig | LovelaceRowConfig,
+>(
+  config: EntitiesCardConfig,
+  entities: T[]
+): boolean => {
+  if (config.title !== undefined && config.show_header_toggle === undefined) {
+    // Default value is show toggle if we can at least toggle 2 entities.
+    let toggleable = 0;
+    for (const rowConf of entities) {
+      if (!("entity" in rowConf)) {
+        continue;
+      }
+      toggleable += Number(DOMAINS_TOGGLE.has(computeDomain(rowConf.entity)));
+      if (toggleable === 2) {
+        break;
+      }
+    }
+    return toggleable === 2;
+  }
+  return !!config.show_header_toggle;
+};
+
 @customElement("hui-entities-card")
 class HuiEntitiesCard extends LitElement implements LovelaceCard {
   public static async getConfigElement(): Promise<LovelaceCardEditor> {
@@ -110,23 +133,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
 
     this._config = config;
     this._configEntities = entities;
-    if (config.title !== undefined && config.show_header_toggle === undefined) {
-      // Default value is show toggle if we can at least toggle 2 entities.
-      let toggleable = 0;
-      for (const rowConf of entities) {
-        if (!("entity" in rowConf)) {
-          continue;
-        }
-        toggleable += Number(DOMAINS_TOGGLE.has(computeDomain(rowConf.entity)));
-        if (toggleable === 2) {
-          break;
-        }
-      }
-      this._showHeaderToggle = toggleable === 2;
-    } else {
-      this._showHeaderToggle = config.show_header_toggle;
-    }
-
+    this._showHeaderToggle = computeShowHeaderToggle(config, entities);
     if (this._config.header) {
       this._headerElement = createHeaderFooterElement(
         this._config.header

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -17,6 +17,7 @@ import {
   type,
   union,
 } from "superstruct";
+import memoizeOne from "memoize-one";
 import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { customType } from "../../../../common/structs/is-custom-type";
@@ -47,6 +48,8 @@ import type {
   SubElementEditorConfig,
 } from "../types";
 import { configElementStyle } from "./config-elements-style";
+import { computeShowHeaderToggle } from "../../cards/hui-entities-card";
+import { processConfigEntities } from "../../common/process-config-entities";
 
 const buttonEntitiesRowConfigStruct = object({
   type: literal("button"),
@@ -209,6 +212,16 @@ export class HuiEntitiesCardEditor
     this._configEntities = processEditorEntities(config.entities);
   }
 
+  private _showHeaderToggle = memoizeOne((config: EntitiesCardConfig) => {
+    if (config.show_header_toggle !== undefined) {
+      return config.show_header_toggle;
+    }
+    return computeShowHeaderToggle(
+      config,
+      processConfigEntities(config.entities)
+    );
+  });
+
   get _title(): string {
     return this._config!.title || "";
   }
@@ -264,7 +277,7 @@ export class HuiEntitiesCardEditor
             )}
           >
             <ha-switch
-              .checked=${this._config!.show_header_toggle !== false}
+              .checked=${this._showHeaderToggle(this._config)}
               .configValue=${"show_header_toggle"}
               @change=${this._valueChanged}
             ></ha-switch>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

If entities card show_header_toggle is not defined, the header uses dynamic logic to decide if it should be calculated. 

In the editor, we always showed it as `on` if undefined, so that would lead to the case where the switch was visibly `on`, but the header toggle was using dynamic logic and disabled, so if you wanted to turn it on you have to toggle off and then on again, which is a confusing UX. 

This fix the switch to reflect the current state of the header toggle, if the value is not defined in yaml. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17475
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
