### PR TITLE
add shadow when scrollable in automation bottom sheet, min height 50vh

### DIFF
--- a/src/components/ha-bottom-sheet.ts
+++ b/src/components/ha-bottom-sheet.ts
@@ -30,7 +30,7 @@ export class HaBottomSheet extends LitElement {
 
   @state() private _dialogMaxViewpointHeight = 70;
 
-  @state() private _dialogMinViewpointHeight = 50;
+  @state() private _dialogMinViewpointHeight = 55;
 
   @state() private _dialogViewportHeight?: number;
 

--- a/src/components/ha-bottom-sheet.ts
+++ b/src/components/ha-bottom-sheet.ts
@@ -30,6 +30,8 @@ export class HaBottomSheet extends LitElement {
 
   @state() private _dialogMaxViewpointHeight = 70;
 
+  @state() private _dialogMinViewpointHeight = 50;
+
   @state() private _dialogViewportHeight?: number;
 
   render() {
@@ -41,6 +43,7 @@ export class HaBottomSheet extends LitElement {
           ? `${this._dialogViewportHeight}vh`
           : "auto",
         maxHeight: `${this._dialogMaxViewpointHeight}vh`,
+        minHeight: `${this._dialogMinViewpointHeight}vh`,
       })}
     >
       <div class="handle-wrapper">
@@ -80,6 +83,7 @@ export class HaBottomSheet extends LitElement {
       this._dialogViewportHeight =
         (this._dialog.offsetHeight / window.innerHeight) * 100;
       this._dialogMaxViewpointHeight = 90;
+      this._dialogMinViewpointHeight = 20;
     } else {
       // after close animation is done close dialog element and fire closed event
       this._dialog.close();


### PR DESCRIPTION



## Proposed change

The bottom sheet now opens to a min height of 50vh, you can still resize it to a smaller size.

The bottom sheet now shows a shadow to indicate the content can be scrolled.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
