### PR TITLE
Create mobile column gap variable in hui-sections-view

### DIFF
--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -365,7 +365,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
 
     @media (max-width: 600px) {
       :host {
-        --column-gap: var(--row-gap);
+        --column-gap: var(--ha-view-sections-narrow-column-gap, var(--row-gap));
       }
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Adds `--ha-view-sections-mobile-column-gap` CSS variable to allow independent control of horizontal spacing on mobile devices in sections view.

## Problem
Currently, the sections view forces `--column-gap: var(--row-gap)` on mobile (≤600px width). This creates two issues:

1. **Lack of control**: Users cannot independently adjust horizontal vs vertical spacing on mobile
2. **Semantic confusion**: On mobile, there's only one column, so "column-gap" is a misnomer - it's actually controlling padding/margins

### Current behavior
- Desktop: `--column-gap` controls horizontal spacing between columns (default: 32px)
- Mobile: `--column-gap` is forced to equal `--row-gap` (default: 8px)
- Result: Increasing `--row-gap` for vertical spacing also increases horizontal padding on mobile

### Example use case
A user wants 24px vertical spacing but only 8px horizontal padding on mobile. Currently impossible without card-mod CSS overrides.

## Solution
Introduce `--ha-view-sections-mobile-column-gap` variable with fallback to current behavior:
```css
@media (max-width: 600px) {
  :host {
    --column-gap: var(--ha-view-sections-mobile-column-gap, var(--row-gap));
  }
}
```

This is **fully backward compatible** - existing configurations continue to work identically.

## Limitations
This is an incremental improvement. The deeper issue is that `--row-gap` and `--column-gap` are semantically overloaded - they controls padding as well as gaps between columns. A more comprehensive fix would introduce dedicated padding variables (e.g., `--ha-view-sections-padding-horizontal`), but that would be a larger refactor affecting the desktop view as well.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->


custom theme:
```yaml
custom-spacing:
  modes:
    light: {}
    dark: {}
  ha-view-sections-row-gap: 24px # becomes --row-gap, default 8px, vertical gap between sections
  ha-view-sections-column-gap: 16px  # becomes --column-gap, default 32px, horizontal gap between sections
  ha-view-sections-mobile-column-gap: 8px # becomes --column-gap if max-width: 600px
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

I don't think any of these `--ha-view-sections` css variables are documented?

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
