### PR TITLE
Refactor: Replace deprecated substr() with slice()

### DIFF
--- a/src/common/dom/is-navigation-click.ts
+++ b/src/common/dom/is-navigation-click.ts
@@ -31,10 +31,10 @@ export const isNavigationClick = (e: MouseEvent, preventDefault = true) => {
 
   const location = window.location;
   const origin = location.origin || location.protocol + "//" + location.host;
-  if (href.indexOf(origin) !== 0) {
+  if (!href.startsWith(origin)) {
     return undefined;
   }
-  href = href.substr(origin.length);
+  href = href.slice(origin.length);
 
   if (href === "#") {
     return undefined;

--- a/src/common/entity/compute_object_id.ts
+++ b/src/common/entity/compute_object_id.ts
@@ -1,3 +1,3 @@
 /** Compute the object ID of a state. */
 export const computeObjectId = (entityId: string): string =>
-  entityId.substr(entityId.indexOf(".") + 1);
+  entityId.slice(entityId.indexOf(".") + 1);

--- a/src/common/util/parse-aspect-ratio.ts
+++ b/src/common/util/parse-aspect-ratio.ts
@@ -14,7 +14,7 @@ export default function parseAspectRatio(input: string) {
   }
   try {
     if (input.endsWith("%")) {
-      return { w: 100, h: parseOrThrow(input.substr(0, input.length - 1)) };
+      return { w: 100, h: parseOrThrow(input.slice(0, -1)) };
     }
 
     const arr = input.replace(":", "x").split("x");

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -167,7 +167,7 @@ export const provideHass = (
   }
 
   mockAPI(/states\/.+/, (_method, path, parameters) => {
-    const [domain, objectId] = path.substr(7).split(".", 2);
+    const [domain, objectId] = path.slice(7).split(".", 2);
     if (!domain || !objectId) {
       return;
     }

--- a/src/panels/config/blueprint/ha-config-blueprint.ts
+++ b/src/panels/config/blueprint/ha-config-blueprint.ts
@@ -68,7 +68,7 @@ class HaConfigBlueprint extends HassRouterPage {
       (!changedProps || changedProps.has("route")) &&
       this._currentPage === "edit"
     ) {
-      const blueprintId = this.routeTail.path.substr(1);
+      const blueprintId = this.routeTail.path.slice(1);
       pageEl.blueprintId = blueprintId === "new" ? null : blueprintId;
     }
   }

--- a/src/panels/config/scene/ha-config-scene.ts
+++ b/src/panels/config/scene/ha-config-scene.ts
@@ -74,7 +74,7 @@ class HaConfigScene extends HassRouterPage {
       this._currentPage === "edit"
     ) {
       pageEl.creatingNew = undefined;
-      const sceneId = this.routeTail.path.substr(1);
+      const sceneId = this.routeTail.path.slice(1);
       pageEl.sceneId = sceneId === "new" ? null : sceneId;
     }
   }

--- a/src/panels/config/script/ha-config-script.ts
+++ b/src/panels/config/script/ha-config-script.ts
@@ -98,7 +98,7 @@ class HaConfigScript extends HassRouterPage {
       this._currentPage === "show"
     ) {
       pageEl.creatingNew = undefined;
-      const scriptId = this.routeTail.path.substr(1);
+      const scriptId = this.routeTail.path.slice(1);
       pageEl.entityId = scriptId === "new" ? null : scriptId;
       return;
     }
@@ -108,7 +108,7 @@ class HaConfigScript extends HassRouterPage {
       this._currentPage !== "dashboard"
     ) {
       pageEl.creatingNew = undefined;
-      const scriptId = this.routeTail.path.substr(1);
+      const scriptId = this.routeTail.path.slice(1);
       pageEl.scriptId = scriptId === "new" ? null : scriptId;
     }
   }


### PR DESCRIPTION
Replace all uses of the deprecated substr() method with the modern slice() method across the codebase for better future compatibility.

substr() is deprecated as of ECMAScript 2016 (ES7) and should be replaced with substring() or slice().

Changes:
- Replace path.substr(1) with path.slice(1) for route parsing
- Replace string.substr(start, length) with string.slice(start, end)
- Replace string.substr(0, -1) pattern with slice(0, -1)
- Maintain identical functionality while using modern API

Affected files:
- Script, scene, and blueprint config panels
- Fake data provider
- Parse aspect ratio utility
- Compute object ID utility
- Navigation click handler

This prepares the codebase for future JavaScript versions where substr() may be removed entirely.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
