### PR TITLE
Automation editor: support multi-select for state triggers/conditions

### DIFF
--- a/src/components/entity/ha-entity-state-picker.ts
+++ b/src/components/entity/ha-entity-state-picker.ts
@@ -58,7 +58,8 @@ class HaEntityStatePicker extends LitElement {
       (changedProps.has("_opened") && this._opened) ||
       changedProps.has("entityId") ||
       changedProps.has("attribute") ||
-      changedProps.has("extraOptions")
+      changedProps.has("extraOptions") ||
+      changedProps.has("hideStates")
     ) {
       const entityIds = this.entityId ? ensureArray(this.entityId) : [];
 

--- a/src/components/entity/ha-entity-states-picker.ts
+++ b/src/components/entity/ha-entity-states-picker.ts
@@ -57,6 +57,15 @@ export class HaEntityStatesPicker extends LitElement {
 
     const value = this.value || [];
     const hide = [...(this.hideStates || []), ...value];
+    const exclusiveValues = (this.extraOptions || [])
+      .filter((opt) => (opt as any)?.exclusive)
+      .map((opt) => (opt as any).value);
+    const anyExclusiveSelected = exclusiveValues.some((v) => value.includes(v));
+    const ANY_STATE_VALUE = "__ANY_STATE_IGNORE_ATTRIBUTES__";
+    const anyStateSelected =
+      this.extraOptions?.some(
+        (opt) => (opt as any)?.value === ANY_STATE_VALUE
+      ) && value.includes(ANY_STATE_VALUE);
 
     return html`
       ${repeat(
@@ -84,7 +93,8 @@ export class HaEntityStatesPicker extends LitElement {
         `
       )}
       <div>
-        ${this.disabled && value.length
+        ${(this.disabled || anyExclusiveSelected || anyStateSelected) &&
+        value.length
           ? nothing
           : keyed(
               value.length,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

In the Automation Editor, the state trigger now prevents selecting the same state value in both the `from` and `to` fields. The UI hides already-selected states from the opposite field and removes overlaps when saving.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

(Disclaimer: This PR is mostly AI generated)

Add multi-select support to the Automation Editor for state-based triggers and conditions:

  - State trigger “from” and “to” now allow selecting multiple states.
  - “Any state (ignore attributes)” is exclusive and hides the additional input when selected.
  - Cross-hide: states selected in “from” are hidden from “to” (and vice versa).
  - State condition “state” now supports multiple selections, matching backend capabilities.

This aligns the UI with backend support for lists (string | string[]).

Docs: https://www.home-assistant.io/docs/automation/trigger/#examples

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

### Trigger

https://github.com/user-attachments/assets/7534dcbc-2a47-4c6f-b56a-750b60a8c1e6

### Condition

https://github.com/user-attachments/assets/1cbc8446-2cc2-4f45-8112-e38c3db80a99



Check out the examples in the documentation: https://www.home-assistant.io/docs/automation/trigger/#examples:~:text=It%E2%80%99s%20possible%20to%20give%20a%20list%20of%20from%20states%20or%20to%20states%3A


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
