### PR TITLE
Only clear from and to trigger in state trigger

### DIFF
--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
@@ -245,18 +245,20 @@ export class HaStateTrigger extends LitElement implements TriggerElement {
       newTrigger.to,
       newTrigger.attribute
     );
+    if (Array.isArray(newTrigger.to) && newTrigger.to.length === 0) {
+      delete newTrigger.to;
+    }
     newTrigger.from = this._applyAnyStateExclusive(
       newTrigger.from,
       newTrigger.attribute
     );
+    if (Array.isArray(newTrigger.from) && newTrigger.from.length === 0) {
+      delete newTrigger.from;
+    }
 
     Object.keys(newTrigger).forEach((key) => {
       const val = newTrigger[key];
-      if (
-        val === undefined ||
-        val === "" ||
-        (Array.isArray(val) && val.length === 0)
-      ) {
+      if (val === undefined || val === "") {
         delete newTrigger[key];
       }
     });


### PR DESCRIPTION
## Proposed change

Following https://github.com/home-assistant/frontend/pull/27455. 
The `entity_id` field should not be clear as it's required.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
