### PR TITLE
Refactor overflow menu in labels data table to have a single instance

### DIFF
--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -328,7 +328,7 @@ class MoreInfoMediaPlayer extends LitElement {
             <div class="position-bar">
               <ha-slider
                 id="position-slider"
-                min="0"
+                min="0"r
                 max=${duration}
                 step="1"
                 .value=${position}

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -328,7 +328,7 @@ class MoreInfoMediaPlayer extends LitElement {
             <div class="position-bar">
               <ha-slider
                 id="position-slider"
-                min="0"r
+                min="0"
                 max=${duration}
                 step="1"
                 .value=${position}

--- a/src/panels/config/labels/ha-config-labels.ts
+++ b/src/panels/config/labels/ha-config-labels.ts
@@ -87,7 +87,7 @@ export class HaConfigLabels extends LitElement {
   })
   private _activeHiddenColumns?: string[];
 
-  @query("#overflow-menu") private _overflowMenu!: HaMdMenu;
+  @query("#overflow-menu") private _overflowMenu?: HaMdMenu;
 
   private _overflowLabel!: LabelRegistryEntry;
 
@@ -182,7 +182,7 @@ export class HaConfigLabels extends LitElement {
             .selected=${label}
             .label=${this.hass.localize("ui.common.overflow_menu")}
             .path=${mdiDotsVertical}
-            @click=${this._showOverflowMenu}
+            @click=${this._toggleOverflowMenu}
           ></ha-icon-button>
         `,
       },
@@ -197,11 +197,12 @@ export class HaConfigLabels extends LitElement {
       }))
   );
 
-  private _showOverflowMenu = (ev) => {
-    if (
-      this._overflowMenu.open &&
-      ev.target === this._overflowMenu.anchorElement
-    ) {
+  private _toggleOverflowMenu = (ev) => {
+    if (!this._overflowMenu) {
+      return;
+    }
+
+    if (this._overflowMenu.open) {
       this._overflowMenu.close();
       return;
     }

--- a/src/panels/config/labels/ha-config-labels.ts
+++ b/src/panels/config/labels/ha-config-labels.ts
@@ -1,6 +1,7 @@
 import {
   mdiDelete,
   mdiDevices,
+  mdiDotsVertical,
   mdiHelpCircle,
   mdiPlus,
   mdiRobot,
@@ -8,7 +9,7 @@ import {
 } from "@mdi/js";
 import type { PropertyValues } from "lit";
 import { LitElement, html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
 import { computeCssColor } from "../../../common/color/compute-color";
@@ -23,7 +24,6 @@ import type {
 } from "../../../components/data-table/ha-data-table";
 import "../../../components/ha-fab";
 import "../../../components/ha-icon-button";
-import "../../../components/ha-icon-overflow-menu";
 import "../../../components/ha-relative-time";
 import type {
   LabelRegistryEntry,
@@ -43,6 +43,7 @@ import "../../../layouts/hass-tabs-subpage-data-table";
 import type { HomeAssistant, Route } from "../../../types";
 import { configSections } from "../ha-panel-config";
 import { showLabelDetailDialog } from "./show-dialog-label-detail";
+import type { HaMdMenu } from "../../../components/ha-md-menu";
 
 @customElement("ha-config-labels")
 export class HaConfigLabels extends LitElement {
@@ -85,6 +86,10 @@ export class HaConfigLabels extends LitElement {
     subscribe: false,
   })
   private _activeHiddenColumns?: string[];
+
+  @query("#overflow-menu") private _overflowMenu!: HaMdMenu;
+
+  private _overflowLabel!: LabelRegistryEntry;
 
   private _columns = memoizeOne((localize: LocalizeFunc, narrow: boolean) => {
     const columns: DataTableColumnContainer<LabelRegistryEntry> = {
@@ -173,34 +178,12 @@ export class HaConfigLabels extends LitElement {
         hideable: false,
         type: "overflow-menu",
         template: (label) => html`
-          <ha-icon-overflow-menu
-            .hass=${this.hass}
-            narrow
-            .items=${[
-              {
-                label: this.hass.localize("ui.panel.config.entities.caption"),
-                path: mdiShape,
-                action: () => this._navigateEntities(label),
-              },
-              {
-                label: this.hass.localize("ui.panel.config.devices.caption"),
-                path: mdiDevices,
-                action: () => this._navigateDevices(label),
-              },
-              {
-                label: this.hass.localize("ui.panel.config.automation.caption"),
-                path: mdiRobot,
-                action: () => this._navigateAutomations(label),
-              },
-              {
-                label: this.hass.localize("ui.common.delete"),
-                path: mdiDelete,
-                action: () => this._removeLabel(label),
-                warning: true,
-              },
-            ]}
-          >
-          </ha-icon-overflow-menu>
+          <ha-icon-button
+            .selected=${label}
+            .label=${this.hass.localize("ui.common.overflow_menu")}
+            .path=${mdiDotsVertical}
+            @click=${this._showOverflowMenu}
+          ></ha-icon-button>
         `,
       },
     };
@@ -213,6 +196,19 @@ export class HaConfigLabels extends LitElement {
         ...label,
       }))
   );
+
+  private _showOverflowMenu = (ev) => {
+    if (
+      this._overflowMenu.open &&
+      ev.target === this._overflowMenu.anchorElement
+    ) {
+      this._overflowMenu.close();
+      return;
+    }
+    this._overflowLabel = ev.target.selected;
+    this._overflowMenu.anchorElement = ev.target;
+    this._overflowMenu.show();
+  };
 
   protected firstUpdated(changedProperties: PropertyValues) {
     super.firstUpdated(changedProperties);
@@ -257,6 +253,32 @@ export class HaConfigLabels extends LitElement {
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
         </ha-fab>
       </hass-tabs-subpage-data-table>
+      <ha-md-menu id="overflow-menu" positioning="fixed">
+        <ha-md-menu-item .clickAction=${this._navigateEntities}>
+          <ha-svg-icon slot="start" .path=${mdiShape}></ha-svg-icon>
+          ${this.hass.localize("ui.panel.config.entities.caption")}
+        </ha-md-menu-item>
+        <ha-md-menu-item .clickAction=${this._navigateDevices}>
+          <ha-svg-icon slot="start" .path=${mdiDevices}></ha-svg-icon>
+          ${this.hass.localize("ui.panel.config.devices.caption")}
+        </ha-md-menu-item>
+        <ha-md-menu-item .clickAction=${this._navigateAutomations}>
+          <ha-svg-icon slot="start" .path=${mdiRobot}></ha-svg-icon>
+          ${this.hass.localize("ui.panel.config.automation.caption")}
+        </ha-md-menu-item>
+        <ha-md-divider role="separator" tabindex="-1"></ha-md-divider>
+        <ha-md-menu-item
+          class="warning"
+          .clickAction=${this._handleRemoveLabelClick}
+        >
+          <ha-svg-icon
+            slot="start"
+            class="warning"
+            .path=${mdiDelete}
+          ></ha-svg-icon>
+          ${this.hass.localize("ui.common.delete")}
+        </ha-md-menu-item>
+      </ha-md-menu>
     `;
   }
 
@@ -317,6 +339,10 @@ export class HaConfigLabels extends LitElement {
     return updated;
   }
 
+  private _handleRemoveLabelClick = () => {
+    this._removeLabel(this._overflowLabel);
+  };
+
   private async _removeLabel(selectedLabel: LabelRegistryEntry) {
     if (
       !(await showConfirmationDialog(this, {
@@ -344,19 +370,23 @@ export class HaConfigLabels extends LitElement {
     }
   }
 
-  private _navigateEntities(label: LabelRegistryEntry) {
-    navigate(`/config/entities?historyBack=1&label=${label.label_id}`);
-  }
-
-  private _navigateDevices(label: LabelRegistryEntry) {
-    navigate(`/config/devices/dashboard?historyBack=1&label=${label.label_id}`);
-  }
-
-  private _navigateAutomations(label: LabelRegistryEntry) {
+  private _navigateEntities = () => {
     navigate(
-      `/config/automation/dashboard?historyBack=1&label=${label.label_id}`
+      `/config/entities?historyBack=1&label=${this._overflowLabel.label_id}`
     );
-  }
+  };
+
+  private _navigateDevices = () => {
+    navigate(
+      `/config/devices/dashboard?historyBack=1&label=${this._overflowLabel.label_id}`
+    );
+  };
+
+  private _navigateAutomations = () => {
+    navigate(
+      `/config/automation/dashboard?historyBack=1&label=${this._overflowLabel.label_id}`
+    );
+  };
 
   private _handleSortingChanged(ev: CustomEvent) {
     this._activeSorting = ev.detail;


### PR DESCRIPTION
## Proposed change
Refactor the overflow menu in labels data table to have a single instance of the overflow menu instead for every row.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #26538 
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
