### PR TITLE
Prettier one line format in style .globals.ts files

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,3 +1,11 @@
 export default {
   trailingComma: "es5",
+  overrides: [
+    {
+      files: "*.globals.ts",
+      options: {
+        printWidth: 9999, // Effectively disables line wrapping for these files
+      },
+    },
+  ],
 };

--- a/src/resources/theme/color/color.globals.ts
+++ b/src/resources/theme/color/color.globals.ts
@@ -117,10 +117,7 @@ export const colorStyles = css`
     /* state color */
     --state-active-color: var(--amber-color);
     --state-inactive-color: var(--grey-color);
-    --state-unavailable-color: var(
-      --state-icon-unavailable-color,
-      var(--disabled-text-color)
-    );
+    --state-unavailable-color: var(--state-icon-unavailable-color, var(--disabled-text-color));
 
     /* state domain colors */
     --state-alarm_control_panel-armed_away-color: var(--green-color);
@@ -198,15 +195,9 @@ export const colorStyles = css`
     --sidebar-selected-icon-color: var(--primary-color);
     --sidebar-icon-color: rgba(var(--rgb-primary-text-color), 0.6);
     --switch-checked-color: var(--primary-color);
-    --switch-checked-button-color: var(
-      --switch-checked-color,
-      var(--primary-background-color)
-    );
+    --switch-checked-button-color: var(--switch-checked-color, var(--primary-background-color));
     --switch-checked-track-color: var(--switch-checked-color, #000000);
-    --switch-unchecked-button-color: var(
-      --switch-unchecked-color,
-      var(--primary-background-color)
-    );
+    --switch-unchecked-button-color: var(--switch-unchecked-color, var(--primary-background-color));
     --switch-unchecked-track-color: var(--switch-unchecked-color, #000000);
     --slider-color: var(--primary-color);
     --slider-secondary-color: var(--light-primary-color);
@@ -252,15 +243,9 @@ export const colorStyles = css`
     --mdc-text-field-idle-line-color: var(--input-idle-line-color);
     --mdc-text-field-hover-line-color: var(--input-hover-line-color);
     --mdc-text-field-disabled-line-color: var(--input-disabled-line-color);
-    --mdc-text-field-outlined-idle-border-color: var(
-      --input-outlined-idle-border-color
-    );
-    --mdc-text-field-outlined-hover-border-color: var(
-      --input-outlined-hover-border-color
-    );
-    --mdc-text-field-outlined-disabled-border-color: var(
-      --input-outlined-disabled-border-color
-    );
+    --mdc-text-field-outlined-idle-border-color: var(--input-outlined-idle-border-color);
+    --mdc-text-field-outlined-hover-border-color: var(--input-outlined-hover-border-color);
+    --mdc-text-field-outlined-disabled-border-color: var(--input-outlined-disabled-border-color);
     --mdc-text-field-fill-color: var(--input-fill-color);
     --mdc-text-field-disabled-fill-color: var(--input-disabled-fill-color);
     --mdc-text-field-ink-color: var(--input-ink-color);
@@ -269,15 +254,9 @@ export const colorStyles = css`
 
     --mdc-select-idle-line-color: var(--input-idle-line-color);
     --mdc-select-hover-line-color: var(--input-hover-line-color);
-    --mdc-select-outlined-idle-border-color: var(
-      --input-outlined-idle-border-color
-    );
-    --mdc-select-outlined-hover-border-color: var(
-      --input-outlined-hover-border-color
-    );
-    --mdc-select-outlined-disabled-border-color: var(
-      --input-outlined-disabled-border-color
-    );
+    --mdc-select-outlined-idle-border-color: var(--input-outlined-idle-border-color);
+    --mdc-select-outlined-hover-border-color: var(--input-outlined-hover-border-color);
+    --mdc-select-outlined-disabled-border-color: var(--input-outlined-disabled-border-color);
     --mdc-select-fill-color: var(--input-fill-color);
     --mdc-select-disabled-fill-color: var(--input-disabled-fill-color);
     --mdc-select-ink-color: var(--input-ink-color);
@@ -285,14 +264,8 @@ export const colorStyles = css`
     --mdc-select-disabled-ink-color: var(--input-disabled-ink-color);
     --mdc-select-dropdown-icon-color: var(--input-dropdown-icon-color);
     --mdc-select-disabled-dropdown-icon-color: var(--input-disabled-ink-color);
-    --ha-assist-chip-filled-container-color: rgba(
-      var(--rgb-primary-text-color),
-      0.15
-    );
-    --ha-assist-chip-active-container-color: rgba(
-      var(--rgb-primary-color),
-      0.15
-    );
+    --ha-assist-chip-filled-container-color: rgba(var(--rgb-primary-text-color), 0.15);
+    --ha-assist-chip-active-container-color: rgba(var(--rgb-primary-color), 0.15);
     --chip-background-color: rgba(var(--rgb-primary-text-color), 0.15);
 
     /* Vaadin */
@@ -354,8 +327,7 @@ export const darkColorStyles = css`
     --codemirror-qualifier: #decb6b;
     --codemirror-type: #decb6b;
     --energy-grid-return-color: #a280db;
-    --map-filter: invert(0.9) hue-rotate(170deg) brightness(1.5) contrast(1.2)
-      saturate(0.3);
+    --map-filter: invert(0.9) hue-rotate(170deg) brightness(1.5) contrast(1.2) saturate(0.3);
     --disabled-color: #464646;
 
     --ha-button-primary-light-color: #4082a040;
@@ -367,9 +339,5 @@ export const darkColorStyles = css`
   }
 `;
 
-export const DefaultPrimaryColor = extractVar(
-  colorStyles,
-  "primary-color",
-  coreColorVariables
-);
+export const DefaultPrimaryColor = extractVar(colorStyles, "primary-color", coreColorVariables);
 export const DefaultAccentColor = extractVar(colorStyles, "accent-color");

--- a/src/resources/theme/main.globals.ts
+++ b/src/resources/theme/main.globals.ts
@@ -28,22 +28,10 @@ export const mainStyles = css`
     --margin-title-rtl: 0 24px 0 0;
 
     /* safe-area-insets */
-    --safe-area-inset-top: var(
-      --app-safe-area-inset-top,
-      env(safe-area-inset-top, 0)
-    );
-    --safe-area-inset-bottom: var(
-      --app-safe-area-inset-bottom,
-      env(safe-area-inset-bottom, 0)
-    );
-    --safe-area-inset-left: var(
-      --app-safe-area-inset-left,
-      env(safe-area-inset-left, 0)
-    );
-    --safe-area-inset-right: var(
-      --app-safe-area-inset-right,
-      env(safe-area-inset-right, 0)
-    );
+    --safe-area-inset-top: var(--app-safe-area-inset-top, env(safe-area-inset-top, 0));
+    --safe-area-inset-bottom: var(--app-safe-area-inset-bottom, env(safe-area-inset-bottom, 0));
+    --safe-area-inset-left: var(--app-safe-area-inset-left, env(safe-area-inset-left, 0));
+    --safe-area-inset-right: var(--app-safe-area-inset-right, env(safe-area-inset-right, 0));
   }
 `;
 

--- a/src/resources/theme/typography.globals.ts
+++ b/src/resources/theme/typography.globals.ts
@@ -1,8 +1,5 @@
 import { css } from "lit";
-import {
-  extractDerivedVars,
-  extractVar,
-} from "../../common/style/derived-css-vars";
+import { extractDerivedVars, extractVar } from "../../common/style/derived-css-vars";
 
 export const typographyStyles = css`
   html {
@@ -17,16 +14,10 @@ export const typographyStyles = css`
     --ha-font-size-m: calc(14px * var(--ha-font-size-scale)); /* 1rem */
     --ha-font-size-l: calc(16px * var(--ha-font-size-scale)); /* 1.142857rem */
     --ha-font-size-xl: calc(20px * var(--ha-font-size-scale)); /* 1.428571rem */
-    --ha-font-size-2xl: calc(
-      24px * var(--ha-font-size-scale)
-    ); /* 1.714286rem */
+    --ha-font-size-2xl: calc(24px * var(--ha-font-size-scale)); /* 1.714286rem */
     --ha-font-size-3xl: calc(28px * var(--ha-font-size-scale)); /* 2rem */
-    --ha-font-size-4xl: calc(
-      32px * var(--ha-font-size-scale)
-    ); /* 2.285714rem */
-    --ha-font-size-5xl: calc(
-      40px * var(--ha-font-size-scale)
-    ); /* 2.857143rem */
+    --ha-font-size-4xl: calc(32px * var(--ha-font-size-scale)); /* 2.285714rem */
+    --ha-font-size-5xl: calc(40px * var(--ha-font-size-scale)); /* 2.857143rem */
 
     --ha-font-weight-light: 300;
     --ha-font-weight-normal: 400;
@@ -60,17 +51,8 @@ export const typographyStyles = css`
 
 export const typographyDerivedVariables = extractDerivedVars(typographyStyles);
 
-export const haFontFamilyBody = extractVar(
-  typographyStyles,
-  "ha-font-family-body"
-);
+export const haFontFamilyBody = extractVar(typographyStyles, "ha-font-family-body");
 
-export const haFontSmoothing = extractVar(
-  typographyStyles,
-  "ha-font-smoothing"
-);
+export const haFontSmoothing = extractVar(typographyStyles, "ha-font-smoothing");
 
-export const haMozOsxFontSmoothing = extractVar(
-  typographyStyles,
-  "ha-moz-osx-font-smoothing"
-);
+export const haMozOsxFontSmoothing = extractVar(typographyStyles, "ha-moz-osx-font-smoothing");

--- a/src/resources/theme/wa.globals.ts
+++ b/src/resources/theme/wa.globals.ts
@@ -6,8 +6,7 @@ export const waMainStyles = css`
     --wa-focus-ring-style: solid;
     --wa-focus-ring-width: 2px;
     --wa-focus-ring-offset: 2px;
-    --wa-focus-ring: var(--wa-focus-ring-style) var(--wa-focus-ring-width)
-      var(--wa-focus-ring-color);
+    --wa-focus-ring: var(--wa-focus-ring-style) var(--wa-focus-ring-width) var(--wa-focus-ring-color);
 
     --wa-space-l: 24px;
     --wa-shadow-l: 0 8px 8px -4px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
## Proposed change
- Avoid auto line breaks in css definitions in `.globals.ts` files

I havn't found a way to do this everywhere in lit css.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
