### PR TITLE
Fix z-index for target picker item row icon

### DIFF
--- a/src/components/target-picker/ha-target-picker-item-row.ts
+++ b/src/components/target-picker/ha-target-picker-item-row.ts
@@ -638,6 +638,7 @@ export class HaTargetPickerItemRow extends LitElement {
       img {
         width: 24px;
         height: 24px;
+        z-index: 1;
       }
       ha-icon-button {
         --mdc-icon-button-size: 32px;


### PR DESCRIPTION
## Proposed change
Set z-index for target picker item row icon to hide the ends of the lines behind the icon.

Before

<img width="342" height="144" alt="image" src="https://github.com/user-attachments/assets/7d9fb405-47e3-4208-a871-053883d7ecce" />

After

<img width="367" height="157" alt="image" src="https://github.com/user-attachments/assets/168cf447-c9bd-4a38-b4a9-ec9adac39983" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
