### PR TITLE
Add automations category to home dashboard area views

### DIFF
--- a/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
@@ -168,9 +168,17 @@ export class HomeAreaViewStrategy extends ReactiveElement {
 
     const summaryEntities = Object.values(entitiesBySummary).flat();
 
+    // Automations section
+    const automationFilter = generateEntityFilter(hass, {
+      domain: "automation",
+      entity_category: "none",
+    });
+    const automations = areaEntities.filter(automationFilter);
+
     // Rest of entities grouped by device
     const otherEntities = areaEntities.filter(
-      (entityId) => !summaryEntities.includes(entityId)
+      (entityId) =>
+        !summaryEntities.includes(entityId) && !automations.includes(entityId)
     );
 
     const entitiesByDevice: Record<string, string[]> = {};
@@ -293,6 +301,21 @@ export class HomeAreaViewStrategy extends ReactiveElement {
         ],
       } satisfies LovelaceSectionRawConfig);
       sections.push(...deviceSections);
+    }
+
+    // Show automations last, if they exist
+    if (automations.length > 0) {
+      sections.push({
+        type: "grid",
+        cards: [
+          computeHeadingCard(
+            hass.localize("ui.panel.lovelace.strategy.home.automations"),
+            "mdi:robot",
+            "/config/automation/dashboard"
+          ),
+          ...automations.map(computeTileCard),
+        ],
+      });
     }
 
     // Allow between 2 and 3 columns (the max should be set to define the width of the header)

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6942,7 +6942,8 @@
             "areas": "Areas",
             "other_areas": "Other areas",
             "unamed_device": "Unnamed device",
-            "others": "Others"
+            "others": "Others",
+            "automations": "Automations"
           },
           "common_controls": {
             "not_loaded": "Usage Prediction integration is not loaded.",


### PR DESCRIPTION
## Proposed change

It always confused me that automations in the home dashboard are shown in the "Others" category without a clear indicator that they are automations. I've managed multiple times to turn off the automation instead of the corresponding light 🙈 

This PR changes the home dashboard to display them in a dedicated "Automations" category at the end of the page to avoid the confusion.

<img width="496" height="210" alt="Bildschirmfoto 2025-10-25 um 20 05 55" src="https://github.com/user-attachments/assets/cd2f08b9-a163-4919-8b40-aa941c0cd25d" />


## Type of change
<!--

  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
