### PR TITLE
Save default panel at user and system level

### DIFF
--- a/src/components/ha-navigation-picker.ts
+++ b/src/components/ha-navigation-picker.ts
@@ -6,6 +6,7 @@ import { fireEvent } from "../common/dom/fire_event";
 import { titleCase } from "../common/string/title-case";
 import { fetchConfig } from "../data/lovelace/config/types";
 import type { LovelaceViewRawConfig } from "../data/lovelace/config/view";
+import { getDefaultPanelUrlPath } from "../data/panel";
 import type { HomeAssistant, PanelInfo, ValueChangedEvent } from "../types";
 import "./ha-combo-box";
 import type { HaComboBox } from "./ha-combo-box";
@@ -44,7 +45,7 @@ const createPanelNavigationItem = (hass: HomeAssistant, panel: PanelInfo) => ({
   path: `/${panel.url_path}`,
   icon: panel.icon ?? "mdi:view-dashboard",
   title:
-    panel.url_path === hass.defaultPanel
+    panel.url_path === getDefaultPanelUrlPath(hass)
       ? hass.localize("panel.states")
       : hass.localize(`panel.${panel.title}`) ||
         panel.title ||

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -80,7 +80,7 @@ export const PANEL_ICONS = {
 
 const panelSorter = (
   reverseSort: string[],
-  defaultPanel: string,
+  defaultPanel: string | null,
   a: PanelInfo,
   b: PanelInfo,
   language: string
@@ -97,7 +97,7 @@ const panelSorter = (
 };
 
 const defaultPanelSorter = (
-  defaultPanel: string,
+  defaultPanel: string | null,
   a: PanelInfo,
   b: PanelInfo,
   language: string

--- a/src/data/frontend.ts
+++ b/src/data/frontend.ts
@@ -14,6 +14,7 @@ declare global {
   interface FrontendUserData {
     core: CoreFrontendUserData;
     sidebar: SidebarFrontendUserData;
+    default_panel: string;
   }
 }
 

--- a/src/data/frontend.ts
+++ b/src/data/frontend.ts
@@ -3,6 +3,7 @@ import type { Connection } from "home-assistant-js-websocket";
 export interface CoreFrontendUserData {
   showAdvanced?: boolean;
   showEntityIdPicker?: boolean;
+  defaultPanel?: string | null;
 }
 
 export interface SidebarFrontendUserData {
@@ -10,14 +11,17 @@ export interface SidebarFrontendUserData {
   hiddenPanels: string[];
 }
 
+export interface CoreFrontendSystemData {
+  defaultPanel?: boolean;
+}
+
 declare global {
   interface FrontendUserData {
     core: CoreFrontendUserData;
     sidebar: SidebarFrontendUserData;
-    default_panel: string | null;
   }
   interface FrontendSystemData {
-    default_panel: string | null;
+    core: CoreFrontendSystemData;
   }
 }
 

--- a/src/data/frontend.ts
+++ b/src/data/frontend.ts
@@ -14,10 +14,10 @@ declare global {
   interface FrontendUserData {
     core: CoreFrontendUserData;
     sidebar: SidebarFrontendUserData;
-    default_panel?: string;
+    default_panel: string | null;
   }
   interface FrontendSystemData {
-    default_panel?: string;
+    default_panel: string | null;
   }
 }
 

--- a/src/data/frontend.ts
+++ b/src/data/frontend.ts
@@ -3,7 +3,7 @@ import type { Connection } from "home-assistant-js-websocket";
 export interface CoreFrontendUserData {
   showAdvanced?: boolean;
   showEntityIdPicker?: boolean;
-  defaultPanel?: string | null;
+  defaultPanel?: string;
 }
 
 export interface SidebarFrontendUserData {
@@ -12,7 +12,7 @@ export interface SidebarFrontendUserData {
 }
 
 export interface CoreFrontendSystemData {
-  defaultPanel?: boolean;
+  defaultPanel?: string;
 }
 
 declare global {

--- a/src/data/frontend.ts
+++ b/src/data/frontend.ts
@@ -14,11 +14,16 @@ declare global {
   interface FrontendUserData {
     core: CoreFrontendUserData;
     sidebar: SidebarFrontendUserData;
-    default_panel: string;
+    default_panel?: string;
+  }
+  interface FrontendSystemData {
+    default_panel?: string;
   }
 }
 
 export type ValidUserDataKey = keyof FrontendUserData;
+
+export type ValidSystemDataKey = keyof FrontendSystemData;
 
 export const fetchFrontendUserData = async <
   UserDataKey extends ValidUserDataKey,
@@ -58,5 +63,48 @@ export const subscribeFrontendUserData = <UserDataKey extends ValidUserDataKey>(
     {
       type: "frontend/subscribe_user_data",
       key: userDataKey,
+    }
+  );
+
+export const fetchFrontendSystemData = async <
+  SystemDataKey extends ValidSystemDataKey,
+>(
+  conn: Connection,
+  key: SystemDataKey
+): Promise<FrontendSystemData[SystemDataKey] | null> => {
+  const result = await conn.sendMessagePromise<{
+    value: FrontendSystemData[SystemDataKey] | null;
+  }>({
+    type: "frontend/get_system_data",
+    key,
+  });
+  return result.value;
+};
+
+export const saveFrontendSystemData = async <
+  SystemDataKey extends ValidSystemDataKey,
+>(
+  conn: Connection,
+  key: SystemDataKey,
+  value: FrontendSystemData[SystemDataKey]
+): Promise<void> =>
+  conn.sendMessagePromise<undefined>({
+    type: "frontend/set_system_data",
+    key,
+    value,
+  });
+
+export const subscribeFrontendSystemData = <
+  SystemDataKey extends ValidSystemDataKey,
+>(
+  conn: Connection,
+  systemDataKey: SystemDataKey,
+  onChange: (data: { value: FrontendSystemData[SystemDataKey] | null }) => void
+) =>
+  conn.subscribeMessage<{ value: FrontendSystemData[SystemDataKey] | null }>(
+    onChange,
+    {
+      type: "frontend/subscribe_system_data",
+      key: systemDataKey,
     }
   );

--- a/src/data/panel.ts
+++ b/src/data/panel.ts
@@ -3,11 +3,6 @@ import type { HomeAssistant, PanelInfo } from "../types";
 /** Panel to show when no panel is picked. */
 export const DEFAULT_PANEL = "lovelace";
 
-export const getCachedDefaultPanelUrlPath = (): string | null => {
-  const defaultPanel = window.localStorage.getItem("defaultPanel");
-  return defaultPanel ? JSON.parse(defaultPanel) : null;
-};
-
 export const getLegacyDefaultPanelUrlPath = (): string | null => {
   const defaultPanel = window.localStorage.getItem("defaultPanel");
   return defaultPanel ? JSON.parse(defaultPanel) : null;

--- a/src/data/panel.ts
+++ b/src/data/panel.ts
@@ -1,20 +1,11 @@
-import { fireEvent } from "../common/dom/fire_event";
 import type { HomeAssistant, PanelInfo } from "../types";
 
 /** Panel to show when no panel is picked. */
 export const DEFAULT_PANEL = "lovelace";
 
-export const getStorageDefaultPanelUrlPath = (): string | undefined => {
+export const getCachedDefaultPanelUrlPath = (): string | null => {
   const defaultPanel = window.localStorage.getItem("defaultPanel");
-
-  return defaultPanel ? JSON.parse(defaultPanel) : undefined;
-};
-
-export const setDefaultPanel = (
-  element: HTMLElement,
-  urlPath: string
-): void => {
-  fireEvent(element, "hass-default-panel", { defaultPanel: urlPath });
+  return defaultPanel ? JSON.parse(defaultPanel) : null;
 };
 
 export const getDefaultPanel = (hass: HomeAssistant): PanelInfo => {

--- a/src/data/panel.ts
+++ b/src/data/panel.ts
@@ -13,11 +13,14 @@ export const getLegacyDefaultPanelUrlPath = (): string | null => {
   return defaultPanel ? JSON.parse(defaultPanel) : null;
 };
 
+export const getDefaultPanelUrlPath = (hass: HomeAssistant): string =>
+  hass.userData?.defaultPanel ||
+  hass.systemData?.defaultPanel ||
+  getLegacyDefaultPanelUrlPath() ||
+  DEFAULT_PANEL;
+
 export const getDefaultPanel = (hass: HomeAssistant): PanelInfo => {
-  const panel =
-    hass.userData?.defaultPanel ||
-    hass.systemData?.defaultPanel ||
-    getLegacyDefaultPanelUrlPath();
+  const panel = getDefaultPanelUrlPath(hass);
 
   return (panel ? hass.panels[panel] : undefined) ?? hass.panels[DEFAULT_PANEL];
 };

--- a/src/data/panel.ts
+++ b/src/data/panel.ts
@@ -8,14 +8,18 @@ export const getCachedDefaultPanelUrlPath = (): string | null => {
   return defaultPanel ? JSON.parse(defaultPanel) : null;
 };
 
-export const getDefaultPanel = (hass: HomeAssistant): PanelInfo => {
-  if (!hass.defaultPanel) {
-    return hass.panels[DEFAULT_PANEL];
-  }
+export const getLegacyDefaultPanelUrlPath = (): string | null => {
+  const defaultPanel = window.localStorage.getItem("defaultPanel");
+  return defaultPanel ? JSON.parse(defaultPanel) : null;
+};
 
-  return hass.panels[hass.defaultPanel]
-    ? hass.panels[hass.defaultPanel]
-    : hass.panels[DEFAULT_PANEL];
+export const getDefaultPanel = (hass: HomeAssistant): PanelInfo => {
+  const panel =
+    hass.userData?.defaultPanel ||
+    hass.systemData?.defaultPanel ||
+    getLegacyDefaultPanelUrlPath();
+
+  return (panel ? hass.panels[panel] : undefined) ?? hass.panels[DEFAULT_PANEL];
 };
 
 export const getPanelNameTranslationKey = (panel: PanelInfo) => {

--- a/src/data/panel.ts
+++ b/src/data/panel.ts
@@ -4,10 +4,10 @@ import type { HomeAssistant, PanelInfo } from "../types";
 /** Panel to show when no panel is picked. */
 export const DEFAULT_PANEL = "lovelace";
 
-export const getStorageDefaultPanelUrlPath = (): string => {
+export const getStorageDefaultPanelUrlPath = (): string | undefined => {
   const defaultPanel = window.localStorage.getItem("defaultPanel");
 
-  return defaultPanel ? JSON.parse(defaultPanel) : DEFAULT_PANEL;
+  return defaultPanel ? JSON.parse(defaultPanel) : undefined;
 };
 
 export const setDefaultPanel = (
@@ -17,10 +17,15 @@ export const setDefaultPanel = (
   fireEvent(element, "hass-default-panel", { defaultPanel: urlPath });
 };
 
-export const getDefaultPanel = (hass: HomeAssistant): PanelInfo =>
-  hass.panels[hass.defaultPanel]
+export const getDefaultPanel = (hass: HomeAssistant): PanelInfo => {
+  if (!hass.defaultPanel) {
+    return hass.panels[DEFAULT_PANEL];
+  }
+
+  return hass.panels[hass.defaultPanel]
     ? hass.panels[hass.defaultPanel]
     : hass.panels[DEFAULT_PANEL];
+};
 
 export const getPanelNameTranslationKey = (panel: PanelInfo) => {
   if (panel.url_path === "lovelace") {

--- a/src/dialogs/sidebar/dialog-edit-sidebar.ts
+++ b/src/dialogs/sidebar/dialog-edit-sidebar.ts
@@ -20,6 +20,7 @@ import {
 } from "../../data/frontend";
 import type { HomeAssistant } from "../../types";
 import { showConfirmationDialog } from "../generic/show-dialog-box";
+import { getDefaultPanelUrlPath } from "../../data/panel";
 
 @customElement("dialog-edit-sidebar")
 class DialogEditSidebar extends LitElement {
@@ -94,9 +95,11 @@ class DialogEditSidebar extends LitElement {
 
     const panels = this._panels(this.hass.panels);
 
+    const defaultPanel = getDefaultPanelUrlPath(this.hass);
+
     const [beforeSpacer, afterSpacer] = computePanels(
       this.hass.panels,
-      this.hass.defaultPanel,
+      defaultPanel,
       this._order,
       this._hidden,
       this.hass.locale
@@ -120,12 +123,12 @@ class DialogEditSidebar extends LitElement {
     ].map((panel) => ({
       value: panel.url_path,
       label:
-        panel.url_path === this.hass.defaultPanel
+        panel.url_path === defaultPanel
           ? panel.title || this.hass.localize("panel.states")
           : this.hass.localize(`panel.${panel.title}`) || panel.title || "?",
       icon: panel.icon || undefined,
       iconPath:
-        panel.url_path === this.hass.defaultPanel && !panel.icon
+        panel.url_path === defaultPanel && !panel.icon
           ? PANEL_ICONS.lovelace
           : panel.url_path in PANEL_ICONS
             ? PANEL_ICONS[panel.url_path]

--- a/src/layouts/home-assistant-main.ts
+++ b/src/layouts/home-assistant-main.ts
@@ -47,9 +47,7 @@ export class HomeAssistantMain extends LitElement {
     const sidebarNarrow = this._sidebarNarrow || this._externalSidebar;
 
     const isPanelReady =
-      this.hass.panels &&
-      this.hass.userData !== undefined &&
-      this.hass.systemData !== undefined;
+      this.hass.panels && this.hass.userData && this.hass.systemData;
 
     return html`
       <ha-drawer

--- a/src/layouts/home-assistant-main.ts
+++ b/src/layouts/home-assistant-main.ts
@@ -1,5 +1,5 @@
 import type { PropertyValues, TemplateResult } from "lit";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import type { HASSDomEvent } from "../common/dom/fire_event";
 import { fireEvent } from "../common/dom/fire_event";
@@ -46,10 +46,15 @@ export class HomeAssistantMain extends LitElement {
   protected render(): TemplateResult {
     const sidebarNarrow = this._sidebarNarrow || this._externalSidebar;
 
+    const isPanelReady =
+      this.hass.panels &&
+      this.hass.userData !== undefined &&
+      this.hass.systemData !== undefined;
+
     return html`
       <ha-drawer
         .type=${sidebarNarrow ? "modal" : ""}
-        .open=${sidebarNarrow ? this._drawerOpen : undefined}
+        .open=${sidebarNarrow ? this._drawerOpen : false}
         .direction=${computeRTLDirection(this.hass)}
         @MDCDrawer:closed=${this._drawerClosed}
       >
@@ -59,12 +64,14 @@ export class HomeAssistantMain extends LitElement {
           .route=${this.route}
           .alwaysExpand=${sidebarNarrow || this.hass.dockedSidebar === "docked"}
         ></ha-sidebar>
-        <partial-panel-resolver
-          .narrow=${this.narrow}
-          .hass=${this.hass}
-          .route=${this.route}
-          slot="appContent"
-        ></partial-panel-resolver>
+        ${isPanelReady
+          ? html`<partial-panel-resolver
+              .narrow=${this.narrow}
+              .hass=${this.hass}
+              .route=${this.route}
+              slot="appContent"
+            ></partial-panel-resolver>`
+          : nothing}
       </ha-drawer>
     `;
   }

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -4,7 +4,7 @@ import { customElement, state } from "lit/decorators";
 import type { Connection } from "home-assistant-js-websocket";
 import { isNavigationClick } from "../common/dom/is-navigation-click";
 import { navigate } from "../common/navigate";
-import { getStorageDefaultPanelUrlPath } from "../data/panel";
+import { getCachedDefaultPanelUrlPath } from "../data/panel";
 import type { WindowWithPreloads } from "../data/preloads";
 import type { RecorderInfo } from "../data/recorder";
 import { getRecorderInfo } from "../data/recorder";
@@ -54,7 +54,7 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
     const path = curPath();
 
     if (["", "/"].includes(path)) {
-      const defaultPanel = getStorageDefaultPanelUrlPath();
+      const defaultPanel = getCachedDefaultPanelUrlPath();
       if (defaultPanel) {
         navigate(`/${defaultPanel}${location.search}`, { replace: true });
       }

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -52,12 +52,6 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
     super();
     const path = curPath();
 
-    // if (["", "/"].includes(path)) {
-    //   const defaultPanel = getCachedDefaultPanelUrlPath();
-    //   if (defaultPanel) {
-    //     navigate(`/${defaultPanel}${location.search}`, { replace: true });
-    //   }
-    // }
     this._route = {
       prefix: "",
       path,

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -54,9 +54,10 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
     const path = curPath();
 
     if (["", "/"].includes(path)) {
-      navigate(`/${getStorageDefaultPanelUrlPath()}${location.search}`, {
-        replace: true,
-      });
+      const defaultPanel = getStorageDefaultPanelUrlPath();
+      if (defaultPanel) {
+        navigate(`/${defaultPanel}${location.search}`, { replace: true });
+      }
     }
     this._route = {
       prefix: "",

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -1,10 +1,10 @@
+import type { Connection } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
 import { html } from "lit";
 import { customElement, state } from "lit/decorators";
-import type { Connection } from "home-assistant-js-websocket";
+import { storage } from "../common/decorators/storage";
 import { isNavigationClick } from "../common/dom/is-navigation-click";
 import { navigate } from "../common/navigate";
-import { getCachedDefaultPanelUrlPath } from "../data/panel";
 import type { WindowWithPreloads } from "../data/preloads";
 import type { RecorderInfo } from "../data/recorder";
 import { getRecorderInfo } from "../data/recorder";
@@ -23,7 +23,6 @@ import {
 } from "../util/register-service-worker";
 import "./ha-init-page";
 import "./home-assistant-main";
-import { storage } from "../common/decorators/storage";
 
 const useHash = __DEMO__;
 const curPath = () =>

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -53,12 +53,12 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
     super();
     const path = curPath();
 
-    if (["", "/"].includes(path)) {
-      const defaultPanel = getCachedDefaultPanelUrlPath();
-      if (defaultPanel) {
-        navigate(`/${defaultPanel}${location.search}`, { replace: true });
-      }
-    }
+    // if (["", "/"].includes(path)) {
+    //   const defaultPanel = getCachedDefaultPanelUrlPath();
+    //   if (defaultPanel) {
+    //     navigate(`/${defaultPanel}${location.search}`, { replace: true });
+    //   }
+    // }
     this._route = {
       prefix: "",
       path,

--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -188,6 +188,10 @@ class PartialPanelResolver extends HassRouterPage {
   }
 
   private async _updateRoutes(oldPanels?: HomeAssistant["panels"]) {
+    if (this.hass.defaultPanel) {
+      await this.hass.loadDefaultPanel();
+    }
+
     this.routerOptions = this._getRoutes(this.hass.panels);
 
     if (

--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -188,7 +188,7 @@ class PartialPanelResolver extends HassRouterPage {
   }
 
   private async _updateRoutes(oldPanels?: HomeAssistant["panels"]) {
-    if (this.hass.defaultPanel) {
+    if (!this.hass.defaultPanel) {
       await this.hass.loadDefaultPanel();
     }
 

--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -188,10 +188,6 @@ class PartialPanelResolver extends HassRouterPage {
   }
 
   private async _updateRoutes(oldPanels?: HomeAssistant["panels"]) {
-    if (!this.hass.defaultPanel) {
-      await this.hass.loadDefaultPanel();
-    }
-
     this.routerOptions = this._getRoutes(this.hass.panels);
 
     if (

--- a/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
@@ -13,10 +13,11 @@ import type {
   LovelaceDashboardCreateParams,
   LovelaceDashboardMutableParams,
 } from "../../../../data/lovelace/dashboard";
-import { DEFAULT_PANEL, setDefaultPanel } from "../../../../data/panel";
+import { DEFAULT_PANEL } from "../../../../data/panel";
 import { haStyleDialog } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import type { LovelaceDashboardDetailsDialogParams } from "./show-dialog-lovelace-dashboard-detail";
+import { saveFrontendUserData } from "../../../../data/frontend";
 
 @customElement("dialog-lovelace-dashboard-detail")
 export class DialogLovelaceDashboardDetail extends LitElement {
@@ -256,10 +257,11 @@ export class DialogLovelaceDashboardDetail extends LitElement {
     if (!urlPath) {
       return;
     }
-    setDefaultPanel(
-      this,
-      urlPath === this.hass.defaultPanel ? DEFAULT_PANEL : urlPath
-    );
+    saveFrontendUserData(this.hass.connection, "core", {
+      ...this.hass.userData,
+      defaultPanel:
+        urlPath === this.hass.userData?.defaultPanel ? DEFAULT_PANEL : urlPath,
+    });
   }
 
   private async _updateDashboard() {

--- a/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
@@ -4,10 +4,11 @@ import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { slugify } from "../../../../common/string/slugify";
+import "../../../../components/ha-button";
 import { createCloseHeading } from "../../../../components/ha-dialog";
 import "../../../../components/ha-form/ha-form";
-import "../../../../components/ha-button";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
+import { saveFrontendSystemData } from "../../../../data/frontend";
 import type {
   LovelaceDashboard,
   LovelaceDashboardCreateParams,
@@ -16,8 +17,8 @@ import type {
 import { DEFAULT_PANEL } from "../../../../data/panel";
 import { haStyleDialog } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
+import { showConfirmationDialog } from "../../../lovelace/custom-card-helpers";
 import type { LovelaceDashboardDetailsDialogParams } from "./show-dialog-lovelace-dashboard-detail";
-import { saveFrontendUserData } from "../../../../data/frontend";
 
 @customElement("dialog-lovelace-dashboard-detail")
 export class DialogLovelaceDashboardDetail extends LitElement {
@@ -60,7 +61,8 @@ export class DialogLovelaceDashboardDetail extends LitElement {
     if (!this._params || !this._data) {
       return nothing;
     }
-    const defaultPanelUrlPath = this.hass.defaultPanel;
+    const defaultPanelUrlPath =
+      this.hass.systemData?.defaultPanel || DEFAULT_PANEL;
     const titleInvalid = !this._data.title || !this._data.title.trim();
 
     return html`
@@ -252,15 +254,37 @@ export class DialogLovelaceDashboardDetail extends LitElement {
     };
   }
 
-  private _toggleDefault() {
+  private async _toggleDefault() {
     const urlPath = this._params?.urlPath;
     if (!urlPath) {
       return;
     }
-    saveFrontendUserData(this.hass.connection, "core", {
-      ...this.hass.userData,
-      defaultPanel:
-        urlPath === this.hass.userData?.defaultPanel ? DEFAULT_PANEL : urlPath,
+
+    const defaultPanel = this.hass.systemData?.defaultPanel || DEFAULT_PANEL;
+    // Add warning dialog to saying that this will change the default dashboard for all users
+    const confirm = await showConfirmationDialog(this, {
+      title: this.hass.localize(
+        urlPath === defaultPanel
+          ? "ui.panel.config.lovelace.dashboards.detail.remove_default_confirm_title"
+          : "ui.panel.config.lovelace.dashboards.detail.set_default_confirm_title"
+      ),
+      text: this.hass.localize(
+        urlPath === defaultPanel
+          ? "ui.panel.config.lovelace.dashboards.detail.remove_default_confirm_text"
+          : "ui.panel.config.lovelace.dashboards.detail.set_default_confirm_text"
+      ),
+      confirmText: this.hass.localize("ui.common.ok"),
+      dismissText: this.hass.localize("ui.common.cancel"),
+      destructive: false,
+    });
+
+    if (!confirm) {
+      return;
+    }
+
+    saveFrontendSystemData(this.hass.connection, "core", {
+      ...this.hass.systemData,
+      defaultPanel: urlPath === defaultPanel ? undefined : urlPath,
     });
   }
 

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -404,6 +404,8 @@ export class HaConfigLovelaceDashboards extends LitElement {
       return html` <hass-loading-screen></hass-loading-screen> `;
     }
 
+    const defaultPanel = this.hass.systemData?.defaultPanel || DEFAULT_PANEL;
+
     return html`
       <hass-tabs-subpage-data-table
         .hass=${this.hass}
@@ -417,10 +419,7 @@ export class HaConfigLovelaceDashboards extends LitElement {
           this._dashboards,
           this.hass.localize
         )}
-        .data=${this._getItems(
-          this._dashboards,
-          this.hass.defaultPanel || DEFAULT_PANEL
-        )}
+        .data=${this._getItems(this._dashboards, defaultPanel)}
         .initialGroupColumn=${this._activeGrouping}
         .initialCollapsedGroups=${this._activeCollapsed}
         .initialSorting=${this._activeSorting}

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -45,6 +45,7 @@ import {
   fetchDashboards,
   updateDashboard,
 } from "../../../../data/lovelace/dashboard";
+import { DEFAULT_PANEL } from "../../../../data/panel";
 import { showConfirmationDialog } from "../../../../dialogs/generic/show-dialog-box";
 import "../../../../layouts/hass-loading-screen";
 import "../../../../layouts/hass-tabs-subpage-data-table";
@@ -286,7 +287,7 @@ export class HaConfigLovelaceDashboards extends LitElement {
   );
 
   private _getItems = memoize(
-    (dashboards: LovelaceDashboard[], defaultUrlPath: string) => {
+    (dashboards: LovelaceDashboard[], defaultUrlPath: string | null) => {
       const defaultMode = (
         this.hass.panels?.lovelace?.config as LovelacePanelConfig
       ).mode;
@@ -416,7 +417,10 @@ export class HaConfigLovelaceDashboards extends LitElement {
           this._dashboards,
           this.hass.localize
         )}
-        .data=${this._getItems(this._dashboards, this.hass.defaultPanel)}
+        .data=${this._getItems(
+          this._dashboards,
+          this.hass.defaultPanel || DEFAULT_PANEL
+        )}
         .initialGroupColumn=${this._activeGrouping}
         .initialCollapsedGroups=${this._activeCollapsed}
         .initialSorting=${this._activeSorting}

--- a/src/panels/lovelace/editor/select-dashboard/hui-dialog-select-dashboard.ts
+++ b/src/panels/lovelace/editor/select-dashboard/hui-dialog-select-dashboard.ts
@@ -3,20 +3,21 @@ import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import "../../../../components/ha-md-dialog";
+import "../../../../components/ha-button";
 import "../../../../components/ha-dialog-header";
 import "../../../../components/ha-icon-button";
+import "../../../../components/ha-md-dialog";
+import type { HaMdDialog } from "../../../../components/ha-md-dialog";
 import "../../../../components/ha-md-select";
 import "../../../../components/ha-md-select-option";
-import "../../../../components/ha-button";
 import "../../../../components/ha-spinner";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
 import type { LovelaceDashboard } from "../../../../data/lovelace/dashboard";
 import { fetchDashboards } from "../../../../data/lovelace/dashboard";
+import { getDefaultPanelUrlPath } from "../../../../data/panel";
 import { haStyleDialog } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import type { SelectDashboardDialogParams } from "./show-select-dashboard-dialog";
-import type { HaMdDialog } from "../../../../components/ha-md-dialog";
 
 @customElement("hui-dialog-select-dashboard")
 export class HuiDialogSelectDashboard extends LitElement {
@@ -143,7 +144,9 @@ export class HuiDialogSelectDashboard extends LitElement {
       ...(this._params!.dashboards || (await fetchDashboards(this.hass))),
     ];
 
-    const currentPath = this._fromUrlPath || this.hass.defaultPanel;
+    const defaultPanel = getDefaultPanelUrlPath(this.hass);
+
+    const currentPath = this._fromUrlPath || defaultPanel;
     for (const dashboard of this._dashboards!) {
       if (dashboard.url_path !== currentPath) {
         this._toUrlPath = dashboard.url_path;

--- a/src/panels/lovelace/editor/select-view/hui-dialog-select-view.ts
+++ b/src/panels/lovelace/editor/select-view/hui-dialog-select-view.ts
@@ -16,6 +16,7 @@ import { fetchConfig } from "../../../../data/lovelace/config/types";
 import { isStrategyView } from "../../../../data/lovelace/config/view";
 import type { LovelaceDashboard } from "../../../../data/lovelace/dashboard";
 import { fetchDashboards } from "../../../../data/lovelace/dashboard";
+import { getDefaultPanelUrlPath } from "../../../../data/panel";
 import { haStyleDialog } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import type { SelectViewDialogParams } from "./show-select-view-dialog";
@@ -60,6 +61,9 @@ export class HuiDialogSelectView extends LitElement {
     if (!this._params) {
       return nothing;
     }
+
+    const defaultPanel = getDefaultPanelUrlPath(this.hass);
+
     return html`
       <ha-dialog
         open
@@ -76,7 +80,7 @@ export class HuiDialogSelectView extends LitElement {
                 "ui.panel.lovelace.editor.select_view.dashboard_label"
               )}
               .disabled=${!this._dashboards.length}
-              .value=${this._urlPath || this.hass.defaultPanel}
+              .value=${this._urlPath || defaultPanel}
               @selected=${this._dashboardChanged}
               @closed=${stopPropagation}
               fixedMenuPosition

--- a/src/panels/profile/ha-pick-dashboard-row.ts
+++ b/src/panels/profile/ha-pick-dashboard-row.ts
@@ -6,8 +6,8 @@ import "../../components/ha-select";
 import "../../components/ha-settings-row";
 import type { LovelaceDashboard } from "../../data/lovelace/dashboard";
 import { fetchDashboards } from "../../data/lovelace/dashboard";
-import { setDefaultPanel } from "../../data/panel";
 import type { HomeAssistant } from "../../types";
+import { saveFrontendUserData } from "../../data/frontend";
 
 @customElement("ha-pick-dashboard-row")
 class HaPickDashboardRow extends LitElement {
@@ -73,10 +73,13 @@ class HaPickDashboardRow extends LitElement {
 
   private _dashboardChanged(ev) {
     const urlPath = ev.target.value;
-    if (!urlPath || urlPath === this.hass.defaultPanel) {
+    if (!urlPath || urlPath === this.hass.userData?.defaultPanel) {
       return;
     }
-    setDefaultPanel(this, urlPath);
+    saveFrontendUserData(this.hass.connection, "core", {
+      ...this.hass.userData,
+      defaultPanel: urlPath,
+    });
   }
 }
 

--- a/src/panels/profile/ha-profile-section-general.ts
+++ b/src/panels/profile/ha-profile-section-general.ts
@@ -154,6 +154,10 @@ class HaProfileSectionGeneral extends LitElement {
               .narrow=${this.narrow}
               .hass=${this.hass}
             ></ha-pick-first-weekday-row>
+            <ha-pick-dashboard-row
+              .narrow=${this.narrow}
+              .hass=${this.hass}
+            ></ha-pick-dashboard-row>
             <ha-settings-row .narrow=${this.narrow}>
               <span slot="heading">
                 ${this.hass.localize(
@@ -208,10 +212,6 @@ class HaProfileSectionGeneral extends LitElement {
               .narrow=${this.narrow}
               .hass=${this.hass}
             ></ha-pick-theme-row>
-            <ha-pick-dashboard-row
-              .narrow=${this.narrow}
-              .hass=${this.hass}
-            ></ha-pick-dashboard-row>
             ${this.hass.dockedSidebar !== "auto" || !this.narrow
               ? html`
                   <ha-force-narrow-row

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -287,15 +287,15 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       subscribeFrontendUserData(conn, "core", ({ value: userData }) =>
         this._updateHass({ userData })
       ).catch(() => {
-        // Catch errors to systemData subscription (e.g., if the backend
-        // doesn't support it for cast) and set to null so frontend can continue
+        // Catch errors to systemData subscription (e.g., for Cast if the backend
+        // isn't up to date) and set to null so frontend can continue
         this._updateHass({ userData: null });
       });
       subscribeFrontendSystemData(conn, "core", ({ value: systemData }) =>
         this._updateHass({ systemData })
       ).catch(() => {
-        // Catch errors to systemData subscription (e.g., if the backend
-        // doesn't support it for cast) and set to null so frontend can continue
+        // Catch errors to systemData subscription (e.g., for Cast if the backend
+        // isn't up to date) and set to null so frontend can continue
         this._updateHass({ systemData: null });
       });
       clearInterval(this.__backendPingInterval);

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -290,14 +290,18 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         this._updateHass({ userData: userData || {} })
       ).catch(() => {
         // eslint-disable-next-line no-console
-        console.error("Failed to subscribe to user data, setting to empty object");
+        console.error(
+          "Failed to subscribe to user data, setting to empty object"
+        );
         this._updateHass({ userData: {} });
       });
       subscribeFrontendSystemData(conn, "core", ({ value: systemData }) =>
         this._updateHass({ systemData: systemData || {} })
       ).catch(() => {
         // eslint-disable-next-line no-console
-        console.error("Failed to subscribe to system data, setting to empty object");
+        console.error(
+          "Failed to subscribe to system data, setting to empty object"
+        );
         this._updateHass({ systemData: {} });
       });
       clearInterval(this.__backendPingInterval);

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -30,7 +30,7 @@ import { translationMetadata } from "../resources/translations-metadata";
 import type { Constructor, HomeAssistant, ServiceCallResponse } from "../types";
 import { getLocalLanguage } from "../util/common-translation";
 import { fetchWithAuth } from "../util/fetch-with-auth";
-import { getState } from "../util/ha-pref-storage";
+import { getState, storeState } from "../util/ha-pref-storage";
 import hassCallApi, { hassCallApiRaw } from "../util/hass-call-api";
 import type { HassBaseEl } from "./hass-base-mixin";
 import { computeStateName } from "../common/entity/compute_state_name";
@@ -285,6 +285,14 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       subscribeFrontendUserData(conn, "core", ({ value: userData }) => {
         this._updateHass({ userData });
       });
+      subscribeFrontendUserData(
+        conn,
+        "default_panel",
+        ({ value: defaultPanel }) => {
+          this._updateHass({ defaultPanel: defaultPanel || DEFAULT_PANEL });
+          storeState(this.hass!);
+        }
+      );
 
       clearInterval(this.__backendPingInterval);
       this.__backendPingInterval = setInterval(() => {

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -284,18 +284,21 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       subscribeConfig(conn, (config) => this._updateHass({ config }));
       subscribeServices(conn, (services) => this._updateHass({ services }));
       subscribePanels(conn, (panels) => this._updateHass({ panels }));
+      // Catch errors to userData and systemData subscription (e.g., for Cast
+      // if the backend isn't up to date) and set to null so frontend can
+      // continue
       subscribeFrontendUserData(conn, "core", ({ value: userData }) =>
         this._updateHass({ userData })
       ).catch(() => {
-        // Catch errors to systemData subscription (e.g., for Cast if the backend
-        // isn't up to date) and set to null so frontend can continue
+        // eslint-disable-next-line no-console
+        console.error("Failed to subscribe to user data, setting to null");
         this._updateHass({ userData: null });
       });
       subscribeFrontendSystemData(conn, "core", ({ value: systemData }) =>
         this._updateHass({ systemData })
       ).catch(() => {
-        // Catch errors to systemData subscription (e.g., for Cast if the backend
-        // isn't up to date) and set to null so frontend can continue
+        // eslint-disable-next-line no-console
+        console.error("Failed to subscribe to system data, setting to null");
         this._updateHass({ systemData: null });
       });
       clearInterval(this.__backendPingInterval);

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -38,7 +38,6 @@ import { fetchWithAuth } from "../util/fetch-with-auth";
 import { getState, storeState } from "../util/ha-pref-storage";
 import hassCallApi, { hassCallApiRaw } from "../util/hass-call-api";
 import type { HassBaseEl } from "./hass-base-mixin";
-import { DEFAULT_PANEL } from "../data/panel";
 
 export const connectionMixin = <T extends Constructor<HassBaseEl>>(
   superClass: T
@@ -65,7 +64,9 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         services: null as any,
         user: null as any,
         panelUrl: (this as any)._panelUrl,
-        defaultPanel: DEFAULT_PANEL,
+        defaultPanel: null,
+        systemDefaultPanel: null,
+        userDefaultPanel: null,
         language,
         selectedLanguage: null,
         locale: {

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -288,18 +288,18 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       // if the backend isn't up to date) and set to null so frontend can
       // continue
       subscribeFrontendUserData(conn, "core", ({ value: userData }) =>
-        this._updateHass({ userData })
+        this._updateHass({ userData: userData || {} })
       ).catch(() => {
         // eslint-disable-next-line no-console
         console.error("Failed to subscribe to user data, setting to null");
-        this._updateHass({ userData: null });
+        this._updateHass({ userData: {} });
       });
       subscribeFrontendSystemData(conn, "core", ({ value: systemData }) =>
-        this._updateHass({ systemData })
+        this._updateHass({ systemData: systemData || {} })
       ).catch(() => {
         // eslint-disable-next-line no-console
         console.error("Failed to subscribe to system data, setting to null");
-        this._updateHass({ systemData: null });
+        this._updateHass({ systemData: {} });
       });
       clearInterval(this.__backendPingInterval);
       this.__backendPingInterval = setInterval(() => {

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -290,14 +290,14 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         this._updateHass({ userData: userData || {} })
       ).catch(() => {
         // eslint-disable-next-line no-console
-        console.error("Failed to subscribe to user data, setting to null");
+        console.error("Failed to subscribe to user data, setting to empty object");
         this._updateHass({ userData: {} });
       });
       subscribeFrontendSystemData(conn, "core", ({ value: systemData }) =>
         this._updateHass({ systemData: systemData || {} })
       ).catch(() => {
         // eslint-disable-next-line no-console
-        console.error("Failed to subscribe to system data, setting to null");
+        console.error("Failed to subscribe to system data, setting to empty object");
         this._updateHass({ systemData: {} });
       });
       clearInterval(this.__backendPingInterval);

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -284,9 +284,8 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       subscribeConfig(conn, (config) => this._updateHass({ config }));
       subscribeServices(conn, (services) => this._updateHass({ services }));
       subscribePanels(conn, (panels) => this._updateHass({ panels }));
-      // Catch errors to userData and systemData subscription (e.g., for Cast
-      // if the backend isn't up to date) and set to null so frontend can
-      // continue
+      // Catch errors to userData and systemData subscription (e.g. if the
+      // backend isn't up to date) and set to null so frontend can continue
       subscribeFrontendUserData(conn, "core", ({ value: userData }) =>
         this._updateHass({ userData: userData || {} })
       ).catch(() => {

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -286,10 +286,18 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       subscribePanels(conn, (panels) => this._updateHass({ panels }));
       subscribeFrontendUserData(conn, "core", ({ value: userData }) =>
         this._updateHass({ userData })
-      );
+      ).catch(() => {
+        // Catch errors to systemData subscription (e.g., if the backend
+        // doesn't support it for cast) and set to null so frontend can continue
+        this._updateHass({ userData: null });
+      });
       subscribeFrontendSystemData(conn, "core", ({ value: systemData }) =>
         this._updateHass({ systemData })
-      );
+      ).catch(() => {
+        // Catch errors to systemData subscription (e.g., if the backend
+        // doesn't support it for cast) and set to null so frontend can continue
+        this._updateHass({ systemData: null });
+      });
       clearInterval(this.__backendPingInterval);
       this.__backendPingInterval = setInterval(() => {
         if (this.hass?.connected) {

--- a/src/state/sidebar-mixin.ts
+++ b/src/state/sidebar-mixin.ts
@@ -1,5 +1,4 @@
 import type { HASSDomEvent } from "../common/dom/fire_event";
-import { saveFrontendUserData } from "../data/frontend";
 import type { Constructor, HomeAssistant } from "../types";
 import { storeState } from "../util/ha-pref-storage";
 import type { HassBaseEl } from "./hass-base-mixin";
@@ -8,20 +7,14 @@ interface DockSidebarParams {
   dock: HomeAssistant["dockedSidebar"];
 }
 
-interface DefaultPanelParams {
-  defaultPanel: HomeAssistant["defaultPanel"];
-}
-
 declare global {
   // for fire event
   interface HASSDomEvents {
     "hass-dock-sidebar": DockSidebarParams;
-    "hass-default-panel": DefaultPanelParams;
   }
   // for add event listener
   interface HTMLElementEventMap {
     "hass-dock-sidebar": HASSDomEvent<DockSidebarParams>;
-    "hass-default-panel": HASSDomEvent<DefaultPanelParams>;
   }
 }
 
@@ -32,21 +25,6 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       this.addEventListener("hass-dock-sidebar", (ev) => {
         this._updateHass({ dockedSidebar: ev.detail.dock });
         storeState(this.hass!);
-      });
-      this.addEventListener("hass-default-panel", (ev) => {
-        const defaultPanel = ev.detail.defaultPanel;
-        this._updateHass({ defaultPanel });
-        storeState(this.hass!);
-        try {
-          saveFrontendUserData(
-            this.hass!.connection,
-            "default_panel",
-            defaultPanel
-          );
-        } catch (err) {
-          // eslint-disable-next-line no-console
-          console.error("Failed to save default panel", err);
-        }
       });
     }
   };

--- a/src/state/sidebar-mixin.ts
+++ b/src/state/sidebar-mixin.ts
@@ -1,4 +1,5 @@
 import type { HASSDomEvent } from "../common/dom/fire_event";
+import { saveFrontendUserData } from "../data/frontend";
 import type { Constructor, HomeAssistant } from "../types";
 import { storeState } from "../util/ha-pref-storage";
 import type { HassBaseEl } from "./hass-base-mixin";
@@ -33,8 +34,19 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         storeState(this.hass!);
       });
       this.addEventListener("hass-default-panel", (ev) => {
-        this._updateHass({ defaultPanel: ev.detail.defaultPanel });
+        const defaultPanel = ev.detail.defaultPanel;
+        this._updateHass({ defaultPanel });
         storeState(this.hass!);
+        try {
+          saveFrontendUserData(
+            this.hass!.connection,
+            "default_panel",
+            defaultPanel
+          );
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error("Failed to save default panel", err);
+        }
       });
     }
   };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3515,8 +3515,12 @@
               "delete": "Delete",
               "update": "Update",
               "create": "Create",
-              "set_default": "Set as default on this device",
-              "remove_default": "Remove as default on this device"
+              "set_default": "Set as default",
+              "remove_default": "Remove as default",
+              "set_default_confirm_title": "Set as default dashboard?",
+              "set_default_confirm_text": "This will replace the current default dashboard. Users can still override their default dashboard in their profile settings.",
+              "remove_default_confirm_title": "Remove default dashboard?",
+              "remove_default_confirm_text": "The default dashboard will be changed to Overview for every user. Users can still override their default dashboard in their profile settings."
             }
           },
           "resources": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8665,7 +8665,9 @@
           "header": "Dashboard",
           "description": "Pick a default dashboard for this device.",
           "dropdown_label": "Dashboard",
-          "default_dashboard_label": "Overview (default)"
+          "lovelace": "Overview",
+          "home": "Home",
+          "system": "Auto (use system settings)"
         },
         "change_password": {
           "header": "Change password",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8667,7 +8667,7 @@
         },
         "dashboard": {
           "header": "Dashboard",
-          "description": "Pick a default dashboard for this device.",
+          "description": "Pick a default dashboard to show.",
           "dropdown_label": "Dashboard",
           "lovelace": "Overview",
           "home": "Home",

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,10 @@ import type { AreaRegistryEntry } from "./data/area_registry";
 import type { DeviceRegistryEntry } from "./data/device_registry";
 import type { EntityRegistryDisplayEntry } from "./data/entity_registry";
 import type { FloorRegistryEntry } from "./data/floor_registry";
-import type { CoreFrontendUserData } from "./data/frontend";
+import type {
+  CoreFrontendSystemData,
+  CoreFrontendUserData,
+} from "./data/frontend";
 import type {
   FrontendLocaleData,
   getHassTranslations,
@@ -248,10 +251,10 @@ export interface HomeAssistant {
   vibrate: boolean;
   debugConnection: boolean;
   dockedSidebar: "docked" | "always_hidden" | "auto";
-  defaultPanel: string | null;
   moreInfoEntityId: string | null;
   user?: CurrentUser;
   userData?: CoreFrontendUserData | null;
+  systemData?: CoreFrontendSystemData | null;
   hassUrl(path?): string;
   callService<T = any>(
     domain: ServiceCallRequest["domain"],
@@ -283,7 +286,6 @@ export interface HomeAssistant {
     configFlow?: Parameters<typeof getHassTranslations>[4]
   ): Promise<LocalizeFunc>;
   loadFragmentTranslation(fragment: string): Promise<LocalizeFunc | undefined>;
-  loadDefaultPanel(): Promise<void>;
   formatEntityState(stateObj: HassEntity, state?: string): string;
   formatEntityAttributeValue(
     stateObj: HassEntity,

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,8 +249,6 @@ export interface HomeAssistant {
   debugConnection: boolean;
   dockedSidebar: "docked" | "always_hidden" | "auto";
   defaultPanel: string | null;
-  userDefaultPanel: string | null;
-  systemDefaultPanel: string | null;
   moreInfoEntityId: string | null;
   user?: CurrentUser;
   userData?: CoreFrontendUserData | null;
@@ -285,7 +283,7 @@ export interface HomeAssistant {
     configFlow?: Parameters<typeof getHassTranslations>[4]
   ): Promise<LocalizeFunc>;
   loadFragmentTranslation(fragment: string): Promise<LocalizeFunc | undefined>;
-  loadDefaultPanel(): Promise<string | null | undefined>;
+  loadDefaultPanel(): Promise<void>;
   formatEntityState(stateObj: HassEntity, state?: string): string;
   formatEntityAttributeValue(
     stateObj: HassEntity,

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,9 +248,9 @@ export interface HomeAssistant {
   vibrate: boolean;
   debugConnection: boolean;
   dockedSidebar: "docked" | "always_hidden" | "auto";
-  defaultPanel?: string | null;
-  userDefaultPanel?: string | null;
-  systemDefaultPanel?: string | null;
+  defaultPanel: string | null;
+  userDefaultPanel: string | null;
+  systemDefaultPanel: string | null;
   moreInfoEntityId: string | null;
   user?: CurrentUser;
   userData?: CoreFrontendUserData | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -253,8 +253,8 @@ export interface HomeAssistant {
   dockedSidebar: "docked" | "always_hidden" | "auto";
   moreInfoEntityId: string | null;
   user?: CurrentUser;
-  userData?: CoreFrontendUserData | null;
-  systemData?: CoreFrontendSystemData | null;
+  userData?: CoreFrontendUserData;
+  systemData?: CoreFrontendSystemData;
   hassUrl(path?): string;
   callService<T = any>(
     domain: ServiceCallRequest["domain"],

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,7 +248,9 @@ export interface HomeAssistant {
   vibrate: boolean;
   debugConnection: boolean;
   dockedSidebar: "docked" | "always_hidden" | "auto";
-  defaultPanel: string;
+  defaultPanel?: string | null;
+  userDefaultPanel?: string | null;
+  systemDefaultPanel?: string | null;
   moreInfoEntityId: string | null;
   user?: CurrentUser;
   userData?: CoreFrontendUserData | null;
@@ -283,6 +285,7 @@ export interface HomeAssistant {
     configFlow?: Parameters<typeof getHassTranslations>[4]
   ): Promise<LocalizeFunc>;
   loadFragmentTranslation(fragment: string): Promise<LocalizeFunc | undefined>;
+  loadDefaultPanel(): Promise<string | null | undefined>;
   formatEntityState(stateObj: HassEntity, state?: string): string;
   formatEntityAttributeValue(
     stateObj: HassEntity,

--- a/src/util/ha-pref-storage.ts
+++ b/src/util/ha-pref-storage.ts
@@ -9,7 +9,9 @@ const STORED_STATE = [
   "suspendWhenHidden",
   "enableShortcuts",
   "defaultPanel",
-];
+] as const;
+
+type StoredHomeAssistant = Pick<HomeAssistant, (typeof STORED_STATE)[number]>;
 
 export function storeState(hass: HomeAssistant) {
   try {
@@ -31,8 +33,8 @@ export function storeState(hass: HomeAssistant) {
   }
 }
 
-export function getState() {
-  const state = {};
+export function getState(): Partial<StoredHomeAssistant> {
+  const state = {} as Partial<StoredHomeAssistant>;
 
   STORED_STATE.forEach((key) => {
     const storageItem = window.localStorage.getItem(key);

--- a/src/util/ha-pref-storage.ts
+++ b/src/util/ha-pref-storage.ts
@@ -8,7 +8,6 @@ const STORED_STATE = [
   "debugConnection",
   "suspendWhenHidden",
   "enableShortcuts",
-  "defaultPanel",
 ] as const;
 
 type StoredHomeAssistant = Pick<HomeAssistant, (typeof STORED_STATE)[number]>;

--- a/test/util/ha-pref-storage.test.ts
+++ b/test/util/ha-pref-storage.test.ts
@@ -24,7 +24,7 @@ describe("ha-pref-storage", () => {
     window.localStorage.setItem = vi.fn();
 
     storeState(mockHass as unknown as HomeAssistant);
-    expect(window.localStorage.setItem).toHaveBeenCalledTimes(8);
+    expect(window.localStorage.setItem).toHaveBeenCalledTimes(7);
     expect(window.localStorage.setItem).toHaveBeenCalledWith(
       "dockedSidebar",
       JSON.stringify("auto")


### PR DESCRIPTION
## Breaking change

The select from the profile page now update the user default panel
The `set as default` button from the dashboards config page now updates the system default panel

Per device default panel is not supported anymore to be consistent with sidebar settings.

## Proposed change

Alternative PR to https://github.com/home-assistant/frontend/pull/25702.

We also want to add default dashboard at the system level so this settings should be separated from sidebar.

- Needs https://github.com/home-assistant/core/pull/155945 for system storage (error is handled if the system storage websocket is not available to avoid UI blocking)

Changes : 
- [x] save the default panel per user when a user change it.
- [x] load the default panel from user data 
- [x] Load default panel **before** HA navigate to default panel
- [x] Compatible with existing default panel
- [x] Add system storage

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/18626
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
