### PR TITLE
Shift stats in history by 1 hour

### DIFF
--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -435,9 +435,9 @@ export const convertStatisticsToHistory = (
   Object.entries(orderedStatistics).forEach(([key, value]) => {
     const entityHistoryStates: EntityHistoryState[] = value.map((e) => ({
       s: e.mean != null ? e.mean.toString() : e.state!.toString(),
-      lc: e.start / 1000,
+      lc: e.end / 1000,
       a: {},
-      lu: e.start / 1000,
+      lu: e.end / 1000,
     }));
     statsHistoryStates[key] = entityHistoryStates;
   });

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -313,9 +313,14 @@ class HaPanelHistory extends LitElement {
       return;
     }
 
+    const statsStartDate = new Date(this._startDate);
+    // History uses the end datapoint of the statistic, so if we want the
+    // graph to start at 7AM, need to fetch the statistic from 6AM.
+    statsStartDate.setHours(statsStartDate.getHours() - 1);
+
     const statistics = await fetchStatistics(
       this.hass!,
-      this._startDate,
+      statsStartDate,
       this._endDate,
       statisticIds,
       "hour",

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -162,7 +162,7 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
   private async _fetchStatistics(sensorNumericDeviceClasses: string[]) {
     const now = new Date();
     const start = new Date();
-    start.setHours(start.getHours() - this._hoursToShow);
+    start.setHours(start.getHours() - this._hoursToShow - 1);
 
     const statistics = await fetchStatistics(
       this.hass!,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
When converting a statistics datapoint for the history graph, use the end time instead of the start time, since that makes more sense in the history chart. Prevents weird discontinuities at the boundary, e.g.

<img width="1557" height="537" alt="image" src="https://github.com/user-attachments/assets/080ca121-ae65-4d22-96d0-bbb267401336" />

The datapoint there at 1PM was actually the stored state for 1PM-2PM, so it makes more sense to treat that as 2PM. 

And fixed:

<img width="1553" height="591" alt="image" src="https://github.com/user-attachments/assets/ffce586c-eb3e-4078-98c2-204843427523" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
