### PR TITLE
Hide "add hardware" button for hardware integrations

### DIFF
--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -528,18 +528,20 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                     </ha-button>
                   `
                 : nothing}
-              <ha-button
-                .appearance=${canAddDevice ? "filled" : "accent"}
-                @click=${this._addIntegration}
-              >
-                ${this._manifest?.integration_type
-                  ? this.hass.localize(
-                      `ui.panel.config.integrations.integration_page.add_${this._manifest.integration_type}`
-                    )
-                  : this.hass.localize(
-                      `ui.panel.config.integrations.integration_page.add_entry`
-                    )}
-              </ha-button>
+              ${this._manifest?.integration_type !== "hardware"
+                ? html`<ha-button
+                    .appearance=${canAddDevice ? "filled" : "accent"}
+                    @click=${this._addIntegration}
+                  >
+                    ${this._manifest?.integration_type
+                      ? this.hass.localize(
+                          `ui.panel.config.integrations.integration_page.add_${this._manifest.integration_type}`
+                        )
+                      : this.hass.localize(
+                          `ui.panel.config.integrations.integration_page.add_entry`
+                        )}
+                  </ha-button>`
+                : nothing}
               ${Array.from(supportedSubentryTypes).map(
                 (flowType) =>
                   html`<ha-button


### PR DESCRIPTION
## Proposed change

This change hides the "Add hardware" button for hardware integrations, as they cannot be added via the UI.

There are already various special cases in the frontend, e.g. [to hide them from the "add integrations" dialog](https://github.com/home-assistant/frontend/pull/24345), but the button to add another entry is currently not hidden from the actual integration page. This PR does that.

Before | After
--- | ---
<img width="1072" height="348" alt="Bildschirmfoto 2025-10-19 um 23 35 03" src="https://github.com/user-attachments/assets/c55539e3-a2b9-4eb1-839f-de7aae365f1c" /> | <img width="1058" height="343" alt="Bildschirmfoto 2025-10-19 um 23 16 25" src="https://github.com/user-attachments/assets/fc62334f-4d5d-42df-9d2c-2545cf931f29" />

See the linked issue and (alternative) Core PR below for more information on the issue.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/154570
- This PR is related to issue or discussion:
- Link to documentation pull request:

Another alternative is keeping the button, but adding a more helpful error message, instead of showing "not_implemented":
- https://github.com/home-assistant/core/pull/154575

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
