### PR TITLE
Add undo/redo functionality to automation editor

### DIFF
--- a/src/dialogs/shortcuts/dialog-shortcuts.ts
+++ b/src/dialogs/shortcuts/dialog-shortcuts.ts
@@ -104,6 +104,16 @@ const _SHORTCUTS: Section[] = [
         descriptionTranslationKey:
           "ui.dialogs.shortcuts.automation_script.save",
       },
+      {
+        shortcut: [CTRL_CMD, "Z"],
+        descriptionTranslationKey:
+          "ui.dialogs.shortcuts.automation_script.undo",
+      },
+      {
+        shortcut: [CTRL_CMD, "Y"],
+        descriptionTranslationKey:
+          "ui.dialogs.shortcuts.automation_script.redo",
+      },
     ],
   },
   {

--- a/src/mixins/undo-redo-mixin.ts
+++ b/src/mixins/undo-redo-mixin.ts
@@ -20,21 +20,21 @@ export const UndoRedoMixin = <T extends Constructor<LitElement>, ConfigType>(
     }
 
     public undo() {
-      const _currentConfig = this.currentConfig;
-      if (this._undoStack.length === 0 || !_currentConfig) {
+      const currentConfig = this.currentConfig;
+      if (this._undoStack.length === 0 || !currentConfig) {
         return;
       }
-      this._redoStack.push({ ..._currentConfig });
+      this._redoStack.push({ ...currentConfig });
       const config = this._undoStack.pop()!;
       this.applyUndoRedo(config);
     }
 
     public redo() {
-      const _currentConfig = this.currentConfig;
-      if (this._redoStack.length === 0 || !_currentConfig) {
+      const currentConfig = this.currentConfig;
+      if (this._redoStack.length === 0 || !currentConfig) {
         return;
       }
-      this._undoStack.push({ ..._currentConfig });
+      this._undoStack.push({ ...currentConfig });
       const config = this._redoStack.pop()!;
       this.applyUndoRedo(config);
     }

--- a/src/mixins/undo-redo-mixin.ts
+++ b/src/mixins/undo-redo-mixin.ts
@@ -1,0 +1,55 @@
+import type { LitElement } from "lit";
+import type { Constructor } from "../types";
+
+export const UndoRedoMixin = <T extends Constructor<LitElement>, ConfigType>(
+  superClass: T
+) => {
+  class UndoRedoClass extends superClass {
+    private _undoStack: ConfigType[] = [];
+
+    private _redoStack: ConfigType[] = [];
+
+    protected pushToUndo(config: ConfigType) {
+      this._undoStack.push({ ...config });
+      this._redoStack = [];
+    }
+
+    public undo() {
+      const _currentConfig = this.currentConfig;
+      if (this._undoStack.length === 0 || !_currentConfig) {
+        return;
+      }
+      this._redoStack.push({ ..._currentConfig });
+      const config = this._undoStack.pop()!;
+      this.applyUndoRedo(config);
+    }
+
+    public redo() {
+      const _currentConfig = this.currentConfig;
+      if (this._redoStack.length === 0 || !_currentConfig) {
+        return;
+      }
+      this._undoStack.push({ ..._currentConfig });
+      const config = this._redoStack.pop()!;
+      this.applyUndoRedo(config);
+    }
+
+    public get canUndo(): boolean {
+      return this._undoStack.length > 0;
+    }
+
+    public get canRedo(): boolean {
+      return this._redoStack.length > 0;
+    }
+
+    protected get currentConfig(): ConfigType | undefined {
+      return undefined;
+    }
+
+    protected applyUndoRedo(_: ConfigType) {
+      throw new Error("applyUndoRedo not implemented");
+    }
+  }
+
+  return UndoRedoClass;
+};

--- a/src/mixins/undo-redo-mixin.ts
+++ b/src/mixins/undo-redo-mixin.ts
@@ -9,7 +9,12 @@ export const UndoRedoMixin = <T extends Constructor<LitElement>, ConfigType>(
 
     private _redoStack: ConfigType[] = [];
 
+    protected _undoStackLimit = 75;
+
     protected pushToUndo(config: ConfigType) {
+      if (this._undoStack.length >= this._undoStackLimit) {
+        this._undoStack.shift();
+      }
       this._undoStack.push({ ...config });
       this._redoStack = [];
     }

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -218,27 +218,26 @@ export class HaAutomationEditor extends UndoRedoMixin<
         .header=${this._config.alias ||
         this.hass.localize("ui.panel.config.automation.editor.default_name")}
       >
+        ${this._mode === "gui"
+          ? html`<ha-icon-button
+                slot="toolbar-icon"
+                .label=${this.hass.localize("ui.common.undo")}
+                .path=${mdiUndo}
+                @click=${this.undo}
+                ?disabled=${!this.canUndo}
+              >
+              </ha-icon-button>
+              <ha-icon-button
+                slot="toolbar-icon"
+                .label=${this.hass.localize("ui.common.redo")}
+                .path=${mdiRedo}
+                @click=${this.redo}
+                ?disabled=${!this.canRedo}
+              >
+              </ha-icon-button>`
+          : nothing}
         ${this._config?.id && !this.narrow
           ? html`
-              ${this._mode === "gui"
-                ? html` <ha-icon-button
-                      slot="toolbar-icon"
-                      .label=${this.hass.localize("ui.common.undo")}
-                      .path=${mdiUndo}
-                      @click=${this.undo}
-                      ?disabled=${!this.canUndo}
-                    >
-                    </ha-icon-button>
-                    <ha-icon-button
-                      slot="toolbar-icon"
-                      .label=${this.hass.localize("ui.common.redo")}
-                      .path=${mdiRedo}
-                      @click=${this.redo}
-                      ?disabled=${!this.canRedo}
-                    >
-                    </ha-icon-button>`
-                : nothing}
-
               <ha-button
                 appearance="plain"
                 size="small"

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -1146,7 +1146,7 @@ export class HaAutomationEditor extends UndoRedoMixin<
       Delete: () => this._deleteSelectedRow(),
       Backspace: () => this._deleteSelectedRow(),
       z: () => this.undo(),
-      Z: () => this.redo(),
+      y: () => this.redo(),
     };
   }
 

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -224,7 +224,7 @@ export class HaAutomationEditor extends UndoRedoMixin<
                 .label=${this.hass.localize("ui.common.undo")}
                 .path=${mdiUndo}
                 @click=${this.undo}
-                ?disabled=${!this.canUndo}
+                .disabled=${!this.canUndo}
               >
               </ha-icon-button>
               <ha-icon-button
@@ -232,7 +232,7 @@ export class HaAutomationEditor extends UndoRedoMixin<
                 .label=${this.hass.localize("ui.common.redo")}
                 .path=${mdiRedo}
                 @click=${this.redo}
-                ?disabled=${!this.canRedo}
+                .disabled=${!this.canRedo}
               >
               </ha-icon-button>`
           : nothing}
@@ -261,7 +261,7 @@ export class HaAutomationEditor extends UndoRedoMixin<
             ? html`<ha-list-item
                   graphic="icon"
                   @click=${this.undo}
-                  ?disabled=${!this.canUndo}
+                  .disabled=${!this.canUndo}
                 >
                   ${this.hass.localize("ui.common.undo")}
                   <ha-svg-icon slot="graphic" .path=${mdiUndo}></ha-svg-icon>
@@ -269,7 +269,7 @@ export class HaAutomationEditor extends UndoRedoMixin<
                 <ha-list-item
                   graphic="icon"
                   @click=${this.redo}
-                  ?disabled=${!this.canRedo}
+                  .disabled=${!this.canRedo}
                 >
                   ${this.hass.localize("ui.common.redo")}
                   <ha-svg-icon slot="graphic" .path=${mdiRedo}></ha-svg-icon>

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -218,7 +218,7 @@ export class HaAutomationEditor extends UndoRedoMixin<
         .header=${this._config.alias ||
         this.hass.localize("ui.panel.config.automation.editor.default_name")}
       >
-        ${this._mode === "gui"
+        ${this._mode === "gui" && !this.narrow
           ? html`<ha-icon-button
                 slot="toolbar-icon"
                 .label=${this.hass.localize("ui.common.undo")}
@@ -256,6 +256,25 @@ export class HaAutomationEditor extends UndoRedoMixin<
             .label=${this.hass.localize("ui.common.menu")}
             .path=${mdiDotsVertical}
           ></ha-icon-button>
+
+          ${this._mode === "gui" && this.narrow
+            ? html`<ha-list-item
+                  graphic="icon"
+                  @click=${this.undo}
+                  ?disabled=${!this.canUndo}
+                >
+                  ${this.hass.localize("ui.common.undo")}
+                  <ha-svg-icon slot="graphic" .path=${mdiUndo}></ha-svg-icon>
+                </ha-list-item>
+                <ha-list-item
+                  graphic="icon"
+                  @click=${this.redo}
+                  ?disabled=${!this.canRedo}
+                >
+                  ${this.hass.localize("ui.common.redo")}
+                  <ha-svg-icon slot="graphic" .path=${mdiRedo}></ha-svg-icon>
+                </ha-list-item>`
+            : nothing}
 
           <ha-list-item
             graphic="icon"

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -166,7 +166,7 @@ export class HaManualAutomationEditor extends LitElement {
         .disabled=${this.disabled || this.saving}
         .narrow=${this.narrow}
         @open-sidebar=${this._openSidebar}
-        @request-close-sidebar=${this._triggerCloseSidebar}
+        @request-close-sidebar=${this.triggerCloseSidebar}
         @close-sidebar=${this._handleCloseSidebar}
         root
         sidebar
@@ -213,7 +213,7 @@ export class HaManualAutomationEditor extends LitElement {
         .disabled=${this.disabled || this.saving}
         .narrow=${this.narrow}
         @open-sidebar=${this._openSidebar}
-        @request-close-sidebar=${this._triggerCloseSidebar}
+        @request-close-sidebar=${this.triggerCloseSidebar}
         @close-sidebar=${this._handleCloseSidebar}
         root
         sidebar
@@ -255,7 +255,7 @@ export class HaManualAutomationEditor extends LitElement {
         .highlightedActions=${this._pastedConfig?.actions || []}
         @value-changed=${this._actionChanged}
         @open-sidebar=${this._openSidebar}
-        @request-close-sidebar=${this._triggerCloseSidebar}
+        @request-close-sidebar=${this.triggerCloseSidebar}
         @close-sidebar=${this._handleCloseSidebar}
         .hass=${this.hass}
         .narrow=${this.narrow}
@@ -351,7 +351,7 @@ export class HaManualAutomationEditor extends LitElement {
     };
   }
 
-  private _triggerCloseSidebar() {
+  public triggerCloseSidebar() {
     if (this._sidebarConfig) {
       if (this._sidebarElement) {
         this._sidebarElement.triggerCloseSidebar();
@@ -393,7 +393,7 @@ export class HaManualAutomationEditor extends LitElement {
   }
 
   private _saveAutomation() {
-    this._triggerCloseSidebar();
+    this.triggerCloseSidebar();
     fireEvent(this, "save-automation");
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -416,6 +416,7 @@
       "next": "Next",
       "back": "Back",
       "undo": "Undo",
+      "redo": "Redo",
       "move": "Move",
       "save": "Save",
       "apply": "Apply",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2067,7 +2067,9 @@
           "cut": "to cut the selected item and place it on the clipboard",
           "delete": "to delete the selected item",
           "paste": "to paste automation/script YAML from clipboard to editor",
-          "save": "to save automation/script"
+          "save": "to save automation/script",
+          "undo": "to undo last change",
+          "redo": "to redo last undone change"
         },
         "charts": {
           "title": "Charts",


### PR DESCRIPTION
## Proposed change
Add a undo/redo functionality to the automation editor. This can be very handy when tinkering around want to quickly go back and forth with changes. The undo/redo stack is limited to the browser and editing "session". So when the user leaves the editor the stacks are discarded. The PR changes the keyboard shortcut mixin as well to distinguish between lower and upper case shortcuts.

This is a FR as well: https://github.com/orgs/home-assistant/discussions/796

<video src="https://github.com/user-attachments/assets/cc0a9c58-ee0f-4fe1-b6a9-6277bac7f51a" /> |

Blueprints:

<video src="https://github.com/user-attachments/assets/03e13f0a-8628-44e6-90e0-7768a459b679" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
