### PR TITLE
Fix media image on dashboard-level background

### DIFF
--- a/src/panels/lovelace/views/hui-view-background.ts
+++ b/src/panels/lovelace/views/hui-view-background.ts
@@ -109,6 +109,7 @@ export class HUIViewBackground extends LitElement {
 
   protected willUpdate(changedProperties: PropertyValues<this>) {
     super.willUpdate(changedProperties);
+    let applyTheme = false;
     if (changedProperties.has("hass") && this.hass) {
       const oldHass = changedProperties.get("hass");
       if (
@@ -116,16 +117,18 @@ export class HUIViewBackground extends LitElement {
         this.hass.themes !== oldHass.themes ||
         this.hass.selectedTheme !== oldHass.selectedTheme
       ) {
-        this._applyTheme();
-        return;
+        applyTheme = true;
       }
     }
 
     if (changedProperties.has("background")) {
-      this._applyTheme();
+      applyTheme = true;
       this._fetchMedia();
     }
     if (changedProperties.has("resolvedImage")) {
+      applyTheme = true;
+    }
+    if (applyTheme) {
       this._applyTheme();
     }
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When `hass` and `background` properties were changed in the same update cycle, the early short-circuit return from the hass handler caused the module to skip the expected fetchMedia function execution. 

This apparently only manifests when you set the background object at the dashboard level, instead of the view level, which I didn't even realize we support (undocumented?), but the code is there. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #27921
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
