### PR TITLE
Fix auth language picker styles

### DIFF
--- a/landing-page/src/ha-landing-page.ts
+++ b/landing-page/src/ha-landing-page.ts
@@ -1,22 +1,25 @@
 import "@material/mwc-linear-progress";
-import { type PropertyValues, css, html, nothing } from "lit";
+import { mdiOpenInNew } from "@mdi/js";
+import { css, html, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { extractSearchParam } from "../../src/common/url/search-params";
 import "../../src/components/ha-alert";
+import "../../src/components/ha-button";
 import "../../src/components/ha-fade-in";
 import "../../src/components/ha-spinner";
-import { haStyle } from "../../src/resources/styles";
-import "../../src/onboarding/onboarding-welcome-links";
-import "./components/landing-page-network";
-import "./components/landing-page-logs";
-import { extractSearchParam } from "../../src/common/url/search-params";
-import { onBoardingStyles } from "../../src/onboarding/styles";
+import "../../src/components/ha-svg-icon";
 import { makeDialogManager } from "../../src/dialogs/make-dialog-manager";
-import { LandingPageBaseElement } from "./landing-page-base-element";
+import "../../src/onboarding/onboarding-welcome-links";
+import { onBoardingStyles } from "../../src/onboarding/styles";
+import { haStyle } from "../../src/resources/styles";
+import "./components/landing-page-logs";
+import "./components/landing-page-network";
 import {
   getSupervisorNetworkInfo,
   pingSupervisor,
   type NetworkInfo,
 } from "./data/supervisor";
+import { LandingPageBaseElement } from "./landing-page-base-element";
 
 export const ASSUME_CORE_START_SECONDS = 60;
 const SCHEDULE_CORE_CHECK_SECONDS = 1;
@@ -94,16 +97,21 @@ class HaLandingPage extends LandingPageBaseElement {
         <ha-language-picker
           .value=${this.language}
           .label=${""}
+          button-style
           native-name
           @value-changed=${this._languageChanged}
           inline-arrow
         ></ha-language-picker>
-        <a
+        <ha-button
+          appearance="plain"
+          variant="neutral"
           href="https://www.home-assistant.io/getting-started/onboarding/"
           target="_blank"
           rel="noreferrer noopener"
-          >${this.localize("ui.panel.page-onboarding.help")}</a
         >
+          ${this.localize("ui.panel.page-onboarding.help")}
+          <ha-svg-icon slot="end" .path=${mdiOpenInNew}></ha-svg-icon>
+        </ha-button>
       </div>
     `;
   }
@@ -218,26 +226,8 @@ class HaLandingPage extends LandingPageBaseElement {
       ha-alert p {
         text-align: unset;
       }
-      ha-language-picker {
-        display: block;
-        width: 200px;
-        border-radius: var(--ha-border-radius-sm);
-        overflow: hidden;
-        --ha-select-height: 40px;
-        --mdc-select-fill-color: none;
-        --mdc-select-label-ink-color: var(--primary-text-color, #212121);
-        --mdc-select-ink-color: var(--primary-text-color, #212121);
-        --mdc-select-idle-line-color: transparent;
-        --mdc-select-hover-line-color: transparent;
-        --mdc-select-dropdown-icon-color: var(--primary-text-color, #212121);
-        --mdc-shape-small: 0;
-      }
-      a {
-        text-decoration: none;
-        color: var(--primary-text-color);
-        margin-right: 16px;
-        margin-inline-end: 16px;
-        margin-inline-start: initial;
+      .footer ha-svg-icon {
+        --mdc-icon-size: var(--ha-space-5);
       }
       ha-fade-in {
         min-height: calc(100vh - 64px - 88px);

--- a/src/auth/ha-authorize.ts
+++ b/src/auth/ha-authorize.ts
@@ -1,4 +1,5 @@
 /* eslint-disable lit/prefer-static-styles */
+import { mdiOpenInNew } from "@mdi/js";
 import type { PropertyValues } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
@@ -6,6 +7,8 @@ import punycode from "punycode";
 import { applyThemesOnElement } from "../common/dom/apply_themes_on_element";
 import { extractSearchParamsObject } from "../common/url/search-params";
 import "../components/ha-alert";
+import "../components/ha-button";
+import "../components/ha-svg-icon";
 import type { AuthProvider, AuthUrlSearchParams } from "../data/auth";
 import { fetchAuthProviders } from "../data/auth";
 import { litLocalizeLiteMixin } from "../mixins/lit-localize-lite-mixin";
@@ -133,25 +136,8 @@ export class HaAuthorize extends litLocalizeLiteMixin(LitElement) {
           justify-content: space-between;
           align-items: center;
         }
-        ha-language-picker {
-          width: 200px;
-          border-radius: var(--ha-border-radius-sm);
-          overflow: hidden;
-          --ha-select-height: 40px;
-          --mdc-select-fill-color: none;
-          --mdc-select-label-ink-color: var(--primary-text-color, #212121);
-          --mdc-select-ink-color: var(--primary-text-color, #212121);
-          --mdc-select-idle-line-color: transparent;
-          --mdc-select-hover-line-color: transparent;
-          --mdc-select-dropdown-icon-color: var(--primary-text-color, #212121);
-          --mdc-shape-small: 0;
-        }
-        .footer a {
-          text-decoration: none;
-          color: var(--primary-text-color);
-          margin-right: 16px;
-          margin-inline-end: 16px;
-          margin-inline-start: initial;
+        .footer ha-svg-icon {
+          --mdc-icon-size: var(--ha-space-5);
         }
         h1 {
           font-size: var(--ha-font-size-3xl);
@@ -205,16 +191,21 @@ export class HaAuthorize extends litLocalizeLiteMixin(LitElement) {
         <ha-language-picker
           .value=${this.language}
           .label=${""}
+          button-style
           native-name
           @value-changed=${this._languageChanged}
           inline-arrow
         ></ha-language-picker>
-        <a
+        <ha-button
+          appearance="plain"
+          variant="neutral"
           href="https://www.home-assistant.io/docs/authentication/"
           target="_blank"
           rel="noreferrer noopener"
-          >${this.localize("ui.panel.page-authorize.help")}</a
         >
+          ${this.localize("ui.panel.page-authorize.help")}
+          <ha-svg-icon slot="end" .path=${mdiOpenInNew}></ha-svg-icon>
+        </ha-button>
       </div>
     `;
   }


### PR DESCRIPTION
## Proposed change
- Add button-style to language picker
  - Use a ha-button plain neutral for the picker field
- Use language picker button-style in `ha-auth` and `ha-landing-page`
- Migrate help link to `ha-button` in `ha-auth` and `ha-landing-page`


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
