### PR TITLE
Add a state filter to logbook card

### DIFF
--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -52,6 +52,8 @@ export class HaLogbook extends LitElement {
 
   @property({ attribute: false }) public deviceIds?: string[];
 
+  @property({ attribute: false }) public stateFilter?: string[];
+
   @property({ type: Boolean }) public narrow = false;
 
   @property({ type: Boolean, reflect: true }) public virtualize = false;
@@ -165,7 +167,7 @@ export class HaLogbook extends LitElement {
   protected willUpdate(changedProps: PropertyValues): void {
     let changed = changedProps.has("time");
 
-    for (const key of ["entityIds", "deviceIds"]) {
+    for (const key of ["entityIds", "deviceIds", "stateFilter"]) {
       if (!changedProps.has(key)) {
         continue;
       }
@@ -352,9 +354,19 @@ export class HaLogbook extends LitElement {
       "recent" in this.time
         ? findStartOfRecentTime(new Date(), this.time.recent)
         : undefined;
+
+    let eventsFiltered: LogbookEntry[] | undefined;
+    if (this.stateFilter && this.stateFilter.length > 0) {
+      eventsFiltered = streamMessage.events.filter(
+        (e) => e.state && this.stateFilter?.includes(e.state)
+      );
+    } else {
+      eventsFiltered = [...streamMessage.events];
+    }
+
     // Put newest ones on top. Reverse works in-place so
     // make a copy first.
-    const newEntries = [...streamMessage.events].reverse();
+    const newEntries = eventsFiltered.reverse();
     if (!this._logbookEntries || !this._logbookEntries.length) {
       this._logbookEntries = newEntries;
       return;

--- a/src/panels/lovelace/cards/hui-logbook-card.ts
+++ b/src/panels/lovelace/cards/hui-logbook-card.ts
@@ -64,6 +64,8 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
 
   @state() private _targetPickerValue: HassServiceTarget = {};
 
+  @state() private _stateFilter?: string[];
+
   public getCardSize(): number {
     return 9 + (this._config?.title ? 1 : 0);
   }
@@ -129,6 +131,8 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
     };
 
     this._targetPickerValue = target;
+
+    this._stateFilter = ensureArray(config.state_filter);
   }
 
   private _getEntityIds(): string[] | undefined {
@@ -209,6 +213,7 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
             .hass=${this.hass}
             .time=${this._time}
             .entityIds=${this._getEntityIds()}
+            .stateFilter=${this._stateFilter}
             narrow
             relative-time
             virtualize

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -345,6 +345,7 @@ export interface LogbookCardConfig extends LovelaceCardConfig {
   title?: string;
   hours_to_show?: number;
   theme?: string;
+  state_filter?: string[];
 }
 
 interface GeoLocationSourceConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-logbook-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-logbook-card-editor.ts
@@ -10,6 +10,7 @@ import {
   string,
 } from "superstruct";
 import type { HassServiceTarget } from "home-assistant-js-websocket";
+import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-entities-picker";
 import "../../../../components/ha-target-picker";
@@ -24,6 +25,7 @@ import { DEFAULT_HOURS_TO_SHOW } from "../../cards/hui-logbook-card";
 import { targetStruct } from "../../../../data/script";
 import { getSensorNumericDeviceClasses } from "../../../../data/sensor";
 import type { HaEntityPickerEntityFilterFunc } from "../../../../data/entity";
+import { resolveEntityIDs } from "../../../../data/selector";
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -33,6 +35,7 @@ const cardConfigStruct = assign(
     hours_to_show: optional(number()),
     theme: optional(string()),
     target: optional(targetStruct),
+    state_filter: optional(array(string())),
   })
 );
 
@@ -49,6 +52,13 @@ const SCHEMA = [
         selector: { number: { mode: "box", min: 1 } },
       },
     ],
+  },
+  {
+    name: "state_filter",
+    context: {
+      filter_entity: "context_entities",
+    },
+    selector: { state: { multiple: true } },
   },
 ] as const;
 
@@ -106,7 +116,13 @@ export class HuiLogbookCardEditor
     return html`
       <ha-form
         .hass=${this.hass}
-        .data=${this._config}
+        .data=${this._data(
+          this._config,
+          this._targetPicker,
+          this.hass.entities,
+          this.hass.devices,
+          this.hass.areas
+        )}
         .schema=${SCHEMA}
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
@@ -122,6 +138,25 @@ export class HuiLogbookCardEditor
     `;
   }
 
+  private _data = memoizeOne(
+    (
+      config: LogbookCardConfig,
+      target: HassServiceTarget,
+      entities: HomeAssistant["entities"],
+      devices: HomeAssistant["devices"],
+      areas: HomeAssistant["areas"]
+    ) => ({
+      ...config,
+      context_entities: resolveEntityIDs(
+        this.hass!,
+        target,
+        entities,
+        devices,
+        areas
+      ),
+    })
+  );
+
   private _filterFunc: HaEntityPickerEntityFilterFunc = (entity) =>
     filterLogbookCompatibleEntities(entity, this._sensorNumericDeviceClasses);
 
@@ -131,7 +166,9 @@ export class HuiLogbookCardEditor
   }
 
   private _valueChanged(ev: CustomEvent): void {
-    fireEvent(this, "config-changed", { config: ev.detail.value });
+    const newConfig = { ...ev.detail.value };
+    delete newConfig.context_entities;
+    fireEvent(this, "config-changed", { config: newConfig });
   }
 
   private _computeLabelCallback = (schema: SchemaUnion<typeof SCHEMA>) => {
@@ -142,6 +179,10 @@ export class HuiLogbookCardEditor
         )} (${this.hass!.localize(
           "ui.panel.lovelace.editor.card.config.optional"
         )})`;
+      case "state_filter":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.card.logbook.state_filter"
+        );
       default:
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.generic.${schema.name}`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7651,7 +7651,8 @@
             },
             "logbook": {
               "name": "Activity",
-              "description": "The Activity card shows a list of events for entities."
+              "description": "The Activity card shows a list of events for entities.",
+              "state_filter": "State filter"
             },
             "history-graph": {
               "name": "History graph",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Add an optional state filter to logbook/activity card. Sometimes you want to have a log of some rare events, like maybe a leak sensor turning on, and the fact that a target entity transfers from `off` -> `unknown` -> `off` 100+ times is both uninteresting and clutters the display uselessly. 

Fairly highly voted [feature request](https://community.home-assistant.io/t/logbook-card-filter-states/336632).

<img width="1007" height="719" alt="image" src="https://github.com/user-attachments/assets/3691fc20-feab-47a7-a9c7-67be3e8af69b" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://community.home-assistant.io/t/logbook-card-filter-states/336632
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41515

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
