### PR TITLE
Always display device name in entity picker

### DIFF
--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -157,7 +157,7 @@ export class HaEntityPicker extends LitElement {
     const isRTL = computeRTL(this.hass);
 
     const primary = entityName || deviceName || entityId;
-    const secondary = [areaName, entityName ? deviceName : undefined]
+    const secondary = [areaName, deviceName]
       .filter(Boolean)
       .join(isRTL ? " ◂ " : " ▸ ");
 
@@ -325,7 +325,7 @@ export class HaEntityPicker extends LitElement {
         const domainName = domainToName(hass.localize, computeDomain(entityId));
 
         const primary = entityName || deviceName || entityId;
-        const secondary = [areaName, entityName ? deviceName : undefined]
+        const secondary = [areaName, deviceName]
           .filter(Boolean)
           .join(isRTL ? " ◂ " : " ▸ ");
         const a11yLabel = [deviceName, entityName].filter(Boolean).join(" - ");


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Currently, when the entity name is the same as the device name (either by being the primary entity of the device or by having a custom friendly name set equal to the device name), the device name is not displayed in the entity picker. This makes it look like the entity does not belong to the device since it deviates from the others, and it is not clear for an user as to why.

<img width="534" height="616" alt="swappy-20251008_231239" src="https://github.com/user-attachments/assets/ea490a04-12e9-4cf1-917b-218f804e907a" />


For consistency, this PR makes the device name always visible.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
