### PR TITLE
Auto refresh summary dashboard when registries changed

### DIFF
--- a/src/panels/climate/ha-panel-climate.ts
+++ b/src/panels/climate/ha-panel-climate.ts
@@ -2,6 +2,7 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { goBack } from "../../common/navigate";
+import { debounce } from "../../common/util/debounce";
 import "../../components/ha-icon-button-arrow-prev";
 import "../../components/ha-menu-button";
 import type { LovelaceConfig } from "../../data/lovelace/config/types";
@@ -38,17 +39,55 @@ class PanelClimate extends LitElement {
   }
 
   public willUpdate(changedProps: PropertyValues) {
+    super.willUpdate(changedProps);
+    // Initial setup
     if (!this.hasUpdated) {
       this.hass.loadFragmentTranslation("lovelace");
+      this._setLovelace();
+      return;
     }
+
     if (!changedProps.has("hass")) {
       return;
     }
+
     const oldHass = changedProps.get("hass") as this["hass"];
-    if (oldHass?.locale !== this.hass.locale) {
+    if (oldHass && oldHass.localize !== this.hass.localize) {
       this._setLovelace();
+      return;
+    }
+
+    if (oldHass && this.hass) {
+      // If the entity registry changed, ask the user if they want to refresh the config
+      if (
+        oldHass.entities !== this.hass.entities ||
+        oldHass.devices !== this.hass.devices ||
+        oldHass.areas !== this.hass.areas ||
+        oldHass.floors !== this.hass.floors
+      ) {
+        if (this.hass.config.state === "RUNNING") {
+          this._debounceRegistriesChanged();
+          return;
+        }
+      }
+      // If ha started, refresh the config
+      if (
+        this.hass.config.state === "RUNNING" &&
+        oldHass.config.state !== "RUNNING"
+      ) {
+        this._setLovelace();
+      }
     }
   }
+
+  private _debounceRegistriesChanged = debounce(
+    () => this._registriesChanged(),
+    200
+  );
+
+  private _registriesChanged = async () => {
+    this._setLovelace();
+  };
 
   private _back(ev) {
     ev.stopPropagation();
@@ -89,9 +128,12 @@ class PanelClimate extends LitElement {
   }
 
   private _setLovelace() {
+    // Create a new views to force re-render of hui-view
+    const config = { ...CLIMATE_LOVELACE_CONFIG };
+    config.views = config.views.map((view) => ({ ...view }));
     this._lovelace = {
-      config: CLIMATE_LOVELACE_CONFIG,
-      rawConfig: CLIMATE_LOVELACE_CONFIG,
+      config: config,
+      rawConfig: config,
       editMode: false,
       urlPath: "climate",
       mode: "generated",

--- a/src/panels/climate/ha-panel-climate.ts
+++ b/src/panels/climate/ha-panel-climate.ts
@@ -1,25 +1,23 @@
-import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
-import { LitElement, css, html } from "lit";
+import type { CSSResultGroup, PropertyValues } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { goBack } from "../../common/navigate";
 import { debounce } from "../../common/util/debounce";
+import { deepEqual } from "../../common/util/deep-equal";
 import "../../components/ha-icon-button-arrow-prev";
 import "../../components/ha-menu-button";
-import type { LovelaceConfig } from "../../data/lovelace/config/types";
+import type { LovelaceStrategyViewConfig } from "../../data/lovelace/config/view";
 import { haStyle } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
+import { generateLovelaceViewStrategy } from "../lovelace/strategies/get-strategy";
 import type { Lovelace } from "../lovelace/types";
 import "../lovelace/views/hui-view";
 import "../lovelace/views/hui-view-container";
 
-const CLIMATE_LOVELACE_CONFIG: LovelaceConfig = {
-  views: [
-    {
-      strategy: {
-        type: "climate",
-      },
-    },
-  ],
+const CLIMATE_LOVELACE_VIEW_CONFIG: LovelaceStrategyViewConfig = {
+  strategy: {
+    type: "climate",
+  },
 };
 
 @customElement("ha-panel-climate")
@@ -33,10 +31,6 @@ class PanelClimate extends LitElement {
   @state() private _lovelace?: Lovelace;
 
   @state() private _searchParms = new URLSearchParams(window.location.search);
-
-  public firstUpdated(_changedProperties: PropertyValues): void {
-    super.firstUpdated(_changedProperties);
-  }
 
   public willUpdate(changedProps: PropertyValues) {
     super.willUpdate(changedProps);
@@ -94,46 +88,63 @@ class PanelClimate extends LitElement {
     goBack();
   }
 
-  protected render(): TemplateResult {
+  protected render() {
     return html`
       <div class="header">
         <div class="toolbar">
-          ${this._searchParms.has("historyBack")
-            ? html`
-                <ha-icon-button-arrow-prev
-                  @click=${this._back}
-                  slot="navigationIcon"
-                ></ha-icon-button-arrow-prev>
-              `
-            : html`
-                <ha-menu-button
-                  slot="navigationIcon"
-                  .hass=${this.hass}
-                  .narrow=${this.narrow}
-                ></ha-menu-button>
-              `}
+          ${
+            this._searchParms.has("historyBack")
+              ? html`
+                  <ha-icon-button-arrow-prev
+                    @click=${this._back}
+                    slot="navigationIcon"
+                  ></ha-icon-button-arrow-prev>
+                `
+              : html`
+                  <ha-menu-button
+                    slot="navigationIcon"
+                    .hass=${this.hass}
+                    .narrow=${this.narrow}
+                  ></ha-menu-button>
+                `
+          }
           <div class="main-title">${this.hass.localize("panel.climate")}</div>
         </div>
       </div>
-
-      <hui-view-container .hass=${this.hass}>
-        <hui-view
-          .hass=${this.hass}
-          .narrow=${this.narrow}
-          .lovelace=${this._lovelace}
-          .index=${this._viewIndex}
-        ></hui-view>
+      ${
+        this._lovelace
+          ? html`
+              <hui-view-container .hass=${this.hass}>
+                <hui-view
+                  .hass=${this.hass}
+                  .narrow=${this.narrow}
+                  .lovelace=${this._lovelace}
+                  .index=${this._viewIndex}
+                ></hui-view
+              ></hui-view-container>
+            `
+          : nothing
+      }
       </hui-view-container>
     `;
   }
 
-  private _setLovelace() {
-    // Create a new views to force re-render of hui-view
-    const config = { ...CLIMATE_LOVELACE_CONFIG };
-    config.views = config.views.map((view) => ({ ...view }));
+  private async _setLovelace() {
+    const viewConfig = await generateLovelaceViewStrategy(
+      CLIMATE_LOVELACE_VIEW_CONFIG,
+      this.hass
+    );
+
+    const config = { views: [viewConfig] };
+    const rawConfig = { views: [CLIMATE_LOVELACE_VIEW_CONFIG] };
+
+    if (deepEqual(config, this._lovelace?.config)) {
+      return;
+    }
+
     this._lovelace = {
       config: config,
-      rawConfig: config,
+      rawConfig: rawConfig,
       editMode: false,
       urlPath: "climate",
       mode: "generated",

--- a/src/panels/light/ha-panel-light.ts
+++ b/src/panels/light/ha-panel-light.ts
@@ -2,6 +2,7 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { goBack } from "../../common/navigate";
+import { debounce } from "../../common/util/debounce";
 import "../../components/ha-icon-button-arrow-prev";
 import "../../components/ha-menu-button";
 import type { LovelaceConfig } from "../../data/lovelace/config/types";
@@ -34,17 +35,55 @@ class PanelLight extends LitElement {
   @state() private _searchParms = new URLSearchParams(window.location.search);
 
   public willUpdate(changedProps: PropertyValues) {
+    super.willUpdate(changedProps);
+    // Initial setup
     if (!this.hasUpdated) {
       this.hass.loadFragmentTranslation("lovelace");
+      this._setLovelace();
+      return;
     }
+
     if (!changedProps.has("hass")) {
       return;
     }
+
     const oldHass = changedProps.get("hass") as this["hass"];
-    if (oldHass?.locale !== this.hass.locale) {
+    if (oldHass && oldHass.localize !== this.hass.localize) {
       this._setLovelace();
+      return;
+    }
+
+    if (oldHass && this.hass) {
+      // If the entity registry changed, ask the user if they want to refresh the config
+      if (
+        oldHass.entities !== this.hass.entities ||
+        oldHass.devices !== this.hass.devices ||
+        oldHass.areas !== this.hass.areas ||
+        oldHass.floors !== this.hass.floors
+      ) {
+        if (this.hass.config.state === "RUNNING") {
+          this._debounceRegistriesChanged();
+          return;
+        }
+      }
+      // If ha started, refresh the config
+      if (
+        this.hass.config.state === "RUNNING" &&
+        oldHass.config.state !== "RUNNING"
+      ) {
+        this._setLovelace();
+      }
     }
   }
+
+  private _debounceRegistriesChanged = debounce(
+    () => this._registriesChanged(),
+    200
+  );
+
+  private _registriesChanged = async () => {
+    this._setLovelace();
+  };
 
   private _back(ev) {
     ev.stopPropagation();
@@ -85,9 +124,12 @@ class PanelLight extends LitElement {
   }
 
   private _setLovelace() {
+    // Create a new views to force re-render of hui-view
+    const config = { ...LIGHT_LOVELACE_CONFIG };
+    config.views = config.views.map((view) => ({ ...view }));
     this._lovelace = {
-      config: LIGHT_LOVELACE_CONFIG,
-      rawConfig: LIGHT_LOVELACE_CONFIG,
+      config: config,
+      rawConfig: config,
       editMode: false,
       urlPath: "light",
       mode: "generated",

--- a/src/panels/light/ha-panel-light.ts
+++ b/src/panels/light/ha-panel-light.ts
@@ -1,25 +1,23 @@
-import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
-import { LitElement, css, html } from "lit";
+import type { CSSResultGroup, PropertyValues } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { goBack } from "../../common/navigate";
 import { debounce } from "../../common/util/debounce";
+import { deepEqual } from "../../common/util/deep-equal";
 import "../../components/ha-icon-button-arrow-prev";
 import "../../components/ha-menu-button";
-import type { LovelaceConfig } from "../../data/lovelace/config/types";
+import type { LovelaceStrategyViewConfig } from "../../data/lovelace/config/view";
 import { haStyle } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
+import { generateLovelaceViewStrategy } from "../lovelace/strategies/get-strategy";
 import type { Lovelace } from "../lovelace/types";
 import "../lovelace/views/hui-view";
 import "../lovelace/views/hui-view-container";
 
-const LIGHT_LOVELACE_CONFIG: LovelaceConfig = {
-  views: [
-    {
-      strategy: {
-        type: "light",
-      },
-    },
-  ],
+const LIGHT_LOVELACE_VIEW_CONFIG: LovelaceStrategyViewConfig = {
+  strategy: {
+    type: "light",
+  },
 };
 
 @customElement("ha-panel-light")
@@ -90,46 +88,63 @@ class PanelLight extends LitElement {
     goBack();
   }
 
-  protected render(): TemplateResult {
+  protected render() {
     return html`
       <div class="header">
         <div class="toolbar">
-          ${this._searchParms.has("historyBack")
-            ? html`
-                <ha-icon-button-arrow-prev
-                  @click=${this._back}
-                  slot="navigationIcon"
-                ></ha-icon-button-arrow-prev>
-              `
-            : html`
-                <ha-menu-button
-                  slot="navigationIcon"
-                  .hass=${this.hass}
-                  .narrow=${this.narrow}
-                ></ha-menu-button>
-              `}
+          ${
+            this._searchParms.has("historyBack")
+              ? html`
+                  <ha-icon-button-arrow-prev
+                    @click=${this._back}
+                    slot="navigationIcon"
+                  ></ha-icon-button-arrow-prev>
+                `
+              : html`
+                  <ha-menu-button
+                    slot="navigationIcon"
+                    .hass=${this.hass}
+                    .narrow=${this.narrow}
+                  ></ha-menu-button>
+                `
+          }
           <div class="main-title">${this.hass.localize("panel.light")}</div>
         </div>
       </div>
-
-      <hui-view-container .hass=${this.hass}>
-        <hui-view
-          .hass=${this.hass}
-          .narrow=${this.narrow}
-          .lovelace=${this._lovelace}
-          .index=${this._viewIndex}
-        ></hui-view>
+      ${
+        this._lovelace
+          ? html`
+              <hui-view-container .hass=${this.hass}>
+                <hui-view
+                  .hass=${this.hass}
+                  .narrow=${this.narrow}
+                  .lovelace=${this._lovelace}
+                  .index=${this._viewIndex}
+                ></hui-view
+              ></hui-view-container>
+            `
+          : nothing
+      }
       </hui-view-container>
     `;
   }
 
-  private _setLovelace() {
-    // Create a new views to force re-render of hui-view
-    const config = { ...LIGHT_LOVELACE_CONFIG };
-    config.views = config.views.map((view) => ({ ...view }));
+  private async _setLovelace() {
+    const viewConfig = await generateLovelaceViewStrategy(
+      LIGHT_LOVELACE_VIEW_CONFIG,
+      this.hass
+    );
+
+    const config = { views: [viewConfig] };
+    const rawConfig = { views: [LIGHT_LOVELACE_VIEW_CONFIG] };
+
+    if (deepEqual(config, this._lovelace?.config)) {
+      return;
+    }
+
     this._lovelace = {
       config: config,
-      rawConfig: config,
+      rawConfig: rawConfig,
       editMode: false,
       urlPath: "light",
       mode: "generated",


### PR DESCRIPTION
## Proposed change

Auto refresh summary dashboard when registries changed.

I think we should consider added a subscription logic to the strategy generation so refresh rules can be added into each strategy definition.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
