### PR TITLE
Follow-up: revert ultimate fallback to undefined in computeEntityEntryName

### DIFF
--- a/src/common/entity/compute_entity_name.ts
+++ b/src/common/entity/compute_entity_name.ts
@@ -31,7 +31,7 @@ export const computeEntityEntryName = (
     entry.name ||
     ("original_name" in entry && entry.original_name != null
       ? String(entry.original_name)
-      : "");
+      : undefined);
 
   const device = entry.device_id ? hass.devices[entry.device_id] : undefined;
 

--- a/test/common/entity/compute_entity_name.test.ts
+++ b/test/common/entity/compute_entity_name.test.ts
@@ -159,4 +159,25 @@ describe("computeEntityEntryName", () => {
     expect(computeEntityEntryName(entry as any, hass as any)).toBe("2");
     vi.restoreAllMocks();
   });
+
+  it("returns undefined when entity has device but no name or original_name", () => {
+    vi.spyOn(computeDeviceNameModule, "computeDeviceName").mockReturnValue(
+      "Kitchen Device"
+    );
+
+    const entry = {
+      entity_id: "sensor.kitchen_sensor",
+      // No name property
+      // No original_name property
+      device_id: "dev1",
+    };
+    const hass = {
+      devices: { dev1: {} },
+      states: {},
+    };
+
+    // Should return undefined to maintain function contract
+    expect(computeEntityEntryName(entry as any, hass as any)).toBeUndefined();
+    vi.restoreAllMocks();
+  });
 });


### PR DESCRIPTION
## Proposed change

Follow-up to #26599 addressing maintainer feedback from @bramkragten.

Reverts the ultimate fallback from `""` to `undefined` to preserve the original function contract (`string | undefined`) and maintain consistency with existing test expectations.

The core fix (String coercion for numeric `original_name`) remains intact to prevent the crash in #25363.

**Added test case** to lock in the undefined behavior for entities with devices but no name/original_name, preventing future regressions.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml
# Not applicable - this is a function contract fix that maintains 
# existing behavior while preventing crashes
```

## Additional information

- This PR fixes or closes issue: -
- This PR is related to issue or discussion: #26599 (follow-up); original crash: #25363
- Link to documentation pull request: -

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!-- Thank you for contributing <3 -->

[docs-repository]: https://github.com/home-assistant/home-assistant.io