### PR TITLE
Data table: add default sort direction

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -173,7 +173,7 @@ export class HaDataTable extends LitElement {
 
   private _sortColumns: SortableColumnContainer = {};
 
-  private _defaultSortColumn = "";
+  private _defaultSortColumn?: string;
 
   private _defaultSortDirection: SortingDirection = null;
 

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -848,7 +848,7 @@ export class HaDataTable extends LitElement {
     }
 
     fireEvent(this, "sorting-changed", {
-      column: this.sortColumn,
+      column: this.sortColumn!,
       direction: this.sortDirection,
     });
   }

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -240,7 +240,7 @@ export class HaDataTable extends LitElement {
 
     for (const columnId in this.columns) {
       if (this.columns[columnId].direction) {
-        this._defaultSortDirection = this.columns[columnId].direction!;
+        this._defaultSortDirection = this.columns[columnId].direction;
         this._defaultSortColumn = columnId;
         break;
       }

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -173,6 +173,10 @@ export class HaDataTable extends LitElement {
 
   private _sortColumns: SortableColumnContainer = {};
 
+  private _defaultSortColumn = "";
+
+  private _defaultSortDirection: SortingDirection = null;
+
   private _curRequest = 0;
 
   private _lastUpdate = 0;
@@ -232,6 +236,14 @@ export class HaDataTable extends LitElement {
     if (this._filteredData.length) {
       // Force update of location of rows
       this._filteredData = [...this._filteredData];
+    }
+
+    for (const columnId in this.columns) {
+      if (this.columns[columnId].direction) {
+        this._defaultSortDirection = this.columns[columnId].direction!;
+        this._defaultSortColumn = columnId;
+        break;
+      }
     }
   }
 
@@ -830,9 +842,13 @@ export class HaDataTable extends LitElement {
     }
 
     this.sortColumn = this.sortDirection === null ? undefined : columnId;
+    if (!this.sortColumn) {
+      this.sortDirection = this._defaultSortDirection;
+      this.sortColumn = this._defaultSortColumn;
+    }
 
     fireEvent(this, "sorting-changed", {
-      column: columnId,
+      column: this.sortColumn,
       direction: this.sortDirection,
     });
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Currently after a 3rd click on some column's header, a table is sorted in some unknown order.
This PR adds default sorting settings.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/17222
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
