### PR TITLE
Use progress ring for updates on config dashboard

### DIFF
--- a/src/panels/config/dashboard/ha-config-updates.ts
+++ b/src/panels/config/dashboard/ha-config-updates.ts
@@ -58,10 +58,13 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
   );
 
   private _renderUpdateProgress(entity: UpdateEntity) {
-    if (entity.attributes.update_percentage !== null) {
+    if (entity.attributes.update_percentage != null) {
       return html`<ha-progress-ring
         size="small"
         .value=${entity.attributes.update_percentage}
+        .label=${this.hass.localize(
+          "ui.panel.config.updates.update_in_progress"
+        )}
       ></ha-progress-ring>`;
     }
 


### PR DESCRIPTION
## Proposed change
Use a progress ring for updates when available on the config dashboard

Normal
<img width="622" height="102" alt="image" src="https://github.com/user-attachments/assets/1cec8343-14b7-4499-8b45-f50377f70240" />

Narrow
<img width="555" height="105" alt="image" src="https://github.com/user-attachments/assets/32c36977-7a53-4469-b036-59917fa83399" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
