### PR TITLE
Hide media players summary when no entities exist

### DIFF
--- a/src/panels/lovelace/strategies/home/home-main-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-main-view-strategy.ts
@@ -142,67 +142,80 @@ export class HomeMainViewStrategy extends ReactiveElement {
       column_span: maxColumns,
     } as LovelaceStrategySectionConfig;
 
+    // Check if there are any media player entities
+    const mediaPlayerFilter = generateEntityFilter(hass, {
+      domain: "media_player",
+      entity_category: "none",
+    });
+    const hasMediaPlayers = Object.keys(hass.states).some(mediaPlayerFilter);
+
+    const summaryCards: LovelaceCardConfig[] = [
+      {
+        type: "heading",
+        heading: hass.localize("ui.panel.lovelace.strategy.home.summaries"),
+      },
+      {
+        type: "home-summary",
+        summary: "light",
+        vertical: true,
+        tap_action: {
+          action: "navigate",
+          navigation_path: "/light?historyBack=1",
+        },
+        grid_options: {
+          rows: 2,
+          columns: 4,
+        },
+      } satisfies HomeSummaryCard,
+      {
+        type: "home-summary",
+        summary: "climate",
+        vertical: true,
+        tap_action: {
+          action: "navigate",
+          navigation_path: "/climate?historyBack=1",
+        },
+        grid_options: {
+          rows: 2,
+          columns: 4,
+        },
+      } satisfies HomeSummaryCard,
+      {
+        type: "home-summary",
+        summary: "safety",
+        vertical: true,
+        tap_action: {
+          action: "navigate",
+          navigation_path: "/safety?historyBack=1",
+        },
+        grid_options: {
+          rows: 2,
+          columns: 4,
+        },
+      } satisfies HomeSummaryCard,
+    ];
+
+    // Only add media players summary if there are media player entities
+    if (hasMediaPlayers) {
+      summaryCards.push({
+        type: "home-summary",
+        summary: "media_players",
+        vertical: true,
+        tap_action: {
+          action: "navigate",
+          navigation_path: "media-players",
+        },
+        grid_options: {
+          rows: 2,
+          columns: 4,
+        },
+      } satisfies HomeSummaryCard);
+    }
+
     const summarySection: LovelaceSectionConfig = {
       type: "grid",
       column_span: maxColumns,
-      cards: [
-        {
-          type: "heading",
-          heading: hass.localize("ui.panel.lovelace.strategy.home.summaries"),
-        },
-        {
-          type: "home-summary",
-          summary: "light",
-          vertical: true,
-          tap_action: {
-            action: "navigate",
-            navigation_path: "/light?historyBack=1",
-          },
-          grid_options: {
-            rows: 2,
-            columns: 4,
-          },
-        } satisfies HomeSummaryCard,
-        {
-          type: "home-summary",
-          summary: "climate",
-          vertical: true,
-          tap_action: {
-            action: "navigate",
-            navigation_path: "/climate?historyBack=1",
-          },
-          grid_options: {
-            rows: 2,
-            columns: 4,
-          },
-        } satisfies HomeSummaryCard,
-        {
-          type: "home-summary",
-          summary: "safety",
-          vertical: true,
-          tap_action: {
-            action: "navigate",
-            navigation_path: "/safety?historyBack=1",
-          },
-          grid_options: {
-            rows: 2,
-            columns: 4,
-          },
-        } satisfies HomeSummaryCard,
-        {
-          type: "home-summary",
-          summary: "media_players",
-          vertical: true,
-          tap_action: {
-            action: "navigate",
-            navigation_path: "media-players",
-          },
-          grid_options: {
-            rows: 2,
-            columns: 4,
-          },
-        } satisfies HomeSummaryCard,
-      ],
+      cards: summaryCards,
     };
 
     const weatherFilter = generateEntityFilter(hass, {


### PR DESCRIPTION
## Proposed change

My system currently does not contain any media players, so it seems unnecessary to display the corresponding summary/button. This PR changes the strategy to only display it, if any `media_player` entities exist.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
