### PR TITLE
Automation sidebar bottom fade and safe area fixes

### DIFF
--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -131,9 +131,13 @@ export default class HaAutomationSidebarCard extends LitElement {
   }
 
   private _canScrollDown(element: HTMLElement) {
+    const safeAreaInsetBottom =
+      parseFloat(
+        getComputedStyle(element).getPropertyValue("--safe-area-inset-bottom")
+      ) || 0;
     this._contentScrollable =
       (element.scrollHeight ?? 0) - (element.clientHeight ?? 0) >
-      (element.scrollTop ?? 0);
+      (element.scrollTop ?? 0) + safeAreaInsetBottom;
   }
 
   private _closeSidebar() {

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -63,7 +63,7 @@ export default class HaAutomationSidebarCard extends LitElement {
     this._updateHeaderHeight();
   }
 
-  protected updated(_changedProperties: PropertyValues): void {
+  protected updated(changedProperties: PropertyValues): void {
     if (_changedProperties.has("hass") || _changedProperties.has("narrow")) {
       this._updateHeaderHeight();
     }

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -49,6 +49,8 @@ export default class HaAutomationSidebarCard extends LitElement {
 
   @query(".card-content") private _contentElement!: HTMLDivElement;
 
+  @query("ha-dialog-header") private _headerElement?: HTMLElement;
+
   private _contentSize = new ResizeController(this, {
     target: null,
     callback: (entries) => {
@@ -154,7 +156,7 @@ export default class HaAutomationSidebarCard extends LitElement {
 
   private _updateHeaderHeight() {
     requestAnimationFrame(() => {
-      const header = this.shadowRoot?.querySelector("ha-dialog-header");
+      const header = this._headerElement;
       if (header) {
         const headerHeight = header.offsetHeight;
         this.style.setProperty(

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -49,8 +49,6 @@ export default class HaAutomationSidebarCard extends LitElement {
 
   @query(".card-content") private _contentElement!: HTMLDivElement;
 
-  @query("ha-dialog-header") private _headerElement?: HTMLElement;
-
   private _contentSize = new ResizeController(this, {
     target: null,
     callback: (entries) => {
@@ -62,13 +60,6 @@ export default class HaAutomationSidebarCard extends LitElement {
 
   protected firstUpdated(_changedProperties: PropertyValues): void {
     this._contentSize.observe(this._contentElement);
-    this._updateHeaderHeight();
-  }
-
-  protected updated(changedProperties: PropertyValues): void {
-    if (changedProperties.has("hass") || changedProperties.has("narrow")) {
-      this._updateHeaderHeight();
-    }
   }
 
   protected render() {
@@ -154,19 +145,6 @@ export default class HaAutomationSidebarCard extends LitElement {
     ev.preventDefault();
   }
 
-  private _updateHeaderHeight() {
-    requestAnimationFrame(() => {
-      const header = this._headerElement;
-      if (header) {
-        const headerHeight = header.offsetHeight;
-        this.style.setProperty(
-          "--ha-dialog-header-height",
-          `${headerHeight}px`
-        );
-      }
-    });
-  }
-
   static styles = css`
     ha-card {
       position: relative;
@@ -174,7 +152,8 @@ export default class HaAutomationSidebarCard extends LitElement {
       width: 100%;
       border-color: var(--primary-color);
       border-width: 2px;
-      display: block;
+      display: flex;
+      flex-direction: column;
     }
 
     @media all and (max-width: 870px) {
@@ -228,13 +207,11 @@ export default class HaAutomationSidebarCard extends LitElement {
     }
 
     .card-content {
-      max-height: calc(
-        100% - max(var(--safe-area-inset-bottom, 0px), 16px) - var(
-            --ha-dialog-header-height
-          )
-      );
+      flex: 1 1 auto;
+      min-height: 0;
       overflow: auto;
       margin-top: 0;
+      padding-bottom: max(var(--safe-area-inset-bottom, 0px), 32px);
     }
 
     @media all and (max-width: 870px) {
@@ -243,8 +220,7 @@ export default class HaAutomationSidebarCard extends LitElement {
       }
 
       .card-content {
-        max-height: calc(100% - var(--ha-dialog-header-height) - 34px);
-        overflow: auto;
+        padding-bottom: 42px;
       }
     }
   `;

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -198,14 +198,14 @@ export default class HaAutomationSidebarCard extends LitElement {
     }
 
     .card-content {
-      max-height: calc(100% - var(--safe-area-inset-bottom) - 88px);
+      max-height: calc(100% - var(--safe-area-inset-bottom, 0px) - 88px);
       overflow: auto;
       margin-top: 0;
     }
 
     @media (min-width: 450px) and (min-height: 500px) {
       .card-content {
-        max-height: calc(100% - var(--safe-area-inset-bottom) - 112px);
+        max-height: calc(100% - var(--safe-area-inset-bottom, 0px) - 112px);
         overflow: auto;
       }
     }

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -184,10 +184,10 @@ export default class HaAutomationSidebarCard extends LitElement {
 
     .fade {
       position: fixed;
-      bottom: -12px;
+      bottom: calc(-12px - var(--safe-area-inset-bottom, 0px));
       left: 0;
       right: 0;
-      height: 12px;
+      height: calc(12px + var(--safe-area-inset-bottom, 0px));
       pointer-events: none;
       transition: box-shadow 180ms ease-in-out;
     }

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -208,7 +208,7 @@ export default class HaAutomationSidebarCard extends LitElement {
     }
 
     .fade {
-      position: fixed;
+      position: absolute;
       bottom: calc(-12px - var(--safe-area-inset-bottom, 0px));
       left: 0;
       right: 0;
@@ -227,7 +227,8 @@ export default class HaAutomationSidebarCard extends LitElement {
         100% - var(--safe-area-inset-bottom, 0px) - var(
             --ha-dialog-header-height,
             88px
-          )
+          ) +
+          16px
       );
       overflow: auto;
       margin-top: 0;

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -119,13 +119,9 @@ export default class HaAutomationSidebarCard extends LitElement {
         <div class="card-content" @scroll=${this._onScroll}>
           <slot></slot>
         </div>
-        ${this.narrow
-          ? html`
-              <div
-                class="fade ${this._contentScrollable ? "scrollable" : ""}"
-              ></div>
-            `
-          : nothing}
+        <div
+          class=${classMap({ fade: true, scrollable: this._contentScrollable })}
+        ></div>
       </ha-card>
     `;
   }
@@ -172,6 +168,7 @@ export default class HaAutomationSidebarCard extends LitElement {
 
   static styles = css`
     ha-card {
+      position: relative;
       height: 100%;
       width: 100%;
       border-color: var(--primary-color);
@@ -215,11 +212,15 @@ export default class HaAutomationSidebarCard extends LitElement {
       height: calc(12px + var(--safe-area-inset-bottom, 0px));
       pointer-events: none;
       transition: box-shadow 180ms ease-in-out;
+      background-color: var(
+        --ha-dialog-surface-background,
+        var(--mdc-theme-surface, #fff)
+      );
+      transform: rotate(180deg);
     }
 
     .fade.scrollable {
       box-shadow: var(--bar-box-shadow);
-      transform: rotate(180deg);
     }
 
     .card-content {
@@ -235,6 +236,16 @@ export default class HaAutomationSidebarCard extends LitElement {
     }
 
     @media (min-width: 450px) and (min-height: 500px) {
+      .fade {
+        bottom: 0;
+        left: 2px;
+        right: 2px;
+        height: 16px;
+        border-radius: var(--ha-card-border-radius);
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+
       .card-content {
         max-height: calc(
           100% - var(--safe-area-inset-bottom, 0px) - var(

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -141,7 +141,7 @@ export default class HaAutomationSidebarCard extends LitElement {
       ) || 0;
     this._contentScrollable =
       (element.scrollHeight ?? 0) - (element.clientHeight ?? 0) >
-      (element.scrollTop ?? 0) + safeAreaInsetBottom;
+      (element.scrollTop ?? 0) + safeAreaInsetBottom + 16;
   }
 
   private _closeSidebar() {
@@ -226,8 +226,7 @@ export default class HaAutomationSidebarCard extends LitElement {
     .card-content {
       max-height: calc(
         100% - var(--safe-area-inset-bottom, 0px) - var(
-            --ha-dialog-header-height,
-            88px
+            --ha-dialog-header-height
           ) -
           16px
       );
@@ -249,9 +248,9 @@ export default class HaAutomationSidebarCard extends LitElement {
       .card-content {
         max-height: calc(
           100% - var(--safe-area-inset-bottom, 0px) - var(
-              --ha-dialog-header-height,
-              112px
-            )
+              --ha-dialog-header-height
+            ) -
+            32px
         );
         overflow: auto;
       }

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -198,14 +198,14 @@ export default class HaAutomationSidebarCard extends LitElement {
     }
 
     .card-content {
-      max-height: calc(100% - 80px);
+      max-height: calc(100% - var(--safe-area-inset-bottom) - 88px);
       overflow: auto;
       margin-top: 0;
     }
 
     @media (min-width: 450px) and (min-height: 500px) {
       .card-content {
-        max-height: calc(100% - 104px);
+        max-height: calc(100% - var(--safe-area-inset-bottom) - 112px);
         overflow: auto;
       }
     }

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -205,11 +205,17 @@ export default class HaAutomationSidebarCard extends LitElement {
     }
 
     .fade {
-      position: absolute;
-      bottom: calc(-12px - var(--safe-area-inset-bottom, 0px));
+      position: fixed;
+      bottom: calc(
+        (
+            var(--ha-dialog-header-height, 12px) +
+              var(--safe-area-inset-bottom, 0px)
+          ) *
+          -1
+      );
       left: 0;
       right: 0;
-      height: calc(12px + var(--safe-area-inset-bottom, 0px));
+      height: var(--ha-dialog-header-height, 12px);
       pointer-events: none;
       transition: box-shadow 180ms ease-in-out;
       background-color: var(
@@ -236,6 +242,7 @@ export default class HaAutomationSidebarCard extends LitElement {
 
     @media (min-width: 450px) and (min-height: 500px) {
       .fade {
+        position: absolute;
         bottom: 0;
         left: 2px;
         right: 2px;

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -218,8 +218,8 @@ export default class HaAutomationSidebarCard extends LitElement {
       );
       transform: rotate(180deg);
       border-radius: var(--ha-card-border-radius);
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
+      border-bottom-left-radius: var(--ha-border-radius-square);
+      border-bottom-right-radius: var(--ha-border-radius-square);
     }
 
     .fade.scrollable {
@@ -228,7 +228,7 @@ export default class HaAutomationSidebarCard extends LitElement {
 
     .card-content {
       max-height: calc(
-        100% - var(--safe-area-inset-bottom, 0px) - var(
+        100% - max(var(--safe-area-inset-bottom, 0px), 16px) - var(
             --ha-dialog-header-height
           )
       );
@@ -238,13 +238,11 @@ export default class HaAutomationSidebarCard extends LitElement {
 
     @media all and (max-width: 870px) {
       .fade {
-        position: fixed;
-        bottom: calc(var(--ha-dialog-header-height) * -1);
-        height: var(--ha-dialog-header-height, 12px);
+        border-radius: var(--ha-border-radius-square);
       }
 
       .card-content {
-        max-height: calc(100% - var(--ha-dialog-header-height) - 32px);
+        max-height: calc(100% - var(--ha-dialog-header-height) - 34px);
         overflow: auto;
       }
     }

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -205,17 +205,11 @@ export default class HaAutomationSidebarCard extends LitElement {
     }
 
     .fade {
-      position: fixed;
-      bottom: calc(
-        (
-            var(--ha-dialog-header-height, 12px) +
-              var(--safe-area-inset-bottom, 0px)
-          ) *
-          -1
-      );
-      left: 0;
-      right: 0;
-      height: var(--ha-dialog-header-height, 12px);
+      position: absolute;
+      bottom: 1px;
+      left: 1px;
+      right: 1px;
+      height: 16px;
       pointer-events: none;
       transition: box-shadow 180ms ease-in-out;
       background-color: var(
@@ -223,6 +217,9 @@ export default class HaAutomationSidebarCard extends LitElement {
         var(--mdc-theme-surface, #fff)
       );
       transform: rotate(180deg);
+      border-radius: var(--ha-card-border-radius);
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
     }
 
     .fade.scrollable {
@@ -233,32 +230,21 @@ export default class HaAutomationSidebarCard extends LitElement {
       max-height: calc(
         100% - var(--safe-area-inset-bottom, 0px) - var(
             --ha-dialog-header-height
-          ) -
-          16px
+          )
       );
       overflow: auto;
       margin-top: 0;
     }
 
-    @media (min-width: 450px) and (min-height: 500px) {
+    @media all and (max-width: 870px) {
       .fade {
-        position: absolute;
-        bottom: 0;
-        left: 2px;
-        right: 2px;
-        height: 16px;
-        border-radius: var(--ha-card-border-radius);
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
+        position: fixed;
+        bottom: calc(var(--ha-dialog-header-height) * -1);
+        height: var(--ha-dialog-header-height, 12px);
       }
 
       .card-content {
-        max-height: calc(
-          100% - var(--safe-area-inset-bottom, 0px) - var(
-              --ha-dialog-header-height
-            ) -
-            32px
-        );
+        max-height: calc(100% - var(--ha-dialog-header-height) - 32px);
         overflow: auto;
       }
     }

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -64,7 +64,6 @@ export default class HaAutomationSidebarCard extends LitElement {
   }
 
   protected updated(_changedProperties: PropertyValues): void {
-    super.updated(_changedProperties);
     if (_changedProperties.has("hass") || _changedProperties.has("narrow")) {
       this._updateHeaderHeight();
     }

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -60,6 +60,14 @@ export default class HaAutomationSidebarCard extends LitElement {
 
   protected firstUpdated(_changedProperties: PropertyValues): void {
     this._contentSize.observe(this._contentElement);
+    this._updateHeaderHeight();
+  }
+
+  protected updated(_changedProperties: PropertyValues): void {
+    super.updated(_changedProperties);
+    if (_changedProperties.has("hass") || _changedProperties.has("narrow")) {
+      this._updateHeaderHeight();
+    }
   }
 
   protected render() {
@@ -149,6 +157,19 @@ export default class HaAutomationSidebarCard extends LitElement {
     ev.preventDefault();
   }
 
+  private _updateHeaderHeight() {
+    requestAnimationFrame(() => {
+      const header = this.shadowRoot?.querySelector("ha-dialog-header");
+      if (header) {
+        const headerHeight = header.offsetHeight;
+        this.style.setProperty(
+          "--ha-dialog-header-height",
+          `${headerHeight}px`
+        );
+      }
+    });
+  }
+
   static styles = css`
     ha-card {
       height: 100%;
@@ -202,14 +223,24 @@ export default class HaAutomationSidebarCard extends LitElement {
     }
 
     .card-content {
-      max-height: calc(100% - var(--safe-area-inset-bottom, 0px) - 88px);
+      max-height: calc(
+        100% - var(--safe-area-inset-bottom, 0px) - var(
+            --ha-dialog-header-height,
+            88px
+          )
+      );
       overflow: auto;
       margin-top: 0;
     }
 
     @media (min-width: 450px) and (min-height: 500px) {
       .card-content {
-        max-height: calc(100% - var(--safe-area-inset-bottom, 0px) - 112px);
+        max-height: calc(
+          100% - var(--safe-area-inset-bottom, 0px) - var(
+              --ha-dialog-header-height,
+              112px
+            )
+        );
         overflow: auto;
       }
     }

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -64,7 +64,7 @@ export default class HaAutomationSidebarCard extends LitElement {
   }
 
   protected updated(changedProperties: PropertyValues): void {
-    if (_changedProperties.has("hass") || _changedProperties.has("narrow")) {
+    if (changedProperties.has("hass") || changedProperties.has("narrow")) {
       this._updateHeaderHeight();
     }
   }

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -228,7 +228,7 @@ export default class HaAutomationSidebarCard extends LitElement {
         100% - var(--safe-area-inset-bottom, 0px) - var(
             --ha-dialog-header-height,
             88px
-          ) +
+          ) -
           16px
       );
       overflow: auto;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Restores bottom fade element and repositions the content and fade optiion to fit with and without safe areas.

**Without safe areas**:

Desktop:
<img width="3078" height="1258" alt="image" src="https://github.com/user-attachments/assets/649a4fcb-f4fb-4066-80fb-4692f341dbde" />
Scrolled to bottom:
<img width="3005" height="1251" alt="image" src="https://github.com/user-attachments/assets/a2140d64-4371-492b-8473-d03e28847b5c" />

Mobile:
<img width="626" height="1158" alt="image" src="https://github.com/user-attachments/assets/73f4fa2b-c9e9-4b62-8c51-28cd10baa007" />
Scrolled to bottom:
<img width="615" height="1161" alt="image" src="https://github.com/user-attachments/assets/52560095-f04d-491e-b03a-6c94a55d5de4" />

**With safe areas**:

Desktop:
<img width="3001" height="1255" alt="image" src="https://github.com/user-attachments/assets/af27e8f8-48ca-4106-a919-661fcca17b2b" />
Scrolled to bottom:
<img width="3045" height="1248" alt="image" src="https://github.com/user-attachments/assets/6513043a-c6e7-424c-bdf9-52b9dc17993d" />

Mobile:
<img width="678" height="1156" alt="image" src="https://github.com/user-attachments/assets/7ad828ef-352b-4ab5-966e-ebc4b38ca714" />
Scrolled to bottom:
<img width="618" height="1163" alt="image" src="https://github.com/user-attachments/assets/938f3303-14f3-40be-ab1f-05f64cb81fd1" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
