### PR TITLE
Add support for service action description placeholders

### DIFF
--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -465,10 +465,16 @@ export class HaServiceControl extends LitElement {
       ? computeObjectId(this._value.action)
       : undefined;
 
+    const descriptionPlaceholders =
+      domain && serviceName
+        ? this.hass.services[domain]?.[serviceName]?.description_placeholders
+        : undefined;
+
     const description =
       (serviceName &&
         this.hass.localize(
-          `component.${domain}.services.${serviceName}.description`
+          `component.${domain}.services.${serviceName}.description`,
+          descriptionPlaceholders
         )) ||
       serviceData?.description;
 
@@ -537,7 +543,8 @@ export class HaServiceControl extends LitElement {
             .disabled=${this.disabled}
             .value=${this._value?.data?.entity_id}
             .label=${this.hass.localize(
-              `component.${domain}.services.${serviceName}.fields.entity_id.description`
+              `component.${domain}.services.${serviceName}.fields.entity_id.description`,
+              descriptionPlaceholders
             ) || entityId.description}
             @value-changed=${this._entityPicked}
             allow-custom-entity
@@ -575,7 +582,8 @@ export class HaServiceControl extends LitElement {
                 left-chevron
                 .expanded=${!dataField.collapsed}
                 .header=${this.hass.localize(
-                  `component.${domain}.services.${serviceName}.sections.${dataField.key}.name`
+                  `component.${domain}.services.${serviceName}.sections.${dataField.key}.name`,
+                  descriptionPlaceholders
                 ) ||
                 dataField.name ||
                 dataField.key}
@@ -611,7 +619,10 @@ export class HaServiceControl extends LitElement {
     serviceName: string | undefined
   ) {
     return this.hass!.localize(
-      `component.${domain}.services.${serviceName}.sections.${dataField.key}.description`
+      `component.${domain}.services.${serviceName}.sections.${dataField.key}.description`,
+      domain && serviceName
+        ? this.hass.services[domain]?.[serviceName]?.description_placeholders
+        : undefined
     );
   }
 
@@ -658,6 +669,10 @@ export class HaServiceControl extends LitElement {
     }
 
     const showOptional = showOptionalToggle(dataField);
+    const descriptionPlaceholders =
+      domain && serviceName
+        ? this.hass.services[domain]?.[serviceName]?.description_placeholders
+        : undefined;
 
     return dataField.selector &&
       (!dataField.advanced ||
@@ -679,7 +694,8 @@ export class HaServiceControl extends LitElement {
               ></ha-checkbox>`}
           <span slot="heading"
             >${this.hass.localize(
-              `component.${domain}.services.${serviceName}.fields.${dataField.key}.name`
+              `component.${domain}.services.${serviceName}.fields.${dataField.key}.name`,
+              descriptionPlaceholders
             ) ||
             dataField.name ||
             dataField.key}</span
@@ -689,7 +705,8 @@ export class HaServiceControl extends LitElement {
               breaks
               allow-svg
               .content=${this.hass.localize(
-                `component.${domain}.services.${serviceName}.fields.${dataField.key}.description`
+                `component.${domain}.services.${serviceName}.fields.${dataField.key}.description`,
+                descriptionPlaceholders
               ) || dataField?.description}
             ></ha-markdown>
           </span>

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -467,7 +467,7 @@ export class HaServiceControl extends LitElement {
 
     const descriptionPlaceholders =
       domain && serviceName
-        ? this.hass.services[domain]?.[serviceName]?.description_placeholders
+        ? this.hass.services[domain][serviceName].description_placeholders
         : undefined;
 
     const description =
@@ -621,7 +621,7 @@ export class HaServiceControl extends LitElement {
     return this.hass!.localize(
       `component.${domain}.services.${serviceName}.sections.${dataField.key}.description`,
       domain && serviceName
-        ? this.hass.services[domain]?.[serviceName]?.description_placeholders
+        ? this.hass.services[domain][serviceName].description_placeholders
         : undefined
     );
   }
@@ -671,7 +671,7 @@ export class HaServiceControl extends LitElement {
     const showOptional = showOptionalToggle(dataField);
     const descriptionPlaceholders =
       domain && serviceName
-        ? this.hass.services[domain]?.[serviceName]?.description_placeholders
+        ? this.hass.services[domain][serviceName].description_placeholders
         : undefined;
 
     return dataField.selector &&

--- a/src/components/ha-service-picker.ts
+++ b/src/components/ha-service-picker.ts
@@ -39,7 +39,6 @@ class HaServicePicker extends LitElement {
   @query("ha-generic-picker") private _picker?: HaGenericPicker;
 
   public async open() {
-    await this.hass.loadBackendTranslation("services");
     await this.updateComplete;
     await this._picker?.open();
   }

--- a/src/components/ha-service-picker.ts
+++ b/src/components/ha-service-picker.ts
@@ -39,6 +39,7 @@ class HaServicePicker extends LitElement {
   @query("ha-generic-picker") private _picker?: HaGenericPicker;
 
   public async open() {
+    await this.hass.loadBackendTranslation("services");
     await this.updateComplete;
     await this._picker?.open();
   }
@@ -92,8 +93,14 @@ class HaServicePicker extends LitElement {
           `;
         }
 
+        const descriptionPlaceholders =
+          this.hass.services[domain]?.[service]?.description_placeholders;
+
         const serviceName =
-          localize(`component.${domain}.services.${service}.name`) ||
+          localize(
+            `component.${domain}.services.${service}.name`,
+            descriptionPlaceholders
+          ) ||
           services[domain][service].name ||
           service;
 
@@ -163,16 +170,21 @@ class HaServicePicker extends LitElement {
             const serviceId = `${domain}.${service}`;
             const domainName = domainToName(localize, domain);
 
+            const descriptionPlaceholders =
+              this.hass.services[domain]?.[service]?.description_placeholders;
+
             const name =
               this.hass.localize(
-                `component.${domain}.services.${service}.name`
+                `component.${domain}.services.${service}.name`,
+                descriptionPlaceholders
               ) ||
               services[domain][service].name ||
               service;
 
             const description =
               this.hass.localize(
-                `component.${domain}.services.${service}.description`
+                `component.${domain}.services.${service}.description`,
+                descriptionPlaceholders
               ) ||
               services[domain][service].description ||
               "";

--- a/src/components/ha-service-picker.ts
+++ b/src/components/ha-service-picker.ts
@@ -93,7 +93,7 @@ class HaServicePicker extends LitElement {
         }
 
         const descriptionPlaceholders =
-          this.hass.services[domain]?.[service]?.description_placeholders;
+          this.hass.services[domain][service].description_placeholders;
 
         const serviceName =
           localize(
@@ -170,7 +170,7 @@ class HaServicePicker extends LitElement {
             const domainName = domainToName(localize, domain);
 
             const descriptionPlaceholders =
-              this.hass.services[domain]?.[service]?.description_placeholders;
+              this.hass.services[domain][service].description_placeholders;
 
             const name =
               this.hass.localize(

--- a/src/data/script_i18n.ts
+++ b/src/data/script_i18n.ts
@@ -219,9 +219,13 @@ const tryDescribeAction = <T extends ActionType>(
 
     if (config.action) {
       const [domain, serviceName] = config.action.split(".", 2);
+      const descriptionPlaceholders =
+        hass.services[domain]?.[serviceName]?.description_placeholders;
       const service =
-        hass.localize(`component.${domain}.services.${serviceName}.name`) ||
-        hass.services[domain][serviceName]?.name;
+        hass.localize(
+          `component.${domain}.services.${serviceName}.name`,
+          descriptionPlaceholders
+        ) || hass.services[domain][serviceName]?.name;
 
       if (config.metadata) {
         return hass.localize(

--- a/src/data/script_i18n.ts
+++ b/src/data/script_i18n.ts
@@ -220,7 +220,7 @@ const tryDescribeAction = <T extends ActionType>(
     if (config.action) {
       const [domain, serviceName] = config.action.split(".", 2);
       const descriptionPlaceholders =
-        hass.services[domain]?.[serviceName]?.description_placeholders;
+        hass.services[domain][serviceName].description_placeholders;
       const service =
         hass.localize(
           `component.${domain}.services.${serviceName}.name`,

--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -721,7 +721,7 @@ class DialogAddAutomationElement
             name: `${domain ? "" : `${domainToName(localize, dmn)}: `}${
               this.hass.localize(
                 `component.${dmn}.services.${service}.name`,
-                this.hass.services[dmn]?.[service]?.description_placeholders
+                this.hass.services[dmn][service].description_placeholders
               ) ||
               services[dmn][service]?.name ||
               service
@@ -729,7 +729,7 @@ class DialogAddAutomationElement
             description:
               this.hass.localize(
                 `component.${dmn}.services.${service}.description`,
-                this.hass.services[dmn]?.[service]?.description_placeholders
+                this.hass.services[dmn][service].description_placeholders
               ) ||
               services[dmn][service]?.description ||
               "",

--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -719,13 +719,17 @@ class DialogAddAutomationElement
             `,
             key: `${DYNAMIC_PREFIX}${dmn}.${service}`,
             name: `${domain ? "" : `${domainToName(localize, dmn)}: `}${
-              this.hass.localize(`component.${dmn}.services.${service}.name`) ||
+              this.hass.localize(
+                `component.${dmn}.services.${service}.name`,
+                this.hass.services[dmn]?.[service]?.description_placeholders
+              ) ||
               services[dmn][service]?.name ||
               service
             }`,
             description:
               this.hass.localize(
-                `component.${dmn}.services.${service}.description`
+                `component.${dmn}.services.${service}.description`,
+                this.hass.services[dmn]?.[service]?.description_placeholders
               ) ||
               services[dmn][service]?.description ||
               "",

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
@@ -93,8 +93,12 @@ export default class HaAutomationSidebarAction extends LitElement {
         ".",
         2
       );
+
       title = `${domainToName(this.hass.localize, domain)}: ${
-        this.hass.localize(`component.${domain}.services.${service}.name`) ||
+        this.hass.localize(
+          `component.${domain}.services.${service}.name`,
+          this.hass.services[domain][service].description_placeholders
+        ) ||
         this.hass.services[domain][service]?.name ||
         title
       }`;

--- a/src/panels/developer-tools/action/developer-tools-action.ts
+++ b/src/panels/developer-tools/action/developer-tools-action.ts
@@ -135,6 +135,11 @@ class HaPanelDevAction extends LitElement {
       ? computeObjectId(this._serviceData?.action)
       : undefined;
 
+    const descriptionPlaceholders =
+      domain && serviceName
+        ? this.hass.services[domain]?.[serviceName]?.description_placeholders
+        : undefined;
+
     return html`
       <div class="content">
         <p>
@@ -307,12 +312,14 @@ class HaPanelDevAction extends LitElement {
                       <td><pre>${field.key}</pre></td>
                       <td>
                         ${this.hass.localize(
-                          `component.${domain}.services.${serviceName}.fields.${field.key}.description`
+                          `component.${domain}.services.${serviceName}.fields.${field.key}.description`,
+                          descriptionPlaceholders
                         ) || field.description}
                       </td>
                       <td>
                         ${this.hass.localize(
-                          `component.${domain}.services.${serviceName}.fields.${field.key}.example`
+                          `component.${domain}.services.${serviceName}.fields.${field.key}.example`,
+                          descriptionPlaceholders
                         ) || field.example}
                       </td>
                     </tr>`
@@ -643,7 +650,11 @@ class HaPanelDevAction extends LitElement {
         } catch (_err: any) {
           value =
             this.hass.localize(
-              `component.${domain}.services.${serviceName}.fields.${field.key}.example`
+              `component.${domain}.services.${serviceName}.fields.${field.key}.example`,
+              domain && serviceName
+                ? this.hass.services[domain]?.[serviceName]
+                    ?.description_placeholders
+                : undefined
             ) || field.example;
         }
         example[field.key] = value;

--- a/src/panels/developer-tools/action/developer-tools-action.ts
+++ b/src/panels/developer-tools/action/developer-tools-action.ts
@@ -137,7 +137,7 @@ class HaPanelDevAction extends LitElement {
 
     const descriptionPlaceholders =
       domain && serviceName
-        ? this.hass.services[domain]?.[serviceName]?.description_placeholders
+        ? this.hass.services[domain][serviceName].description_placeholders
         : undefined;
 
     return html`
@@ -652,8 +652,8 @@ class HaPanelDevAction extends LitElement {
             this.hass.localize(
               `component.${domain}.services.${serviceName}.fields.${field.key}.example`,
               domain && serviceName
-                ? this.hass.services[domain]?.[serviceName]
-                    ?.description_placeholders
+                ? this.hass.services[domain][serviceName]
+                    .description_placeholders
                 : undefined
             ) || field.example;
         }

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -401,8 +401,8 @@ class HaLogbookRenderer extends LitElement {
       ${
         this.hass.localize(
           `component.${item.context_domain}.services.${item.context_service}.name`,
-          this.hass.services[item.context_domain]?.[item.context_service]
-            ?.description_placeholders
+          this.hass.services[item.context_domain][item.context_service]
+            .description_placeholders
         ) ||
         this.hass.services[item.context_domain]?.[item.context_service]?.name ||
         item.context_service

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -400,7 +400,9 @@ class HaLogbookRenderer extends LitElement {
         ? `${domainToName(this.hass.localize, item.context_domain)}:
       ${
         this.hass.localize(
-          `component.${item.context_domain}.services.${item.context_service}.name`
+          `component.${item.context_domain}.services.${item.context_service}.name`,
+          this.hass.services[item.context_domain]?.[item.context_service]
+            ?.description_placeholders
         ) ||
         this.hass.services[item.context_domain]?.[item.context_service]?.name ||
         item.context_service

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -67,7 +67,10 @@ export const handleAction = async (
         await hass.loadBackendTranslation("title");
         const localize = await hass.loadBackendTranslation("services");
         serviceName = `${domainToName(localize, domain)}: ${
-          localize(`component.${domain}.services.${service}.name`) ||
+          localize(
+            `component.${domain}.services.${service}.name`,
+            hass.services[domain][service].description_placeholders
+          ) ||
           serviceDomains[domain][service].name ||
           service
         }`;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add support for service action description placeholders

- [x] Core PR: https://github.com/home-assistant/core/pull/154984
- [x] Needs: JS Websocket PR: https://github.com/home-assistant/home-assistant-js-websocket/pull/661

An example is added via the Core PR using the Kitchen Sink integration.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Setup Kitchen sink to validate the PR with action `kitchen_sink.test_service_1`

```json
...  
  "services": {
    "test_service_1": {
      "name": "Test action {meep_1}",
      "description": "Fake action for testing {meep_2}",
      "fields": {
        "field_1": {
          "name": "Field 1 {meep_3}",
          "description": "Number of seconds {meep_4}",
          "example": "Example: {meep_5}"
        },
        "field_2": {
          "name": "Field 2",
          "description": "Mode",
          "example": "Field 2 example"
        },
        "field_3": {
          "name": "Field 3",
          "description": "Number of hours"
        },
        "field_4": {
          "name": "Field 4",
          "description": "Direction"
        }
      },
      "sections": {
        "advanced_fields": {
          "name": "Advanced options",
          "description": "Some very advanced things"
        }
      }
    }
  }
...
```
Service definition:
```python
    hass.services.async_register(
        DOMAIN,
        "test_service_1",
        service_handler,
        SCHEMA_SERVICE_TEST_SERVICE_1,
        description_placeholders={
            "meep_1": "foo",
            "meep_2": "bar",
            "meep_3": "beer",
            "meep_4": "milk",
            "meep_5": "https://example.com",
        },
    )
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
