### PR TITLE
Automation Editor: Move overflow actions to sidebar only

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -565,6 +565,9 @@ export interface TriggerSidebarConfig extends BaseSidebarConfig {
   close: () => void;
   rename: () => void;
   disable: () => void;
+  duplicate: () => void;
+  cut: () => void;
+  copy: () => void;
   config: Trigger;
   yamlMode: boolean;
   uiSupported: boolean;
@@ -575,6 +578,10 @@ export interface ConditionSidebarConfig extends BaseSidebarConfig {
   close: () => void;
   rename: () => void;
   disable: () => void;
+  test: () => void;
+  duplicate: () => void;
+  cut: () => void;
+  copy: () => void;
   config: Condition;
   yamlMode: boolean;
   uiSupported: boolean;
@@ -585,6 +592,10 @@ export interface ActionSidebarConfig extends BaseSidebarConfig {
   close: () => void;
   rename: () => void;
   disable: () => void;
+  duplicate: () => void;
+  cut: () => void;
+  copy: () => void;
+  run: () => void;
   config: {
     action: Action;
   };
@@ -595,6 +606,7 @@ export interface ActionSidebarConfig extends BaseSidebarConfig {
 export interface OptionSidebarConfig extends BaseSidebarConfig {
   close: () => void;
   rename: () => void;
+  duplicate: () => void;
 }
 
 export interface ScriptFieldSidebarConfig extends BaseSidebarConfig {

--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -258,54 +258,57 @@ export default class HaAutomationActionRow extends LitElement {
           .label=${this.hass.localize("ui.common.menu")}
           .path=${mdiDotsVertical}
         ></ha-icon-button>
-        <ha-md-menu-item .clickAction=${this._runAction}>
-          ${this.hass.localize("ui.panel.config.automation.editor.actions.run")}
-          <ha-svg-icon slot="start" .path=${mdiPlay}></ha-svg-icon>
-        </ha-md-menu-item>
 
         ${!this.optionsInSidebar
-          ? html` <ha-md-menu-item
-              .clickAction=${this._renameAction}
-              .disabled=${this.disabled}
-            >
-              ${this.hass.localize(
-                "ui.panel.config.automation.editor.actions.rename"
-              )}
-              <ha-svg-icon slot="start" .path=${mdiRenameBox}></ha-svg-icon>
-            </ha-md-menu-item>`
+          ? html`<ha-md-menu-item .clickAction=${this._runAction}>
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.actions.run"
+                )}
+                <ha-svg-icon slot="start" .path=${mdiPlay}></ha-svg-icon>
+              </ha-md-menu-item>
+              <ha-md-menu-item
+                .clickAction=${this._renameAction}
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.actions.rename"
+                )}
+                <ha-svg-icon slot="start" .path=${mdiRenameBox}></ha-svg-icon>
+              </ha-md-menu-item>
+              <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>
+              <ha-md-menu-item
+                .clickAction=${this._duplicateAction}
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.actions.duplicate"
+                )}
+                <ha-svg-icon
+                  slot="start"
+                  .path=${mdiContentDuplicate}
+                ></ha-svg-icon>
+              </ha-md-menu-item>
+
+              <ha-md-menu-item
+                .clickAction=${this._copyAction}
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.triggers.copy"
+                )}
+                <ha-svg-icon slot="start" .path=${mdiContentCopy}></ha-svg-icon>
+              </ha-md-menu-item>
+
+              <ha-md-menu-item
+                .clickAction=${this._cutAction}
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.triggers.cut"
+                )}
+                <ha-svg-icon slot="start" .path=${mdiContentCut}></ha-svg-icon>
+              </ha-md-menu-item>`
           : nothing}
-
-        <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>
-
-        <ha-md-menu-item
-          .clickAction=${this._duplicateAction}
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.actions.duplicate"
-          )}
-          <ha-svg-icon slot="start" .path=${mdiContentDuplicate}></ha-svg-icon>
-        </ha-md-menu-item>
-
-        <ha-md-menu-item
-          .clickAction=${this._copyAction}
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.triggers.copy"
-          )}
-          <ha-svg-icon slot="start" .path=${mdiContentCopy}></ha-svg-icon>
-        </ha-md-menu-item>
-
-        <ha-md-menu-item
-          .clickAction=${this._cutAction}
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.triggers.cut"
-          )}
-          <ha-svg-icon slot="start" .path=${mdiContentCut}></ha-svg-icon>
-        </ha-md-menu-item>
 
         <ha-md-menu-item
           .clickAction=${this._moveUp}
@@ -325,50 +328,53 @@ export default class HaAutomationActionRow extends LitElement {
 
         ${!this.optionsInSidebar
           ? html`<ha-md-menu-item
-              .clickAction=${this._toggleYamlMode}
-              .disabled=${!this._uiModeAvailable || !!this._warnings}
-            >
-              ${this.hass.localize(
-                `ui.panel.config.automation.editor.edit_${!this._yamlMode ? "yaml" : "ui"}`
-              )}
-              <ha-svg-icon slot="start" .path=${mdiPlaylistEdit}></ha-svg-icon>
-            </ha-md-menu-item>`
+                .clickAction=${this._toggleYamlMode}
+                .disabled=${!this._uiModeAvailable || !!this._warnings}
+              >
+                ${this.hass.localize(
+                  `ui.panel.config.automation.editor.edit_${!this._yamlMode ? "yaml" : "ui"}`
+                )}
+                <ha-svg-icon
+                  slot="start"
+                  .path=${mdiPlaylistEdit}
+                ></ha-svg-icon>
+              </ha-md-menu-item>
+
+              <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>
+
+              <ha-md-menu-item
+                .clickAction=${this._onDisable}
+                .disabled=${this.disabled}
+              >
+                ${this.action.enabled === false
+                  ? this.hass.localize(
+                      "ui.panel.config.automation.editor.actions.enable"
+                    )
+                  : this.hass.localize(
+                      "ui.panel.config.automation.editor.actions.disable"
+                    )}
+                <ha-svg-icon
+                  slot="start"
+                  .path=${this.action.enabled === false
+                    ? mdiPlayCircleOutline
+                    : mdiStopCircleOutline}
+                ></ha-svg-icon>
+              </ha-md-menu-item>
+              <ha-md-menu-item
+                class="warning"
+                .clickAction=${this._onDelete}
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.actions.delete"
+                )}
+                <ha-svg-icon
+                  class="warning"
+                  slot="start"
+                  .path=${mdiDelete}
+                ></ha-svg-icon>
+              </ha-md-menu-item>`
           : nothing}
-
-        <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>
-
-        <ha-md-menu-item
-          .clickAction=${this._onDisable}
-          .disabled=${this.disabled}
-        >
-          ${this.action.enabled === false
-            ? this.hass.localize(
-                "ui.panel.config.automation.editor.actions.enable"
-              )
-            : this.hass.localize(
-                "ui.panel.config.automation.editor.actions.disable"
-              )}
-          <ha-svg-icon
-            slot="start"
-            .path=${this.action.enabled === false
-              ? mdiPlayCircleOutline
-              : mdiStopCircleOutline}
-          ></ha-svg-icon>
-        </ha-md-menu-item>
-        <ha-md-menu-item
-          class="warning"
-          .clickAction=${this._onDelete}
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.actions.delete"
-          )}
-          <ha-svg-icon
-            class="warning"
-            slot="start"
-            .path=${mdiDelete}
-          ></ha-svg-icon>
-        </ha-md-menu-item>
       </ha-md-button-menu>
 
       ${!this.optionsInSidebar
@@ -664,6 +670,10 @@ export default class HaAutomationActionRow extends LitElement {
       },
       disable: this._onDisable,
       delete: this._onDelete,
+      copy: this._copyAction,
+      cut: this._cutAction,
+      duplicate: this._duplicateAction,
+      run: this._runAction,
       config: {
         action: sidebarAction,
       },

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -172,14 +172,14 @@ export default class HaAutomationConditionRow extends LitElement {
         >
         </ha-icon-button>
 
-        <ha-md-menu-item .clickAction=${this._testCondition}>
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.conditions.test"
-          )}
-          <ha-svg-icon slot="start" .path=${mdiFlask}></ha-svg-icon>
-        </ha-md-menu-item>
         ${!this.optionsInSidebar
           ? html`
+              <ha-md-menu-item .clickAction=${this._testCondition}>
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.conditions.test"
+                )}
+                <ha-svg-icon slot="start" .path=${mdiFlask}></ha-svg-icon>
+              </ha-md-menu-item>
               <ha-md-menu-item
                 .clickAction=${this._renameCondition}
                 .disabled=${this.disabled}
@@ -189,40 +189,43 @@ export default class HaAutomationConditionRow extends LitElement {
                 )}
                 <ha-svg-icon slot="start" .path=${mdiRenameBox}></ha-svg-icon>
               </ha-md-menu-item>
+
+              <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>
+
+              <ha-md-menu-item
+                .clickAction=${this._duplicateCondition}
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.actions.duplicate"
+                )}
+                <ha-svg-icon
+                  slot="start"
+                  .path=${mdiContentDuplicate}
+                ></ha-svg-icon>
+              </ha-md-menu-item>
+
+              <ha-md-menu-item
+                .clickAction=${this._copyCondition}
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.triggers.copy"
+                )}
+                <ha-svg-icon slot="start" .path=${mdiContentCopy}></ha-svg-icon>
+              </ha-md-menu-item>
+
+              <ha-md-menu-item
+                .clickAction=${this._cutCondition}
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.triggers.cut"
+                )}
+                <ha-svg-icon slot="start" .path=${mdiContentCut}></ha-svg-icon>
+              </ha-md-menu-item>
             `
           : nothing}
-
-        <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>
-
-        <ha-md-menu-item
-          .clickAction=${this._duplicateCondition}
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.actions.duplicate"
-          )}
-          <ha-svg-icon slot="start" .path=${mdiContentDuplicate}></ha-svg-icon>
-        </ha-md-menu-item>
-
-        <ha-md-menu-item
-          .clickAction=${this._copyCondition}
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.triggers.copy"
-          )}
-          <ha-svg-icon slot="start" .path=${mdiContentCopy}></ha-svg-icon>
-        </ha-md-menu-item>
-
-        <ha-md-menu-item
-          .clickAction=${this._cutCondition}
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.triggers.cut"
-          )}
-          <ha-svg-icon slot="start" .path=${mdiContentCut}></ha-svg-icon>
-        </ha-md-menu-item>
 
         <ha-md-menu-item
           .clickAction=${this._moveUp}
@@ -242,51 +245,54 @@ export default class HaAutomationConditionRow extends LitElement {
 
         ${!this.optionsInSidebar
           ? html`<ha-md-menu-item
-              .clickAction=${this._toggleYamlMode}
-              .disabled=${this._uiSupported(this.condition.condition) ||
-              !!this._warnings}
-            >
-              ${this.hass.localize(
-                `ui.panel.config.automation.editor.edit_${!this._yamlMode ? "yaml" : "ui"}`
-              )}
-              <ha-svg-icon slot="start" .path=${mdiPlaylistEdit}></ha-svg-icon>
-            </ha-md-menu-item>`
+                .clickAction=${this._toggleYamlMode}
+                .disabled=${this._uiSupported(this.condition.condition) ||
+                !!this._warnings}
+              >
+                ${this.hass.localize(
+                  `ui.panel.config.automation.editor.edit_${!this._yamlMode ? "yaml" : "ui"}`
+                )}
+                <ha-svg-icon
+                  slot="start"
+                  .path=${mdiPlaylistEdit}
+                ></ha-svg-icon>
+              </ha-md-menu-item>
+
+              <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>
+
+              <ha-md-menu-item
+                .clickAction=${this._onDisable}
+                .disabled=${this.disabled}
+              >
+                ${this.condition.enabled === false
+                  ? this.hass.localize(
+                      "ui.panel.config.automation.editor.actions.enable"
+                    )
+                  : this.hass.localize(
+                      "ui.panel.config.automation.editor.actions.disable"
+                    )}
+                <ha-svg-icon
+                  slot="start"
+                  .path=${this.condition.enabled === false
+                    ? mdiPlayCircleOutline
+                    : mdiStopCircleOutline}
+                ></ha-svg-icon>
+              </ha-md-menu-item>
+              <ha-md-menu-item
+                class="warning"
+                .clickAction=${this._onDelete}
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.actions.delete"
+                )}
+                <ha-svg-icon
+                  class="warning"
+                  slot="start"
+                  .path=${mdiDelete}
+                ></ha-svg-icon>
+              </ha-md-menu-item>`
           : nothing}
-
-        <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>
-
-        <ha-md-menu-item
-          .clickAction=${this._onDisable}
-          .disabled=${this.disabled}
-        >
-          ${this.condition.enabled === false
-            ? this.hass.localize(
-                "ui.panel.config.automation.editor.actions.enable"
-              )
-            : this.hass.localize(
-                "ui.panel.config.automation.editor.actions.disable"
-              )}
-          <ha-svg-icon
-            slot="start"
-            .path=${this.condition.enabled === false
-              ? mdiPlayCircleOutline
-              : mdiStopCircleOutline}
-          ></ha-svg-icon>
-        </ha-md-menu-item>
-        <ha-md-menu-item
-          class="warning"
-          .clickAction=${this._onDelete}
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.actions.delete"
-          )}
-          <ha-svg-icon
-            class="warning"
-            slot="start"
-            .path=${mdiDelete}
-          ></ha-svg-icon>
-        </ha-md-menu-item>
       </ha-md-button-menu>
 
       ${!this.optionsInSidebar
@@ -640,6 +646,10 @@ export default class HaAutomationConditionRow extends LitElement {
       },
       disable: this._onDisable,
       delete: this._onDelete,
+      duplicate: this._duplicateCondition,
+      copy: this._copyCondition,
+      cut: this._cutCondition,
+      test: this._testCondition,
       config: sidebarCondition,
       uiSupported: this._uiSupported(sidebarCondition.condition),
       yamlMode: this._yamlMode,

--- a/src/panels/config/automation/option/ha-automation-option-row.ts
+++ b/src/panels/config/automation/option/ha-automation-option-row.ts
@@ -142,21 +142,21 @@ export default class HaAutomationOptionRow extends LitElement {
                 )}
                 <ha-svg-icon slot="graphic" .path=${mdiRenameBox}></ha-svg-icon>
               </ha-md-menu-item>
+
+              <ha-md-menu-item
+                @click=${this._duplicateOption}
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.actions.duplicate"
+                )}
+                <ha-svg-icon
+                  slot="graphic"
+                  .path=${mdiContentDuplicate}
+                ></ha-svg-icon>
+              </ha-md-menu-item>
             `
           : nothing}
-
-        <ha-md-menu-item
-          @click=${this._duplicateOption}
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.actions.duplicate"
-          )}
-          <ha-svg-icon
-            slot="graphic"
-            .path=${mdiContentDuplicate}
-          ></ha-svg-icon>
-        </ha-md-menu-item>
 
         <ha-md-menu-item
           @click=${this._moveUp}
@@ -174,20 +174,22 @@ export default class HaAutomationOptionRow extends LitElement {
           <ha-svg-icon slot="graphic" .path=${mdiArrowDown}></ha-svg-icon>
         </ha-md-menu-item>
 
-        <ha-md-menu-item
-          @click=${this._removeOption}
-          class="warning"
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.actions.type.choose.remove_option"
-          )}
-          <ha-svg-icon
-            class="warning"
-            slot="graphic"
-            .path=${mdiDelete}
-          ></ha-svg-icon>
-        </ha-md-menu-item>
+        ${!this.optionsInSidebar
+          ? html`<ha-md-menu-item
+              @click=${this._removeOption}
+              class="warning"
+              .disabled=${this.disabled}
+            >
+              ${this.hass.localize(
+                "ui.panel.config.automation.editor.actions.type.choose.remove_option"
+              )}
+              <ha-svg-icon
+                class="warning"
+                slot="graphic"
+                .path=${mdiDelete}
+              ></ha-svg-icon>
+            </ha-md-menu-item>`
+          : nothing}
       </ha-md-button-menu>
 
       ${!this.optionsInSidebar ? this._renderContent() : nothing}
@@ -261,9 +263,9 @@ export default class HaAutomationOptionRow extends LitElement {
     `;
   }
 
-  private _duplicateOption() {
+  private _duplicateOption = () => {
     fireEvent(this, "duplicate");
-  }
+  };
 
   private _moveUp() {
     fireEvent(this, "move-up");
@@ -361,6 +363,7 @@ export default class HaAutomationOptionRow extends LitElement {
       },
       toggleYamlMode: () => false, // no yaml mode for options
       delete: this._removeOption,
+      duplicate: this._duplicateOption,
     } satisfies OptionSidebarConfig);
     this._selected = true;
     this._collapsed = false;

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
@@ -1,5 +1,9 @@
 import {
+  mdiContentCopy,
+  mdiContentCut,
+  mdiContentDuplicate,
   mdiDelete,
+  mdiPlay,
   mdiPlayCircleOutline,
   mdiPlaylistEdit,
   mdiRenameBox,
@@ -93,6 +97,11 @@ export default class HaAutomationSidebarAction extends LitElement {
     >
       <span slot="title">${title}</span>
       <span slot="subtitle">${subtitle}</span>
+
+      <ha-md-menu-item slot="menu-items" .clickAction=${this.config.run}>
+        ${this.hass.localize("ui.panel.config.automation.editor.actions.run")}
+        <ha-svg-icon slot="start" .path=${mdiPlay}></ha-svg-icon>
+      </ha-md-menu-item>
       <ha-md-menu-item
         slot="menu-items"
         .clickAction=${this.config.rename}
@@ -102,6 +111,37 @@ export default class HaAutomationSidebarAction extends LitElement {
           "ui.panel.config.automation.editor.triggers.rename"
         )}
         <ha-svg-icon slot="start" .path=${mdiRenameBox}></ha-svg-icon>
+      </ha-md-menu-item>
+      <ha-md-divider
+        slot="menu-items"
+        role="separator"
+        tabindex="-1"
+      ></ha-md-divider>
+      <ha-md-menu-item
+        slot="menu-items"
+        .clickAction=${this.config.duplicate}
+        .disabled=${this.disabled}
+      >
+        ${this.hass.localize(
+          "ui.panel.config.automation.editor.actions.duplicate"
+        )}
+        <ha-svg-icon slot="start" .path=${mdiContentDuplicate}></ha-svg-icon>
+      </ha-md-menu-item>
+      <ha-md-menu-item
+        slot="menu-items"
+        .clickAction=${this.config.copy}
+        .disabled=${this.disabled}
+      >
+        ${this.hass.localize("ui.panel.config.automation.editor.triggers.copy")}
+        <ha-svg-icon slot="start" .path=${mdiContentCopy}></ha-svg-icon>
+      </ha-md-menu-item>
+      <ha-md-menu-item
+        slot="menu-items"
+        .clickAction=${this.config.cut}
+        .disabled=${this.disabled}
+      >
+        ${this.hass.localize("ui.panel.config.automation.editor.triggers.cut")}
+        <ha-svg-icon slot="start" .path=${mdiContentCut}></ha-svg-icon>
       </ha-md-menu-item>
       <ha-md-menu-item
         slot="menu-items"

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-condition.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-condition.ts
@@ -1,5 +1,9 @@
 import {
+  mdiContentCopy,
+  mdiContentCut,
+  mdiContentDuplicate,
   mdiDelete,
+  mdiFlask,
   mdiPlayCircleOutline,
   mdiPlaylistEdit,
   mdiRenameBox,
@@ -80,6 +84,12 @@ export default class HaAutomationSidebarCondition extends LitElement {
     >
       <span slot="title">${title}</span>
       <span slot="subtitle">${subtitle}</span>
+      <ha-md-menu-item slot="menu-items" .clickAction=${this.config.test}>
+        ${this.hass.localize(
+          "ui.panel.config.automation.editor.conditions.test"
+        )}
+        <ha-svg-icon slot="start" .path=${mdiFlask}></ha-svg-icon>
+      </ha-md-menu-item>
       <ha-md-menu-item
         slot="menu-items"
         .clickAction=${this.config.rename}
@@ -89,6 +99,41 @@ export default class HaAutomationSidebarCondition extends LitElement {
           "ui.panel.config.automation.editor.triggers.rename"
         )}
         <ha-svg-icon slot="start" .path=${mdiRenameBox}></ha-svg-icon>
+      </ha-md-menu-item>
+
+      <ha-md-divider
+        slot="menu-items"
+        role="separator"
+        tabindex="-1"
+      ></ha-md-divider>
+
+      <ha-md-menu-item
+        slot="menu-items"
+        .clickAction=${this.config.duplicate}
+        .disabled=${this.disabled}
+      >
+        ${this.hass.localize(
+          "ui.panel.config.automation.editor.actions.duplicate"
+        )}
+        <ha-svg-icon slot="start" .path=${mdiContentDuplicate}></ha-svg-icon>
+      </ha-md-menu-item>
+
+      <ha-md-menu-item
+        slot="menu-items"
+        .clickAction=${this.config.copy}
+        .disabled=${this.disabled}
+      >
+        ${this.hass.localize("ui.panel.config.automation.editor.triggers.copy")}
+        <ha-svg-icon slot="start" .path=${mdiContentCopy}></ha-svg-icon>
+      </ha-md-menu-item>
+
+      <ha-md-menu-item
+        slot="menu-items"
+        .clickAction=${this.config.cut}
+        .disabled=${this.disabled}
+      >
+        ${this.hass.localize("ui.panel.config.automation.editor.triggers.cut")}
+        <ha-svg-icon slot="start" .path=${mdiContentCut}></ha-svg-icon>
       </ha-md-menu-item>
       <ha-md-menu-item
         slot="menu-items"

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-option.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-option.ts
@@ -1,4 +1,4 @@
-import { mdiDelete, mdiRenameBox } from "@mdi/js";
+import { mdiContentDuplicate, mdiDelete, mdiRenameBox } from "@mdi/js";
 import { css, html, LitElement } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import type { OptionSidebarConfig } from "../../../../data/automation";
@@ -52,6 +52,17 @@ export default class HaAutomationSidebarOption extends LitElement {
           "ui.panel.config.automation.editor.triggers.rename"
         )}
         <ha-svg-icon slot="start" .path=${mdiRenameBox}></ha-svg-icon>
+      </ha-md-menu-item>
+
+      <ha-md-menu-item
+        slot="menu-items"
+        @click=${this.config.duplicate}
+        .disabled=${this.disabled}
+      >
+        ${this.hass.localize(
+          "ui.panel.config.automation.editor.actions.duplicate"
+        )}
+        <ha-svg-icon slot="graphic" .path=${mdiContentDuplicate}></ha-svg-icon>
       </ha-md-menu-item>
       <ha-md-divider
         slot="menu-items"

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-trigger.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-trigger.ts
@@ -1,4 +1,7 @@
 import {
+  mdiContentCopy,
+  mdiContentCut,
+  mdiContentDuplicate,
   mdiDelete,
   mdiIdentifier,
   mdiPlayCircleOutline,
@@ -101,6 +104,45 @@ export default class HaAutomationSidebarTrigger extends LitElement {
               <ha-svg-icon slot="start" .path=${mdiIdentifier}></ha-svg-icon>
             </ha-md-menu-item>`
           : nothing}
+
+        <ha-md-divider
+          slot="menu-items"
+          role="separator"
+          tabindex="-1"
+        ></ha-md-divider>
+
+        <ha-md-menu-item
+          slot="menu-items"
+          .clickAction=${this.config.duplicate}
+          .disabled=${this.disabled}
+        >
+          ${this.hass.localize(
+            "ui.panel.config.automation.editor.triggers.duplicate"
+          )}
+          <ha-svg-icon slot="start" .path=${mdiContentDuplicate}></ha-svg-icon>
+        </ha-md-menu-item>
+
+        <ha-md-menu-item
+          slot="menu-items"
+          .clickAction=${this.config.copy}
+          .disabled=${this.disabled}
+        >
+          ${this.hass.localize(
+            "ui.panel.config.automation.editor.triggers.copy"
+          )}
+          <ha-svg-icon slot="start" .path=${mdiContentCopy}></ha-svg-icon>
+        </ha-md-menu-item>
+
+        <ha-md-menu-item
+          slot="menu-items"
+          .clickAction=${this.config.cut}
+          .disabled=${this.disabled}
+        >
+          ${this.hass.localize(
+            "ui.panel.config.automation.editor.triggers.cut"
+          )}
+          <ha-svg-icon slot="start" .path=${mdiContentCut}></ha-svg-icon>
+        </ha-md-menu-item>
         <ha-md-menu-item
           slot="menu-items"
           .clickAction=${this._toggleYamlMode}

--- a/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
@@ -179,7 +179,7 @@ export default class HaAutomationTriggerRow extends LitElement {
         ></ha-icon-button>
 
         ${!this.optionsInSidebar
-          ? html` <ha-md-menu-item
+          ? html`<ha-md-menu-item
                 .clickAction=${this._renameTrigger}
                 .disabled=${this.disabled || type === "list"}
               >
@@ -199,38 +199,41 @@ export default class HaAutomationTriggerRow extends LitElement {
                 <ha-svg-icon slot="start" .path=${mdiIdentifier}></ha-svg-icon>
               </ha-md-menu-item>
 
-              <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>`
+              <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>
+
+              <ha-md-menu-item
+                .clickAction=${this._duplicateTrigger}
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.triggers.duplicate"
+                )}
+                <ha-svg-icon
+                  slot="start"
+                  .path=${mdiContentDuplicate}
+                ></ha-svg-icon>
+              </ha-md-menu-item>
+
+              <ha-md-menu-item
+                .clickAction=${this._copyTrigger}
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.triggers.copy"
+                )}
+                <ha-svg-icon slot="start" .path=${mdiContentCopy}></ha-svg-icon>
+              </ha-md-menu-item>
+
+              <ha-md-menu-item
+                .clickAction=${this._cutTrigger}
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.triggers.cut"
+                )}
+                <ha-svg-icon slot="start" .path=${mdiContentCut}></ha-svg-icon>
+              </ha-md-menu-item>`
           : nothing}
-
-        <ha-md-menu-item
-          .clickAction=${this._duplicateTrigger}
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.triggers.duplicate"
-          )}
-          <ha-svg-icon slot="start" .path=${mdiContentDuplicate}></ha-svg-icon>
-        </ha-md-menu-item>
-
-        <ha-md-menu-item
-          .clickAction=${this._copyTrigger}
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.triggers.copy"
-          )}
-          <ha-svg-icon slot="start" .path=${mdiContentCopy}></ha-svg-icon>
-        </ha-md-menu-item>
-
-        <ha-md-menu-item
-          .clickAction=${this._cutTrigger}
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.triggers.cut"
-          )}
-          <ha-svg-icon slot="start" .path=${mdiContentCut}></ha-svg-icon>
-        </ha-md-menu-item>
 
         <ha-md-menu-item
           .clickAction=${this._moveUp}
@@ -262,43 +265,44 @@ export default class HaAutomationTriggerRow extends LitElement {
                   .path=${mdiPlaylistEdit}
                 ></ha-svg-icon>
               </ha-md-menu-item>
+
+              <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>
+
+              <ha-md-menu-item
+                .clickAction=${this._onDisable}
+                .disabled=${this.disabled || type === "list"}
+              >
+                ${"enabled" in this.trigger && this.trigger.enabled === false
+                  ? this.hass.localize(
+                      "ui.panel.config.automation.editor.actions.enable"
+                    )
+                  : this.hass.localize(
+                      "ui.panel.config.automation.editor.actions.disable"
+                    )}
+                <ha-svg-icon
+                  slot="start"
+                  .path=${"enabled" in this.trigger &&
+                  this.trigger.enabled === false
+                    ? mdiPlayCircleOutline
+                    : mdiStopCircleOutline}
+                ></ha-svg-icon>
+              </ha-md-menu-item>
+              <ha-md-menu-item
+                .clickAction=${this._onDelete}
+                class="warning"
+                .disabled=${this.disabled}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.actions.delete"
+                )}
+                <ha-svg-icon
+                  class="warning"
+                  slot="start"
+                  .path=${mdiDelete}
+                ></ha-svg-icon>
+              </ha-md-menu-item>
             `
           : nothing}
-
-        <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>
-
-        <ha-md-menu-item
-          .clickAction=${this._onDisable}
-          .disabled=${this.disabled || type === "list"}
-        >
-          ${"enabled" in this.trigger && this.trigger.enabled === false
-            ? this.hass.localize(
-                "ui.panel.config.automation.editor.actions.enable"
-              )
-            : this.hass.localize(
-                "ui.panel.config.automation.editor.actions.disable"
-              )}
-          <ha-svg-icon
-            slot="start"
-            .path=${"enabled" in this.trigger && this.trigger.enabled === false
-              ? mdiPlayCircleOutline
-              : mdiStopCircleOutline}
-          ></ha-svg-icon>
-        </ha-md-menu-item>
-        <ha-md-menu-item
-          .clickAction=${this._onDelete}
-          class="warning"
-          .disabled=${this.disabled}
-        >
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.actions.delete"
-          )}
-          <ha-svg-icon
-            class="warning"
-            slot="start"
-            .path=${mdiDelete}
-          ></ha-svg-icon>
-        </ha-md-menu-item>
       </ha-md-button-menu>
       ${!this.optionsInSidebar
         ? html`${this._warnings
@@ -486,6 +490,9 @@ export default class HaAutomationTriggerRow extends LitElement {
       },
       disable: this._onDisable,
       delete: this._onDelete,
+      copy: this._copyTrigger,
+      duplicate: this._duplicateTrigger,
+      cut: this._cutTrigger,
       config: trigger || this.trigger,
       uiSupported: this._uiSupported(this._getType(trigger || this.trigger)),
       yamlMode: this._yamlMode,

--- a/src/panels/config/script/ha-script-field-row.ts
+++ b/src/panels/config/script/ha-script-field-row.ts
@@ -1,11 +1,8 @@
-import { mdiDelete, mdiDotsVertical } from "@mdi/js";
 import type { CSSResultGroup } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { fireEvent } from "../../../common/dom/fire_event";
-import { preventDefaultStopPropagation } from "../../../common/dom/prevent_default_stop_propagation";
-import { stopPropagation } from "../../../common/dom/stop_propagation";
 import type { LocalizeKeys } from "../../../common/translations/localize";
 import "../../../components/ha-automation-row";
 import "../../../components/ha-card";
@@ -63,34 +60,6 @@ export default class HaScriptFieldRow extends LitElement {
           <h3 slot="header">${this.key}</h3>
 
           <slot name="icons" slot="icons"></slot>
-          <ha-md-button-menu
-            slot="icons"
-            @click=${preventDefaultStopPropagation}
-            @keydown=${stopPropagation}
-            @closed=${stopPropagation}
-            positioning="fixed"
-          >
-            <ha-icon-button
-              slot="trigger"
-              .label=${this.hass.localize("ui.common.menu")}
-              .path=${mdiDotsVertical}
-            ></ha-icon-button>
-
-            <ha-md-menu-item
-              class="warning"
-              .clickAction=${this._onDelete}
-              .disabled=${this.disabled}
-            >
-              ${this.hass.localize(
-                "ui.panel.config.automation.editor.actions.delete"
-              )}
-              <ha-svg-icon
-                class="warning"
-                slot="graphic"
-                .path=${mdiDelete}
-              ></ha-svg-icon>
-            </ha-md-menu-item>
-          </ha-md-button-menu>
         </ha-automation-row>
       </ha-card>
       <div


### PR DESCRIPTION
## Proposed change
- Row overflow actions are just to move the row
- sidebar contains all actions


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
