### PR TITLE
Introduce new number formatting for Switzerland

### DIFF
--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -32,6 +32,8 @@ export const numberFormatToLocale = (
       return ["de", "es", "it"]; // Use German with fallback to Spanish then Italian formatting 1.234.567,89
     case NumberFormat.space_comma:
       return ["fr", "sv", "cs"]; // Use French with fallback to Swedish and Czech formatting 1 234 567,89
+    case NumberFormat.quote_decimal:
+      return ["de-CH"]; // Use German (Switzerland) formatting 1'234'567.89
     case NumberFormat.system:
       return undefined;
     default:

--- a/src/data/translation.ts
+++ b/src/data/translation.ts
@@ -6,6 +6,7 @@ export enum NumberFormat {
   system = "system",
   comma_decimal = "comma_decimal",
   decimal_comma = "decimal_comma",
+  quote_decimal = "quote_decimal",
   space_comma = "space_comma",
   none = "none",
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8440,6 +8440,7 @@
             "system": "Use system locale",
             "comma_decimal": "1,234,567.89",
             "decimal_comma": "1.234.567,89",
+            "quote_decimal": "1'234'567.89",
             "space_comma": "1 234 567,89",
             "none": "None"
           }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
In the German speaking part of Switzerland we use single quotes to group thousands, and the period as the decimal separator: 1'234.56 vs. 1.234,56 in Germany. See eg. https://www.localeplanet.com/icu/de-CH/index.html.

Using the German language would give us confusing commas as the decimal separator etc. As long as there is no German (Switzerland) `de-CH` locale we can live with a formatting override.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #27254
- This PR is related to issue or discussion: #20342 
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
