### PR TITLE
Disconnect streaming <img> when closing media dialog

### DIFF
--- a/src/panels/media-browser/hui-dialog-web-browser-play-media.ts
+++ b/src/panels/media-browser/hui-dialog-web-browser-play-media.ts
@@ -20,6 +20,11 @@ export class HuiDialogWebBrowserPlayMedia extends LitElement {
 
   public closeDialog() {
     this._params = undefined;
+    const img = this.renderRoot.querySelector("img");
+    if (img) {
+      // Unload streaming images so the connection can be closed
+      img.src = "";
+    }
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
When viewing an image entity in the media browser, for some reason I don't quite understand it is served as a streaming image instead of a static image, so the browser never considers the img download complete.

When viewing the media item in the browser it opens a dialog with the \<img> element, and even when we close the dialog and remove the \<img> from the DOM, the browser still holds the connection and keeps trying to download the image. 

After viewing the dialog 6 times, the maximum number of simultaneous open connections is exhausted and the whole frontend can no longer communicate with the backend, and it becomes unusable until the page is hard closed and reset. 

This change resets the img src when the dialog is closed, which is a way to force the browser to sever the connection and cleanup. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #25993
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
