### PR TITLE
Automation editor: Copy always enabled

### DIFF
--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
@@ -145,11 +145,7 @@ export default class HaAutomationSidebarAction extends LitElement {
           <span class="shortcut-placeholder ${isMac ? "mac" : ""}"></span>
         </div>
       </ha-md-menu-item>
-      <ha-md-menu-item
-        slot="menu-items"
-        .clickAction=${this.config.copy}
-        .disabled=${this.disabled}
-      >
+      <ha-md-menu-item slot="menu-items" .clickAction=${this.config.copy}>
         <ha-svg-icon slot="start" .path=${mdiContentCopy}></ha-svg-icon>
         <div class="overflow-label">
           ${this.hass.localize(

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-condition.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-condition.ts
@@ -150,11 +150,7 @@ export default class HaAutomationSidebarCondition extends LitElement {
         </div>
       </ha-md-menu-item>
 
-      <ha-md-menu-item
-        slot="menu-items"
-        .clickAction=${this.config.copy}
-        .disabled=${this.disabled}
-      >
+      <ha-md-menu-item slot="menu-items" .clickAction=${this.config.copy}>
         <ha-svg-icon slot="start" .path=${mdiContentCopy}></ha-svg-icon>
         <div class="overflow-label">
           ${this.hass.localize(

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-trigger.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-trigger.ts
@@ -137,11 +137,7 @@ export default class HaAutomationSidebarTrigger extends LitElement {
           ></ha-svg-icon>
         </ha-md-menu-item>
 
-        <ha-md-menu-item
-          slot="menu-items"
-          .clickAction=${this.config.copy}
-          .disabled=${this.disabled}
-        >
+        <ha-md-menu-item slot="menu-items" .clickAction=${this.config.copy}>
           <ha-svg-icon slot="start" .path=${mdiContentCopy}></ha-svg-icon>
           <div class="overflow-label">
             ${this.hass.localize(


### PR DESCRIPTION
## Proposed change
- Copy row was disabled when automation is disabled, but copy should be always possible.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
