### PR TITLE
Don't use ha-automation-row-selected to know if the item was selected

### DIFF
--- a/src/components/ha-sortable.ts
+++ b/src/components/ha-sortable.ts
@@ -15,19 +15,14 @@ declare global {
     "item-added": {
       index: number;
       data: any;
+      item: any;
     };
     "item-removed": {
       index: number;
     };
     "drag-start": undefined;
     "drag-end": undefined;
-    "item-cloned": HaSortableClonedEventData;
   }
-}
-
-export interface HaSortableClonedEventData {
-  item: any;
-  clone: any;
 }
 
 export type HaSortableOptions = Omit<
@@ -154,7 +149,6 @@ export class HaSortable extends LitElement {
       onUpdate: this._handleUpdate,
       onAdd: this._handleAdd,
       onRemove: this._handleRemove,
-      onClone: this._handleClone,
     };
 
     if (this.draggableSelector) {
@@ -187,15 +181,12 @@ export class HaSortable extends LitElement {
     fireEvent(this, "item-added", {
       index: evt.newIndex,
       data: evt.item.sortableData,
+      item: evt.item,
     });
   };
 
   private _handleRemove = (evt) => {
     fireEvent(this, "item-removed", { index: evt.oldIndex });
-  };
-
-  private _handleClone = (evt) => {
-    fireEvent(this, "item-cloned", evt);
   };
 
   private _handleEnd = async (evt) => {

--- a/src/panels/config/automation/action/ha-automation-action.ts
+++ b/src/panels/config/automation/action/ha-automation-action.ts
@@ -9,7 +9,6 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import { nextRender } from "../../../../common/util/render-status";
 import "../../../../components/ha-button";
 import "../../../../components/ha-sortable";
-import type { HaSortableClonedEventData } from "../../../../components/ha-sortable";
 import "../../../../components/ha-svg-icon";
 import {
   ACTION_BUILDING_BLOCKS,
@@ -76,7 +75,6 @@ export default class HaAutomationAction extends LitElement {
         @item-moved=${this._actionMoved}
         @item-added=${this._actionAdded}
         @item-removed=${this._actionRemoved}
-        @item-cloned=${this._actionCloned}
       >
         <div class="rows ${!this.optionsInSidebar ? "no-sidebar" : ""}">
           ${repeat(
@@ -300,12 +298,8 @@ export default class HaAutomationAction extends LitElement {
 
   private async _actionAdded(ev: CustomEvent): Promise<void> {
     ev.stopPropagation();
-    const { index, data } = ev.detail;
-    let selected = false;
-    if (data?.["ha-automation-row-selected"]) {
-      selected = true;
-      delete data["ha-automation-row-selected"];
-    }
+    const { index, data, item } = ev.detail;
+    const selected = item.isSelected();
 
     let actions = [
       ...this.actions.slice(0, index),
@@ -361,12 +355,6 @@ export default class HaAutomationAction extends LitElement {
     }
 
     fireEvent(this, "value-changed", { value: actions });
-  }
-
-  private _actionCloned(ev: CustomEvent<HaSortableClonedEventData>) {
-    if (ev.detail.item.action && ev.detail.item.isSelected()) {
-      ev.detail.item.action["ha-automation-row-selected"] = true;
-    }
   }
 
   private _duplicateAction(ev: CustomEvent) {

--- a/src/panels/config/automation/action/ha-automation-action.ts
+++ b/src/panels/config/automation/action/ha-automation-action.ts
@@ -298,7 +298,8 @@ export default class HaAutomationAction extends LitElement {
 
   private async _actionAdded(ev: CustomEvent): Promise<void> {
     ev.stopPropagation();
-    const { index, data, item } = ev.detail;
+    const { index, data } = ev.detail;
+    const item = ev.detail.item as HaAutomationActionRow;
     const selected = item.isSelected();
 
     let actions = [

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -10,7 +10,6 @@ import { nextRender } from "../../../../common/util/render-status";
 import "../../../../components/ha-button";
 import "../../../../components/ha-button-menu";
 import "../../../../components/ha-sortable";
-import type { HaSortableClonedEventData } from "../../../../components/ha-sortable";
 import "../../../../components/ha-svg-icon";
 import type {
   AutomationClipboard,
@@ -153,7 +152,6 @@ export default class HaAutomationCondition extends LitElement {
         @item-moved=${this._conditionMoved}
         @item-added=${this._conditionAdded}
         @item-removed=${this._conditionRemoved}
-        @item-cloned=${this._conditionCloned}
       >
         <div class="rows ${!this.optionsInSidebar ? "no-sidebar" : ""}">
           ${repeat(
@@ -318,12 +316,8 @@ export default class HaAutomationCondition extends LitElement {
 
   private async _conditionAdded(ev: CustomEvent): Promise<void> {
     ev.stopPropagation();
-    const { index, data } = ev.detail;
-    let selected = false;
-    if (data?.["ha-automation-row-selected"]) {
-      selected = true;
-      delete data["ha-automation-row-selected"];
-    }
+    const { index, data, item } = ev.detail;
+    const selected = item.isSelected();
     let conditions = [
       ...this.conditions.slice(0, index),
       data,
@@ -359,12 +353,6 @@ export default class HaAutomationCondition extends LitElement {
     // Ensure condition is removed even after update
     const conditions = this.conditions.filter((c) => c !== condition);
     fireEvent(this, "value-changed", { value: conditions });
-  }
-
-  private _conditionCloned(ev: CustomEvent<HaSortableClonedEventData>) {
-    if (ev.detail.item.isSelected()) {
-      ev.detail.item.condition["ha-automation-row-selected"] = true;
-    }
   }
 
   private _conditionChanged(ev: CustomEvent) {

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -316,7 +316,8 @@ export default class HaAutomationCondition extends LitElement {
 
   private async _conditionAdded(ev: CustomEvent): Promise<void> {
     ev.stopPropagation();
-    const { index, data, item } = ev.detail;
+    const { index, data } = ev.detail;
+    const item = ev.detail.item as HaAutomationConditionRow;
     const selected = item.isSelected();
     let conditions = [
       ...this.conditions.slice(0, index),

--- a/src/panels/config/automation/option/ha-automation-option.ts
+++ b/src/panels/config/automation/option/ha-automation-option.ts
@@ -9,7 +9,6 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import { nextRender } from "../../../../common/util/render-status";
 import "../../../../components/ha-button";
 import "../../../../components/ha-sortable";
-import type { HaSortableClonedEventData } from "../../../../components/ha-sortable";
 import "../../../../components/ha-svg-icon";
 import type { AutomationClipboard } from "../../../../data/automation";
 import type { Option } from "../../../../data/script";
@@ -65,7 +64,6 @@ export default class HaAutomationOption extends LitElement {
         @item-moved=${this._optionMoved}
         @item-added=${this._optionAdded}
         @item-removed=${this._optionRemoved}
-        @item-cloned=${this._optionCloned}
       >
         <div class="rows ${!this.optionsInSidebar ? "no-sidebar" : ""}">
           ${repeat(
@@ -240,12 +238,8 @@ export default class HaAutomationOption extends LitElement {
 
   private async _optionAdded(ev: CustomEvent): Promise<void> {
     ev.stopPropagation();
-    const { index, data } = ev.detail;
-    let selected = false;
-    if (data?.["ha-automation-row-selected"]) {
-      selected = true;
-      delete data["ha-automation-row-selected"];
-    }
+    const { index, data, item } = ev.detail;
+    const selected = item.isSelected();
 
     const options = [
       ...this.options.slice(0, index),
@@ -271,12 +265,6 @@ export default class HaAutomationOption extends LitElement {
     // Ensure option is removed even after update
     const options = this.options.filter((o) => o !== option);
     fireEvent(this, "value-changed", { value: options });
-  }
-
-  private _optionCloned(ev: CustomEvent<HaSortableClonedEventData>) {
-    if (ev.detail.item.isSelected()) {
-      ev.detail.item.option["ha-automation-row-selected"] = true;
-    }
   }
 
   private _optionChanged(ev: CustomEvent) {

--- a/src/panels/config/automation/option/ha-automation-option.ts
+++ b/src/panels/config/automation/option/ha-automation-option.ts
@@ -238,7 +238,8 @@ export default class HaAutomationOption extends LitElement {
 
   private async _optionAdded(ev: CustomEvent): Promise<void> {
     ev.stopPropagation();
-    const { index, data, item } = ev.detail;
+    const { index, data } = ev.detail;
+    const item = ev.detail.item as HaAutomationOptionRow;
     const selected = item.isSelected();
 
     const options = [

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -10,7 +10,6 @@ import { nextRender } from "../../../../common/util/render-status";
 import "../../../../components/ha-button";
 import "../../../../components/ha-button-menu";
 import "../../../../components/ha-sortable";
-import type { HaSortableClonedEventData } from "../../../../components/ha-sortable";
 import "../../../../components/ha-svg-icon";
 import type {
   AutomationClipboard,
@@ -72,7 +71,6 @@ export default class HaAutomationTrigger extends LitElement {
         @item-moved=${this._triggerMoved}
         @item-added=${this._triggerAdded}
         @item-removed=${this._triggerRemoved}
-        @item-cloned=${this._triggerCloned}
       >
         <div class="rows ${!this.optionsInSidebar ? "no-sidebar" : ""}">
           ${repeat(
@@ -259,12 +257,8 @@ export default class HaAutomationTrigger extends LitElement {
 
   private async _triggerAdded(ev: CustomEvent): Promise<void> {
     ev.stopPropagation();
-    const { index, data } = ev.detail;
-    let selected = false;
-    if (data?.["ha-automation-row-selected"]) {
-      selected = true;
-      delete data["ha-automation-row-selected"];
-    }
+    const { index, data, item } = ev.detail;
+    const selected = item.isSelected();
 
     let triggers = [
       ...this.triggers.slice(0, index),
@@ -301,12 +295,6 @@ export default class HaAutomationTrigger extends LitElement {
     // Ensure trigger is removed even after update
     const triggers = this.triggers.filter((t) => t !== trigger);
     fireEvent(this, "value-changed", { value: triggers });
-  }
-
-  private _triggerCloned(ev: CustomEvent<HaSortableClonedEventData>) {
-    if (ev.detail.item.isSelected()) {
-      ev.detail.item.trigger["ha-automation-row-selected"] = true;
-    }
   }
 
   private _triggerChanged(ev: CustomEvent) {

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -257,7 +257,8 @@ export default class HaAutomationTrigger extends LitElement {
 
   private async _triggerAdded(ev: CustomEvent): Promise<void> {
     ev.stopPropagation();
-    const { index, data, item } = ev.detail;
+    const { index, data } = ev.detail;
+    const item = ev.detail.item as HaAutomationTriggerRow;
     const selected = item.isSelected();
 
     let triggers = [


### PR DESCRIPTION
## Proposed change

Don't use ha-automation-row-selected to know if the item was selected

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/26780
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
