### PR TITLE
Translate dashboard panel url error message

### DIFF
--- a/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
@@ -309,6 +309,15 @@ export class DialogLovelaceDashboardDetail extends LitElement {
       }
       this.closeDialog();
     } catch (err: any) {
+      if (err?.translation_key === "url_already_exists") {
+        this._error = {
+          url_path: this.hass!.localize(
+            "ui.panel.config.lovelace.dashboards.detail.url_already_exists",
+            err?.translation_placeholders
+          ),
+        };
+        return;
+      }
       this._error = { base: err?.message || "Unknown error" };
     } finally {
       this._submitting = false;

--- a/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
@@ -309,16 +309,20 @@ export class DialogLovelaceDashboardDetail extends LitElement {
       }
       this.closeDialog();
     } catch (err: any) {
-      if (err?.translation_key === "url_already_exists") {
-        this._error = {
-          url_path: this.hass!.localize(
-            "ui.panel.config.lovelace.dashboards.detail.url_already_exists",
-            err?.translation_placeholders
-          ),
-        };
-        return;
+      let localizedErrorMessage: string | undefined;
+      if (err?.translation_domain && err?.translation_key) {
+        const localize = await this.hass.loadBackendTranslation(
+          "exceptions",
+          err.translation_domain
+        );
+        localizedErrorMessage = localize(
+          `component.${err.translation_domain}.exceptions.${err.translation_key}.message`,
+          err.translation_placeholders
+        );
       }
-      this._error = { base: err?.message || "Unknown error" };
+      this._error = {
+        base: localizedErrorMessage || err?.message || "Unknown error",
+      };
     } finally {
       this._submitting = false;
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3522,7 +3522,6 @@
               "title": "Title",
               "title_required": "Title is required.",
               "url": "URL",
-              "url_already_exists": "The {url} URL is already in use. Please choose a different one.",
               "url_error_msg": "The URL should contain a - and cannot contain spaces or special characters, except for _ and -",
               "require_admin": "Admin only",
               "delete": "Delete",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3522,6 +3522,7 @@
               "title": "Title",
               "title_required": "Title is required.",
               "url": "URL",
+              "url_already_exists": "The {url} URL is already in use. Please choose a different one.",
               "url_error_msg": "The URL should contain a - and cannot contain spaces or special characters, except for _ and -",
               "require_admin": "Admin only",
               "delete": "Delete",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
If the user tries to create a new dashboard with a URL that already exist, the current error message contains technical details and is not translatable (#27162).

This PR uses the translation_key from the updated error message in https://github.com/home-assistant/core/pull/153501 to display an improved translated error message.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #27162
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
