### PR TITLE
Fix error message when creating dashboard with same url path

### DIFF
--- a/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
@@ -283,6 +283,14 @@ export class DialogLovelaceDashboardDetail extends LitElement {
       }
       this.closeDialog();
     } catch (err: any) {
+      if (err.code === "invalid_format") {
+        this._error = {
+          url_path: this.hass.localize(
+            "ui.panel.config.lovelace.dashboards.detail.url_unique_error_msg"
+          ),
+        };
+        return;
+      }
       this._error = { base: err?.message || "Unknown error" };
     } finally {
       this._submitting = false;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3426,6 +3426,7 @@
               "title_required": "Title is required.",
               "url": "URL",
               "url_error_msg": "The URL should contain a - and cannot contain spaces or special characters, except for _ and -",
+              "url_unique_error_msg": "This URL is already in use. Please choose a different one",
               "require_admin": "Admin only",
               "delete": "Delete",
               "update": "Update",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Previously, the UI surfaced the raw backend error message when a duplicate URL was submitted. This could be confusing or overly technical for end-users.

This PR replaces that behavior with a controlled, user-friendly message. Instead of exposing the backend text directly, the frontend now detects the duplicate URL error and displays a clearer prompt such as:

“This URL is already in use. Please choose a different one.”

Also now the error is displayed in the right position, next to the url path input. 

### Old error message
<img width="888" height="717" alt="image" src="https://github.com/user-attachments/assets/ba25664b-02a6-4124-9406-e235e8ee30cc" />

### New error message
<img width="482" height="598" alt="Screenshot 2025-09-26 at 11 57 59" src="https://github.com/user-attachments/assets/9e116f30-311b-43c3-8b69-31c2711d42df" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #27162
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
