### PR TITLE
Proposal: Simplify automation conditions

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -387,6 +387,18 @@ export const normalizeAutomationConfig = <
     }
   }
 
+  // We move all conditions into the action for display
+  if (config.conditions) {
+    if (config.actions) {
+      (config.actions as Action[]).unshift(
+        ...(config.conditions as Condition[])
+      );
+    } else {
+      config.actions = config.conditions;
+    }
+    delete config.conditions;
+  }
+
   return config;
 };
 

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -45,8 +45,6 @@ import { documentationUrl } from "../../../util/documentation-url";
 import { showToast } from "../../../util/toast";
 import "./action/ha-automation-action";
 import type HaAutomationAction from "./action/ha-automation-action";
-import "./condition/ha-automation-condition";
-import type HaAutomationCondition from "./condition/ha-automation-condition";
 import "./ha-automation-sidebar";
 import type HaAutomationSidebar from "./ha-automation-sidebar";
 import { showPasteReplaceDialog } from "./paste-replace-dialog/show-dialog-paste-replace";
@@ -157,53 +155,6 @@ export class HaManualAutomationEditor extends LitElement {
         root
         sidebar
       ></ha-automation-trigger>
-
-      <div class="header">
-        <h2 id="conditions-heading" class="name">
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.conditions.header"
-          )}
-          <span class="small"
-            >(${this.hass.localize("ui.common.optional")})</span
-          >
-        </h2>
-        <a
-          href=${documentationUrl(this.hass, "/docs/automation/condition/")}
-          target="_blank"
-          rel="noreferrer"
-        >
-          <ha-icon-button
-            .path=${mdiHelpCircle}
-            .label=${this.hass.localize(
-              "ui.panel.config.automation.editor.conditions.learn_more"
-            )}
-          ></ha-icon-button>
-        </a>
-      </div>
-      ${!ensureArray(this.config.conditions)?.length
-        ? html`<p>
-            ${this.hass.localize(
-              "ui.panel.config.automation.editor.conditions.description",
-              { user: this.hass.user?.name || "Alice" }
-            )}
-          </p>`
-        : nothing}
-
-      <ha-automation-condition
-        role="region"
-        aria-labelledby="conditions-heading"
-        .conditions=${this.config.conditions || []}
-        .highlightedConditions=${this._pastedConfig?.conditions || []}
-        @value-changed=${this._conditionChanged}
-        .hass=${this.hass}
-        .disabled=${this.disabled || this.saving}
-        .narrow=${this.narrow}
-        @open-sidebar=${this._openSidebar}
-        @request-close-sidebar=${this._closeSidebar}
-        @close-sidebar=${this._handleCloseSidebar}
-        root
-        sidebar
-      ></ha-automation-condition>
 
       <div class="header">
         <h2 id="actions-heading" class="name">
@@ -584,9 +535,9 @@ export class HaManualAutomationEditor extends LitElement {
   }
 
   private _getCollapsableElements() {
-    return this.shadowRoot!.querySelectorAll<
-      HaAutomationAction | HaAutomationCondition
-    >("ha-automation-action, ha-automation-condition");
+    return this.shadowRoot!.querySelectorAll<HaAutomationAction>(
+      "ha-automation-action"
+    );
   }
 
   public expandAll() {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4109,9 +4109,6 @@
             },
             "conditions": {
               "name": "Conditions",
-              "header": "And if",
-              "description": "All conditions added here need to be satisfied for the automation to run. A condition can be satisfied or not at any given time, for example: ''If {user} is home''. You can use building blocks to create more complex conditions.",
-              "learn_more": "Learn more about conditions",
               "add": "Add condition",
               "search": "Search condition",
               "add_building_block": "Add building block",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This is a proposal (hence marked WIP) to simplify automation conditions. 

Today, we have conditions at the top-level of an automation and we allow the actions part of an automation to contain conditions. They both behave the same, and stop the automation from further running. 

There is however 1 subtle difference. Automation-level conditions will prevent the automation from being marked as "triggered".

With this PR, I want to argue that for the user, there is no difference when setting up an automation. We should be able to show automation level conditions together with the automation actions (which can also contain conditions).

With this PR, when the frontend loads an automation, it will automatically migrate it such that the automation conditions are at the top of automation actions. This allows us to completely remove the conditions section of the automation editor, further simplifying the flow. We could consider promoting conditions in our "Add actions" flow if we feel they are now too hidden.

When a user hits save, all conditions at the top of the actions key will be migrated to be part of the automation conditions.

Example stored in YAML:

```yaml
- alias: Condition Test
  triggers:
  - trigger: state
    entity_id:
    - switch.ac
    to: 'on'
    from: 'off'
  conditions:
  - condition: sun
    before: sunrise
    after: sunset
  actions:
  - action: light.turn_on
    metadata: {}
    data: {}
    target:
      area_id: brewhouse
```

How the frontend will render it:

```yaml
- alias: Condition Test
  triggers:
  - trigger: state
    entity_id:
    - switch.ac
    to: 'on'
    from: 'off'
  actions:
  - condition: sun
    before: sunrise
    after: sunset
  - action: light.turn_on
    metadata: {}
    data: {}
    target:
      area_id: brewhouse
```

<img width="1088" height="755" alt="image" src="https://github.com/user-attachments/assets/35954460-defb-41c5-a424-5f4b5f2db9d6" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
