### PR TITLE
Use ha-filter-chips for target picker

### DIFF
--- a/src/components/chips/ha-filter-chip.ts
+++ b/src/components/chips/ha-filter-chip.ts
@@ -1,9 +1,9 @@
+import { styles as elevatedStyles } from "@material/web/chips/internal/elevated-styles";
 import { FilterChip } from "@material/web/chips/internal/filter-chip";
 import { styles } from "@material/web/chips/internal/filter-styles";
 import { styles as selectableStyles } from "@material/web/chips/internal/selectable-styles";
 import { styles as sharedStyles } from "@material/web/chips/internal/shared-styles";
 import { styles as trailingIconStyles } from "@material/web/chips/internal/trailing-icon-styles";
-import { styles as elevatedStyles } from "@material/web/chips/internal/elevated-styles";
 import { css, html } from "lit";
 import { customElement, property } from "lit/decorators";
 
@@ -30,6 +30,7 @@ export class HaFilterChip extends FilterChip {
           var(--rgb-primary-text-color),
           0.15
         );
+        border-radius: var(--ha-border-radius-md);
       }
     `,
   ];

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -76,7 +76,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
 
   @state() private _narrow = false;
 
-  @state() private _pickerFilters: TargetTypeFloorless[] = [];
+  @state() private _pickerFilter?: TargetTypeFloorless;
 
   @state() private _pickerWrapperOpen = false;
 
@@ -330,12 +330,16 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     });
   };
 
-  private _handleUpdatePickerFilters(ev: CustomEvent<TargetTypeFloorless[]>) {
-    this._updatePickerFilters(ev.detail);
+  private _handleUpdatePickerFilter(
+    ev: CustomEvent<TargetTypeFloorless | undefined>
+  ) {
+    this._updatePickerFilter(
+      typeof ev.detail === "string" ? ev.detail : undefined
+    );
   }
 
-  private _updatePickerFilters = (filters: TargetTypeFloorless[]) => {
-    this._pickerFilters = filters;
+  private _updatePickerFilter = (filter?: TargetTypeFloorless) => {
+    this._pickerFilter = filter;
   };
 
   private _hidePicker() {
@@ -355,8 +359,8 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     return html`
       <ha-target-picker-selector
         .hass=${this.hass}
-        @filter-types-changed=${this._handleUpdatePickerFilters}
-        .filterTypes=${this._pickerFilters}
+        @filter-type-changed=${this._handleUpdatePickerFilter}
+        .filterType=${this._pickerFilter}
         @target-picked=${this._handleTargetPicked}
         @create-domain-picked=${this._handleCreateDomain}
         .targetValue=${this.value}

--- a/src/components/target-picker/ha-target-picker-selector.ts
+++ b/src/components/target-picker/ha-target-picker-selector.ts
@@ -1,6 +1,6 @@
 import type { LitVirtualizer } from "@lit-labs/virtualizer";
 import { consume } from "@lit/context";
-import { mdiCheck, mdiPlus, mdiTextureBox } from "@mdi/js";
+import { mdiPlus, mdiTextureBox } from "@mdi/js";
 import Fuse from "fuse.js";
 import type { HassServiceTarget } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing, type PropertyValues } from "lit";
@@ -43,9 +43,9 @@ import { haStyleScrollbar } from "../../resources/styles";
 import { loadVirtualizer } from "../../resources/virtualizer";
 import type { HomeAssistant } from "../../types";
 import { brandsUrl } from "../../util/brands-url";
+import "../chips/ha-filter-chip";
 import type { HaDevicePickerDeviceFilterFunc } from "../device/ha-device-picker";
 import "../entity/state-badge";
-import "../ha-button";
 import "../ha-combo-box-item";
 import "../ha-floor-icon";
 import "../ha-md-list";
@@ -430,21 +430,15 @@ export class HaTargetPickerSelector extends LitElement {
 
       const selected = this.filterTypes.includes(filterType);
       return html`
-        <ha-button
+        <ha-filter-chip
           @click=${this._toggleFilter}
           .type=${filterType}
-          size="small"
-          .variant=${selected ? "brand" : "neutral"}
-          appearance="filled"
-          no-shrink
-        >
-          ${selected
-            ? html`<ha-svg-icon slot="start" .path=${mdiCheck}></ha-svg-icon>`
-            : nothing}
-          ${this.hass.localize(
+          .selected=${selected}
+          .label=${this.hass.localize(
             `ui.components.target-picker.type.${filterType === "entity" ? "entities" : `${filterType}s`}` as LocalizeKeys
           )}
-        </ha-button>
+        >
+        </ha-filter-chip>
       `;
     });
   }
@@ -944,6 +938,7 @@ export class HaTargetPickerSelector extends LitElement {
   }
 
   private _toggleFilter(ev: any) {
+    ev.stopPropagation();
     this._resetSelectedItem();
     this._filterHeader = undefined;
     const type = ev.target.type as TargetTypeFloorless;
@@ -997,15 +992,18 @@ export class HaTargetPickerSelector extends LitElement {
         gap: var(--ha-space-2);
         padding: var(--ha-space-3) var(--ha-space-3);
         overflow: auto;
-        --ha-button-border-radius: var(--ha-border-radius-md);
       }
 
       :host([mode="dialog"]) .filter {
         padding: var(--ha-space-3) var(--ha-space-4);
       }
 
-      .filter ha-button {
+      .filter ha-filter-chip {
         flex-shrink: 0;
+        --md-filter-chip-selected-container-color: var(
+          --ha-color-fill-primary-normal-hover
+        );
+        color: var(--primary-color);
       }
 
       .filter .separator {

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -18,7 +18,6 @@ import { classMap } from "lit/directives/class-map";
 import { fireEvent } from "../common/dom/fire_event";
 import type { LocalizeFunc } from "../common/translations/localize";
 import "../components/chips/ha-assist-chip";
-import "../components/chips/ha-filter-chip";
 import "../components/data-table/ha-data-table";
 import type {
   DataTableColumnContainer,


### PR DESCRIPTION
## Proposed change
- target picker
	- use `ha-filter-chips` instead if `ha-button` for target-picker-filter
		- inside a `ha-chip-set`
		- adopted border-radius for all filter chips
	- Restrict filter to 1 selected. Approved by design

<img width="715" height="587" alt="grafik" src="https://github.com/user-attachments/assets/239620ff-ffc2-4a9c-a0be-95967526baa3" />

<img width="715" height="587" alt="grafik" src="https://github.com/user-attachments/assets/6658c5fe-f9dc-4891-a10e-3e22608abdd2" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
