### PR TITLE
Add dialog for showing offline Zigbee devices

### DIFF
--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-offline-devices.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-offline-devices.ts
@@ -1,0 +1,139 @@
+import type { TemplateResult } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { mdiChevronRight, mdiDevices } from "@mdi/js";
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import "../../../../../components/buttons/ha-progress-button";
+import "../../../../../components/ha-alert";
+import "../../../../../components/ha-button";
+import { createCloseHeading } from "../../../../../components/ha-dialog";
+import "../../../../../components/ha-md-list-item";
+import "../../../../../components/ha-md-list";
+import "../../../../../components/ha-select";
+import type { HassDialog } from "../../../../../dialogs/make-dialog-manager";
+import type { HomeAssistant } from "../../../../../types";
+import type { ZHADevice } from "../../../../../data/zha";
+import { fetchDevices } from "../../../../../data/zha";
+import { haStyleDialog } from "../../../../../resources/styles";
+import "../../../../../components/ha-spinner";
+import "../../../../../components/ha-svg-icon";
+
+@customElement("dialog-zha-offline-devices")
+class DialogZHAOfflineDevices extends LitElement implements HassDialog {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _opened = false;
+
+  @state() private _offlineDevices: ZHADevice[] = [];
+
+  @state() private _isLoading = false;
+
+  @state() private _error: any;
+
+  public showDialog(): void {
+    this._opened = true;
+    this._loadDevices();
+  }
+
+  private async _loadDevices() {
+    this._isLoading = true;
+    try {
+      const devices = await fetchDevices(this.hass);
+      this._offlineDevices = devices.filter((d) => !d.available);
+    } catch (err: any) {
+      this._error = err.message || err;
+    }
+    this._isLoading = false;
+  }
+
+  public closeDialog() {
+    this._opened = false;
+    this._offlineDevices = [];
+    this._isLoading = false;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+    return true;
+  }
+
+  private _renderItem(device: ZHADevice) {
+    return html`<ha-md-list-item
+      type="link"
+      href="/config/devices/device/${device.device_reg_id}"
+    >
+      <ha-svg-icon .path=${mdiDevices} slot="start"></ha-svg-icon>
+      <span slot="headline">${device.user_given_name} (${device.ieee})</span>
+      <span slot="supporting-text">
+        ${this.hass.localize(
+          "ui.panel.config.zha.offline_devices_dialog.last_seen",
+          {
+            date: new Date(device.last_seen).toLocaleString(this.hass.language),
+          }
+        )}
+      </span>
+      <ha-svg-icon slot="end" .path=${mdiChevronRight}></ha-svg-icon>
+    </ha-md-list-item>`;
+  }
+
+  protected render(): TemplateResult | typeof nothing {
+    if (!this._opened) {
+      return nothing;
+    }
+
+    return html`
+      <ha-dialog
+        open
+        scrimClickAction
+        escapeKeyAction
+        @closed=${this.closeDialog}
+        .heading=${createCloseHeading(
+          this.hass,
+          this.hass.localize("ui.panel.config.zha.offline_devices_dialog.title")
+        )}
+      >
+        ${this._error
+          ? html`<ha-alert alert-type="error"
+              >${this.hass.localize(
+                "ui.panel.config.zha.offline_devices_dialog.error_loading",
+                { error: this._error }
+              )}
+            </ha-alert>`
+          : nothing}
+        ${this._isLoading
+          ? html`<ha-spinner></ha-spinner>`
+          : this._offlineDevices.length !== 0
+            ? html`<ha-md-list>
+                ${this._offlineDevices.map((device) =>
+                  this._renderItem(device)
+                )}
+              </ha-md-list>`
+            : html`<ha-alert>
+                ${this.hass.localize(
+                  "ui.panel.config.zha.offline_devices_dialog.no_offline_devices"
+                )}
+              </ha-alert>`}
+
+        <ha-button
+          slot="primaryAction"
+          appearance="plain"
+          @click=${this.closeDialog}
+          >${this.hass.localize("ui.common.close")}
+        </ha-button>
+      </ha-dialog>
+    `;
+  }
+
+  static styles = [
+    haStyleDialog,
+    css`
+      ha-spinner {
+        display: block;
+        margin: 16px auto;
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-zha-offline-devices": DialogZHAOfflineDevices;
+  }
+}

--- a/src/panels/config/integrations/integration-panels/zha/show-dialog-zha-offline-devices.ts
+++ b/src/panels/config/integrations/integration-panels/zha/show-dialog-zha-offline-devices.ts
@@ -1,0 +1,12 @@
+import { fireEvent } from "../../../../../common/dom/fire_event";
+
+export const loadZHAOfflineDevicesDialog = () =>
+  import("./dialog-zha-offline-devices");
+
+export const showZHAOfflineDevicesDialog = (element: HTMLElement): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-zha-offline-devices",
+    dialogImport: loadZHAOfflineDevicesDialog,
+    dialogParams: {},
+  });
+};

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -43,6 +43,7 @@ import type { HomeAssistant, Route } from "../../../../../types";
 import { fileDownload } from "../../../../../util/file_download";
 import "../../../ha-config-section";
 import { showZHAChangeChannelDialog } from "./show-dialog-zha-change-channel";
+import { showZHAOfflineDevicesDialog } from "./show-dialog-zha-offline-devices";
 
 const MULTIPROTOCOL_ADDON_URL = "socket://core-silabs-multiprotocol:9999";
 
@@ -147,28 +148,37 @@ class ZHAConfigDashboard extends LitElement {
               </div>
             </div>
           </div>
-          ${this.configEntryId
-            ? html`<div class="card-actions">
-                <ha-button
-                  href=${`/config/devices/dashboard?historyBack=1&config_entry=${this.configEntryId}`}
-                  appearance="plain"
-                  size="small"
-                >
-                  ${this.hass.localize(
-                    "ui.panel.config.devices.caption"
-                  )}</ha-button
-                >
-                <ha-button
-                  appearance="plain"
-                  size="small"
-                  href=${`/config/entities/dashboard?historyBack=1&config_entry=${this.configEntryId}`}
-                >
-                  ${this.hass.localize(
-                    "ui.panel.config.entities.caption"
-                  )}</ha-button
-                >
-              </div>`
-            : ""}
+          <div class="card-actions" id="status-card-actions">
+            <ha-button
+              id="btn-offline-devices"
+              appearance="plain"
+              size="small"
+              @click=${this._handleShowOfflineDevices}
+              >${this.hass.localize(
+                "ui.panel.config.zha.configuration_page.button_offline_devices"
+              )}</ha-button
+            >
+            ${this.configEntryId
+              ? html` <ha-button
+                    href=${`/config/devices/dashboard?historyBack=1&config_entry=${this.configEntryId}`}
+                    appearance="plain"
+                    size="small"
+                  >
+                    ${this.hass.localize(
+                      "ui.panel.config.devices.caption"
+                    )}</ha-button
+                  >
+                  <ha-button
+                    appearance="plain"
+                    size="small"
+                    href=${`/config/entities/dashboard?historyBack=1&config_entry=${this.configEntryId}`}
+                  >
+                    ${this.hass.localize(
+                      "ui.panel.config.entities.caption"
+                    )}</ha-button
+                  >`
+              : nothing}
+          </div>
         </ha-card>
         <ha-card
           class="network-settings"
@@ -417,6 +427,10 @@ class ZHAConfigDashboard extends LitElement {
       schema.name;
   }
 
+  private _handleShowOfflineDevices() {
+    showZHAOfflineDevicesDialog(this);
+  }
+
   static get styles(): CSSResultGroup {
     return [
       haStyle,
@@ -430,6 +444,14 @@ class ZHAConfigDashboard extends LitElement {
         ha-card .card-actions {
           display: flex;
           justify-content: flex-end;
+        }
+
+        #status-card-actions {
+          justify-content: center;
+        }
+
+        .card-actions #btn-offline-devices {
+          margin-right: auto;
         }
 
         .network-settings ha-settings-row {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5893,7 +5893,8 @@
             "channel_dialog": {
               "title": "Multiprotocol add-on in use",
               "text": "Zigbee and Thread share the same adapter and must use the same channel. Change the channel of both networks by reconfiguring multiprotocol from the hardware menu."
-            }
+            },
+            "button_offline_devices": "Offline devices"
           },
           "add_device_page": {
             "spinner": "Searching for Zigbee devices…",
@@ -6004,6 +6005,12 @@
             "channel_has_been_changed": "Network channel has been changed",
             "devices_will_rejoin": "Devices will re-join the network over time. This may take a few minutes.",
             "channel_auto": "Smart"
+          },
+          "offline_devices_dialog": {
+            "title": "Offline devices",
+            "last_seen": "Last seen at {date}",
+            "error_loading": "Error loading offline devices: {error}",
+            "no_offline_devices": "No offline devices found"
           }
         },
         "zwave_js": {


### PR DESCRIPTION
## Proposed change
Add a dialog for showing offline Zigbee devices. You could view them in the visualization tab but on mobile I do find it easier to have it in a list. It took me also a few minutes until i realized i can see them in visualization tab as well 🙂 

| <img width="490" height="359" alt="image" src="https://github.com/user-attachments/assets/30be3ca1-9424-4b90-9819-ef01f04a36ae" /> | <img width="413" height="235" alt="image" src="https://github.com/user-attachments/assets/e685cf77-3bdb-49f5-9a5b-c608840d616c" /> |
| :-: | :-: |
| <img width="536" height="181" alt="image" src="https://github.com/user-attachments/assets/f56e7b21-9394-490c-8fec-e754ff0ac9c5" /> | |

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
