### PR TITLE
Add current states to history charts

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -317,7 +317,7 @@ export class HaChartBase extends LitElement {
                 borderColor: borderColor || color,
               })}
             ></div>
-            <div class="label">${name} ${current_state_text}</div>
+            <div class="label">${name}${current_state_text}</div>
           </li>`;
         })}
         ${items.length > overflowLimit

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -293,6 +293,15 @@ export class HaChartBase extends LitElement {
           };
           const color = itemStyle?.color as string;
           const borderColor = itemStyle?.borderColor as string;
+
+          const current_state_text =
+            item.current_state != null
+              ? html`(<b
+                    >${item.current_state}
+                    ${(this.options?.yAxis as YAXisOption)?.name ?? ""}</b
+                  >)`
+              : "";
+
           return html`<li
             .id=${id}
             @click=${this._legendClick}
@@ -306,12 +315,7 @@ export class HaChartBase extends LitElement {
                 borderColor: borderColor || color,
               })}
             ></div>
-            <div class="label">
-              ${name} (<b
-                >${item.current_state}
-                ${(this.options?.yAxis as YAXisOption)?.name}</b
-              >)
-            </div>
+            <div class="label">${name} ${current_state_text}</div>
           </li>`;
         })}
         ${items.length > overflowLimit

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -21,6 +21,7 @@ import { fireEvent } from "../../common/dom/fire_event";
 import { listenMediaQuery } from "../../common/dom/media_query";
 import { themesContext } from "../../data/context";
 import type { Themes } from "../../data/ws-themes";
+import { isUnavailableState } from "../../data/entity";
 import type { ECOption } from "../../resources/echarts";
 import type { HomeAssistant } from "../../types";
 import { isMac } from "../../util/is_mac";
@@ -295,7 +296,8 @@ export class HaChartBase extends LitElement {
           const borderColor = itemStyle?.borderColor as string;
 
           const current_state_text =
-            item.current_state != null
+            item.current_state != null &&
+            !isUnavailableState(item.current_state)
               ? html`(<b
                     >${item.current_state}
                     ${(this.options?.yAxis as YAXisOption)?.name ?? ""}</b

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -249,7 +249,11 @@ export class HaChartBase extends LitElement {
       legend.data ||
       datasets
         .filter((d) => (d.data as any[])?.length && (d.id || d.name))
-        .map((d) => ({ id: d.id, name: d.name }));
+        .map((d) => ({
+          id: d.id,
+          name: d.name,
+          current_state: this.hass.states[d.id!]?.state,
+        }));
 
     const isMobile = window.matchMedia(
       "all and (max-width: 450px), all and (max-height: 500px)"
@@ -302,7 +306,12 @@ export class HaChartBase extends LitElement {
                 borderColor: borderColor || color,
               })}
             ></div>
-            <div class="label">${name}</div>
+            <div class="label">
+              ${name} (<b
+                >${item.current_state}
+                ${(this.options?.yAxis as YAXisOption)?.name}</b
+              >)
+            </div>
           </li>`;
         })}
         ${items.length > overflowLimit
@@ -1021,9 +1030,6 @@ export class HaChartBase extends LitElement {
       padding: 0 2px;
       box-sizing: border-box;
       overflow: hidden;
-    }
-    .chart-legend.multiple-items li {
-      max-width: 220px;
     }
     .chart-legend .hidden {
       color: var(--secondary-text-color);

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -298,7 +298,7 @@ export class HaChartBase extends LitElement {
           const current_state_text =
             item.current_state != null &&
             !isUnavailableState(item.current_state)
-              ? html`(<b
+              ? html` (<b
                     >${item.current_state}
                     ${(this.options?.yAxis as YAXisOption)?.name ?? ""}</b
                   >)`

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -219,6 +219,22 @@ export class StateHistoryCharts extends LitElement {
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
     if (changedProps.size === 1 && changedProps.has("hass")) {
+      const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+
+      // Update when one of the relevant states changes
+      if (this.historyData?.line) {
+        for (const line of this.historyData.line) {
+          for (const data of line.data) {
+            const hasSensorChanged =
+              oldHass?.states[data.entity_id]?.state !==
+              this.hass.states[data.entity_id]?.state;
+            if (hasSensorChanged) {
+              return true;
+            }
+          }
+        }
+      }
+
       return false;
     }
     if (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The current sensor values were not directly visible in the history charts. To obtain them, you had to move the cursor to the current time on the timeline, which was relatively time-consuming, and only then would the current values appear in the tooltip. However, the current status value is very important in many use cases and should be immediately visible. The aim of this change is to display the current sensor values.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
