### PR TITLE
Fix ha-target-picker remove/expad buttons after tooltip migration

### DIFF
--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -522,6 +522,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
 
   private _handleExpand(ev) {
     const target = ev.currentTarget as any;
+    const id = target.id.replace(/^expand-/, "");
     const newAreas: string[] = [];
     const newDevices: string[] = [];
     const newEntities: string[] = [];
@@ -529,7 +530,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     if (target.type === "floor_id") {
       Object.values(this.hass.areas).forEach((area) => {
         if (
-          area.floor_id === target.id &&
+          area.floor_id === id &&
           !this.value!.area_id?.includes(area.area_id) &&
           this._areaMeetsFilter(area)
         ) {
@@ -539,7 +540,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     } else if (target.type === "area_id") {
       Object.values(this.hass.devices).forEach((device) => {
         if (
-          device.area_id === target.id &&
+          device.area_id === id &&
           !this.value!.device_id?.includes(device.id) &&
           this._deviceMeetsFilter(device)
         ) {
@@ -548,7 +549,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
       });
       Object.values(this.hass.entities).forEach((entity) => {
         if (
-          entity.area_id === target.id &&
+          entity.area_id === id &&
           !this.value!.entity_id?.includes(entity.entity_id) &&
           this._entityRegMeetsFilter(entity)
         ) {
@@ -558,7 +559,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     } else if (target.type === "device_id") {
       Object.values(this.hass.entities).forEach((entity) => {
         if (
-          entity.device_id === target.id &&
+          entity.device_id === id &&
           !this.value!.entity_id?.includes(entity.entity_id) &&
           this._entityRegMeetsFilter(entity)
         ) {
@@ -568,7 +569,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     } else if (target.type === "label_id") {
       Object.values(this.hass.areas).forEach((area) => {
         if (
-          area.labels.includes(target.id) &&
+          area.labels.includes(id) &&
           !this.value!.area_id?.includes(area.area_id) &&
           this._areaMeetsFilter(area)
         ) {
@@ -577,7 +578,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
       });
       Object.values(this.hass.devices).forEach((device) => {
         if (
-          device.labels.includes(target.id) &&
+          device.labels.includes(id) &&
           !this.value!.device_id?.includes(device.id) &&
           this._deviceMeetsFilter(device)
         ) {
@@ -586,7 +587,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
       });
       Object.values(this.hass.entities).forEach((entity) => {
         if (
-          entity.labels.includes(target.id) &&
+          entity.labels.includes(id) &&
           !this.value!.entity_id?.includes(entity.entity_id) &&
           this._entityRegMeetsFilter(entity, true)
         ) {
@@ -606,14 +607,15 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     if (newAreas.length) {
       value = this._addItems(value, "area_id", newAreas);
     }
-    value = this._removeItem(value, target.type, target.id);
+    value = this._removeItem(value, target.type, id);
     fireEvent(this, "value-changed", { value });
   }
 
   private _handleRemove(ev) {
     const target = ev.currentTarget as any;
+    const id = target.id.replace(/^remove-/, "");
     fireEvent(this, "value-changed", {
-      value: this._removeItem(this.value, target.type, target.id),
+      value: this._removeItem(this.value, target.type, id),
     });
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Fix for an issue introduced in commit dcbc8b627f4cfb9d3fa64ea8bba9c34beb8085cf when migrating ha-tooltip to WebAwesome.

What changed:
  - Before: The id was set as .id=${id} (just the entity/device/area ID)
  - After: The id is set as .id="remove-${id}" (prefixed with "remove-")

The problem: 
In src/components/ha-target-picker.ts:613-618, the _handleRemove method expects target.id to be the actual ID (like light.living_room), but now it's receiving remove-light.living_room, causing the removal logic to fail.

The same issue exists with the expand button (.id="expand-${id}").

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #26540 
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
