### PR TITLE
Fix entities card size and add grid contstraints

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -24,6 +24,7 @@ import type {
   LovelaceHeaderFooter,
 } from "../types";
 import type { EntitiesCardConfig } from "./types";
+import { haStyleScrollbar } from "../../../resources/styles";
 
 export const computeShowHeaderToggle = <
   T extends EntityConfig | LovelaceRowConfig,
@@ -244,7 +245,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
                     `}
               </h1>
             `}
-        <div id="states" class="card-content">
+        <div id="states" class="card-content ha-scrollbar">
           ${this._configEntities!.map((entityConf) =>
             this._renderEntity(entityConf)
           )}
@@ -257,70 +258,73 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
     `;
   }
 
-  static styles = css`
-    ha-card {
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-    }
-    .card-header {
-      display: flex;
-      justify-content: space-between;
-    }
+  static styles = [
+    haStyleScrollbar,
+    css`
+      ha-card {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+      }
+      .card-header {
+        display: flex;
+        justify-content: space-between;
+      }
 
-    .card-header .name {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
+      .card-header .name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
-    #states {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      gap: var(--entities-card-row-gap, var(--card-row-gap, 8px));
-      overflow-y: auto;
-    }
+      #states {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: var(--entities-card-row-gap, var(--card-row-gap, 8px));
+        overflow-y: auto;
+      }
 
-    #states > div > * {
-      overflow: clip visible;
-    }
+      #states > div > * {
+        overflow: clip visible;
+      }
 
-    #states > div {
-      position: relative;
-    }
+      #states > div {
+        position: relative;
+      }
 
-    .icon {
-      padding: 0px 18px 0px 8px;
-    }
+      .icon {
+        padding: 0px 18px 0px 8px;
+      }
 
-    .header {
-      border-top-left-radius: var(
-        --ha-card-border-radius,
-        var(--ha-border-radius-lg)
-      );
-      border-top-right-radius: var(
-        --ha-card-border-radius,
-        var(--ha-border-radius-lg)
-      );
-      margin-bottom: 16px;
-      overflow: hidden;
-    }
+      .header {
+        border-top-left-radius: var(
+          --ha-card-border-radius,
+          var(--ha-border-radius-lg)
+        );
+        border-top-right-radius: var(
+          --ha-card-border-radius,
+          var(--ha-border-radius-lg)
+        );
+        margin-bottom: 16px;
+        overflow: hidden;
+      }
 
-    .footer {
-      border-bottom-left-radius: var(
-        --ha-card-border-radius,
-        var(--ha-border-radius-lg)
-      );
-      border-bottom-right-radius: var(
-        --ha-card-border-radius,
-        var(--ha-border-radius-lg)
-      );
-      margin-top: -16px;
-      overflow: hidden;
-    }
-  `;
+      .footer {
+        border-bottom-left-radius: var(
+          --ha-card-border-radius,
+          var(--ha-border-radius-lg)
+        );
+        border-bottom-right-radius: var(
+          --ha-card-border-radius,
+          var(--ha-border-radius-lg)
+        );
+        margin-top: -16px;
+        overflow: hidden;
+      }
+    `,
+  ];
 
   private _renderEntity(entityConf: LovelaceRowConfig): TemplateResult {
     const element = createRowElement(

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -1,6 +1,6 @@
 import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, state } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { DOMAINS_TOGGLE } from "../../../common/const";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { computeDomain } from "../../../common/entity/compute_domain";
@@ -20,6 +20,7 @@ import type {
 import type {
   LovelaceCard,
   LovelaceCardEditor,
+  LovelaceGridOptions,
   LovelaceHeaderFooter,
 } from "../types";
 import type { EntitiesCardConfig } from "./types";
@@ -74,6 +75,8 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   @state() private _config?: EntitiesCardConfig;
 
   private _hass?: HomeAssistant;
+
+  @property({ attribute: false }) public layout?: string;
 
   private _configEntities?: LovelaceRowConfig[];
 
@@ -137,6 +140,14 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
     }
 
     return size;
+  }
+
+  public getGridOptions(): LovelaceGridOptions {
+    return {
+      columns: 12,
+      min_columns: 6,
+      min_rows: 2,
+    };
   }
 
   public setConfig(config: EntitiesCardConfig): void {

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -147,9 +147,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
     return {
       columns: 12,
       min_columns: 6,
-      min_rows:
-        (this._config?.title || this._showHeaderToggle ? 2 : 1) +
-        this._config.entities.length,
+      min_rows: this._config?.title || this._showHeaderToggle ? 3 : 2,
     };
   }
 

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -147,7 +147,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
     return {
       columns: 12,
       min_columns: 6,
-      min_rows: 2,
+      min_rows: (this._config?.title || this._showHeaderToggle ? 2 : 1) + this._config.entities.length,
     };
   }
 

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -147,7 +147,9 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
     return {
       columns: 12,
       min_columns: 6,
-      min_rows: (this._config?.title || this._showHeaderToggle ? 2 : 1) + this._config.entities.length,
+      min_rows:
+        (this._config?.title || this._showHeaderToggle ? 2 : 1) +
+        this._config.entities.length,
     };
   }
 

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -280,6 +280,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
       display: flex;
       flex-direction: column;
       gap: var(--entities-card-row-gap, var(--card-row-gap, 8px));
+      overflow-y: auto;
     }
 
     #states > div > * {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Similar fix to #27052 and #27683

This card was not updated to use grid layout sizing, and was missing layout constraints.

Also allows overflow with list when grid is smaller than entities shown + uses ha-scrollbar styling.

The default card size is unchanged and no layout options will size to the number of entities as before.

<details>
<summary>Screenshots</summary>

Grid:

<img width="1390" height="625" alt="image" src="https://github.com/user-attachments/assets/07f73ef8-71ce-43cf-991d-ee9f5648caa2" />

<img width="1503" height="788" alt="image" src="https://github.com/user-attachments/assets/2295597d-0418-46f5-95cf-36f500296b5b" />

<img width="1633" height="881" alt="image" src="https://github.com/user-attachments/assets/eaa47cbf-9f2d-4c6f-b86f-ece87a95ac2f" />

<img width="1471" height="1176" alt="image" src="https://github.com/user-attachments/assets/a2908198-3098-4065-ac9d-03843817e6fe" />

Masonry:
<img width="1726" height="440" alt="image" src="https://github.com/user-attachments/assets/60748482-40e4-4afb-96ad-127825682210" />

Sidebar (masonry):
<img width="1481" height="336" alt="image" src="https://github.com/user-attachments/assets/ee885149-2454-4fbf-9b4f-7518916a9c93" />

Panel:
<img width="1846" height="1896" alt="image" src="https://github.com/user-attachments/assets/61d884e5-a3fc-42dd-a395-ad8cdc0d9a4e" />

</details>

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
