### PR TITLE
Fix translation keys of energy-compare card

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-compare-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-compare-card.ts
@@ -80,41 +80,44 @@ export class HuiEnergyCompareCard
 
     return html`
       <ha-alert dismissable @alert-dismissed-clicked=${this._stopCompare}>
-        ${this.hass.localize("ui.panel.energy.compare.info", {
-          start: html`<b
-            >${formatDate(
-              this._start!,
-              this.hass.locale,
-              this.hass.config
-            )}${dayDifference > 0
-              ? ` -
+        ${this.hass.localize(
+          "ui.panel.lovelace.cards.energy.energy_compare.info",
+          {
+            start: html`<b
+              >${formatDate(
+                this._start!,
+                this.hass.locale,
+                this.hass.config
+              )}${dayDifference > 0
+                ? ` -
           ${formatDate(
             this._end || endOfDay(new Date()),
             this.hass.locale,
             this.hass.config
           )}`
-              : ""}</b
-          >`,
-          end: html`<b
-              >${formatDate(
-                this._startCompare,
-                this.hass.locale,
-                this.hass.config
-              )}${dayDifference > 0
-                ? ` -
-          ${formatDate(this._endCompare, this.hass.locale, this.hass.config)}`
                 : ""}</b
-            >
-            <button class="link" @click=${this._changeCompareMode}>
-              (${this._compareMode === CompareMode.PREVIOUS
-                ? this.hass.localize(
-                    "ui.panel.energy.compare.compare_previous_year"
-                  )
-                : this.hass.localize(
-                    "ui.panel.energy.compare.compare_previous_period"
-                  )})
-            </button>`,
-        })}
+            >`,
+            end: html`<b
+                >${formatDate(
+                  this._startCompare,
+                  this.hass.locale,
+                  this.hass.config
+                )}${dayDifference > 0
+                  ? ` -
+          ${formatDate(this._endCompare, this.hass.locale, this.hass.config)}`
+                  : ""}</b
+              >
+              <button class="link" @click=${this._changeCompareMode}>
+                (${this._compareMode === CompareMode.PREVIOUS
+                  ? this.hass.localize(
+                      "ui.panel.lovelace.cards.energy.energy_compare.compare_previous_year"
+                    )
+                  : this.hass.localize(
+                      "ui.panel.lovelace.cards.energy.energy_compare.compare_previous_period"
+                    )})
+              </button>`,
+          }
+        )}
       </ha-alert>
     `;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7088,6 +7088,11 @@
               "card_indicates_energy_used": "This card indicates how much of the electricity consumed by your home was generated using non-fossil fuels like solar, wind, and nuclear. The higher, the better!",
               "low_carbon_energy_consumed": "Low-carbon electricity consumed",
               "low_carbon_energy_not_calculated": "Consumed low-carbon electricity couldn't be calculated"
+            },
+            "energy_compare": {
+              "info": "You are comparing the period {start} with the period {end}",
+              "compare_previous_year": "Compare previous year",
+              "compare_previous_period": "Compare previous period"
             }
           },
           "heading": {
@@ -9336,11 +9341,6 @@
       "energy": {
         "download_data": "[%key:ui::panel::history::download_data%]",
         "configure": "[%key:ui::dialogs::quick-bar::commands::navigation::energy%]",
-        "compare": {
-          "info": "You are comparing the period {start} with the period {end}",
-          "compare_previous_year": "Compare previous year",
-          "compare_previous_period": "Compare previous period"
-        },
         "setup": {
           "next": "Next",
           "back": "Back",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This change fixes that the energy-compare card stays empty when you use it outside the energy dashboard. Root cause is that it used the translations of the energy panel which are not available for cards (until you load the energy panel and go back). Solution is to use the `lovelace` panel prefix for these translations.

Side-effect is that all translations have to be copied in Lokalise, discussed this approach in the related issue #27746.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Configuration of a whole section
```yaml
type: grid
cards:
  - type: energy-date-selection
    grid_options:
      columns: full
  - type: energy-compare
    grid_options:
      columns: full
  - type: energy-sources-table
    grid_options:
      columns: full
column_span: 4


```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #27746
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
