### PR TITLE
Fix activity card height and add constraints for grid layout

### DIFF
--- a/src/panels/lovelace/cards/hui-logbook-card.ts
+++ b/src/panels/lovelace/cards/hui-logbook-card.ts
@@ -189,6 +189,7 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
       >
         <div class="content">
           <ha-logbook
+            class=${classMap({ "is-masonry": this.layout === "masonry" })}
             .hass=${this.hass}
             .time=${this._time}
             .entityIds=${this._getEntityIds()}
@@ -212,6 +213,7 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
         }
 
         .content {
+          height: 100%;
           padding: 0 16px 16px;
         }
 
@@ -220,8 +222,12 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
         }
 
         ha-logbook {
-          height: 385px;
           display: block;
+          height: 100%;
+        }
+
+        ha-logbook.is-masonry {
+          height: 385px;
         }
 
         :host([ispanel]) .content,

--- a/src/panels/lovelace/cards/hui-logbook-card.ts
+++ b/src/panels/lovelace/cards/hui-logbook-card.ts
@@ -14,7 +14,11 @@ import { findEntities } from "../common/find-entities";
 import { processConfigEntities } from "../common/process-config-entities";
 import "../components/hui-warning";
 import type { EntityConfig } from "../entity-rows/types";
-import type { LovelaceCard, LovelaceCardEditor } from "../types";
+import type {
+  LovelaceCard,
+  LovelaceCardEditor,
+  LovelaceGridOptions,
+} from "../types";
 import type { LogbookCardConfig } from "./types";
 import { resolveEntityIDs } from "../../../data/selector";
 import { ensureArray } from "../../../common/array/ensure-array";
@@ -62,6 +66,15 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
 
   public getCardSize(): number {
     return 9 + (this._config?.title ? 1 : 0);
+  }
+
+  public getGridOptions(): LovelaceGridOptions {
+    return {
+      rows: 6,
+      columns: 12,
+      min_columns: 6,
+      min_rows: this._config?.title ? 4 : 3,
+    };
   }
 
   public validateTarget(

--- a/src/panels/lovelace/cards/hui-logbook-card.ts
+++ b/src/panels/lovelace/cards/hui-logbook-card.ts
@@ -202,7 +202,10 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
       >
         <div class="content">
           <ha-logbook
-            class=${classMap({ "is-masonry": this.layout === "masonry" })}
+            class=${classMap({
+              "is-grid": this.layout === "grid",
+              "is-panel": this.layout === "panel",
+            })}
             .hass=${this.hass}
             .time=${this._time}
             .entityIds=${this._getEntityIds()}
@@ -235,12 +238,13 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
         }
 
         ha-logbook {
+          height: 385px;
           display: block;
-          height: 100%;
         }
 
-        ha-logbook.is-masonry {
-          height: 385px;
+        ha-logbook.is-grid,
+        ha-logbook.is-panel {
+          height: 100%;
         }
 
         :host([ispanel]) .content,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Similar fix to #27052 this card was not updated to use grid layout sizing, and was missing layout constraints

<details>
<summary>Screenshots</summary>

Grid:
<img width="838" height="563" alt="image" src="https://github.com/user-attachments/assets/2eb518d5-4264-4ea0-889b-0bff377165ba" />

No title:
<img width="1223" height="730" alt="image" src="https://github.com/user-attachments/assets/33577ab9-2c74-4e22-bc5d-20f84fd380d7" />

With title (+1 row min):
<img width="1116" height="611" alt="image" src="https://github.com/user-attachments/assets/847d5ba8-6d80-43c5-b165-adce64cb248e" />

Masonry:
<img width="1556" height="870" alt="image" src="https://github.com/user-attachments/assets/c81b63cf-8199-491c-80db-1fd0210cef70" />

Sidebar (masonry):
<img width="1606" height="701" alt="image" src="https://github.com/user-attachments/assets/b4028726-dc51-4453-bb2a-34ce26f618b6" />

Panel:
<img width="1853" height="1936" alt="image" src="https://github.com/user-attachments/assets/26b2c56c-6288-44d0-bed0-bf2db9dbe6a6" />

</details>

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
