### PR TITLE
Add service titles to automation action sidebar

### DIFF
--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
@@ -20,7 +20,8 @@ import "../../../../components/ha-md-divider";
 import "../../../../components/ha-md-menu-item";
 import { ACTION_BUILDING_BLOCKS } from "../../../../data/action";
 import type { ActionSidebarConfig } from "../../../../data/automation";
-import type { RepeatAction } from "../../../../data/script";
+import { domainToName } from "../../../../data/integration";
+import type { RepeatAction, ServiceAction } from "../../../../data/script";
 import type { HomeAssistant } from "../../../../types";
 import { isMac } from "../../../../util/is_mac";
 import type HaAutomationConditionEditor from "../action/ha-automation-action-editor";
@@ -83,10 +84,21 @@ export default class HaAutomationSidebarAction extends LitElement {
       "ui.panel.config.automation.editor.actions.action"
     );
 
-    const title =
+    let title =
       this.hass.localize(
         `ui.panel.config.automation.editor.actions.type.${type}.label` as LocalizeKeys
       ) || type;
+
+    if (type === "service" && (actionConfig as ServiceAction).action) {
+      const [domain, service] = (actionConfig as ServiceAction).action!.split(
+        "."
+      );
+      title = `${domainToName(this.hass.localize, domain)}: ${
+        this.hass.localize(`component.${domain}.services.${service}.name`) ||
+        this.hass.services[domain][service]?.name ||
+        title
+      }`;
+    }
 
     const description = isBuildingBlock
       ? this.hass.localize(

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
@@ -91,7 +91,8 @@ export default class HaAutomationSidebarAction extends LitElement {
 
     if (type === "service" && (actionConfig as ServiceAction).action) {
       const [domain, service] = (actionConfig as ServiceAction).action!.split(
-        "."
+        ".",
+        2
       );
       title = `${domainToName(this.hass.localize, domain)}: ${
         this.hass.localize(`component.${domain}.services.${service}.name`) ||


### PR DESCRIPTION
## Proposed change
- Automation editor - action sidebar
  - instead of "Perform action" show the actual service translation
  - fix #27504

<img width="553" height="248" alt="grafik" src="https://github.com/user-attachments/assets/ae0223b1-804b-4f31-a9ea-5d8646359078" />

<img width="553" height="248" alt="grafik" src="https://github.com/user-attachments/assets/fbfa1851-2de6-450d-a7fc-6bd8447fd4b0" />



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
