### PR TITLE
Add trigger/condition/action dialog - Show device group always on top

### DIFF
--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -383,9 +383,16 @@ class DialogAddAutomationElement
 
         generatedCollections.push({
           titleKey: collection.titleKey,
-          groups: groups.sort((a, b) =>
-            stringCompare(a.name, b.name, this.hass.locale.language)
-          ),
+          groups: groups.sort((a, b) => {
+            // make sure device is always on top
+            if (a.key === "device" || a.key === "device_id") {
+              return -1;
+            }
+            if (b.key === "device" || b.key === "device_id") {
+              return 1;
+            }
+            return stringCompare(a.name, b.name, this.hass.locale.language);
+          }),
         });
       });
       return generatedCollections;


### PR DESCRIPTION
## Proposed change
- copy the behavoir as it was before to have the device group always as first option.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
