### PR TITLE
Move automation and script `ha-alert`s to main flow

### DIFF
--- a/src/components/ha-alert.ts
+++ b/src/components/ha-alert.ts
@@ -119,6 +119,7 @@ class HaAlert extends LitElement {
     .main-content {
       overflow-wrap: anywhere;
       word-break: break-word;
+      line-height: normal;
       margin-left: 8px;
       margin-right: 0;
       margin-inline-start: 8px;

--- a/src/components/ha-alert.ts
+++ b/src/components/ha-alert.ts
@@ -122,7 +122,7 @@ class HaAlert extends LitElement {
       margin-left: 8px;
       margin-right: 0;
       margin-inline-start: 8px;
-      margin-inline-end: 0;
+      margin-inline-end: 8px;
     }
     .title {
       margin-top: 2px;

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -460,9 +460,9 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
                           .disabled=${this._readOnly}
                           .dirty=${this._dirty}
                           .saving=${this._saving}
-                          @editor-save=${this._handleSaveAutomation}
-                          @save-automation=${this._handleSaveAutomation}
                           @value-changed=${this._valueChanged}
+                          @save-automation=${this._handleSaveAutomation}
+                          @editor-save=${this._handleSaveAutomation}
                         >
                           <div class="alert-wrapper" slot="alerts">
                             ${this._errors || stateObj?.state === UNAVAILABLE

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -567,7 +567,7 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
                           </ha-button>
                         </ha-alert>
                       `
-                    : ""}
+                    : nothing}
                   <ha-yaml-editor
                     copy-clipboard
                     .hass=${this.hass}

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -465,9 +465,10 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
                           .errors=${this._errors}
                           .hasBlueprintConfig=${Boolean(this._blueprintConfig)}
                           .validationErrors=${this._validationErrors}
-                          @value-changed=${this._valueChanged}
-                          @save-automation=${this._handleSaveAutomation}
+                          @duplicate-automation=${this._duplicate}
                           @editor-save=${this._handleSaveAutomation}
+                          @save-automation=${this._handleSaveAutomation}
+                          @value-changed=${this._valueChanged}
                         ></manual-automation-editor>
                       `}
                 </div>

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -12,6 +12,7 @@ import {
   mdiPlayCircleOutline,
   mdiPlaylistEdit,
   mdiRenameBox,
+  mdiRobotConfused,
   mdiStopCircleOutline,
   mdiTag,
   mdiTransitConnection,
@@ -462,14 +463,91 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
                           .disabled=${this._readOnly}
                           .dirty=${this._dirty}
                           .saving=${this._saving}
-                          .errors=${this._errors}
-                          .hasBlueprintConfig=${Boolean(this._blueprintConfig)}
-                          .validationErrors=${this._validationErrors}
-                          @duplicate-automation=${this._duplicate}
                           @editor-save=${this._handleSaveAutomation}
                           @save-automation=${this._handleSaveAutomation}
                           @value-changed=${this._valueChanged}
-                        ></manual-automation-editor>
+                        >
+                          <div class="alert-wrapper" slot="alerts">
+                            ${this._errors || stateObj?.state === UNAVAILABLE
+                              ? html`<ha-alert
+                                  alert-type="error"
+                                  .title=${stateObj?.state === UNAVAILABLE
+                                    ? this.hass.localize(
+                                        "ui.panel.config.automation.editor.unavailable"
+                                      )
+                                    : undefined}
+                                >
+                                  ${this._errors || this._validationErrors}
+                                  ${stateObj?.state === UNAVAILABLE
+                                    ? html`<ha-svg-icon
+                                        slot="icon"
+                                        .path=${mdiRobotConfused}
+                                      ></ha-svg-icon>`
+                                    : nothing}
+                                </ha-alert>`
+                              : nothing}
+                            ${this._blueprintConfig
+                              ? html`<ha-alert alert-type="info">
+                                  ${this.hass.localize(
+                                    "ui.panel.config.automation.editor.confirm_take_control"
+                                  )}
+                                  <div slot="action" style="display: flex;">
+                                    <ha-button
+                                      appearance="plain"
+                                      @click=${this._takeControlSave}
+                                      >${this.hass.localize(
+                                        "ui.common.yes"
+                                      )}</ha-button
+                                    >
+                                    <ha-button
+                                      appearance="plain"
+                                      @click=${this._revertBlueprint}
+                                      >${this.hass.localize(
+                                        "ui.common.no"
+                                      )}</ha-button
+                                    >
+                                  </div>
+                                </ha-alert>`
+                              : this._readOnly
+                                ? html`<ha-alert
+                                    alert-type="warning"
+                                    dismissable
+                                    >${this.hass.localize(
+                                      "ui.panel.config.automation.editor.read_only"
+                                    )}
+                                    <ha-button
+                                      appearance="filled"
+                                      size="small"
+                                      variant="warning"
+                                      slot="action"
+                                      @click=${this._duplicate}
+                                    >
+                                      ${this.hass.localize(
+                                        "ui.panel.config.automation.editor.migrate"
+                                      )}
+                                    </ha-button>
+                                  </ha-alert>`
+                                : nothing}
+                            ${stateObj?.state === "off"
+                              ? html`
+                                  <ha-alert alert-type="info">
+                                    ${this.hass.localize(
+                                      "ui.panel.config.automation.editor.disabled"
+                                    )}
+                                    <ha-button
+                                      size="small"
+                                      slot="action"
+                                      @click=${this._toggle}
+                                    >
+                                      ${this.hass.localize(
+                                        "ui.panel.config.automation.editor.enable"
+                                      )}
+                                    </ha-button>
+                                  </ha-alert>
+                                `
+                              : nothing}
+                          </div>
+                        </manual-automation-editor>
                       `}
                 </div>
               `
@@ -1104,6 +1182,25 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
           max-width: 1040px;
           padding: 28px 20px 0;
           display: block;
+        }
+
+        :not(.yaml-mode) > .alert-wrapper {
+          position: sticky;
+          top: -24px;
+          margin-top: -24px;
+          z-index: 100;
+          width: 100%;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 8px;
+        }
+
+        :not(.yaml-mode) > .alert-wrapper ha-alert {
+          background-color: var(--card-background-color);
+          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+          border-radius: var(--ha-border-radius-sm);
+          margin-bottom: 0;
         }
 
         manual-automation-editor {

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -499,7 +499,7 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
                           .isWide=${this.isWide}
                           .stateObj=${stateObj}
                           .config=${this._config}
-                          .disabled=${Boolean(this._readOnly)}
+                          .disabled=${this._readOnly}
                           .saving=${this._saving}
                           .dirty=${this._dirty}
                           @value-changed=${this._valueChanged}
@@ -513,7 +513,7 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
                           .isWide=${this.isWide}
                           .stateObj=${stateObj}
                           .config=${this._config}
-                          .disabled=${Boolean(this._readOnly)}
+                          .disabled=${this._readOnly}
                           .dirty=${this._dirty}
                           .saving=${this._saving}
                           @value-changed=${this._valueChanged}

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -446,11 +446,8 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
                           .disabled=${this._readOnly}
                           .saving=${this._saving}
                           .dirty=${this._dirty}
-                          @duplicate=${this._duplicate}
-                          @revert-blueprint=${this._revertBlueprint}
-                          @save-automation=${this._handleSaveAutomation}
-                          @take-control-save=${this._takeControlSave}
                           @value-changed=${this._valueChanged}
+                          @save-automation=${this._handleSaveAutomation}
                         ></blueprint-automation-editor>
                       `
                     : html`

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -1185,6 +1185,7 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
           position: sticky;
           top: -24px;
           margin-top: -24px;
+          margin-bottom: -8px;
           z-index: 100;
           width: 100%;
           display: flex;

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -12,7 +12,6 @@ import {
   mdiPlayCircleOutline,
   mdiPlaylistEdit,
   mdiRenameBox,
-  mdiRobotConfused,
   mdiStopCircleOutline,
   mdiTag,
   mdiTransitConnection,
@@ -432,62 +431,6 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
           class=${this._mode === "yaml" ? "yaml-mode" : ""}
           @subscribe-automation-config=${this._subscribeAutomationConfig}
         >
-          <div class="error-wrapper">
-            ${this._errors || stateObj?.state === UNAVAILABLE
-              ? html`<ha-alert
-                  alert-type="error"
-                  .title=${stateObj?.state === UNAVAILABLE
-                    ? this.hass.localize(
-                        "ui.panel.config.automation.editor.unavailable"
-                      )
-                    : undefined}
-                >
-                  ${this._errors || this._validationErrors}
-                  ${stateObj?.state === UNAVAILABLE
-                    ? html`<ha-svg-icon
-                        slot="icon"
-                        .path=${mdiRobotConfused}
-                      ></ha-svg-icon>`
-                    : nothing}
-                </ha-alert>`
-              : ""}
-            ${this._blueprintConfig
-              ? html`<ha-alert alert-type="info">
-                  ${this.hass.localize(
-                    "ui.panel.config.automation.editor.confirm_take_control"
-                  )}
-                  <div slot="action" style="display: flex;">
-                    <ha-button
-                      appearance="plain"
-                      @click=${this._takeControlSave}
-                      >${this.hass.localize("ui.common.yes")}</ha-button
-                    >
-                    <ha-button
-                      appearance="plain"
-                      @click=${this._revertBlueprint}
-                      >${this.hass.localize("ui.common.no")}</ha-button
-                    >
-                  </div>
-                </ha-alert>`
-              : this._readOnly
-                ? html`<ha-alert alert-type="warning" dismissable
-                    >${this.hass.localize(
-                      "ui.panel.config.automation.editor.read_only"
-                    )}
-                    <ha-button
-                      appearance="filled"
-                      size="small"
-                      variant="warning"
-                      slot="action"
-                      @click=${this._duplicate}
-                    >
-                      ${this.hass.localize(
-                        "ui.panel.config.automation.editor.migrate"
-                      )}
-                    </ha-button>
-                  </ha-alert>`
-                : nothing}
-          </div>
           ${this._mode === "gui"
             ? html`
                 <div>
@@ -502,8 +445,11 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
                           .disabled=${this._readOnly}
                           .saving=${this._saving}
                           .dirty=${this._dirty}
-                          @value-changed=${this._valueChanged}
+                          @duplicate=${this._duplicate}
+                          @revert-blueprint=${this._revertBlueprint}
                           @save-automation=${this._handleSaveAutomation}
+                          @take-control-save=${this._takeControlSave}
+                          @value-changed=${this._valueChanged}
                         ></blueprint-automation-editor>
                       `
                     : html`
@@ -516,6 +462,9 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
                           .disabled=${this._readOnly}
                           .dirty=${this._dirty}
                           .saving=${this._saving}
+                          .errors=${this._errors}
+                          .hasBlueprintConfig=${Boolean(this._blueprintConfig)}
+                          .validationErrors=${this._validationErrors}
                           @value-changed=${this._valueChanged}
                           @save-automation=${this._handleSaveAutomation}
                           @editor-save=${this._handleSaveAutomation}
@@ -1154,22 +1103,6 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
           max-width: 1040px;
           padding: 28px 20px 0;
           display: block;
-        }
-
-        :not(.yaml-mode) > .error-wrapper {
-          position: absolute;
-          top: 4px;
-          z-index: 100;
-          width: 100%;
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-        }
-
-        :not(.yaml-mode) > .error-wrapper ha-alert {
-          background-color: var(--card-background-color);
-          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-          border-radius: var(--ha-border-radius-sm);
         }
 
         manual-automation-editor {

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -1159,7 +1159,7 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
         :not(.yaml-mode) > .error-wrapper {
           position: absolute;
           top: 4px;
-          z-index: 3;
+          z-index: 100;
           width: 100%;
           display: flex;
           flex-direction: column;

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -1185,7 +1185,6 @@ export class HaAutomationEditor extends PreventUnsavedMixin(
           position: sticky;
           top: -24px;
           margin-top: -24px;
-          margin-bottom: -8px;
           z-index: 100;
           width: 100%;
           display: flex;

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -292,7 +292,7 @@ export class HaManualAutomationEditor extends LitElement {
                         ></ha-svg-icon>`
                       : nothing}
                   </ha-alert>`
-                : ""}
+                : nothing}
               ${this.hasBlueprintConfig
                 ? html`<ha-alert alert-type="info">
                     ${this.hass.localize(

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -120,20 +120,6 @@ export class HaManualAutomationEditor extends LitElement {
 
   private _renderContent() {
     return html`
-      ${this.stateObj?.state === "off"
-        ? html`
-            <ha-alert alert-type="info">
-              ${this.hass.localize(
-                "ui.panel.config.automation.editor.disabled"
-              )}
-              <ha-button size="small" slot="action" @click=${this._enable}>
-                ${this.hass.localize(
-                  "ui.panel.config.automation.editor.enable"
-                )}
-              </ha-button>
-            </ha-alert>
-          `
-        : nothing}
       ${this.config.description
         ? html`<ha-markdown
             class="description"
@@ -343,6 +329,24 @@ export class HaManualAutomationEditor extends LitElement {
                       </ha-button>
                     </ha-alert>`
                   : nothing}
+              ${this.stateObj?.state === "off"
+                ? html`
+                    <ha-alert alert-type="info">
+                      ${this.hass.localize(
+                        "ui.panel.config.automation.editor.disabled"
+                      )}
+                      <ha-button
+                        size="small"
+                        slot="action"
+                        @click=${this._enable}
+                      >
+                        ${this.hass.localize(
+                          "ui.panel.config.automation.editor.enable"
+                        )}
+                      </ha-button>
+                    </ha-alert>
+                  `
+                : nothing}
             </div>
 
             ${this._renderContent()}
@@ -745,6 +749,7 @@ export class HaManualAutomationEditor extends LitElement {
           display: flex;
           flex-direction: column;
           align-items: center;
+          gap: 8px;
         }
 
         .alert-wrapper ha-alert {

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -463,7 +463,7 @@ export class HaManualAutomationEditor extends LitElement {
   }
 
   private _duplicate() {
-    fireEvent(this, "duplicate");
+    fireEvent(this, "duplicate-automation");
   }
 
   private _takeControlSave() {
@@ -769,7 +769,7 @@ declare global {
   }
 
   interface HASSDomEvents {
-    duplicate: undefined;
+    "duplicate-automation": undefined;
     "close-sidebar": undefined;
     "open-sidebar": SidebarConfig;
     "request-close-sidebar": undefined;

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -1,7 +1,7 @@
-import { mdiContentSave, mdiHelpCircle, mdiRobotConfused } from "@mdi/js";
+import { mdiContentSave, mdiHelpCircle } from "@mdi/js";
 import type { HassEntity } from "home-assistant-js-websocket";
 import { load } from "js-yaml";
-import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
+import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
@@ -53,7 +53,6 @@ import type HaAutomationSidebar from "./ha-automation-sidebar";
 import { showPasteReplaceDialog } from "./paste-replace-dialog/show-dialog-paste-replace";
 import { manualEditorStyles, saveFabStyles } from "./styles";
 import "./trigger/ha-automation-trigger";
-import { UNAVAILABLE } from "../../../data/entity";
 
 const baseConfigStruct = object({
   alias: optional(string()),
@@ -89,13 +88,6 @@ export class HaManualAutomationEditor extends LitElement {
   @property({ attribute: false }) public stateObj?: HassEntity;
 
   @property({ attribute: false }) public dirty = false;
-
-  @property({ attribute: false }) public errors?: string;
-
-  @property({ attribute: false }) public hasBlueprintConfig = false;
-
-  @property({ attribute: false })
-  public validationErrors?: (string | TemplateResult)[];
 
   @state() private _pastedConfig?: ManualAutomationConfig;
 
@@ -274,81 +266,7 @@ export class HaManualAutomationEditor extends LitElement {
       >
         <div class="content-wrapper">
           <div class="content">
-            <div class="alert-wrapper">
-              ${this.errors || this.stateObj?.state === UNAVAILABLE
-                ? html`<ha-alert
-                    alert-type="error"
-                    .title=${this.stateObj?.state === UNAVAILABLE
-                      ? this.hass.localize(
-                          "ui.panel.config.automation.editor.unavailable"
-                        )
-                      : undefined}
-                  >
-                    ${this.errors || this.validationErrors}
-                    ${this.stateObj?.state === UNAVAILABLE
-                      ? html`<ha-svg-icon
-                          slot="icon"
-                          .path=${mdiRobotConfused}
-                        ></ha-svg-icon>`
-                      : nothing}
-                  </ha-alert>`
-                : nothing}
-              ${this.hasBlueprintConfig
-                ? html`<ha-alert alert-type="info">
-                    ${this.hass.localize(
-                      "ui.panel.config.automation.editor.confirm_take_control"
-                    )}
-                    <div slot="action" style="display: flex;">
-                      <ha-button
-                        appearance="plain"
-                        @click=${this._takeControlSave}
-                        >${this.hass.localize("ui.common.yes")}</ha-button
-                      >
-                      <ha-button
-                        appearance="plain"
-                        @click=${this._revertBlueprint}
-                        >${this.hass.localize("ui.common.no")}</ha-button
-                      >
-                    </div>
-                  </ha-alert>`
-                : this.disabled
-                  ? html`<ha-alert alert-type="warning" dismissable
-                      >${this.hass.localize(
-                        "ui.panel.config.automation.editor.read_only"
-                      )}
-                      <ha-button
-                        appearance="filled"
-                        size="small"
-                        variant="warning"
-                        slot="action"
-                        @click=${this._duplicate}
-                      >
-                        ${this.hass.localize(
-                          "ui.panel.config.automation.editor.migrate"
-                        )}
-                      </ha-button>
-                    </ha-alert>`
-                  : nothing}
-              ${this.stateObj?.state === "off"
-                ? html`
-                    <ha-alert alert-type="info">
-                      ${this.hass.localize(
-                        "ui.panel.config.automation.editor.disabled"
-                      )}
-                      <ha-button
-                        size="small"
-                        slot="action"
-                        @click=${this._enable}
-                      >
-                        ${this.hass.localize(
-                          "ui.panel.config.automation.editor.enable"
-                        )}
-                      </ha-button>
-                    </ha-alert>
-                  `
-                : nothing}
-            </div>
-
+            <slot name="alerts"></slot>
             ${this._renderContent()}
           </div>
           <ha-fab
@@ -455,27 +373,6 @@ export class HaManualAutomationEditor extends LitElement {
     fireEvent(this, "value-changed", {
       value: { ...this.config!, actions: ev.detail.value as Action[] },
     });
-  }
-
-  private async _enable(): Promise<void> {
-    if (!this.hass || !this.stateObj) {
-      return;
-    }
-    await this.hass.callService("automation", "turn_on", {
-      entity_id: this.stateObj.entity_id,
-    });
-  }
-
-  private _duplicate() {
-    fireEvent(this, "duplicate-automation");
-  }
-
-  private _takeControlSave() {
-    fireEvent(this, "take-control-save");
-  }
-
-  private _revertBlueprint() {
-    fireEvent(this, "revert-blueprint");
   }
 
   private _saveAutomation() {
@@ -739,29 +636,8 @@ export class HaManualAutomationEditor extends LitElement {
           line-height: 0;
         }
 
-        .alert-wrapper {
-          position: sticky;
-          top: -24px;
-          margin-top: -24px;
-          margin-bottom: -16px;
-          z-index: 100;
-          width: 100%;
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          gap: 8px;
-        }
-
-        .alert-wrapper ha-alert {
-          background-color: var(--card-background-color);
-          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-          border-radius: var(--ha-border-radius-sm);
-          margin-bottom: 0;
-        }
-
-        ha-alert {
-          display: block;
-          margin-bottom: 16px;
+        .description {
+          margin-top: 16px;
         }
       `,
     ];
@@ -774,11 +650,9 @@ declare global {
   }
 
   interface HASSDomEvents {
-    "duplicate-automation": undefined;
     "close-sidebar": undefined;
     "open-sidebar": SidebarConfig;
+    "save-automation": undefined;
     "request-close-sidebar": undefined;
-    "revert-blueprint": undefined;
-    "take-control-save": undefined;
   }
 }

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -650,9 +650,8 @@ declare global {
   }
 
   interface HASSDomEvents {
-    "close-sidebar": undefined;
     "open-sidebar": SidebarConfig;
-    "save-automation": undefined;
     "request-close-sidebar": undefined;
+    "close-sidebar": undefined;
   }
 }

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -288,7 +288,7 @@ export class HaManualAutomationEditor extends LitElement {
       >
         <div class="content-wrapper">
           <div class="content">
-            <div class="error-wrapper">
+            <div class="alert-wrapper">
               ${this.errors || this.stateObj?.state === UNAVAILABLE
                 ? html`<ha-alert
                     alert-type="error"
@@ -735,11 +735,11 @@ export class HaManualAutomationEditor extends LitElement {
           line-height: 0;
         }
 
-        .error-wrapper {
+        .alert-wrapper {
           position: sticky;
           top: -24px;
           margin-top: -24px;
-          margin-bottom: -163px;
+          margin-bottom: -16px;
           z-index: 100;
           width: 100%;
           display: flex;
@@ -747,7 +747,7 @@ export class HaManualAutomationEditor extends LitElement {
           align-items: center;
         }
 
-        .error-wrapper ha-alert {
+        .alert-wrapper ha-alert {
           background-color: var(--card-background-color);
           box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
           border-radius: var(--ha-border-radius-sm);

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -384,60 +384,6 @@ export class HaScriptEditor extends SubscribeMixin(
           </ha-list-item>
         </ha-button-menu>
         <div class=${this._mode === "yaml" ? "yaml-mode" : ""}>
-          <div class="error-wrapper">
-            ${this._errors || stateObj?.state === UNAVAILABLE
-              ? html`<ha-alert
-                  alert-type="error"
-                  .title=${stateObj?.state === UNAVAILABLE
-                    ? this.hass.localize(
-                        "ui.panel.config.script.editor.unavailable"
-                      )
-                    : undefined}
-                >
-                  ${this._errors || this._validationErrors}
-                  ${stateObj?.state === UNAVAILABLE
-                    ? html`<ha-svg-icon
-                        slot="icon"
-                        .path=${mdiRobotConfused}
-                      ></ha-svg-icon>`
-                    : nothing}
-                </ha-alert>`
-              : nothing}
-            ${this._blueprintConfig
-              ? html`<ha-alert alert-type="info">
-                  ${this.hass.localize(
-                    "ui.panel.config.script.editor.confirm_take_control"
-                  )}
-                  <div slot="action" style="display: flex;">
-                    <ha-button
-                      appearance="plain"
-                      @click=${this._takeControlSave}
-                      >${this.hass.localize("ui.common.yes")}</ha-button
-                    >
-                    <ha-button
-                      appearance="plain"
-                      @click=${this._revertBlueprint}
-                      >${this.hass.localize("ui.common.no")}</ha-button
-                    >
-                  </div>
-                </ha-alert>`
-              : this._readOnly
-                ? html`<ha-alert alert-type="warning" dismissable
-                    >${this.hass.localize(
-                      "ui.panel.config.script.editor.read_only"
-                    )}
-                    <ha-button
-                      appearance="plain"
-                      slot="action"
-                      @click=${this._duplicate}
-                    >
-                      ${this.hass.localize(
-                        "ui.panel.config.script.editor.migrate"
-                      )}
-                    </ha-button>
-                  </ha-alert>`
-                : nothing}
-          </div>
           ${this._mode === "gui"
             ? html`
                 <div>
@@ -464,9 +410,18 @@ export class HaScriptEditor extends SubscribeMixin(
                           .disabled=${this._readOnly}
                           .dirty=${this._dirty}
                           .saving=${this._saving}
-                          @value-changed=${this._valueChanged}
+                          .errors=${this._errors}
+                          .stateObj=${this._entityId
+                            ? this.hass.states[this._entityId]
+                            : undefined}
+                          .hasBlueprintConfig=${Boolean(this._blueprintConfig)}
+                          .validationErrors=${this._validationErrors}
+                          @duplicate-script=${this._duplicate}
                           @editor-save=${this._handleSaveScript}
+                          @revert-blueprint=${this._revertBlueprint}
                           @save-script=${this._handleSaveScript}
+                          @take-control-save=${this._takeControlSave}
+                          @value-changed=${this._valueChanged}
                         ></manual-script-editor>
                       `}
                 </div>
@@ -1069,27 +1024,13 @@ export class HaScriptEditor extends SubscribeMixin(
           flex-direction: column;
           padding-bottom: 0;
         }
+
         manual-script-editor,
         blueprint-script-editor {
           margin: 0 auto;
           max-width: 1040px;
           padding: 28px 20px 0;
           display: block;
-        }
-
-        :not(.yaml-mode) > .error-wrapper {
-          position: absolute;
-          top: 4px;
-          z-index: 100;
-          width: 100%;
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-        }
-        :not(.yaml-mode) > .error-wrapper ha-alert {
-          background-color: var(--card-background-color);
-          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-          border-radius: var(--ha-border-radius-sm);
         }
 
         manual-script-editor {

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -1080,7 +1080,7 @@ export class HaScriptEditor extends SubscribeMixin(
         :not(.yaml-mode) > .error-wrapper {
           position: absolute;
           top: 4px;
-          z-index: 3;
+          z-index: 100;
           width: 100%;
           display: flex;
           flex-direction: column;

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -12,6 +12,7 @@ import {
   mdiPlay,
   mdiPlaylistEdit,
   mdiRenameBox,
+  mdiRobotConfused,
   mdiTag,
   mdiTransitConnection,
   mdiUnfoldLessHorizontal,
@@ -409,19 +410,71 @@ export class HaScriptEditor extends SubscribeMixin(
                           .disabled=${this._readOnly}
                           .dirty=${this._dirty}
                           .saving=${this._saving}
-                          .errors=${this._errors}
-                          .stateObj=${this._entityId
-                            ? this.hass.states[this._entityId]
-                            : undefined}
-                          .hasBlueprintConfig=${Boolean(this._blueprintConfig)}
-                          .validationErrors=${this._validationErrors}
-                          @duplicate-script=${this._duplicate}
-                          @editor-save=${this._handleSaveScript}
-                          @revert-blueprint=${this._revertBlueprint}
-                          @save-script=${this._handleSaveScript}
-                          @take-control-save=${this._takeControlSave}
                           @value-changed=${this._valueChanged}
-                        ></manual-script-editor>
+                          @editor-save=${this._handleSaveScript}
+                          @save-script=${this._handleSaveScript}
+                        >
+                          <div class="alert-wrapper" slot="alerts">
+                            ${this._errors || stateObj?.state === UNAVAILABLE
+                              ? html`<ha-alert
+                                  alert-type="error"
+                                  .title=${stateObj?.state === UNAVAILABLE
+                                    ? this.hass.localize(
+                                        "ui.panel.config.script.editor.unavailable"
+                                      )
+                                    : undefined}
+                                >
+                                  ${this._errors || this._validationErrors}
+                                  ${stateObj?.state === UNAVAILABLE
+                                    ? html`<ha-svg-icon
+                                        slot="icon"
+                                        .path=${mdiRobotConfused}
+                                      ></ha-svg-icon>`
+                                    : nothing}
+                                </ha-alert>`
+                              : nothing}
+                            ${this._blueprintConfig
+                              ? html`<ha-alert alert-type="info">
+                                  ${this.hass.localize(
+                                    "ui.panel.config.script.editor.confirm_take_control"
+                                  )}
+                                  <div slot="action" style="display: flex;">
+                                    <ha-button
+                                      appearance="plain"
+                                      @click=${this._takeControlSave}
+                                      >${this.hass.localize(
+                                        "ui.common.yes"
+                                      )}</ha-button
+                                    >
+                                    <ha-button
+                                      appearance="plain"
+                                      @click=${this._revertBlueprint}
+                                      >${this.hass.localize(
+                                        "ui.common.no"
+                                      )}</ha-button
+                                    >
+                                  </div>
+                                </ha-alert>`
+                              : this._readOnly
+                                ? html`<ha-alert
+                                    alert-type="warning"
+                                    dismissable
+                                    >${this.hass.localize(
+                                      "ui.panel.config.script.editor.read_only"
+                                    )}
+                                    <ha-button
+                                      appearance="plain"
+                                      slot="action"
+                                      @click=${this._duplicate}
+                                    >
+                                      ${this.hass.localize(
+                                        "ui.panel.config.script.editor.migrate"
+                                      )}
+                                    </ha-button>
+                                  </ha-alert>`
+                                : nothing}
+                          </div>
+                        </manual-script-editor>
                       `}
                 </div>
               `
@@ -1023,13 +1076,47 @@ export class HaScriptEditor extends SubscribeMixin(
           flex-direction: column;
           padding-bottom: 0;
         }
-
         manual-script-editor,
         blueprint-script-editor {
           margin: 0 auto;
           max-width: 1040px;
           padding: 28px 20px 0;
           display: block;
+        }
+
+        :not(.yaml-mode) > .error-wrapper {
+          position: absolute;
+          top: 4px;
+          z-index: 3;
+          width: 100%;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+        }
+        :not(.yaml-mode) > .error-wrapper ha-alert {
+          background-color: var(--card-background-color);
+          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+          border-radius: var(--ha-border-radius-sm);
+        }
+
+        .alert-wrapper {
+          position: sticky;
+          top: -24px;
+          margin-top: -24px;
+          margin-bottom: 8px;
+          z-index: 100;
+          width: 100%;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 8px;
+        }
+
+        .alert-wrapper ha-alert {
+          background-color: var(--card-background-color);
+          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+          border-radius: var(--ha-border-radius-sm);
+          margin-bottom: 0;
         }
 
         manual-script-editor {

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -12,7 +12,6 @@ import {
   mdiPlay,
   mdiPlaylistEdit,
   mdiRenameBox,
-  mdiRobotConfused,
   mdiTag,
   mdiTransitConnection,
   mdiUnfoldLessHorizontal,

--- a/src/panels/config/script/manual-script-editor.ts
+++ b/src/panels/config/script/manual-script-editor.ts
@@ -1,6 +1,6 @@
-import { mdiContentSave, mdiHelpCircle } from "@mdi/js";
+import { mdiContentSave, mdiHelpCircle, mdiRobotConfused } from "@mdi/js";
 import { load } from "js-yaml";
-import type { CSSResultGroup, PropertyValues } from "lit";
+import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
@@ -14,6 +14,7 @@ import {
   optional,
   string,
 } from "superstruct";
+import type { HassEntity } from "home-assistant-js-websocket";
 import { ensureArray } from "../../../common/array/ensure-array";
 import { canOverrideAlphanumericInput } from "../../../common/dom/can-override-input";
 import { fireEvent } from "../../../common/dom/fire_event";
@@ -42,6 +43,7 @@ import { showPasteReplaceDialog } from "../automation/paste-replace-dialog/show-
 import { manualEditorStyles, saveFabStyles } from "../automation/styles";
 import "./ha-script-fields";
 import type HaScriptFields from "./ha-script-fields";
+import { UNAVAILABLE } from "../../../data/entity";
 
 const scriptConfigStruct = object({
   alias: optional(string()),
@@ -68,6 +70,17 @@ export class HaManualScriptEditor extends LitElement {
   @property({ attribute: false }) public config!: ScriptConfig;
 
   @property({ attribute: false }) public dirty = false;
+
+  @property({ attribute: false }) public stateObj?: HassEntity;
+
+  @property({ attribute: false }) public errors?: string;
+
+  @property({ attribute: false }) public hasBlueprintConfig = false;
+
+  @property({ attribute: false }) public validationErrors?: (
+    | string
+    | TemplateResult
+  )[];
 
   @query("ha-script-fields")
   private _scriptFields?: HaScriptFields;
@@ -201,7 +214,64 @@ export class HaManualScriptEditor extends LitElement {
         })}
       >
         <div class="content-wrapper">
-          <div class="content">${this._renderContent()}</div>
+          <div class="content">
+            <div class="alert-wrapper">
+              ${this.errors || this.stateObj?.state === UNAVAILABLE
+                ? html`<ha-alert
+                    alert-type="error"
+                    .title=${this.stateObj?.state === UNAVAILABLE
+                      ? this.hass.localize(
+                          "ui.panel.config.script.editor.unavailable"
+                        )
+                      : undefined}
+                  >
+                    ${this.errors || this.validationErrors}
+                    ${this.stateObj?.state === UNAVAILABLE
+                      ? html`<ha-svg-icon
+                          slot="icon"
+                          .path=${mdiRobotConfused}
+                        ></ha-svg-icon>`
+                      : nothing}
+                  </ha-alert>`
+                : nothing}
+              ${this.hasBlueprintConfig
+                ? html`<ha-alert alert-type="info">
+                    ${this.hass.localize(
+                      "ui.panel.config.script.editor.confirm_take_control"
+                    )}
+                    <div slot="action" style="display: flex;">
+                      <ha-button
+                        appearance="plain"
+                        @click=${this._takeControlSave}
+                        >${this.hass.localize("ui.common.yes")}</ha-button
+                      >
+                      <ha-button
+                        appearance="plain"
+                        @click=${this._revertBlueprint}
+                        >${this.hass.localize("ui.common.no")}</ha-button
+                      >
+                    </div>
+                  </ha-alert>`
+                : this.disabled
+                  ? html`<ha-alert alert-type="warning" dismissable
+                      >${this.hass.localize(
+                        "ui.panel.config.script.editor.read_only"
+                      )}
+                      <ha-button
+                        appearance="plain"
+                        slot="action"
+                        @click=${this._duplicate}
+                      >
+                        ${this.hass.localize(
+                          "ui.panel.config.script.editor.migrate"
+                        )}
+                      </ha-button>
+                    </ha-alert>`
+                  : nothing}
+            </div>
+
+            ${this._renderContent()}
+          </div>
           <ha-fab
             slot="fab"
             class=${this.dirty ? "dirty" : ""}
@@ -271,6 +341,18 @@ export class HaManualScriptEditor extends LitElement {
   public disconnectedCallback() {
     window.removeEventListener("paste", this._handlePaste);
     super.disconnectedCallback();
+  }
+
+  private _duplicate() {
+    fireEvent(this, "duplicate-script");
+  }
+
+  private _takeControlSave() {
+    fireEvent(this, "take-control-save");
+  }
+
+  private _revertBlueprint() {
+    fireEvent(this, "revert-blueprint");
   }
 
   private _handlePaste = async (ev: ClipboardEvent) => {
@@ -522,6 +604,25 @@ export class HaManualScriptEditor extends LitElement {
           font-weight: var(--ha-font-weight-normal);
           flex: 1;
         }
+
+        .alert-wrapper {
+          position: sticky;
+          top: -24px;
+          margin-top: -24px;
+          margin-bottom: 16px;
+          z-index: 100;
+          width: 100%;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+        }
+
+        .alert-wrapper ha-alert {
+          background-color: var(--card-background-color);
+          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+          border-radius: var(--ha-border-radius-sm);
+          margin-bottom: 0;
+        }
       `,
     ];
   }
@@ -530,5 +631,12 @@ export class HaManualScriptEditor extends LitElement {
 declare global {
   interface HTMLElementTagNameMap {
     "manual-script-editor": HaManualScriptEditor;
+  }
+
+  interface HASSDomEvents {
+    "duplicate-script": undefined;
+    "take-control-save": undefined;
+    "revert-blueprint": undefined;
+    "save-script": undefined;
   }
 }

--- a/src/panels/config/script/manual-script-editor.ts
+++ b/src/panels/config/script/manual-script-editor.ts
@@ -615,6 +615,7 @@ export class HaManualScriptEditor extends LitElement {
           display: flex;
           flex-direction: column;
           align-items: center;
+          gap: 8px;
         }
 
         .alert-wrapper ha-alert {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Moves ha-alert items to main flow via use of slot

Also adds 8px padding to main content to give the action breathing room as well as fixing the line height to make sure the text is centered. 


**Before**:
<img width="718" height="194" alt="image" src="https://github.com/user-attachments/assets/1df08e38-8124-4bd7-80ba-2549ecd4757b" />

<img width="1779" height="420" alt="image" src="https://github.com/user-attachments/assets/2d0b46d7-4a9c-4ecf-97ab-b4f59df312a1" />

**Before adding text padding and line height**:
<img width="1371" height="129" alt="image" src="https://github.com/user-attachments/assets/1108c9e3-6594-45d0-add5-501a9d40dd21" />

**Final results**:

https://github.com/user-attachments/assets/4af0ca26-3942-40ac-accb-33a5d9d9f1e6

https://github.com/user-attachments/assets/a7f483e5-221d-4d55-a255-3f5d9237b234

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
