### PR TITLE
Show multi-domain translations in state-picker

### DIFF
--- a/src/components/entity/ha-entity-state-picker.ts
+++ b/src/components/entity/ha-entity-state-picker.ts
@@ -77,16 +77,26 @@ class HaEntityStatePicker extends LitElement {
         }));
       });
 
-      const options: StateOption[] = [];
-      const optionsSet = new Set<string>();
+      const optionLabels: Record<string, string[]> = {};
       for (const entityOptions of entitiesOptions) {
         for (const option of entityOptions) {
-          if (!optionsSet.has(option.value)) {
-            optionsSet.add(option.value);
-            options.push(option);
+          if (!(option.value in optionLabels)) {
+            optionLabels[option.value] = [option.label];
+          } else {
+            const labels = optionLabels[option.value];
+            if (!labels.includes(option.label)) {
+              labels.push(option.label);
+            }
           }
         }
       }
+
+      const options = Object.entries(optionLabels).map<StateOption>(
+        ([value, labels]) => ({
+          value,
+          label: labels.join(" / "),
+        })
+      );
 
       if (this.extraOptions) {
         options.unshift(...this.extraOptions);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
When we use a state selector w/ multiple entities, those entities could have the same common states with different translations. 

For example if we have a state trigger with a moisture binary sensor and a light (newly added feature allows multiple entities), both of those entities have the state "on", but the state selector will offer the state options "Wet" or "Dry". 

It is kind of odd that selecting the "Wet" option really means "when the light turns on", but that's how it will work in the backend.

It's still a bit strange result, but maybe we want to show all possible unique state translations of the common state, e.g.:

<img width="491" height="718" alt="image" src="https://github.com/user-attachments/assets/a5cf8aed-f966-44dc-9261-97feec8c3e04" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
