### PR TITLE
Display entities without area in summary dashboard

### DIFF
--- a/src/panels/climate/strategies/climate-view-strategy.ts
+++ b/src/panels/climate/strategies/climate-view-strategy.ts
@@ -115,6 +115,24 @@ const processAreasForClimate = (
   return cards;
 };
 
+const processUnassignedEntities = (
+  hass: HomeAssistant,
+  entities: string[]
+): LovelaceCardConfig[] => {
+  const unassignedFilter = generateEntityFilter(hass, {
+    area: null,
+  });
+  const unassignedEntities = entities.filter(unassignedFilter);
+  const areaCards: LovelaceCardConfig[] = [];
+  const computeTileCard = computeAreaTileCardConfig(hass, "", true);
+
+  for (const entityId of unassignedEntities) {
+    areaCards.push(computeTileCard(entityId));
+  }
+
+  return areaCards;
+};
+
 @customElement("climate-view-strategy")
 export class ClimateViewStrategy extends ReactiveElement {
   static async generate(
@@ -190,10 +208,33 @@ export class ClimateViewStrategy extends ReactiveElement {
       }
     }
 
+    // Process unassigned entities
+    const unassignedCards = processUnassignedEntities(hass, entities);
+
+    if (unassignedCards.length > 0) {
+      const section: LovelaceSectionRawConfig = {
+        type: "grid",
+        column_span: 2,
+        cards: [
+          {
+            type: "heading",
+            heading:
+              sections.length > 0
+                ? hass.localize(
+                    "ui.panel.lovelace.strategy.climate.other_devices"
+                  )
+                : hass.localize("ui.panel.lovelace.strategy.climate.devices"),
+          },
+          ...unassignedCards,
+        ],
+      };
+      sections.push(section);
+    }
+
     return {
       type: "sections",
       max_columns: 2,
-      sections: sections || [],
+      sections: sections,
     };
   }
 }

--- a/src/panels/lovelace/cards/hui-home-summary-card.ts
+++ b/src/panels/lovelace/cards/hui-home-summary-card.ts
@@ -87,11 +87,6 @@ export class HuiHomeSummaryCard extends LitElement implements LovelaceCard {
     const allEntities = Object.keys(this.hass!.states);
 
     const areas = Object.values(this.hass.areas);
-    const areasFilter = generateEntityFilter(this.hass, {
-      area: areas.map((area) => area.area_id),
-    });
-
-    const entitiesInsideArea = allEntities.filter(areasFilter);
 
     switch (this._config.summary) {
       case "light": {
@@ -100,7 +95,7 @@ export class HuiHomeSummaryCard extends LitElement implements LovelaceCard {
           generateEntityFilter(this.hass!, filter)
         );
 
-        const lightEntities = findEntities(entitiesInsideArea, lightsFilters);
+        const lightEntities = findEntities(allEntities, lightsFilters);
 
         const onLights = lightEntities.filter((entityId) => {
           const s = this.hass!.states[entityId]?.state;
@@ -153,7 +148,7 @@ export class HuiHomeSummaryCard extends LitElement implements LovelaceCard {
           generateEntityFilter(this.hass!, filter)
         );
 
-        const safetyEntities = findEntities(entitiesInsideArea, safetyFilters);
+        const safetyEntities = findEntities(allEntities, safetyFilters);
 
         const locks = safetyEntities.filter((entityId) => {
           const domain = computeDomain(entityId);
@@ -204,7 +199,7 @@ export class HuiHomeSummaryCard extends LitElement implements LovelaceCard {
         );
 
         const mediaPlayerEntities = findEntities(
-          entitiesInsideArea,
+          allEntities,
           mediaPlayerFilters
         );
 

--- a/src/panels/lovelace/strategies/home/home-media-players-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-media-players-view-strategy.ts
@@ -59,6 +59,26 @@ const processAreasForMediaPlayers = (
   return cards;
 };
 
+const processUnassignedEntities = (
+  hass: HomeAssistant,
+  entities: string[]
+): LovelaceCardConfig[] => {
+  const unassignedFilter = generateEntityFilter(hass, {
+    area: null,
+  });
+  const unassignedEntities = entities.filter(unassignedFilter);
+  const areaCards: LovelaceCardConfig[] = [];
+
+  for (const entityId of unassignedEntities) {
+    areaCards.push({
+      type: "media-control",
+      entity: entityId,
+    } satisfies MediaControlCardConfig);
+  }
+
+  return areaCards;
+};
+
 @customElement("home-media-players-view-strategy")
 export class HomeMMediaPlayersViewStrategy extends ReactiveElement {
   static async generate(
@@ -134,10 +154,35 @@ export class HomeMMediaPlayersViewStrategy extends ReactiveElement {
       }
     }
 
+    // Process unassigned entities
+    const unassignedCards = processUnassignedEntities(hass, entities);
+
+    if (unassignedCards.length > 0) {
+      const section: LovelaceSectionRawConfig = {
+        type: "grid",
+        column_span: 2,
+        cards: [
+          {
+            type: "heading",
+            heading:
+              sections.length > 0
+                ? hass.localize(
+                    "ui.panel.lovelace.strategy.home_media_players.other_media_players"
+                  )
+                : hass.localize(
+                    "ui.panel.lovelace.strategy.home_media_players.media_players"
+                  ),
+          },
+          ...unassignedCards,
+        ],
+      };
+      sections.push(section);
+    }
+
     return {
       type: "sections",
       max_columns: 2,
-      sections: sections || [],
+      sections: sections,
     };
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6975,6 +6975,22 @@
           "common_controls": {
             "not_loaded": "Usage Prediction integration is not loaded.",
             "no_data": "This place will soon fill up with the entities you use most often, based on your activity."
+          },
+          "light": {
+            "lights": "Lights",
+            "other_lights": "Other lights"
+          },
+          "safety": {
+            "devices": "Devices",
+            "other_devices": "Other devices"
+          },
+          "climate": {
+            "devices": "Devices",
+            "other_devices": "Other devices"
+          },
+          "home_media_players": {
+            "media_players": "Media players",
+            "other_media_players": "Other media players"
           }
         },
         "cards": {

--- a/test/common/entity/entity_filter.test.ts
+++ b/test/common/entity/entity_filter.test.ts
@@ -388,4 +388,70 @@ describe("generateEntityFilter", () => {
       expect(filter("light.no_area")).toBe(false);
     });
   });
+
+  describe("null filtering", () => {
+    it("should filter entities with no area when null is used", () => {
+      const filter = generateEntityFilter(mockHass, { area: null });
+
+      expect(filter("light.no_area")).toBe(true);
+      expect(filter("light.living_room")).toBe(false);
+    });
+
+    it("should filter entities with specific area OR no area when null is in array", () => {
+      const filter = generateEntityFilter(mockHass, {
+        area: ["living_room", null],
+      });
+
+      expect(filter("light.living_room")).toBe(true);
+      expect(filter("sensor.temperature")).toBe(true);
+      expect(filter("light.no_area")).toBe(true);
+      expect(filter("switch.kitchen")).toBe(false);
+    });
+
+    it("should filter entities with no floor when null is used", () => {
+      const filter = generateEntityFilter(mockHass, { floor: null });
+
+      expect(filter("light.no_area")).toBe(true);
+      expect(filter("light.living_room")).toBe(false);
+    });
+
+    it("should filter entities with specific floor OR no floor", () => {
+      const filter = generateEntityFilter(mockHass, {
+        floor: ["main_floor", null],
+      });
+
+      expect(filter("light.living_room")).toBe(true);
+      expect(filter("switch.kitchen")).toBe(true);
+      expect(filter("light.no_area")).toBe(true);
+      expect(filter("light.bedroom")).toBe(false);
+    });
+
+    it("should filter entities with no device when null is used", () => {
+      const filter = generateEntityFilter(mockHass, { device: null });
+
+      expect(filter("light.living_room")).toBe(false);
+      expect(filter("light.no_area")).toBe(false);
+    });
+
+    it("should filter entities with specific device OR no device", () => {
+      const filter = generateEntityFilter(mockHass, {
+        device: ["device1", null],
+      });
+
+      expect(filter("light.living_room")).toBe(true);
+      expect(filter("switch.kitchen")).toBe(false);
+    });
+
+    it("should combine null filtering with other criteria", () => {
+      const filter = generateEntityFilter(mockHass, {
+        domain: "light",
+        area: ["living_room", null],
+      });
+
+      expect(filter("light.living_room")).toBe(true);
+      expect(filter("light.no_area")).toBe(true);
+      expect(filter("light.bedroom")).toBe(false);
+      expect(filter("sensor.temperature")).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Proposed change

Fixes https://github.com/home-assistant/frontend/issues/27787

1. Adds support for no area, no floor and no device in entity filter by using `null` option.

The following filter will match with entity unassigned to an area.  
```yaml
area: null
```

2. Use this new filter to adds entities/devices unassigned to an area to the summary dashboard (light, climate and safety).

A new section is added below the floors and areas.

<img width="610" height="625" alt="CleanShot 2025-11-04 at 09 49 32" src="https://github.com/user-attachments/assets/932d0247-6cff-43ea-85c8-4c7ecb80011f" />

Note : the media players views from the home strategy also supports this unassigned entities section.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
