### PR TITLE
Set header bar min height and make sure items are centered

### DIFF
--- a/src/components/ha-dialog-header.ts
+++ b/src/components/ha-dialog-header.ts
@@ -49,7 +49,7 @@ export class HaDialogHeader extends LitElement {
           display: flex;
           flex-direction: row;
           align-items: center;
-          padding: 4px;
+          padding: 0 var(--ha-space-1);
           box-sizing: border-box;
         }
         .header-content {

--- a/src/components/ha-dialog-header.ts
+++ b/src/components/ha-dialog-header.ts
@@ -78,11 +78,6 @@ export class HaDialogHeader extends LitElement {
           line-height: var(--ha-line-height-normal);
           color: var(--secondary-text-color);
         }
-        @media all and (min-width: 450px) and (min-height: 500px) {
-          .header-bar {
-            padding: 16px;
-          }
-        }
         .header-navigation-icon {
           flex: none;
           min-width: 8px;

--- a/src/components/ha-dialog-header.ts
+++ b/src/components/ha-dialog-header.ts
@@ -78,6 +78,11 @@ export class HaDialogHeader extends LitElement {
           line-height: var(--ha-line-height-normal);
           color: var(--secondary-text-color);
         }
+        @media all and (min-width: 450px) and (min-height: 500px) {
+          .header-bar {
+            padding: 0 var(--ha-space-2);
+          }
+        }
         .header-navigation-icon {
           flex: none;
           min-width: 8px;

--- a/src/components/ha-dialog-header.ts
+++ b/src/components/ha-dialog-header.ts
@@ -54,7 +54,7 @@ export class HaDialogHeader extends LitElement {
         }
         .header-content {
           flex: 1;
-          padding: 10px 4px;
+          padding: 10px var(--ha-space-1);
           display: flex;
           flex-direction: column;
           justify-content: center;
@@ -67,7 +67,7 @@ export class HaDialogHeader extends LitElement {
         .header-title {
           height: var(
             --ha-dialog-header-title-height,
-            calc(var(--ha-font-size-xl) + 4px)
+            calc(var(--ha-font-size-xl) + var(--ha-space-1))
           );
           font-size: var(--ha-font-size-xl);
           line-height: var(--ha-line-height-condensed);
@@ -85,14 +85,14 @@ export class HaDialogHeader extends LitElement {
         }
         .header-navigation-icon {
           flex: none;
-          min-width: 8px;
+          min-width: var(--ha-space-2);
           height: 100%;
           display: flex;
           flex-direction: row;
         }
         .header-action-items {
           flex: none;
-          min-width: 8px;
+          min-width: var(--ha-space-2);
           height: 100%;
           display: flex;
           flex-direction: row;

--- a/src/components/ha-dialog-header.ts
+++ b/src/components/ha-dialog-header.ts
@@ -55,6 +55,10 @@ export class HaDialogHeader extends LitElement {
         .header-content {
           flex: 1;
           padding: 10px 4px;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          min-height: var(--ha-space-12);
           min-width: 0;
           overflow: hidden;
           text-overflow: ellipsis;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Originally was set to 48px in the ha-wa-dialog PR, but was removed (https://github.com/home-assistant/frontend/commit/b68464c5d5a04f5abcd1be41dc9ffd4e03a38e32) due to issues with other dialogs, specifically the add card dialog

Also adjusted padding since the height handles top and bottom, and added space tokens.

<details>
<summary>Testing</summary>
Restart (ha-wa-dialog):
<img width="956" height="525" alt="image" src="https://github.com/user-attachments/assets/c12fceef-7126-4991-b871-37685b539dd1" />
<img width="806" height="233" alt="image" src="https://github.com/user-attachments/assets/f0616ceb-2f6b-4e5b-8c86-37c74a9b5341" />

Add card dialog:
<img width="1485" height="488" alt="image" src="https://github.com/user-attachments/assets/651bc86a-9d27-475d-828d-ec984402c70e" />
<img width="765" height="408" alt="image" src="https://github.com/user-attachments/assets/3d3c6be7-0a47-40b0-9df6-7a837eb1eeec" />

More info:
<img width="1000" height="225" alt="image" src="https://github.com/user-attachments/assets/5bfc56f5-b0a2-4ce2-9553-ed993bdb9323" />
<img width="706" height="348" alt="image" src="https://github.com/user-attachments/assets/3e15c653-0b9d-4c85-b4a6-c6af31186380" />

More info (no subtitle):
<img width="1070" height="436" alt="image" src="https://github.com/user-attachments/assets/ebc8c1fe-1b13-4f45-86cb-585d2bf58049" />
<img width="668" height="400" alt="image" src="https://github.com/user-attachments/assets/39a9865b-8980-40ac-8f84-6e5aac5d2893" />

Backup dialog:
<img width="1175" height="481" alt="image" src="https://github.com/user-attachments/assets/c80297e0-a815-469f-9f90-d4cff3652554" />
<img width="760" height="483" alt="image" src="https://github.com/user-attachments/assets/4f5390bb-3c93-4b46-b7aa-01acf8536bc7" />

Fixes issue for new PR with height jumping when adding a subtitle: https://github.com/home-assistant/frontend/pull/27529

<img width="776" height="478" alt="image" src="https://github.com/user-attachments/assets/77377dd5-88e1-456a-83c0-f0b104e08d67" />
<img width="793" height="320" alt="image" src="https://github.com/user-attachments/assets/f02270a8-8eba-4964-9395-e6d6037bf15c" />

</details>



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
