### PR TITLE
Restore trigger id in overflow menu for trigger

### DIFF
--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-trigger.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-trigger.ts
@@ -3,6 +3,7 @@ import {
   mdiContentCopy,
   mdiContentCut,
   mdiDelete,
+  mdiIdentifier,
   mdiPlayCircleOutline,
   mdiPlaylistEdit,
   mdiPlusCircleMultipleOutline,
@@ -40,6 +41,8 @@ export default class HaAutomationSidebarTrigger extends LitElement {
   @property({ type: Number, attribute: "sidebar-key" })
   public sidebarKey?: number;
 
+  @state() private _requestShowId = false;
+
   @state() private _warnings?: string[];
 
   @query(".sidebar-editor")
@@ -47,6 +50,7 @@ export default class HaAutomationSidebarTrigger extends LitElement {
 
   protected willUpdate(changedProperties) {
     if (changedProperties.has("config")) {
+      this._requestShowId = false;
       this._warnings = undefined;
       if (this.config) {
         this.yamlMode = this.config.yamlMode;
@@ -100,6 +104,24 @@ export default class HaAutomationSidebarTrigger extends LitElement {
             <span class="shortcut-placeholder ${isMac ? "mac" : ""}"></span>
           </div>
         </ha-md-menu-item>
+
+        ${!this.yamlMode &&
+        !("id" in this.config.config) &&
+        !this._requestShowId
+          ? html`<ha-md-menu-item
+              slot="menu-items"
+              .clickAction=${this._showTriggerId}
+              .disabled=${this.disabled || type === "list"}
+            >
+              <ha-svg-icon slot="start" .path=${mdiIdentifier}></ha-svg-icon>
+              <div class="overflow-label">
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.triggers.edit_id"
+                )}
+                <span class="shortcut-placeholder ${isMac ? "mac" : ""}"></span>
+              </div>
+            </ha-md-menu-item>`
+          : nothing}
 
         <ha-md-divider
           slot="menu-items"
@@ -250,6 +272,7 @@ export default class HaAutomationSidebarTrigger extends LitElement {
             @value-changed=${this._valueChangedSidebar}
             @yaml-changed=${this._yamlChangedSidebar}
             .uiSupported=${this.config.uiSupported}
+            .showId=${this._requestShowId}
             .yamlMode=${this.yamlMode}
             .disabled=${this.disabled}
             @ui-mode-not-available=${this._handleUiModeNotAvailable}
@@ -290,6 +313,10 @@ export default class HaAutomationSidebarTrigger extends LitElement {
 
   private _toggleYamlMode = () => {
     fireEvent(this, "toggle-yaml-mode");
+  };
+
+  private _showTriggerId = () => {
+    this._requestShowId = true;
   };
 
   static styles = [sidebarEditorStyles, overflowStyles];

--- a/src/panels/config/automation/trigger/ha-automation-trigger-editor.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-editor.ts
@@ -29,12 +29,16 @@ export default class HaAutomationTriggerEditor extends LitElement {
 
   @property({ type: Boolean, attribute: "sidebar" }) public inSidebar = false;
 
+  @property({ type: Boolean, attribute: "show-id" }) public showId = false;
+
   @query("ha-yaml-editor") public yamlEditor?: HaYamlEditor;
 
   protected render() {
     const type = isTriggerList(this.trigger) ? "list" : this.trigger.trigger;
 
     const yamlMode = this.yamlMode || !this.uiSupported;
+
+    const showId = "id" in this.trigger || this.showId;
 
     return html`
       <div
@@ -70,20 +74,15 @@ export default class HaAutomationTriggerEditor extends LitElement {
               ></ha-yaml-editor>
             `
           : html`
-              ${!isTriggerList(this.trigger)
+              ${showId && !isTriggerList(this.trigger)
                 ? html`
                     <ha-textfield
-                      .label=${`${this.hass.localize(
+                      .label=${this.hass.localize(
                         "ui.panel.config.automation.editor.triggers.id"
-                      )} (${this.hass.localize(
-                        "ui.panel.config.automation.editor.triggers.optional"
-                      )})`}
+                      )}
                       .value=${this.trigger.id || ""}
                       .disabled=${this.disabled}
                       @change=${this._idChanged}
-                      .helper=${this.hass.localize(
-                        "ui.panel.config.automation.editor.triggers.id_helper"
-                      )}
                     ></ha-textfield>
                   `
                 : nothing}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3945,7 +3945,6 @@
               "add": "Add trigger",
               "empty_search": "No triggers found for {term}",
               "id": "Trigger ID",
-              "id_helper": "Helps identify each run based on which trigger fired.",
               "optional": "Optional",
               "edit_id": "Edit ID",
               "duplicate": "[%key:ui::common::duplicate%]",


### PR DESCRIPTION
## Proposed change

The overflow was moved to the form with this PR : https://github.com/home-assistant/frontend/pull/27093
But it's too advanced, this PR re-add it to the sidebar overflow menu

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
