### PR TITLE
Only show devices dialog at the end of a flow chain

### DIFF
--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -408,7 +408,8 @@ class DataEntryFlowDialog extends LitElement {
                                   .devices=${this._devices(
                                     this._params.flowConfig.showDevices,
                                     Object.values(this.hass.devices),
-                                    this._step.result?.entry_id
+                                    this._step.result?.entry_id,
+                                    this._params.carryOverDevices
                                   )}
                                 ></step-flow-create-entry>
                               `}

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -474,13 +474,13 @@ class DataEntryFlowDialog extends LitElement {
     this._step = _step;
     if (_step.type === "create_entry" && _step.next_flow) {
       // skip device rename if there is a chained flow
+      this._step = undefined;
+      this._handler = undefined;
+      if (this._unsubDataEntryFlowProgress) {
+        this._unsubDataEntryFlowProgress();
+        this._unsubDataEntryFlowProgress = undefined;
+      }
       if (_step.next_flow[0] === "config_flow") {
-        this._step = undefined;
-        this._handler = undefined;
-        if (this._unsubDataEntryFlowProgress) {
-          this._unsubDataEntryFlowProgress();
-          this._unsubDataEntryFlowProgress = undefined;
-        }
         showConfigFlowDialog(this._params!.dialogParentElement!, {
           continueFlowId: _step.next_flow[1],
           carryOverDevices: this._devices(
@@ -489,19 +489,19 @@ class DataEntryFlowDialog extends LitElement {
             _step.result?.entry_id,
             this._params!.carryOverDevices
           ).map((device) => device.id),
+          dialogClosedCallback: this._params!.dialogClosedCallback,
         });
       } else if (_step.next_flow[0] === "options_flow") {
-        this.closeDialog();
         showOptionsFlowDialog(
           this._params!.dialogParentElement!,
           _step.result!,
           {
             continueFlowId: _step.next_flow[1],
             navigateToResult: this._params!.navigateToResult,
+            dialogClosedCallback: this._params!.dialogClosedCallback,
           }
         );
       } else if (_step.next_flow[0] === "config_subentries_flow") {
-        this.closeDialog();
         showSubConfigFlowDialog(
           this._params!.dialogParentElement!,
           _step.result!,
@@ -509,6 +509,7 @@ class DataEntryFlowDialog extends LitElement {
           {
             continueFlowId: _step.next_flow[1],
             navigateToResult: this._params!.navigateToResult,
+            dialogClosedCallback: this._params!.dialogClosedCallback,
           }
         );
       } else {

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -178,16 +178,10 @@ class DataEntryFlowDialog extends LitElement {
     (
       showDevices: boolean,
       devices: DeviceRegistryEntry[],
-      entry_id?: string,
-      carryOverDevices: Record<string, DeviceRegistryEntry[]> = {}
+      entry_id?: string
     ) =>
       showDevices && entry_id
-        ? [
-            ...Object.values(carryOverDevices ?? {}).flat(),
-            ...devices.filter((device) =>
-              device.config_entries.includes(entry_id)
-            ),
-          ]
+        ? devices.filter((device) => device.config_entries.includes(entry_id))
         : []
   );
 
@@ -216,12 +210,13 @@ class DataEntryFlowDialog extends LitElement {
       case "menu":
         return this._params.flowConfig.renderMenuHeader(this.hass, this._step);
       case "create_entry": {
-        const devicesLength = this._devices(
-          this._params.flowConfig.showDevices,
-          Object.values(this.hass.devices),
-          this._step.result?.entry_id,
-          this._params.carryOverDevices
-        ).length;
+        const devicesLength =
+          this._devices(
+            this._params.flowConfig.showDevices,
+            Object.values(this.hass.devices),
+            this._step.result?.entry_id
+          ).length +
+          Object.values(this._params.carryOverDevices ?? {}).flat().length;
         return this.hass.localize(
           `ui.panel.config.integrations.config_flow.${
             devicesLength ? "device_created" : "success"
@@ -408,9 +403,10 @@ class DataEntryFlowDialog extends LitElement {
                                   .devices=${this._devices(
                                     this._params.flowConfig.showDevices,
                                     Object.values(this.hass.devices),
-                                    this._step.result?.entry_id,
-                                    this._params.carryOverDevices
+                                    this._step.result?.entry_id
                                   )}
+                                  .carryOverDevices=${this._params
+                                    .carryOverDevices}
                                 ></step-flow-create-entry>
                               `}
                 `}

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -32,6 +32,7 @@ import "./step-flow-menu";
 import "./step-flow-progress";
 import { showOptionsFlowDialog } from "./show-dialog-options-flow";
 import { showSubConfigFlowDialog } from "./show-dialog-sub-config-flow";
+import { showConfigFlowDialog } from "./show-dialog-config-flow";
 
 let instance = 0;
 
@@ -480,10 +481,7 @@ class DataEntryFlowDialog extends LitElement {
           this._unsubDataEntryFlowProgress();
           this._unsubDataEntryFlowProgress = undefined;
         }
-        this.showDialog({
-          ...this._params!,
-          manifest: undefined,
-          domain: undefined,
+        showConfigFlowDialog(this._params!.dialogParentElement!, {
           continueFlowId: _step.next_flow[1],
           carryOverDevices: this._devices(
             this._params!.flowConfig.showDevices,
@@ -494,19 +492,28 @@ class DataEntryFlowDialog extends LitElement {
         });
       } else if (_step.next_flow[0] === "options_flow") {
         this.closeDialog();
-        showOptionsFlowDialog(this, _step.result!, {
-          continueFlowId: _step.next_flow[1],
-          navigateToResult: this._params!.navigateToResult,
-        });
+        showOptionsFlowDialog(
+          this._params!.dialogParentElement!,
+          _step.result!,
+          {
+            continueFlowId: _step.next_flow[1],
+            navigateToResult: this._params!.navigateToResult,
+          }
+        );
       } else if (_step.next_flow[0] === "config_subentries_flow") {
         this.closeDialog();
-        showSubConfigFlowDialog(this, _step.result!, _step.next_flow[0], {
-          continueFlowId: _step.next_flow[1],
-          navigateToResult: this._params!.navigateToResult,
-        });
+        showSubConfigFlowDialog(
+          this._params!.dialogParentElement!,
+          _step.result!,
+          _step.next_flow[0],
+          {
+            continueFlowId: _step.next_flow[1],
+            navigateToResult: this._params!.navigateToResult,
+          }
+        );
       } else {
         this.closeDialog();
-        showAlertDialog(this, {
+        showAlertDialog(this._params!.dialogParentElement!, {
           text: this.hass.localize(
             "ui.panel.config.integrations.config_flow.error",
             { error: `Unsupported next flow type: ${_step.next_flow[0]}` }

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -482,6 +482,8 @@ class DataEntryFlowDialog extends LitElement {
         }
         this.showDialog({
           ...this._params!,
+          manifest: undefined,
+          domain: undefined,
           continueFlowId: _step.next_flow[1],
           carryOverDevices: this._devices(
             this._params!.flowConfig.showDevices,

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -178,10 +178,16 @@ class DataEntryFlowDialog extends LitElement {
     (
       showDevices: boolean,
       devices: DeviceRegistryEntry[],
-      entry_id?: string
+      entry_id?: string,
+      carryOverDevices: Record<string, DeviceRegistryEntry[]> = {}
     ) =>
       showDevices && entry_id
-        ? devices.filter((device) => device.config_entries.includes(entry_id))
+        ? [
+            ...Object.values(carryOverDevices ?? {}).flat(),
+            ...devices.filter((device) =>
+              device.config_entries.includes(entry_id)
+            ),
+          ]
         : []
   );
 
@@ -213,7 +219,8 @@ class DataEntryFlowDialog extends LitElement {
         const devicesLength = this._devices(
           this._params.flowConfig.showDevices,
           Object.values(this.hass.devices),
-          this._step.result?.entry_id
+          this._step.result?.entry_id,
+          this._params.carryOverDevices
         ).length;
         return this.hass.localize(
           `ui.panel.config.integrations.config_flow.${

--- a/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
@@ -13,7 +13,6 @@ import type {
 } from "../../data/data_entry_flow";
 import type { IntegrationManifest } from "../../data/integration";
 import type { HomeAssistant } from "../../types";
-import type { DeviceRegistryEntry } from "../../data/device_registry";
 
 export interface FlowConfig {
   flowType: FlowType;
@@ -171,7 +170,7 @@ export interface DataEntryFlowDialogParams {
   showAdvanced?: boolean;
   dialogParentElement?: HTMLElement;
   navigateToResult?: boolean;
-  carryOverDevices?: Record<string, DeviceRegistryEntry[]>;
+  carryOverDevices?: string[];
 }
 
 export const loadDataEntryFlowDialog = () => import("./dialog-data-entry-flow");

--- a/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
@@ -13,6 +13,7 @@ import type {
 } from "../../data/data_entry_flow";
 import type { IntegrationManifest } from "../../data/integration";
 import type { HomeAssistant } from "../../types";
+import type { DeviceRegistryEntry } from "../../data/device_registry";
 
 export interface FlowConfig {
   flowType: FlowType;
@@ -170,6 +171,7 @@ export interface DataEntryFlowDialogParams {
   showAdvanced?: boolean;
   dialogParentElement?: HTMLElement;
   navigateToResult?: boolean;
+  carryOverDevices?: Record<string, DeviceRegistryEntry[]>;
 }
 
 export const loadDataEntryFlowDialog = () => import("./dialog-data-entry-flow");

--- a/src/dialogs/config-flow/step-flow-create-entry.ts
+++ b/src/dialogs/config-flow/step-flow-create-entry.ts
@@ -266,9 +266,7 @@ class StepFlowCreateEntry extends LitElement {
       await Promise.allSettled(entityUpdates);
     }
 
-    fireEvent(this, "flow-update", { step: undefined });
     if (this.step.next_flow) {
-      // start the next flow
       if (this.step.next_flow[0] === "config_flow") {
         showConfigFlowDialog(this, {
           continueFlowId: this.step.next_flow[1],
@@ -301,13 +299,16 @@ class StepFlowCreateEntry extends LitElement {
           ),
         });
       }
-    } else if (this.step.result && this.navigateToResult) {
-      if (this.devices.length === 1) {
-        navigate(`/config/devices/device/${this.devices[0].id}`);
-      } else {
-        navigate(
-          `/config/integrations/integration/${this.step.result.domain}#config_entry=${this.step.result.entry_id}`
-        );
+    } else {
+      fireEvent(this, "flow-update", { step: undefined });
+      if (this.step.result && this.navigateToResult) {
+        if (this.devices.length === 1) {
+          navigate(`/config/devices/device/${this.devices[0].id}`);
+        } else {
+          navigate(
+            `/config/integrations/integration/${this.step.result.domain}#config_entry=${this.step.result.entry_id}`
+          );
+        }
       }
     }
   }

--- a/src/dialogs/config-flow/step-flow-create-entry.ts
+++ b/src/dialogs/config-flow/step-flow-create-entry.ts
@@ -27,6 +27,7 @@ import { showAlertDialog } from "../generic/show-dialog-box";
 import { showVoiceAssistantSetupDialog } from "../voice-assistant-setup/show-voice-assistant-setup-dialog";
 import type { FlowConfig } from "./show-dialog-data-entry-flow";
 import { configFlowContentStyles } from "./styles";
+import { getConfigEntries } from "../../data/config_entries";
 
 @customElement("step-flow-create-entry")
 class StepFlowCreateEntry extends LitElement {
@@ -37,6 +38,8 @@ class StepFlowCreateEntry extends LitElement {
   @property({ attribute: false }) public step!: DataEntryFlowStepCreateEntry;
 
   @property({ attribute: false }) public devices!: DeviceRegistryEntry[];
+
+  private _domains: Record<string, string> = {};
 
   public navigateToResult = false;
 
@@ -57,6 +60,11 @@ class StepFlowCreateEntry extends LitElement {
           (!domain || computeDomain(entity.entity_id) === domain)
       )
   );
+
+  protected firstUpdated(changedProps: PropertyValues) {
+    super.firstUpdated(changedProps);
+    this._loadDomains();
+  }
 
   protected willUpdate(changedProps: PropertyValues) {
     if (!changedProps.has("devices") && !changedProps.has("hass")) {
@@ -92,6 +100,12 @@ class StepFlowCreateEntry extends LitElement {
 
   protected render(): TemplateResult {
     const localize = this.hass.localize;
+    const domains = this.step.result
+      ? {
+          ...this._domains,
+          [this.step.result.entry_id]: this.step.result.domain,
+        }
+      : this._domains;
     return html`
       <div class="content">
         ${this.flowConfig.renderCreateEntryDescription(this.hass, this.step)}
@@ -118,15 +132,16 @@ class StepFlowCreateEntry extends LitElement {
                     (device) => html`
                       <div class="device">
                         <div class="device-info">
-                          ${this.step.result?.domain
+                          ${device.primary_config_entry &&
+                          domains[device.primary_config_entry]
                             ? html`<img
                                 slot="graphic"
                                 alt=${domainToName(
                                   this.hass.localize,
-                                  this.step.result.domain
+                                  domains[device.primary_config_entry]
                                 )}
                                 src=${brandsUrl({
-                                  domain: this.step.result.domain,
+                                  domain: domains[device.primary_config_entry],
                                   type: "icon",
                                   darkOptimized: this.hass.themes?.darkMode,
                                 })}
@@ -182,6 +197,13 @@ class StepFlowCreateEntry extends LitElement {
         >
       </div>
     `;
+  }
+
+  private async _loadDomains() {
+    const domains = await getConfigEntries(this.hass);
+    this._domains = Object.fromEntries(
+      domains.map((domain) => [domain.entry_id, domain.domain])
+    );
   }
 
   private async _flowDone(): Promise<void> {

--- a/src/dialogs/config-flow/step-flow-create-entry.ts
+++ b/src/dialogs/config-flow/step-flow-create-entry.ts
@@ -66,7 +66,10 @@ class StepFlowCreateEntry extends LitElement {
       return;
     }
 
-    if (this.step.next_flow && this.devices.length === 0) {
+    if (
+      this.step.next_flow &&
+      (this.step.next_flow[0] === "config_flow" || this.devices.length === 0)
+    ) {
       this._flowDone();
       return;
     }
@@ -257,6 +260,9 @@ class StepFlowCreateEntry extends LitElement {
         showConfigFlowDialog(this, {
           continueFlowId: this.step.next_flow[1],
           navigateToResult: this.navigateToResult,
+          carryOverDevices: {
+            [this.step.result!.entry_id]: this.devices,
+          },
         });
       } else if (this.step.next_flow[0] === "options_flow") {
         showOptionsFlowDialog(this, this.step.result!, {

--- a/src/dialogs/config-flow/step-flow-create-entry.ts
+++ b/src/dialogs/config-flow/step-flow-create-entry.ts
@@ -200,9 +200,9 @@ class StepFlowCreateEntry extends LitElement {
   }
 
   private async _loadDomains() {
-    const domains = await getConfigEntries(this.hass);
+    const entries = await getConfigEntries(this.hass);
     this._domains = Object.fromEntries(
-      domains.map((domain) => [domain.entry_id, domain.domain])
+      entries.map((entry) => [entry.entry_id, entry.domain])
     );
   }
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When a config flow chains another config flow after it, it will skip the device rename dialog and pass its devices to the next flow. All new devices from all flows will be shown after the last flow.

Devices are passed on separated by their `entry_id`. This is not used right now but we can use it in the future to group them by integration and/or deduplicate them.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
