### PR TITLE
Fix restrict-task-creation workflow

### DIFF
--- a/.github/workflows/restrict-task-creation.yml
+++ b/.github/workflows/restrict-task-creation.yml
@@ -9,7 +9,7 @@ jobs:
   check-authorization:
     runs-on: ubuntu-latest
     # Only run if this is a Task issue type (from the issue form)
-    if: github.event.issue.issue_type == 'Task'
+    if: github.event.issue.type.name == 'Task'
     steps:
       - name: Check if user is authorized
         uses: actions/github-script@v7


### PR DESCRIPTION
## Proposed change
Fix restrict-task-creation workflow by correctly using `type.name` of the `issue` object.

Same as:
- https://github.com/home-assistant/core/pull/150774 (which was confirmed working [here](https://github.com/home-assistant/core/issues/150777))


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
