### PR TITLE
Sync charts zoom in history tab

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -362,12 +362,6 @@ export class HaChartBase extends LitElement {
         fireEvent(this, "chart-click", e);
       });
 
-      this.chart.getZr().on("mouseup", () => {
-        if (this._modifierPressed) {
-          this._syncZoomState();
-        }
-      });
-
       if (!this.options?.dataZoom) {
         this.chart.getZr().on("dblclick", this._handleClickZoom);
       }
@@ -923,26 +917,6 @@ export class HaChartBase extends LitElement {
     fireEvent(this, "chart-zoom", { start, end });
   }
 
-  private _syncZoomState() {
-    if (!this.chart) return;
-
-    const option = this.chart.getOption();
-    const dataZoom = option.dataZoom;
-
-    if (dataZoom && Array.isArray(dataZoom) && dataZoom.length > 0) {
-      const zoom = dataZoom[0];
-      const start = typeof zoom.start === "number" ? zoom.start : 0;
-      const end = typeof zoom.end === "number" ? zoom.end : 100;
-      const isZoomed = start !== 0 || end !== 100;
-
-      if (isZoomed !== this._isZoomed) {
-        this._isZoomed = isZoomed;
-        this._zoomRatio = (end - start) / 100;
-        fireEvent(this, "chart-zoom", { start, end });
-      }
-    }
-  }
-
   private _legendClick(ev: any) {
     if (!this.chart) {
       return;
@@ -1098,9 +1072,6 @@ declare global {
     "chart-zoom": {
       start: number;
       end: number;
-      chartIndex?: number;
-      startTime?: Date;
-      endTime?: Date;
     };
   }
 }

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -894,7 +894,7 @@ export class HaChartBase extends LitElement {
       zoomData.endValue !== undefined
     ) {
       const option = this.chart!.getOption();
-      const xAxis = (option as any).xAxis?.[0] ?? (option as any).xAxis;
+      const xAxis = option.xAxis?.[0] ?? option.xAxis;
 
       if (xAxis?.min && xAxis?.max) {
         const axisMin = new Date(xAxis.min).getTime();

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -63,6 +63,9 @@ export class HaChartBase extends LitElement {
   @property({ attribute: "small-controls", type: Boolean })
   public smallControls?: boolean;
 
+  @property({ attribute: "hide-reset-button", type: Boolean })
+  public hideResetButton?: boolean;
+
   // extraComponents is not reactive and should not trigger updates
   public extraComponents?: any[];
 
@@ -215,7 +218,7 @@ export class HaChartBase extends LitElement {
         </div>
         ${this._renderLegend()}
         <div class="chart-controls ${classMap({ small: this.smallControls })}">
-          ${this._isZoomed
+          ${this._isZoomed && !this.hideResetButton
             ? html`<ha-icon-button
                 class="zoom-reset"
                 .path=${mdiRestart}

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -869,6 +869,15 @@ export class HaChartBase extends LitElement {
     });
   };
 
+  public zoom(start: number, end: number, silent = false) {
+    this.chart?.dispatchAction({
+      type: "dataZoom",
+      start,
+      end,
+      silent,
+    });
+  }
+
   private _handleZoomReset() {
     this.chart?.dispatchAction({ type: "dataZoom", start: 0, end: 100 });
   }

--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -272,9 +272,6 @@ export class StateHistoryChartLine extends LitElement {
           min: this.startTime,
           max: this.endTime,
           boundaryGap: [0, 0],
-          axisPointer: {
-            show: false,
-          },
         },
         yAxis: {
           type: this.logarithmicScale ? "log" : "value",

--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -97,6 +97,7 @@ export class StateHistoryChartLine extends LitElement {
         style=${styleMap({ height: this.height })}
         @dataset-hidden=${this._datasetHidden}
         @dataset-unhidden=${this._datasetUnhidden}
+        @chart-zoom=${this._handleDataZoom}
         .expandLegend=${this.expandLegend}
         .hideResetButton=${this.hideResetButton}
       ></ha-chart-base>
@@ -196,6 +197,16 @@ export class StateHistoryChartLine extends LitElement {
     this._hiddenStats.delete(ev.detail.id);
   }
 
+  private _handleDataZoom(ev: CustomEvent) {
+    fireEvent(this, "chart-zoom", {
+      start: ev.detail.start ?? 0,
+      end: ev.detail.end ?? 100,
+      chartIndex: this.chartIndex,
+      startTime: ev.detail.startTime,
+      endTime: ev.detail.endTime,
+    });
+  }
+
   public willUpdate(changedProps: PropertyValues) {
     if (
       changedProps.has("data") ||
@@ -255,6 +266,10 @@ export class StateHistoryChartLine extends LitElement {
           type: "time",
           min: this.startTime,
           max: this.endTime,
+          boundaryGap: [0, 0],
+          axisPointer: {
+            show: false,
+          },
         },
         yAxis: {
           type: this.logarithmicScale ? "log" : "value",

--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -203,12 +203,10 @@ export class StateHistoryChartLine extends LitElement {
   }
 
   private _handleDataZoom(ev: CustomEvent) {
-    fireEvent(this, "chart-zoom", {
+    fireEvent(this, "chart-zoom-with-index", {
       start: ev.detail.start ?? 0,
       end: ev.detail.end ?? 100,
       chartIndex: this.chartIndex,
-      startTime: ev.detail.startTime,
-      endTime: ev.detail.endTime,
     });
   }
 
@@ -271,7 +269,6 @@ export class StateHistoryChartLine extends LitElement {
           type: "time",
           min: this.startTime,
           max: this.endTime,
-          boundaryGap: [0, 0],
         },
         yAxis: {
           type: this.logarithmicScale ? "log" : "value",

--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -66,6 +66,9 @@ export class StateHistoryChartLine extends LitElement {
   @property({ attribute: "expand-legend", type: Boolean })
   public expandLegend?: boolean;
 
+  @property({ attribute: "hide-reset-button", type: Boolean })
+  public hideResetButton?: boolean;
+
   @state() private _chartData: LineSeriesOption[] = [];
 
   @state() private _entityIds: string[] = [];
@@ -95,6 +98,7 @@ export class StateHistoryChartLine extends LitElement {
         @dataset-hidden=${this._datasetHidden}
         @dataset-unhidden=${this._datasetUnhidden}
         .expandLegend=${this.expandLegend}
+        .hideResetButton=${this.hideResetButton}
       ></ha-chart-base>
     `;
   }

--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -197,6 +197,11 @@ export class StateHistoryChartLine extends LitElement {
     this._hiddenStats.delete(ev.detail.id);
   }
 
+  public zoom(start: number, end: number) {
+    const chartBase = this.shadowRoot!.querySelector("ha-chart-base")!;
+    chartBase.zoom(start, end, true);
+  }
+
   private _handleDataZoom(ev: CustomEvent) {
     fireEvent(this, "chart-zoom", {
       start: ev.detail.start ?? 0,

--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -265,6 +265,11 @@ export class StateHistoryChartTimeline extends LitElement {
     };
   }
 
+  public zoom(start: number, end: number) {
+    const chartBase = this.shadowRoot!.querySelector("ha-chart-base")!;
+    chartBase.zoom(start, end, true);
+  }
+
   private _handleDataZoom(ev: CustomEvent) {
     fireEvent(this, "chart-zoom", {
       start: ev.detail.start ?? 0,

--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -204,14 +204,10 @@ export class StateHistoryChartTimeline extends LitElement {
         type: "time",
         min: this.startTime,
         max: this.endTime,
-        boundaryGap: [0, 0],
         axisTick: {
           show: true,
         },
         splitLine: {
-          show: false,
-        },
-        axisPointer: {
           show: false,
         },
       },

--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -71,6 +71,7 @@ export class StateHistoryChartTimeline extends LitElement {
         .data=${this._chartData as ECOption["series"]}
         small-controls
         @chart-click=${this._handleChartClick}
+        @chart-zoom=${this._handleDataZoom}
         .hideResetButton=${this.hideResetButton}
       ></ha-chart-base>
     `;
@@ -203,10 +204,14 @@ export class StateHistoryChartTimeline extends LitElement {
         type: "time",
         min: this.startTime,
         max: this.endTime,
+        boundaryGap: [0, 0],
         axisTick: {
           show: true,
         },
         splitLine: {
+          show: false,
+        },
+        axisPointer: {
           show: false,
         },
       },
@@ -258,6 +263,16 @@ export class StateHistoryChartTimeline extends LitElement {
         formatter: this._renderTooltip,
       },
     };
+  }
+
+  private _handleDataZoom(ev: CustomEvent) {
+    fireEvent(this, "chart-zoom", {
+      start: ev.detail.start ?? 0,
+      end: ev.detail.end ?? 100,
+      chartIndex: this.chartIndex,
+      startTime: ev.detail.startTime,
+      endTime: ev.detail.endTime,
+    });
   }
 
   private _generateData() {

--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -267,12 +267,10 @@ export class StateHistoryChartTimeline extends LitElement {
   }
 
   private _handleDataZoom(ev: CustomEvent) {
-    fireEvent(this, "chart-zoom", {
+    fireEvent(this, "chart-zoom-with-index", {
       start: ev.detail.start ?? 0,
       end: ev.detail.end ?? 100,
       chartIndex: this.chartIndex,
-      startTime: ev.detail.startTime,
-      endTime: ev.detail.endTime,
     });
   }
 

--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -51,6 +51,9 @@ export class StateHistoryChartTimeline extends LitElement {
 
   @property({ attribute: false, type: Number }) public chartIndex?;
 
+  @property({ attribute: "hide-reset-button", type: Boolean })
+  public hideResetButton?: boolean;
+
   @state() private _chartData: CustomSeriesOption[] = [];
 
   @state() private _chartOptions?: ECOption;
@@ -68,6 +71,7 @@ export class StateHistoryChartTimeline extends LitElement {
         .data=${this._chartData as ECOption["series"]}
         small-controls
         @chart-click=${this._handleChartClick}
+        .hideResetButton=${this.hideResetButton}
       ></ha-chart-base>
     `;
   }

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -31,13 +31,6 @@ const chunkData = (inputArray: any[], chunks: number) =>
 declare global {
   interface HASSDomEvents {
     "y-width-changed": { value: number; chartIndex: number };
-    "chart-zoom": {
-      start: number;
-      end: number;
-      chartIndex?: number;
-      startTime?: Date | undefined;
-      endTime?: Date | undefined;
-    };
   }
 }
 

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -1,5 +1,5 @@
 import type { PropertyValues } from "lit";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, eventOptions, property, state } from "lit/decorators";
 import type { RenderItemFunction } from "@lit-labs/virtualizer/virtualize";
 import { mdiRestart } from "@mdi/js";
@@ -12,9 +12,12 @@ import type {
 } from "../../data/history";
 import { loadVirtualizer } from "../../resources/virtualizer";
 import type { HomeAssistant } from "../../types";
+import type { StateHistoryChartLine } from "./state-history-chart-line";
+import type { StateHistoryChartTimeline } from "./state-history-chart-timeline";
+import "../ha-fab";
+import "../ha-svg-icon";
 import "./state-history-chart-line";
 import "./state-history-chart-timeline";
-import "../ha-icon-button";
 
 const CANVAS_TIMELINE_ROWS_CHUNK = 10; // Split up the canvases to avoid hitting the render limit
 
@@ -139,15 +142,17 @@ export class StateHistoryCharts extends LitElement {
             this._renderHistoryItem(item, index)
           )}`}
       ${this._hasZoomedCharts
-        ? html`<ha-icon-button
-            class="floating-reset-button"
-            .path=${mdiRestart}
-            @click=${this._handleGlobalZoomReset}
-            title=${this.hass.localize(
+        ? html`<ha-fab
+            slot="fab"
+            .label=${this.hass.localize(
               "ui.components.history_charts.zoom_reset"
             )}
-          ></ha-icon-button>`
-        : ""}
+            extended
+            @click=${this._handleGlobalZoomReset}
+          >
+            <ha-svg-icon slot="icon" .path=${mdiRestart}></ha-svg-icon>
+          </ha-fab>`
+        : nothing}
     `;
   }
 
@@ -316,14 +321,14 @@ export class StateHistoryCharts extends LitElement {
     requestAnimationFrame(() => {
       const chartComponents = this.renderRoot.querySelectorAll(
         "state-history-chart-line, state-history-chart-timeline"
-      );
+      ) as unknown as (StateHistoryChartLine | StateHistoryChartTimeline)[];
 
-      chartComponents.forEach((chartComponent: any, index) => {
+      chartComponents.forEach((chartComponent, index) => {
         if (index === sourceChartIndex) {
           return;
         }
 
-        if (chartComponent.zoom) {
+        if ("zoom" in chartComponent) {
           chartComponent.zoom(start, end);
         }
       });

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -34,6 +34,11 @@ const chunkData = (inputArray: any[], chunks: number) =>
 declare global {
   interface HASSDomEvents {
     "y-width-changed": { value: number; chartIndex: number };
+    "chart-zoom-with-index": {
+      start: number;
+      end: number;
+      chartIndex: number;
+    };
   }
 }
 
@@ -144,10 +149,10 @@ export class StateHistoryCharts extends LitElement {
       ${this._hasZoomedCharts
         ? html`<ha-fab
             slot="fab"
+            class="reset-button"
             .label=${this.hass.localize(
               "ui.components.history_charts.zoom_reset"
             )}
-            extended
             @click=${this._handleGlobalZoomReset}
           >
             <ha-svg-icon slot="icon" .path=${mdiRestart}></ha-svg-icon>
@@ -182,7 +187,7 @@ export class StateHistoryCharts extends LitElement {
           .maxYAxis=${this.maxYAxis}
           .fitYData=${this.fitYData}
           @y-width-changed=${this._yWidthChanged}
-          @chart-zoom=${this._handleTimelineSync}
+          @chart-zoom-with-index=${this._handleTimelineSync}
           .height=${this.virtualize ? undefined : this.height}
           .expandLegend=${this.expandLegend}
           hide-reset-button
@@ -203,7 +208,7 @@ export class StateHistoryCharts extends LitElement {
         .chartIndex=${index}
         .clickForMoreInfo=${this.clickForMoreInfo}
         @y-width-changed=${this._yWidthChanged}
-        @chart-zoom=${this._handleTimelineSync}
+        @chart-zoom-with-index=${this._handleTimelineSync}
         hide-reset-button
       ></state-history-chart-timeline>
     </div> `;
@@ -294,18 +299,14 @@ export class StateHistoryCharts extends LitElement {
     this._maxYWidth = Math.max(...Object.values(this._childYWidths), 0);
   }
 
-  private _handleTimelineSync(e: CustomEvent<HASSDomEvents["chart-zoom"]>) {
+  private _handleTimelineSync(
+    e: CustomEvent<HASSDomEvents["chart-zoom-with-index"]>
+  ) {
     if (this._isSyncing) {
       return;
     }
 
-    const {
-      start,
-      end,
-      chartIndex,
-      startTime: _startTime,
-      endTime: _endTime,
-    } = e.detail;
+    const { start, end, chartIndex } = e.detail;
 
     this._hasZoomedCharts = start !== 0 || end !== 100;
     this._syncZoomToAllCharts(start, end, chartIndex);
@@ -439,24 +440,10 @@ export class StateHistoryCharts extends LitElement {
     state-history-chart-line {
       width: 100%;
     }
-
-    .floating-reset-button {
+    .reset-button {
       position: fixed;
-      bottom: 24px;
-      right: 24px;
-      z-index: 1000;
-      background: var(--card-background-color);
-      border-radius: 50%;
-      --mdc-icon-button-size: 56px;
-      --mdc-icon-size: 24px;
-      color: var(--primary-color);
-      box-shadow: var(--ha-card-box-shadow, 0px 2px 4px rgba(0, 0, 0, 0.16));
-      border: 1px solid var(--divider-color);
-    }
-
-    .floating-reset-button:hover {
-      background: var(--primary-color);
-      color: var(--text-primary-on-accent-color, white);
+      bottom: calc(24px + var(--safe-area-inset-bottom));
+      right: calc(24px + var(--safe-area-inset-bottom));
     }
   `;
 }

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -330,17 +330,8 @@ export class StateHistoryCharts extends LitElement {
           return;
         }
 
-        const chartBase =
-          chartComponent.renderRoot?.querySelector("ha-chart-base");
-
-        if (chartBase && chartBase.chart) {
-          chartBase.chart.dispatchAction({
-            type: "dataZoom",
-            dataZoomId: "dataZoom",
-            start: start,
-            end: end,
-            silent: true,
-          });
+        if (chartComponent.zoom) {
+          chartComponent.zoom(start, end);
         }
       });
 

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -346,13 +346,7 @@ export class StateHistoryCharts extends LitElement {
           chartComponent.renderRoot?.querySelector("ha-chart-base");
 
         if (chartBase && chartBase.chart) {
-          chartBase.chart.dispatchAction({
-            type: "dataZoom",
-            dataZoomId: "dataZoom",
-            start: 0,
-            end: 100,
-            silent: true,
-          });
+          chartBase.zoom(0, 100);
         }
       });
       this._isSyncing = false;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add synchronized zoom functionality across multiple charts in the History tab with a unified reset interface. When users zoom into one chart, all charts automatically synchronize to the same time range, providing a cohesive view of historical data across different entities and chart types.


https://github.com/user-attachments/assets/77510e16-87ed-40af-98dd-0e3138f4e4b5



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #23766  
- This PR is related to issue or discussion:
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
