### PR TITLE
Make enum colors stable in history chart

### DIFF
--- a/src/components/chart/timeline-color.ts
+++ b/src/components/chart/timeline-color.ts
@@ -6,6 +6,8 @@ import { computeDomain } from "../../common/entity/compute_domain";
 import { stateColorProperties } from "../../common/entity/state_color";
 import { UNAVAILABLE, UNKNOWN } from "../../data/entity";
 import { computeCssValue } from "../../resources/css-variables";
+import { computeStateDomain } from "../../common/entity/compute_state_domain";
+import { FIXED_DOMAIN_STATES } from "../../common/entity/get_states";
 
 const DOMAIN_STATE_SHADES: Record<string, Record<string, number>> = {
   media_player: {
@@ -51,6 +53,28 @@ function computeTimelineStateColor(
 let colorIndex = 0;
 const stateColorMap = new Map<string, string>();
 
+function computeTimelineEnumColor(
+  state: string,
+  computedStyles: CSSStyleDeclaration,
+  stateObj?: HassEntity
+): string | undefined {
+  if (!stateObj) {
+    return undefined;
+  }
+  const domain = computeStateDomain(stateObj);
+  const states =
+    FIXED_DOMAIN_STATES[domain] ||
+    (domain === "sensor" &&
+      stateObj.attributes.device_class === "enum" &&
+      stateObj.attributes.options) ||
+    [];
+  const idx = states.indexOf(state);
+  if (idx === -1) {
+    return undefined;
+  }
+  return getGraphColorByIndex(idx, computedStyles);
+}
+
 function computeTimeLineGenericColor(
   state: string,
   computedStyles: CSSStyleDeclaration
@@ -71,6 +95,7 @@ export function computeTimelineColor(
 ): string {
   return (
     computeTimelineStateColor(state, computedStyles, stateObj) ||
+    computeTimelineEnumColor(state, computedStyles, stateObj) ||
     computeTimeLineGenericColor(state, computedStyles)
   );
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
For `enum` type sensors (and uncolored domains with fixed states), make the history chart timeline always use the same color for the same enum state, by using the index of the state's position in the options list as the graph color.

This ensures that while any given state's color will be random, that it should always be the _same_ color every time it is shown in a history timeline. 

Currently all the colors may be different each time you reload the page.

This may have the slightly negative effect that there may be less overall variety in chart colors, and more charts will be biased more toward the first few primary chart colors. But in my opinion I think this is better. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
