### PR TITLE
Use `rgb(from ...)`

### DIFF
--- a/build-scripts/babel-plugins/rgb-from-plugin.cjs
+++ b/build-scripts/babel-plugins/rgb-from-plugin.cjs
@@ -1,0 +1,35 @@
+module.exports = function rgbFromTransformPlugin({ types: t }) {
+  return {
+    name: "rgb-from-transform",
+    visitor: {
+      TaggedTemplateExpression(path) {
+        // Only process css tagged templates
+        if (!t.isIdentifier(path.node.tag, { name: "css" })) return;
+
+        // Get build configuration from babel options
+        const { latestBuild } = this.opts || {};
+
+        // Only transform for legacy builds
+        if (latestBuild) return;
+
+        // Process each template literal part
+        path.node.quasi.quasis.forEach((quasi) => {
+          let css = quasi.value.raw;
+
+          // Legacy build: rgb(from var(--color) r g b / 0.5) → rgba(var(--rgb-color), 0.5)
+          css = css.replace(
+            /rgb\(\s*from\s+var\((--[^)]+)\)\s+r\s+g\s+b\s*\/\s*([0-9.]+)\s*\)/g,
+            (_, colorVar, opacity) => {
+              const rgbVar = colorVar.replace("--", "--rgb-");
+              return `rgba(var(${rgbVar}), ${opacity})`;
+            }
+          );
+
+          if (css !== quasi.value.raw) {
+            quasi.value.raw = quasi.value.cooked = css;
+          }
+        });
+      },
+    },
+  };
+};

--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -119,6 +119,8 @@ module.exports.babelOptions = ({
         ignoreModuleNotFound: true,
       },
     ],
+    // Transform rgb(from ...) syntax for legacy builds
+    [path.join(BABEL_PLUGINS, "rgb-from-plugin.cjs"), { latestBuild }],
     // Minify template literals for production
     isProdBuild && [
       "template-html-minifier",

--- a/hassio/src/backups/hassio-backups.ts
+++ b/hassio/src/backups/hassio-backups.ts
@@ -381,7 +381,8 @@ export class HassioBackups extends LitElement {
           justify-content: space-between;
           align-items: center;
           height: 58px;
-          border-bottom: 1px solid rgba(var(--rgb-primary-text-color), 0.12);
+          border-bottom: 1px solid
+            rgb(from var(--primary-text-color) r g b / 0.12);
         }
         .header-toolbar {
           display: flex;

--- a/src/components/chips/ha-filter-chip.ts
+++ b/src/components/chips/ha-filter-chip.ts
@@ -26,9 +26,8 @@ export class HaFilterChip extends FilterChip {
         --md-sys-color-on-secondary-container: var(--primary-text-color);
         --md-filter-chip-container-shape: 16px;
         --md-filter-chip-outline-color: var(--outline-color);
-        --md-filter-chip-selected-container-color: rgba(
-          var(--rgb-primary-text-color),
-          0.15
+        --md-filter-chip-selected-container-color: rgb(
+          from var(--primary-text-color) r g b / 0.15
         );
       }
     `,

--- a/src/components/chips/ha-input-chip.ts
+++ b/src/components/chips/ha-input-chip.ts
@@ -21,9 +21,8 @@ export class HaInputChip extends InputChip {
         --md-sys-color-on-secondary-container: var(--primary-text-color);
         --md-input-chip-container-shape: 16px;
         --md-input-chip-outline-color: var(--outline-color);
-        --md-input-chip-selected-container-color: rgba(
-          var(--rgb-primary-text-color),
-          0.15
+        --md-input-chip-selected-container-color: rgb(
+          from var(--primary-text-color) r g b / 0.15
         );
         --ha-input-chip-selected-container-opacity: 1;
         --md-input-chip-label-text-font: Roboto, sans-serif;

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -1064,7 +1064,7 @@ export class HaDataTable extends LitElement {
         }
 
         .mdc-data-table__row--selected {
-          background-color: rgba(var(--rgb-primary-color), 0.04);
+          background-color: rgb(from var(--primary-color) r g b / 0.04);
         }
 
         .mdc-data-table__row {
@@ -1087,7 +1087,7 @@ export class HaDataTable extends LitElement {
         .mdc-data-table__row.clickable:not(
             .mdc-data-table__row--selected
           ):hover {
-          background-color: rgba(var(--rgb-primary-text-color), 0.04);
+          background-color: rgb(from var(--primary-text-color) r g b / 0.04);
         }
 
         .mdc-data-table__header-cell {

--- a/src/components/ha-combo-box.ts
+++ b/src/components/ha-combo-box.ts
@@ -30,7 +30,7 @@ registerStyles(
       padding: 0 !important;
     }
     :host([focused]:not([disabled])) {
-      background-color: rgba(var(--rgb-primary-text-color, 0, 0, 0), 0.12);
+      background-color: rgb(from var(--primary-text-color) r g b / 0.12);
     }
     :host([selected]:not([disabled])) {
       background-color: transparent;

--- a/src/components/ha-icon-button-group.ts
+++ b/src/components/ha-icon-button-group.ts
@@ -22,7 +22,7 @@ export class HaIconButtonGroup extends LitElement {
       padding: 0;
     }
     ::slotted(.separator) {
-      background-color: rgba(var(--rgb-primary-text-color), 0.15);
+      background-color: rgb(from var(--primary-text-color) r g b / 0.15);
       width: 1px;
       margin: 0 1px;
       height: 40px;

--- a/src/components/ha-items-display-editor.ts
+++ b/src/components/ha-items-display-editor.ts
@@ -394,8 +394,8 @@ export class HaItemDisplayEditor extends LitElement {
     }
     ha-md-list-item.drag-selected {
       box-shadow:
-        0px 0px 8px 4px rgba(var(--rgb-accent-color), 0.8),
-        inset 0px 2px 8px 4px rgba(var(--rgb-accent-color), 0.4);
+        0px 0px 8px 4px rgb(from var(--accent-color) r g b / 0.8),
+        inset 0px 2px 8px 4px rgb(from var(--accent-color) r g b / 0.4);
       border-radius: 8px;
     }
     ha-md-list-item ha-icon-button {

--- a/src/components/ha-label.ts
+++ b/src/components/ha-label.ts
@@ -21,9 +21,8 @@ class HaLabel extends LitElement {
         :host {
           --ha-label-text-color: var(--primary-text-color);
           --ha-label-icon-color: var(--primary-text-color);
-          --ha-label-background-color: rgba(
-            var(--rgb-primary-text-color),
-            0.15
+          --ha-label-background-color: rgb(
+            from var(--primary-text-color) r g b / 0.15
           );
           --ha-label-background-opacity: 1;
           border: 1px solid var(--outline-color);

--- a/src/components/ha-md-menu-item.ts
+++ b/src/components/ha-md-menu-item.ts
@@ -18,9 +18,8 @@ export class HaMdMenuItem extends MenuItemEl {
         --md-sys-color-surface: var(--card-background-color);
         --md-sys-color-on-surface: var(--primary-text-color);
         --md-sys-color-on-surface-variant: var(--secondary-text-color);
-        --md-sys-color-secondary-container: rgba(
-          var(--rgb-primary-color),
-          0.15
+        --md-sys-color-secondary-container: rgb(
+          from var(--primary-color) r g b / 0.15
         );
         --md-sys-color-on-secondary-container: var(--text-primary-color);
         --mdc-icon-size: 16px;

--- a/src/components/ha-qr-code.ts
+++ b/src/components/ha-qr-code.ts
@@ -60,25 +60,23 @@ export class HaQrCode extends LitElement {
         changedProperties.has("centerImage"))
     ) {
       const computedStyles = getComputedStyle(this);
-      const textRgb = computedStyles.getPropertyValue(
-        "--rgb-primary-text-color"
-      );
-      const backgroundRgb = computedStyles.getPropertyValue(
-        "--rgb-card-background-color"
+      const textColor = computedStyles.getPropertyValue("--primary-text-color");
+      const backgroundColor = computedStyles.getPropertyValue(
+        "--card-background-color"
       );
       const textHex = rgb2hex(
-        textRgb.split(",").map((a) => parseInt(a, 10)) as [
-          number,
-          number,
-          number,
-        ]
+        textColor
+          .split("(")[1]
+          .split(")")[0]
+          .split(",")
+          .map((a) => parseInt(a, 10)) as [number, number, number]
       );
       const backgroundHex = rgb2hex(
-        backgroundRgb.split(",").map((a) => parseInt(a, 10)) as [
-          number,
-          number,
-          number,
-        ]
+        backgroundColor
+          .split("(")[1]
+          .split(")")[0]
+          .split(",")
+          .map((a) => parseInt(a, 10)) as [number, number, number]
       );
 
       QRCode.toCanvas(canvas, this.data, {

--- a/src/components/ha-sortable.ts
+++ b/src/components/ha-sortable.ts
@@ -110,7 +110,7 @@ export class HaSortable extends LitElement {
 
         .sortable-ghost {
           box-shadow: 0 0 0 2px var(--primary-color);
-          background: rgba(var(--rgb-primary-color), 0.25);
+          background: rgb(from var(--primary-color) r g b / 0.25);
           border-radius: 4px;
           opacity: 0.4;
         }

--- a/src/components/ha-sub-menu.ts
+++ b/src/components/ha-sub-menu.ts
@@ -21,9 +21,8 @@ export class HaSubMenu extends SubMenu {
         --md-sys-color-surface: var(--card-background-color);
         --md-sys-color-on-surface: var(--primary-text-color);
         --md-sys-color-on-surface-variant: var(--secondary-text-color);
-        --md-sys-color-secondary-container: rgba(
-          var(--rgb-primary-color),
-          0.15
+        --md-sys-color-secondary-container: rgb(
+          from var(--primary-color) r g b / 0.15
         );
         --md-sys-color-on-secondary-container: var(--text-primary-color);
         --mdc-icon-size: 16px;

--- a/src/components/ha-suggest-with-ai-button.ts
+++ b/src/components/ha-suggest-with-ai-button.ts
@@ -173,22 +173,22 @@ export class HaSuggestWithAIButton extends LitElement {
     }
 
     ha-assist-chip.error {
-      box-shadow: 0 0 12px 4px rgba(var(--rgb-error-color), 0.8);
+      box-shadow: 0 0 12px 4px rgb(from var(--error-color) r g b / 0.8);
     }
 
     ha-assist-chip.done {
-      box-shadow: 0 0 12px 4px rgba(var(--rgb-primary-color), 0.8);
+      box-shadow: 0 0 12px 4px rgb(from var(--primary-color) r g b / 0.8);
     }
 
     @keyframes pulse-glow {
       0% {
-        box-shadow: 0 0 0 0 rgba(var(--rgb-primary-color), 0);
+        box-shadow: 0 0 0 0 rgb(from var(--primary-color) r g b / 0);
       }
       50% {
-        box-shadow: 0 0 8px 2px rgba(var(--rgb-primary-color), 0.6);
+        box-shadow: 0 0 8px 2px rgb(from var(--primary-color) r g b / 0.6);
       }
       100% {
-        box-shadow: 0 0 0 0 rgba(var(--rgb-primary-color), 0);
+        box-shadow: 0 0 0 0 rgb(from var(--primary-color) r g b / 0);
       }
     }
   `;

--- a/src/components/map/ha-map.ts
+++ b/src/components/map/ha-map.ts
@@ -742,7 +742,7 @@ export class HaMap extends ReactiveElement {
     .marker-cluster div {
       background-clip: padding-box;
       background-color: var(--primary-color);
-      border: 3px solid rgba(var(--rgb-primary-color), 0.2);
+      border: 3px solid rgb(from var(--primary-color) r g b / 0.2);
       width: 32px;
       height: 32px;
       border-radius: 20px;

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -1171,7 +1171,7 @@ export class HaMediaPlayerBrowse extends LitElement {
         }
 
         .child .play.can_expand {
-          background-color: rgba(var(--rgb-card-background-color), 0.5);
+          background-color: rgb(from var(--card-background-color) r g b / 0.5);
           top: auto;
           bottom: 0px;
           right: 8px;
@@ -1210,7 +1210,7 @@ export class HaMediaPlayerBrowse extends LitElement {
         ha-list-item .graphic .play {
           opacity: 0;
           transition: all 0.5s;
-          background-color: rgba(var(--rgb-card-background-color), 0.5);
+          background-color: rgb(from var(--card-background-color) r g b / 0.5);
           border-radius: 50%;
           --mdc-icon-button-size: 40px;
         }
@@ -1347,7 +1347,7 @@ export class HaMediaPlayerBrowse extends LitElement {
           bottom: 0px;
           right: -24px;
           --mdc-fab-box-shadow: none;
-          --mdc-theme-secondary: rgba(var(--rgb-primary-color), 0.5);
+          --mdc-theme-secondary: rgb(from var(--primary-color) r g b / 0.5);
         }
 
         lit-virtualizer {

--- a/src/components/trace/hat-script-graph.ts
+++ b/src/components/trace/hat-script-graph.ts
@@ -722,8 +722,8 @@ export class HatScriptGraph extends LitElement {
         --track-clr: var(--track-color, var(--accent-color));
         --hover-clr: var(--hover-color, var(--primary-color));
         --disabled-clr: var(--disabled-color, var(--disabled-text-color));
-        --disabled-active-clr: rgba(var(--rgb-primary-color), 0.5);
-        --disabled-hover-clr: rgba(var(--rgb-primary-color), 0.7);
+        --disabled-active-clr: rgb(from var(--primary-color) r g b / 0.5);
+        --disabled-hover-clr: rgb(from var(--primary-color) r g b / 0.7);
         --default-trigger-color: 3, 169, 244;
         --rgb-trigger-color: var(--trigger-color, var(--default-trigger-color));
         --background-clr: var(--background-color, white);

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -745,7 +745,7 @@ export class MoreInfoDialog extends LitElement {
 
         .title button.breadcrumb:focus-visible,
         .title button.breadcrumb:hover {
-          background-color: rgba(var(--rgb-secondary-text-color), 0.08);
+          background-color: rgb(from var(--secondary-text-color) r g b / 0.08);
         }
       `,
     ];

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -825,7 +825,7 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
     }
 
     .selection-bar {
-      background: rgba(var(--rgb-primary-color), 0.1);
+      background: rgb(from var(--primary-color) r g b / 0.1);
       width: 100%;
       height: 100%;
       display: flex;

--- a/src/panels/config/cloud/account/dialog-cloud-support-package.ts
+++ b/src/panels/config/cloud/account/dialog-cloud-support-package.ts
@@ -157,7 +157,7 @@ export class DialogSupportPackage extends LitElement {
     }
 
     table > tbody > tr:nth-child(odd) {
-      background-color: rgba(var(--rgb-primary-text-color), 0.04);
+      background-color: rgb(from var(--primary-text-color) r g b / 0.04);
     }
 
     table > tbody > tr > td {
@@ -170,7 +170,7 @@ export class DialogSupportPackage extends LitElement {
     }
 
     table > tbody > tr:hover {
-      background-color: rgba(var(--rgb-primary-text-color), 0.08);
+      background-color: rgb(from var(--primary-text-color) r g b / 0.08);
     }
 
     tr {

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -1055,10 +1055,10 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
           padding: 0;
         }
         .discovered {
-          --md-list-container-color: rgba(var(--rgb-success-color), 0.2);
+          --md-list-container-color: rgb(from var(--success-color) r g b / 0.2);
         }
         .attention {
-          --md-list-container-color: rgba(var(--rgb-warning-color), 0.2);
+          --md-list-container-color: rgb(from var(--warning-color) r g b / 0.2);
         }
         ha-md-list-item {
           --md-list-item-top-space: 4px;

--- a/src/panels/config/tags/tag-image.ts
+++ b/src/panels/config/tags/tag-image.ts
@@ -66,13 +66,13 @@ export class HaTagImage extends LitElement {
     }
     @keyframes glow {
       0% {
-        box-shadow: 0px 0px 24px 0px rgba(var(--rgb-primary-color), 0);
+        box-shadow: 0px 0px 24px 0px rgb(from var(--primary-color) r g b / 0);
       }
       10% {
-        box-shadow: 0px 0px 24px 0px rgba(var(--rgb-primary-color), 1);
+        box-shadow: 0px 0px 24px 0px rgb(from var(--primary-color) r g b / 1);
       }
       100% {
-        box-shadow: 0px 0px 24px 0px rgba(var(--rgb-primary-color), 0);
+        box-shadow: 0px 0px 24px 0px rgb(from var(--primary-color) r g b / 0);
       }
     }
   `;

--- a/src/panels/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/developer-tools/statistics/developer-tools-statistics.ts
@@ -757,7 +757,7 @@ class HaPanelDevStatistics extends KeyboardShortcutMixin(LitElement) {
         }
 
         .selection-bar {
-          background: rgba(var(--rgb-primary-color), 0.1);
+          background: rgb(from var(--primary-color) r g b / 0.1);
           width: 100%;
           display: flex;
           align-items: center;

--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -476,7 +476,9 @@ class PanelEnergy extends LitElement {
           padding-left: 32px;
           padding-inline-start: 32px;
           padding-inline-end: initial;
-          --disabled-text-color: rgba(var(--rgb-text-primary-color), 0.5);
+          --disabled-text-color: rgb(
+            from var(--text-primary-color) r g b / 0.5
+          );
           direction: var(--direction);
           --date-range-picker-max-height: calc(100vh - 80px);
         }

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -620,7 +620,7 @@ class HaLogbookRenderer extends LitElement {
         }
 
         .entry:hover {
-          background-color: rgba(var(--rgb-primary-text-color), 0.04);
+          background-color: rgb(from var(--primary-text-color) r g b / 0.04);
         }
 
         .narrow:not(.no-icon) .time {

--- a/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
@@ -1166,7 +1166,7 @@ export class HuiEnergySourcesTableCard
         text-align: var(--float-start);
       }
       .mdc-data-table__row:not(.mdc-data-table__row--selected):hover {
-        background-color: rgba(var(--rgb-primary-text-color), 0.04);
+        background-color: rgb(from var(--primary-text-color) r g b / 0.04);
       }
       .clickable {
         cursor: pointer;

--- a/src/resources/codemirror.ts
+++ b/src/resources/codemirror.ts
@@ -72,15 +72,15 @@ export const haTheme = EditorView.theme({
   },
 
   ".cm-selectionBackground, ::selection": {
-    backgroundColor: "rgba(var(--rgb-primary-color), 0.1)",
+    backgroundColor: "rgb(from var(--primary-color) r g b / 0.1)",
   },
 
   "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground": {
-    backgroundColor: "rgba(var(--rgb-primary-color), 0.2)",
+    backgroundColor: "rgb(from var(--primary-color) r g b / 0.2)",
   },
 
   ".cm-activeLine": {
-    backgroundColor: "rgba(var(--rgb-secondary-text-color), 0.1)",
+    backgroundColor: "rgb(from var(--secondary-text-color) r g b / 0.1)",
   },
 
   ".cm-scroller": { outline: "none" },
@@ -176,15 +176,15 @@ export const haTheme = EditorView.theme({
   },
 
   ".cm-selectionMatch": {
-    backgroundColor: "rgba(var(--rgb-primary-color), 0.1)",
+    backgroundColor: "rgb(from var(--primary-color) r g b / 0.1)",
   },
 
   ".cm-searchMatch": {
-    backgroundColor: "rgba(var(--rgb-accent-color), .2)",
-    outline: "1px solid rgba(var(--rgb-accent-color), .4)",
+    backgroundColor: "rgb(from var(--accent-color) r g b / .2)",
+    outline: "1px solid rgb(from var(--accent-color) r g b / .4)",
   },
   ".cm-searchMatch.selected": {
-    backgroundColor: "rgba(var(--rgb-accent-color), .4)",
+    backgroundColor: "rgb(from var(--accent-color) r g b / .4)",
     outline: "1px solid var(--accent-color)",
   },
 

--- a/src/resources/theme/color/color.globals.ts
+++ b/src/resources/theme/color/color.globals.ts
@@ -196,7 +196,7 @@ export const colorStyles = css`
     --sidebar-background-color: var(--card-background-color);
     --sidebar-selected-text-color: var(--primary-color);
     --sidebar-selected-icon-color: var(--primary-color);
-    --sidebar-icon-color: rgba(var(--rgb-primary-text-color), 0.6);
+    --sidebar-icon-color: rgb(from var(--primary-text-color) r g b / 0.6);
     --switch-checked-color: var(--primary-color);
     --switch-checked-button-color: var(
       --switch-checked-color,
@@ -212,7 +212,7 @@ export const colorStyles = css`
     --slider-secondary-color: var(--light-primary-color);
     --slider-track-color: var(--scrollbar-thumb-color);
     --label-badge-background-color: var(--card-background-color);
-    --label-badge-text-color: rgba(var(--rgb-primary-text-color), 0.8);
+    --label-badge-text-color: rgb(from var(--primary-text-color) r g b / 0.8);
     --table-header-background-color: var(--input-fill-color);
     --table-row-background-color: var(--primary-background-color);
     --table-row-alternative-background-color: var(--secondary-background-color);
@@ -236,9 +236,13 @@ export const colorStyles = css`
     --app-header-text-color: var(--text-primary-color);
     --app-header-background-color: var(--primary-color);
     --app-theme-color: var(--app-header-background-color);
-    --mdc-checkbox-unchecked-color: rgba(var(--rgb-primary-text-color), 0.54);
+    --mdc-checkbox-unchecked-color: rgb(
+      from var(--primary-text-color) r g b / 0.54
+    );
     --mdc-checkbox-disabled-color: var(--disabled-text-color);
-    --mdc-radio-unchecked-color: rgba(var(--rgb-primary-text-color), 0.54);
+    --mdc-radio-unchecked-color: rgb(
+      from var(--primary-text-color) r g b / 0.54
+    );
     --mdc-radio-disabled-color: var(--disabled-text-color);
     --mdc-tab-text-label-color-default: var(--primary-text-color);
     --mdc-button-disabled-ink-color: var(--disabled-text-color);
@@ -283,15 +287,13 @@ export const colorStyles = css`
     --mdc-select-disabled-ink-color: var(--input-disabled-ink-color);
     --mdc-select-dropdown-icon-color: var(--input-dropdown-icon-color);
     --mdc-select-disabled-dropdown-icon-color: var(--input-disabled-ink-color);
-    --ha-assist-chip-filled-container-color: rgba(
-      var(--rgb-primary-text-color),
-      0.15
+    --ha-assist-chip-filled-container-color: rgb(
+      from var(--primary-text-color) r g b / 0.15
     );
-    --ha-assist-chip-active-container-color: rgba(
-      var(--rgb-primary-color),
-      0.15
+    --ha-assist-chip-active-container-color: rgb(
+      from var(--primary-color) r g b / 0.15
     );
-    --chip-background-color: rgba(var(--rgb-primary-text-color), 0.15);
+    --chip-background-color: rgb(from var(--primary-text-color) r g b / 0.15);
 
     /* Vaadin */
     --material-body-text-color: var(--primary-text-color);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
It's now possible to natively make a color, even defined in a variable, transparent using `rgb(from var(--color) r g b / 0.5)`. This has many benefits, including using a single source of truth and avoiding cluttery `--rgb-color` variables, and works on all "modern" browsers. This PR doesn't remove the `--rgb` variables, as they're still needed by third party cards and old browsers, but it switches to using `rgb(from ...)` in "modern" environments.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

None

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
