### PR TITLE
fix: add shadow design tokens for consistent styling

### DIFF
--- a/src/resources/theme/color/semantic.globals.ts
+++ b/src/resources/theme/color/semantic.globals.ts
@@ -9,6 +9,9 @@ export const semanticColorStyles = css`
   html {
     --ha-color-focus: var(--ha-color-orange-60);
 
+    /* shadow */
+    --ha-color-shadow: #00000033;
+
     /* text */
     --ha-color-text-primary: var(--ha-color-neutral-05);
     --ha-color-text-secondary: var(--ha-color-neutral-40);
@@ -157,6 +160,9 @@ export const semanticColorStyles = css`
 
 export const darkSemanticColorStyles = css`
   html {
+    /* shadow */
+    --ha-color-shadow: #000000b2;
+
     /* text */
     --ha-color-text-primary: var(--white-color);
     --ha-color-text-secondary: var(--ha-color-neutral-80);

--- a/src/resources/theme/core.globals.ts
+++ b/src/resources/theme/core.globals.ts
@@ -42,6 +42,25 @@ export const coreStyles = css`
     --ha-space-18: 72px;
     --ha-space-19: 76px;
     --ha-space-20: 80px;
+
+    /* Shadow tokens */
+    --ha-shadow-offset-x-sm: 0px;
+    --ha-shadow-offset-x-md: 0px;
+    --ha-shadow-offset-x-lg: 0px;
+    --ha-shadow-offset-y-sm: 2px;
+    --ha-shadow-offset-y-md: 4px;
+    --ha-shadow-offset-y-lg: 8px;
+    --ha-shadow-blur-sm: 4px;
+    --ha-shadow-blur-md: 8px;
+    --ha-shadow-blur-lg: 12px;
+    --ha-shadow-spread-sm: 0px;
+    --ha-shadow-spread-md: 0px;
+    --ha-shadow-spread-lg: 0px;
+
+    /* Compound shadow styles */
+    --ha-shadow-sm: var(--ha-shadow-offset-x-sm) var(--ha-shadow-offset-y-sm) var(--ha-shadow-blur-sm) var(--ha-shadow-spread-sm) var(--ha-color-shadow);
+    --ha-shadow-md: var(--ha-shadow-offset-x-md) var(--ha-shadow-offset-y-md) var(--ha-shadow-blur-md) var(--ha-shadow-spread-md) var(--ha-color-shadow);
+    --ha-shadow-lg: var(--ha-shadow-offset-x-lg) var(--ha-shadow-offset-y-lg) var(--ha-shadow-blur-lg) var(--ha-shadow-spread-lg) var(--ha-color-shadow);
   }
 `;
 


### PR DESCRIPTION
### Proposed change

- Implement core shadow tokens for the design system to provide reusable shadow styles across components. This adds foundational shadow tokens (offset, blur, spread) and semantic shadow colors that adapt to light/dark themes, enabling consistent shadow styling throughout the application.

fixed: #27277 

### Type of change
- [x] New feature (thank you!)

### Additional information
- This PR implements shadow tokens as specified in the design system requirements
- Adds core tokens: `--ha-shadow-offset-*`, `--ha-shadow-blur-*`, `--ha-shadow-spread-*`
- Adds semantic color tokens: `--ha-color-shadow` with different opacity for light/dark themes
- Adds compound shadow styles: `--ha-shadow-sm`, `--ha-shadow-md`, `--ha-shadow-lg`
- All values use PX units as specified