### PR TITLE
Add show-automation-editor event for custom cards & panels

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -15,6 +15,16 @@ import { CONDITION_BUILDING_BLOCKS } from "./condition";
 export const AUTOMATION_DEFAULT_MODE: (typeof MODES)[number] = "single";
 export const AUTOMATION_DEFAULT_MAX = 10;
 
+declare global {
+  interface HASSDomEvents {
+    /**
+     * Dispatched to open the automation editor.
+     * Used by custom cards/panels to trigger the editor view.
+     */
+    "show-automation-editor": ShowAutomationEditorParams;
+  }
+}
+
 export interface AutomationEntity extends HassEntityBase {
   attributes: HassEntityAttributeBase & {
     id?: string;
@@ -545,4 +555,9 @@ export interface AutomationClipboard {
   trigger?: Trigger;
   condition?: Condition;
   action?: Action;
+}
+
+export interface ShowAutomationEditorParams {
+  data?: Partial<AutomationConfig>;
+  expanded?: boolean;
 }

--- a/src/panels/custom/ha-panel-custom.ts
+++ b/src/panels/custom/ha-panel-custom.ts
@@ -63,16 +63,6 @@ export class HaPanelCustom extends ReactiveElement {
     this._setProperties = setProperties;
   }
 
-  public connectedCallback() {
-    super.connectedCallback();
-    // Listen for requests from embedded iframe to show the automation editor
-    this.addEventListener("ha-show-automation-editor", (ev: Event) => {
-      ev.stopPropagation();
-      const detail = (ev as CustomEvent).detail || {};
-      showAutomationEditor(detail.config, detail.expanded);
-    });
-  }
-
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._cleanupPanel();

--- a/src/panels/custom/ha-panel-custom.ts
+++ b/src/panels/custom/ha-panel-custom.ts
@@ -5,8 +5,6 @@ import type { NavigateOptions } from "../../common/navigate";
 import { navigate } from "../../common/navigate";
 import { deepEqual } from "../../common/util/deep-equal";
 import type { CustomPanelInfo } from "../../data/panel_custom";
-import type { AutomationConfig } from "../../data/automation";
-import { showAutomationEditor } from "../../data/automation";
 import type { HomeAssistant, Route } from "../../types";
 import { createCustomPanelElement } from "../../util/custom-panel/create-custom-panel-element";
 import {
@@ -44,23 +42,6 @@ export class HaPanelCustom extends ReactiveElement {
   // instead of their iframe window.
   public navigate = (path: string, options?: NavigateOptions) =>
     navigate(path, options);
-
-  /**
-   * Open the automation editor in the main window and optionally prefill it.
-   *
-   * The automation editor reads its initial data from a module-scoped
-   * variable in the main application. Custom panels can call this method
-   * on `window.customPanel` to set the editor's initial data and open the
-   * editor prefilled.
-   *
-   * @param data Partial automation configuration to prefill the editor with.
-   * @param expanded If true, open the editor in expanded mode.
-   * @public
-   */
-  public showAutomationEditor = (
-    data?: Partial<AutomationConfig>,
-    expanded?: boolean
-  ) => showAutomationEditor(data, expanded);
 
   public registerIframe(initialize, setProperties) {
     initialize(this.panel, {

--- a/src/panels/custom/ha-panel-custom.ts
+++ b/src/panels/custom/ha-panel-custom.ts
@@ -45,10 +45,18 @@ export class HaPanelCustom extends ReactiveElement {
   public navigate = (path: string, options?: NavigateOptions) =>
     navigate(path, options);
 
-  // The automation editor reads its init data from the module-scoped
-  // `initialAutomationEditorData` in the main app. Expose this method so
-  // custom panels can set that data in the main context and open the editor
-  // prefilled.
+  /**
+   * Open the automation editor in the main window and optionally prefill it.
+   *
+   * The automation editor reads its initial data from a module-scoped
+   * variable in the main application. Custom panels can call this method
+   * on `window.customPanel` to set the editor's initial data and open the
+   * editor prefilled.
+   *
+   * @param data Partial automation configuration to prefill the editor with.
+   * @param expanded If true, open the editor in expanded mode.
+   * @public
+   */
   public showAutomationEditor = (
     data?: Partial<AutomationConfig>,
     expanded?: boolean

--- a/src/state/automation-editor-mixin.ts
+++ b/src/state/automation-editor-mixin.ts
@@ -1,0 +1,26 @@
+import type { PropertyValues } from "lit";
+import type { HASSDomEvent } from "../common/dom/fire_event";
+import {
+  showAutomationEditor,
+  type ShowAutomationEditorParams,
+} from "../data/automation";
+import type { Constructor } from "../types";
+import type { HassBaseEl } from "./hass-base-mixin";
+
+export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
+  class extends superClass {
+    protected firstUpdated(changedProps: PropertyValues) {
+      super.firstUpdated(changedProps);
+      this.addEventListener("show-automation-editor", (ev) =>
+        this._handleShowAutomationEditor(
+          ev as HASSDomEvent<ShowAutomationEditorParams>
+        )
+      );
+    }
+
+    private _handleShowAutomationEditor(
+      ev: HASSDomEvent<ShowAutomationEditorParams>
+    ) {
+      showAutomationEditor(ev.detail.data, ev.detail.expanded);
+    }
+  };

--- a/src/state/hass-element.ts
+++ b/src/state/hass-element.ts
@@ -8,6 +8,7 @@ import { HassBaseEl } from "./hass-base-mixin";
 import { loggingMixin } from "./logging-mixin";
 import { contextMixin } from "./context-mixin";
 import MoreInfoMixin from "./more-info-mixin";
+import AutomationEditorMixin from "./automation-editor-mixin";
 import ActionMixin from "./action-mixin";
 import NotificationMixin from "./notification-mixin";
 import { panelTitleMixin } from "./panel-title-mixin";
@@ -26,6 +27,7 @@ export class HassElement extends ext(HassBaseEl, [
   TranslationsMixin,
   StateDisplayMixin,
   MoreInfoMixin,
+  AutomationEditorMixin,
   ActionMixin,
   SidebarMixin,
   DisconnectToastMixin,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
~~Expose `showAutomationEditor(data?: Partial<AutomationConfig>, expanded?: boolean)` as a public method on the `ha-panel-custom`. This allows custom panels (iframes) to open the Automation Editor prefilled with data.~~

Add a new event for `show-automation-editor`. This allows custom cards & panels to open the Automation Editor prefilled with data.

Until now, only the core UI could open the automation editor prefilled. Custom panels (iframes) had no way to do this, because the editor initialization (initialAutomationEditorData) was only accessible inside the main app. By exposing showAutomationEditor, embedded panels can now trigger the same flow and hand over prefilled data.

Use case:
For the KNX integration we provide a Telegram Monitor. This tool shows how KNX devices on the network exchange messages with each other (e.g., a wall switch sending a telegram to a light actuator). We want to add a feature that lets the user create an automation directly from such a telegram, like so:

https://github.com/user-attachments/assets/9cb5b065-6cb3-4792-87e5-0a0f13bdb075

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
