### PR TITLE
Give a warning body in preview for empty stack cards

### DIFF
--- a/src/panels/lovelace/cards/hui-error-card.ts
+++ b/src/panels/lovelace/cards/hui-error-card.ts
@@ -45,6 +45,8 @@ export class HuiErrorCard extends LitElement implements LovelaceCard {
   protected render() {
     const error =
       this._config?.error ||
+      (this.severity === "warning" &&
+        this.hass?.localize("ui.errors.config.configuration_warning")) ||
       this.hass?.localize("ui.errors.config.configuration_error");
     const showTitle =
       this.hass === undefined || this.hass?.user?.is_admin || this.preview;

--- a/src/panels/lovelace/cards/hui-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-stack-card.ts
@@ -7,6 +7,8 @@ import type { LovelaceCard, LovelaceCardEditor } from "../types";
 import "./hui-card";
 import type { HuiCard } from "./hui-card";
 import type { StackCardConfig } from "./types";
+import { createErrorCardElement } from "../create-element/create-element-base";
+import type { HuiErrorCard } from "./hui-error-card";
 
 export abstract class HuiStackCard<T extends StackCardConfig = StackCardConfig>
   extends LitElement
@@ -27,6 +29,8 @@ export abstract class HuiStackCard<T extends StackCardConfig = StackCardConfig>
 
   @state() protected _cards?: HuiCard[];
 
+  @state() protected _errorCard?: HuiErrorCard;
+
   @state() protected _config?: T;
 
   @property({ attribute: false }) public layout?: string;
@@ -44,6 +48,15 @@ export abstract class HuiStackCard<T extends StackCardConfig = StackCardConfig>
       const element = this._createCardElement(card);
       return element;
     });
+    if (this._cards.length === 0) {
+      this._errorCard = createErrorCardElement({
+        type: "error",
+        severity: "warning",
+        message: "Empty card",
+      });
+    } else {
+      this._errorCard = undefined;
+    }
   }
 
   protected update(changedProperties) {
@@ -54,11 +67,17 @@ export abstract class HuiStackCard<T extends StackCardConfig = StackCardConfig>
         this._cards.forEach((card) => {
           card.hass = this.hass;
         });
+        if (this._errorCard) {
+          this._errorCard.hass = this.hass;
+        }
       }
       if (changedProperties.has("preview")) {
         this._cards.forEach((card) => {
           card.preview = this.preview;
         });
+        if (this._errorCard) {
+          this._errorCard.preview = this.preview;
+        }
       }
     }
 
@@ -87,6 +106,7 @@ export abstract class HuiStackCard<T extends StackCardConfig = StackCardConfig>
         : ""}
       <div id="root" dir=${this.hass ? computeRTLDirection(this.hass) : "ltr"}>
         ${this._cards}
+        ${this.preview && this._errorCard ? this._errorCard : nothing}
       </div>
     `;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2104,6 +2104,7 @@
         "visual_editor_not_supported_reason_type": "The visual editor is not available for this type of element.",
         "edit_in_yaml_supported": "You can still edit your config using YAML.",
         "configuration_error": "Configuration error",
+        "configuration_warning": "Configuration warning",
         "configuration_error_reason": "The configuration is not valid. Check the logs for more information.",
         "no_type_provided": "No type provided.",
         "editor_not_supported": "Visual editor is not supported for this configuration",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Give a warning body for stack cards that don't have any cards. In a sections view every card must have at least a body of some size, or else it is unselectable/uneditable. It looks better in masonry as well.

<img width="517" height="456" alt="image" src="https://github.com/user-attachments/assets/030be1ad-4e09-42b1-9ddc-cee6a9474022" />

This warning is only displayed in preview mode, as I'm guessing maybe at least some users use custom cards to generate dynamic list of cards for stack, and probably don't need/want to see this on their dashboard if that generates an empty display. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #27344
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
