### PR TITLE
disable browser autofill on search inputs

### DIFF
--- a/src/components/search-input.ts
+++ b/src/components/search-input.ts
@@ -34,6 +34,7 @@ class SearchInput extends LitElement {
     return html`
       <ha-textfield
         .autofocus=${this.autofocus}
+        autocomplete="off"
         .label=${this.label || this.hass.localize("ui.common.search")}
         .value=${this.filter || ""}
         icon


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR disables browser autofill for the `search-input` component by adding  
`autocomplete="off"` to the underlying `<ha-textfield>` element.

Browsers were incorrectly autofilling saved usernames or email addresses into
search boxes across the frontend. This negatively affects the user experience,
especially in dialogs such as *Add to Dashboard*, where a search field is
not meant to receive login credentials or personal autofill data.

This change prevents unexpected autofill behavior while keeping the
component's function and design unchanged.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
-->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Suppling a configuration snippet makes it easier for a maintainer to test
  your PR.
-->
```yaml
# No configuration required.
