### PR TITLE
Redesign media player more-info dialog

### DIFF
--- a/gallery/src/data/media_players.ts
+++ b/gallery/src/data/media_players.ts
@@ -8,7 +8,7 @@ export const createMediaPlayerEntities = () => [
     media_artist: "Technohead",
     // Pause + Seek + Volume Set + Volume Mute + Previous Track + Next Track + Play Media +
     // Select Source + Stop + Clear + Play + Shuffle Set
-    supported_features: 129599,
+    supported_features: 64063,
     entity_picture: "/images/album_cover_2.jpg",
     media_duration: 300,
     media_position: 50,

--- a/gallery/src/data/media_players.ts
+++ b/gallery/src/data/media_players.ts
@@ -8,7 +8,7 @@ export const createMediaPlayerEntities = () => [
     media_artist: "Technohead",
     // Pause + Seek + Volume Set + Volume Mute + Previous Track + Next Track + Play Media +
     // Select Source + Stop + Clear + Play + Shuffle Set
-    supported_features: 64063,
+    supported_features: 129599,
     entity_picture: "/images/album_cover_2.jpg",
     media_duration: 300,
     media_position: 50,
@@ -17,6 +17,9 @@ export const createMediaPlayerEntities = () => [
       new Date().getTime() - 23000
     ).toISOString(),
     volume_level: 0.5,
+    source_list: ["AirPlay", "Blu-Ray", "TV", "USB", "iPod (USB)"],
+    sound_mode_list: ["Movie", "Music", "Game", "Pure Audio"],
+    sound_mode: "Music",
   }),
   getEntity("media_player", "music_playing", "playing", {
     friendly_name: "Playing The Music",
@@ -25,7 +28,7 @@ export const createMediaPlayerEntities = () => [
     media_artist: "Technohead",
     // Pause + Seek + Volume Set + Volume Mute + Previous Track + Next Track + Play Media +
     // Select Source + Stop + Clear + Play + Shuffle Set + Browse Media + Grouping
-    supported_features: 719423,
+    supported_features: 784959,
     entity_picture: "/images/album_cover.jpg",
     media_duration: 300,
     media_position: 0,
@@ -34,6 +37,8 @@ export const createMediaPlayerEntities = () => [
       new Date().getTime() - 23000
     ).toISOString(),
     volume_level: 0.5,
+    sound_mode_list: ["Movie", "Music", "Game", "Pure Audio"],
+    sound_mode: "Music",
   }),
   getEntity("media_player", "stream_playing", "playing", {
     friendly_name: "Playing the Stream",
@@ -149,15 +154,18 @@ export const createMediaPlayerEntities = () => [
   }),
   getEntity("media_player", "receiver_on", "on", {
     source_list: ["AirPlay", "Blu-Ray", "TV", "USB", "iPod (USB)"],
+    sound_mode_list: ["Movie", "Music", "Game", "Pure Audio"],
     volume_level: 0.63,
     is_volume_muted: false,
     source: "TV",
+    sound_mode: "Movie",
     friendly_name: "Receiver (selectable sources)",
     // Volume Set + Volume Mute + On + Off + Select Source + Play + Sound Mode
     supported_features: 84364,
   }),
   getEntity("media_player", "receiver_off", "off", {
     source_list: ["AirPlay", "Blu-Ray", "TV", "USB", "iPod (USB)"],
+    sound_mode_list: ["Movie", "Music", "Game", "Pure Audio"],
     friendly_name: "Receiver (selectable sources)",
     // Volume Set + Volume Mute + On + Off + Select Source + Play + Sound Mode
     supported_features: 84364,

--- a/gallery/src/data/media_players.ts
+++ b/gallery/src/data/media_players.ts
@@ -18,6 +18,7 @@ export const createMediaPlayerEntities = () => [
     ).toISOString(),
     volume_level: 0.5,
     source_list: ["AirPlay", "Blu-Ray", "TV", "USB", "iPod (USB)"],
+    source: "AirPlay",
     sound_mode_list: ["Movie", "Music", "Game", "Pure Audio"],
     sound_mode: "Music",
   }),

--- a/gallery/src/data/media_players.ts
+++ b/gallery/src/data/media_players.ts
@@ -40,6 +40,7 @@ export const createMediaPlayerEntities = () => [
     volume_level: 0.5,
     sound_mode_list: ["Movie", "Music", "Game", "Pure Audio"],
     sound_mode: "Music",
+    group_members: ["media_player.playing", "media_player.stream_playing"],
   }),
   getEntity("media_player", "stream_playing", "playing", {
     friendly_name: "Playing the Stream",

--- a/gallery/src/data/media_players.ts
+++ b/gallery/src/data/media_players.ts
@@ -24,8 +24,8 @@ export const createMediaPlayerEntities = () => [
     media_title: "I Wanna Be A Hippy (Flamman & Abraxas Radio Mix)",
     media_artist: "Technohead",
     // Pause + Seek + Volume Set + Volume Mute + Previous Track + Next Track + Play Media +
-    // Select Source + Stop + Clear + Play + Shuffle Set + Browse Media
-    supported_features: 195135,
+    // Select Source + Stop + Clear + Play + Shuffle Set + Browse Media + Grouping
+    supported_features: 719423,
     entity_picture: "/images/album_cover.jpg",
     media_duration: 300,
     media_position: 0,

--- a/gallery/src/pages/components/ha-marquee-text.markdown
+++ b/gallery/src/pages/components/ha-marquee-text.markdown
@@ -1,0 +1,37 @@
+---
+title: Marquee Text
+---
+
+# Marquee Text `<ha-marquee-text>`
+
+Marquee text component scrolls text horizontally if it overflows its container. It supports pausing on hover and customizable speed and pause duration.
+
+## Implementation
+
+### Example Usage
+
+<ha-marquee-text style="width: 200px;">
+    This is a long text that will scroll horizontally if it overflows the container.
+</ha-marquee-text>
+
+```html
+<ha-marquee-text style="width: 200px;">
+  This is a long text that will scroll horizontally if it overflows the
+  container.
+</ha-marquee-text>
+```
+
+### API
+
+**Slots**
+
+- default slot: The text content to be displayed and scrolled.
+  - no default
+
+**Properties/Attributes**
+
+| Name           | Type    | Default | Description                                                                  |
+| -------------- | ------- | ------- | ---------------------------------------------------------------------------- |
+| speed          | number  | `15`    | The speed of the scrolling animation. Higher values result in faster scroll. |
+| pause-on-hover | boolean | `true`  | Whether to pause the scrolling animation when                                |
+| pause-duration | number  | `1000`  | The delay in milliseconds before the scrolling animation starts/restarts.    |

--- a/gallery/src/pages/components/ha-marquee-text.ts
+++ b/gallery/src/pages/components/ha-marquee-text.ts
@@ -1,0 +1,25 @@
+import { css, LitElement } from "lit";
+import { customElement } from "lit/decorators";
+import "../../../../src/components/ha-card";
+import "../../../../src/components/ha-marquee-text";
+
+@customElement("demo-components-ha-marquee-text")
+export class DemoHaMarqueeText extends LitElement {
+  static styles = css`
+    ha-card {
+      max-width: 600px;
+      margin: 24px auto;
+    }
+    .card-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-components-ha-marquee-text": DemoHaMarqueeText;
+  }
+}

--- a/src/components/ha-marquee-text.ts
+++ b/src/components/ha-marquee-text.ts
@@ -40,7 +40,9 @@ export class HaMarqueeText extends LitElement {
     this._setupAnimation();
   }
 
-  protected updated(changedProps: Map<string, unknown>) {
+  protected updated(changedProps: PropertyValues) {
+    super.updated(changedProps);
+
     if (changedProps.has("text")) {
       this._setupAnimation();
     }

--- a/src/components/ha-marquee-text.ts
+++ b/src/components/ha-marquee-text.ts
@@ -1,0 +1,168 @@
+import { LitElement, html, css } from "lit";
+import { customElement, property, query } from "lit/decorators";
+
+@customElement("ha-marquee-text")
+export class HaMarqueeText extends LitElement {
+  @property({ type: String }) text = "";
+
+  @property({ type: Number }) speed = 15; // pixels per second
+
+  @property({ type: Number, attribute: "pause-duration" }) pauseDuration = 1000; // ms delay at ends
+
+  @property({ type: Boolean, attribute: "pause-on-hover" }) pauseOnHover =
+    false;
+
+  private _direction: "left" | "right" = "left";
+
+  private _animationFrame?: number;
+
+  @query(".marquee-container")
+  private _container?: HTMLDivElement;
+
+  @query(".marquee-text")
+  private _textSpan?: HTMLSpanElement;
+
+  private _position = 0;
+
+  private _maxOffset = 0;
+
+  private _pauseTimeout?: number;
+
+  render() {
+    return html`
+      <div
+        class="marquee-container"
+        @mouseenter=${this._onMouseEnter}
+        @mouseleave=${this._onMouseLeave}
+        aria-label=${this.text}
+        role="marquee"
+      >
+        <span class="marquee-text">${this.text}</span>
+      </div>
+    `;
+  }
+
+  firstUpdated() {
+    this._setupAnimation();
+  }
+
+  updated(changedProps: Map<string, unknown>) {
+    if (changedProps.has("text")) {
+      this._setupAnimation();
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    if (this._animationFrame) {
+      cancelAnimationFrame(this._animationFrame);
+    }
+    if (this._pauseTimeout) {
+      clearTimeout(this._pauseTimeout);
+      this._pauseTimeout = undefined;
+    }
+  }
+
+  private _setupAnimation() {
+    if (!this._container || !this._textSpan) return;
+    this._position = 0;
+    this._direction = "left";
+    this._maxOffset = Math.max(
+      0,
+      this._textSpan.offsetWidth - this._container.offsetWidth
+    );
+    this._textSpan.style.transform = `translateX(0px)`;
+    if (this._animationFrame) {
+      cancelAnimationFrame(this._animationFrame);
+    }
+    if (this._pauseTimeout) {
+      clearTimeout(this._pauseTimeout);
+      this._pauseTimeout = undefined;
+    }
+    this._animate();
+  }
+
+  private _animate = () => {
+    if (!this._container || !this._textSpan) return;
+    const dt = 1 / 60; // ~16ms per frame
+    const pxPerFrame = this.speed * dt;
+    let reachedEnd = false;
+    if (this._direction === "left") {
+      this._position -= pxPerFrame;
+      if (this._position <= -this._maxOffset) {
+        this._position = -this._maxOffset;
+        this._direction = "right";
+        reachedEnd = true;
+      }
+    } else {
+      this._position += pxPerFrame;
+      if (this._position >= 0) {
+        this._position = 0;
+        this._direction = "left";
+        reachedEnd = true;
+      }
+    }
+    this._textSpan.style.transform = `translateX(${this._position}px)`;
+    if (reachedEnd) {
+      this._pauseTimeout = window.setTimeout(() => {
+        this._pauseTimeout = undefined;
+        this._animationFrame = requestAnimationFrame(this._animate);
+      }, this.pauseDuration);
+    } else {
+      this._animationFrame = requestAnimationFrame(this._animate);
+    }
+  };
+
+  private _onMouseEnter = () => {
+    if (this.pauseOnHover && this._animationFrame) {
+      cancelAnimationFrame(this._animationFrame);
+      this._animationFrame = undefined;
+    }
+    if (this.pauseOnHover && this._pauseTimeout) {
+      clearTimeout(this._pauseTimeout);
+      this._pauseTimeout = undefined;
+    }
+  };
+
+  private _onMouseLeave = () => {
+    if (this.pauseOnHover && !this._animationFrame && !this._pauseTimeout) {
+      this._animate();
+    }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+      overflow: hidden;
+      width: 100%;
+      --marquee-height: 32px;
+    }
+
+    .marquee-container {
+      position: relative;
+      width: 100%;
+      height: var(--marquee-height, 32px);
+      white-space: nowrap;
+      overflow: hidden;
+      user-select: none;
+      cursor: default;
+    }
+
+    .marquee-text {
+      position: absolute;
+      left: 0;
+      transform: translateY(-50%);
+      will-change: transform;
+      font-size: 1em;
+      line-height: var(--marquee-height, 32px);
+      pointer-events: none;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-marquee-text": HaMarqueeText;
+  }
+}

--- a/src/components/ha-marquee-text.ts
+++ b/src/components/ha-marquee-text.ts
@@ -15,8 +15,8 @@ export class HaMarqueeText extends LitElement {
 
   @property({ type: Number, attribute: "pause-duration" }) pauseDuration = 1000; // ms delay at ends
 
-  @property({ type: Boolean, attribute: "pause-on-hover" }) pauseOnHover =
-    false;
+  @property({ type: Boolean, attribute: "pause-on-hover" })
+  pauseOnHover = false;
 
   private _direction: "left" | "right" = "left";
 
@@ -66,6 +66,8 @@ export class HaMarqueeText extends LitElement {
         class="marquee-container"
         @mouseenter=${this._handleMouseEnter}
         @mouseleave=${this._handleMouseLeave}
+        @touchstart=${this._handleMouseEnter}
+        @touchend=${this._handleMouseLeave}
         aria-label=${this.text}
         role="marquee"
       >

--- a/src/components/ha-marquee-text.ts
+++ b/src/components/ha-marquee-text.ts
@@ -5,7 +5,7 @@ import {
   css,
   type PropertyValues,
 } from "lit";
-import { customElement, property, query } from "lit/decorators";
+import { customElement, eventOptions, property, query } from "lit/decorators";
 
 @customElement("ha-marquee-text")
 export class HaMarqueeText extends LitElement {
@@ -128,6 +128,7 @@ export class HaMarqueeText extends LitElement {
     }
   };
 
+  @eventOptions({ passive: true })
   private _handleMouseEnter() {
     if (this.pauseOnHover && this._animationFrame) {
       cancelAnimationFrame(this._animationFrame);

--- a/src/components/ha-marquee-text.ts
+++ b/src/components/ha-marquee-text.ts
@@ -1,5 +1,5 @@
-import type {
-  TemplateResult,
+import {
+  type TemplateResult,
   LitElement,
   html,
   css,

--- a/src/components/ha-marquee-text.ts
+++ b/src/components/ha-marquee-text.ts
@@ -66,8 +66,6 @@ export class HaMarqueeText extends LitElement {
         @mouseleave=${this._handleMouseLeave}
         @touchstart=${this._handleMouseEnter}
         @touchend=${this._handleMouseLeave}
-        aria-label=${this.textContent.trim() || ""}
-        role="marquee"
       >
         <span class="marquee-text"><slot></slot></span>
       </div>

--- a/src/components/ha-marquee-text.ts
+++ b/src/components/ha-marquee-text.ts
@@ -1,4 +1,10 @@
-import { LitElement, html, css } from "lit";
+import type {
+  TemplateResult,
+  LitElement,
+  html,
+  css,
+  type PropertyValues,
+} from "lit";
 import { customElement, property, query } from "lit/decorators";
 
 @customElement("ha-marquee-text")
@@ -28,31 +34,19 @@ export class HaMarqueeText extends LitElement {
 
   private _pauseTimeout?: number;
 
-  render() {
-    return html`
-      <div
-        class="marquee-container"
-        @mouseenter=${this._onMouseEnter}
-        @mouseleave=${this._onMouseLeave}
-        aria-label=${this.text}
-        role="marquee"
-      >
-        <span class="marquee-text">${this.text}</span>
-      </div>
-    `;
-  }
+  protected firstUpdated(changedProps: PropertyValues) {
+    super.firstUpdated(changedProps);
 
-  firstUpdated() {
     this._setupAnimation();
   }
 
-  updated(changedProps: Map<string, unknown>) {
+  protected updated(changedProps: Map<string, unknown>) {
     if (changedProps.has("text")) {
       this._setupAnimation();
     }
   }
 
-  disconnectedCallback() {
+  public disconnectedCallback() {
     super.disconnectedCallback();
 
     if (this._animationFrame) {
@@ -64,8 +58,25 @@ export class HaMarqueeText extends LitElement {
     }
   }
 
+  protected render(): TemplateResult {
+    return html`
+      <div
+        class="marquee-container"
+        @mouseenter=${this._handleMouseEnter}
+        @mouseleave=${this._handleMouseLeave}
+        aria-label=${this.text}
+        role="marquee"
+      >
+        <span class="marquee-text">${this.text}</span>
+      </div>
+    `;
+  }
+
   private _setupAnimation() {
-    if (!this._container || !this._textSpan) return;
+    if (!this._container || !this._textSpan) {
+      return;
+    }
+
     this._position = 0;
     this._direction = "left";
     this._maxOffset = Math.max(
@@ -84,7 +95,10 @@ export class HaMarqueeText extends LitElement {
   }
 
   private _animate = () => {
-    if (!this._container || !this._textSpan) return;
+    if (!this._container || !this._textSpan) {
+      return;
+    }
+
     const dt = 1 / 60; // ~16ms per frame
     const pxPerFrame = this.speed * dt;
     let reachedEnd = false;
@@ -114,7 +128,7 @@ export class HaMarqueeText extends LitElement {
     }
   };
 
-  private _onMouseEnter = () => {
+  private _handleMouseEnter() {
     if (this.pauseOnHover && this._animationFrame) {
       cancelAnimationFrame(this._animationFrame);
       this._animationFrame = undefined;
@@ -123,26 +137,23 @@ export class HaMarqueeText extends LitElement {
       clearTimeout(this._pauseTimeout);
       this._pauseTimeout = undefined;
     }
-  };
+  }
 
-  private _onMouseLeave = () => {
+  private _handleMouseLeave() {
     if (this.pauseOnHover && !this._animationFrame && !this._pauseTimeout) {
       this._animate();
     }
-  };
+  }
 
   static styles = css`
     :host {
       display: block;
       overflow: hidden;
       width: 100%;
-      --marquee-height: 32px;
     }
 
     .marquee-container {
-      position: relative;
       width: 100%;
-      height: var(--marquee-height, 32px);
       white-space: nowrap;
       overflow: hidden;
       user-select: none;
@@ -150,12 +161,10 @@ export class HaMarqueeText extends LitElement {
     }
 
     .marquee-text {
-      position: absolute;
-      left: 0;
-      transform: translateY(-50%);
+      display: inline-block;
+      vertical-align: middle;
       will-change: transform;
       font-size: 1em;
-      line-height: var(--marquee-height, 32px);
       pointer-events: none;
     }
   `;

--- a/src/components/ha-marquee-text.ts
+++ b/src/components/ha-marquee-text.ts
@@ -9,8 +9,6 @@ import { customElement, property, query } from "lit/decorators";
 
 @customElement("ha-marquee-text")
 export class HaMarqueeText extends LitElement {
-  @property({ type: String }) text = "";
-
   @property({ type: Number }) speed = 15; // pixels per second
 
   @property({ type: Number, attribute: "pause-duration" }) pauseDuration = 1000; // ms delay at ends
@@ -68,10 +66,10 @@ export class HaMarqueeText extends LitElement {
         @mouseleave=${this._handleMouseLeave}
         @touchstart=${this._handleMouseEnter}
         @touchend=${this._handleMouseLeave}
-        aria-label=${this.text}
+        aria-label=${this.textContent.trim() || ""}
         role="marquee"
       >
-        <span class="marquee-text">${this.text}</span>
+        <span class="marquee-text"><slot></slot></span>
       </div>
     `;
   }

--- a/src/dialogs/more-info/const.ts
+++ b/src/dialogs/more-info/const.ts
@@ -34,6 +34,7 @@ export const DOMAINS_WITH_NEW_MORE_INFO = [
   "valve",
   "water_heater",
   "weather",
+  "media_player",
 ];
 /** Domains with full height more info dialog */
 export const DOMAINS_FULL_HEIGHT_MORE_INFO = ["update"];

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -259,12 +259,12 @@ class MoreInfoMediaPlayer extends LitElement {
     const stateObj = this.stateObj;
     const controls = computeMediaControls(stateObj, true);
     const coverUrl = stateObj.attributes.entity_picture || "";
-    const duration = stateObj.attributes.media_duration || 0;
-    const durationFormated = stateObj.attributes.media_duration
-      ? this._formateDuration(duration)
-      : 0;
     const playerObj = new HassMediaPlayerEntity(this.hass, this.stateObj);
     const position = Math.floor(playerObj.currentProgress) || 0;
+    const duration = stateObj.attributes.media_duration || 0;
+    const remaining = duration - position;
+    const durationFormated =
+      remaining > 0 ? this._formateDuration(remaining) : 0;
     const postionFormated = this._formateDuration(position);
     const primaryTitle = playerObj.primaryTitle;
     const secondaryTitle = playerObj.secondaryTitle;

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -291,25 +291,6 @@ class MoreInfoMediaPlayer extends LitElement {
                 ? html`<div class="media-artist">${secondaryTitle}</div>`
                 : nothing}
             </div>
-            <div>
-              ${!isUnavailableState(stateObj.state) &&
-              supportsFeature(stateObj, MediaPlayerEntityFeature.BROWSE_MEDIA)
-                ? html`
-                    <ha-button
-                      @click=${this._showBrowseMedia}
-                      appearance="plain"
-                      variant="neutral"
-                      size="small"
-                    >
-                      <ha-svg-icon
-                        .path=${mdiPlayBoxMultiple}
-                        slot="start"
-                      ></ha-svg-icon>
-                      ${this.hass.localize("ui.card.media_player.browse_media")}
-                    </ha-button>
-                  `
-                : nothing}
-            </div>
           </div>`
         : nothing}
       ${duration && duration > 0
@@ -375,20 +356,6 @@ class MoreInfoMediaPlayer extends LitElement {
             </div>
             <div class="side-control">
               ${["media_next_track", "shuffle_set"].map((action) => {
-                const control = controls?.find((c) => c.action === action);
-                return control
-                  ? html`<ha-icon-button
-                      action=${action}
-                      @click=${this._handleClick}
-                      .path=${control.icon}
-                      .label=${this.hass.localize(
-                        "ui.card.media_player.media_pause"
-                      )}
-                    >
-                    </ha-icon-button>`
-                  : nothing;
-              })}
-              ${["turn_on", "turn_off"].map((action) => {
                 const control = controls?.find((c) => c.action === action);
                 return control
                   ? html`<ha-icon-button

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -535,7 +535,6 @@ class MoreInfoMediaPlayer extends LitElement {
     .volume ha-slider,
     .position-bar ha-slider {
       width: 100%;
-      --md-sys-color-primary: var(--disabled-color);
     }
 
     .volume,

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -267,6 +267,8 @@ class MoreInfoMediaPlayer extends LitElement {
     const postionFormated = this._formateDuration(position);
     const primaryTitle = playerObj.primaryTitle;
     const secondaryTitle = playerObj.secondaryTitle;
+    const turnOn = controls?.find((c) => c.action === "turn_on");
+    const turnOff = controls?.find((c) => c.action === "turn_off");
 
     return html`
       ${coverUrl
@@ -388,6 +390,18 @@ class MoreInfoMediaPlayer extends LitElement {
       ${this._renderVolumeControl()}
 
       <div class="bottom-controls">
+        ${turnOn
+          ? html`<ha-button
+              action=${turnOn.action}
+              @click=${this._handleClick}
+              appearance="plain"
+              variant="neutral"
+              size="small"
+            >
+              <ha-svg-icon .path=${turnOn.icon} slot="start"></ha-svg-icon>
+              ${this.hass.localize(`ui.card.media_player.${turnOn.action}`)}
+            </ha-button>`
+          : nothing}
         ${!isUnavailableState(stateObj.state) &&
         supportsFeature(stateObj, MediaPlayerEntityFeature.BROWSE_MEDIA)
           ? html`
@@ -406,25 +420,18 @@ class MoreInfoMediaPlayer extends LitElement {
             `
           : nothing}
         ${this._renderGrouping()}
-        ${["turn_on", "turn_off"].map((action) => {
-          const control = controls?.find((c) => c.action === action);
-          return control
-            ? html`<ha-button
-                action=${action}
-                @click=${this._handleClick}
-                appearance="plain"
-                variant="neutral"
-                size="small"
-              >
-                <ha-svg-icon
-                  .path=${control.icon}
-                  aria-label=".${this.hass.localize(
-                    `ui.card.media_player.${control.action}`
-                  )}"
-                ></ha-svg-icon>
-              </ha-button>`
-            : nothing;
-        })}
+        ${turnOff
+          ? html`<ha-button
+              action=${turnOff.action}
+              @click=${this._handleClick}
+              appearance="plain"
+              variant="neutral"
+              size="small"
+            >
+              <ha-svg-icon .path=${turnOff.icon} slot="start"></ha-svg-icon>
+              ${this.hass.localize(`ui.card.media_player.${turnOff.action}`)}
+            </ha-button>`
+          : nothing}
       </div>
 
       <div class="bottom-controls">

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -289,18 +289,16 @@ class MoreInfoMediaPlayer extends LitElement {
             ${primaryTitle
               ? html`<ha-marquee-text
                   class="media-title"
-                  .text=${primaryTitle}
                   speed="30"
                   pause-on-hover
-                ></ha-marquee-text>`
+                >${primaryTitle}</ha-marquee-text>`
               : nothing}
             ${secondaryTitle
               ? html`<ha-marquee-text
                   class="media-artist"
-                  .text=${secondaryTitle}
                   speed="30"
                   pause-on-hover
-                ></ha-marquee-text>`
+                >${secondaryTitle}</ha-marquee-text>`
               : nothing}
           </div>`
         : nothing}

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -11,6 +11,7 @@ import {
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
+import { classMap } from "lit/directives/class-map";
 import { stateActive } from "../../../common/entity/state_active";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import { formatDurationDigital } from "../../../common/datetime/format_duration";
@@ -271,9 +272,10 @@ class MoreInfoMediaPlayer extends LitElement {
       ${coverUrl
         ? html`<div class="cover-container">
             <img
-              class="cover-image${stateObj.state === "playing"
-                ? " cover-image--playing"
-                : ""}"
+              class=${classMap({
+                "cover-image": true,
+                "cover-image--playing": stateObj.state === "playing",
+              })}
               src=${coverUrl}
               alt=${ifDefined(primaryTitle)}
             />

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -291,14 +291,18 @@ class MoreInfoMediaPlayer extends LitElement {
                   class="media-title"
                   speed="30"
                   pause-on-hover
-                >${primaryTitle}</ha-marquee-text>`
+                >
+                  ${primaryTitle}
+                </ha-marquee-text>`
               : nothing}
             ${secondaryTitle
               ? html`<ha-marquee-text
                   class="media-artist"
                   speed="30"
                   pause-on-hover
-                >${secondaryTitle}</ha-marquee-text>`
+                >
+                  ${secondaryTitle}
+                </ha-marquee-text>`
               : nothing}
           </div>`
         : nothing}

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -595,6 +595,7 @@ class MoreInfoMediaPlayer extends LitElement {
     }
 
     .grouping-label {
+      display: block;
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -333,7 +333,7 @@ class MoreInfoMediaPlayer extends LitElement {
                       @click=${this._handleClick}
                       .path=${control.icon}
                       .label=${this.hass.localize(
-                        "ui.card.media_player.media_pause"
+                              `ui.card.media_player.${control.action}`
                       )}
                     >
                     </ha-icon-button>`
@@ -355,7 +355,7 @@ class MoreInfoMediaPlayer extends LitElement {
                         <ha-svg-icon
                           .path=${control.icon}
                           .label=${this.hass.localize(
-                            "ui.card.media_player.media_pause"
+                                  `ui.card.media_player.${control.action}`
                           )}
                         ></ha-svg-icon>
                       </ha-button>`
@@ -372,7 +372,7 @@ class MoreInfoMediaPlayer extends LitElement {
                       @click=${this._handleClick}
                       .path=${control.icon}
                       .label=${this.hass.localize(
-                        "ui.card.media_player.media_pause"
+                              `ui.card.media_player.${control.action}`
                       )}
                     >
                     </ha-icon-button>`
@@ -405,13 +405,17 @@ class MoreInfoMediaPlayer extends LitElement {
         ${["turn_on", "turn_off"].map((action) => {
           const control = controls?.find((c) => c.action === action);
           return control
-            ? html`<ha-icon-button
+            ? html`<ha-button
                 action=${action}
                 @click=${this._handleClick}
-                .path=${control.icon}
-                .label=${this.hass.localize("ui.card.media_player.media_pause")}
+                appearance="plain"
+                variant="neutral"
+                size="small"
               >
-              </ha-icon-button>`
+                      <ha-svg-icon
+                              .path=${control.icon}
+                      ></ha-svg-icon>
+              </ha-button>`
             : nothing;
         })}
       </div>

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -215,18 +215,24 @@ class MoreInfoMediaPlayer extends LitElement {
     supportsFeature(stateObj, MediaPlayerEntityFeature.GROUPING)
       ? html`
           <ha-button
+            class="grouping"
             @click=${this._showGroupMediaPlayers}
             appearance="plain"
             variant="neutral"
             size="small"
           >
-            <ha-svg-icon .path=${mdiSpeakerMultiple} slot="start"></ha-svg-icon>
-            ${hasMultipleMembers
-              ? html`<span class="badge">
-                  ${stateObj.attributes.group_members?.length || 4}
-                </span>`
-              : nothing}
-            <span class="grouping-label">
+            <div slot="start">
+              <ha-svg-icon
+                .path=${mdiSpeakerMultiple}
+                slot="start"
+              ></ha-svg-icon>
+              ${hasMultipleMembers
+                ? html`<span class="badge">
+                    ${stateObj.attributes.group_members?.length || 4}
+                  </span>`
+                : nothing}
+            </div>
+            <span>
               ${hasMultipleMembers
                 ? stateObj.attributes.group_members
                     ?.filter((member) => member !== stateObj.entity_id)
@@ -542,8 +548,8 @@ class MoreInfoMediaPlayer extends LitElement {
 
     .badge {
       position: absolute;
-      top: -6px;
-      left: 24px;
+      top: -10px;
+      left: 16px;
       display: flex;
       justify-content: center;
       align-items: center;
@@ -594,12 +600,16 @@ class MoreInfoMediaPlayer extends LitElement {
       align-items: center;
     }
 
-    .grouping-label {
+    .grouping::part(label) {
       display: block;
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
       max-width: 100px;
+    }
+
+    .grouping::part(start) {
+      position: relative;
     }
   `;
 

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -41,8 +41,6 @@ import "../../../components/ha-md-button-menu";
 import "../../../components/chips/ha-assist-chip";
 import "../../../components/ha-md-menu-item";
 import "../../../components/ha-marquee-text";
-import { computeEntityName } from "../../../common/entity/compute_entity_name";
-import { computeStateName } from "../../../common/entity/compute_state_name";
 
 @customElement("more-info-media_player")
 class MoreInfoMediaPlayer extends LitElement {
@@ -677,18 +675,6 @@ class MoreInfoMediaPlayer extends LitElement {
       entity_id: this.stateObj.entity_id,
       seek_position: newValue,
     });
-  }
-
-  protected _getFriendlyNameForGroupMember(member: string): string {
-    const stateObj = this.hass.states[member];
-
-    if (stateObj) {
-      const stateName = computeStateName(stateObj);
-      const entityName = computeEntityName(stateObj, this.hass);
-
-      return entityName || stateName;
-    }
-    return member;
   }
 }
 

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -38,6 +38,7 @@ import HassMediaPlayerEntity from "../../../util/hass-media-player-model";
 import "../../../components/ha-md-button-menu";
 import "../../../components/chips/ha-assist-chip";
 import "../../../components/ha-md-menu-item";
+import "../../../components/ha-marquee-text";
 
 @customElement("more-info-media_player")
 class MoreInfoMediaPlayer extends LitElement {
@@ -283,14 +284,22 @@ class MoreInfoMediaPlayer extends LitElement {
           )}
       ${primaryTitle || secondaryTitle
         ? html`<div class="media-info-row">
-            <div class="media-info">
-              ${primaryTitle
-                ? html`<div class="media-title">${primaryTitle}</div>`
-                : nothing}
-              ${secondaryTitle
-                ? html`<div class="media-artist">${secondaryTitle}</div>`
-                : nothing}
-            </div>
+            ${primaryTitle
+              ? html`<ha-marquee-text
+                  class="media-title"
+                  .text=${primaryTitle}
+                  speed="15"
+                  pause-on-hover
+                ></ha-marquee-text>`
+              : nothing}
+            ${secondaryTitle
+              ? html`<ha-marquee-text
+                  class="media-artist"
+                  .text=${secondaryTitle}
+                  speed="15"
+                  pause-on-hover
+                ></ha-marquee-text>`
+              : nothing}
           </div>`
         : nothing}
       ${duration && duration > 0
@@ -543,9 +552,8 @@ class MoreInfoMediaPlayer extends LitElement {
 
     .media-info-row {
       display: flex;
-      align-items: center;
+      flex-direction: column;
       justify-content: space-between;
-      gap: 16px;
       margin: 8px 0 8px 8px;
     }
 

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -408,8 +408,40 @@ class MoreInfoMediaPlayer extends LitElement {
       ${this._renderVolumeControl()}
 
       <div class="bottom-controls">
-        ${this._renderSourceControl()} ${this._renderSoundMode()}
+        ${!isUnavailableState(stateObj.state) &&
+        supportsFeature(stateObj, MediaPlayerEntityFeature.BROWSE_MEDIA)
+          ? html`
+              <ha-button
+                @click=${this._showBrowseMedia}
+                appearance="plain"
+                variant="neutral"
+                size="small"
+              >
+                <ha-svg-icon
+                  .path=${mdiPlayBoxMultiple}
+                  slot="start"
+                ></ha-svg-icon>
+                ${this.hass.localize("ui.card.media_player.browse_media")}
+              </ha-button>
+            `
+          : nothing}
         ${this._renderGrouping()}
+        ${["turn_on", "turn_off"].map((action) => {
+          const control = controls?.find((c) => c.action === action);
+          return control
+            ? html`<ha-icon-button
+                action=${action}
+                @click=${this._handleClick}
+                .path=${control.icon}
+                .label=${this.hass.localize("ui.card.media_player.media_pause")}
+              >
+              </ha-icon-button>`
+            : nothing;
+        })}
+      </div>
+
+      <div class="bottom-controls">
+        ${this._renderSourceControl()} ${this._renderSoundMode()}
       </div>
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -77,17 +77,15 @@ class MoreInfoMediaPlayer extends LitElement {
       darkOptimized: this.hass.themes?.darkMode,
     });
 
-    return brandUrl
-      ? html`
-          <img
-            src=${brandUrl}
-            alt=${entry.platform}
-            title=${entry.platform}
-            width="24"
-            height="24"
-          />
-        `
-      : nothing;
+    return html`
+      <img
+        src=${brandUrl}
+        alt=${entry.platform}
+        title=${entry.platform}
+        width="24"
+        height="24"
+      />
+    `;
   }
 
   protected _renderVolumeControl() {

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -20,8 +20,6 @@ import "../../../components/ha-select";
 import "../../../components/ha-slider";
 import "../../../components/ha-button";
 import "../../../components/ha-svg-icon";
-import "../../../components/chips/ha-chip-set";
-import "../../../components/chips/ha-filter-chip";
 import { showMediaBrowserDialog } from "../../../components/media-player/show-media-browser-dialog";
 import { showJoinMediaPlayersDialog } from "../../../components/media-player/show-join-media-players-dialog";
 import { isUnavailableState } from "../../../data/entity";
@@ -37,6 +35,9 @@ import {
 } from "../../../data/media-player";
 import type { HomeAssistant } from "../../../types";
 import HassMediaPlayerEntity from "../../../util/hass-media-player-model";
+import "../../../components/ha-md-button-menu";
+import "../../../components/chips/ha-assist-chip";
+import "../../../components/ha-md-menu-item";
 
 @customElement("more-info-media_player")
 class MoreInfoMediaPlayer extends LitElement {

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -333,7 +333,7 @@ class MoreInfoMediaPlayer extends LitElement {
                       @click=${this._handleClick}
                       .path=${control.icon}
                       .label=${this.hass.localize(
-                              `ui.card.media_player.${control.action}`
+                        `ui.card.media_player.${control.action}`
                       )}
                     >
                     </ha-icon-button>`
@@ -354,8 +354,8 @@ class MoreInfoMediaPlayer extends LitElement {
                       >
                         <ha-svg-icon
                           .path=${control.icon}
-                          .label=${this.hass.localize(
-                                  `ui.card.media_player.${control.action}`
+                          aria-label=${this.hass.localize(
+                            `ui.card.media_player.${control.action}`
                           )}
                         ></ha-svg-icon>
                       </ha-button>`
@@ -372,7 +372,7 @@ class MoreInfoMediaPlayer extends LitElement {
                       @click=${this._handleClick}
                       .path=${control.icon}
                       .label=${this.hass.localize(
-                              `ui.card.media_player.${control.action}`
+                        `ui.card.media_player.${control.action}`
                       )}
                     >
                     </ha-icon-button>`
@@ -412,9 +412,12 @@ class MoreInfoMediaPlayer extends LitElement {
                 variant="neutral"
                 size="small"
               >
-                      <ha-svg-icon
-                              .path=${control.icon}
-                      ></ha-svg-icon>
+                <ha-svg-icon
+                  .path=${control.icon}
+                  aria-label=".${this.hass.localize(
+                    `ui.card.media_player.${control.action}`
+                  )}"
+                ></ha-svg-icon>
               </ha-button>`
             : nothing;
         })}

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -202,9 +202,7 @@ class MoreInfoMediaPlayer extends LitElement {
                   </span>`
                 : nothing}
             </div>
-            <span>
-              ${this.hass.localize("ui.card.media_player.join")}
-            </span>
+            <span>${this.hass.localize("ui.card.media_player.join")}</span>
           </ha-button>
         `
       : nothing}`;
@@ -245,9 +243,7 @@ class MoreInfoMediaPlayer extends LitElement {
     const turnOff = controls?.find((c) => c.action === "turn_off");
 
     return html`
-      <div class="controls-row">
-       ${this._renderSourceControl()}
-      </div>
+      <div class="controls-row">${this._renderSourceControl()}</div>
 
       ${coverUrl
         ? html`<div class="cover-container">
@@ -387,7 +383,7 @@ class MoreInfoMediaPlayer extends LitElement {
               </ha-button>
             `
           : nothing}
-          ${this._renderGrouping()}
+        ${this._renderGrouping()}
         <span class="flex"></span>
         ${turnOn
           ? html`<ha-button

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -42,7 +42,6 @@ import "../../../components/ha-md-menu-item";
 import "../../../components/ha-marquee-text";
 import { computeEntityName } from "../../../common/entity/compute_entity_name";
 import { computeStateName } from "../../../common/entity/compute_state_name";
-import { brandsUrl } from "../../../util/brands-url";
 
 @customElement("more-info-media_player")
 class MoreInfoMediaPlayer extends LitElement {
@@ -59,33 +58,6 @@ class MoreInfoMediaPlayer extends LitElement {
       minutes,
       seconds,
     })!;
-  }
-
-  protected _renderIntegrationLogo() {
-    if (!this.stateObj) {
-      return nothing;
-    }
-
-    const entry = this.hass.entities[this.stateObj.entity_id];
-    if (!entry || !entry.platform) {
-      return nothing;
-    }
-
-    const brandUrl = brandsUrl({
-      domain: entry.platform,
-      type: "icon",
-      darkOptimized: this.hass.themes?.darkMode,
-    });
-
-    return html`
-      <img
-        src=${brandUrl}
-        alt=${entry.platform}
-        title=${entry.platform}
-        width="24"
-        height="24"
-      />
-    `;
   }
 
   protected _renderVolumeControl() {
@@ -231,14 +203,7 @@ class MoreInfoMediaPlayer extends LitElement {
                 : nothing}
             </div>
             <span>
-              ${hasMultipleMembers
-                ? groupMembers
-                    ?.filter((member) => member !== stateObj.entity_id)
-                    .map((member) =>
-                      this._getFriendlyNameForGroupMember(member)
-                    )
-                    .join(", ")
-                : this.hass.localize("ui.card.media_player.join")}
+              ${this.hass.localize("ui.card.media_player.join")}
             </span>
           </ha-button>
         `
@@ -281,9 +246,7 @@ class MoreInfoMediaPlayer extends LitElement {
 
     return html`
       <div class="controls-row">
-        ${this._renderIntegrationLogo()} ${this._renderSourceControl()}
-        <span class="flex"></span>
-        ${this._renderGrouping()}
+       ${this._renderSourceControl()}
       </div>
 
       ${coverUrl
@@ -424,6 +387,7 @@ class MoreInfoMediaPlayer extends LitElement {
               </ha-button>
             `
           : nothing}
+          ${this._renderGrouping()}
         <span class="flex"></span>
         ${turnOn
           ? html`<ha-button

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -288,7 +288,7 @@ class MoreInfoMediaPlayer extends LitElement {
               ? html`<ha-marquee-text
                   class="media-title"
                   .text=${primaryTitle}
-                  speed="15"
+                  speed="30"
                   pause-on-hover
                 ></ha-marquee-text>`
               : nothing}
@@ -296,7 +296,7 @@ class MoreInfoMediaPlayer extends LitElement {
               ? html`<ha-marquee-text
                   class="media-artist"
                   .text=${secondaryTitle}
-                  speed="15"
+                  speed="30"
                   pause-on-hover
                 ></ha-marquee-text>`
               : nothing}

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -492,7 +492,7 @@ class MoreInfoMediaPlayer extends LitElement {
     }
 
     .empty-cover {
-      background-color: var(--disabled-color);
+      background-color: var(--secondary-background-color);
       font-size: 1.5em;
       color: var(--secondary-text-color);
     }
@@ -526,7 +526,9 @@ class MoreInfoMediaPlayer extends LitElement {
       flex: 1;
     }
 
-    .volume {
+    .volume,
+    .position-bar,
+    .main-control {
       direction: ltr;
     }
 
@@ -534,10 +536,6 @@ class MoreInfoMediaPlayer extends LitElement {
     .position-bar ha-slider {
       width: 100%;
       --md-sys-color-primary: var(--disabled-color);
-    }
-
-    .source-input {
-      direction: var(--direction);
     }
 
     .volume,
@@ -558,9 +556,9 @@ class MoreInfoMediaPlayer extends LitElement {
       border-radius: 10px;
       font-weight: var(--ha-font-weight-normal);
       font-size: var(--ha-font-size-xs);
-      background-color: var(--accent-color);
+      background-color: var(--primary-color);
       padding: 0 4px;
-      color: var(--text-accent-color, var(--text-primary-color));
+      color: var(--primary-text-color);
     }
 
     .position-bar {
@@ -667,7 +665,7 @@ class MoreInfoMediaPlayer extends LitElement {
     });
   }
 
-  private _handleMediaSeekChanged(e: Event): void {
+  private async _handleMediaSeekChanged(e: Event): Promise<void> {
     if (!this.stateObj) {
       return;
     }

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -517,8 +517,13 @@ class MoreInfoMediaPlayer extends LitElement {
 
     .volume ha-svg-icon {
       padding: 4px;
-      height: 24px;
-      width: 24px;
+      height: 16px;
+      width: 16px;
+    }
+
+    .volume ha-icon-button {
+      --mdc-icon-button-size: 32px;
+      --mdc-icon-size: 16px;
     }
 
     .badge {
@@ -549,6 +554,7 @@ class MoreInfoMediaPlayer extends LitElement {
       justify-content: space-between;
       color: var(--secondary-text-color);
       padding: 0 8px;
+      font-size: var(--ha-font-size-s);
     }
 
     .media-info-row {
@@ -565,7 +571,7 @@ class MoreInfoMediaPlayer extends LitElement {
     }
 
     .media-artist {
-      font-size: var(--ha-font-size-lg);
+      font-size: var(--ha-font-size-l);
       font-weight: var(--ha-font-weight-normal);
       color: var(--secondary-text-color);
     }

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -256,12 +256,12 @@ class MoreInfoMediaPlayer extends LitElement {
     const stateObj = this.stateObj;
     const controls = computeMediaControls(stateObj, true);
     const coverUrl = stateObj.attributes.entity_picture || "";
-    const duration = stateObj.attributes.media_duration;
+    const duration = stateObj.attributes.media_duration || 0;
     const durationFormated = stateObj.attributes.media_duration
-      ? this._formateDuration(stateObj.attributes.media_duration)
+      ? this._formateDuration(duration)
       : 0;
     const playerObj = new HassMediaPlayerEntity(this.hass, this.stateObj);
-    const position = Math.floor(playerObj.currentProgress);
+    const position = Math.floor(playerObj.currentProgress) || 0;
     const postionFormated = this._formateDuration(position);
     const primaryTitle = playerObj.primaryTitle;
     const secondaryTitle = playerObj.secondaryTitle;

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -552,13 +552,6 @@ class MoreInfoMediaPlayer extends LitElement {
       padding: 0 8px;
     }
 
-    .source-input ha-chip {
-      --ha-chip-selected-color: var(--primary-color);
-      --ha-chip-text-color: var(--text-primary-color);
-      --ha-chip-background-color: var(--card-background-color);
-      --ha-chip-border-color: var(--primary-color);
-    }
-
     .media-info-row {
       display: flex;
       flex-direction: column;

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -208,8 +208,8 @@ class MoreInfoMediaPlayer extends LitElement {
       return nothing;
     }
     const stateObj = this.stateObj;
-    const groupMembers = stateObj.attributes.group_members?.length;
-    const hasMultipleMembers = groupMembers && groupMembers > 1;
+    const groupMembers = stateObj.attributes.group_members;
+    const hasMultipleMembers = groupMembers && groupMembers?.length > 1;
 
     return html`${!isUnavailableState(stateObj.state) &&
     supportsFeature(stateObj, MediaPlayerEntityFeature.GROUPING)
@@ -228,13 +228,13 @@ class MoreInfoMediaPlayer extends LitElement {
               ></ha-svg-icon>
               ${hasMultipleMembers
                 ? html`<span class="badge">
-                    ${stateObj.attributes.group_members?.length || 4}
+                    ${groupMembers?.length || 4}
                   </span>`
                 : nothing}
             </div>
             <span>
               ${hasMultipleMembers
-                ? stateObj.attributes.group_members
+                ? groupMembers
                     ?.filter((member) => member !== stateObj.entity_id)
                     .map((member) =>
                       this._getFriendlyNameForGroupMember(member)
@@ -337,6 +337,8 @@ class MoreInfoMediaPlayer extends LitElement {
                   "ui.card.media_player.track_position"
                 )}
                 @change=${this._handleMediaSeekChanged}
+                ?disabled=${!stateActive(stateObj) ||
+                !supportsFeature(stateObj, MediaPlayerEntityFeature.SEEK)}
               ></ha-slider>
               <div class="position-info-row">
                 <span class="position-time">${postionFormated}</span>

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -389,6 +389,10 @@ class MoreInfoMediaPlayer extends LitElement {
         : nothing}
       ${this._renderVolumeControl()}
 
+      <div class="chips">
+        ${this._renderSourceControl()} ${this._renderSoundMode()}
+      </div>
+
       <div class="bottom-controls">
         ${turnOn
           ? html`<ha-button
@@ -420,22 +424,17 @@ class MoreInfoMediaPlayer extends LitElement {
             `
           : nothing}
         ${this._renderGrouping()}
+        <span class="flex"></span>
         ${turnOff
-          ? html`<ha-button
+          ? html`<ha-icon-button
               action=${turnOff.action}
               @click=${this._handleClick}
-              appearance="plain"
-              variant="neutral"
-              size="small"
-            >
-              <ha-svg-icon .path=${turnOff.icon} slot="start"></ha-svg-icon>
-              ${this.hass.localize(`ui.card.media_player.${turnOff.action}`)}
-            </ha-button>`
+              .label=${this.hass.localize(
+                `ui.card.media_player.${turnOff.action}`
+              )}
+              .path=${turnOff.icon}
+            ></ha-icon-button>`
           : nothing}
-      </div>
-
-      <div class="bottom-controls">
-        ${this._renderSourceControl()} ${this._renderSoundMode()}
       </div>
     `;
   }
@@ -509,6 +508,10 @@ class MoreInfoMediaPlayer extends LitElement {
       justify-content: center;
     }
 
+    .flex {
+      flex: 1;
+    }
+
     .volume {
       direction: ltr;
     }
@@ -579,10 +582,15 @@ class MoreInfoMediaPlayer extends LitElement {
       font-weight: 500;
     }
 
+    .chips {
+      display: flex;
+      gap: 8px;
+    }
+
     .bottom-controls {
       display: flex;
       gap: 8px;
-      justify-content: center;
+      align-items: center;
     }
   `;
 

--- a/src/dialogs/more-info/ha-more-info-info.ts
+++ b/src/dialogs/more-info/ha-more-info-info.ts
@@ -137,10 +137,6 @@ export class MoreInfoInfo extends LitElement {
       --video-max-height: calc(100vh - 72px - 79px - 60px);
     }
 
-    [data-domain="media_player"] .content {
-      padding-top: 0;
-    }
-
     more-info-content {
       position: relative;
       display: flex;

--- a/src/dialogs/more-info/ha-more-info-info.ts
+++ b/src/dialogs/more-info/ha-more-info-info.ts
@@ -137,6 +137,10 @@ export class MoreInfoInfo extends LitElement {
       --video-max-height: calc(100vh - 72px - 79px - 60px);
     }
 
+    [data-domain="media_player"] .content {
+      padding-top: 0;
+    }
+
     more-info-content {
       position: relative;
       display: flex;

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -22,6 +22,7 @@ import { demoPanels } from "./demo_panels";
 import { demoServices } from "./demo_services";
 import type { Entity } from "./entity";
 import { getEntity } from "./entity";
+import type { EntityRegistryDisplayEntry } from "../data/entity_registry";
 
 const ensureArray = <T>(val: T | T[]): T[] =>
   Array.isArray(val) ? val : [val];
@@ -147,6 +148,17 @@ export const provideHass = (
     } else {
       updateStates(states);
     }
+
+    for (const ent of ensureArray(newEntities)) {
+      hass().entities[ent.entityId] = {
+        entity_id: ent.entityId,
+        name: ent.name,
+        icon: ent.icon,
+        platform: "demo",
+        labels: [],
+      } satisfies EntityRegistryDisplayEntry;
+    }
+
     updateFormatFunctions();
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -213,7 +213,7 @@
       "media_player": {
         "source": "Source",
         "sound_mode": "Sound mode",
-        "browse_media": "Play media",
+        "browse_media": "Media",
         "turn_on": "Turn on",
         "turn_off": "Turn off",
         "media_play": "Play",
@@ -230,7 +230,7 @@
         "shuffle_set": "Shuffle",
         "text_to_speak": "Text to speak",
         "nothing_playing": "Nothing playing",
-        "join": "Join",
+        "join": "Players",
         "media_players": "Media players",
         "select_all": "Select all",
         "idle": "Idle",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -213,7 +213,7 @@
       "media_player": {
         "source": "Source",
         "sound_mode": "Sound mode",
-        "browse_media": "Media",
+        "browse_media": "Browse media",
         "turn_on": "Turn on",
         "turn_off": "Turn off",
         "media_play": "Play",
@@ -230,7 +230,7 @@
         "shuffle_set": "Shuffle",
         "text_to_speak": "Text to speak",
         "nothing_playing": "Nothing playing",
-        "join": "Players",
+        "join": "Join",
         "media_players": "Media players",
         "select_all": "Select all",
         "idle": "Idle",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -233,7 +233,8 @@
         "join": "Join",
         "media_players": "Media players",
         "select_all": "Select all",
-        "idle": "Idle"
+        "idle": "Idle",
+        "track_position": "Track position"
       },
       "persistent_notification": {
         "dismiss": "Dismiss"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -213,7 +213,7 @@
       "media_player": {
         "source": "Source",
         "sound_mode": "Sound mode",
-        "browse_media": "Browse media",
+        "browse_media": "Play media",
         "turn_on": "Turn on",
         "turn_off": "Turn off",
         "media_play": "Play",


### PR DESCRIPTION
## Proposed change

Redesign the media player more-info dialog. Preview can be found [here](https://deploy-preview-26904--home-assistant-gallery.netlify.app/#more-info/media-player)


Based on design evaluation in https://www.figma.com/design/7h74CnHOxmw5mTKxdI9c33/Media-player---dialog?node-id=0-1&p=f&t=erXeIMqYyMBT61MH-0

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Related feature request: https://github.com/orgs/home-assistant/discussions/726

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
