### PR TITLE
Refactor: Replace Object.keys().includes() with 'in' operator

### DIFF
--- a/src/dialogs/more-info/ha-more-info-settings.ts
+++ b/src/dialogs/more-info/ha-more-info-settings.ts
@@ -70,9 +70,7 @@ export class HaMoreInfoSettings extends LitElement {
     if (!this.entry) {
       return;
     }
-    if (
-      !Object.keys(PLATFORMS_WITH_SETTINGS_TAB).includes(this.entry.platform)
-    ) {
+    if (!(this.entry.platform in PLATFORMS_WITH_SETTINGS_TAB)) {
       this._settingsElementTag = "entity-registry-settings";
       return;
     }

--- a/src/onboarding/onboarding-restore-backup.ts
+++ b/src/onboarding/onboarding-restore-backup.ts
@@ -209,9 +209,7 @@ class OnboardingRestoreBackup extends LitElement {
       }
 
       if (this._cloudStatus?.logged_in && !this._backupId) {
-        this._backup = backups.find(({ agents }) =>
-          Object.keys(agents).includes(CLOUD_AGENT)
-        );
+        this._backup = backups.find(({ agents }) => CLOUD_AGENT in agents);
 
         if (!this._backup) {
           this._view = "empty_cloud";

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -442,9 +442,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                     : nothing}
                   ${this._manifest?.is_built_in &&
                   this._manifest.quality_scale &&
-                  Object.keys(QUALITY_SCALE_MAP).includes(
-                    this._manifest.quality_scale
-                  )
+                  this._manifest.quality_scale in QUALITY_SCALE_MAP
                     ? html`
                         <div class="integration-info">
                           <a

--- a/src/panels/lovelace/editor/badge-editor/hui-dialog-create-badge.ts
+++ b/src/panels/lovelace/editor/badge-editor/hui-dialog-create-badge.ts
@@ -222,9 +222,9 @@ export class HuiCreateDialogBadge
   private _handleBadgePicked(ev) {
     const config = ev.detail.config;
     if (this._params!.entities && this._params!.entities.length) {
-      if (Object.keys(config).includes("entities")) {
+      if ("entities" in config) {
         config.entities = this._params!.entities;
-      } else if (Object.keys(config).includes("entity")) {
+      } else if ("entity" in config) {
         config.entity = this._params!.entities[0];
       }
     }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
@@ -244,9 +244,9 @@ export class HuiCreateDialogCard
   private _handleCardPicked(ev) {
     const config = ev.detail.config;
     if (this._params!.entities && this._params!.entities.length) {
-      if (Object.keys(config).includes("entities")) {
+      if ("entities" in config) {
         config.entities = this._params!.entities;
-      } else if (Object.keys(config).includes("entity")) {
+      } else if ("entity" in config) {
         config.entity = this._params!.entities[0];
       }
     }

--- a/src/panels/lovelace/editor/config-elements/hui-statistic-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistic-card-editor.ts
@@ -129,8 +129,7 @@ export class HuiStatisticCardEditor
           name: "period",
           required: true,
           selector:
-            selectedPeriodKey &&
-            Object.keys(periods).includes(selectedPeriodKey)
+            selectedPeriodKey && selectedPeriodKey in periods
               ? {
                   select: {
                     multiple: false,


### PR DESCRIPTION
Optimize object property checks by replacing the verbose Object.keys(obj).includes(key) pattern with the more efficient and readable 'key in obj' operator.

Benefits:
- More performant (O(1) vs O(n) for Object.keys().includes())
- More idiomatic JavaScript
- Shorter and more readable code
- Better TypeScript type inference

Changes:
- Replace Object.keys(config).includes('entities') with 'entities' in config
- Replace Object.keys(config).includes('entity') with 'entity' in config
- Replace Object.keys(map).includes(key) with key in map
- Apply across card editors, config panels, and dialogs

Affected files:
- Badge and card creation dialogs
- Statistic card editor
- Integration page quality scale check
- Onboarding backup cloud agent detection
- More info settings platform detection

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
