### PR TITLE
Tile name with entity area

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -25,6 +25,7 @@ import type {
 } from "../../../../components/ha-form/types";
 import "../../../../components/ha-svg-icon";
 import type { HomeAssistant } from "../../../../types";
+import { getEntityEntryContext } from "../../../../common/entity/context/get_entity_context";
 import type {
   LovelaceCardFeatureConfig,
   LovelaceCardFeatureContext,
@@ -266,21 +267,12 @@ export class HuiTileCardEditor
     }
 
     const entityRegistry = this.hass.entities[entityId];
-
-    // Check if entity has direct area assignment
-    if (entityRegistry?.area_id) {
-      return true;
+    if (!entityRegistry) {
+      return false;
     }
 
-    // Check if entity has a device and that device has an area
-    if (entityRegistry?.device_id) {
-      const device = this.hass.devices[entityRegistry.device_id];
-      if (device?.area_id) {
-        return true;
-      }
-    }
-
-    return false;
+    const context = getEntityEntryContext(entityRegistry, this.hass);
+    return context.area !== null;
   }
 
   private _getEntityAreaId(entityId: string): string | null {
@@ -289,21 +281,12 @@ export class HuiTileCardEditor
     }
 
     const entityRegistry = this.hass.entities[entityId];
-
-    // Check if entity has direct area assignment
-    if (entityRegistry?.area_id) {
-      return entityRegistry.area_id;
+    if (!entityRegistry) {
+      return null;
     }
 
-    // Check if entity has a device and that device has an area
-    if (entityRegistry?.device_id) {
-      const device = this.hass.devices[entityRegistry.device_id];
-      if (device?.area_id) {
-        return device.area_id;
-      }
-    }
-
-    return null;
+    const context = getEntityEntryContext(entityRegistry, this.hass);
+    return context.area?.area_id || null;
   }
 
   protected render() {

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -105,7 +105,7 @@ export class HuiTileCardEditor
                 {
                   name: "name",
                   selector: { text: {} },
-                  disabled: useEntityAreaName,
+                  disabled: useEntityAreaName && entityHasArea,
                 },
                 {
                   name: "use_entity_area_name",
@@ -401,9 +401,6 @@ export class HuiTileCardEditor
           config.name = area.name;
         }
       }
-    } else if (config.use_entity_area_name === false) {
-      // When switching off, remove the name if it was set by the area
-      delete config.name;
     }
 
     fireEvent(this, "config-changed", { config });

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7780,7 +7780,8 @@
               "content_layout_options": {
                 "horizontal": "Horizontal",
                 "vertical": "Vertical"
-              }
+              },
+              "use_entity_area_name": "Use entity area name"
             },
             "vertical-stack": {
               "name": "Vertical stack",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

In the tile card editor, I propose to add a switch to set the tile name to the area name of the selected entity.

I guess it is a common use case to create tiles in a section for the same type of entity of different areas, this could help to speed up a little bit the tile configuration.

<img width="1042" height="442" alt="Capture d’écran du 2025-08-20 08-56-33" src="https://github.com/user-attachments/assets/5687f5d6-0eaa-459a-b446-a6f93ab11417" />

<img width="1042" height="442" alt="Capture d’écran du 2025-08-20 08-56-45" src="https://github.com/user-attachments/assets/56120a60-3536-4b9e-9ee9-14592d8b8c9f" />

Set the switch ON change the value of the name input field.
If the entity does not have area, the switch is set to OFF and disabled, the name input filed keep its previous value (behavior before this PR)

<img width="1042" height="442" alt="image" src="https://github.com/user-attachments/assets/f971a9a1-c330-433b-9435-ddd17f01ece6" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: tile
entity: switch.0xdc8e95fffe013356
icon: mdi:globe-light
name: Cuisine
features_position: bottom
vertical: false
use_entity_area_name: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: home-assistant/home-assistant.io/pull/40516

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
