### PR TITLE
Do not show error message when action has no response in dev tools

### DIFF
--- a/src/data/service.ts
+++ b/src/data/service.ts
@@ -4,7 +4,7 @@ import type { Action } from "./script";
 export const callExecuteScript = (
   hass: HomeAssistant,
   sequence: Action | Action[]
-): Promise<{ context: Context; response: Record<string, any> }> =>
+): Promise<{ context: Context; response: Record<string, any> | null }> =>
   hass.callWS({
     type: "execute_script",
     sequence,

--- a/src/panels/developer-tools/action/developer-tools-action.ts
+++ b/src/panels/developer-tools/action/developer-tools-action.ts
@@ -51,7 +51,7 @@ class HaPanelDevAction extends LitElement {
   @state() private _response?: {
     domain: string;
     service: string;
-    result: Record<string, any>;
+    result: Record<string, any> | null;
     media?: Promise<TemplateResult | typeof nothing>;
   };
 
@@ -205,7 +205,7 @@ class HaPanelDevAction extends LitElement {
           </ha-progress-button>
         </div>
       </div>
-      ${this._response
+      ${this._response?.result
         ? html`<div class="content response">
             <ha-card
               .header=${this.hass.localize(
@@ -491,7 +491,7 @@ class HaPanelDevAction extends LitElement {
         service,
         result,
         media:
-          "media_source_id" in result
+          result && "media_source_id" in result
             ? resolveMediaSource(this.hass, result.media_source_id).then(
                 (resolved) =>
                   resolved.mime_type.startsWith("image/")


### PR DESCRIPTION
# Proposed change

Do not show error message when action has no response in dev tools.

It fixes this issue : 
<img width="896" height="100" alt="CleanShot 2025-09-24 at 17 50 52" src="https://github.com/user-attachments/assets/ddfcc458-afa2-40fa-8581-6b7286cc98a3" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
