### PR TITLE
Rename subentry

### DIFF
--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -42,6 +42,19 @@ export const getSubEntries = (hass: HomeAssistant, entry_id: string) =>
     entry_id,
   });
 
+export const renameSubEntry = (
+  hass: HomeAssistant,
+  entry_id: string,
+  subentry_id: string,
+  newTitle: string
+) =>
+  hass.callWS({
+    type: "config_entries/subentries/rename",
+    entry_id,
+    subentry_id,
+    newTitle,
+  });
+
 export const deleteSubEntry = (
   hass: HomeAssistant,
   entry_id: string,

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -42,17 +42,17 @@ export const getSubEntries = (hass: HomeAssistant, entry_id: string) =>
     entry_id,
   });
 
-export const renameSubEntry = (
+export const updateSubEntry = (
   hass: HomeAssistant,
   entry_id: string,
   subentry_id: string,
-  new_title: string
+  updatedValues: SubEntryMutableParams
 ) =>
   hass.callWS({
-    type: "config_entries/subentries/rename",
+    type: "config_entries/subentries/update",
     entry_id,
     subentry_id,
-    new_title,
+    ...updatedValues,
   });
 
 export const deleteSubEntry = (
@@ -71,6 +71,10 @@ export type ConfigEntryMutableParams = Partial<
     ConfigEntry,
     "title" | "pref_disable_new_entities" | "pref_disable_polling"
   >
+>;
+
+export type SubEntryMutableParams = Partial<
+  Pick<SubEntry, "title" | "unique_id">
 >;
 
 // https://github.com/home-assistant/core/blob/2286dea636fda001f03433ba14d7adbda43979e5/homeassistant/config_entries.py#L81

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -74,7 +74,7 @@ export type ConfigEntryMutableParams = Partial<
 >;
 
 export type SubEntryMutableParams = Partial<
-  Pick<SubEntry, "title" | "unique_id">
+  Pick<SubEntry, "title">
 >;
 
 // https://github.com/home-assistant/core/blob/2286dea636fda001f03433ba14d7adbda43979e5/homeassistant/config_entries.py#L81

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -73,9 +73,7 @@ export type ConfigEntryMutableParams = Partial<
   >
 >;
 
-export type SubEntryMutableParams = Partial<
-  Pick<SubEntry, "title">
->;
+export type SubEntryMutableParams = Partial<Pick<SubEntry, "title">>;
 
 // https://github.com/home-assistant/core/blob/2286dea636fda001f03433ba14d7adbda43979e5/homeassistant/config_entries.py#L81
 export const ERROR_STATES: ConfigEntry["state"][] = [

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -46,13 +46,13 @@ export const renameSubEntry = (
   hass: HomeAssistant,
   entry_id: string,
   subentry_id: string,
-  newTitle: string
+  new_title: string
 ) =>
   hass.callWS({
     type: "config_entries/subentries/rename",
     entry_id,
     subentry_id,
-    newTitle,
+    new_title,
   });
 
 export const deleteSubEntry = (

--- a/src/panels/config/integrations/ha-config-sub-entry-row.ts
+++ b/src/panels/config/integrations/ha-config-sub-entry-row.ts
@@ -224,9 +224,7 @@ class HaConfigSubEntryRow extends LitElement {
 
   private async _handleRenameSub(): Promise<void> {
     const newName = await showPromptDialog(this, {
-      title: this.hass.localize(
-        "ui.common.rename"
-      ),
+      title: this.hass.localize("ui.common.rename"),
       defaultValue: this.subEntry.title,
       inputLabel: this.hass.localize(
         "ui.panel.config.integrations.rename_input_label"

--- a/src/panels/config/integrations/ha-config-sub-entry-row.ts
+++ b/src/panels/config/integrations/ha-config-sub-entry-row.ts
@@ -12,7 +12,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import type { ConfigEntry, SubEntry } from "../../../data/config_entries";
-import { deleteSubEntry, renameSubEntry } from "../../../data/config_entries";
+import { deleteSubEntry, updateSubEntry } from "../../../data/config_entries";
 import type { DeviceRegistryEntry } from "../../../data/device_registry";
 import type { DiagnosticInfo } from "../../../data/diagnostics";
 import type { EntityRegistryEntry } from "../../../data/entity_registry";
@@ -235,11 +235,11 @@ class HaConfigSubEntryRow extends LitElement {
     if (newName === null) {
       return;
     }
-    await renameSubEntry(
+    await updateSubEntry(
       this.hass,
       this.entry.entry_id,
       this.subEntry.subentry_id,
-      newName
+      { title: newName }
     );
   }
 

--- a/src/panels/config/integrations/ha-config-sub-entry-row.ts
+++ b/src/panels/config/integrations/ha-config-sub-entry-row.ts
@@ -225,7 +225,7 @@ class HaConfigSubEntryRow extends LitElement {
   private async _handleRenameSub(): Promise<void> {
     const newName = await showPromptDialog(this, {
       title: this.hass.localize(
-        "ui.panel.config.integrations.rename_subentry_dialog"
+        "ui.common.rename"
       ),
       defaultValue: this.subEntry.title,
       inputLabel: this.hass.localize(

--- a/src/panels/config/integrations/ha-config-sub-entry-row.ts
+++ b/src/panels/config/integrations/ha-config-sub-entry-row.ts
@@ -227,7 +227,7 @@ class HaConfigSubEntryRow extends LitElement {
       title: this.hass.localize(
         "ui.panel.config.integrations.rename_subentry_dialog"
       ),
-      defaultValue: this.entry.title,
+      defaultValue: this.subEntry.title,
       inputLabel: this.hass.localize(
         "ui.panel.config.integrations.rename_input_label"
       ),

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5382,6 +5382,7 @@
           "integration_not_found": "Integration not found.",
           "details": "Integration details",
           "rename_dialog": "Edit the name of this config entry",
+          "rename_subentry_dialog": "Edit the name of this config subentry",
           "rename_input_label": "Entry name",
           "search": "Search integrations",
           "search_brand": "Search for a brand name",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5382,7 +5382,6 @@
           "integration_not_found": "Integration not found.",
           "details": "Integration details",
           "rename_dialog": "Edit the name of this config entry",
-          "rename_subentry_dialog": "Edit the name of this config subentry",
           "rename_input_label": "Entry name",
           "search": "Search integrations",
           "search_brand": "Search for a brand name",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add new functionality to rename subentry.
- Requires core PR with the new functionality for handling the websocket command: https://github.com/home-assistant/core/pull/150843

Add new menu item to rename subentry:
<img width="847" height="668" alt="image" src="https://github.com/user-attachments/assets/1fb1e38d-62e9-4ca5-b82f-4b4d9f77017a" />
Dialog popup when the rename menu item is clicked:
<img width="1118" height="681" alt="image" src="https://github.com/user-attachments/assets/561445c6-aeb0-4b0e-8031-7bef99c68c50" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
-

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/175
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
