### PR TITLE
Add predicate filter to ha-selector-entity

### DIFF
--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -219,11 +219,16 @@ export interface DurationSelector {
   } | null;
 }
 
+export interface Predicate<T> {
+  test(value: T): boolean;
+}
+
 interface EntitySelectorFilter {
   integration?: string;
   domain?: string | readonly string[];
   device_class?: string | readonly string[];
   supported_features?: number | [number];
+  predicate?: Predicate<HassEntity>;
 }
 
 export interface EntitySelector {
@@ -795,6 +800,7 @@ export const filterSelectorEntities = (
     device_class: filterDeviceClass,
     supported_features: filterSupportedFeature,
     integration: filterIntegration,
+    predicate: filterPredicate,
   } = filterEntity;
 
   if (filterDomain) {
@@ -833,6 +839,10 @@ export const filterSelectorEntities = (
     filterIntegration &&
     entitySources?.[entity.entity_id]?.domain !== filterIntegration
   ) {
+    return false;
+  }
+
+  if (filterPredicate && !filterPredicate.test(entity)) {
     return false;
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Filtering in `ha-selector-entity` is limited (to domain, device_class, integration and supported_features).
For example, it is not possible to filter entities of a specific device.
The proposed approach allows user-defined filters to be defined by a custom predicate.
Particularly necessary for use cases in external components.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```ts

<ha-selector
	.selector=${{
		entity: {
			filter: [
				{
					predicate: {
						test: (entity: HassEntity) => this.filterEntitiesByUnitAndType(entity, someMoreArguments, ...)
					}
				}
			]
		}
	}}
	// ....
>
</ha-selector>

private filterEntitiesByUnitAndType(entity: HassEntity, boolean someArguments, ...) {
   return true/false; // based on custom conditions
}
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
