### PR TITLE
Default card name to friendly name

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,5 +235,8 @@
     "tslib": "2.8.1",
     "@material/mwc-list@^0.27.0": "patch:@material/mwc-list@npm%3A0.27.0#~/.yarn/patches/@material-mwc-list-npm-0.27.0-5344fc9de4.patch"
   },
-  "packageManager": "yarn@4.10.3"
+  "packageManager": "yarn@4.10.3",
+  "volta": {
+    "node": "22.21.1"
+  }
 }

--- a/src/components/entity/ha-entity-name-picker.ts
+++ b/src/components/entity/ha-entity-name-picker.ts
@@ -312,7 +312,7 @@ export class HaEntityNamePicker extends LitElement {
   private _toValue = memoizeOne(
     (items: EntityNameItem[]): typeof this.value => {
       if (items.length === 0) {
-        return "";
+        return undefined;
       }
       if (items.length === 1) {
         const item = items[0];

--- a/src/panels/lovelace/common/entity/compute-lovelace-entity-name.ts
+++ b/src/panels/lovelace/common/entity/compute-lovelace-entity-name.ts
@@ -1,28 +1,29 @@
 import type { HassEntity } from "home-assistant-js-websocket";
-import {
-  DEFAULT_ENTITY_NAME,
-  type EntityNameItem,
-} from "../../../../common/entity/compute_entity_name_display";
-import type { HomeAssistant } from "../../../../types";
 import { ensureArray } from "../../../../common/array/ensure-array";
+import type { EntityNameItem } from "../../../../common/entity/compute_entity_name_display";
+import { computeStateName } from "../../../../common/entity/compute_state_name";
+import type { HomeAssistant } from "../../../../types";
 
 /**
  * Computes the display name for an entity in Lovelace (cards and badges).
  *
  * @param hass - The Home Assistant instance
  * @param stateObj - The entity state object
- * @param nameConfig - The name configuration (string for override, or EntityNameItem[] for structured naming)
+ * @param config - The name configuration (string for override, or EntityNameItem[] for structured naming)
  * @returns The computed entity name
  */
 export const computeLovelaceEntityName = (
   hass: HomeAssistant,
   stateObj: HassEntity | undefined,
-  nameConfig: string | EntityNameItem | EntityNameItem[] | undefined
+  config: string | EntityNameItem | EntityNameItem[] | undefined
 ): string => {
-  if (typeof nameConfig === "string") {
-    return nameConfig;
+  // If no config is provided, fall back to the default state name
+  if (!config) {
+    return stateObj ? computeStateName(stateObj) : "";
   }
-  const config = nameConfig || DEFAULT_ENTITY_NAME;
+  if (typeof config === "string") {
+    return config;
+  }
   if (stateObj) {
     return hass.formatEntityName(stateObj, config);
   }

--- a/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
@@ -4,7 +4,6 @@ import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { array, assert, assign, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
 import { supportsFeature } from "../../../../common/entity/supports-feature";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-form/ha-form";
@@ -65,9 +64,7 @@ export class HuiAlarmPanelCardEditor
         {
           name: "name",
           selector: {
-            entity_name: {
-              default_name: DEFAULT_ENTITY_NAME,
-            },
+            entity_name: {},
           },
           context: { entity: "entity" },
         },

--- a/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
@@ -5,7 +5,6 @@ import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { assert, assign, boolean, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
 import "../../../../components/ha-form/ha-form";
 import type {
   HaFormSchema,
@@ -73,7 +72,7 @@ export class HuiButtonCardEditor
         {
           name: "name",
           selector: {
-            entity_name: { default_name: DEFAULT_ENTITY_NAME },
+            entity_name: {},
           },
           context: { entity: "entity" },
         },

--- a/src/panels/lovelace/editor/config-elements/hui-entity-badge-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entity-badge-editor.ts
@@ -13,7 +13,6 @@ import {
   string,
   union,
 } from "superstruct";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-form/ha-form";
@@ -86,9 +85,7 @@ export class HuiEntityBadgeEditor
             {
               name: "name",
               selector: {
-                entity_name: {
-                  default_name: DEFAULT_ENTITY_NAME,
-                },
+                entity_name: {},
               },
               context: { entity: "entity" },
             },

--- a/src/panels/lovelace/editor/config-elements/hui-entity-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entity-card-editor.ts
@@ -1,5 +1,4 @@
 import { assert, assign, boolean, object, optional, string } from "superstruct";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
 import type { HaFormSchema } from "../../../../components/ha-form/types";
 import { headerFooterConfigStructs } from "../../header-footer/structs";
@@ -26,9 +25,7 @@ const SCHEMA = [
   {
     name: "name",
     selector: {
-      entity_name: {
-        default_name: DEFAULT_ENTITY_NAME,
-      },
+      entity_name: {},
     },
     context: { entity: "entity" },
   },

--- a/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
@@ -14,7 +14,6 @@ import {
   string,
 } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import { NON_NUMERIC_ATTRIBUTES } from "../../../../data/entity_attributes";
@@ -102,9 +101,7 @@ export class HuiGaugeCardEditor
         {
           name: "name",
           selector: {
-            entity_name: {
-              default_name: DEFAULT_ENTITY_NAME,
-            },
+            entity_name: {},
           },
           context: { entity: "entity" },
         },

--- a/src/panels/lovelace/editor/config-elements/hui-humidifier-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-humidifier-card-editor.ts
@@ -14,7 +14,6 @@ import {
 } from "superstruct";
 import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
 import "../../../../components/ha-expansion-panel";
 import "../../../../components/ha-form/ha-form";
 import type {
@@ -61,9 +60,7 @@ const SCHEMA = [
   {
     name: "name",
     selector: {
-      entity_name: {
-        default_name: DEFAULT_ENTITY_NAME,
-      },
+      entity_name: {},
     },
     context: { entity: "entity" },
   },

--- a/src/panels/lovelace/editor/config-elements/hui-light-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-light-card-editor.ts
@@ -1,10 +1,9 @@
+import { mdiGestureTap } from "@mdi/js";
 import type { CSSResultGroup } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { assert, assign, object, optional, string } from "superstruct";
-import { mdiGestureTap } from "@mdi/js";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
@@ -37,9 +36,7 @@ const SCHEMA = [
   {
     name: "name",
     selector: {
-      entity_name: {
-        default_name: DEFAULT_ENTITY_NAME,
-      },
+      entity_name: {},
     },
     context: { entity: "entity" },
   },

--- a/src/panels/lovelace/editor/config-elements/hui-media-control-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-media-control-card-editor.ts
@@ -2,7 +2,6 @@ import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { assert, assign, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
 import "../../../../components/ha-form/ha-form";
 import type {
   HaFormSchema,
@@ -33,9 +32,7 @@ const SCHEMA = [
   {
     name: "name",
     selector: {
-      entity_name: {
-        default_name: DEFAULT_ENTITY_NAME,
-      },
+      entity_name: {},
     },
     context: { entity: "entity" },
   },

--- a/src/panels/lovelace/editor/config-elements/hui-picture-entity-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-entity-card-editor.ts
@@ -1,8 +1,8 @@
-import memoizeOne from "memoize-one";
 import { mdiGestureTap } from "@mdi/js";
 import type { CSSResultGroup } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
 import {
   assert,
   assign,
@@ -15,7 +15,6 @@ import {
 } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { computeDomain } from "../../../../common/entity/compute_domain";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-form/ha-form";
 import type {
@@ -71,9 +70,7 @@ export class HuiPictureEntityCardEditor
         {
           name: "name",
           selector: {
-            entity_name: {
-              default_name: DEFAULT_ENTITY_NAME,
-            },
+            entity_name: {},
           },
           context: { entity: "entity" },
         },

--- a/src/panels/lovelace/editor/config-elements/hui-plant-status-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-plant-status-card-editor.ts
@@ -2,7 +2,6 @@ import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { assert, assign, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
@@ -25,9 +24,7 @@ const SCHEMA = [
   {
     name: "name",
     selector: {
-      entity_name: {
-        default_name: DEFAULT_ENTITY_NAME,
-      },
+      entity_name: {},
     },
     context: { entity: "entity" },
   },

--- a/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
@@ -1,7 +1,7 @@
-import memoizeOne from "memoize-one";
 import type { CSSResultGroup } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
 import {
   assert,
   assign,
@@ -12,18 +12,17 @@ import {
   string,
   union,
 } from "superstruct";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
-import type { LocalizeFunc } from "../../../../common/translations/localize";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
+import { DEFAULT_HOURS_TO_SHOW } from "../../cards/hui-sensor-card";
 import type { SensorCardConfig } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import { entityNameStruct } from "../structs/entity-name-struct";
 import { configElementStyle } from "./config-elements-style";
-import { DEFAULT_HOURS_TO_SHOW } from "../../cards/hui-sensor-card";
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -71,9 +70,7 @@ export class HuiSensorCardEditor
         {
           name: "name",
           selector: {
-            entity_name: {
-              default_name: DEFAULT_ENTITY_NAME,
-            },
+            entity_name: {},
           },
           context: { entity: "entity" },
         },

--- a/src/panels/lovelace/editor/config-elements/hui-thermostat-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-thermostat-card-editor.ts
@@ -14,7 +14,7 @@ import {
 } from "superstruct";
 import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
+import { computeDomain } from "../../../../common/entity/compute_domain";
 import "../../../../components/ha-expansion-panel";
 import "../../../../components/ha-form/ha-form";
 import type {
@@ -35,7 +35,6 @@ import type { EditDetailElementEvent, EditSubElementEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
 import "./hui-card-features-editor";
 import type { FeatureType } from "./hui-card-features-editor";
-import { computeDomain } from "../../../../common/entity/compute_domain";
 
 const COMPATIBLE_FEATURES_TYPES: Record<string, FeatureType[]> = {
   climate: [
@@ -89,9 +88,7 @@ export class HuiThermostatCardEditor
         {
           name: "name",
           selector: {
-            entity_name: {
-              default_name: DEFAULT_ENTITY_NAME,
-            },
+            entity_name: {},
           },
           context: { entity: "entity" },
         },

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -16,7 +16,6 @@ import {
 } from "superstruct";
 import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
 import { orderProperties } from "../../../../common/util/order-properties";
 import "../../../../components/ha-expansion-panel";
@@ -102,9 +101,7 @@ export class HuiTileCardEditor
             {
               name: "name",
               selector: {
-                entity_name: {
-                  default_name: DEFAULT_ENTITY_NAME,
-                },
+                entity_name: {},
               },
               context: { entity: "entity" },
             },

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -12,7 +12,6 @@ import {
   string,
 } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
 import { supportsFeature } from "../../../../common/entity/supports-feature";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-form/ha-form";
@@ -153,9 +152,7 @@ export class HuiWeatherForecastCardEditor
         {
           name: "name",
           selector: {
-            entity_name: {
-              default_name: DEFAULT_ENTITY_NAME,
-            },
+            entity_name: {},
           },
           context: { entity: "entity" },
         },

--- a/src/panels/lovelace/editor/heading-badge-editor/hui-entity-heading-badge-editor.ts
+++ b/src/panels/lovelace/editor/heading-badge-editor/hui-entity-heading-badge-editor.ts
@@ -13,7 +13,6 @@ import {
   union,
 } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { DEFAULT_ENTITY_NAME } from "../../../../common/entity/compute_entity_name_display";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-expansion-panel";
 import "../../../../components/ha-form/ha-form";
@@ -94,9 +93,7 @@ export class HuiHeadingEntityEditor
                 {
                   name: "name",
                   selector: {
-                    entity_name: {
-                      default_name: DEFAULT_ENTITY_NAME,
-                    },
+                    entity_name: {},
                   },
                   context: { entity: "entity" },
                 },

--- a/test/panels/lovelace/common/entity/compute-lovelace-entity-name.test.ts
+++ b/test/panels/lovelace/common/entity/compute-lovelace-entity-name.test.ts
@@ -25,7 +25,8 @@ describe("computeLovelaceEntityName", () => {
   it("return state name when nameConfig is empty string", () => {
     const mockFormatEntityName = vi.fn();
     const hass = createMockHass(mockFormatEntityName);
-    const stateObj = mockStateObj({ entity_id: "light.kitchen" });
+    const stateObj = mockStateObj({ entity_id: "light.kitchen", attributes: { friendly_name: "Kitchen Light" },
+ });
 
     const result = computeLovelaceEntityName(hass, stateObj, "");
 

--- a/test/panels/lovelace/common/entity/compute-lovelace-entity-name.test.ts
+++ b/test/panels/lovelace/common/entity/compute-lovelace-entity-name.test.ts
@@ -25,8 +25,10 @@ describe("computeLovelaceEntityName", () => {
   it("return state name when nameConfig is empty string", () => {
     const mockFormatEntityName = vi.fn();
     const hass = createMockHass(mockFormatEntityName);
-    const stateObj = mockStateObj({ entity_id: "light.kitchen", attributes: { friendly_name: "Kitchen Light" },
- });
+    const stateObj = mockStateObj({
+      entity_id: "light.kitchen",
+      attributes: { friendly_name: "Kitchen Light" },
+    });
 
     const result = computeLovelaceEntityName(hass, stateObj, "");
 

--- a/test/panels/lovelace/common/entity/compute-lovelace-entity-name.test.ts
+++ b/test/panels/lovelace/common/entity/compute-lovelace-entity-name.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { DEFAULT_ENTITY_NAME } from "../../../../../src/common/entity/compute_entity_name_display";
 import { computeLovelaceEntityName } from "../../../../../src/panels/lovelace/common/entity/compute-lovelace-entity-name";
 import type { HomeAssistant } from "../../../../../src/types";
 import { mockStateObj } from "../../../../common/entity/context/context-mock";
@@ -23,30 +22,29 @@ describe("computeLovelaceEntityName", () => {
     expect(mockFormatEntityName).not.toHaveBeenCalled();
   });
 
-  it("returns empty string when nameConfig is empty string", () => {
+  it("return state name when nameConfig is empty string", () => {
     const mockFormatEntityName = vi.fn();
     const hass = createMockHass(mockFormatEntityName);
     const stateObj = mockStateObj({ entity_id: "light.kitchen" });
 
     const result = computeLovelaceEntityName(hass, stateObj, "");
 
-    expect(result).toBe("");
+    expect(result).toBe("Kitchen Light");
     expect(mockFormatEntityName).not.toHaveBeenCalled();
   });
 
-  it("calls formatEntityName with DEFAULT_ENTITY_NAME when nameConfig is undefined", () => {
+  it("return state name when nameConfig is undefined", () => {
     const mockFormatEntityName = vi.fn(() => "Formatted Name");
     const hass = createMockHass(mockFormatEntityName);
-    const stateObj = mockStateObj({ entity_id: "light.kitchen" });
+    const stateObj = mockStateObj({
+      entity_id: "light.kitchen",
+      attributes: { friendly_name: "Kitchen Light" },
+    });
 
     const result = computeLovelaceEntityName(hass, stateObj, undefined);
 
-    expect(result).toBe("Formatted Name");
-    expect(mockFormatEntityName).toHaveBeenCalledTimes(1);
-    expect(mockFormatEntityName).toHaveBeenCalledWith(
-      stateObj,
-      DEFAULT_ENTITY_NAME
-    );
+    expect(result).toBe("Kitchen Light");
+    expect(mockFormatEntityName).not.toHaveBeenCalled();
   });
 
   it("calls formatEntityName with EntityNameItem config", () => {


### PR DESCRIPTION
## Proposed change

Following https://github.com/home-assistant/frontend/pull/27065.

The previous PR introduced a breaking change to fallback to device + entity name when no name set.
This PR restores the previous behavior : default to friendly name

Reasons of this changes : 
- To not introduce breaking change yet with this release.
- To avoid inconsistency between dashboard and other usage where friendly name is still used (voice, entity_id, yaml editor, etc...). 

So this feature is opt-in for now.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
