### PR TITLE
forwardHaptic on node rather than window.

### DIFF
--- a/src/components/entity/ha-entity-toggle.ts
+++ b/src/components/entity/ha-entity-toggle.ts
@@ -112,7 +112,7 @@ export class HaEntityToggle extends LitElement {
     if (!this.hass || !this.stateObj) {
       return;
     }
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
     const stateDomain = computeStateDomain(this.stateObj);
     let serviceDomain;
     let service;

--- a/src/components/ha-switch.ts
+++ b/src/components/ha-switch.ts
@@ -15,7 +15,7 @@ export class HaSwitch extends SwitchBase {
     super.firstUpdated();
     this.addEventListener("change", () => {
       if (this.haptic) {
-        forwardHaptic("light");
+        forwardHaptic(this, "light");
       }
     });
   }

--- a/src/data/haptics.ts
+++ b/src/data/haptics.ts
@@ -28,6 +28,6 @@ declare global {
   }
 }
 
-export const forwardHaptic = (hapticType: HapticType) => {
-  fireEvent(window, "haptic", hapticType);
+export const forwardHaptic = (node: HTMLElement, hapticType: HapticType) => {
+  fireEvent(node, "haptic", hapticType);
 };

--- a/src/dialogs/more-info/controls/more-info-fan.ts
+++ b/src/dialogs/more-info/controls/more-info-fan.ts
@@ -42,7 +42,7 @@ class MoreInfoFan extends LitElement {
 
   private _toggle = () => {
     const service = this.stateObj?.state === "on" ? "turn_off" : "turn_on";
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
     this.hass.callService("fan", service, {
       entity_id: this.stateObj!.entity_id,
     });

--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -310,7 +310,7 @@ class MoreInfoLight extends LitElement {
 
   private _toggle = () => {
     const service = this.stateObj?.state === "on" ? "turn_off" : "turn_on";
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
     this.hass.callService("light", service, {
       entity_id: this.stateObj!.entity_id,
     });

--- a/src/panels/config/integrations/integration-panels/zha/zha-cluster-attributes.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-cluster-attributes.ts
@@ -210,10 +210,10 @@ export class ZHAClusterAttributes extends LitElement {
       this._readingAttribute = true;
       try {
         this._attributeValue = await readAttributeValue(this.hass, data);
-        forwardHaptic("success");
+        forwardHaptic(this, "success");
         button.actionSuccess();
       } catch (_err: any) {
-        forwardHaptic("failure");
+        forwardHaptic(this, "failure");
         button.actionError();
       } finally {
         this._readingAttribute = false;

--- a/src/panels/config/scene/ha-scene-dashboard.ts
+++ b/src/panels/config/scene/ha-scene-dashboard.ts
@@ -1087,7 +1087,7 @@ ${rejected
         name: computeStateName(scene),
       }),
     });
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
   };
 
   private _deleteConfirm(scene: SceneEntity): void {

--- a/src/panels/developer-tools/action/developer-tools-action.ts
+++ b/src/panels/developer-tools/action/developer-tools-action.ts
@@ -443,7 +443,7 @@ class HaPanelDevAction extends LitElement {
     const button = ev.currentTarget as HaProgressButton;
 
     if (this._yamlMode && !this._yamlValid) {
-      forwardHaptic("failure");
+      forwardHaptic(this, "failure");
       button.actionError();
       this._error = this.hass.localize(
         "ui.panel.developer-tools.tabs.actions.errors.yaml.invalid_yaml"
@@ -465,7 +465,7 @@ class HaPanelDevAction extends LitElement {
     );
 
     if (this._error !== undefined) {
-      forwardHaptic("failure");
+      forwardHaptic(this, "failure");
       button.actionError();
       return;
     }
@@ -534,7 +534,7 @@ class HaPanelDevAction extends LitElement {
       ) {
         return;
       }
-      forwardHaptic("failure");
+      forwardHaptic(this, "failure");
       button.actionError();
 
       let localizedErrorMessage: string | undefined;

--- a/src/panels/lovelace/card-features/hui-area-controls-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-area-controls-card-feature.ts
@@ -177,7 +177,7 @@ class HuiAreaControlsCardFeature
       .map((entityId) => this.hass!.states[entityId] as HassEntity | undefined)
       .filter((v): v is HassEntity => Boolean(v));
 
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
     toggleGroupEntities(this.hass, entities);
   }
 

--- a/src/panels/lovelace/card-features/hui-lock-commands-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-lock-commands-card-feature.ts
@@ -69,7 +69,7 @@ class HuiLockCommandsCardFeature
     if (!this.hass || !this._stateObj || !service) {
       return;
     }
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
     callProtectedLockService(this, this.hass, this._stateObj, service);
   }
 

--- a/src/panels/lovelace/card-features/hui-toggle-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-toggle-card-feature.ts
@@ -112,7 +112,7 @@ class HuiToggleCardFeature extends LitElement implements LovelaceCardFeature {
     if (!this.hass || !this._stateObj) {
       return;
     }
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
     const stateDomain = computeDomain(this._stateObj.entity_id);
     const serviceDomain = stateDomain;
     const service = turnOn ? "turn_on" : "turn_off";

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -53,7 +53,7 @@ export const handleAction = async (
         (e) => e.user === hass!.user?.id
       ))
   ) {
-    forwardHaptic("warning");
+    forwardHaptic(node, "warning");
 
     let serviceName;
     if (
@@ -107,7 +107,7 @@ export const handleAction = async (
             "ui.panel.lovelace.cards.actions.no_entity_more_info"
           ),
         });
-        forwardHaptic("failure");
+        forwardHaptic(node, "failure");
       }
       break;
     }
@@ -122,7 +122,7 @@ export const handleAction = async (
             "ui.panel.lovelace.cards.actions.no_navigation_path"
           ),
         });
-        forwardHaptic("failure");
+        forwardHaptic(node, "failure");
       }
       break;
     case "url": {
@@ -132,21 +132,21 @@ export const handleAction = async (
         showToast(node, {
           message: hass.localize("ui.panel.lovelace.cards.actions.no_url"),
         });
-        forwardHaptic("failure");
+        forwardHaptic(node, "failure");
       }
       break;
     }
     case "toggle": {
       if (config.entity) {
         toggleEntity(hass, config.entity!);
-        forwardHaptic("light");
+        forwardHaptic(node, "light");
       } else {
         showToast(node, {
           message: hass.localize(
             "ui.panel.lovelace.cards.actions.no_entity_toggle"
           ),
         });
-        forwardHaptic("failure");
+        forwardHaptic(node, "failure");
       }
       break;
     }
@@ -156,7 +156,7 @@ export const handleAction = async (
         showToast(node, {
           message: hass.localize("ui.panel.lovelace.cards.actions.no_action"),
         });
-        forwardHaptic("failure");
+        forwardHaptic(node, "failure");
         return;
       }
       const [domain, service] = (actionConfig.perform_action ||
@@ -167,7 +167,7 @@ export const handleAction = async (
         actionConfig.data ?? actionConfig.service_data,
         actionConfig.target
       );
-      forwardHaptic("light");
+      forwardHaptic(node, "light");
       break;
     }
     case "assist": {

--- a/src/panels/lovelace/components/hui-entities-toggle.ts
+++ b/src/panels/lovelace/components/hui-entities-toggle.ts
@@ -58,7 +58,7 @@ class HuiEntitiesToggle extends LitElement {
   `;
 
   private _callService(ev: MouseEvent): void {
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
     const turnOn = (ev.target as HaSwitch).checked;
     turnOnOffEntities(this.hass!, this._toggleEntities!, turnOn!);
   }

--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -103,7 +103,7 @@ class HuiInputSelectEntityRow extends LitElement implements LovelaceRow {
       return;
     }
 
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
 
     setInputSelectOption(this.hass!, stateObj.entity_id, option);
   }

--- a/src/panels/lovelace/entity-rows/hui-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-select-entity-row.ts
@@ -104,7 +104,7 @@ class HuiSelectEntityRow extends LitElement implements LovelaceRow {
       return;
     }
 
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
 
     setSelectOption(this.hass!, stateObj.entity_id, option);
   }

--- a/src/panels/profile/ha-set-vibrate-row.ts
+++ b/src/panels/profile/ha-set-vibrate-row.ts
@@ -39,7 +39,7 @@ class HaSetVibrateRow extends LitElement {
     fireEvent(this, "hass-vibrate", {
       vibrate,
     });
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
   }
 }
 

--- a/src/state-control/cover/ha-state-control-cover-toggle.ts
+++ b/src/state-control/cover/ha-state-control-cover-toggle.ts
@@ -40,7 +40,7 @@ export class HaStateControlCoverToggle extends LitElement {
     if (!this.hass || !this.stateObj) {
       return;
     }
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
 
     await this.hass.callService(
       "cover",

--- a/src/state-control/ha-state-control-toggle.ts
+++ b/src/state-control/ha-state-control-toggle.ts
@@ -46,7 +46,7 @@ export class HaStateControlToggle extends LitElement {
     if (!this.hass || !this.stateObj) {
       return;
     }
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
     const stateDomain = computeDomain(this.stateObj.entity_id);
     let serviceDomain;
     let service;

--- a/src/state-control/lock/ha-state-control-lock-toggle.ts
+++ b/src/state-control/lock/ha-state-control-lock-toggle.ts
@@ -68,7 +68,7 @@ export class HaStateControlLockToggle extends LitElement {
     if (!this.hass || !this.stateObj) {
       return;
     }
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
     fireEvent(this, "lock-service-called");
     callProtectedLockService(
       this,

--- a/src/state-control/valve/ha-state-control-valve-toggle.ts
+++ b/src/state-control/valve/ha-state-control-valve-toggle.ts
@@ -40,7 +40,7 @@ export class HaStateControlValveToggle extends LitElement {
     if (!this.hass || !this.stateObj) {
       return;
     }
-    forwardHaptic("light");
+    forwardHaptic(this, "light");
 
     await this.hass.callService(
       "valve",

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -127,7 +127,7 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
               );
             }
             if (notifyOnError) {
-              forwardHaptic("failure");
+              forwardHaptic(this, "failure");
               const lokalize = await this.hass!.loadBackendTranslation(
                 "exceptions",
                 err.translation_domain


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Custom elements cannot captue the `haptic` event as it is fired on `window`. Capturing at window does not work even though the specs say that capture phase should be called before bubble phase, but this has proven to not be correct in testing with Chrome in that bubble event handler to pass to companion app is called before capture event handler to stop immediate propagation. Therefore this change sets `forwardHaptic` to use node for `fireEvent` such that the event can be correctly captured at window and custom elements can replace with a different haptic.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

Without this change, the only way to intercept haptics is via a messy hack at the Frontend/App messaging level. This was attemped in button-card, see [button-card#1010](https://github.com/custom-cards/button-card/pull/1010/files#diff-721d68e111124207af76dd2d20778ba7d90ccbde6770363f39f4d03a05ec8b56) and has been abandoned in favour of this PR and the simpler approach of event capture.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
