### PR TITLE
Add description support to fields in object selector

### DIFF
--- a/src/components/ha-selector/ha-selector-object.ts
+++ b/src/components/ha-selector/ha-selector-object.ts
@@ -52,9 +52,10 @@ export class HaObjectSelector extends LitElement {
     const translationKey = this.selector.object?.translation_key;
 
     if (this.localizeValue && translationKey) {
-      const label = this.localizeValue(
-        `${translationKey}.fields.${schema.name}`
-      );
+      const label =
+        this.localizeValue(`${translationKey}.fields.${schema.name}.name`) ||
+        // Fallback for backward compatibility
+        this.localizeValue(`${translationKey}.fields.${schema.name}`);
       if (label) {
         return label;
       }
@@ -66,14 +67,14 @@ export class HaObjectSelector extends LitElement {
     const translationKey = this.selector.object?.translation_key;
 
     if (this.localizeValue && translationKey) {
-      const description = this.localizeValue(
-        `${translationKey}.fields_description.${schema.name}`
+      const helper = this.localizeValue(
+        `${translationKey}.fields.${schema.name}.description`
       );
-      if (description) {
-        return description;
+      if (helper) {
+        return helper;
       }
     }
-    return this.selector.object?.fields?.[schema.name]?.description || "";
+    return this.selector.object?.fields?.[schema.name]?.helper || "";
   };
 
   private _renderItem(item: any, index: number) {

--- a/src/components/ha-selector/ha-selector-object.ts
+++ b/src/components/ha-selector/ha-selector-object.ts
@@ -74,7 +74,7 @@ export class HaObjectSelector extends LitElement {
         return helper;
       }
     }
-    return this.selector.object?.fields?.[schema.name]?.helper || "";
+    return this.selector.object?.fields?.[schema.name]?.description || "";
   };
 
   private _renderItem(item: any, index: number) {

--- a/src/components/ha-selector/ha-selector-object.ts
+++ b/src/components/ha-selector/ha-selector-object.ts
@@ -62,6 +62,20 @@ export class HaObjectSelector extends LitElement {
     return this.selector.object?.fields?.[schema.name]?.label || schema.name;
   };
 
+  private _computeHelper = (schema: HaFormSchema): string => {
+    const translationKey = this.selector.object?.translation_key;
+
+    if (this.localizeValue && translationKey) {
+      const description = this.localizeValue(
+        `${translationKey}.fields_description.${schema.name}`
+      );
+      if (description) {
+        return description;
+      }
+    }
+    return this.selector.object?.fields?.[schema.name]?.description || "";
+  };
+
   private _renderItem(item: any, index: number) {
     const labelField =
       this.selector.object!.label_field ||
@@ -214,6 +228,7 @@ export class HaObjectSelector extends LitElement {
       schema: this._schema(this.selector),
       data: {},
       computeLabel: this._computeLabel,
+      computeHelper: this._computeHelper,
       submitText: this.hass.localize("ui.common.add"),
     });
 

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -352,7 +352,7 @@ export interface NumberSelector {
 interface ObjectSelectorField {
   selector: Selector;
   label?: string;
-  description?: string;
+  helper?: string;
   required?: boolean;
 }
 

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -352,6 +352,7 @@ export interface NumberSelector {
 interface ObjectSelectorField {
   selector: Selector;
   label?: string;
+  description?: string;
   required?: boolean;
 }
 

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -352,7 +352,7 @@ export interface NumberSelector {
 interface ObjectSelectorField {
   selector: Selector;
   label?: string;
-  helper?: string;
+  description?: string;
   required?: boolean;
 }
 


### PR DESCRIPTION
## Proposed change

Add support for description and description translations for fields in object selector. 


Example of core usage : 

### Before
```json
"selector": {
  "answers": {
    "fields": {
      "id": "Answer ID"
      "sentences": "Sentences"
    }
  }
}
```

### After
```json
"selector": {
  "answers": {
    "fields": {
      "id": {
        "name": "Answer ID",
        "description": "The ID of the answer to use."
      },
      "sentences": {
        "name": "Sentences",
        "description": "A list of sentences to choose from."
      }
    }
  }
}
```

The previous format is still valid and and kept as backward compatibility.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
