### PR TITLE
Align state content picker with entity name picker

### DIFF
--- a/src/components/entity/ha-entity-state-content-picker.ts
+++ b/src/components/entity/ha-entity-state-content-picker.ts
@@ -1,23 +1,39 @@
-import { mdiDragHorizontalVariant } from "@mdi/js";
+import "@material/mwc-menu/mwc-menu-surface";
+import { mdiDragHorizontalVariant, mdiPlus } from "@mdi/js";
+import type { ComboBoxLitRenderer } from "@vaadin/combo-box/lit";
+import type { IFuseOptions } from "fuse.js";
+import Fuse from "fuse.js";
 import type { HassEntity } from "home-assistant-js-websocket";
-import type { PropertyValues } from "lit";
-import { LitElement, css, html, nothing } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
 import memoizeOne from "memoize-one";
 import { ensureArray } from "../../common/array/ensure-array";
 import { fireEvent } from "../../common/dom/fire_event";
+import { stopPropagation } from "../../common/dom/stop_propagation";
 import { computeDomain } from "../../common/entity/compute_domain";
 import {
   STATE_DISPLAY_SPECIAL_CONTENT,
   STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS,
 } from "../../state-display/state-display";
 import type { HomeAssistant, ValueChangedEvent } from "../../types";
-import "../ha-combo-box";
-import "../ha-sortable";
-import "../chips/ha-input-chip";
+import "../chips/ha-assist-chip";
 import "../chips/ha-chip-set";
+import "../chips/ha-input-chip";
+import "../ha-combo-box";
 import type { HaComboBox } from "../ha-combo-box";
+import "../ha-sortable";
+
+interface StateContentOption {
+  primary: string;
+  value: string;
+}
+
+const rowRenderer: ComboBoxLitRenderer<StateContentOption> = (item) => html`
+  <ha-combo-box-item type="button">
+    <span slot="headline">${item.primary}</span>
+  </ha-combo-box-item>
+`;
 
 const HIDDEN_ATTRIBUTES = [
   "access_token",
@@ -74,7 +90,7 @@ const HIDDEN_ATTRIBUTES = [
 ];
 
 @customElement("ha-entity-state-content-picker")
-class HaEntityStatePicker extends LitElement {
+export class HaStateContentPicker extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public entityId?: string;
@@ -95,26 +111,28 @@ class HaEntityStatePicker extends LitElement {
 
   @property() public helper?: string;
 
-  @state() private _opened = false;
+  @query(".container", true) private _container?: HTMLDivElement;
 
   @query("ha-combo-box", true) private _comboBox!: HaComboBox;
 
-  protected shouldUpdate(changedProps: PropertyValues) {
-    return !(!changedProps.has("_opened") && this._opened);
-  }
+  @state() private _opened = false;
 
-  private options = memoizeOne(
+  private _editIndex?: number;
+
+  private _options = memoizeOne(
     (entityId?: string, stateObj?: HassEntity, allowName?: boolean) => {
       const domain = entityId ? computeDomain(entityId) : undefined;
       return [
         {
-          label: this.hass.localize("ui.components.state-content-picker.state"),
+          primary: this.hass.localize(
+            "ui.components.state-content-picker.state"
+          ),
           value: "state",
         },
         ...(allowName
           ? [
               {
-                label: this.hass.localize(
+                primary: this.hass.localize(
                   "ui.components.state-content-picker.name"
                 ),
                 value: "name",
@@ -122,13 +140,13 @@ class HaEntityStatePicker extends LitElement {
             ]
           : []),
         {
-          label: this.hass.localize(
+          primary: this.hass.localize(
             "ui.components.state-content-picker.last_changed"
           ),
           value: "last_changed",
         },
         {
-          label: this.hass.localize(
+          primary: this.hass.localize(
             "ui.components.state-content-picker.last_updated"
           ),
           value: "last_updated",
@@ -137,7 +155,7 @@ class HaEntityStatePicker extends LitElement {
           ? STATE_DISPLAY_SPECIAL_CONTENT.filter((content) =>
               STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS[domain]?.includes(content)
             ).map((content) => ({
-              label: this.hass.localize(
+              primary: this.hass.localize(
                 `ui.components.state-content-picker.${content}`
               ),
               value: content,
@@ -146,107 +164,200 @@ class HaEntityStatePicker extends LitElement {
         ...Object.keys(stateObj?.attributes ?? {})
           .filter((a) => !HIDDEN_ATTRIBUTES.includes(a))
           .map((attribute) => ({
+            primary: this.hass.formatEntityAttributeName(stateObj!, attribute),
             value: attribute,
-            label: this.hass.formatEntityAttributeName(stateObj!, attribute),
           })),
-      ];
+      ] satisfies StateContentOption[];
     }
   );
 
-  private _filter = "";
-
   protected render() {
-    if (!this.hass) {
-      return nothing;
-    }
-
     const value = this._value;
 
     const stateObj = this.entityId
       ? this.hass.states[this.entityId]
       : undefined;
 
-    const options = this.options(this.entityId, stateObj, this.allowName);
-    const optionItems = options.filter(
-      (option) => !this._value.includes(option.value)
-    );
+    const options = this._options(this.entityId, stateObj, this.allowName);
 
     return html`
-      ${value?.length
-        ? html`
-            <ha-sortable
-              no-style
-              @item-moved=${this._moveItem}
-              .disabled=${this.disabled}
-              handle-selector="button.primary.action"
-            >
-              <ha-chip-set>
-                ${repeat(
-                  this._value,
-                  (item) => item,
-                  (item, idx) => {
-                    const label =
-                      options.find((option) => option.value === item)?.label ||
-                      item;
-                    return html`
-                      <ha-input-chip
-                        .idx=${idx}
-                        @remove=${this._removeItem}
-                        .label=${label}
-                        selected
-                      >
-                        <ha-svg-icon
-                          slot="icon"
-                          .path=${mdiDragHorizontalVariant}
-                        ></ha-svg-icon>
-                        ${label}
-                      </ha-input-chip>
-                    `;
-                  }
-                )}
-              </ha-chip-set>
-            </ha-sortable>
-          `
-        : nothing}
+      ${this.label ? html`<label>${this.label}</label>` : nothing}
+      <div class="container ${this.disabled ? "disabled" : ""}">
+        <ha-sortable
+          no-style
+          @item-moved=${this._moveItem}
+          .disabled=${this.disabled}
+          handle-selector="button.primary.action"
+          filter=".add"
+        >
+          <ha-chip-set>
+            ${repeat(
+              this._value,
+              (item) => item,
+              (item: string, idx) => {
+                const label = options.find((o) => o.value === item)?.primary;
+                const isValid = !!label;
+                return html`
+                  <ha-input-chip
+                    data-idx=${idx}
+                    @remove=${this._removeItem}
+                    @click=${this._editItem}
+                    .label=${label || item}
+                    .selected=${!this.disabled}
+                    .disabled=${this.disabled}
+                    class=${!isValid ? "invalid" : ""}
+                  >
+                    <ha-svg-icon
+                      slot="icon"
+                      .path=${mdiDragHorizontalVariant}
+                    ></ha-svg-icon>
+                  </ha-input-chip>
+                `;
+              }
+            )}
+            ${this.disabled
+              ? nothing
+              : html`
+                  <ha-assist-chip
+                    @click=${this._addItem}
+                    .disabled=${this.disabled}
+                    label=${this.hass.localize(
+                      "ui.components.entity.entity-state-content-picker.add"
+                    )}
+                    class="add"
+                  >
+                    <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
+                  </ha-assist-chip>
+                `}
+          </ha-chip-set>
+        </ha-sortable>
 
-      <ha-combo-box
-        item-value-path="value"
-        item-label-path="label"
-        .hass=${this.hass}
-        .label=${this.label}
-        .helper=${this.helper}
-        .disabled=${this.disabled}
-        .required=${this.required && !value.length}
-        .value=${""}
-        .items=${optionItems}
-        allow-custom-value
-        @filter-changed=${this._filterChanged}
-        @value-changed=${this._comboBoxValueChanged}
-        @opened-changed=${this._openedChanged}
-      ></ha-combo-box>
+        <mwc-menu-surface
+          .open=${this._opened}
+          @closed=${this._onClosed}
+          @opened=${this._onOpened}
+          @input=${stopPropagation}
+          .anchor=${this._container}
+        >
+          <ha-combo-box
+            .hass=${this.hass}
+            .value=${""}
+            .autofocus=${this.autofocus}
+            .disabled=${this.disabled || !this.entityId}
+            .required=${this.required && !value.length}
+            .helper=${this.helper}
+            .items=${options}
+            allow-custom-value
+            item-id-path="value"
+            item-value-path="value"
+            item-label-path="primary"
+            .renderer=${rowRenderer}
+            @opened-changed=${this._openedChanged}
+            @value-changed=${this._comboBoxValueChanged}
+            @filter-changed=${this._filterChanged}
+          >
+          </ha-combo-box>
+        </mwc-menu-surface>
+      </div>
     `;
+  }
+
+  private _onClosed(ev) {
+    ev.stopPropagation();
+    this._opened = false;
+    this._editIndex = undefined;
+  }
+
+  private async _onOpened(ev) {
+    if (!this._opened) {
+      return;
+    }
+    ev.stopPropagation();
+    this._opened = true;
+    await this._comboBox?.focus();
+    await this._comboBox?.open();
+  }
+
+  private async _addItem(ev) {
+    ev.stopPropagation();
+    this._opened = true;
+  }
+
+  private async _editItem(ev) {
+    ev.stopPropagation();
+    const idx = parseInt(ev.currentTarget.dataset.idx, 10);
+    this._editIndex = idx;
+    this._opened = true;
   }
 
   private get _value() {
     return !this.value ? [] : ensureArray(this.value);
   }
 
+  private _toValue = memoizeOne((value: string[]): typeof this.value => {
+    if (value.length === 0) {
+      return undefined;
+    }
+    if (value.length === 1) {
+      return value[0];
+    }
+    return value;
+  });
+
   private _openedChanged(ev: ValueChangedEvent<boolean>) {
-    this._opened = ev.detail.value;
-    this._comboBox.filteredItems = this._comboBox.items;
+    const open = ev.detail.value;
+    if (open) {
+      const options = this._comboBox.items || [];
+
+      const initialValue =
+        this._editIndex != null ? this._value[this._editIndex] : "";
+      const filteredItems = this._filterSelectedOptions(options, initialValue);
+
+      this._comboBox.filteredItems = filteredItems;
+      this._comboBox.setInputValue(initialValue);
+    } else {
+      this._opened = false;
+    }
   }
 
-  private _filterChanged(ev?: CustomEvent): void {
-    this._filter = ev?.detail.value || "";
+  private _filterSelectedOptions = (
+    options: StateContentOption[],
+    current?: string
+  ) => {
+    const value = this._value;
 
-    const filteredItems = this._comboBox.items?.filter((item) => {
-      const label = item.label || item.value;
-      return label.toLowerCase().includes(this._filter?.toLowerCase());
-    });
+    return options.filter(
+      (option) => !value.includes(option.value) || option.value === current
+    );
+  };
 
-    if (this._filter) {
-      filteredItems?.unshift({ label: this._filter, value: this._filter });
+  private _filterChanged(ev: ValueChangedEvent<string>) {
+    const input = ev.detail.value;
+    const filter = input?.toLowerCase() || "";
+    const options = this._comboBox.items || [];
+
+    const currentValue =
+      this._editIndex != null ? this._value[this._editIndex] : "";
+
+    this._comboBox.filteredItems = this._filterSelectedOptions(
+      options,
+      currentValue
+    );
+
+    if (!filter) {
+      return;
     }
+
+    const fuseOptions: IFuseOptions<StateContentOption> = {
+      keys: ["primary", "secondary", "value"],
+      isCaseSensitive: false,
+      minMatchCharLength: Math.min(filter.length, 2),
+      threshold: 0.2,
+      ignoreDiacritics: true,
+    };
+
+    const fuse = new Fuse(this._comboBox.filteredItems, fuseOptions);
+    const filteredItems = fuse.search(filter).map((result) => result.item);
 
     this._comboBox.filteredItems = filteredItems;
   }
@@ -260,43 +371,40 @@ class HaEntityStatePicker extends LitElement {
     newValue.splice(newIndex, 0, element);
     this._setValue(newValue);
     await this.updateComplete;
-    this._filterChanged();
+    this._filterChanged({ detail: { value: "" } } as ValueChangedEvent<string>);
   }
 
   private async _removeItem(ev) {
     ev.stopPropagation();
-    const value: string[] = [...this._value];
-    value.splice(ev.target.idx, 1);
+    const value = [...this._value];
+    const idx = parseInt(ev.target.dataset.idx, 10);
+    value.splice(idx, 1);
     this._setValue(value);
     await this.updateComplete;
-    this._filterChanged();
+    this._filterChanged({ detail: { value: "" } } as ValueChangedEvent<string>);
   }
 
-  private _comboBoxValueChanged(ev: CustomEvent): void {
+  private _comboBoxValueChanged(ev: ValueChangedEvent<string>): void {
     ev.stopPropagation();
-    const newValue = ev.detail.value;
+    const value = ev.detail.value;
 
-    if (this.disabled || newValue === "") {
+    if (this.disabled || value === "") {
       return;
     }
 
-    const currentValue = this._value;
+    const newValue = [...this._value];
 
-    if (currentValue.includes(newValue)) {
-      return;
+    if (this._editIndex != null) {
+      newValue[this._editIndex] = value;
+    } else {
+      newValue.push(value);
     }
 
-    setTimeout(() => {
-      this._filterChanged();
-      this._comboBox.setInputValue("");
-    }, 0);
-
-    this._setValue([...currentValue, newValue]);
+    this._setValue(newValue);
   }
 
   private _setValue(value: string[]) {
-    const newValue =
-      value.length === 0 ? undefined : value.length === 1 ? value[0] : value;
+    const newValue = this._toValue(value);
     this.value = newValue;
     fireEvent(this, "value-changed", {
       value: newValue,
@@ -306,10 +414,64 @@ class HaEntityStatePicker extends LitElement {
   static styles = css`
     :host {
       position: relative;
+      width: 100%;
+    }
+
+    .container {
+      position: relative;
+      background-color: var(--mdc-text-field-fill-color, whitesmoke);
+      border-radius: var(--ha-border-radius-sm);
+      border-end-end-radius: var(--ha-border-radius-square);
+      border-end-start-radius: var(--ha-border-radius-square);
+    }
+    .container:after {
+      display: block;
+      content: "";
+      position: absolute;
+      pointer-events: none;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 1px;
+      width: 100%;
+      background-color: var(
+        --mdc-text-field-idle-line-color,
+        rgba(0, 0, 0, 0.42)
+      );
+      transform:
+        height 180ms ease-in-out,
+        background-color 180ms ease-in-out;
+    }
+    .container.disabled:after {
+      background-color: var(
+        --mdc-text-field-disabled-line-color,
+        rgba(0, 0, 0, 0.42)
+      );
+    }
+    .container:focus-within:after {
+      height: 2px;
+      background-color: var(--mdc-theme-primary);
+    }
+
+    label {
+      display: block;
+      margin: 0 0 var(--ha-space-2);
+    }
+
+    .add {
+      order: 1;
+    }
+
+    mwc-menu-surface {
+      --mdc-menu-min-width: 100%;
     }
 
     ha-chip-set {
-      padding: 8px 0;
+      padding: var(--ha-space-2) var(--ha-space-2);
+    }
+
+    .invalid {
+      text-decoration: line-through;
     }
 
     .sortable-fallback {
@@ -329,6 +491,6 @@ class HaEntityStatePicker extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "ha-entity-state-content-picker": HaEntityStatePicker;
+    "ha-entity-state-content-picker": HaStateContentPicker;
   }
 }

--- a/src/components/ha-selector/ha-selector-ui-state-content.ts
+++ b/src/components/ha-selector/ha-selector-ui-state-content.ts
@@ -36,7 +36,7 @@ export class HaSelectorUiStateContent extends SubscribeMixin(LitElement) {
         .helper=${this.helper}
         .disabled=${this.disabled}
         .required=${this.required}
-        .allowName=${this.selector.ui_state_content?.allow_name}
+        .allowName=${this.selector.ui_state_content?.allow_name || false}
       ></ha-entity-state-content-picker>
     `;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -676,6 +676,9 @@
         },
         "entity-state-picker": {
           "state": "State"
+        },
+        "entity-state-content-picker": {
+          "add": "Add"
         }
       },
       "target-picker": {


### PR DESCRIPTION
## Proposed change

Align state content picker with entity name picker.

<img width="420" height="93" alt="CleanShot 2025-10-16 at 09 51 31" src="https://github.com/user-attachments/assets/938ae904-11c0-4cba-bc72-d1c0cf0b11c1" />

The features and the behavior for default state didn't change yet. It's only a design change for now. I will look to have the same logic as the entity name : 
- display the default value
- removing all the chips will hide the state.

It will be another PR because it has impact on the card configuration (`hide_state` will be removed).

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
