### PR TITLE
Fix todo item date picker displaying previous day

### DIFF
--- a/src/panels/todo/dialog-todo-item-editor.ts
+++ b/src/panels/todo/dialog-todo-item-editor.ts
@@ -255,6 +255,10 @@ class DialogTodoItemEditor extends LitElement {
 
   // Parse a date in the browser timezone
   private _parseDate(dateStr: string): Date {
+    // If it's a date-only string (no 'T'), parse as midnight in browser time to avoid offset issues
+    if (!dateStr.includes("T")) {
+      return new Date(dateStr + "T00:00:00");
+    }
     const tzDate = new TZDate(dateStr, this._timeZone!);
     return new Date(tzDate.getTime());
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
When adding or editing a todo item with a due date (without time), selecting a date from the date picker would display the previous day in the form field.

Root cause

The _parseDate method was applying timezone conversion to date-only strings (e.g., "2025-10-16"), causing the date to shift for users in negative offset timezones.

Solution

The fix checks if the string is date-only (no T character) and parses it as midnight browser time to avoid offset issues.

Timed events (when a due time is also specified) continue to properly respect timezone conversion as expected.

Test plan
  - Date-only selection displays correct date on first save
  - Time + date selection still respects timezone conversion
  - Manual testing with various timezones

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #27657
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io