### PR TITLE
Invert floor sort order to match physical layout

### DIFF
--- a/src/data/floor_registry.ts
+++ b/src/data/floor_registry.ts
@@ -76,7 +76,7 @@ export const floorCompare =
       const floorA = entries?.[a];
       const floorB = entries?.[b];
       if (floorA && floorB && floorA.level !== floorB.level) {
-        return (floorA.level ?? 9999) - (floorB.level ?? 9999);
+        return (floorB.level ?? -9999) - (floorA.level ?? -9999);
       }
       const nameA = floorA?.name ?? a;
       const nameB = floorB?.name ?? b;

--- a/test/data/floor_registry.test.ts
+++ b/test/data/floor_registry.test.ts
@@ -26,7 +26,7 @@ describe("floorCompare", () => {
   });
 
   describe("floorCompare(entries)", () => {
-    it("sorts by level, then by name", () => {
+    it("sorts by level descending (highest to lowest), then by name", () => {
       const entries = {
         floor1: { name: "Ground Floor", level: 0 } as FloorRegistryEntry,
         floor2: { name: "First Floor", level: 1 } as FloorRegistryEntry,
@@ -35,13 +35,13 @@ describe("floorCompare", () => {
       const floors = ["floor1", "floor2", "floor3"];
 
       expect(floors.sort(floorCompare(entries))).toEqual([
-        "floor3",
-        "floor1",
         "floor2",
+        "floor1",
+        "floor3",
       ]);
     });
 
-    it("treats null level as 9999, placing it at the end", () => {
+    it("treats null level as -9999, placing it at the end", () => {
       const entries = {
         floor1: { name: "Ground Floor", level: 0 } as FloorRegistryEntry,
         floor2: { name: "First Floor", level: 1 } as FloorRegistryEntry,
@@ -50,8 +50,8 @@ describe("floorCompare", () => {
       const floors = ["floor2", "floor3", "floor1"];
 
       expect(floors.sort(floorCompare(entries))).toEqual([
-        "floor1",
         "floor2",
+        "floor1",
         "floor3",
       ]);
     });


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Change floor sorting from lowest-to-highest to highest-to-lowest, so floors appear in their physical order with upper floors at the top and basements at the bottom.

- Upper floors (e.g., 3, 2, 1) → top of list
- Ground floor (0) → middle
- Basements (e.g., -1, -2) → bottom of list
- Floors without level (null) → at very bottom (sorted by name)

Changed fallback from 9999 to -9999 for null levels to ensure they still appear at the bottom after inverting the sort order.


## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

I guess this could theoretically be seen as a breaking change, since it changes the default sort order of the floors, but I don't know whether I'd go as far as saying that this would "break functionality"

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

hmm... I'm not sure what category to put this in 😅 

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Related changes:

- https://github.com/home-assistant/frontend/pull/27552
- https://github.com/home-assistant/frontend/pull/27553
- https://github.com/home-assistant/frontend/pull/27559

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
