### PR TITLE
Add more-info panel for event entity

### DIFF
--- a/src/dialogs/more-info/const.ts
+++ b/src/dialogs/more-info/const.ts
@@ -51,6 +51,7 @@ export const DOMAINS_WITH_MORE_INFO = [
   "cover",
   "date",
   "datetime",
+  "event",
   "fan",
   "group",
   "humidifier",
@@ -88,7 +89,6 @@ export const DOMAINS_HIDE_DEFAULT_MORE_INFO = [
   "select",
   "text",
   "update",
-  "event",
 ];
 
 /** Domains that should have the history hidden in the more info dialog. */

--- a/src/dialogs/more-info/controls/more-info-event.ts
+++ b/src/dialogs/more-info/controls/more-info-event.ts
@@ -1,0 +1,36 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+import "../../../components/ha-attributes";
+import "../../../components/ha-yaml-editor";
+import type { HomeAssistant } from "../../../types";
+
+@customElement("more-info-event")
+class MoreInfoEvent extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public stateObj?: HassEntity;
+
+  protected render() {
+    if (!this.hass || !this.stateObj) {
+      return nothing;
+    }
+
+    return html`<p>
+        ${this.hass.localize("ui.components.attributes.expansion_header")}
+      </p>
+
+      <ha-yaml-editor
+        .hass=${this.hass}
+        .value=${this.stateObj.attributes}
+        auto-update
+        read-only
+      ></ha-yaml-editor>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "more-info-event": MoreInfoEvent;
+  }
+}

--- a/src/dialogs/more-info/state_more_info_control.ts
+++ b/src/dialogs/more-info/state_more_info_control.ts
@@ -16,6 +16,7 @@ const LAZY_LOADED_MORE_INFO_CONTROL = {
   cover: () => import("./controls/more-info-cover"),
   date: () => import("./controls/more-info-date"),
   datetime: () => import("./controls/more-info-datetime"),
+  event: () => import("./controls/more-info-event"),
   fan: () => import("./controls/more-info-fan"),
   group: () => import("./controls/more-info-group"),
   humidifier: () => import("./controls/more-info-humidifier"),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Currently **event entities** use the default `more-info-default` panel.

This change adds a readonly yaml editor to display the attributes of **event entities** by introducing a new `more-info-event` panel. The purpose is to simply creation of automations based on events and event data by providing a visual aid and allowing users to copy attributes.

Screenshots are based on the example `event.backup_automatic_backup` event entity.

Current:
<img width="725" height="514" alt="image" src="https://github.com/user-attachments/assets/1f8cba16-8b4d-44f5-bf14-6493cc528c42" />

Proposed new (readonly yaml editor with only the copy and fullscreen actions):
<img width="637" height="520" alt="image" src="https://github.com/user-attachments/assets/cd835560-3a31-4173-b1ec-128c80c357e4" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
