### PR TITLE
Improve addon configuration UI

### DIFF
--- a/hassio/src/addon-view/config/hassio-addon-config.ts
+++ b/hassio/src/addon-view/config/hassio-addon-config.ts
@@ -104,6 +104,14 @@ class HassioAddonConfig extends LitElement {
   }
 
   private _convertSchemaElement(entry: any): HaFormSchema {
+    if (entry.type === "schema" && !entry.multiple) {
+      return {
+        name: entry.name,
+        type: "expandable",
+        required: entry.required,
+        schema: this._convertSchemaElements(entry.schema),
+      };
+    }
     const selector = this._convertSchemaElementToSelector(entry, false);
     if (selector) {
       return {

--- a/hassio/src/addon-view/config/hassio-addon-config.ts
+++ b/hassio/src/addon-view/config/hassio-addon-config.ts
@@ -92,67 +92,75 @@ class HassioAddonConfig extends LitElement {
 
   private _convertSchema = memoizeOne(
     // Convert supervisor schema to selectors
-    (schema: Record<string, any>): HaFormSchema[] =>
-      schema.map((entry) => {
-        if (entry.type === "select") {
-          return {
-            name: entry.name,
-            required: entry.required,
-            selector: { select: { options: entry.options } },
-          };
-        }
-        if (entry.type === "string") {
-          return entry.multiple
-            ? {
-                name: entry.name,
-                required: entry.required,
-                selector: {
-                  select: { options: [], multiple: true, custom_value: true },
-                },
-              }
-            : {
-                name: entry.name,
-                required: entry.required,
-                selector: {
-                  text: {
-                    type: entry.format
-                      ? entry.format
-                      : MASKED_FIELDS.includes(entry.name)
-                        ? "password"
-                        : "text",
-                  },
-                },
-              };
-        }
-        if (entry.type === "boolean") {
-          return {
-            name: entry.name,
-            required: entry.required,
-            selector: { boolean: {} },
-          };
-        }
-        if (entry.type === "schema") {
-          return {
-            name: entry.name,
-            required: entry.required,
-            selector: { object: {} },
-          };
-        }
-        if (entry.type === "float" || entry.type === "integer") {
-          return {
+    (schema: readonly HaFormSchema[]): HaFormSchema[] =>
+      this._convertSchemaElements(schema)
+  );
+
+  private _convertSchemaElements(
+    schema: readonly HaFormSchema[]
+  ): HaFormSchema[] {
+    return schema.map((entry) => this._convertSchemaElement(entry));
+  }
+
+  private _convertSchemaElement(entry: any): HaFormSchema {
+    if (entry.type === "select") {
+      return {
+        name: entry.name,
+        required: entry.required,
+        selector: { select: { options: entry.options } },
+      };
+    }
+    if (entry.type === "string") {
+      return entry.multiple
+        ? {
             name: entry.name,
             required: entry.required,
             selector: {
-              number: {
-                mode: "box",
-                step: entry.type === "float" ? "any" : undefined,
+              select: { options: [], multiple: true, custom_value: true },
+            },
+          }
+        : {
+            name: entry.name,
+            required: entry.required,
+            selector: {
+              text: {
+                type: entry.format
+                  ? entry.format
+                  : MASKED_FIELDS.includes(entry.name)
+                    ? "password"
+                    : "text",
               },
             },
           };
-        }
-        return entry;
-      })
-  );
+    }
+    if (entry.type === "boolean") {
+      return {
+        name: entry.name,
+        required: entry.required,
+        selector: { boolean: {} },
+      };
+    }
+    if (entry.type === "schema") {
+      return {
+        name: entry.name,
+        required: entry.required,
+        selector: { object: {} },
+      };
+    }
+    if (entry.type === "float" || entry.type === "integer") {
+      return {
+        name: entry.name,
+        required: entry.required,
+        selector: {
+          number: {
+            mode: "box",
+            step: entry.type === "float" ? "any" : undefined,
+          },
+        },
+      };
+    }
+    return entry;
+  }
 
   private _filteredSchema = memoizeOne(
     (options: Record<string, unknown>, schema: HaFormSchema[]) =>

--- a/hassio/src/addon-view/config/hassio-addon-config.ts
+++ b/hassio/src/addon-view/config/hassio-addon-config.ts
@@ -33,7 +33,7 @@ import { haStyle } from "../../../../src/resources/styles";
 import type { HomeAssistant } from "../../../../src/types";
 import { suggestAddonRestart } from "../../dialogs/suggestAddonRestart";
 import { hassioStyle } from "../../resources/hassio-style";
-import type { Selector } from "../../../../src/data/selector";
+import type { ObjectSelector, Selector } from "../../../../src/data/selector";
 
 const SUPPORTED_UI_TYPES = [
   "string",
@@ -139,7 +139,19 @@ class HassioAddonConfig extends LitElement {
       return { boolean: {} };
     }
     if (entry.type === "schema") {
-      return { object: {} };
+      const fields: NonNullable<ObjectSelector["object"]>["fields"] = {};
+      for (const child_entry of entry.schema) {
+        fields[child_entry.name] = {
+          required: child_entry.required,
+          selector: this._convertSchemaElementToSelector(child_entry, true)!,
+        };
+      }
+      return {
+        object: {
+          multiple: entry.multiple,
+          fields,
+        },
+      };
     }
     if (entry.type === "float" || entry.type === "integer") {
       return {

--- a/hassio/src/addon-view/config/hassio-addon-config.ts
+++ b/hassio/src/addon-view/config/hassio-addon-config.ts
@@ -104,7 +104,7 @@ class HassioAddonConfig extends LitElement {
   }
 
   private _convertSchemaElement(entry: any): HaFormSchema {
-    const selector = this._convertSchemaElementToSelector(entry);
+    const selector = this._convertSchemaElementToSelector(entry, false);
     if (selector) {
       return {
         name: entry.name,
@@ -115,7 +115,10 @@ class HassioAddonConfig extends LitElement {
     return entry;
   }
 
-  private _convertSchemaElementToSelector(entry: any): Selector | null {
+  private _convertSchemaElementToSelector(
+    entry: any,
+    force: boolean
+  ): Selector | null {
     if (entry.type === "select") {
       return { select: { options: entry.options } };
     }
@@ -145,6 +148,9 @@ class HassioAddonConfig extends LitElement {
           step: entry.type === "float" ? "any" : undefined,
         },
       };
+    }
+    if (force) {
+      return { object: {} };
     }
     return null;
   }

--- a/hassio/src/addon-view/config/hassio-addon-config.ts
+++ b/hassio/src/addon-view/config/hassio-addon-config.ts
@@ -93,60 +93,65 @@ class HassioAddonConfig extends LitElement {
   private _convertSchema = memoizeOne(
     // Convert supervisor schema to selectors
     (schema: Record<string, any>): HaFormSchema[] =>
-      schema.map((entry) =>
-        entry.type === "select"
-          ? {
-              name: entry.name,
-              required: entry.required,
-              selector: { select: { options: entry.options } },
-            }
-          : entry.type === "string"
-            ? entry.multiple
-              ? {
-                  name: entry.name,
-                  required: entry.required,
-                  selector: {
-                    select: { options: [], multiple: true, custom_value: true },
+      schema.map((entry) => {
+        if (entry.type === "select") {
+          return {
+            name: entry.name,
+            required: entry.required,
+            selector: { select: { options: entry.options } },
+          };
+        }
+        if (entry.type === "string") {
+          return entry.multiple
+            ? {
+                name: entry.name,
+                required: entry.required,
+                selector: {
+                  select: { options: [], multiple: true, custom_value: true },
+                },
+              }
+            : {
+                name: entry.name,
+                required: entry.required,
+                selector: {
+                  text: {
+                    type: entry.format
+                      ? entry.format
+                      : MASKED_FIELDS.includes(entry.name)
+                        ? "password"
+                        : "text",
                   },
-                }
-              : {
-                  name: entry.name,
-                  required: entry.required,
-                  selector: {
-                    text: {
-                      type: entry.format
-                        ? entry.format
-                        : MASKED_FIELDS.includes(entry.name)
-                          ? "password"
-                          : "text",
-                    },
-                  },
-                }
-            : entry.type === "boolean"
-              ? {
-                  name: entry.name,
-                  required: entry.required,
-                  selector: { boolean: {} },
-                }
-              : entry.type === "schema"
-                ? {
-                    name: entry.name,
-                    required: entry.required,
-                    selector: { object: {} },
-                  }
-                : entry.type === "float" || entry.type === "integer"
-                  ? {
-                      name: entry.name,
-                      required: entry.required,
-                      selector: {
-                        number: {
-                          mode: "box",
-                          step: entry.type === "float" ? "any" : undefined,
-                        },
-                      },
-                    }
-                  : entry
-      )
+                },
+              };
+        }
+        if (entry.type === "boolean") {
+          return {
+            name: entry.name,
+            required: entry.required,
+            selector: { boolean: {} },
+          };
+        }
+        if (entry.type === "schema") {
+          return {
+            name: entry.name,
+            required: entry.required,
+            selector: { object: {} },
+          };
+        }
+        if (entry.type === "float" || entry.type === "integer") {
+          return {
+            name: entry.name,
+            required: entry.required,
+            selector: {
+              number: {
+                mode: "box",
+                step: entry.type === "float" ? "any" : undefined,
+              },
+            },
+          };
+        }
+        return entry;
+      })
   );
 
   private _filteredSchema = memoizeOne(

--- a/hassio/src/addon-view/config/hassio-addon-config.ts
+++ b/hassio/src/addon-view/config/hassio-addon-config.ts
@@ -11,7 +11,10 @@ import "../../../../src/components/ha-alert";
 import "../../../../src/components/ha-button-menu";
 import "../../../../src/components/ha-card";
 import "../../../../src/components/ha-form/ha-form";
-import type { HaFormSchema } from "../../../../src/components/ha-form/types";
+import type {
+  HaFormSchema,
+  HaFormDataContainer,
+} from "../../../../src/components/ha-form/types";
 import "../../../../src/components/ha-formfield";
 import "../../../../src/components/ha-icon-button";
 import "../../../../src/components/ha-list-item";
@@ -53,6 +56,13 @@ const ADDON_YAML_SCHEMA = DEFAULT_SCHEMA.extend([
 
 const MASKED_FIELDS = ["password", "secret", "token"];
 
+function getFieldKey(
+  entry: HaFormSchema,
+  options?: { path?: string[] }
+): string {
+  return options?.path ? [...options.path, entry.name].join(".") : entry.name;
+}
+
 @customElement("hassio-addon-config")
 class HassioAddonConfig extends LitElement {
   @property({ attribute: false }) public addon!: HassioAddonDetails;
@@ -79,16 +89,27 @@ class HassioAddonConfig extends LitElement {
 
   @query("ha-yaml-editor") private _editor?: HaYamlEditor;
 
-  public computeLabel = (entry: HaFormSchema): string =>
-    this.addon.translations[this.hass.language]?.configuration?.[entry.name]
+  public computeLabel = (
+    entry: HaFormSchema,
+    _data: HaFormDataContainer,
+    options?: { path?: string[] }
+  ): string =>
+    this.addon.translations[this.hass.language]?.configuration?.[
+      getFieldKey(entry, options)
+    ]?.name ||
+    this.addon.translations.en?.configuration?.[getFieldKey(entry, options)]
       ?.name ||
-    this.addon.translations.en?.configuration?.[entry.name]?.name ||
     entry.name;
 
-  public computeHelper = (entry: HaFormSchema): string =>
-    this.addon.translations[this.hass.language]?.configuration?.[entry.name]
+  public computeHelper = (
+    entry: HaFormSchema,
+    options?: { path?: string[] }
+  ): string =>
+    this.addon.translations[this.hass.language]?.configuration?.[
+      getFieldKey(entry, options)
+    ]?.description ||
+    this.addon.translations.en?.configuration?.[getFieldKey(entry, options)]
       ?.description ||
-    this.addon.translations.en?.configuration?.[entry.name]?.description ||
     "";
 
   private _convertSchema = memoizeOne(

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -29,9 +29,15 @@ export type AddonState =
   | null;
 export type AddonRepository = "core" | "local" | string;
 
+interface AddonFieldTranslation {
+  name?: string;
+  description?: string;
+  fields?: Record<string, AddonFieldTranslation>;
+}
+
 interface AddonTranslations {
   network?: Record<string, string>;
-  configuration?: Record<string, { name?: string; description?: string }>;
+  configuration?: Record<string, AddonFieldTranslation>;
 }
 
 export interface HassioAddonInfo {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Improve the addon configuration UI for complex configuration schemas by reusing the existing infrastructure for [Object selectors](https://www.home-assistant.io/docs/blueprint/selectors/#object-selector).

- Display top-level `dict` fields as expandable sections instead of falling back to the YAML editor.
- Display a reorderable list for `list[dict]` instead of falling back to the YAML editor.
- Display a nested editor for nested `dict` instead of falling back to the YAML editor.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Based on [`addons/mosquitto/config.yaml`](https://github.com/home-assistant/addons/blob/258168959bb4d2b90851d4db2f51d4571ad51d78/mosquitto/config.yaml):
```yaml
options:
  logins: []
  customize:
    active: false
    folder: mosquitto
schema:
  logins:
    - username: str
      password: password
      password_pre_hashed: "bool?"
  customize:
    active: bool
    folder: str
```

## Screenshots

### Lists of objects (`list[dict]`)
<img width="400" src="https://github.com/user-attachments/assets/28081029-78dd-429a-be32-dbb178d98fde" />

### Expandable sections (top-level `dict`)
<img width="400" src="https://github.com/user-attachments/assets/e97dfeb2-f689-485a-b1d5-a9016d46e54b" />

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: home-assistant/supervisor#6171
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
