### PR TITLE
Migrate generic dialog-box to ha-wa-dialog

### DIFF
--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -1,4 +1,4 @@
-import { mdiAlertOutline } from "@mdi/js";
+import { mdiAlertOutline, mdiClose } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
@@ -70,6 +70,15 @@ class DialogBox extends LitElement {
         aria-describedby="dialog-box-description"
       >
         <ha-dialog-header slot="header">
+          ${!confirmPrompt
+            ? html`<slot name="headerNavigationIcon" slot="navigationIcon">
+                <ha-icon-button
+                  data-dialog="close"
+                  .label=${this.hass?.localize("ui.common.close") ?? "Close"}
+                  .path=${mdiClose}
+                ></ha-icon-button
+              ></slot>`
+            : nothing}
           <span slot="title" id="dialog-box-title">
             ${this._params.warning
               ? html`<ha-svg-icon

--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -167,8 +167,8 @@ class DialogBox extends LitElement {
   }
 
   private _dialogClosed() {
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
     if (!this._closeState) {
-      fireEvent(this, "dialog-closed", { dialog: this.localName });
       this._cancel();
     }
     this._closeState = undefined;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This changes a lot of UI areas, quite a bit of testing will be needed here. Not found anything so far that will cause issues, but some dialogs may have special setups (these should probably not use the generic dialog anyway)

Only differences found so far are dialogs now use the standard default width, which standardizes the varying dialog size based on the amount of content/text etc.

<details>
<summary>From</summary>

<img width="1183" height="1016" alt="image" src="https://github.com/user-attachments/assets/8a5027c1-ca66-4da6-b3b6-1a9cc8260063" />
<img width="1450" height="688" alt="image" src="https://github.com/user-attachments/assets/f703047d-4725-45da-8190-727d6cc53f63" />

<img width="1431" height="936" alt="image" src="https://github.com/user-attachments/assets/13700d78-b1d0-4e1d-ae7a-5e793245f7cc" />

<img width="1068" height="451" alt="image" src="https://github.com/user-attachments/assets/668045d7-510a-4166-8e3b-fcafb98ab7ef" />

Exit unsaved scene editor:
<img width="1573" height="765" alt="image" src="https://github.com/user-attachments/assets/4695b96f-2505-43b3-ae50-25be9dbb26de" />


</details>

<details>
<summary>To</summary>

<img width="1210" height="928" alt="image" src="https://github.com/user-attachments/assets/fc0cae12-a1cf-4c12-8cf7-02b25a39ba59" />
<img width="1416" height="795" alt="image" src="https://github.com/user-attachments/assets/9df449dd-1202-48a2-992d-6d27dd432936" />

<img width="1075" height="513" alt="image" src="https://github.com/user-attachments/assets/e82f5643-973f-476f-b3d7-47a30e98807a" />

<img width="1455" height="700" alt="image" src="https://github.com/user-attachments/assets/732d6587-48b7-4192-b855-010b948c928c" />

Exit unsaved scene editor:
<img width="1486" height="778" alt="image" src="https://github.com/user-attachments/assets/a418ab18-7b68-4792-bd89-d3dbbd23c5c8" />


</details>

<details>
<summary>Areas affected</summary>

This was generated via a script on 2025-10-27

| File | Count | Functions Used |
|------|-------|----------------|
| [src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts) | 14 | showAlertDialog,showConfirmationDialog, showPromptDialog |
| [src/panels/config/integrations/ha-config-entry-row.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/ha-config-entry-row.ts) | 11 | showAlertDialog,showConfirmationDialog, showPromptDialog |
| [src/panels/config/automation/ha-automation-picker.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/automation/ha-automation-picker.ts) | 11 | showAlertDialog,showConfirmationDialog |
| [hassio/src/ingress-view/hassio-ingress-view.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/ingress-view/hassio-ingress-view.ts) | 10 | showAlertDialog,showConfirmationDialog |
| [hassio/src/addon-view/info/hassio-addon-info.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/addon-view/info/hassio-addon-info.ts) | 10 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/script/ha-script-picker.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/script/ha-script-picker.ts) | 8 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/entities/ha-config-entities.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/entities/ha-config-entities.ts) | 8 | showAlertDialog,showConfirmationDialog |
| [hassio/src/system/hassio-supervisor-info.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/system/hassio-supervisor-info.ts) | 8 | showAlertDialog,showConfirmationDialog |
| [hassio/src/system/hassio-host-info.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/system/hassio-host-info.ts) | 8 | showAlertDialog,showConfirmationDialog, showPromptDialog |
| [src/panels/lovelace/hui-editor.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/hui-editor.ts) | 7 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/helpers/ha-config-helpers.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/helpers/ha-config-helpers.ts) | 7 | showAlertDialog,showConfirmationDialog |
| [src/panels/profile/ha-refresh-tokens-card.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/profile/ha-refresh-tokens-card.ts) | 6 | showAlertDialog,showConfirmationDialog |
| [src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts) | 6 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/scene/ha-scene-editor.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/scene/ha-scene-editor.ts) | 6 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/scene/ha-scene-dashboard.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/scene/ha-scene-dashboard.ts) | 6 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/person/dialog-person-detail.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/person/dialog-person-detail.ts) | 6 | showAlertDialog,showConfirmationDialog, showPromptDialog |
| [src/panels/config/integrations/ha-config-entry-device-row.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/ha-config-entry-device-row.ts) | 6 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/entities/entity-registry-settings-editor.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/entities/entity-registry-settings-editor.ts) | 6 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/devices/ha-config-device-page.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/devices/ha-config-device-page.ts) | 6 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/users/dialog-user-detail.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/users/dialog-user-detail.ts) | 5 | showAlertDialog,showPromptDialog |
| [src/panels/config/integrations/integration-panels/matter/matter-config-dashboard.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/integration-panels/matter/matter-config-dashboard.ts) | 5 | showPromptDialog |
| [src/panels/config/blueprint/ha-blueprint-overview.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/blueprint/ha-blueprint-overview.ts) | 5 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/automation/ha-automation-editor.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/automation/ha-automation-editor.ts) | 5 | showAlertDialog,showConfirmationDialog |
| [hassio/src/dialogs/backup/dialog-hassio-backup.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/dialogs/backup/dialog-hassio-backup.ts) | 5 | showAlertDialog,showConfirmationDialog |
| [src/panels/profile/ha-long-lived-access-tokens-card.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/profile/ha-long-lived-access-tokens-card.ts) | 4 | showAlertDialog,showConfirmationDialog, showPromptDialog |
| [src/panels/lovelace/hui-root.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/hui-root.ts) | 4 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/script/ha-script-editor.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/script/ha-script-editor.ts) | 4 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/lovelace/resources/ha-config-lovelace-resources.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/lovelace/resources/ha-config-lovelace-resources.ts) | 4 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts) | 4 | showAlertDialog |
| [src/panels/config/integrations/ha-config-integrations-dashboard.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/ha-config-integrations-dashboard.ts) | 4 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/energy/components/ha-energy-grid-settings.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/energy/components/ha-energy-grid-settings.ts) | 4 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/devices/ha-config-devices-dashboard.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/devices/ha-config-devices-dashboard.ts) | 4 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/backup/ha-config-backup-backups.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/backup/ha-config-backup-backups.ts) | 4 | showAlertDialog,showConfirmationDialog |
| [src/dialogs/config-flow/dialog-data-entry-flow.ts](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/config-flow/dialog-data-entry-flow.ts) | 4 | showAlertDialog |
| [src/components/ha-picture-upload.ts](https://github.com/home-assistant/frontend/blob/dev/src/components/ha-picture-upload.ts) | 4 | showAlertDialog |
| [hassio/src/update-available/update-available-card.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/update-available/update-available-card.ts) | 4 | showAlertDialog |
| [src/panels/config/storage/dialog-move-datadisk.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/storage/dialog-move-datadisk.ts) | 3 | showAlertDialog |
| [src/panels/config/network/supervisor-network.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/network/supervisor-network.ts) | 3 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts) | 3 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts) | 3 | showAlertDialog |
| [src/panels/config/integrations/dialog-add-integration.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/dialog-add-integration.ts) | 3 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/entities/entity-registry-settings.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/entities/entity-registry-settings.ts) | 3 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/cloud/login/cloud-login.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/cloud/login/cloud-login.ts) | 3 | showAlertDialog,showConfirmationDialog, showPromptDialog |
| [src/panels/config/cloud/account/cloud-account.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/cloud/account/cloud-account.ts) | 3 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/automation/condition/ha-automation-condition-row.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/automation/condition/ha-automation-condition-row.ts) | 3 | showAlertDialog,showPromptDialog |
| [src/panels/config/automation/action/ha-automation-action-row.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/automation/action/ha-automation-action-row.ts) | 3 | showAlertDialog,showPromptDialog |
| [src/panels/config/application_credentials/ha-config-application-credentials.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/application_credentials/ha-config-application-credentials.ts) | 3 | showAlertDialog,showConfirmationDialog |
| [src/dialogs/restart/dialog-restart.ts](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/restart/dialog-restart.ts) | 3 | showAlertDialog,showConfirmationDialog |
| [src/data/regenerate_entity_ids.ts](https://github.com/home-assistant/frontend/blob/dev/src/data/regenerate_entity_ids.ts) | 3 | showAlertDialog,showConfirmationDialog |
| [src/common/integrations/protocolIntegrationPicked.ts](https://github.com/home-assistant/frontend/blob/dev/src/common/integrations/protocolIntegrationPicked.ts) | 3 | showConfirmationDialog |
| [hassio/src/dialogs/network/dialog-hassio-network.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/dialogs/network/dialog-hassio-network.ts) | 3 | showAlertDialog,showConfirmationDialog |
| [hassio/src/backups/hassio-backups.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/backups/hassio-backups.ts) | 3 | showAlertDialog,showConfirmationDialog |
| [src/panels/todo/ha-panel-todo.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/todo/ha-panel-todo.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/profile/ha-change-password-card.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/profile/ha-change-password-card.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/media-browser/ha-panel-media-browser.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/media-browser/ha-panel-media-browser.ts) | 2 | showAlertDialog |
| [src/panels/lovelace/editor/add-entities-to-view.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/editor/add-entities-to-view.ts) | 2 | showAlertDialog |
| [src/panels/lovelace/components/hui-card-options.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/components/hui-card-options.ts) | 2 | showAlertDialog,showPromptDialog |
| [src/panels/history/ha-panel-history.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/history/ha-panel-history.ts) | 2 | showAlertDialog |
| [src/panels/energy/cards/energy-setup-wizard-card.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/energy/cards/energy-setup-wizard-card.ts) | 2 | showAlertDialog |
| [src/panels/developer-tools/template/developer-tools-template.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/developer-tools/template/developer-tools-template.ts) | 2 | showConfirmationDialog |
| [src/panels/config/zone/ha-config-zone.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/zone/ha-config-zone.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts) | 2 | showConfirmationDialog |
| [src/panels/config/voice-assistants/debug/assist-pipeline-run-debug.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/voice-assistants/debug/assist-pipeline-run-debug.ts) | 2 | showAlertDialog,showPromptDialog |
| [src/panels/config/voice-assistants/debug/assist-pipeline-debug.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/voice-assistants/debug/assist-pipeline-debug.ts) | 2 | showAlertDialog |
| [src/panels/config/voice-assistants/assist-pref.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/voice-assistants/assist-pref.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/tags/ha-config-tags.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/tags/ha-config-tags.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/repairs/dialog-system-information.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/repairs/dialog-system-information.ts) | 2 | showAlertDialog |
| [src/panels/config/person/ha-config-person.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/person/ha-config-person.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/labels/ha-config-labels.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/labels/ha-config-labels.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/integrations/integration-panels/matter/dialog-matter-manage-fabrics.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/integration-panels/matter/dialog-matter-manage-fabrics.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/integrations/ha-disabled-config-entry-card.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/ha-disabled-config-entry-card.ts) | 2 | showAlertDialog |
| [src/panels/config/integrations/ha-config-sub-entry-row.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/ha-config-sub-entry-row.ts) | 2 | showConfirmationDialog,showPromptDialog |
| [src/panels/config/integrations/ha-config-integration-page.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/ha-config-integration-page.ts) | 2 | showAlertDialog |
| [src/panels/config/energy/components/ha-energy-water-settings.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/energy/components/ha-energy-water-settings.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/energy/components/ha-energy-solar-settings.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/energy/components/ha-energy-solar-settings.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/energy/components/ha-energy-gas-settings.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/energy/components/ha-energy-gas-settings.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/energy/components/ha-energy-device-settings.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/energy/components/ha-energy-device-settings.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/energy/components/ha-energy-battery-settings.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/energy/components/ha-energy-battery-settings.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/devices/device-detail/integration-elements/zwave_js/device-actions.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/devices/device-detail/integration-elements/zwave_js/device-actions.ts) | 2 | showConfirmationDialog |
| [src/panels/config/cloud/login/cloud-login-panel.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/cloud/login/cloud-login-panel.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/panels/config/cloud/account/dialog-cloud-tts-try.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/cloud/account/dialog-cloud-tts-try.ts) | 2 | showAlertDialog |
| [src/panels/config/cloud/account/cloud-tts-pref.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/cloud/account/cloud-tts-pref.ts) | 2 | showAlertDialog |
| [src/panels/config/backup/helper/download_backup.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/backup/helper/download_backup.ts) | 2 | showAlertDialog |
| [src/panels/config/automation/trigger/ha-automation-trigger-row.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/automation/trigger/ha-automation-trigger-row.ts) | 2 | showAlertDialog,showPromptDialog |
| [src/panels/config/automation/sidebar/ha-automation-sidebar-condition.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/automation/sidebar/ha-automation-sidebar-condition.ts) | 2 | showAlertDialog |
| [src/panels/config/areas/ha-config-areas-dashboard.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/areas/ha-config-areas-dashboard.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [src/dialogs/voice-assistant-setup/cloud/cloud-step-signin.ts](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/voice-assistant-setup/cloud/cloud-step-signin.ts) | 2 | showAlertDialog,showPromptDialog |
| [src/dialogs/tts-try/dialog-tts-try.ts](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/tts-try/dialog-tts-try.ts) | 2 | showAlertDialog |
| [src/dialogs/config-flow/step-flow-create-entry.ts](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/config-flow/step-flow-create-entry.ts) | 2 | showAlertDialog |
| [src/components/ha-assist-chat.ts](https://github.com/home-assistant/frontend/blob/dev/src/components/ha-assist-chat.ts) | 2 | showAlertDialog |
| [hassio/src/system/hassio-core-info.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/system/hassio-core-info.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [hassio/src/dialogs/suggestAddonRestart.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/dialogs/suggestAddonRestart.ts) | 2 | showAlertDialog,showConfirmationDialog |
| [hassio/src/dialogs/registries/dialog-hassio-registries.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/dialogs/registries/dialog-hassio-registries.ts) | 2 | showAlertDialog |
| [hassio/src/components/hassio-upload-backup.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/components/hassio-upload-backup.ts) | 2 | showAlertDialog |
| [src/state/disconnect-toast-mixin.ts](https://github.com/home-assistant/frontend/blob/dev/src/state/disconnect-toast-mixin.ts) | 1 | showAlertDialog |
| [src/panels/todo/dialog-todo-item-editor.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/todo/dialog-todo-item-editor.ts) | 1 | showConfirmationDialog |
| [src/panels/profile/ha-profile-section-general.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/profile/ha-profile-section-general.ts) | 1 | showConfirmationDialog |
| [src/panels/profile/ha-mfa-modules-card.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/profile/ha-mfa-modules-card.ts) | 1 | showConfirmationDialog |
| [src/panels/media-browser/ha-bar-media-player.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/media-browser/ha-bar-media-player.ts) | 1 | showAlertDialog |
| [src/panels/lovelace/heading-badges/hui-error-heading-badge.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/heading-badges/hui-error-heading-badge.ts) | 1 | showAlertDialog |
| [src/panels/lovelace/editor/view-header/hui-dialog-edit-view-header.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/editor/view-header/hui-dialog-edit-view-header.ts) | 1 | showAlertDialog |
| [src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts) | 1 | showAlertDialog |
| [src/panels/lovelace/editor/hui-picture-elements-card-row-editor.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/editor/hui-picture-elements-card-row-editor.ts) | 1 | showConfirmationDialog |
| [src/panels/lovelace/editor/conditions/ha-card-condition-editor.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/editor/conditions/ha-card-condition-editor.ts) | 1 | showAlertDialog |
| [src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts) | 1 | showConfirmationDialog |
| [src/panels/lovelace/editor/badge-editor/hui-dialog-edit-badge.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/editor/badge-editor/hui-dialog-edit-badge.ts) | 1 | showConfirmationDialog |
| [src/panels/lovelace/components/hui-section-edit-mode.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/components/hui-section-edit-mode.ts) | 1 | showConfirmationDialog |
| [src/panels/lovelace/common/handle-action.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/common/handle-action.ts) | 1 | showConfirmationDialog |
| [src/panels/lovelace/common/confirm-action.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/common/confirm-action.ts) | 1 | showConfirmationDialog |
| [src/panels/lovelace/cards/hui-todo-list-card.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/cards/hui-todo-list-card.ts) | 1 | showConfirmationDialog |
| [src/panels/lovelace/badges/hui-error-badge.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/badges/hui-error-badge.ts) | 1 | showAlertDialog |
| [src/panels/developer-tools/statistics/dialog-statistics-fix.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/developer-tools/statistics/dialog-statistics-fix.ts) | 1 | showAlertDialog |
| [src/panels/developer-tools/statistics/dialog-statistics-adjust-sum.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/developer-tools/statistics/dialog-statistics-adjust-sum.ts) | 1 | showAlertDialog |
| [src/panels/developer-tools/statistics/developer-tools-statistics.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/developer-tools/statistics/developer-tools-statistics.ts) | 1 | showConfirmationDialog |
| [src/panels/developer-tools/state/developer-tools-state.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/developer-tools/state/developer-tools-state.ts) | 1 | showAlertDialog |
| [src/panels/developer-tools/event/developer-tools-event.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/developer-tools/event/developer-tools-event.ts) | 1 | showAlertDialog |
| [src/panels/config/voice-assistants/debug/assist-render-pipeline-run.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/voice-assistants/debug/assist-render-pipeline-run.ts) | 1 | showAlertDialog |
| [src/panels/config/users/ha-config-users.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/users/ha-config-users.ts) | 1 | showConfirmationDialog |
| [src/panels/config/storage/ha-config-section-storage.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/storage/ha-config-section-storage.ts) | 1 | showAlertDialog |
| [src/panels/config/script/ha-script-trace.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/script/ha-script-trace.ts) | 1 | showAlertDialog |
| [src/panels/config/network/supervisor-hostname.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/network/supervisor-hostname.ts) | 1 | showAlertDialog |
| [src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts) | 1 | showConfirmationDialog |
| [src/panels/config/logs/ha-config-logs.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/logs/ha-config-logs.ts) | 1 | showAlertDialog |
| [src/panels/config/integrations/integration-panels/zwave_js/zwave_js-provisioned.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-provisioned.ts) | 1 | showConfirmationDialog |
| [src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts) | 1 | showConfirmationDialog |
| [src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts) | 1 | showConfirmationDialog |
| [src/panels/config/integrations/integration-panels/zha/zha-device-card.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts) | 1 | showAlertDialog |
| [src/panels/config/integrations/integration-panels/zha/dialog-zha-change-channel.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/integration-panels/zha/dialog-zha-change-channel.ts) | 1 | showAlertDialog |
| [src/panels/config/integrations/ha-ignored-config-entry-card.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/ha-ignored-config-entry-card.ts) | 1 | showConfirmationDialog |
| [src/panels/config/integrations/ha-config-flow-card.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/integrations/ha-config-flow-card.ts) | 1 | showConfirmationDialog |
| [src/panels/config/helpers/forms/ha-input_select-form.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/helpers/forms/ha-input_select-form.ts) | 1 | showConfirmationDialog |
| [src/panels/config/hardware/dialog-hardware-available.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/hardware/dialog-hardware-available.ts) | 1 | showAlertDialog |
| [src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts) | 1 | showConfirmationDialog |
| [src/panels/config/devices/device-detail/integration-elements/zha/device-actions.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/devices/device-detail/integration-elements/zha/device-actions.ts) | 1 | showConfirmationDialog |
| [src/panels/config/core/ha-config-section-updates.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/core/ha-config-section-updates.ts) | 1 | showAlertDialog |
| [src/panels/config/core/ha-config-section-general.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/core/ha-config-section-general.ts) | 1 | showConfirmationDialog |
| [src/panels/config/cloud/dialog-manage-cloudhook/dialog-manage-cloudhook.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/cloud/dialog-manage-cloudhook/dialog-manage-cloudhook.ts) | 1 | showConfirmationDialog |
| [src/panels/config/backup/ha-config-backup-location.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/backup/ha-config-backup-location.ts) | 1 | showConfirmationDialog |
| [src/panels/config/backup/ha-config-backup-details.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/backup/ha-config-backup-details.ts) | 1 | showConfirmationDialog |
| [src/panels/config/backup/dialogs/dialog-upload-backup.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/backup/dialogs/dialog-upload-backup.ts) | 1 | showAlertDialog |
| [src/panels/config/backup/components/overview/ha-backup-overview-summary.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/backup/components/overview/ha-backup-overview-summary.ts) | 1 | showAlertDialog |
| [src/panels/config/automation/trigger/types/ha-automation-trigger-conversation.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/automation/trigger/types/ha-automation-trigger-conversation.ts) | 1 | showConfirmationDialog |
| [src/panels/config/automation/option/ha-automation-option-row.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/automation/option/ha-automation-option-row.ts) | 1 | showPromptDialog |
| [src/panels/config/automation/ha-automation-trace.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/automation/ha-automation-trace.ts) | 1 | showAlertDialog |
| [src/panels/config/areas/ha-config-area-page.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/areas/ha-config-area-page.ts) | 1 | showConfirmationDialog |
| [src/panels/config/areas/dialog-area-registry-detail.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/areas/dialog-area-registry-detail.ts) | 1 | showConfirmationDialog |
| [src/onboarding/restore-backup/onboarding-restore-backup-upload.ts](https://github.com/home-assistant/frontend/blob/dev/src/onboarding/restore-backup/onboarding-restore-backup-upload.ts) | 1 | showAlertDialog |
| [src/onboarding/onboarding-location.ts](https://github.com/home-assistant/frontend/blob/dev/src/onboarding/onboarding-location.ts) | 1 | showConfirmationDialog |
| [src/dialogs/voice-assistant-setup/voice-assistant-setup-step-area.ts](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-area.ts) | 1 | showAlertDialog |
| [src/dialogs/sidebar/dialog-edit-sidebar.ts](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/sidebar/dialog-edit-sidebar.ts) | 1 | showConfirmationDialog |
| [src/dialogs/quick-bar/ha-quick-bar.ts](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/quick-bar/ha-quick-bar.ts) | 1 | showConfirmationDialog |
| [src/dialogs/more-info/controls/more-info-update.ts](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/more-info/controls/more-info-update.ts) | 1 | showAlertDialog |
| [src/dialogs/more-info/components/lights/ha-more-info-light-favorite-colors.ts](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/more-info/components/lights/ha-more-info-light-favorite-colors.ts) | 1 | showConfirmationDialog |
| [src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts) | 1 | showAlertDialog |
| [src/data/update.ts](https://github.com/home-assistant/frontend/blob/dev/src/data/update.ts) | 1 | showAlertDialog |
| [src/components/media-player/ha-media-upload-button.ts](https://github.com/home-assistant/frontend/blob/dev/src/components/media-player/ha-media-upload-button.ts) | 1 | showAlertDialog |
| [src/components/media-player/ha-media-player-browse.ts](https://github.com/home-assistant/frontend/blob/dev/src/components/media-player/ha-media-player-browse.ts) | 1 | showAlertDialog |
| [src/components/media-player/dialog-media-manage.ts](https://github.com/home-assistant/frontend/blob/dev/src/components/media-player/dialog-media-manage.ts) | 1 | showConfirmationDialog |
| [src/components/ha-selector/ha-selector-file.ts](https://github.com/home-assistant/frontend/blob/dev/src/components/ha-selector/ha-selector-file.ts) | 1 | showAlertDialog |
| [src/components/ha-push-notifications-toggle.ts](https://github.com/home-assistant/frontend/blob/dev/src/components/ha-push-notifications-toggle.ts) | 1 | showPromptDialog |
| [src/components/ha-label-picker.ts](https://github.com/home-assistant/frontend/blob/dev/src/components/ha-label-picker.ts) | 1 | showAlertDialog |
| [src/components/ha-floor-picker.ts](https://github.com/home-assistant/frontend/blob/dev/src/components/ha-floor-picker.ts) | 1 | showAlertDialog |
| [src/components/ha-filter-categories.ts](https://github.com/home-assistant/frontend/blob/dev/src/components/ha-filter-categories.ts) | 1 | showConfirmationDialog |
| [src/components/ha-area-picker.ts](https://github.com/home-assistant/frontend/blob/dev/src/components/ha-area-picker.ts) | 1 | showAlertDialog |
| [src/components/buttons/ha-call-service-button.ts](https://github.com/home-assistant/frontend/blob/dev/src/components/buttons/ha-call-service-button.ts) | 1 | showConfirmationDialog |
| [landing-page/src/components/landing-page-network.ts](https://github.com/home-assistant/frontend/blob/dev/landing-page/src/components/landing-page-network.ts) | 1 | showAlertDialog |
| [hassio/src/dialogs/datadisk/dialog-hassio-datadisk.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/dialogs/datadisk/dialog-hassio-datadisk.ts) | 1 | showAlertDialog |
| [hassio/src/dialogs/backup/dialog-hassio-create-backup.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/dialogs/backup/dialog-hassio-create-backup.ts) | 1 | showAlertDialog |
| [hassio/src/dashboard/hassio-dashboard.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/dashboard/hassio-dashboard.ts) | 1 | showAlertDialog |
| [hassio/src/addon-view/hassio-addon-dashboard.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/addon-view/hassio-addon-dashboard.ts) | 1 | showConfirmationDialog |
| [hassio/src/addon-view/config/hassio-addon-config.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/addon-view/config/hassio-addon-config.ts) | 1 | showConfirmationDialog |
| [hassio/src/addon-store/hassio-addon-store.ts](https://github.com/home-assistant/frontend/blob/dev/hassio/src/addon-store/hassio-addon-store.ts) | 1 | showAlertDialog |


</details>


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
