### PR TITLE
Button feature to support passing of data to script

### DIFF
--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -40,18 +40,29 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
   }
 
   private _pressButton() {
-    if (!this.hass || !this._stateObj) return;
+    if (!this.hass) return;
+
+    if (this._config?.action) {
+      const { action, target, data } = this._config.action;
+      if (action) {
+        const [domain, service] = action.split(".", 2);
+        this.hass.callService(domain, service, {
+          ...(target ?? {}),
+          ...(data ?? {}),
+        });
+        return;
+      }
+    }
+
+    if (!this._stateObj) return;
 
     const domain = computeDomain(this._stateObj.entity_id);
     const service =
       domain === "button" || domain === "input_button" ? "press" : "turn_on";
 
-    const serviceData = {
+    this.hass.callService(domain, service, {
       entity_id: this._stateObj.entity_id,
-      ...(this._config?.data ?? {}),
-    };
-
-    this.hass.callService(domain, service, serviceData);
+    });
   }
 
   static getStubConfig(): ButtonCardFeatureConfig {

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -37,8 +37,9 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
   @state() private _config?: ButtonCardFeatureConfig;
 
   private get _stateObj() {
-    if (!this.hass || !this.context || !this.context.entity_id)
+    if (!this.hass || !this.context || !this.context.entity_id) {
       return undefined;
+    }
     return this.hass.states[this.context.entity_id!] as HassEntity | undefined;
   }
 

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -45,34 +45,22 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
 
   private _handleAction(ev: ActionHandlerEvent) {
     if (!this.hass || !this._stateObj) return;
-
+  
     if (this._config?.button_action) {
-      handleAction(
-        this,
-        this.hass,
-        this._config.button_action,
-        ev.detail.action!
-      );
+      handleAction(this, this.hass, this._config.button_action, ev.detail.action!);
       return;
     }
-
+  
     const domain = computeDomain(this._stateObj.entity_id);
     const service =
       domain === "button" || domain === "input_button" ? "press" : "turn_on";
-
-    this.hass.callService(domain, service, {
-      entity_id: this._stateObj.entity_id,
-    });
+  
+    this.hass.callService(domain, service, { entity_id: this._stateObj.entity_id });
   }
+
 
   static getStubConfig(): ButtonCardFeatureConfig {
     return { type: "button" };
-  }
-
-  public setConfig(config: ButtonCardFeatureConfig): void {
-    if (!config) throw new Error("Invalid configuration");
-
-    this._config = { button_action: { action: "more-info" }, ...config };
   }
 
   protected render() {

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -47,8 +47,7 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
   private _handleAction(ev: ActionHandlerEvent) {
     if (!this.hass || !this.context || !this._config) return;
   
-    if (this._config.action) {
-      // Custom action defined in feature
+    if (this._config.perform_action) {
       handleAction(this, this.hass, this._config, ev.detail.action);
       return;
     }

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -7,7 +7,6 @@ import "../../../components/ha-control-button-group";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
-import type { HomeAssistant } from "../../../types";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { handleAction } from "../common/handle-action";
 import { hasAction } from "../common/has-action";

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -46,7 +46,7 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
   private _handleAction(ev: ActionHandlerEvent) {
     if (!this.hass || !this.context || !this._config) return;
 
-    if (this._config.perform_action) {
+    if (this._config.button_action) {
       handleAction(this, this.hass, this._config, ev.detail.action!);
       return;
     }

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -44,13 +44,25 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
   }
 
   private _handleAction(ev: ActionHandlerEvent) {
-    if (!this.hass || !this._config) return;
-    handleAction(
-      this,
-      this.hass!,
-      this._config.button_action ?? { action: "more-info" },
-      ev.detail.action
-    );
+    if (!this.hass || !this._stateObj) return;
+
+    if (this._config?.button_action) {
+      handleAction(
+        this,
+        this.hass,
+        this._config.button_action,
+        ev.detail.action!
+      );
+      return;
+    }
+
+    const domain = computeDomain(this._stateObj.entity_id);
+    const service =
+      domain === "button" || domain === "input_button" ? "press" : "turn_on";
+
+    this.hass.callService(domain, service, {
+      entity_id: this._stateObj.entity_id,
+    });
   }
 
   static getStubConfig(): ButtonCardFeatureConfig {

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -7,9 +7,9 @@ import "../../../components/ha-control-button-group";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
-import { handleAction } from "../../../common/handle-action";
-import { actionHandler } from "../../../common/util/action-handler";
-import { hasAction } from "../../../common/has-action";
+import { handleAction } from "../../../common/handle-action.ts";
+import { actionHandler } from "../../../common/util/action-handler.ts";
+import { hasAction } from "../../../common/has-action.ts";
 import type { ActionHandlerEvent } from "../../../data/lovelace";
 import type {
   ButtonCardFeatureConfig,

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -7,9 +7,9 @@ import "../../../components/ha-control-button-group";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
-import { handleAction } from "../../../common/handle-action";
-import { actionHandler } from "../../../common/util/action-handler";
-import { hasAction } from "../../../common/has-action";
+import { actionHandler } from "../common/directives/action-handler-directive";
+import { hasAction } from "../common/has-action";
+import { handleAction } from "../common/handle-action";
 import type { ActionHandlerEvent } from "../../../data/lovelace";
 import type {
   ButtonCardFeatureConfig,

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -7,9 +7,8 @@ import "../../../components/ha-control-button-group";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
-import { actionHandler } from "../common/directives/action-handler-directive";
-import { hasAction } from "../common/has-action";
-import { handleAction } from "../common/handle-action";
+import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
+import type { ActionConfig } from "../../../data/lovelace/config/action";
 import type {
   ButtonCardFeatureConfig,
   LovelaceCardFeatureContext,
@@ -46,7 +45,7 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
     if (!this.hass || !this.context || !this._config) return;
 
     if (this._config.button_action) {
-      handleAction(this, this.hass!, this._config!, ev.detail.action!);
+      handleAction(this, this.hass!, this._config.button_action, ev.detail.action!);
       return;
     }
 

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -7,6 +7,7 @@ import "../../../components/ha-control-button-group";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
+import { handleAction } from "../../../common/dom/handle-action";
 import type {
   ButtonCardFeatureConfig,
   LovelaceCardFeatureContext,

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -52,10 +52,6 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
       button_action: undefined,
       ...config,
     };
-
-    this.context = {
-      entity_id: config.entity ?? this.context?.entity_id,
-    };
   }
 
   private _handleAction(ev: ActionHandlerEvent) {

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -8,7 +8,6 @@ import type { HomeAssistant } from "../../../types";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
-import type { ActionConfig } from "../../../data/lovelace/config/action";
 import type {
   ButtonCardFeatureConfig,
   LovelaceCardFeatureContext,

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -7,9 +7,9 @@ import "../../../components/ha-control-button-group";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
-import { handleAction } from "../../../common/handle-action.ts";
-import { actionHandler } from "../../../common/util/action-handler.ts";
-import { hasAction } from "../../../common/has-action.ts";
+import { handleAction } from "../../../common/handle-action";
+import { actionHandler } from "../../../common/util/action-handler";
+import { hasAction } from "../../../common/has-action";
 import type { ActionHandlerEvent } from "../../../data/lovelace";
 import type {
   ButtonCardFeatureConfig,

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -7,8 +7,8 @@ import "../../../components/ha-control-button-group";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
-import { handleAction } from "../../../common/dom/handle-action.js";
-import { actionHandler } from "../../../common/util/action-handler.js";
+import { handleAction } from "../../../common/dom/handle-action";
+import { actionHandler } from "../../../common/util/action-handler";
 import type { ActionHandlerEvent } from "../../../data/lovelace";
 
 import type {

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -43,21 +43,34 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
     return this.hass.states[this.context.entity_id!] as HassEntity | undefined;
   }
 
+  public setConfig(config: ButtonCardFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
   private _handleAction(ev: ActionHandlerEvent) {
     if (!this.hass || !this._stateObj) return;
-  
+
     if (this._config?.button_action) {
-      handleAction(this, this.hass, this._config.button_action, ev.detail.action!);
+      handleAction(
+        this,
+        this.hass,
+        this._config.button_action,
+        ev.detail.action!
+      );
       return;
     }
-  
+
     const domain = computeDomain(this._stateObj.entity_id);
     const service =
       domain === "button" || domain === "input_button" ? "press" : "turn_on";
-  
-    this.hass.callService(domain, service, { entity_id: this._stateObj.entity_id });
-  }
 
+    this.hass.callService(domain, service, {
+      entity_id: this._stateObj.entity_id,
+    });
+  }
 
   static getStubConfig(): ButtonCardFeatureConfig {
     return { type: "button" };

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -7,6 +7,7 @@ import "../../../components/ha-control-button-group";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
+import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { handleAction } from "../common/handle-action";
 import { hasAction } from "../common/has-action";

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -47,7 +47,15 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
     if (!config) {
       throw new Error("Invalid configuration");
     }
-    this._config = config;
+
+    this._config = {
+      button_action: undefined,
+      ...config,
+    };
+
+    this.context = {
+      entity_id: config.entity ?? this.context?.entity_id,
+    };
   }
 
   private _handleAction(ev: ActionHandlerEvent) {
@@ -57,7 +65,7 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
       handleAction(
         this,
         this.hass,
-        this._config.button_action,
+        this._config.button_action as any,
         ev.detail.action!
       );
       return;

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -46,9 +46,12 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
     const service =
       domain === "button" || domain === "input_button" ? "press" : "turn_on";
 
-    this.hass.callService(domain, service, {
+    const serviceData = {
       entity_id: this._stateObj.entity_id,
-    });
+      ...(this._config?.data ?? {}),
+    };
+
+    this.hass.callService(domain, service, serviceData);
   }
 
   static getStubConfig(): ButtonCardFeatureConfig {

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -7,7 +7,10 @@ import "../../../components/ha-control-button-group";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
-import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
+import type { HomeAssistant } from "../../../types";
+import { actionHandler } from "../common/directives/action-handler-directive";
+import { handleAction } from "../common/handle-action";
+import { hasAction } from "../common/has-action";
 import type {
   ButtonCardFeatureConfig,
   LovelaceCardFeatureContext,

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -10,7 +10,6 @@ import { cardFeatureStyles } from "./common/card-feature-styles";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { hasAction } from "../common/has-action";
 import { handleAction } from "../common/handle-action";
-
 import type {
   ButtonCardFeatureConfig,
   LovelaceCardFeatureContext,
@@ -43,13 +42,11 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
     return this.hass.states[this.context.entity_id!] as HassEntity | undefined;
   }
 
-  private _handleAction(ev: Event) {
-    const detail = (ev as CustomEvent).detail;
-    const action = detail?.action;
-    if (!this.hass || !this.context || !this._config || !action) return;
+  private _handleAction(ev: ActionHandlerEvent) {
+    if (!this.hass || !this.context || !this._config) return;
 
     if (this._config.button_action) {
-      handleAction(this, this.hass, this._config, action);
+      handleAction(this, this.hass!, this._config!, ev.detail.action!);
       return;
     }
 

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -10,7 +10,6 @@ import { cardFeatureStyles } from "./common/card-feature-styles";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { hasAction } from "../common/has-action";
 import { handleAction } from "../common/handle-action";
-import type { ActionHandlerEvent } from "../common/directives/action-handler-directive";
 
 import type {
   ButtonCardFeatureConfig,
@@ -44,11 +43,13 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
     return this.hass.states[this.context.entity_id!] as HassEntity | undefined;
   }
 
-  private _handleAction(ev: ActionHandlerEvent) {
-    if (!this.hass || !this.context || !this._config) return;
+  private _handleAction(ev: Event) {
+    const detail = (ev as CustomEvent).detail;
+    const action = detail?.action;
+    if (!this.hass || !this.context || !this._config || !action) return;
 
     if (this._config.button_action) {
-      handleAction(this, this.hass, this._config, ev.detail.action!);
+      handleAction(this, this.hass, this._config, action);
       return;
     }
 
@@ -93,8 +94,8 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
           class="press-button"
           @action=${this._handleAction}
           .actionHandler=${actionHandler({
-            hasHold: hasAction(this._config.perform_action),
-            hasDoubleClick: hasAction(this._config.perform_action),
+            hasHold: hasAction(this._config.button_action),
+            hasDoubleClick: hasAction(this._config.button_action),
           })}
         >
           ${this._config.action_name ??

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -18,7 +18,7 @@ import type {
 
 export const supportsButtonCardFeature = (
   hass: HomeAssistant,
-  context: LovelaceCardFeatureContext,
+  context: LovelaceCardFeatureContext
 ) => {
   const stateObj = context.entity_id
     ? hass.states[context.entity_id]
@@ -47,8 +47,8 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
     handleAction(
       this,
       this.hass!,
-      this._config.button_action!,
-      ev.detail.action,
+      this._config.button_action ?? { action: "more-info" },
+      ev.detail.action
     );
   }
 
@@ -59,14 +59,7 @@ class HuiButtonCardFeature extends LitElement implements LovelaceCardFeature {
   public setConfig(config: ButtonCardFeatureConfig): void {
     if (!config) throw new Error("Invalid configuration");
 
-    const stateObj = this.hass?.states[config.entity_id!];
-    const domain = stateObj ? computeDomain(stateObj.entity_id) : "button";
-
-    const defaultAction = ["button", "input_button"].includes(domain)
-      ? { action: "call-service", perform_action: "press" }
-      : { action: "call-service", perform_action: "turn_on" };
-
-    this._config = { button_action: defaultAction, ...config };
+    this._config = { button_action: { action: "more-info" }, ...config };
   }
 
   protected render() {

--- a/src/panels/lovelace/card-features/hui-button-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-button-card-feature.ts
@@ -10,7 +10,8 @@ import { cardFeatureStyles } from "./common/card-feature-styles";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { hasAction } from "../common/has-action";
 import { handleAction } from "../common/handle-action";
-import type { ActionHandlerEvent } from "../../../data/lovelace";
+import type { ActionHandlerEvent } from "../common/directives/action-handler-directive";
+
 import type {
   ButtonCardFeatureConfig,
   LovelaceCardFeatureContext,

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -5,6 +5,7 @@ import type { OperationMode } from "../../../data/water_heater";
 export interface ButtonCardFeatureConfig {
   type: "button";
   action_name?: string;
+  data?: Record<string, any>; 
 }
 
 export interface CoverOpenCloseCardFeatureConfig {

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -1,4 +1,4 @@
-import type { ActionConfig } from "../structs/action-struct";
+import { ActionConfig } from "../../../data/lovelace";
 import type { AlarmMode } from "../../../data/alarm_control_panel";
 import type { HvacMode } from "../../../data/climate";
 import type { OperationMode } from "../../../data/water_heater";

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -7,7 +7,7 @@ export type ButtonCardData = Record<string, any>;
 export interface ButtonCardFeatureConfig {
   type: "button";
   action_name?: string;
-  data?: ButtenCardData;
+  data?: ButtonCardData;
 }
 
 export interface CoverOpenCloseCardFeatureConfig {

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -2,10 +2,12 @@ import type { AlarmMode } from "../../../data/alarm_control_panel";
 import type { HvacMode } from "../../../data/climate";
 import type { OperationMode } from "../../../data/water_heater";
 
+export type ButtonCardData = Record<string, any>;
+
 export interface ButtonCardFeatureConfig {
   type: "button";
   action_name?: string;
-  data?: Record<string, any>; 
+  data?: ButtenCardData;
 }
 
 export interface CoverOpenCloseCardFeatureConfig {

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -1,13 +1,12 @@
+import type { ActionConfig } from "../structs/action-struct";
 import type { AlarmMode } from "../../../data/alarm_control_panel";
 import type { HvacMode } from "../../../data/climate";
 import type { OperationMode } from "../../../data/water_heater";
 
-export type ButtonCardData = Record<string, any>;
-
 export interface ButtonCardFeatureConfig {
   type: "button";
   action_name?: string;
-  data?: ButtonCardData;
+  perform_action?: ActionConfig;
 }
 
 export interface CoverOpenCloseCardFeatureConfig {

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -1,4 +1,4 @@
-import { ActionConfig } from "../../../data/lovelace";
+import type { ActionConfig } from "../../../data/lovelace";
 import type { AlarmMode } from "../../../data/alarm_control_panel";
 import type { HvacMode } from "../../../data/climate";
 import type { OperationMode } from "../../../data/water_heater";

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -1,4 +1,4 @@
-import type { ActionConfig } from "../../../data/lovelace";
+import type { ActionConfig } from "../../../data/lovelace/config/action";
 import type { AlarmMode } from "../../../data/alarm_control_panel";
 import type { HvacMode } from "../../../data/climate";
 import type { OperationMode } from "../../../data/water_heater";

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -6,7 +6,7 @@ import type { OperationMode } from "../../../data/water_heater";
 export interface ButtonCardFeatureConfig {
   type: "button";
   action_name?: string;
-  perform_action?: ActionConfig;
+  button_action?: ActionConfig;
 }
 
 export interface CoverOpenCloseCardFeatureConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-button-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-button-card-feature-editor.ts
@@ -29,7 +29,7 @@ export class HuiButtonCardFeatureEditor
       },
     },
     {
-      name: "perform_data",
+      name: "perform_action",
       selector: {
         ui_action: {},
       },

--- a/src/panels/lovelace/editor/config-elements/hui-button-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-button-card-feature-editor.ts
@@ -29,9 +29,9 @@ export class HuiButtonCardFeatureEditor
       },
     },
     {
-      name: "data",
+      name: "perform_data",
       selector: {
-        object: {},
+        ui_action: {},
       },
     },
   ]);

--- a/src/panels/lovelace/editor/config-elements/hui-button-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-button-card-feature-editor.ts
@@ -29,7 +29,7 @@ export class HuiButtonCardFeatureEditor
       },
     },
     {
-      name: "perform_action",
+      name: "button_action",
       selector: {
         ui_action: {},
       },

--- a/src/panels/lovelace/editor/config-elements/hui-button-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-button-card-feature-editor.ts
@@ -28,6 +28,12 @@ export class HuiButtonCardFeatureEditor
         text: {},
       },
     },
+    {
+      name: "data"
+      selector: {
+        object: {},
+      },
+    },
   ]);
 
   protected render() {

--- a/src/panels/lovelace/editor/config-elements/hui-button-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-button-card-feature-editor.ts
@@ -29,7 +29,7 @@ export class HuiButtonCardFeatureEditor
       },
     },
     {
-      name: "data"
+      name: "data",
       selector: {
         object: {},
       },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Added the option to pass variables to script. To accomplish this and for a more common interface, I added `button_action`. This will be more intuitive than adding `data` as extra option and it will provide more possibilities when calling a script. Also, there will be a more intuitive action selector in the UI, which will make more sense to many.

edit: sorry for all the commits. Currently my test setup is not working. Also I did change my mind a few times about how to attack this.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
feature:
- type: "button"
  action_name: "Set sensor"
  button_action: 
    action: perform-action
    perform_action: script.random_script
    data:
      entity_id: sensor.one
      variable: value

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]
https://github.com/home-assistant/home-assistant.io/pull/40644

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
