### PR TITLE
Enable partial energy-sources-table by type

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -257,7 +257,7 @@ export const getFossilEnergyConsumption = async (
     period,
   });
 
-interface EnergySourceByType {
+export interface EnergySourceByType {
   grid?: GridSourceTypeEnergyPreference[];
   solar?: SolarSourceTypeEnergyPreference[];
   battery?: BatterySourceTypeEnergyPreference[];

--- a/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
@@ -252,7 +252,14 @@ export class HuiEnergySourcesTableCard
       water: false,
     };
 
-    const types = energySourcesByType(this._data.prefs);
+    const allTypes = energySourcesByType(this._data.prefs);
+    const types = this._config?.types
+      ? Object.fromEntries(
+          Object.entries(allTypes).filter(([key]) =>
+            this._config!.types.includes(key)
+          )
+        )
+      : allTypes;
 
     const computedStyles = getComputedStyle(this);
 

--- a/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
@@ -9,7 +9,7 @@ import { styleMap } from "lit/directives/style-map";
 import { formatNumber } from "../../../../common/number/format_number";
 import { getEnergyColor } from "./common/color";
 import "../../../../components/ha-card";
-import type { EnergyData } from "../../../../data/energy";
+import type { EnergyData, EnergySourceByType } from "../../../../data/energy";
 import {
   energySourcesByType,
   getEnergyDataCollection,
@@ -253,10 +253,11 @@ export class HuiEnergySourcesTableCard
     };
 
     const allTypes = energySourcesByType(this._data.prefs);
-    const types = this._config?.types
+    const pickedTypes = this._config?.types;
+    const types = pickedTypes
       ? Object.fromEntries(
           Object.entries(allTypes).filter(([key]) =>
-            this._config!.types.includes(key)
+            pickedTypes.includes(key as keyof EnergySourceByType)
           )
         )
       : allTypes;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -27,6 +27,7 @@ import type { LovelaceHeaderFooterConfig } from "../header-footer/types";
 import type { LovelaceHeadingBadgeConfig } from "../heading-badges/types";
 import type { TimeFormat } from "../../../data/translation";
 import type { HomeSummary } from "../strategies/home/helpers/home-summaries";
+import type { EnergySourceByType } from "../../../data/energy";
 
 export type AlarmPanelCardConfigState =
   | "arm_away"
@@ -189,6 +190,7 @@ export interface EnergyDevicesDetailGraphCardConfig
 export interface EnergySourcesTableCardConfig extends EnergyCardBaseConfig {
   type: "energy-sources-table";
   title?: string;
+  types?: (keyof EnergySourceByType)[];
 }
 
 export interface EnergySolarGaugeCardConfig extends EnergyCardBaseConfig {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Allow restricting sources table to specific chosen source types. Useful for feature request to customize dashboard to split different categories onto different views.

<img width="1005" height="516" alt="image" src="https://github.com/user-attachments/assets/f6c4517f-764a-4276-9342-ddf86fa696ce" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/1181
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41183

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
