### PR TITLE
Add actions to markdown card

### DIFF
--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -366,6 +366,9 @@ export interface MarkdownCardConfig extends LovelaceCardConfig {
   entity_ids?: string | string[];
   theme?: string;
   show_empty?: boolean;
+  tap_action?: ActionConfig;
+  hold_action?: ActionConfig;
+  double_tap_action?: ActionConfig;
 }
 
 export interface ClockCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-markdown-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-markdown-card-editor.ts
@@ -140,14 +140,6 @@ export class HuiMarkdownCardEditor
         this._config.double_tap_action.action !== "none");
 
     return html`
-      <ha-form
-        .hass=${this.hass}
-        .data=${data}
-        .schema=${schema}
-        .computeLabel=${this._computeLabelCallback}
-        .computeHelper=${this._computeHelperCallback}
-        @value-changed=${this._valueChanged}
-      ></ha-form>
       ${hasActions
         ? html`
             <ha-alert own-margin alert-type="info">
@@ -157,6 +149,14 @@ export class HuiMarkdownCardEditor
             </ha-alert>
           `
         : nothing}
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${schema}
+        .computeLabel=${this._computeLabelCallback}
+        .computeHelper=${this._computeHelperCallback}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
     `;
   }
 

--- a/src/panels/lovelace/editor/config-elements/hui-markdown-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-markdown-card-editor.ts
@@ -42,6 +42,19 @@ export class HuiMarkdownCardEditor
     this._config = config;
   }
 
+  private _hasActions(): boolean {
+    if (!this._config) {
+      return false;
+    }
+    return Boolean(
+      (this._config.tap_action && this._config.tap_action.action !== "none") ||
+        (this._config.hold_action &&
+          this._config.hold_action.action !== "none") ||
+        (this._config.double_tap_action &&
+          this._config.double_tap_action.action !== "none")
+    );
+  }
+
   private _schema = memoizeOne(
     (localize: LocalizeFunc, text_only: boolean) =>
       [
@@ -132,23 +145,7 @@ export class HuiMarkdownCardEditor
       this._config.text_only || false
     );
 
-    const hasActions =
-      (this._config?.tap_action && this._config.tap_action.action !== "none") ||
-      (this._config?.hold_action &&
-        this._config.hold_action.action !== "none") ||
-      (this._config?.double_tap_action &&
-        this._config.double_tap_action.action !== "none");
-
     return html`
-      ${hasActions
-        ? html`
-            <ha-alert own-margin alert-type="info">
-              ${this.hass.localize(
-                "ui.panel.lovelace.editor.card.markdown.interactions_warning"
-              )}
-            </ha-alert>
-          `
-        : nothing}
       <ha-form
         .hass=${this.hass}
         .data=${data}
@@ -190,8 +187,21 @@ export class HuiMarkdownCardEditor
   };
 
   private _computeHelperCallback = (
-    _schema: SchemaUnion<ReturnType<typeof this._schema>>
-  ) => undefined;
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
+    if (schema.name === "interactions") {
+      return this._hasActions()
+        ? html`
+            <ha-alert alert-type="info" own-margin>
+              ${this.hass!.localize(
+                "ui.panel.lovelace.editor.card.markdown.interactions_warning"
+              )}
+            </ha-alert>
+          `
+        : undefined;
+    }
+    return undefined;
+  };
 }
 
 declare global {

--- a/src/panels/lovelace/editor/config-elements/hui-markdown-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-markdown-card-editor.ts
@@ -1,3 +1,4 @@
+import { mdiGestureTap } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -12,6 +13,7 @@ import type {
 import type { HomeAssistant } from "../../../../types";
 import type { MarkdownCardConfig } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
+import { actionConfigStruct } from "../structs/action-struct";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 
 const cardConfigStruct = assign(
@@ -20,6 +22,9 @@ const cardConfigStruct = assign(
     text_only: optional(boolean()),
     title: optional(string()),
     content: string(),
+    tap_action: optional(actionConfigStruct),
+    hold_action: optional(actionConfigStruct),
+    double_tap_action: optional(actionConfigStruct),
   })
 );
 
@@ -64,6 +69,51 @@ export class HuiMarkdownCardEditor
           ? ([{ name: "title", selector: { text: {} } }] as const)
           : []),
         { name: "content", required: true, selector: { template: {} } },
+        {
+          name: "interactions",
+          type: "expandable",
+          flatten: true,
+          iconPath: mdiGestureTap,
+          schema: [
+            {
+              name: "tap_action",
+              selector: {
+                ui_action: {
+                  actions: [
+                    "navigate",
+                    "url",
+                    "perform-action",
+                    "assist",
+                    "none",
+                  ],
+                  default_action: "none",
+                },
+              },
+            },
+            {
+              name: "",
+              type: "optional_actions",
+              flatten: true,
+              schema: (["hold_action", "double_tap_action"] as const).map(
+                (action) => ({
+                  name: action,
+                  selector: {
+                    ui_action: {
+                      actions: [
+                        "navigate",
+                        "url",
+                        "perform-action",
+                        "assist",
+                        "none",
+                      ],
+                      default_action: "none" as const,
+                    },
+                  },
+                })
+              ),
+            },
+          ],
+        },
       ] as const satisfies HaFormSchema[]
   );
 

--- a/src/panels/lovelace/editor/config-elements/hui-markdown-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-markdown-card-editor.ts
@@ -132,14 +132,31 @@ export class HuiMarkdownCardEditor
       this._config.text_only || false
     );
 
+    const hasActions =
+      (this._config?.tap_action && this._config.tap_action.action !== "none") ||
+      (this._config?.hold_action &&
+        this._config.hold_action.action !== "none") ||
+      (this._config?.double_tap_action &&
+        this._config.double_tap_action.action !== "none");
+
     return html`
       <ha-form
         .hass=${this.hass}
         .data=${data}
         .schema=${schema}
         .computeLabel=${this._computeLabelCallback}
+        .computeHelper=${this._computeHelperCallback}
         @value-changed=${this._valueChanged}
       ></ha-form>
+      ${hasActions
+        ? html`
+            <ha-alert own-margin alert-type="info">
+              ${this.hass.localize(
+                "ui.panel.lovelace.editor.card.markdown.interactions_warning"
+              )}
+            </ha-alert>
+          `
+        : nothing}
     `;
   }
 
@@ -171,6 +188,10 @@ export class HuiMarkdownCardEditor
         );
     }
   };
+
+  private _computeHelperCallback = (
+    _schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => undefined;
 }
 
 declare global {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7718,7 +7718,8 @@
                 "card": "Card",
                 "text-only": "Text only"
               },
-              "description": "The Markdown card is used to render Markdown."
+              "description": "The Markdown card is used to render Markdown.",
+              "interactions_warning": "Note: When actions are configured, clicking links in the markdown content will trigger the card action instead of following the link."
             },
             "clock": {
               "name": "Clock",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add actions to markdown card, restricted to tap, hold, double tap and to actions `navigate`, `url`, `perform-action`, `assist`, and `none` as there is no entity for this card.
 
- When an action is set, a message appears to "warn" the user that it disables links in markdown.
- Maybe the "warn" message should be always displayed and styled as `warning` instead of `info`
- Maybe we should think about action only on title ?

<img width="574" height="685" alt="Capture d’écran du 2025-08-31 10-29-28" src="https://github.com/user-attachments/assets/4fea2979-7d7f-4ed6-beff-06fe379f465a" />

<img width="574" height="685" alt="image" src="https://github.com/user-attachments/assets/c78a0c27-d92c-41ba-982d-a7efa726b175" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: markdown
content: >-
  The **Markdown** card allows you to write any text. You can style it **bold**,
  *italicized*, ~strikethrough~ etc. You can do images, links, and more.


  For more information see the [Markdown
  Cheatsheet](https://commonmark.org/help).
title: MD Card
tap_action:
  action: navigate
  navigation_path: /config
hold_action:
  action: perform-action
  perform_action: homeassistant.toggle
  target:
    entity_id: fan.ventilateur_bureau

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/692 and https://github.com/orgs/home-assistant/discussions/713
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/40667

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
