### PR TITLE
Only show panel with default visible flag in sidebar

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -157,7 +157,8 @@ export const computePanels = memoizeOne(
     Object.values(panels).forEach((panel) => {
       if (
         hiddenPanels.includes(panel.url_path) ||
-        (!panel.title && panel.url_path !== defaultPanel)
+        (!panel.title && panel.url_path !== defaultPanel) ||
+        (!panel.default_visible && !panelsOrder.includes(panel.url_path))
       ) {
         return;
       }

--- a/src/dialogs/sidebar/dialog-edit-sidebar.ts
+++ b/src/dialogs/sidebar/dialog-edit-sidebar.ts
@@ -102,6 +102,17 @@ class DialogEditSidebar extends LitElement {
       this.hass.locale
     );
 
+    // Add default hidden panels that are missing in hidden
+    for (const panel of panels) {
+      if (
+        !panel.default_visible &&
+        !this._order.includes(panel.url_path) &&
+        !this._hidden.includes(panel.url_path)
+      ) {
+        this._hidden.push(panel.url_path);
+      }
+    }
+
     const items = [
       ...beforeSpacer,
       ...panels.filter((panel) => this._hidden!.includes(panel.url_path)),

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -320,9 +320,9 @@ export class HaConfigLovelaceDashboards extends LitElement {
 
       if (this.hass.panels.light) {
         result.push({
-          icon: "mdi:lamps",
+          icon: this.hass.panels.light.icon || "mdi:lamps",
           title: this.hass.localize("panel.light"),
-          show_in_sidebar: false,
+          show_in_sidebar: true,
           mode: "storage",
           url_path: "light",
           filename: "",
@@ -334,9 +334,9 @@ export class HaConfigLovelaceDashboards extends LitElement {
 
       if (this.hass.panels.security) {
         result.push({
-          icon: "mdi:security",
+          icon: this.hass.panels.security.icon || "mdi:security",
           title: this.hass.localize("panel.security"),
-          show_in_sidebar: false,
+          show_in_sidebar: true,
           mode: "storage",
           url_path: "security",
           filename: "",
@@ -348,9 +348,9 @@ export class HaConfigLovelaceDashboards extends LitElement {
 
       if (this.hass.panels.climate) {
         result.push({
-          icon: "mdi:home-thermometer",
+          icon: this.hass.panels.climate.icon || "mdi:home-thermometer",
           title: this.hass.localize("panel.climate"),
-          show_in_sidebar: false,
+          show_in_sidebar: true,
           mode: "storage",
           url_path: "climate",
           filename: "",

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,6 +138,7 @@ export interface PanelInfo<T = Record<string, any> | null> {
   title: string | null;
   url_path: string;
   config_panel_domain?: string;
+  default_visible?: boolean;
 }
 
 export type Panels = Record<string, PanelInfo>;


### PR DESCRIPTION
## Proposed change

Only show panel with default visible flag in sidebar. This will allow climate, light and security dashboard to the sidebar even if they are not shown by default.

- Needs https://github.com/home-assistant/core/pull/155506

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
