### PR TITLE
home dashboard: Always select the same weather entity

### DIFF
--- a/src/panels/lovelace/strategies/home/home-main-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-main-view-strategy.ts
@@ -216,7 +216,9 @@ export class HomeMainViewStrategy extends ReactiveElement {
       column_span: maxColumns,
       cards: [],
     };
-    const weatherEntity = Object.keys(hass.states).find(weatherFilter);
+    const weatherEntity = Object.keys(hass.states)
+      .filter(weatherFilter)
+      .sort()[0];
 
     if (weatherEntity) {
       widgetSection.cards!.push(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

If users have multiple weather entities, the home dashboard currently shows a somewhat random one, based on insertion order in the JS hashmap (see https://github.com/home-assistant/frontend/issues/27305). This PR changes two things:

1. it sorts the weather entities and shows the first one to at least always show the same one by default
2. ~it adds a "Weather entity" section to the dashboard config to allow users to explicitly choose the weather entity that is displayed (only if they have multiple weather entities)~ (removed after review)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/27305

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
