### PR TITLE
Add support for next_flow on abort

### DIFF
--- a/src/data/data_entry_flow.ts
+++ b/src/data/data_entry_flow.ts
@@ -79,6 +79,7 @@ export interface DataEntryFlowStepAbort {
   reason: string;
   description_placeholders?: Record<string, string>;
   translation_domain?: string;
+  next_flow?: [FlowType, string]; // [flow_type, flow_id]
 }
 
 export interface DataEntryFlowStepProgress {

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -472,7 +472,10 @@ class DataEntryFlowDialog extends LitElement {
     this._step = undefined;
     await this.updateComplete;
     this._step = _step;
-    if (_step.type === "create_entry" && _step.next_flow) {
+    if (
+      (_step.type === "create_entry" || _step.type === "abort") &&
+      _step.next_flow
+    ) {
       // skip device rename if there is a chained flow
       this._step = undefined;
       this._handler = undefined;
@@ -486,7 +489,7 @@ class DataEntryFlowDialog extends LitElement {
           carryOverDevices: this._devices(
             this._params!.flowConfig.showDevices,
             Object.values(this.hass.devices),
-            _step.result?.entry_id,
+            _step.type === "create_entry" ? _step.result?.entry_id : undefined,
             this._params!.carryOverDevices
           ).map((device) => device.id),
           dialogClosedCallback: this._params!.dialogClosedCallback,

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -495,26 +495,30 @@ class DataEntryFlowDialog extends LitElement {
           dialogClosedCallback: this._params!.dialogClosedCallback,
         });
       } else if (_step.next_flow[0] === "options_flow") {
-        showOptionsFlowDialog(
-          this._params!.dialogParentElement!,
-          _step.result!,
-          {
-            continueFlowId: _step.next_flow[1],
-            navigateToResult: this._params!.navigateToResult,
-            dialogClosedCallback: this._params!.dialogClosedCallback,
-          }
-        );
+        if (_step.type === "create_entry") {
+          showOptionsFlowDialog(
+            this._params!.dialogParentElement!,
+            _step.result!,
+            {
+              continueFlowId: _step.next_flow[1],
+              navigateToResult: this._params!.navigateToResult,
+              dialogClosedCallback: this._params!.dialogClosedCallback,
+            }
+          );
+        }
       } else if (_step.next_flow[0] === "config_subentries_flow") {
-        showSubConfigFlowDialog(
-          this._params!.dialogParentElement!,
-          _step.result!,
-          _step.next_flow[0],
-          {
-            continueFlowId: _step.next_flow[1],
-            navigateToResult: this._params!.navigateToResult,
-            dialogClosedCallback: this._params!.dialogClosedCallback,
-          }
-        );
+        if (_step.type === "create_entry") {
+          showSubConfigFlowDialog(
+            this._params!.dialogParentElement!,
+            _step.result!,
+            _step.next_flow[0],
+            {
+              continueFlowId: _step.next_flow[1],
+              navigateToResult: this._params!.navigateToResult,
+              dialogClosedCallback: this._params!.dialogClosedCallback,
+            }
+          );
+        }
       } else {
         this.closeDialog();
         showAlertDialog(this._params!.dialogParentElement!, {


### PR DESCRIPTION
**Backend PR**: home-assistant/core#154416 can be merged at any time. This does not need to wait for the backend


## Proposed change

Add support for the `next_flow` parameter on abort-type data entry flows. This allows integrations to chain flows even when aborting with a success reason.

### Background

The Improv BLE integration provisions WiFi credentials to devices over Bluetooth. After successful provisioning, the device comes online via WiFi and is discovered by ESPHome through zeroconf. The current flow is:

1. Improv BLE successfully provisions device → aborts with "provision_successful"
2. User sees "Success" message with optional redirect URL
3. User must manually navigate to add the ESPHome device

This creates a poor user experience because:
- The redirect URL often doesn't work reliably
- Users don't understand they need to add the device again
- The provisioning feels incomplete

### Solution

By adding `next_flow` support to abort results, Improv BLE can now:

1. Successfully provision device → abort with "provision_successful" + `next_flow`
2. Wait up to 10 seconds for ESPHome to discover the device
3. If discovered, seamlessly transition the user to the ESPHome config flow
4. User completes setup in one continuous experience

This pattern is useful for any integration that needs to hand off to another integration after a successful operation that results in an abort (not a config entry).

This complements the backend changes in home-assistant/core that add the `next_flow` parameter to the `async_abort()` method.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

N/A - This is a framework-level change that enables new flow patterns. The Improv BLE integration will use this feature to chain to ESPHome after successful WiFi provisioning.

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion: home-assistant/core#XXXXX (Improv BLE flow chaining)
- Link to documentation pull request: N/A (framework feature, no user-facing documentation needed)

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
