### PR TITLE
Fix incorrect logbook entity filters

### DIFF
--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -8,12 +8,12 @@ import { computeDomain } from "../common/entity/compute_domain";
 import { computeStateDomain } from "../common/entity/compute_state_domain";
 import { autoCaseNoun } from "../common/translations/auto_case_noun";
 import type { LocalizeFunc } from "../common/translations/localize";
-import type { HaEntityPickerEntityFilterFunc } from "../components/entity/ha-entity-picker";
 import type { HomeAssistant } from "../types";
 import { UNAVAILABLE, UNKNOWN } from "./entity";
+import { isNumericEntity } from "./history";
 
 const LOGBOOK_LOCALIZE_PATH = "ui.components.logbook.messages";
-export const CONTINUOUS_DOMAINS = ["counter", "proximity", "sensor", "zone"];
+export const CONTINUOUS_DOMAINS = ["counter", "proximity"];
 
 export interface LogbookStreamMessage {
   events: LogbookEntry[];
@@ -326,9 +326,14 @@ export const localizeStateMessage = (
   });
 };
 
-export const filterLogbookCompatibleEntities: HaEntityPickerEntityFilterFunc = (
-  entity
-) =>
-  computeStateDomain(entity) !== "sensor" ||
-  (entity.attributes.unit_of_measurement === undefined &&
-    entity.attributes.state_class === undefined);
+export const filterLogbookCompatibleEntities = (
+  entity,
+  sensorNumericDeviceClasses: string[] = []
+) => {
+  const domain = computeStateDomain(entity);
+  const continuous =
+    CONTINUOUS_DOMAINS.includes(domain) ||
+    (domain === "sensor" &&
+      isNumericEntity(domain, entity, undefined, sensorNumericDeviceClasses));
+  return !continuous;
+};

--- a/src/dialogs/more-info/const.ts
+++ b/src/dialogs/more-info/const.ts
@@ -116,7 +116,8 @@ export const computeShowLogBookComponent = (
 
   const domain = computeDomain(entityId);
   if (
-    (CONTINUOUS_DOMAINS.includes(domain) &&
+    CONTINUOUS_DOMAINS.includes(domain) ||
+    (domain === "sensor" &&
       isNumericEntity(
         domain,
         stateObj,

--- a/src/panels/lovelace/editor/config-elements/hui-logbook-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-logbook-card-editor.ts
@@ -85,6 +85,8 @@ export class HuiLogbookCardEditor
   }
 
   private async _loadNumericDeviceClasses(hass: HomeAssistant) {
+    // ensures that the _load function is not called a second time
+    // if another updated occurs before the async function returns
     this._sensorNumericDeviceClasses = [];
     const deviceClasses = await getSensorNumericDeviceClasses(hass);
     this._sensorNumericDeviceClasses = deviceClasses.numeric_device_classes;

--- a/src/panels/lovelace/editor/config-elements/hui-logbook-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-logbook-card-editor.ts
@@ -22,6 +22,8 @@ import type { LovelaceCardEditor } from "../../types";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import { DEFAULT_HOURS_TO_SHOW } from "../../cards/hui-logbook-card";
 import { targetStruct } from "../../../../data/script";
+import type { HaEntityPickerEntityFilterFunc } from "../../../../components/entity/ha-entity-picker";
+import { getSensorNumericDeviceClasses } from "../../../../data/sensor";
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -59,6 +61,8 @@ export class HuiLogbookCardEditor
 
   @state() private _config?: LogbookCardConfig;
 
+  @state() private _sensorNumericDeviceClasses?: string[];
+
   public setConfig(config: LogbookCardConfig): void {
     assert(config, cardConfigStruct);
     this._config = config;
@@ -80,6 +84,18 @@ export class HuiLogbookCardEditor
     );
   }
 
+  private async _loadNumericDeviceClasses(hass: HomeAssistant) {
+    this._sensorNumericDeviceClasses = [];
+    const deviceClasses = await getSensorNumericDeviceClasses(hass);
+    this._sensorNumericDeviceClasses = deviceClasses.numeric_device_classes;
+  }
+
+  protected updated() {
+    if (this.hass && !this._sensorNumericDeviceClasses) {
+      this._loadNumericDeviceClasses(this.hass);
+    }
+  }
+
   protected render() {
     if (!this.hass || !this._config) {
       return nothing;
@@ -96,13 +112,16 @@ export class HuiLogbookCardEditor
 
       <ha-target-picker
         .hass=${this.hass}
-        .entityFilter=${filterLogbookCompatibleEntities}
+        .entityFilter=${this._filterFunc}
         .value=${this._targetPicker}
         add-on-top
         @value-changed=${this._entitiesChanged}
       ></ha-target-picker>
     `;
   }
+
+  private _filterFunc: HaEntityPickerEntityFilterFunc = (entity) =>
+    filterLogbookCompatibleEntities(entity, this._sensorNumericDeviceClasses);
 
   private _entitiesChanged(ev: CustomEvent): void {
     this._config = { ...this._config!, target: ev.detail.value };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This change completes the full harmonization of logbook rules between frontend and backend, discussed [here](https://github.com/home-assistant/frontend/issues/18847#issuecomment-3109343228).

Specifically this changes:
 - Logbook panel and logbook card editor no longer offser selection of `sensor` domain entities with numeric device classes.
 - Logbook panel and logbook card editor no longer offser selection of `counter` domain entities.
 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/18847
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
