### PR TITLE
Improve network adapter configuration discoverability

### DIFF
--- a/src/components/ha-network.ts
+++ b/src/components/ha-network.ts
@@ -1,4 +1,4 @@
-import { mdiStar } from "@mdi/js";
+import { mdiInformationOutline, mdiStar } from "@mdi/js";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
@@ -71,6 +71,17 @@ export class HaNetwork extends LitElement {
         <span slot="description" data-for="auto_configure">
           ${this.hass.localize("ui.panel.config.network.adapter.detected")}:
           ${format_auto_detected_interfaces(this.networkConfig.adapters)}
+          ${!configured_adapters.length
+            ? html`<div class="info-text">
+                <ha-svg-icon
+                  .path=${mdiInformationOutline}
+                  class="info-icon"
+                ></ha-svg-icon>
+                ${this.hass.localize(
+                  "ui.panel.config.network.adapter.auto_configure_manual_hint"
+                )}
+              </div>`
+            : nothing}
         </span>
       </ha-settings-row>
       ${configured_adapters.length || this._expanded
@@ -170,6 +181,21 @@ export class HaNetwork extends LitElement {
         span[slot="heading"],
         span[slot="description"] {
           cursor: pointer;
+        }
+
+        .info-text {
+          display: flex;
+          align-items: center;
+          margin-top: 8px;
+          color: var(--secondary-text-color);
+        }
+
+        .info-icon {
+          width: 18px;
+          height: 18px;
+          color: var(--info-color, var(--primary-color));
+          margin-right: 8px;
+          flex-shrink: 0;
         }
       `,
     ];

--- a/src/panels/config/network/ha-config-network.ts
+++ b/src/panels/config/network/ha-config-network.ts
@@ -23,10 +23,7 @@ class ConfigNetwork extends LitElement {
   @state() private _error?: { code: string; message: string };
 
   protected render() {
-    if (
-      !this.hass.userData?.showAdvanced ||
-      !isComponentLoaded(this.hass, "network")
-    ) {
+    if (!isComponentLoaded(this.hass, "network")) {
       return nothing;
     }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6664,6 +6664,7 @@
           "ip_information": "IP information",
           "adapter": {
             "auto_configure": "Autoconfigure",
+            "auto_configure_manual_hint": "Uncheck to manually select network adapters",
             "detected": "Detected",
             "adapter": "Adapter"
           }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Improve network configuration discoverability by removing the `showAdvanced` requirement and adding clearer UI hints for manual adapter selection.

### Changes made:

1. **Removed advanced mode requirement**: The network configuration panel is now always visible when the network component is loaded, eliminating the first barrier to access.

2. **Added manual selection hint**: When "Autoconfigure" is checked, an info icon and explanatory text now appear to inform users they can uncheck it to manually select network adapters. This addresses the non-discoverable UI pattern where unchecking a checkbox reveals additional options.

### Why these changes are needed:

- Network adapter configuration is frequently required by users to set up integrations that need specific network interfaces (multicast, interface binding, etc.)
- The double barrier (advanced mode + hidden manual selection) made this essential configuration unnecessarily difficult to discover - even experienced developers have reported being unable to find these settings for nearly a year (see home-assistant/core#128123)
- Users with many network adapters (including virtual ones and VPNs) need to be able to select specific adapters
- The setting is already nested multiple screens deep, so hiding it further creates unnecessary friction
- Other settings on the same configuration page are not considered "advanced"

These changes provide a more intuitive and discoverable user experience while maintaining the clean interface through the collapsible manual selection.

<img width="630" height="319" alt="Screenshot 2025-08-27 at 9 37 27 AM" src="https://github.com/user-attachments/assets/78023db7-8908-4ff3-b2f3-02002354bbf1" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io