### PR TITLE
Fix next flow config flow showing an empty dialog

### DIFF
--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -484,7 +484,7 @@ class DataEntryFlowDialog extends LitElement {
         this._unsubDataEntryFlowProgress = undefined;
       }
       if (_step.next_flow[0] === "config_flow") {
-        showConfigFlowDialog(this._params!.dialogParentElement!, {
+        showConfigFlowDialog(this, {
           continueFlowId: _step.next_flow[1],
           carryOverDevices: this._devices(
             this._params!.flowConfig.showDevices,
@@ -496,32 +496,23 @@ class DataEntryFlowDialog extends LitElement {
         });
       } else if (_step.next_flow[0] === "options_flow") {
         if (_step.type === "create_entry") {
-          showOptionsFlowDialog(
-            this._params!.dialogParentElement!,
-            _step.result!,
-            {
-              continueFlowId: _step.next_flow[1],
-              navigateToResult: this._params!.navigateToResult,
-              dialogClosedCallback: this._params!.dialogClosedCallback,
-            }
-          );
+          showOptionsFlowDialog(this, _step.result!, {
+            continueFlowId: _step.next_flow[1],
+            navigateToResult: this._params!.navigateToResult,
+            dialogClosedCallback: this._params!.dialogClosedCallback,
+          });
         }
       } else if (_step.next_flow[0] === "config_subentries_flow") {
         if (_step.type === "create_entry") {
-          showSubConfigFlowDialog(
-            this._params!.dialogParentElement!,
-            _step.result!,
-            _step.next_flow[0],
-            {
-              continueFlowId: _step.next_flow[1],
-              navigateToResult: this._params!.navigateToResult,
-              dialogClosedCallback: this._params!.dialogClosedCallback,
-            }
-          );
+          showSubConfigFlowDialog(this, _step.result!, _step.next_flow[0], {
+            continueFlowId: _step.next_flow[1],
+            navigateToResult: this._params!.navigateToResult,
+            dialogClosedCallback: this._params!.dialogClosedCallback,
+          });
         }
       } else {
         this.closeDialog();
-        showAlertDialog(this._params!.dialogParentElement!, {
+        showAlertDialog(this, {
           text: this.hass.localize(
             "ui.panel.config.integrations.config_flow.error",
             { error: `Unsupported next flow type: ${_step.next_flow[0]}` }


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Fix this
<img width="858" height="484" alt="image" src="https://github.com/user-attachments/assets/7c7d516a-482b-4245-91cb-866b66d2d844" />

When setting up a ZBT, the zigbee flow doesn't load some times. The reason is that we reused the `dialogParentElement` which was a discovery card that is removed when the first flow is done. So the "show-dialog" even was triggered on a removed element.  The current dialog (`this`) on the other hand is still present and works fine.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
