### PR TITLE
Use progress button for config save button in ZHA dashboard

### DIFF
--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -89,7 +89,7 @@ class ZHAConfigDashboard extends LitElement {
 
   @state() private _generatingBackup = false;
 
-  @query("#config-save-button") private _configSaveButton?: HaProgressButton;
+  @query("#config-save-button") private _configSaveButton!: HaProgressButton;
 
   protected firstUpdated(changedProperties: PropertyValues) {
     super.firstUpdated(changedProperties);

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -89,7 +89,7 @@ class ZHAConfigDashboard extends LitElement {
 
   @state() private _generatingBackup = false;
 
-  @query("#config-save-button") private _configSaveButton!: HaProgressButton;
+  @query("#config-save-button") private _configSaveButton?: HaProgressButton;
 
   protected firstUpdated(changedProperties: PropertyValues) {
     super.firstUpdated(changedProperties);

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -9,7 +9,7 @@ import {
 } from "@mdi/js";
 import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
 import "../../../../../components/buttons/ha-progress-button";
 import "../../../../../components/ha-alert";
 import "../../../../../components/ha-button";
@@ -43,6 +43,7 @@ import type { HomeAssistant, Route } from "../../../../../types";
 import { fileDownload } from "../../../../../util/file_download";
 import "../../../ha-config-section";
 import { showZHAChangeChannelDialog } from "./show-dialog-zha-change-channel";
+import type { HaProgressButton } from "../../../../../components/buttons/ha-progress-button";
 
 const MULTIPROTOCOL_ADDON_URL = "socket://core-silabs-multiprotocol:9999";
 
@@ -87,6 +88,8 @@ class ZHAConfigDashboard extends LitElement {
   @state() private _error?: string;
 
   @state() private _generatingBackup = false;
+
+  @query("#config-save-button") private _configSaveButton?: HaProgressButton;
 
   protected firstUpdated(changedProperties: PropertyValues) {
     super.firstUpdated(changedProperties);
@@ -290,7 +293,8 @@ class ZHAConfigDashboard extends LitElement {
                       ></ha-form>
                     </div>
                     <div class="card-actions">
-                      <ha-button
+                      <ha-progress-button
+                        id="config-save-button"
                         appearance="filled"
                         variant="brand"
                         @click=${this._updateConfiguration}
@@ -298,7 +302,7 @@ class ZHAConfigDashboard extends LitElement {
                         ${this.hass.localize(
                           "ui.panel.config.zha.configuration_page.update_button"
                         )}
-                      </ha-button>
+                      </ha-progress-button>
                     </div>
                   </ha-card>`
               )
@@ -416,7 +420,19 @@ class ZHAConfigDashboard extends LitElement {
   }
 
   private async _updateConfiguration(): Promise<any> {
-    await updateZHAConfiguration(this.hass!, this._configuration!.data);
+    if (!this._configSaveButton) {
+      return;
+    }
+
+    this._configSaveButton.progress = true;
+    try {
+      await updateZHAConfiguration(this.hass!, this._configuration!.data);
+      this._configSaveButton.actionSuccess();
+    } catch (_err: any) {
+      this._configSaveButton.actionError();
+    } finally {
+      this._configSaveButton.progress = false;
+    }
   }
 
   private _computeLabelCallback(localize, section: string) {

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -420,18 +420,14 @@ class ZHAConfigDashboard extends LitElement {
   }
 
   private async _updateConfiguration(): Promise<any> {
-    if (!this._configSaveButton) {
-      return;
-    }
-
-    this._configSaveButton.progress = true;
+    this._configSaveButton!.progress = true;
     try {
       await updateZHAConfiguration(this.hass!, this._configuration!.data);
-      this._configSaveButton.actionSuccess();
+      this._configSaveButton!.actionSuccess();
     } catch (_err: any) {
-      this._configSaveButton.actionError();
+      this._configSaveButton!.actionError();
     } finally {
-      this._configSaveButton.progress = false;
+      this._configSaveButton!.progress = false;
     }
   }
 


### PR DESCRIPTION
## Proposed change
Make use of a progress button in the ZHA dashboard when saving the configuration. Currently, a user cannot tell whether the configuration was saved successfully or failed, nor whether the process is still running.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
