### PR TITLE
Add hide_compound_stats option to energy-devices-graph-card

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
@@ -204,7 +204,14 @@ export class HuiEnergyDevicesGraphCard
 
     const computedStyle = getComputedStyle(this);
 
+    const exclude = this._config?.hide_compound_stats
+      ? energyData.prefs.device_consumption.map((d) => d.included_in_stat)
+      : [];
+
     energyData.prefs.device_consumption.forEach((device, id) => {
+      if (exclude.includes(device.stat_consumption)) {
+        return;
+      }
       const value =
         device.stat_consumption in data
           ? calculateStatisticSumGrowth(data[device.stat_consumption]) || 0

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
@@ -205,7 +205,7 @@ export class HuiEnergyDevicesGraphCard
     const computedStyle = getComputedStyle(this);
 
     const exclude = this._config?.hide_compound_stats
-      ? energyData.prefs.device_consumption.map((d) => d.included_in_stat)
+      ? energyData.prefs.device_consumption.map((d) => d.included_in_stat).filter(Boolean)
       : [];
 
     energyData.prefs.device_consumption.forEach((device, id) => {

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
@@ -205,7 +205,9 @@ export class HuiEnergyDevicesGraphCard
     const computedStyle = getComputedStyle(this);
 
     const exclude = this._config?.hide_compound_stats
-      ? energyData.prefs.device_consumption.map((d) => d.included_in_stat).filter(Boolean)
+      ? energyData.prefs.device_consumption
+          .map((d) => d.included_in_stat)
+          .filter(Boolean)
       : [];
 
     energyData.prefs.device_consumption.forEach((device, id) => {

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -176,6 +176,7 @@ export interface EnergyDevicesGraphCardConfig extends EnergyCardBaseConfig {
   type: "energy-devices-graph";
   title?: string;
   max_devices?: number;
+  hide_compound_stats?: boolean;
 }
 
 export interface EnergyDevicesDetailGraphCardConfig


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The `energy-devices-graph-card` option will allow to hide higher level devices like breakers. It can then be used to display the top N consumers of energy without being polluted by the high values of an entire breaker/phase/whatever.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41086

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
