### PR TITLE
Use dedicated translation key for none option in section background type

### DIFF
--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -63,7 +63,9 @@ export class HuiDialogEditSection extends LitElement {
                       options: [
                         {
                           value: "none",
-                          label: this.hass.localize("ui.common.none"),
+                          label: this.hass.localize(
+                            "ui.panel.lovelace.editor.edit_section.settings.background_type_none_option"
+                          ),
                         },
                         {
                           value: "color",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7261,6 +7261,7 @@
               "column_span_helper": "Larger sections will be made smaller to fit the display. (e.g. on mobile devices)",
               "styling": "Styling",
               "background_type": "Background type",
+              "background_type_none_option": "None",
               "background_type_color_option": "Color",
               "background_color": "Background color"
             },


### PR DESCRIPTION
## Proposed change
Address translator feedback from https://github.com/home-assistant/frontend/pull/26369#issuecomment-3213992789 and make a dedicated translation key for the none option in section background type.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
