### PR TITLE
Consolidate floor sorting with `floorCompare()`

### DIFF
--- a/src/data/area_floor.ts
+++ b/src/data/area_floor.ts
@@ -1,7 +1,6 @@
 import { computeAreaName } from "../common/entity/compute_area_name";
 import { computeDomain } from "../common/entity/compute_domain";
 import { computeFloorName } from "../common/entity/compute_floor_name";
-import { stringCompare } from "../common/string/compare";
 import type { HaDevicePickerDeviceFilterFunc } from "../components/device/ha-device-picker";
 import type { PickerComboBoxItem } from "../components/ha-picker-combo-box";
 import type { HomeAssistant } from "../types";
@@ -13,7 +12,11 @@ import {
 } from "./device_registry";
 import type { HaEntityPickerEntityFilterFunc } from "./entity";
 import type { EntityRegistryDisplayEntry } from "./entity_registry";
-import { getFloorAreaLookup, type FloorRegistryEntry } from "./floor_registry";
+import {
+  floorCompare,
+  getFloorAreaLookup,
+  type FloorRegistryEntry,
+} from "./floor_registry";
 
 export interface FloorComboBoxItem extends PickerComboBoxItem {
   type: "floor" | "area";
@@ -184,6 +187,8 @@ export const getAreasAndFloors = (
     (area) => !area.floor_id || !floorAreaLookup[area.floor_id]
   );
 
+  const compare = floorCompare(haFloors);
+
   // @ts-ignore
   const floorAreaEntries: [
     FloorRegistryEntry | undefined,
@@ -193,12 +198,7 @@ export const getAreasAndFloors = (
       const floor = floors.find((fl) => fl.floor_id === floorId)!;
       return [floor, floorAreas] as const;
     })
-    .sort(([floorA], [floorB]) => {
-      if (floorA.level !== floorB.level) {
-        return (floorA.level ?? 0) - (floorB.level ?? 0);
-      }
-      return stringCompare(floorA.name, floorB.name);
-    });
+    .sort(([floorA], [floorB]) => compare(floorA.floor_id, floorB.floor_id));
 
   const items: FloorComboBoxItem[] = [];
 

--- a/src/data/floor_registry.ts
+++ b/src/data/floor_registry.ts
@@ -68,7 +68,7 @@ export const getFloorAreaLookup = (
 };
 
 export const floorCompare =
-  (entries?: FloorRegistryEntry[], order?: string[]) =>
+  (entries?: HomeAssistant["floors"], order?: string[]) =>
   (a: string, b: string) => {
     const indexA = order ? order.indexOf(a) : -1;
     const indexB = order ? order.indexOf(b) : -1;

--- a/src/data/floor_registry.ts
+++ b/src/data/floor_registry.ts
@@ -73,8 +73,13 @@ export const floorCompare =
     const indexA = order ? order.indexOf(a) : -1;
     const indexB = order ? order.indexOf(b) : -1;
     if (indexA === -1 && indexB === -1) {
-      const nameA = entries?.[a]?.name ?? a;
-      const nameB = entries?.[b]?.name ?? b;
+      const floorA = entries?.[a];
+      const floorB = entries?.[b];
+      if (floorA && floorB && floorA.level !== floorB.level) {
+        return (floorA.level ?? 0) - (floorB.level ?? 0);
+      }
+      const nameA = floorA?.name ?? a;
+      const nameB = floorB?.name ?? b;
       return stringCompare(nameA, nameB);
     }
     if (indexA === -1) {

--- a/src/panels/lovelace/strategies/areas/helpers/areas-strategy-helper.ts
+++ b/src/panels/lovelace/strategies/areas/helpers/areas-strategy-helper.ts
@@ -3,13 +3,11 @@ import { computeStateName } from "../../../../../common/entity/compute_state_nam
 import type { EntityFilterFunc } from "../../../../../common/entity/entity_filter";
 import { generateEntityFilter } from "../../../../../common/entity/entity_filter";
 import { stripPrefixFromEntityName } from "../../../../../common/entity/strip_prefix_from_entity_name";
-import {
-  orderCompare,
-  stringCompare,
-} from "../../../../../common/string/compare";
+import { orderCompare } from "../../../../../common/string/compare";
 import type { AreaRegistryEntry } from "../../../../../data/area_registry";
 import { areaCompare } from "../../../../../data/area_registry";
 import type { FloorRegistryEntry } from "../../../../../data/floor_registry";
+import { floorCompare } from "../../../../../data/floor_registry";
 import type { LovelaceCardConfig } from "../../../../../data/lovelace/config/card";
 import type { HomeAssistant } from "../../../../../types";
 import { supportsAlarmModesCardFeature } from "../../../card-features/hui-alarm-modes-card-feature";
@@ -304,18 +302,11 @@ export const getFloors = (
   floorsOrder?: string[]
 ): FloorRegistryEntry[] => {
   const floors = Object.values(entries);
-  const compare = orderCompare(floorsOrder || []);
+  const compare = floorCompare(entries, floorsOrder);
 
-  return floors.sort((floorA, floorB) => {
-    const order = compare(floorA.floor_id, floorB.floor_id);
-    if (order !== 0) {
-      return order;
-    }
-    if (floorA.level !== floorB.level) {
-      return (floorA.level ?? 0) - (floorB.level ?? 0);
-    }
-    return stringCompare(floorA.name, floorB.name);
-  });
+  return floors.sort((floorA, floorB) =>
+    compare(floorA.floor_id, floorB.floor_id)
+  );
 };
 
 export const computeAreaPath = (areaId: string): string => `areas-${areaId}`;

--- a/test/data/floor_registry.test.ts
+++ b/test/data/floor_registry.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { floorCompare } from "../../src/data/floor_registry";
+import type { FloorRegistryEntry } from "../../src/data/floor_registry";
+
+describe("floorCompare", () => {
+  describe("floorCompare()", () => {
+    it("sorts by floor ID alphabetically", () => {
+      const floors = ["basement", "attic", "ground"];
+
+      expect(floors.sort(floorCompare())).toEqual([
+        "attic",
+        "basement",
+        "ground",
+      ]);
+    });
+
+    it("handles numeric strings in natural order", () => {
+      const floors = ["floor10", "floor2", "floor1"];
+
+      expect(floors.sort(floorCompare())).toEqual([
+        "floor1",
+        "floor2",
+        "floor10",
+      ]);
+    });
+  });
+
+  describe("floorCompare(entries)", () => {
+    it("sorts by floor name from entries", () => {
+      const entries = {
+        floor1: { name: "Ground Floor" } as FloorRegistryEntry,
+        floor2: { name: "First Floor" } as FloorRegistryEntry,
+        floor3: { name: "Basement" } as FloorRegistryEntry,
+      };
+      const floors = ["floor1", "floor2", "floor3"];
+
+      expect(floors.sort(floorCompare(entries))).toEqual([
+        "floor3",
+        "floor2",
+        "floor1",
+      ]);
+    });
+
+    it("falls back to floor ID when entry not found", () => {
+      const entries = {
+        floor1: { name: "Ground Floor" } as FloorRegistryEntry,
+      };
+      const floors = ["xyz", "floor1", "abc"];
+
+      expect(floors.sort(floorCompare(entries))).toEqual([
+        "abc",
+        "floor1",
+        "xyz",
+      ]);
+    });
+  });
+
+  describe("floorCompare(entries, order)", () => {
+    it("follows order array", () => {
+      const entries = {
+        basement: { name: "Basement" } as FloorRegistryEntry,
+        ground: { name: "Ground Floor" } as FloorRegistryEntry,
+        first: { name: "First Floor" } as FloorRegistryEntry,
+      };
+      const order = ["first", "ground", "basement"];
+      const floors = ["basement", "first", "ground"];
+
+      expect(floors.sort(floorCompare(entries, order))).toEqual([
+        "first",
+        "ground",
+        "basement",
+      ]);
+    });
+
+    it("places items not in order array at the end, sorted by name", () => {
+      const entries = {
+        floor1: { name: "First Floor" } as FloorRegistryEntry,
+        floor2: { name: "Ground Floor" } as FloorRegistryEntry,
+        floor3: { name: "Basement" } as FloorRegistryEntry,
+      };
+      const order = ["floor1"];
+      const floors = ["floor3", "floor2", "floor1"];
+
+      expect(floors.sort(floorCompare(entries, order))).toEqual([
+        "floor1",
+        "floor3",
+        "floor2",
+      ]);
+    });
+  });
+});

--- a/test/data/floor_registry.test.ts
+++ b/test/data/floor_registry.test.ts
@@ -26,19 +26,44 @@ describe("floorCompare", () => {
   });
 
   describe("floorCompare(entries)", () => {
-    it("sorts by floor name from entries", () => {
+    it("sorts by level, then by name", () => {
       const entries = {
-        floor1: { name: "Ground Floor" } as FloorRegistryEntry,
-        floor2: { name: "First Floor" } as FloorRegistryEntry,
-        floor3: { name: "Basement" } as FloorRegistryEntry,
+        floor1: { name: "Ground Floor", level: 0 } as FloorRegistryEntry,
+        floor2: { name: "First Floor", level: 1 } as FloorRegistryEntry,
+        floor3: { name: "Basement", level: -1 } as FloorRegistryEntry,
       };
       const floors = ["floor1", "floor2", "floor3"];
 
       expect(floors.sort(floorCompare(entries))).toEqual([
         "floor3",
-        "floor2",
         "floor1",
+        "floor2",
       ]);
+    });
+
+    it("treats null level as 0", () => {
+      const entries = {
+        floor1: { name: "Ground Floor", level: 0 } as FloorRegistryEntry,
+        floor2: { name: "First Floor", level: 1 } as FloorRegistryEntry,
+        floor3: { name: "Basement", level: null } as FloorRegistryEntry,
+      };
+      const floors = ["floor2", "floor3", "floor1"];
+
+      expect(floors.sort(floorCompare(entries))).toEqual([
+        "floor3",
+        "floor1",
+        "floor2",
+      ]);
+    });
+
+    it("sorts by name when levels are equal", () => {
+      const entries = {
+        floor1: { name: "Suite B", level: 1 } as FloorRegistryEntry,
+        floor2: { name: "Suite A", level: 1 } as FloorRegistryEntry,
+      };
+      const floors = ["floor1", "floor2"];
+
+      expect(floors.sort(floorCompare(entries))).toEqual(["floor2", "floor1"]);
     });
 
     it("falls back to floor ID when entry not found", () => {


### PR DESCRIPTION
## Proposed change

Consolidate all floor sorting logic to use the centralized `floorCompare()` function, eliminating code duplication across the codebase.

The `floorCompare()` function was added in the initial floor support but was never used. This PR:
  - Fixes the `floorCompare()` argument type to match `HomeAssistant["floors"]`
  - Adds level-based sorting to `floorCompare()` (custom order → level → name)
  - Updates `getFloors()` helper to use `floorCompare()`
  - Updates `getAreasAndFloors()` to use `floorCompare()`

This ensures consistent floor sorting behavior across all UI components (Lovelace strategies, area/floor pickers, etc.) and makes the code more maintainable.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
