### PR TITLE
Add color and icon defaults for config labels table

### DIFF
--- a/src/panels/config/labels/ha-config-labels.ts
+++ b/src/panels/config/labels/ha-config-labels.ts
@@ -3,6 +3,7 @@ import {
   mdiDevices,
   mdiDotsVertical,
   mdiHelpCircle,
+  mdiLabelOutline,
   mdiPlus,
   mdiRobot,
   mdiShape,
@@ -23,8 +24,10 @@ import type {
   SortingChangedEvent,
 } from "../../../components/data-table/ha-data-table";
 import "../../../components/ha-fab";
+import "../../../components/ha-icon";
 import "../../../components/ha-icon-button";
-import "../../../components/ha-relative-time";
+import type { HaMdMenu } from "../../../components/ha-md-menu";
+import "../../../components/ha-svg-icon";
 import type {
   LabelRegistryEntry,
   LabelRegistryEntryMutableParams,
@@ -43,7 +46,6 @@ import "../../../layouts/hass-tabs-subpage-data-table";
 import type { HomeAssistant, Route } from "../../../types";
 import { configSections } from "../ha-panel-config";
 import { showLabelDetailDialog } from "./show-dialog-label-detail";
-import type { HaMdMenu } from "../../../components/ha-md-menu";
 
 @customElement("ha-config-labels")
 export class HaConfigLabels extends LitElement {
@@ -100,7 +102,9 @@ export class HaConfigLabels extends LitElement {
         label: localize("ui.panel.config.labels.headers.icon"),
         type: "icon",
         template: (label) =>
-          label.icon ? html`<ha-icon .icon=${label.icon}></ha-icon>` : nothing,
+          label.icon
+            ? html`<ha-icon .icon=${label.icon}></ha-icon>`
+            : html`<ha-svg-icon .path=${mdiLabelOutline}></ha-svg-icon>`,
       },
       color: {
         title: "",
@@ -108,18 +112,18 @@ export class HaConfigLabels extends LitElement {
         label: localize("ui.panel.config.labels.headers.color"),
         type: "icon",
         template: (label) =>
-          label.color
-            ? html`<div
-                style=${styleMap({
-                  backgroundColor: computeCssColor(label.color),
-                  borderRadius: "var(--ha-border-radius-md)",
-                  border: "1px solid var(--outline-color)",
-                  boxSizing: "border-box",
-                  width: "20px",
-                  height: "20px",
-                })}
-              ></div>`
-            : nothing,
+          html`<div
+            style=${styleMap({
+              backgroundColor: label.color
+                ? computeCssColor(label.color)
+                : undefined,
+              borderRadius: "var(--ha-border-radius-md)",
+              border: "1px solid var(--outline-color)",
+              boxSizing: "border-box",
+              width: "20px",
+              height: "20px",
+            })}
+          ></div>`,
       },
       name: {
         title: localize("ui.panel.config.labels.headers.name"),

--- a/src/panels/config/labels/ha-config-labels.ts
+++ b/src/panels/config/labels/ha-config-labels.ts
@@ -120,8 +120,8 @@ export class HaConfigLabels extends LitElement {
               borderRadius: "var(--ha-border-radius-md)",
               border: "1px solid var(--outline-color)",
               boxSizing: "border-box",
-              width: "20px",
-              height: "20px",
+              width: "var(--ha-space-5)",
+              height: "var(--ha-space-5)",
             })}
           ></div>`,
       },


### PR DESCRIPTION
## Proposed change
- Label config table
	- add default placeholders for color and icon

Before:
<img width="466" height="707" alt="grafik" src="https://github.com/user-attachments/assets/e4d2f127-065c-42cb-b2f9-2e507e4fdd81" />

After:
<img width="466" height="707" alt="grafik" src="https://github.com/user-attachments/assets/85234392-df98-492f-accc-e5653c449989" />



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
