### PR TITLE
Expose location for calendar events

### DIFF
--- a/src/data/calendar.ts
+++ b/src/data/calendar.ts
@@ -31,6 +31,7 @@ export interface CalendarEventData {
   dtend: string;
   rrule?: string;
   description?: string;
+  location?: string;
 }
 
 export interface CalendarEventMutableParams {
@@ -39,6 +40,7 @@ export interface CalendarEventMutableParams {
   dtend: string;
   rrule?: string;
   description?: string;
+  location?: string;
 }
 
 // The scope of a delete/update for a recurring event
@@ -96,6 +98,7 @@ export const fetchCalendarEvents = async (
         uid: ev.uid,
         summary: ev.summary,
         description: ev.description,
+        location: ev.location,
         dtstart: eventStart,
         dtend: eventEnd,
         recurrence_id: ev.recurrence_id,

--- a/src/panels/calendar/dialog-calendar-event-detail.ts
+++ b/src/panels/calendar/dialog-calendar-event-detail.ts
@@ -80,10 +80,12 @@ class DialogCalendarEventDetail extends LitElement {
               ${this._data!.rrule
                 ? this._renderRRuleAsText(this._data.rrule)
                 : ""}
+              ${this._data.location
+                ? html`${this._data.location} <br />`
+                : nothing}
               ${this._data.description
                 ? html`<br />
-                    <div class="description">${this._data.description}</div>
-                    <br />`
+                    <div class="description">${this._data.description}</div>`
                 : nothing}
             </div>
           </div>
@@ -241,7 +243,7 @@ class DialogCalendarEventDetail extends LitElement {
       haStyleDialog,
       css`
         state-info {
-          line-height: 40px;
+          margin-top: 24px;
         }
         ha-svg-icon {
           width: 40px;

--- a/src/panels/calendar/dialog-calendar-event-editor.ts
+++ b/src/panels/calendar/dialog-calendar-event-editor.ts
@@ -63,6 +63,8 @@ class DialogCalendarEventEditor extends LitElement {
 
   @state() private _description? = "";
 
+  @state() private _location? = "";
+
   @state() private _rrule?: string;
 
   @state() private _allDay = false;
@@ -78,6 +80,8 @@ class DialogCalendarEventEditor extends LitElement {
   // events are persisted, they are relative to the Home Assistant
   // timezone, but floating without a timezone.
   private _timeZone?: string;
+
+  private _hasLocation = false;
 
   public showDialog(params: CalendarEventEditDialogParams): void {
     this._error = undefined;
@@ -99,6 +103,10 @@ class DialogCalendarEventEditor extends LitElement {
       this._allDay = isDate(entry.dtstart);
       this._summary = entry.summary;
       this._description = entry.description;
+      if (entry.location) {
+        this._hasLocation = true;
+        this._location = entry.location || "";
+      }
       this._rrule = entry.rrule;
       if (this._allDay) {
         this._dtstart = new Date(entry.dtstart + "T00:00:00");
@@ -130,6 +138,8 @@ class DialogCalendarEventEditor extends LitElement {
     this._dtend = undefined;
     this._summary = "";
     this._description = "";
+    this._location = "";
+    this._hasLocation = false;
     this._rrule = undefined;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
@@ -180,6 +190,15 @@ class DialogCalendarEventEditor extends LitElement {
             @input=${this._handleSummaryChanged}
             .validationMessage=${this.hass.localize("ui.common.error_required")}
             dialogInitialFocus
+          ></ha-textfield>
+          <ha-textfield
+            class="location"
+            name="location"
+            .label=${this.hass.localize(
+              "ui.components.calendar.event.location"
+            )}
+            .value=${this._location}
+            @change=${this._handleLocationChanged}
           ></ha-textfield>
           <ha-textarea
             class="description"
@@ -326,6 +345,10 @@ class DialogCalendarEventEditor extends LitElement {
     this._description = ev.target.value;
   }
 
+  private _handleLocationChanged(ev) {
+    this._location = ev.target.value;
+  }
+
   private _handleRRuleChanged(ev) {
     this._rrule = ev.detail.value;
   }
@@ -399,6 +422,7 @@ class DialogCalendarEventEditor extends LitElement {
     const data: CalendarEventMutableParams = {
       summary: this._summary,
       description: this._description,
+      location: this._location || (this._hasLocation ? "" : undefined),
       rrule: this._rrule || undefined,
       dtstart: "",
       dtend: "",

--- a/src/panels/calendar/dialog-calendar-event-editor.ts
+++ b/src/panels/calendar/dialog-calendar-event-editor.ts
@@ -105,7 +105,7 @@ class DialogCalendarEventEditor extends LitElement {
       this._description = entry.description;
       if (entry.location) {
         this._hasLocation = true;
-        this._location = entry.location || "";
+        this._location = entry.location;
       }
       this._rrule = entry.rrule;
       if (this._allDay) {
@@ -345,8 +345,8 @@ class DialogCalendarEventEditor extends LitElement {
     this._description = ev.target.value;
   }
 
-  private _handleLocationChanged(ev) {
-    this._location = ev.target.value;
+  private _handleLocationChanged(ev: Event) {
+    this._location = (ev.target as HTMLInputElement).value;
   }
 
   private _handleRRuleChanged(ev) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1236,7 +1236,8 @@
             "times": "times"
           },
           "summary": "Summary",
-          "description": "Description"
+          "description": "Description",
+          "location": "Location"
         },
         "views": {
           "dayGridMonth": "[%key:ui::panel::lovelace::editor::card::calendar::views::dayGridMonth%]",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Expose location for calendar events. Minor CSS tweaks.

Some before and after comparisons below

#### Before (no description no location):

State info alignment feels off here, the gap between the state-info ("Calendar 2" and "3 days ago") seems too big, it's supposed to be lined up with the lower calendar icon but it's spilling into the area next to the upper icon?

<img width="367" height="219" alt="image" src="https://github.com/user-attachments/assets/296e1e40-512d-4a8e-8480-43d1b2bc9d61" />

#### After:

<img width="384" height="228" alt="image" src="https://github.com/user-attachments/assets/327add13-18c6-40df-b855-0af75d82e4f9" />


#### Before (location, no description):
<img width="384" height="225" alt="image" src="https://github.com/user-attachments/assets/671b3e7a-9889-44b5-92cf-715af8d72513" />


#### After (the entity name and location here just happened to be the same):
<img width="392" height="253" alt="image" src="https://github.com/user-attachments/assets/4ce52bbf-452b-4b19-b042-7660600e85ff" />



#### Before (location & description):
<img width="377" height="307" alt="image" src="https://github.com/user-attachments/assets/c9c0dcaa-3f64-4e95-89b1-46139427a80c" />


#### After:

<img width="386" height="302" alt="image" src="https://github.com/user-attachments/assets/d2a80e07-3b53-42c0-b3f6-423596521f05" />



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #27973
- This PR is related to issue or discussion: 
https://github.com/orgs/home-assistant/discussions/187
https://github.com/orgs/home-assistant/discussions/1687
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
