### PR TITLE
Add support for PM4 sensor state

### DIFF
--- a/gallery/src/pages/misc/entity-state.ts
+++ b/gallery/src/pages/misc/entity-state.ts
@@ -39,6 +39,7 @@ const SENSOR_DEVICE_CLASSES = [
   "pm1",
   "pm10",
   "pm25",
+  "pm4",
   "power_factor",
   "power",
   "precipitation",

--- a/src/common/entity/get_states.ts
+++ b/src/common/entity/get_states.ts
@@ -214,6 +214,7 @@ const FIXED_DOMAIN_ATTRIBUTE_STATES = {
       "pm1",
       "pm10",
       "pm25",
+      "pm4",
       "power_factor",
       "power",
       "pressure",

--- a/src/fake_data/entity_component_icons.ts
+++ b/src/fake_data/entity_component_icons.ts
@@ -97,6 +97,9 @@ export const ENTITY_COMPONENT_ICONS: Record<string, ComponentIcons> = {
     pm25: {
       default: "mdi:molecule",
     },
+    pm4: {
+      default: "mdi:molecule",
+    },
     power: {
       default: "mdi:flash",
     },
@@ -672,6 +675,9 @@ export const ENTITY_COMPONENT_ICONS: Record<string, ComponentIcons> = {
       default: "mdi:molecule",
     },
     pm25: {
+      default: "mdi:molecule",
+    },
+    pm4: {
       default: "mdi:molecule",
     },
     power: {

--- a/test/common/entity/get_states.test.ts
+++ b/test/common/entity/get_states.test.ts
@@ -201,6 +201,7 @@ describe("getStates", () => {
           "pm1",
           "pm10",
           "pm25",
+          "pm4",
           "power_factor",
           "power",
           "pressure",
@@ -215,7 +216,7 @@ describe("getStates", () => {
           "volume_flow_rate",
         ])
       );
-      expect(result.length).toBe(34);
+      expect(result.length).toBe(35);
     });
 
     it("should return empty array for unknown attribute", () => {


### PR DESCRIPTION
## Proposed change

Add support for PM4 sensor states (see https://github.com/home-assistant/core/pull/112867).

Noticed while developing https://github.com/home-assistant/core/pull/155678.

Basically just so we get a molecule icon and not the default eye for the new device class: 

<img width="647" height="279" alt="image" src="https://github.com/user-attachments/assets/9f8d5ed2-648a-41e7-adab-be9bdface72f" />


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: See above
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
