### PR TITLE
Add area context in zha, zwave and bluetooth graph

### DIFF
--- a/src/components/chart/ha-network-graph.ts
+++ b/src/components/chart/ha-network-graph.ts
@@ -16,6 +16,7 @@ import { deepEqual } from "../../common/util/deep-equal";
 export interface NetworkNode {
   id: string;
   name?: string;
+  context?: string;
   category?: number;
   value?: number;
   symbolSize?: number;
@@ -188,6 +189,25 @@ export class HaNetworkGraph extends SubscribeMixin(LitElement) {
       label: {
         show: showLabels,
         position: "right",
+        formatter: (params: any) => {
+          const node = params.data;
+          if (node.context) {
+            return `{primary|${node.name}}\n{secondary|${node.context}}`;
+          }
+          return node.name;
+        },
+        rich: {
+          primary: {
+            fontSize: 12,
+          },
+          secondary: {
+            fontSize: 12,
+            color: getComputedStyle(document.body).getPropertyValue(
+              "--secondary-text-color"
+            ),
+            lineHeight: 16,
+          },
+        },
       },
       emphasis: {
         focus: isMobile ? "none" : "adjacency",
@@ -225,6 +245,7 @@ export class HaNetworkGraph extends SubscribeMixin(LitElement) {
           ({
             id: node.id,
             name: node.name,
+            context: node.context,
             category: node.category,
             value: node.value,
             symbolSize: node.symbolSize || 30,

--- a/src/components/chart/ha-network-graph.ts
+++ b/src/components/chart/ha-network-graph.ts
@@ -2,7 +2,10 @@ import type { EChartsType } from "echarts/core";
 import type { GraphSeriesOption } from "echarts/charts";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state, query } from "lit/decorators";
-import type { TopLevelFormatterParams } from "echarts/types/dist/shared";
+import type {
+  CallbackDataParams,
+  TopLevelFormatterParams,
+} from "echarts/types/dist/shared";
 import { mdiFormatTextVariant, mdiGoogleCirclesGroup } from "@mdi/js";
 import memoizeOne from "memoize-one";
 import { listenMediaQuery } from "../../common/dom/media_query";
@@ -189,12 +192,12 @@ export class HaNetworkGraph extends SubscribeMixin(LitElement) {
       label: {
         show: showLabels,
         position: "right",
-        formatter: (params: any) => {
-          const node = params.data;
+        formatter: (params: CallbackDataParams) => {
+          const node = params.data as NetworkNode;
           if (node.context) {
-            return `{primary|${node.name}}\n{secondary|${node.context}}`;
+            return `{primary|${node.name ?? ""}}\n{secondary|${node.context}}`;
           }
-          return node.name;
+          return node.name ?? "";
         },
         rich: {
           primary: {

--- a/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
@@ -195,8 +195,12 @@ export class BluetoothNetworkVisualization extends LitElement {
       ];
       const links: NetworkLink[] = [];
       Object.values(scanners).forEach((scanner) => {
-        const scannerDevice = this._sourceDevices[scanner.source];
-        const { area } = getDeviceContext(scannerDevice, this.hass);
+        const scannerDevice = this._sourceDevices[scanner.source] as
+          | DeviceRegistryEntry
+          | undefined;
+        const area = scannerDevice
+          ? getDeviceContext(scannerDevice, this.hass).area
+          : undefined;
         nodes.push({
           id: scanner.source,
           name:
@@ -234,8 +238,12 @@ export class BluetoothNetworkVisualization extends LitElement {
           });
           return;
         }
-        const device = this._sourceDevices[node.address];
-        const { area } = getDeviceContext(device, this.hass);
+        const device = this._sourceDevices[node.address] as
+          | DeviceRegistryEntry
+          | undefined;
+        const area = device
+          ? getDeviceContext(device, this.hass).area
+          : undefined;
         nodes.push({
           id: node.address,
           name: this._getBluetoothDeviceName(node.address),

--- a/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
@@ -8,6 +8,7 @@ import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { relativeTime } from "../../../../../common/datetime/relative_time";
+import { getDeviceContext } from "../../../../../common/entity/context/get_device_context";
 import { navigate } from "../../../../../common/navigate";
 import { throttle } from "../../../../../common/util/throttle";
 import "../../../../../components/chart/ha-network-graph";
@@ -28,7 +29,6 @@ import type { DeviceRegistryEntry } from "../../../../../data/device_registry";
 import "../../../../../layouts/hass-subpage";
 import type { HomeAssistant, Route } from "../../../../../types";
 import { bluetoothAdvertisementMonitorTabs } from "./bluetooth-advertisement-monitor";
-import { getDeviceContext } from "../../../../../common/entity/context/get_device_context";
 
 const UPDATE_THROTTLE_TIME = 10000;
 
@@ -308,8 +308,8 @@ export class BluetoothNetworkVisualization extends LitElement {
       if (btDevice) {
         tooltipText = `<b>${name}</b><br><b>${this.hass.localize("ui.panel.config.bluetooth.address")}:</b> ${address}<br><b>${this.hass.localize("ui.panel.config.bluetooth.rssi")}:</b> ${btDevice.rssi}<br><b>${this.hass.localize("ui.panel.config.bluetooth.source")}:</b> ${btDevice.source}<br><b>${this.hass.localize("ui.panel.config.bluetooth.updated")}:</b> ${relativeTime(new Date(btDevice.time * 1000), this.hass.locale)}`;
         const device = this._sourceDevices[address];
-        if (device?.area_id) {
-          const area = this.hass.areas[device.area_id];
+        if (device) {
+          const area = getDeviceContext(device, this.hass).area;
           if (area) {
             tooltipText += `<br><b>${this.hass.localize("ui.panel.config.bluetooth.area")}: </b>${area.name}`;
           }
@@ -318,11 +318,9 @@ export class BluetoothNetworkVisualization extends LitElement {
         const device = this._sourceDevices[address];
         if (device) {
           tooltipText = `<b>${name}</b><br><b>${this.hass.localize("ui.panel.config.bluetooth.address")}:</b> ${address}`;
-          if (device.area_id) {
-            const area = this.hass.areas[device.area_id];
-            if (area) {
-              tooltipText += `<br><b>${this.hass.localize("ui.panel.config.bluetooth.area")}: </b>${area.name}`;
-            }
+          const area = getDeviceContext(device, this.hass).area;
+          if (area) {
+            tooltipText += `<br><b>${this.hass.localize("ui.panel.config.bluetooth.area")}: </b>${area.name}`;
           }
         }
       }

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
@@ -203,11 +203,13 @@ export class ZHANetworkVisualizationPage extends LitElement {
       } else {
         category = 2; // End Device
       }
+      const area = device.area_id ? this.hass.areas[device.area_id] : undefined;
 
       // Create node
       nodes.push({
         id: device.ieee,
         name: device.user_given_name || device.name || device.ieee,
+        context: area?.name,
         category,
         value: isCoordinator ? 3 : device.device_type === "Router" ? 2 : 1,
         symbolSize: isCoordinator

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
@@ -19,6 +19,8 @@ import "../../../../../layouts/hass-tabs-subpage";
 import type { HomeAssistant, Route } from "../../../../../types";
 import { formatAsPaddedHex } from "./functions";
 import { zhaTabs } from "./zha-config-dashboard";
+import type { DeviceRegistryEntry } from "../../../../../data/device_registry";
+import { getDeviceContext } from "../../../../../common/entity/context/get_device_context";
 
 @customElement("zha-network-visualization-page")
 export class ZHANetworkVisualizationPage extends LitElement {
@@ -117,8 +119,11 @@ export class ZHANetworkVisualizationPage extends LitElement {
     } else {
       label += `<br><b>${this.hass.localize("ui.panel.config.zha.visualization.device_not_in_db")}</b>`;
     }
-    if (device.area_id) {
-      const area = this.hass.areas[device.area_id];
+    const haDevice = this.hass.devices[device.device_reg_id] as
+      | DeviceRegistryEntry
+      | undefined;
+    if (haDevice) {
+      const area = getDeviceContext(haDevice, this.hass).area;
       if (area) {
         label += `<br><b>${this.hass.localize("ui.panel.config.zha.visualization.area")}: </b>${area.name}`;
       }
@@ -203,8 +208,13 @@ export class ZHANetworkVisualizationPage extends LitElement {
       } else {
         category = 2; // End Device
       }
-      const area = device.area_id ? this.hass.areas[device.area_id] : undefined;
 
+      const haDevice = this.hass.devices[device.device_reg_id] as
+        | DeviceRegistryEntry
+        | undefined;
+      const area = haDevice
+        ? getDeviceContext(haDevice, this.hass).area
+        : undefined;
       // Create node
       nodes.push({
         id: device.ieee,

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
@@ -125,7 +125,7 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
       return tip;
     }
     const { id, name } = data as any;
-    const device = this._devices[id];
+    const device = this._devices[id] as DeviceRegistryEntry | undefined;
     const nodeStatus = this._nodeStatuses[id];
     let tip = `${(params as any).marker} ${name}`;
     tip += `<br><b>${this.hass.localize("ui.panel.config.zwave_js.visualization.node_id")}:</b> ${id}`;
@@ -139,8 +139,8 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
         tip += `<br><b>Z-Wave Plus:</b> ${this.hass.localize("ui.panel.config.zwave_js.visualization.version")} ${nodeStatus.zwave_plus_version}`;
       }
     }
-    if (device?.area_id) {
-      const area = this.hass.areas[device.area_id];
+    if (device) {
+      const area = getDeviceContext(device, this.hass).area;
       if (area) {
         tip += `<br><b>${this.hass.localize("ui.panel.config.zwave_js.visualization.area")}:</b> ${area.name}`;
       }
@@ -204,8 +204,12 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
         if (node.is_controller_node) {
           controllerNode = node.node_id;
         }
-        const device = this._devices[node.node_id];
-        const { area } = getDeviceContext(device, this.hass);
+        const device = this._devices[node.node_id] as
+          | DeviceRegistryEntry
+          | undefined;
+        const area = device
+          ? getDeviceContext(device, this.hass).area
+          : undefined;
         nodes.push({
           id: String(node.node_id),
           name: device?.name_by_user ?? device?.name ?? String(node.node_id),

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
@@ -5,6 +5,7 @@ import type {
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
+import { getDeviceContext } from "../../../../../common/entity/context/get_device_context";
 import { navigate } from "../../../../../common/navigate";
 import { debounce } from "../../../../../common/util/debounce";
 import "../../../../../components/chart/ha-network-graph";
@@ -138,6 +139,12 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
         tip += `<br><b>Z-Wave Plus:</b> ${this.hass.localize("ui.panel.config.zwave_js.visualization.version")} ${nodeStatus.zwave_plus_version}`;
       }
     }
+    if (device?.area_id) {
+      const area = this.hass.areas[device.area_id];
+      if (area) {
+        tip += `<br><b>${this.hass.localize("ui.panel.config.zwave_js.visualization.area")}:</b> ${area.name}`;
+      }
+    }
     return tip;
   };
 
@@ -198,9 +205,11 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
           controllerNode = node.node_id;
         }
         const device = this._devices[node.node_id];
+        const { area } = getDeviceContext(device, this.hass);
         nodes.push({
           id: String(node.node_id),
           name: device?.name_by_user ?? device?.name ?? String(node.node_id),
+          context: area?.name,
           value: node.is_controller_node ? 3 : node.is_routing ? 2 : 1,
           category:
             node.status === NodeStatus.Dead

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6562,7 +6562,8 @@
             "model": "Model",
             "status": "Status",
             "version": "Version",
-            "data_rate": "Data rate"
+            "data_rate": "Data rate",
+            "area": "Area"
           },
           "node_status": {
             "0": "Unknown",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

To continue entity naming migration, adds area context in zha, zwave and bluetooth graph to follow the same pattern we use in more info or device/target picker.

<img width="1000" height="910" alt="CleanShot 2025-11-07 at 11 08 58" src="https://github.com/user-attachments/assets/1643d9b2-9aeb-4d7b-89a3-ec1bc5d8d5d6" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
