### PR TITLE
Add RSSI color gradient to Bluetooth visualization to identify connection problems

### DIFF
--- a/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
@@ -34,6 +34,16 @@ const UPDATE_THROTTLE_TIME = 10000;
 const CORE_SOURCE_ID = "ha";
 const CORE_SOURCE_LABEL = "Home Assistant";
 
+const RSSI_COLOR_THRESHOLDS: [number, string][] = [
+  [-70, "--green-color"], // Excellent: > -70 dBm
+  [-75, "--lime-color"], // Good: -70 to -75 dBm
+  [-80, "--yellow-color"], // Okay: -75 to -80 dBm
+  [-85, "--amber-color"], // Marginal: -80 to -85 dBm
+  [-90, "--orange-color"], // Weak: -85 to -90 dBm
+  [-95, "--deep-orange-color"], // Poor: -90 to -95 dBm
+  [-Infinity, "--red-color"], // Very poor: < -95 dBm
+];
+
 @customElement("bluetooth-network-visualization")
 export class BluetoothNetworkVisualization extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -126,23 +136,11 @@ export class BluetoothNetworkVisualization extends LitElement {
   }
 
   private _getRssiColorVar = memoizeOne((rssi: number): string => {
-    // Color gradient based on RSSI strength (5 dBm steps)
-    const thresholds: [number, string][] = [
-      [-70, "--green-color"], // Excellent: > -70 dBm
-      [-75, "--lime-color"], // Good: -70 to -75 dBm
-      [-80, "--yellow-color"], // Okay: -75 to -80 dBm
-      [-85, "--amber-color"], // Marginal: -80 to -85 dBm
-      [-90, "--orange-color"], // Weak: -85 to -90 dBm
-      [-95, "--deep-orange-color"], // Poor: -90 to -95 dBm
-      [-Infinity, "--red-color"], // Very poor: < -95 dBm
-    ];
-
-    for (const [threshold, colorVar] of thresholds) {
+    for (const [threshold, colorVar] of RSSI_COLOR_THRESHOLDS) {
       if (rssi > threshold) {
         return colorVar;
       }
     }
-
     // Fallback (should never reach here)
     return "--red-color";
   });

--- a/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
@@ -125,6 +125,28 @@ export class BluetoothNetworkVisualization extends LitElement {
     `;
   }
 
+  private _getRssiColorVar = memoizeOne((rssi: number): string => {
+    // Color gradient based on RSSI strength (5 dBm steps)
+    const thresholds: [number, string][] = [
+      [-70, "--green-color"], // Excellent: > -70 dBm
+      [-75, "--lime-color"], // Good: -70 to -75 dBm
+      [-80, "--yellow-color"], // Okay: -75 to -80 dBm
+      [-85, "--amber-color"], // Marginal: -80 to -85 dBm
+      [-90, "--orange-color"], // Weak: -85 to -90 dBm
+      [-95, "--deep-orange-color"], // Poor: -90 to -95 dBm
+      [-Infinity, "--red-color"], // Very poor: < -95 dBm
+    ];
+
+    for (const [threshold, colorVar] of thresholds) {
+      if (rssi > threshold) {
+        return colorVar;
+      }
+    }
+
+    // Fallback (should never reach here)
+    return "--red-color";
+  });
+
   private _formatNetworkData = memoizeOne(
     (
       data: BluetoothDeviceData[],
@@ -206,7 +228,7 @@ export class BluetoothNetworkVisualization extends LitElement {
             symbol: "none",
             lineStyle: {
               width: this._getLineWidth(node.rssi),
-              color: style.getPropertyValue("--primary-color"),
+              color: style.getPropertyValue(this._getRssiColorVar(node.rssi)),
             },
           });
           return;
@@ -227,7 +249,7 @@ export class BluetoothNetworkVisualization extends LitElement {
           lineStyle: {
             width: this._getLineWidth(node.rssi),
             color: device
-              ? style.getPropertyValue("--primary-color")
+              ? style.getPropertyValue(this._getRssiColorVar(node.rssi))
               : style.getPropertyValue("--disabled-color"),
           },
         });


### PR DESCRIPTION
## Proposed change
This PR adds color-coded RSSI signal strength visualization to the Bluetooth network graph, making it immediately obvious which devices have sufficient signal strength for reliable connections.

**Problem:** Users frequently report Bluetooth connection issues when devices have poor signal strength (e.g., -96 dBm). The visualization showed all connection lines in the same color, making it non-obvious which devices would have trouble connecting. Users would open issues not understanding why their devices weren't working.

**Solution:** The visualization now uses a color gradient based on RSSI values:
- **Green** (> -70 dBm): Excellent signal, very reliable
- **Lime** (-70 to -75 dBm): Good signal, still reliable  
- **Yellow** (-75 to -80 dBm): Okay signal, getting marginal
- **Amber** (-80 to -85 dBm): Marginal signal
- **Orange** (-85 to -90 dBm): Weak signal, risky
- **Deep Orange** (-90 to -95 dBm): Poor signal, very unreliable
- **Red** (< -95 dBm): Very poor signal, unusable

**How it helps users optimize coverage:**
- The visualization automatically shows each device connected to the proxy with the best signal
- Red/orange lines immediately show where coverage is insufficient
- As users add Bluetooth proxies, devices automatically "jump" to the closest proxy
- Lines change color from red → orange → yellow → green as coverage improves
- Users can keep adding proxies until the entire visualization is "greenish"

This creates an intuitive feedback loop: see red zones → add proxies → watch lines turn green → know when coverage is adequate.

**Technical improvements:**
- RSSI to color mapping is memoized for performance (only ~70 possible values)
- Unknown/unpaired devices remain gray (disabled color) to distinguish them from paired devices
- Line width still varies with signal strength for additional visual distinction

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
```yaml
# No configuration changes required
# This is a visual improvement to the existing Bluetooth integration UI
```

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: Users frequently report Bluetooth connection issues when devices have poor signal strength
- Link to documentation pull request: N/A - visual change only

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io