### PR TITLE
Don't use context for media selector with 'accept'

### DIFF
--- a/src/components/ha-selector/ha-selector-media.ts
+++ b/src/components/ha-selector/ha-selector-media.ts
@@ -53,9 +53,15 @@ export class HaMediaSelector extends LitElement {
 
   private _contextEntities: string[] | undefined;
 
+  private get _hasAccept(): boolean {
+    return !!this.selector?.media?.accept?.length;
+  }
+
   willUpdate(changedProps: PropertyValues<this>) {
     if (changedProps.has("context")) {
-      this._contextEntities = ensureArray(this.context?.filter_entity);
+      if (!this._hasAccept) {
+        this._contextEntities = ensureArray(this.context?.filter_entity);
+      }
     }
 
     if (changedProps.has("value")) {
@@ -99,10 +105,8 @@ export class HaMediaSelector extends LitElement {
       (stateObj &&
         supportsFeature(stateObj, MediaPlayerEntityFeature.BROWSE_MEDIA));
 
-    const hasAccept = this.selector?.media?.accept?.length;
-
     return html`
-      ${hasAccept ||
+      ${this._hasAccept ||
       (this._contextEntities && this._contextEntities.length <= 1)
         ? nothing
         : html`
@@ -148,7 +152,7 @@ export class HaMediaSelector extends LitElement {
                 : this.value.metadata?.title || this.value.media_content_id}
               @click=${this._pickMedia}
               @keydown=${this._handleKeyDown}
-              class=${this.disabled || (!entityId && !hasAccept)
+              class=${this.disabled || (!entityId && !this._hasAccept)
                 ? "disabled"
                 : ""}
             >
@@ -215,7 +219,7 @@ export class HaMediaSelector extends LitElement {
 
   private _entityChanged(ev: CustomEvent) {
     ev.stopPropagation();
-    if (this.context?.filter_entity) {
+    if (!this._hasAccept && this.context?.filter_entity) {
       fireEvent(this, "value-changed", {
         value: {
           media_content_id: "",
@@ -257,7 +261,7 @@ export class HaMediaSelector extends LitElement {
                 media_content_type: id.media_content_type,
                 media_content_id: id.media_content_id,
               })),
-              ...(this.context?.filter_entity
+              ...(!this._hasAccept && this.context?.filter_entity
                 ? { browse_entity_id: this._getActiveEntityId() }
                 : {}),
             },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Fix a bug introduced with my previous play_media media selector changes. 

In general the use of context is too greedy and picks up unintended usage in services that have entity_id unrelated to the media selector. 

The specific bug that was identified can be fixed by not using context for any media selector with 'accept' setting, as 'accept' is supposed to be a signal to the selector that it is not browsing media for a specific entity. This was partially done in the original PR, but I missed a few spots where the context was still affecting the behavior.

Someday we may need to make the context more targetted and identify a _specific_ field to get context from, instead of just globally trying to grab anything that looks like an entity or device, but I don't believe there are any current usages now where this matters. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #26770
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
