### PR TITLE
Make custom text more discoverable in entity name picker

### DIFF
--- a/src/components/entity/ha-entity-name-picker.ts
+++ b/src/components/entity/ha-entity-name-picker.ts
@@ -147,9 +147,9 @@ export class HaEntityNamePicker extends LitElement {
     return items;
   });
 
-  private _customTextOption = memoizeOne((text: string) => ({
+  private _customNameOption = memoizeOne((text: string) => ({
     primary: this.hass.localize(
-      "ui.components.entity.entity-name-picker.use_custom_name"
+      "ui.components.entity.entity-name-picker.custom_name"
     ),
     secondary: `"${text}"`,
     field_label: text,
@@ -319,7 +319,7 @@ export class HaEntityNamePicker extends LitElement {
       const filteredItems = this._filterSelectedOptions(options, initialValue);
 
       if (initialItem && initialItem.type === "text" && initialItem.text) {
-        filteredItems.push(this._customTextOption(initialItem.text));
+        filteredItems.push(this._customNameOption(initialItem.text));
       }
       this._comboBox.filteredItems = filteredItems;
       this._comboBox.setInputValue(initialValue);
@@ -375,7 +375,7 @@ export class HaEntityNamePicker extends LitElement {
     const fuse = new Fuse(this._comboBox.filteredItems, fuseOptions);
     const filteredItems = fuse.search(filter).map((result) => result.item);
 
-    filteredItems.push(this._customTextOption(input));
+    filteredItems.push(this._customNameOption(input));
     this._comboBox.filteredItems = filteredItems;
   }
 

--- a/src/components/entity/ha-entity-name-picker.ts
+++ b/src/components/entity/ha-entity-name-picker.ts
@@ -25,6 +25,7 @@ import "../ha-sortable";
 interface EntityNameOption {
   primary: string;
   secondary?: string;
+  field_label: string;
   value: string;
 }
 
@@ -121,6 +122,7 @@ export class HaEntityNamePicker extends LitElement {
       return {
         primary,
         secondary,
+        field_label: primary,
         value: name,
       };
     });
@@ -214,7 +216,7 @@ export class HaEntityNamePicker extends LitElement {
             allow-custom-value
             item-id-path="value"
             item-value-path="value"
-            item-label-path="primary"
+            item-label-path="field_label"
             .renderer=${rowRenderer}
             @opened-changed=${this._openedChanged}
             @value-changed=${this._comboBoxValueChanged}
@@ -294,6 +296,16 @@ export class HaEntityNamePicker extends LitElement {
 
       const filteredItems = this._filterSelectedOptions(options, initialValue);
 
+      if (initialItem && initialItem.type === "text" && initialItem.text) {
+        filteredItems.push({
+          primary: this.hass.localize(
+            "ui.components.entity.entity-name-picker.use_custom_name"
+          ),
+          secondary: `"${initialItem.text}"`,
+          field_label: initialItem.text,
+          value: initialItem.text,
+        });
+      }
       this._comboBox.filteredItems = filteredItems;
       this._comboBox.setInputValue(initialValue);
     } else {
@@ -352,6 +364,14 @@ export class HaEntityNamePicker extends LitElement {
     const fuse = new Fuse(this._comboBox.filteredItems, fuseOptions);
     const filteredItems = fuse.search(filter).map((result) => result.item);
 
+    filteredItems.push({
+      primary: this.hass.localize(
+        "ui.components.entity.entity-name-picker.use_custom_name"
+      ),
+      secondary: `"${input}"`,
+      field_label: input,
+      value: input,
+    });
     this._comboBox.filteredItems = filteredItems;
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -667,7 +667,7 @@
             "device_missing": "No related device"
           },
           "add": "Add",
-          "use_custom_name": "Use custom name"
+          "custom_name": "Custom name"
         },
         "entity-attribute-picker": {
           "attribute": "Attribute",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -666,7 +666,8 @@
             "floor_missing": "No floor assigned",
             "device_missing": "No related device"
           },
-          "add": "Add"
+          "add": "Add",
+          "use_custom_name": "Use custom name"
         },
         "entity-attribute-picker": {
           "attribute": "Attribute",


### PR DESCRIPTION
## Proposed change

Make custom text more discoverable in entity name picker

<img width="462" height="261" alt="CleanShot 2025-10-14 at 14 04 27" src="https://github.com/user-attachments/assets/8f396723-eda0-4f18-9d48-08c53b554e64" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
