### PR TITLE
Fix ARIA role typo: Change 'seperator' to 'separator' in todo-list card

### DIFF
--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -319,7 +319,7 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
                   )}
                 </p>`
               : this._reordering
-                ? html`<div class="header" role="seperator">
+                ? html`<div class="header" role="separator">
                       <h2>
                         ${this.hass!.localize(
                           "ui.panel.lovelace.cards.todo-list.reorder_items"
@@ -331,7 +331,7 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
                 : nothing}
             ${!this._reordering && uncheckedItems.length
               ? html`
-                  <div class="header" role="seperator">
+                  <div class="header" role="separator">
                     <h2>
                       ${this.hass!.localize(
                         "ui.panel.lovelace.cards.todo-list.unchecked_items"
@@ -346,9 +346,9 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
               ? html`
                   <div>
                     ${uncheckedItems.length
-                      ? html`<div class="divider" role="seperator"></div>`
+                      ? html`<div class="divider" role="separator"></div>`
                       : nothing}
-                    <div class="header" role="seperator">
+                    <div class="header" role="separator">
                       <h2>
                         ${this.hass!.localize(
                           "ui.panel.lovelace.cards.todo-list.no_status_items"


### PR DESCRIPTION
Correct typo in ARIA role attribute from 'role=seperator' to 'role=separator' in hui-todo-list-card.ts. This improves accessibility for screen readers.

Fixed 4 instances in:
- Reorder items header
- Unchecked items header
- No status items divider and header

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
