### PR TITLE
Add collapse/expand all for automations

### DIFF
--- a/src/components/ha-selector/ha-selector-action.ts
+++ b/src/components/ha-selector/ha-selector-action.ts
@@ -1,7 +1,7 @@
 import { consume, ContextProvider } from "@lit/context";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fullEntitiesContext } from "../../data/context";
 import {
@@ -13,6 +13,7 @@ import { migrateAutomationAction } from "../../data/script";
 import type { ActionSelector } from "../../data/selector";
 import { SubscribeMixin } from "../../mixins/subscribe-mixin";
 import "../../panels/config/automation/action/ha-automation-action";
+import type HaAutomationAction from "../../panels/config/automation/action/ha-automation-action";
 import type { HomeAssistant } from "../../types";
 
 @customElement("ha-selector-action")
@@ -34,6 +35,9 @@ export class HaActionSelector extends SubscribeMixin(LitElement) {
   _entityReg: EntityRegistryEntry[] | undefined;
 
   @state() private _entitiesContext;
+
+  @query("ha-automation-action")
+  private _actionElement?: HaAutomationAction;
 
   protected hassSubscribeRequiredHostProps = ["_entitiesContext"];
 
@@ -59,6 +63,14 @@ export class HaActionSelector extends SubscribeMixin(LitElement) {
         this._entitiesContext.setValue(entities);
       }),
     ];
+  }
+
+  public expandAll() {
+    this._actionElement?.expandAll();
+  }
+
+  public collapseAll() {
+    this._actionElement?.collapseAll();
   }
 
   protected render() {

--- a/src/components/ha-selector/ha-selector-condition.ts
+++ b/src/components/ha-selector/ha-selector-condition.ts
@@ -1,8 +1,9 @@
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, query } from "lit/decorators";
 import type { Condition } from "../../data/automation";
 import type { ConditionSelector } from "../../data/selector";
 import "../../panels/config/automation/condition/ha-automation-condition";
+import type HaAutomationCondition from "../../panels/config/automation/condition/ha-automation-condition";
 import type { HomeAssistant } from "../../types";
 
 @customElement("ha-selector-condition")
@@ -19,6 +20,9 @@ export class HaConditionSelector extends LitElement {
 
   @property({ type: Boolean, reflect: true }) public disabled = false;
 
+  @query("ha-automation-condition")
+  private _conditionElement?: HaAutomationCondition;
+
   protected render() {
     return html`
       ${this.label ? html`<label>${this.label}</label>` : nothing}
@@ -30,6 +34,14 @@ export class HaConditionSelector extends LitElement {
         .optionsInSidebar=${!!this.selector.condition?.optionsInSidebar}
       ></ha-automation-condition>
     `;
+  }
+
+  public expandAll() {
+    this._conditionElement?.expandAll();
+  }
+
+  public collapseAll() {
+    this._conditionElement?.collapseAll();
   }
 
   static styles = css`

--- a/src/data/action.ts
+++ b/src/data/action.ts
@@ -91,6 +91,15 @@ export const isService = (key: string | undefined): boolean | undefined =>
 export const getService = (key: string): string =>
   key.substring(SERVICE_PREFIX.length);
 
+export const COLLAPSIBLE_ACTION_ELEMENTS = [
+  "ha-automation-action-choose",
+  "ha-automation-action-condition",
+  "ha-automation-action-if",
+  "ha-automation-action-parallel",
+  "ha-automation-action-repeat",
+  "ha-automation-action-sequence",
+];
+
 export const ACTION_BUILDING_BLOCKS = [
   "choose",
   "if",

--- a/src/data/condition.ts
+++ b/src/data/condition.ts
@@ -52,3 +52,9 @@ export const CONDITION_GROUPS: AutomationElementGroup = {
 } as const;
 
 export const CONDITION_BUILDING_BLOCKS = ["and", "or", "not"];
+
+export const COLLAPSIBLE_CONDITION_ELEMENTS = [
+  "ha-automation-condition-and",
+  "ha-automation-condition-not",
+  "ha-automation-condition-or",
+];

--- a/src/panels/config/automation/action/ha-automation-action-editor.ts
+++ b/src/panels/config/automation/action/ha-automation-action-editor.ts
@@ -5,11 +5,15 @@ import { dynamicElement } from "../../../../common/dom/dynamic-element-directive
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-yaml-editor";
 import type { HaYamlEditor } from "../../../../components/ha-yaml-editor";
+import { COLLAPSIBLE_ACTION_ELEMENTS } from "../../../../data/action";
 import { migrateAutomationAction, type Action } from "../../../../data/script";
 import type { HomeAssistant } from "../../../../types";
 import "../ha-automation-editor-warning";
 import { editorStyles } from "../styles";
-import { getAutomationActionType } from "./ha-automation-action-row";
+import {
+  getAutomationActionType,
+  type ActionElement,
+} from "./ha-automation-action-row";
 
 @customElement("ha-automation-action-editor")
 export default class HaAutomationActionEditor extends LitElement {
@@ -33,6 +37,9 @@ export default class HaAutomationActionEditor extends LitElement {
     false;
 
   @query("ha-yaml-editor") public yamlEditor?: HaYamlEditor;
+
+  @query(COLLAPSIBLE_ACTION_ELEMENTS.join(", "))
+  private _collapsibleElement?: ActionElement;
 
   protected render() {
     const yamlMode = this.yamlMode || !this.uiSupported;
@@ -101,6 +108,14 @@ export default class HaAutomationActionEditor extends LitElement {
       ...ev.detail.value,
     };
     fireEvent(this, "value-changed", { value });
+  }
+
+  public expandAll() {
+    this._collapsibleElement?.expandAll?.();
+  }
+
+  public collapseAll() {
+    this._collapsibleElement?.collapseAll?.();
   }
 
   static styles = editorStyles;

--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -667,6 +667,7 @@ export default class HaAutomationActionRow extends LitElement {
       yamlMode: this._yamlMode,
     } satisfies ActionSidebarConfig);
     this._selected = true;
+    this._collapsed = false;
 
     if (this.narrow) {
       this.scrollIntoView({

--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -109,6 +109,8 @@ export const getAutomationActionType = memoizeOne(
 
 export interface ActionElement extends LitElement {
   action: Action;
+  expandAll?: () => void;
+  collapseAll?: () => void;
 }
 
 export const handleChangeEvent = (element: ActionElement, ev: CustomEvent) => {
@@ -181,7 +183,7 @@ export default class HaAutomationActionRow extends LitElement {
   @state() private _warnings?: string[];
 
   @query("ha-automation-action-editor")
-  private actionEditor?: HaAutomationActionEditor;
+  private _actionEditor?: HaAutomationActionEditor;
 
   protected willUpdate(changedProperties: PropertyValues) {
     if (changedProperties.has("yamlMode")) {
@@ -479,7 +481,7 @@ export default class HaAutomationActionRow extends LitElement {
     this.openSidebar(value); // refresh sidebar
 
     if (this._yamlMode && !this.optionsInSidebar) {
-      this.actionEditor?.yamlEditor?.setValue(value);
+      this._actionEditor?.yamlEditor?.setValue(value);
     }
   };
 
@@ -582,7 +584,7 @@ export default class HaAutomationActionRow extends LitElement {
       if (this._selected && this.optionsInSidebar) {
         this.openSidebar(value); // refresh sidebar
       } else if (this._yamlMode) {
-        this.actionEditor?.yamlEditor?.setValue(value);
+        this._actionEditor?.yamlEditor?.setValue(value);
       }
     }
   };
@@ -691,7 +693,26 @@ export default class HaAutomationActionRow extends LitElement {
   }
 
   public collapse() {
-    this._collapsed = true;
+    if (this.optionsInSidebar) {
+      this._collapsed = true;
+      return;
+    }
+
+    this.updateComplete.then(() => {
+      this.shadowRoot!.querySelector("ha-expansion-panel")!.expanded = false;
+    });
+  }
+
+  public expandAll() {
+    this.expand();
+
+    this._actionEditor?.expandAll();
+  }
+
+  public collapseAll() {
+    this.collapse();
+
+    this._actionEditor?.collapseAll();
   }
 
   private _uiSupported = memoizeOne(

--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -677,9 +677,18 @@ export default class HaAutomationActionRow extends LitElement {
   }
 
   public expand() {
+    if (this.optionsInSidebar) {
+      this._collapsed = false;
+      return;
+    }
+
     this.updateComplete.then(() => {
       this.shadowRoot!.querySelector("ha-expansion-panel")!.expanded = true;
     });
+  }
+
+  public collapse() {
+    this._collapsed = true;
   }
 
   private _uiSupported = memoizeOne(

--- a/src/panels/config/automation/action/types/ha-automation-action-choose.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-choose.ts
@@ -1,5 +1,5 @@
 import { type CSSResultGroup, LitElement, css, html } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
 import { ensureArray } from "../../../../../common/array/ensure-array";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-button";
@@ -7,7 +7,9 @@ import type { Action, ChooseAction, Option } from "../../../../../data/script";
 import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import "../../option/ha-automation-option";
+import type HaAutomationOption from "../../option/ha-automation-option";
 import "../ha-automation-action";
+import type HaAutomationAction from "../ha-automation-action";
 import type { ActionElement } from "../ha-automation-action-row";
 
 @customElement("ha-automation-action-choose")
@@ -23,6 +25,10 @@ export class HaChooseAction extends LitElement implements ActionElement {
   @property({ type: Boolean }) public indent = false;
 
   @state() private _showDefault = false;
+
+  @query("ha-automation-option") private _optionElement?: HaAutomationOption;
+
+  @query("ha-automation-action") private _actionElement?: HaAutomationAction;
 
   public static get defaultConfig(): ChooseAction {
     return { choose: [{ conditions: [], sequence: [] }] };
@@ -102,6 +108,16 @@ export class HaChooseAction extends LitElement implements ActionElement {
       delete newValue.default;
     }
     fireEvent(this, "value-changed", { value: newValue });
+  }
+
+  public expandAll() {
+    this._optionElement?.expandAll();
+    this._actionElement?.expandAll();
+  }
+
+  public collapseAll() {
+    this._optionElement?.collapseAll();
+    this._actionElement?.collapseAll();
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/automation/action/types/ha-automation-action-condition.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-condition.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, query } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { stringCompare } from "../../../../../common/string/compare";
@@ -14,6 +14,7 @@ import {
 } from "../../../../../data/condition";
 import type { Entries, HomeAssistant } from "../../../../../types";
 import "../../condition/ha-automation-condition-editor";
+import type HaAutomationConditionEditor from "../../condition/ha-automation-condition-editor";
 import "../../condition/types/ha-automation-condition-and";
 import "../../condition/types/ha-automation-condition-device";
 import "../../condition/types/ha-automation-condition-not";
@@ -40,6 +41,9 @@ export class HaConditionAction extends LitElement implements ActionElement {
   @property({ type: Boolean, attribute: "sidebar" }) public inSidebar = false;
 
   @property({ type: Boolean, attribute: "indent" }) public indent = false;
+
+  @query("ha-automation-condition-editor")
+  private _conditionEditor?: HaAutomationConditionEditor;
 
   public static get defaultConfig(): Omit<Condition, "state" | "entity_id"> {
     return { condition: "state" };
@@ -145,6 +149,14 @@ export class HaConditionAction extends LitElement implements ActionElement {
     (type: string) =>
       customElements.get(`ha-automation-condition-${type}`) !== undefined
   );
+
+  public expandAll() {
+    this._conditionEditor?.expandAll();
+  }
+
+  public collapseAll() {
+    this._conditionEditor?.collapseAll();
+  }
 
   static styles = css`
     ha-select {

--- a/src/panels/config/automation/action/types/ha-automation-action-if.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-if.ts
@@ -1,13 +1,21 @@
 import type { CSSResultGroup } from "lit";
 import { css, html, LitElement } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import {
+  customElement,
+  property,
+  query,
+  queryAll,
+  state,
+} from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-textfield";
 import type { Action, IfAction } from "../../../../../data/script";
 import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import type { Condition } from "../../../../lovelace/common/validate-condition";
+import type HaAutomationCondition from "../../condition/ha-automation-condition";
 import "../ha-automation-action";
+import type HaAutomationAction from "../ha-automation-action";
 import type { ActionElement } from "../ha-automation-action-row";
 
 @customElement("ha-automation-action-if")
@@ -23,6 +31,12 @@ export class HaIfAction extends LitElement implements ActionElement {
   @property({ type: Boolean }) public indent = false;
 
   @state() private _showElse = false;
+
+  @query("ha-automation-condition")
+  private _conditionElement?: HaAutomationCondition;
+
+  @queryAll("ha-automation-action")
+  private _actionElements?: HaAutomationAction[];
 
   public static get defaultConfig(): IfAction {
     return {
@@ -130,6 +144,16 @@ export class HaIfAction extends LitElement implements ActionElement {
       delete newValue.else;
     }
     fireEvent(this, "value-changed", { value: newValue });
+  }
+
+  public expandAll() {
+    this._conditionElement?.expandAll();
+    this._actionElements?.forEach((element) => element.expandAll?.());
+  }
+
+  public collapseAll() {
+    this._conditionElement?.collapseAll();
+    this._actionElements?.forEach((element) => element.collapseAll?.());
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/automation/action/types/ha-automation-action-parallel.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-parallel.ts
@@ -1,12 +1,13 @@
 import type { CSSResultGroup } from "lit";
 import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, query } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-textfield";
 import type { Action, ParallelAction } from "../../../../../data/script";
 import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import "../ha-automation-action";
+import type HaAutomationAction from "../ha-automation-action";
 import type { ActionElement } from "../ha-automation-action-row";
 
 @customElement("ha-automation-action-parallel")
@@ -20,6 +21,9 @@ export class HaParallelAction extends LitElement implements ActionElement {
   @property({ attribute: false }) public action!: ParallelAction;
 
   @property({ type: Boolean }) public indent = false;
+
+  @query("ha-automation-action")
+  private _actionElement?: HaAutomationAction;
 
   public static get defaultConfig(): ParallelAction {
     return {
@@ -51,6 +55,14 @@ export class HaParallelAction extends LitElement implements ActionElement {
         parallel: value,
       },
     });
+  }
+
+  public expandAll() {
+    this._actionElement?.expandAll();
+  }
+
+  public collapseAll() {
+    this._actionElement?.collapseAll();
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/automation/action/types/ha-automation-action-sequence.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-sequence.ts
@@ -1,6 +1,6 @@
 import type { CSSResultGroup } from "lit";
 import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { query, customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-textfield";
 import type { Action, SequenceAction } from "../../../../../data/script";
@@ -8,6 +8,7 @@ import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import "../ha-automation-action";
 import type { ActionElement } from "../ha-automation-action-row";
+import type HaAutomationAction from "../ha-automation-action";
 
 @customElement("ha-automation-action-sequence")
 export class HaSequenceAction extends LitElement implements ActionElement {
@@ -20,6 +21,9 @@ export class HaSequenceAction extends LitElement implements ActionElement {
   @property({ attribute: false }) public action!: SequenceAction;
 
   @property({ type: Boolean }) public indent = false;
+
+  @query("ha-automation-action")
+  private _actionElement?: HaAutomationAction;
 
   public static get defaultConfig(): SequenceAction {
     return {
@@ -51,6 +55,14 @@ export class HaSequenceAction extends LitElement implements ActionElement {
         sequence: value,
       },
     });
+  }
+
+  public expandAll() {
+    this._actionElement?.expandAll();
+  }
+
+  public collapseAll() {
+    this._actionElement?.collapseAll();
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/automation/condition/ha-automation-condition-editor.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-editor.ts
@@ -8,9 +8,11 @@ import "../../../../components/ha-yaml-editor";
 import type { HaYamlEditor } from "../../../../components/ha-yaml-editor";
 import type { Condition } from "../../../../data/automation";
 import { expandConditionWithShorthand } from "../../../../data/automation";
+import { COLLAPSIBLE_CONDITION_ELEMENTS } from "../../../../data/condition";
 import type { HomeAssistant } from "../../../../types";
 import "../ha-automation-editor-warning";
 import { editorStyles } from "../styles";
+import type { ConditionElement } from "./ha-automation-condition-row";
 
 @customElement("ha-automation-condition-editor")
 export default class HaAutomationConditionEditor extends LitElement {
@@ -32,6 +34,9 @@ export default class HaAutomationConditionEditor extends LitElement {
     false;
 
   @query("ha-yaml-editor") public yamlEditor?: HaYamlEditor;
+
+  @query(COLLAPSIBLE_CONDITION_ELEMENTS.join(", "))
+  private _collapsibleElement?: ConditionElement;
 
   private _processedCondition = memoizeOne((condition) =>
     expandConditionWithShorthand(condition)
@@ -106,6 +111,14 @@ export default class HaAutomationConditionEditor extends LitElement {
       ...ev.detail.value,
     };
     fireEvent(this, "value-changed", { value });
+  }
+
+  public expandAll() {
+    this._collapsibleElement?.expandAll?.();
+  }
+
+  public collapseAll() {
+    this._collapsibleElement?.collapseAll?.();
   }
 
   static styles = [

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -70,6 +70,8 @@ import "./types/ha-automation-condition-zone";
 
 export interface ConditionElement extends LitElement {
   condition: Condition;
+  expandAll?: () => void;
+  collapseAll?: () => void;
 }
 
 export const handleChangeEvent = (
@@ -587,6 +589,18 @@ export default class HaAutomationConditionRow extends LitElement {
 
   public collapse() {
     this._collapsed = true;
+  }
+
+  public expandAll() {
+    this.expand();
+
+    this.conditionEditor?.expandAll();
+  }
+
+  public collapseAll() {
+    this.collapse();
+
+    this.conditionEditor?.collapseAll();
   }
 
   private _handleUiModeNotAvailable(ev: CustomEvent) {

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -631,6 +631,7 @@ export default class HaAutomationConditionRow extends LitElement {
       yamlMode: this._yamlMode,
     } satisfies ConditionSidebarConfig);
     this._selected = true;
+    this._collapsed = false;
 
     if (this.narrow) {
       this.scrollIntoView({

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -575,9 +575,18 @@ export default class HaAutomationConditionRow extends LitElement {
   };
 
   public expand() {
+    if (this.optionsInSidebar) {
+      this._collapsed = false;
+      return;
+    }
+
     this.updateComplete.then(() => {
       this.shadowRoot!.querySelector("ha-expansion-panel")!.expanded = true;
     });
+  }
+
+  public collapse() {
+    this._collapsed = true;
   }
 
   private _handleUiModeNotAvailable(ev: CustomEvent) {

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -2,7 +2,7 @@ import { mdiDrag, mdiPlus } from "@mdi/js";
 import deepClone from "deep-clone-simple";
 import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, queryAll, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
 import { storage } from "../../../../common/decorators/storage";
 import { fireEvent } from "../../../../common/dom/fire_event";
@@ -22,7 +22,6 @@ import {
   PASTE_VALUE,
   showAddAutomationElementDialog,
 } from "../show-add-automation-element-dialog";
-import type HaAutomationConditionEditor from "./ha-automation-condition-editor";
 import "./ha-automation-condition-row";
 import type HaAutomationConditionRow from "./ha-automation-condition-row";
 
@@ -53,6 +52,9 @@ export default class HaAutomationCondition extends LitElement {
     storage: "sessionStorage",
   })
   public _clipboard?: AutomationClipboard;
+
+  @queryAll("ha-automation-condition-row")
+  private _conditionRowElements?: HaAutomationConditionRow[];
 
   private _focusLastConditionOnChange = false;
 
@@ -123,56 +125,15 @@ export default class HaAutomationCondition extends LitElement {
     }
   }
 
-  private _getRowElements() {
-    return this.shadowRoot!.querySelectorAll<HaAutomationConditionRow>(
-      "ha-automation-condition-row"
-    );
-  }
-
-  private _getChildCollapsableElements(
-    row: HaAutomationConditionRow
-  ): NodeListOf<HaAutomationCondition> | undefined {
-    const editor = row.shadowRoot!.querySelector<HaAutomationConditionEditor>(
-      "ha-automation-condition-editor"
-    );
-    if (editor) {
-      const buildingBlock = editor.shadowRoot?.querySelector(
-        CONDITION_BUILDING_BLOCKS.map(
-          (block) => `ha-automation-condition-${block}`
-        ).join(", ")
-      );
-      if (buildingBlock) {
-        return buildingBlock.shadowRoot?.querySelectorAll<HaAutomationCondition>(
-          "ha-automation-condition"
-        );
-      }
-    }
-    return undefined;
-  }
-
   public expandAll() {
-    this._getRowElements().forEach((row) => {
-      row.expand();
-
-      const childElements = this._getChildCollapsableElements(row);
-      if (childElements) {
-        childElements.forEach((element) => {
-          element.expandAll();
-        });
-      }
+    this._conditionRowElements?.forEach((row) => {
+      row.expandAll();
     });
   }
 
   public collapseAll() {
-    this._getRowElements().forEach((row) => {
-      row.collapse();
-
-      const childElements = this._getChildCollapsableElements(row);
-      if (childElements) {
-        childElements.forEach((element) => {
-          element.collapseAll();
-        });
-      }
+    this._conditionRowElements?.forEach((row) => {
+      row.collapseAll();
     });
   }
 

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -22,6 +22,7 @@ import {
   PASTE_VALUE,
   showAddAutomationElementDialog,
 } from "../show-add-automation-element-dialog";
+import type HaAutomationConditionEditor from "./ha-automation-condition-editor";
 import "./ha-automation-condition-row";
 import type HaAutomationConditionRow from "./ha-automation-condition-row";
 
@@ -122,12 +123,56 @@ export default class HaAutomationCondition extends LitElement {
     }
   }
 
-  public expandAll() {
-    const rows = this.shadowRoot!.querySelectorAll<HaAutomationConditionRow>(
+  private _getRowElements() {
+    return this.shadowRoot!.querySelectorAll<HaAutomationConditionRow>(
       "ha-automation-condition-row"
-    )!;
-    rows.forEach((row) => {
+    );
+  }
+
+  private _getChildCollapsableElements(
+    row: HaAutomationConditionRow
+  ): NodeListOf<HaAutomationCondition> | undefined {
+    const editor = row.shadowRoot!.querySelector<HaAutomationConditionEditor>(
+      "ha-automation-condition-editor"
+    );
+    if (editor) {
+      const buildingBlock = editor.shadowRoot?.querySelector(
+        CONDITION_BUILDING_BLOCKS.map(
+          (block) => `ha-automation-condition-${block}`
+        ).join(", ")
+      );
+      if (buildingBlock) {
+        return buildingBlock.shadowRoot?.querySelectorAll<HaAutomationCondition>(
+          "ha-automation-condition"
+        );
+      }
+    }
+    return undefined;
+  }
+
+  public expandAll() {
+    this._getRowElements().forEach((row) => {
       row.expand();
+
+      const childElements = this._getChildCollapsableElements(row);
+      if (childElements) {
+        childElements.forEach((element) => {
+          element.expandAll?.();
+        });
+      }
+    });
+  }
+
+  public collapseAll() {
+    this._getRowElements().forEach((row) => {
+      row.collapse();
+
+      const childElements = this._getChildCollapsableElements(row);
+      if (childElements) {
+        childElements.forEach((element) => {
+          element.collapseAll?.();
+        });
+      }
     });
   }
 

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -157,7 +157,7 @@ export default class HaAutomationCondition extends LitElement {
       const childElements = this._getChildCollapsableElements(row);
       if (childElements) {
         childElements.forEach((element) => {
-          element.expandAll?.();
+          element.expandAll();
         });
       }
     });
@@ -170,7 +170,7 @@ export default class HaAutomationCondition extends LitElement {
       const childElements = this._getChildCollapsableElements(row);
       if (childElements) {
         childElements.forEach((element) => {
-          element.collapseAll?.();
+          element.collapseAll();
         });
       }
     });

--- a/src/panels/config/automation/condition/types/ha-automation-condition-logical.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-logical.ts
@@ -1,9 +1,10 @@
 import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, query } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import type { LogicalCondition } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 import "../ha-automation-condition";
+import type HaAutomationCondition from "../ha-automation-condition";
 import type { ConditionElement } from "../ha-automation-condition-row";
 
 @customElement("ha-automation-condition-logical")
@@ -22,6 +23,9 @@ export abstract class HaLogicalCondition
   @property({ type: Boolean, attribute: "sidebar" }) public optionsInSidebar =
     false;
 
+  @query("ha-automation-condition")
+  private _conditionElement?: HaAutomationCondition;
+
   protected render() {
     return html`
       <ha-automation-condition
@@ -33,6 +37,14 @@ export abstract class HaLogicalCondition
         .narrow=${this.narrow}
       ></ha-automation-condition>
     `;
+  }
+
+  public expandAll() {
+    this._conditionElement?.expandAll?.();
+  }
+
+  public collapseAll() {
+    this._conditionElement?.collapseAll?.();
   }
 
   private _valueChanged(ev: CustomEvent): void {

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -16,6 +16,8 @@ import {
   mdiStopCircleOutline,
   mdiTag,
   mdiTransitConnection,
+  mdiUnfoldLessHorizontal,
+  mdiUnfoldMoreHorizontal,
 } from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
@@ -369,6 +371,30 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
             )}
             <ha-svg-icon slot="graphic" .path=${mdiPlaylistEdit}></ha-svg-icon>
           </ha-list-item>
+
+          ${!useBlueprint
+            ? html`
+                <ha-list-item graphic="icon" @click=${this._collapseAll}>
+                  <ha-svg-icon
+                    slot="graphic"
+                    .path=${mdiUnfoldLessHorizontal}
+                  ></ha-svg-icon>
+                  ${this.hass.localize(
+                    "ui.panel.config.automation.editor.collapse_all"
+                  )}
+                </ha-list-item>
+
+                <ha-list-item graphic="icon" @click=${this._expandAll}>
+                  <ha-svg-icon
+                    slot="graphic"
+                    .path=${mdiUnfoldMoreHorizontal}
+                  ></ha-svg-icon>
+                  ${this.hass.localize(
+                    "ui.panel.config.automation.editor.expand_all"
+                  )}
+                </ha-list-item>
+              `
+            : nothing}
 
           <li divider role="separator"></li>
 
@@ -1101,6 +1127,14 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
 
   protected async promptDiscardChanges() {
     return this._confirmUnsavedChanged();
+  }
+
+  private _collapseAll() {
+    this._manualEditor?.collapseAll();
+  }
+
+  private _expandAll() {
+    this._manualEditor?.expandAll();
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -39,7 +39,9 @@ import type { HomeAssistant } from "../../../types";
 import { documentationUrl } from "../../../util/documentation-url";
 import { showToast } from "../../../util/toast";
 import "./action/ha-automation-action";
+import type HaAutomationAction from "./action/ha-automation-action";
 import "./condition/ha-automation-condition";
+import type HaAutomationCondition from "./condition/ha-automation-condition";
 import "./ha-automation-sidebar";
 import { showPasteReplaceDialog } from "./paste-replace-dialog/show-dialog-paste-replace";
 import { saveFabStyles } from "./styles";
@@ -569,6 +571,24 @@ export class HaManualAutomationEditor extends LitElement {
     showToast(this, {
       message: "",
       duration: 0,
+    });
+  }
+
+  private _getCollapsableElements() {
+    return this.shadowRoot!.querySelectorAll<
+      HaAutomationAction | HaAutomationCondition
+    >("ha-automation-action, ha-automation-condition");
+  }
+
+  public expandAll() {
+    this._getCollapsableElements().forEach((element) => {
+      element.expandAll();
+    });
+  }
+
+  public collapseAll() {
+    this._getCollapsableElements().forEach((element) => {
+      element.collapseAll();
     });
   }
 

--- a/src/panels/config/automation/option/ha-automation-option-row.ts
+++ b/src/panels/config/automation/option/ha-automation-option-row.ts
@@ -365,9 +365,18 @@ export default class HaAutomationOptionRow extends LitElement {
   }
 
   public expand() {
+    if (this.optionsInSidebar) {
+      this._collapsed = false;
+      return;
+    }
+
     this.updateComplete.then(() => {
       this.shadowRoot!.querySelector("ha-expansion-panel")!.expanded = true;
     });
+  }
+
+  public collapse() {
+    this._collapsed = true;
   }
 
   private _toggleCollapse() {

--- a/src/panels/config/automation/option/ha-automation-option-row.ts
+++ b/src/panels/config/automation/option/ha-automation-option-row.ts
@@ -9,7 +9,7 @@ import {
 } from "@mdi/js";
 import type { CSSResultGroup } from "lit";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { ensureArray } from "../../../../common/array/ensure-array";
 import { fireEvent } from "../../../../common/dom/fire_event";
@@ -37,7 +37,9 @@ import {
 } from "../../../../dialogs/generic/show-dialog-box";
 import type { HomeAssistant } from "../../../../types";
 import "../action/ha-automation-action";
+import type HaAutomationAction from "../action/ha-automation-action";
 import "../condition/ha-automation-condition";
+import type HaAutomationCondition from "../condition/ha-automation-condition";
 import { editorStyles, rowStyles } from "../styles";
 
 @customElement("ha-automation-option-row")
@@ -68,6 +70,12 @@ export default class HaAutomationOptionRow extends LitElement {
   @state()
   @consume({ context: fullEntitiesContext, subscribe: true })
   _entityReg!: EntityRegistryEntry[];
+
+  @query("ha-automation-condition")
+  private _conditionElement?: HaAutomationCondition;
+
+  @query("ha-automation-action")
+  private _actionElement?: HaAutomationAction;
 
   private _expandedChanged(ev) {
     if (ev.currentTarget.id !== "option") {
@@ -378,6 +386,20 @@ export default class HaAutomationOptionRow extends LitElement {
 
   public collapse() {
     this._collapsed = true;
+  }
+
+  public expandAll() {
+    this.expand();
+
+    this._conditionElement?.expandAll();
+    this._actionElement?.expandAll();
+  }
+
+  public collapseAll() {
+    this.collapse();
+
+    this._conditionElement?.collapseAll();
+    this._actionElement?.collapseAll();
   }
 
   private _toggleCollapse() {

--- a/src/panels/config/automation/option/ha-automation-option-row.ts
+++ b/src/panels/config/automation/option/ha-automation-option-row.ts
@@ -355,6 +355,7 @@ export default class HaAutomationOptionRow extends LitElement {
       delete: this._removeOption,
     } satisfies OptionSidebarConfig);
     this._selected = true;
+    this._collapsed = false;
 
     if (this.narrow) {
       this.scrollIntoView({

--- a/src/panels/config/automation/option/ha-automation-option.ts
+++ b/src/panels/config/automation/option/ha-automation-option.ts
@@ -14,6 +14,8 @@ import "../../../../components/ha-svg-icon";
 import type { AutomationClipboard } from "../../../../data/automation";
 import type { Option } from "../../../../data/script";
 import type { HomeAssistant } from "../../../../types";
+import type HaAutomationAction from "../action/ha-automation-action";
+import type HaAutomationCondition from "../condition/ha-automation-condition";
 import "./ha-automation-option-row";
 import type HaAutomationOptionRow from "./ha-automation-option-row";
 
@@ -143,12 +145,39 @@ export default class HaAutomationOption extends LitElement {
     }
   }
 
-  public expandAll() {
-    const rows = this.shadowRoot!.querySelectorAll<HaAutomationOptionRow>(
+  private _getRowElements() {
+    return this.shadowRoot!.querySelectorAll<HaAutomationOptionRow>(
       "ha-automation-option-row"
-    )!;
-    rows.forEach((row) => {
-      row.expand();
+    );
+  }
+
+  public expandAll() {
+    this._getRowElements().forEach((row) => {
+      row.expand?.();
+
+      const childElements = row.shadowRoot?.querySelectorAll<
+        HaAutomationAction | HaAutomationCondition
+      >("ha-automation-action, ha-automation-condition");
+      if (childElements) {
+        childElements.forEach((element) => {
+          element.expandAll?.();
+        });
+      }
+    });
+  }
+
+  public collapseAll() {
+    this._getRowElements().forEach((row) => {
+      row.collapse();
+
+      const childElements = row.shadowRoot?.querySelectorAll<
+        HaAutomationAction | HaAutomationCondition
+      >("ha-automation-action, ha-automation-condition");
+      if (childElements) {
+        childElements.forEach((element) => {
+          element.collapseAll?.();
+        });
+      }
     });
   }
 

--- a/src/panels/config/automation/option/ha-automation-option.ts
+++ b/src/panels/config/automation/option/ha-automation-option.ts
@@ -2,7 +2,7 @@ import { mdiDrag, mdiPlus } from "@mdi/js";
 import deepClone from "deep-clone-simple";
 import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, queryAll, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
 import { storage } from "../../../../common/decorators/storage";
 import { fireEvent } from "../../../../common/dom/fire_event";
@@ -14,8 +14,6 @@ import "../../../../components/ha-svg-icon";
 import type { AutomationClipboard } from "../../../../data/automation";
 import type { Option } from "../../../../data/script";
 import type { HomeAssistant } from "../../../../types";
-import type HaAutomationAction from "../action/ha-automation-action";
-import type HaAutomationCondition from "../condition/ha-automation-condition";
 import "./ha-automation-option-row";
 import type HaAutomationOptionRow from "./ha-automation-option-row";
 
@@ -42,6 +40,9 @@ export default class HaAutomationOption extends LitElement {
     storage: "sessionStorage",
   })
   public _clipboard?: AutomationClipboard;
+
+  @queryAll("ha-automation-option-row")
+  private _optionRowElements?: HaAutomationOptionRow[];
 
   private _focusLastOptionOnChange = false;
 
@@ -145,40 +146,12 @@ export default class HaAutomationOption extends LitElement {
     }
   }
 
-  private _getRowElements() {
-    return this.shadowRoot!.querySelectorAll<HaAutomationOptionRow>(
-      "ha-automation-option-row"
-    );
-  }
-
   public expandAll() {
-    this._getRowElements().forEach((row) => {
-      row.expand();
-
-      const childElements = row.shadowRoot?.querySelectorAll<
-        HaAutomationAction | HaAutomationCondition
-      >("ha-automation-action, ha-automation-condition");
-      if (childElements) {
-        childElements.forEach((element) => {
-          element.expandAll();
-        });
-      }
-    });
+    this._optionRowElements?.forEach((row) => row.expandAll());
   }
 
   public collapseAll() {
-    this._getRowElements().forEach((row) => {
-      row.collapse();
-
-      const childElements = row.shadowRoot?.querySelectorAll<
-        HaAutomationAction | HaAutomationCondition
-      >("ha-automation-action, ha-automation-condition");
-      if (childElements) {
-        childElements.forEach((element) => {
-          element.collapseAll();
-        });
-      }
-    });
+    this._optionRowElements?.forEach((row) => row.collapseAll());
   }
 
   private _addOption = () => {

--- a/src/panels/config/automation/option/ha-automation-option.ts
+++ b/src/panels/config/automation/option/ha-automation-option.ts
@@ -153,14 +153,14 @@ export default class HaAutomationOption extends LitElement {
 
   public expandAll() {
     this._getRowElements().forEach((row) => {
-      row.expand?.();
+      row.expand();
 
       const childElements = row.shadowRoot?.querySelectorAll<
         HaAutomationAction | HaAutomationCondition
       >("ha-automation-action, ha-automation-condition");
       if (childElements) {
         childElements.forEach((element) => {
-          element.expandAll?.();
+          element.expandAll();
         });
       }
     });
@@ -175,7 +175,7 @@ export default class HaAutomationOption extends LitElement {
       >("ha-automation-action, ha-automation-condition");
       if (childElements) {
         childElements.forEach((element) => {
-          element.collapseAll?.();
+          element.collapseAll();
         });
       }
     });

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -15,6 +15,8 @@ import {
   mdiRobotConfused,
   mdiTag,
   mdiTransitConnection,
+  mdiUnfoldLessHorizontal,
+  mdiUnfoldMoreHorizontal,
 } from "@mdi/js";
 import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { LitElement, css, html, nothing } from "lit";
@@ -340,6 +342,30 @@ export class HaScriptEditor extends SubscribeMixin(
             )}
             <ha-svg-icon slot="graphic" .path=${mdiPlaylistEdit}></ha-svg-icon>
           </ha-list-item>
+
+          ${!useBlueprint
+            ? html`
+                <ha-list-item graphic="icon" @click=${this._collapseAll}>
+                  <ha-svg-icon
+                    slot="graphic"
+                    .path=${mdiUnfoldLessHorizontal}
+                  ></ha-svg-icon>
+                  ${this.hass.localize(
+                    "ui.panel.config.automation.editor.collapse_all"
+                  )}
+                </ha-list-item>
+
+                <ha-list-item graphic="icon" @click=${this._expandAll}>
+                  <ha-svg-icon
+                    slot="graphic"
+                    .path=${mdiUnfoldMoreHorizontal}
+                  ></ha-svg-icon>
+                  ${this.hass.localize(
+                    "ui.panel.config.automation.editor.expand_all"
+                  )}
+                </ha-list-item>
+              `
+            : nothing}
 
           <li divider role="separator"></li>
 
@@ -1028,6 +1054,14 @@ export class HaScriptEditor extends SubscribeMixin(
 
   protected async promptDiscardChanges() {
     return this._confirmUnsavedChanged();
+  }
+
+  private _collapseAll() {
+    this._manualEditor?.collapseAll();
+  }
+
+  private _expandAll() {
+    this._manualEditor?.expandAll();
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/script/ha-script-field-row.ts
+++ b/src/panels/config/script/ha-script-field-row.ts
@@ -141,6 +141,22 @@ export default class HaScriptFieldRow extends LitElement {
     this._collapsed = !this._collapsed;
   }
 
+  public expand() {
+    this._collapsed = false;
+  }
+
+  public collapse() {
+    this._collapsed = true;
+  }
+
+  public expandSelectorRow() {
+    this._selectorRowCollapsed = false;
+  }
+
+  public collapseSelectorRow() {
+    this._selectorRowCollapsed = true;
+  }
+
   private _toggleSelectorRowCollapse() {
     this._selectorRowCollapsed = !this._selectorRowCollapsed;
   }

--- a/src/panels/config/script/ha-script-field-row.ts
+++ b/src/panels/config/script/ha-script-field-row.ts
@@ -1,7 +1,7 @@
 import { mdiDelete, mdiDotsVertical } from "@mdi/js";
 import type { CSSResultGroup } from "lit";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { preventDefaultStopPropagation } from "../../../common/dom/prevent_default_stop_propagation";
@@ -19,6 +19,7 @@ import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 import "./ha-script-field-selector-editor";
+import type HaScriptFieldSelectorEditor from "./ha-script-field-selector-editor";
 
 @customElement("ha-script-field-row")
 export default class HaScriptFieldRow extends LitElement {
@@ -44,6 +45,9 @@ export default class HaScriptFieldRow extends LitElement {
   @state() private _selectorRowSelected = false;
 
   @state() private _selectorRowCollapsed = false;
+
+  @query("ha-script-field-selector-editor")
+  private _selectorEditor?: HaScriptFieldSelectorEditor;
 
   protected render() {
     return html`
@@ -159,6 +163,20 @@ export default class HaScriptFieldRow extends LitElement {
 
   private _toggleSelectorRowCollapse() {
     this._selectorRowCollapsed = !this._selectorRowCollapsed;
+  }
+
+  public expandAll() {
+    this.expand();
+    this.expandSelectorRow();
+
+    this._selectorEditor?.expandAll();
+  }
+
+  public collapseAll() {
+    this.collapse();
+    this.collapseSelectorRow();
+
+    this._selectorEditor?.collapseAll();
   }
 
   private _toggleSidebar(ev: Event) {

--- a/src/panels/config/script/ha-script-field-row.ts
+++ b/src/panels/config/script/ha-script-field-row.ts
@@ -171,6 +171,7 @@ export default class HaScriptFieldRow extends LitElement {
     }
 
     this._selected = true;
+    this._collapsed = false;
     this.openSidebar();
   }
 
@@ -184,6 +185,7 @@ export default class HaScriptFieldRow extends LitElement {
     }
 
     this._selectorRowSelected = true;
+    this._selectorRowCollapsed = false;
     this.openSidebar(true);
   }
 

--- a/src/panels/config/script/ha-script-field-selector-editor.ts
+++ b/src/panels/config/script/ha-script-field-selector-editor.ts
@@ -1,12 +1,16 @@
 import type { CSSResultGroup } from "lit";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../common/dom/fire_event";
 import type { LocalizeKeys } from "../../../common/translations/localize";
 import "../../../components/ha-alert";
 import "../../../components/ha-form/ha-form";
+import type { HaForm } from "../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../components/ha-form/types";
+import type { HaSelector } from "../../../components/ha-selector/ha-selector";
+import type { HaActionSelector } from "../../../components/ha-selector/ha-selector-action";
+import type { HaConditionSelector } from "../../../components/ha-selector/ha-selector-condition";
 import "../../../components/ha-yaml-editor";
 import type { Field } from "../../../data/script";
 import { SELECTOR_SELECTOR_BUILDING_BLOCKS } from "../../../data/selector/selector_selector";
@@ -32,6 +36,9 @@ export default class HaScriptFieldSelectorEditor extends LitElement {
   @state() private _uiError?: Record<string, string>;
 
   @state() private _yamlError?: undefined | "yaml_error" | "key_not_unique";
+
+  @query("ha-form")
+  private _formElement?: HaForm;
 
   private _schema = memoizeOne(
     (selector: any) =>
@@ -137,6 +144,41 @@ export default class HaScriptFieldSelectorEditor extends LitElement {
   private _computeError = (error: string) =>
     this.hass.localize(`ui.panel.config.script.editor.field.${error}` as any) ||
     error;
+
+  private _getSelectorElements() {
+    if (this._formElement) {
+      const selectors =
+        this._formElement.shadowRoot?.querySelectorAll<HaSelector>(
+          "ha-selector"
+        );
+
+      const selectorElements: (HaConditionSelector | HaActionSelector)[] = [];
+
+      selectors?.forEach((selector) => {
+        selectorElements.push(
+          ...Array.from(
+            selector.shadowRoot?.querySelectorAll<
+              HaConditionSelector | HaActionSelector
+            >("ha-selector-condition, ha-selector-action") || []
+          )
+        );
+      });
+      return selectorElements;
+    }
+    return [];
+  }
+
+  public expandAll() {
+    this._getSelectorElements().forEach((element) => {
+      element.expandAll?.();
+    });
+  }
+
+  public collapseAll() {
+    this._getSelectorElements().forEach((element) => {
+      element.collapseAll?.();
+    });
+  }
 
   static get styles(): CSSResultGroup {
     return [

--- a/src/panels/config/script/ha-script-fields.ts
+++ b/src/panels/config/script/ha-script-fields.ts
@@ -1,19 +1,15 @@
 import { mdiPlus } from "@mdi/js";
 import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, queryAll } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-button";
 import "../../../components/ha-button-menu";
-import type { HaForm } from "../../../components/ha-form/ha-form";
 import "../../../components/ha-svg-icon";
 import type { Fields } from "../../../data/script";
 import type { HomeAssistant } from "../../../types";
-import type HaAutomationAction from "../automation/action/ha-automation-action";
-import type HaAutomationCondition from "../automation/condition/ha-automation-condition";
 import "./ha-script-field-row";
 import type HaScriptFieldRow from "./ha-script-field-row";
-import type HaScriptFieldSelectorEditor from "./ha-script-field-selector-editor";
 
 @customElement("ha-script-fields")
 export default class HaScriptFields extends LitElement {
@@ -26,6 +22,9 @@ export default class HaScriptFields extends LitElement {
   @property({ attribute: false }) public highlightedFields?: Fields;
 
   @property({ type: Boolean }) public narrow = false;
+
+  @queryAll("ha-script-field-row")
+  private _fieldRowElements?: HaScriptFieldRow[];
 
   private _focusLastActionOnChange = false;
 
@@ -143,62 +142,15 @@ export default class HaScriptFields extends LitElement {
     return key;
   }
 
-  private _getRowElements() {
-    return this.shadowRoot!.querySelectorAll<HaScriptFieldRow>(
-      "ha-script-field-row"
-    );
-  }
-
-  private _getChildCollapsableElements(
-    row: HaScriptFieldRow
-  ): NodeListOf<HaAutomationAction | HaAutomationCondition> | undefined {
-    const editor = row.shadowRoot!.querySelector<HaScriptFieldSelectorEditor>(
-      "ha-script-field-selector-editor"
-    );
-    if (editor) {
-      const form = editor.shadowRoot?.querySelector<HaForm>("ha-form");
-      if (form) {
-        const selector = form.shadowRoot?.querySelector("ha-selector");
-        if (selector) {
-          const buildingBlockSelector = selector.shadowRoot?.querySelector(
-            "ha-selector-condition, ha-selector-action"
-          );
-          if (buildingBlockSelector) {
-            return buildingBlockSelector.shadowRoot?.querySelectorAll<
-              HaAutomationAction | HaAutomationCondition
-            >("ha-automation-action, ha-automation-condition");
-          }
-        }
-      }
-    }
-    return undefined;
-  }
-
   public expandAll() {
-    this._getRowElements().forEach((row) => {
-      row.expand();
-      row.expandSelectorRow();
-
-      const childElements = this._getChildCollapsableElements(row);
-      if (childElements) {
-        childElements.forEach((element) => {
-          element.expandAll();
-        });
-      }
+    this._fieldRowElements?.forEach((row) => {
+      row.expandAll();
     });
   }
 
   public collapseAll() {
-    this._getRowElements().forEach((row) => {
-      row.collapse();
-      row.collapseSelectorRow();
-
-      const childElements = this._getChildCollapsableElements(row);
-      if (childElements) {
-        childElements.forEach((element) => {
-          element.collapseAll();
-        });
-      }
+    this._fieldRowElements?.forEach((row) => {
+      row.collapseAll();
     });
   }
 

--- a/src/panels/config/script/manual-script-editor.ts
+++ b/src/panels/config/script/manual-script-editor.ts
@@ -30,6 +30,7 @@ import type { HomeAssistant } from "../../../types";
 import { documentationUrl } from "../../../util/documentation-url";
 import { showToast } from "../../../util/toast";
 import "../automation/action/ha-automation-action";
+import type HaAutomationAction from "../automation/action/ha-automation-action";
 import "../automation/ha-automation-sidebar";
 import { showPasteReplaceDialog } from "../automation/paste-replace-dialog/show-dialog-paste-replace";
 import { saveFabStyles } from "../automation/styles";
@@ -456,6 +457,24 @@ export class HaManualScriptEditor extends LitElement {
   private _saveScript() {
     this._closeSidebar();
     fireEvent(this, "save-script");
+  }
+
+  private _getCollapsableElements() {
+    return this.shadowRoot!.querySelectorAll<
+      HaAutomationAction | HaScriptFields
+    >("ha-automation-action, ha-script-fields");
+  }
+
+  public expandAll() {
+    this._getCollapsableElements().forEach((element) => {
+      element.expandAll();
+    });
+  }
+
+  public collapseAll() {
+    this._getCollapsableElements().forEach((element) => {
+      element.collapseAll();
+    });
   }
 
   static get styles(): CSSResultGroup {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3792,6 +3792,8 @@
             "automation_settings": "Automation settings",
             "move_up": "Move up",
             "move_down": "Move down",
+            "collapse_all": "Collapse all",
+            "expand_all": "Expand all",
             "description": {
               "label": "Description",
               "placeholder": "Optional description",


### PR DESCRIPTION
## Proposed change
- Add overflow option to collapse and expand all rows in automation and script editor
- on select automation row expand the content if possible.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
