### PR TITLE
Fix malformed HTML tags in backup backups component

### DIFF
--- a/src/panels/config/backup/ha-config-backup-backups.ts
+++ b/src/panels/config/backup/ha-config-backup-backups.ts
@@ -372,16 +372,14 @@ class HaConfigBackupBackups extends SubscribeMixin(LitElement) {
         clickable
         id="backup_id"
         has-filters
-        .filters=${
-          Object.values(this._filters).filter((filter) =>
-            Array.isArray(filter)
-              ? filter.length
-              : filter &&
-                Object.values(filter).some((val) =>
-                  Array.isArray(val) ? val.length : val
-                )
-          ).length
-        }
+        .filters=${Object.values(this._filters).filter((filter) =>
+          Array.isArray(filter)
+            ? filter.length
+            : filter &&
+              Object.values(filter).some((val) =>
+                Array.isArray(val) ? val.length : val
+              )
+        ).length}
         selectable
         .selected=${this._selected.length}
         .initialGroupColumn=${this._activeGrouping}
@@ -423,30 +421,28 @@ class HaConfigBackupBackups extends SubscribeMixin(LitElement) {
         </div>
 
         <div slot="selection-bar">
-          ${
-            !this.narrow
-              ? html`
-                  <ha-button
-                    appearance="plain"
-                    @click=${this._deleteSelected}
-                    variant="danger"
-                  >
-                    ${this.hass.localize(
-                      "ui.panel.config.backup.backups.delete_selected"
-                    )}
-                  </ha-button>
-                `
-              : html`
-                  <ha-icon-button
-                    .label=${this.hass.localize(
-                      "ui.panel.config.backup.backups.delete_selected"
-                    )}
-                    .path=${mdiDelete}
-                    class="warning"
-                    @click=${this._deleteSelected}
-                  ></ha-icon-button>
-                `
-          }
+          ${!this.narrow
+            ? html`
+                <ha-button
+                  appearance="plain"
+                  @click=${this._deleteSelected}
+                  variant="danger"
+                >
+                  ${this.hass.localize(
+                    "ui.panel.config.backup.backups.delete_selected"
+                  )}
+                </ha-button>
+              `
+            : html`
+                <ha-icon-button
+                  .label=${this.hass.localize(
+                    "ui.panel.config.backup.backups.delete_selected"
+                  )}
+                  .path=${mdiDelete}
+                  class="warning"
+                  @click=${this._deleteSelected}
+                ></ha-icon-button>
+              `}
         </div>
 
         <ha-filter-states
@@ -459,43 +455,39 @@ class HaConfigBackupBackups extends SubscribeMixin(LitElement) {
           expanded
           .narrow=${this.narrow}
         ></ha-filter-states>
-        ${
-          !this._needsOnboarding
-            ? html`
-                <ha-fab
-                  slot="fab"
-                  ?disabled=${backupInProgress}
-                  .label=${this.hass.localize(
-                    "ui.panel.config.backup.backups.new_backup"
-                  )}
-                  extended
-                  @click=${this._newBackup}
-                >
-                  ${backupInProgress
-                    ? html`<div slot="icon" class="loading">
-                        <ha-spinner .size=${"small"}></ha-spinner>
-                      </div>`
-                    : html`<ha-svg-icon
-                        slot="icon"
-                        .path=${mdiPlus}
-                      ></ha-svg-icon>`}
-                </ha-fab>
-              `
-            : nothing
-        }
+        ${!this._needsOnboarding
+          ? html`
+              <ha-fab
+                slot="fab"
+                ?disabled=${backupInProgress}
+                .label=${this.hass.localize(
+                  "ui.panel.config.backup.backups.new_backup"
+                )}
+                extended
+                @click=${this._newBackup}
+              >
+                ${backupInProgress
+                  ? html`<div slot="icon" class="loading">
+                      <ha-spinner .size=${"small"}></ha-spinner>
+                    </div>`
+                  : html`<ha-svg-icon
+                      slot="icon"
+                      .path=${mdiPlus}
+                    ></ha-svg-icon>`}
+              </ha-fab>
+            `
+          : nothing}
       </hass-tabs-subpage-data-table>
       <ha-md-menu id="overflow-menu" positioning="fixed">
-          <ha-md-menu-item .clickAction=${this._downloadBackup}>
-              <ha-svg-icon slot="start" .path=${mdiDownload}></ha-svg-icon>
-            ${this.hass.localize("ui.common.download")}
-          </ha-md-menu-item>
-            <ha-md-menu-item class="warning" .clickAction=${this._deleteBackup}>
-              <ha-svg-icon slot="start" .path=${mdiDelete}></ha-svg-icon>
-            ${this.hass.localize("ui.common.delete")}
-            </ha-md-menu-item>
-        </ha-md-menu>
-      >
-      </ha-icon-overflow-menu>
+        <ha-md-menu-item .clickAction=${this._downloadBackup}>
+          <ha-svg-icon slot="start" .path=${mdiDownload}></ha-svg-icon>
+          ${this.hass.localize("ui.common.download")}
+        </ha-md-menu-item>
+        <ha-md-menu-item class="warning" .clickAction=${this._deleteBackup}>
+          <ha-svg-icon slot="start" .path=${mdiDelete}></ha-svg-icon>
+          ${this.hass.localize("ui.common.delete")}
+        </ha-md-menu-item>
+      </ha-md-menu>
     `;
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR fixes malformed HTML tags in the backup backups component (`ha-config-backup-backups`) that were causing invalid HTML structure in the render template.

The component had orphaned closing tags at the end of its render method:
- An extra `>` closing tag with no corresponding opening tag
- A `</ha-icon-overflow-menu>` closing tag with no corresponding opening element


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

**Note:** While the core fix was removing two malformed closing tags, the pre-commit formatters (ESLint/Prettier) also applied code style improvements to the surrounding template code for consistency.

Extra '>' character and orphaned closing tag in rendered HTML:

<img width="1431" height="1045" alt="grafik" src="https://github.com/user-attachments/assets/d924160e-8f93-4130-bcc2-02796060524b" />


- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
