### PR TITLE
Add background opacity option to section styling

### DIFF
--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -4,6 +4,7 @@ import type { LovelaceStrategyConfig } from "./strategy";
 
 export interface LovelaceSectionStyleConfig {
   background_color?: string;
+  background_opacity?: number;
 }
 
 export interface LovelaceBaseSectionConfig {

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -95,7 +95,7 @@ export class HuiDialogEditSection extends LitElement {
                     },
                   },
                   disabled: !enableBackground,
-                }
+                },
               ],
             },
           ],

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -18,6 +18,7 @@ interface SettingsData {
   column_span?: number;
   background_type: "none" | "color";
   background_color?: number[];
+  background_opacity?: number;
 }
 
 @customElement("hui-section-settings-editor")
@@ -82,6 +83,19 @@ export class HuiDialogEditSection extends LitElement {
                   },
                   disabled: !enableBackground,
                 },
+                {
+                  name: "background_opacity",
+                  selector: {
+                    number: {
+                      min: 0,
+                      max: 100,
+                      step: 1,
+                      mode: "slider",
+                      unit_of_measurement: "%",
+                    },
+                  },
+                  disabled: !enableBackground,
+                }
               ],
             },
           ],
@@ -106,6 +120,7 @@ export class HuiDialogEditSection extends LitElement {
       background_color: this.config.style?.background_color
         ? hex2rgb(this.config.style?.background_color as any)
         : [],
+      background_opacity: this.config.style?.background_opacity || 100,
     };
 
     const schema = this._schema(
@@ -154,11 +169,13 @@ export class HuiDialogEditSection extends LitElement {
       newConfig.style = {
         ...newConfig.style,
         background_color: rgb2hex(newData.background_color as any),
+        background_opacity: newData.background_opacity,
       };
     } else {
       newConfig.style = {
         ...newConfig.style,
         background_color: undefined,
+        background_opacity: undefined,
       };
     }
 

--- a/src/panels/lovelace/sections/hui-grid-section.ts
+++ b/src/panels/lovelace/sections/hui-grid-section.ts
@@ -20,6 +20,7 @@ import "../components/hui-card-edit-mode";
 import { moveCard } from "../editor/config-util";
 import type { LovelaceCardPath } from "../editor/lovelace-path";
 import type { Lovelace } from "../types";
+import {hex2rgb} from "../../../common/color/convert-color";
 
 const CARD_SORTABLE_OPTIONS: HaSortableOptions = {
   delay: 100,
@@ -86,7 +87,10 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
       ? IMPORT_MODE_CARD_SORTABLE_OPTIONS
       : CARD_SORTABLE_OPTIONS;
 
-    const background = this._config.style?.background_color;
+    const backgroundOpacity = (this._config.style?.background_opacity || 100) / 100;
+    const background = this._config.style?.background_color
+      ? `rgba(${hex2rgb(this._config.style.background_color)}, ${backgroundOpacity})`
+      : undefined;
 
     return html`
       <ha-sortable

--- a/src/panels/lovelace/sections/hui-grid-section.ts
+++ b/src/panels/lovelace/sections/hui-grid-section.ts
@@ -20,7 +20,7 @@ import "../components/hui-card-edit-mode";
 import { moveCard } from "../editor/config-util";
 import type { LovelaceCardPath } from "../editor/lovelace-path";
 import type { Lovelace } from "../types";
-import {hex2rgb} from "../../../common/color/convert-color";
+import { hex2rgb } from "../../../common/color/convert-color";
 
 const CARD_SORTABLE_OPTIONS: HaSortableOptions = {
   delay: 100,
@@ -87,7 +87,8 @@ export class GridSection extends LitElement implements LovelaceSectionElement {
       ? IMPORT_MODE_CARD_SORTABLE_OPTIONS
       : CARD_SORTABLE_OPTIONS;
 
-    const backgroundOpacity = (this._config.style?.background_opacity || 100) / 100;
+    const backgroundOpacity =
+      (this._config.style?.background_opacity || 100) / 100;
     const background = this._config.style?.background_color
       ? `rgba(${hex2rgb(this._config.style.background_color)}, ${backgroundOpacity})`
       : undefined;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7262,7 +7262,8 @@
               "styling": "Styling",
               "background_type": "Background type",
               "background_type_color_option": "Color",
-              "background_color": "Background color"
+              "background_color": "Background color",
+              "background_opacity": "Background opacity"
             },
             "visibility": {
               "explanation": "The section will be shown when ALL conditions below are fulfilled. If no conditions are set, the section will always be shown."


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add background opacity option to the recently introduced section background styling (https://github.com/home-assistant/frontend/pull/26369)

| <img width="585" height="513" alt="image" src="https://github.com/user-attachments/assets/40fa3e98-65b5-4bdb-bcc9-388378b87dba" /> | <img width="622" height="615" alt="image" src="https://github.com/user-attachments/assets/00ded2e7-0467-42b4-9314-66f64f5c172c" /> |
|:-:|:-:|

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
