### PR TITLE
Always show compact header for dashboards

### DIFF
--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -148,6 +148,10 @@ export class HaDialog extends DialogBase {
         white-space: nowrap;
         display: block;
         padding-left: 4px;
+        padding-right: 4px;
+        margin-right: 12px;
+        margin-inline-end: 12px;
+        margin-inline-start: initial;
       }
       .header_button {
         text-decoration: none;

--- a/src/dialogs/dialog-list-items/dialog-list-items.ts
+++ b/src/dialogs/dialog-list-items/dialog-list-items.ts
@@ -48,7 +48,7 @@ export class ListItemsDialog
         hideActions
       >
         <div class="container">
-          <ha-md-list @click=${this._dialogClosed}>
+          <ha-md-list>
             ${this._params.items.map(
               (item) => html`
                 <ha-md-list-item

--- a/src/dialogs/dialog-list-items/dialog-list-items.ts
+++ b/src/dialogs/dialog-list-items/dialog-list-items.ts
@@ -1,0 +1,106 @@
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../common/dom/fire_event";
+import { createCloseHeading } from "../../components/ha-dialog";
+import "../../components/ha-icon";
+import "../../components/ha-md-list";
+import "../../components/ha-md-list-item";
+import "../../components/ha-svg-icon";
+import type { HomeAssistant } from "../../types";
+import type { HassDialog } from "../make-dialog-manager";
+import type { ListItemsDialogParams } from "./show-list-items-dialog";
+
+@customElement("dialog-list-items")
+export class ListItemsDialog
+  extends LitElement
+  implements HassDialog<ListItemsDialogParams>
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @state() private _params?: ListItemsDialogParams;
+
+  public async showDialog(params: ListItemsDialogParams): Promise<void> {
+    this._params = params;
+  }
+
+  private _dialogClosed(): void {
+    this._params = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  private _itemClicked(ev: CustomEvent): void {
+    const item = (ev.currentTarget as any).item;
+    if (!item) return;
+    item.action();
+    this._dialogClosed();
+  }
+
+  protected render() {
+    if (!this._params || !this.hass) {
+      return nothing;
+    }
+
+    return html`
+      <ha-dialog
+        open
+        .heading=${createCloseHeading(this.hass, this._params.title ?? " ")}
+        @closed=${this._dialogClosed}
+        hideActions
+      >
+        <div class="container">
+          <ha-md-list @click=${this._dialogClosed}>
+            ${this._params.items.map(
+              (item) => html`
+                <ha-md-list-item
+                  type="button"
+                  @click=${this._itemClicked}
+                  .item=${item}
+                >
+                  ${item.iconPath
+                    ? html`
+                        <ha-svg-icon
+                          .path=${item.iconPath}
+                          slot="start"
+                          class="item-icon"
+                        ></ha-svg-icon>
+                      `
+                    : item.icon
+                      ? html`
+                          <ha-icon
+                            icon=${item.icon}
+                            slot="start"
+                            class="item-icon"
+                          ></ha-icon>
+                        `
+                      : nothing}
+                  <span class="headline">${item.label}</span>
+                  ${item.description
+                    ? html`
+                        <span class="supporting-text">${item.description}</span>
+                      `
+                    : nothing}
+                </ha-md-list-item>
+              `
+            )}
+          </ha-md-list>
+        </div>
+      </ha-dialog>
+    `;
+  }
+
+  static styles = css`
+    ha-dialog {
+      /* Place above other dialogs */
+      --dialog-z-index: 104;
+      --dialog-content-padding: 0;
+      --md-list-item-leading-space: 24px;
+      --md-list-item-trailing-space: 24px;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-list-items": ListItemsDialog;
+  }
+}

--- a/src/dialogs/dialog-list-items/show-list-items-dialog.ts
+++ b/src/dialogs/dialog-list-items/show-list-items-dialog.ts
@@ -1,0 +1,24 @@
+import { fireEvent } from "../../common/dom/fire_event";
+
+interface ListItem {
+  icon?: string;
+  iconPath?: string;
+  label: string;
+  description?: string;
+  action: () => any;
+}
+
+export interface ListItemsDialogParams {
+  title?: string;
+  items: ListItem[];
+}
+
+export const showListItemsDialog = (
+  element: HTMLElement,
+  params: ListItemsDialogParams
+) =>
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-list-items",
+    dialogImport: () => import("./dialog-list-items"),
+    dialogParams: params,
+  });

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -841,6 +841,9 @@ class HUIRoot extends LitElement {
     showAreaRegistryDetailDialog(this, {
       createEntry: async (values) => {
         const area = await createAreaRegistryEntry(this.hass, values);
+        if (isStrategyDashboard(this.lovelace!.rawConfig)) {
+          fireEvent(this, "config-refresh");
+        }
         showToast(this, {
           message: this.hass.localize(
             "ui.panel.lovelace.menu.add_area_success"


### PR DESCRIPTION
## Proposed change

Following https://github.com/home-assistant/frontend/pull/26644.
Always display a compact header. The add button is moved to the overflow menu on mobile. The dialog can be upgraded to a bottom sheet later.

<img width="533" height="327" alt="CleanShot 2025-08-26 at 15 28 06" src="https://github.com/user-attachments/assets/ae76aad9-1a63-4374-87af-0328f7e3fbe7" />

<img width="364" height="343" alt="CleanShot 2025-08-26 at 15 28 07" src="https://github.com/user-attachments/assets/f4071ff9-7662-47ba-be27-559a464e8f7c" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
