### PR TITLE
data/floor_registry: Use 9999 fallback for null floor levels

### DIFF
--- a/src/data/floor_registry.ts
+++ b/src/data/floor_registry.ts
@@ -76,7 +76,7 @@ export const floorCompare =
       const floorA = entries?.[a];
       const floorB = entries?.[b];
       if (floorA && floorB && floorA.level !== floorB.level) {
-        return (floorA.level ?? 0) - (floorB.level ?? 0);
+        return (floorA.level ?? 9999) - (floorB.level ?? 9999);
       }
       const nameA = floorA?.name ?? a;
       const nameB = floorB?.name ?? b;

--- a/test/data/floor_registry.test.ts
+++ b/test/data/floor_registry.test.ts
@@ -41,18 +41,18 @@ describe("floorCompare", () => {
       ]);
     });
 
-    it("treats null level as 0", () => {
+    it("treats null level as 9999, placing it at the end", () => {
       const entries = {
         floor1: { name: "Ground Floor", level: 0 } as FloorRegistryEntry,
         floor2: { name: "First Floor", level: 1 } as FloorRegistryEntry,
-        floor3: { name: "Basement", level: null } as FloorRegistryEntry,
+        floor3: { name: "Unassigned", level: null } as FloorRegistryEntry,
       };
       const floors = ["floor2", "floor3", "floor1"];
 
       expect(floors.sort(floorCompare(entries))).toEqual([
-        "floor3",
         "floor1",
         "floor2",
+        "floor3",
       ]);
     });
 


### PR DESCRIPTION


## Proposed change

Change the fallback for null floor levels from 0 to 9999, ensuring floors without a defined level appear at the bottom when sorted (after all numbered floors, including negative basement levels).

This matches the original intent from #20206 which added support for floors without levels.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Related PRs:

- https://github.com/home-assistant/frontend/pull/20206
- https://github.com/home-assistant/frontend/pull/27552
- https://github.com/home-assistant/frontend/pull/27553

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
