### PR TITLE
Force dark-only themes to be in dark mode

### DIFF
--- a/src/panels/profile/ha-pick-theme-row.ts
+++ b/src/panels/profile/ha-pick-theme-row.ts
@@ -192,10 +192,12 @@ export class HaPickThemeRow extends LitElement {
   }
 
   private _supportsModeSelection(themeName: string): boolean {
-    if (!(themeName in this.hass.themes.themes)) {
+    const theme = this.hass.themes.themes[themeName];
+    if (!theme) {
       return false; // User's theme no longer exists
     }
-    return "modes" in this.hass.themes.themes[themeName];
+
+    return !!(theme.modes && "light" in theme.modes && "dark" in theme.modes);
   }
 
   private _handleDarkMode(ev: CustomEvent) {

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -97,8 +97,12 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         ? this.hass.themes.themes[themeName]
         : undefined;
 
-      if (selectedTheme && darkMode && !selectedTheme.modes) {
-        darkMode = false;
+      if (selectedTheme) {
+        if (!selectedTheme.modes || !("dark" in selectedTheme.modes)) {
+          darkMode = false;
+        } else if (!("light" in selectedTheme.modes)) {
+          darkMode = true;
+        }
       }
 
       themeSettings = { ...themeSettings, dark: darkMode };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
The current handling of some dark mode themes does not match the documentation.

Currently, if you define a theme with modes, and modes includes _only_ a dark mode key, we still show the light/dark option when selecting that theme. Selecting dark mode works correctly, but selecting light mode applies the theme in light mode. The documentation says:

>  Since this example theme only has a dark mode defined, this mode will automatically be used.

> This theme has both a light and a dark mode section. That tells the frontend to allow the user to choose which mode to use from the user profile.

This implies the auto/light/dark selector should _only_ be visible when a theme has both a light and dark mode. When the theme is dark only, it should be forced to be dark mode so long as that theme is selected. (Or if a theme has modes: light only, it should not show a selector and light mode should be forced.)

The only one weird thing that still seems off here is it's possible to set a dark-mode only theme as the default light mode theme, and it's possible to set a light-mode only theme as the default dark mode theme. If that is done, and the user selects "Use default theme" & "Light Mode", he will get a dark mode theme, or if he selectes "Use default theme" & "Dark mode", he will get a light mode theme. That seems kind of confusing, but seems to be the logical result of how the dark mode system is built, so I'm not sure if anything should be done there. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #26579
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
