### PR TITLE
Standardise fixed top ha-dialog usages and fix safe areas

### DIFF
--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -100,6 +100,7 @@ export class HaDialog extends DialogBase {
       }
       .mdc-dialog__container {
         align-items: var(--vertical-align-dialog, center);
+        padding: var(--dialog-container-padding, var(--ha-space-0));
       }
       .mdc-dialog__title {
         padding: 16px 16px 0 16px;
@@ -133,7 +134,7 @@ export class HaDialog extends DialogBase {
           --ha-dialog-surface-background,
           var(--mdc-theme-surface, #fff)
         );
-        padding: var(--dialog-surface-padding);
+        padding: var(--dialog-surface-padding, var(--ha-space-0));
       }
       :host([flexContent]) .mdc-dialog .mdc-dialog__content {
         display: flex;

--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -113,10 +113,10 @@ export class HaDialog extends DialogBase {
       }
       .mdc-dialog .mdc-dialog__content {
         position: var(--dialog-content-position, relative);
-        padding: var(--dialog-content-padding, 24px);
+        padding: var(--dialog-content-padding, var(--ha-space-6));
       }
       :host([hideactions]) .mdc-dialog .mdc-dialog__content {
-        padding-bottom: var(--dialog-content-padding, 24px);
+        padding-bottom: var(--dialog-content-padding, var(--ha-space-6));
       }
       .mdc-dialog .mdc-dialog__surface {
         position: var(--dialog-surface-position, relative);

--- a/src/components/media-player/dialog-media-manage.ts
+++ b/src/components/media-player/dialog-media-manage.ts
@@ -18,7 +18,7 @@ import {
   removeLocalMedia,
 } from "../../data/media_source";
 import { showConfirmationDialog } from "../../dialogs/generic/show-dialog-box";
-import { haStyleDialog } from "../../resources/styles";
+import { haStyleDialog, haStyleDialogFixedTop } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import "../ha-button";
 import "../ha-check-list-item";
@@ -305,6 +305,7 @@ class DialogMediaManage extends LitElement {
   static get styles(): CSSResultGroup {
     return [
       haStyleDialog,
+      haStyleDialogFixedTop,
       css`
         ha-dialog {
           --dialog-z-index: 9;
@@ -314,8 +315,6 @@ class DialogMediaManage extends LitElement {
         @media (min-width: 800px) {
           ha-dialog {
             --mdc-dialog-max-width: 800px;
-            --dialog-surface-position: fixed;
-            --dialog-surface-top: 40px;
             --mdc-dialog-max-height: calc(100vh - 72px);
           }
         }

--- a/src/components/media-player/dialog-media-manage.ts
+++ b/src/components/media-player/dialog-media-manage.ts
@@ -315,7 +315,9 @@ class DialogMediaManage extends LitElement {
         @media (min-width: 800px) {
           ha-dialog {
             --mdc-dialog-max-width: 800px;
-            --mdc-dialog-max-height: calc(100vh - 72px);
+            --mdc-dialog-max-height: calc(
+              100vh - var(--ha-space-18) - var(--safe-area-inset-y)
+            );
           }
         }
 

--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -19,7 +19,7 @@ import type {
   MediaPlayerItem,
   MediaPlayerLayoutType,
 } from "../../data/media-player";
-import { haStyleDialog } from "../../resources/styles";
+import { haStyleDialog, haStyleDialogFixedTop } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import "../ha-dialog";
 import "../ha-dialog-header";
@@ -223,6 +223,7 @@ class DialogMediaPlayerBrowse extends LitElement {
   static get styles(): CSSResultGroup {
     return [
       haStyleDialog,
+      haStyleDialogFixedTop,
       css`
         ha-dialog {
           --dialog-z-index: 9;
@@ -230,23 +231,30 @@ class DialogMediaPlayerBrowse extends LitElement {
         }
 
         ha-media-player-browse {
-          --media-browser-max-height: calc(100vh - 65px);
+          --media-browser-max-height: calc(
+            100vh - 65px - var(--safe-area-inset-top, 0) -
+              var(--safe-area-inset-bottom, 0)
+          );
         }
 
         :host(.opened) ha-media-player-browse {
-          height: calc(100vh - 65px);
+          height: calc(
+            100vh - 65px - var(--safe-area-inset-top, 0) -
+              var(--safe-area-inset-bottom, 0)
+          );
         }
 
         @media (min-width: 800px) {
           ha-dialog {
             --mdc-dialog-max-width: 800px;
-            --dialog-surface-position: fixed;
-            --dialog-surface-top: 40px;
-            --mdc-dialog-max-height: calc(100vh - 72px);
+            --mdc-dialog-max-height: calc(100% - 72px);
           }
           ha-media-player-browse {
             position: initial;
-            --media-browser-max-height: calc(100vh - 145px);
+            --media-browser-max-height: calc(
+              100vh - 145px - var(--safe-area-inset-top, 0) -
+                var(--safe-area-inset-bottom, 0)
+            );
             width: 700px;
           }
         }

--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -254,21 +254,13 @@ class DialogMediaPlayerBrowse extends LitElement {
           ha-dialog {
             --mdc-dialog-max-width: 800px;
             --mdc-dialog-max-height: calc(
-              100vh -
-                72px - var(--safe-area-inset-top, var(--ha-space-0)) - var(
-                  --safe-area-inset-bottom,
-                  var(--ha-space-0)
-                )
+              100vh - var(--ha-space-18) - var(--safe-area-inset-y)
             );
           }
           ha-media-player-browse {
             position: initial;
             --media-browser-max-height: calc(
-              100vh -
-                145px - var(--safe-area-inset-top, var(--ha-space-0)) - var(
-                  --safe-area-inset-bottom,
-                  var(--ha-space-0)
-                )
+              100vh - 145px - var(--safe-area-inset-y)
             );
             width: 700px;
           }

--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -237,9 +237,7 @@ class DialogMediaPlayerBrowse extends LitElement {
         }
 
         :host(.opened) ha-media-player-browse {
-          height: calc(
-            100vh - 65px - var(--safe-area-inset-y)
-          );
+          height: calc(100vh - 65px - var(--safe-area-inset-y));
         }
 
         @media (min-width: 800px) {

--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -238,11 +238,7 @@ class DialogMediaPlayerBrowse extends LitElement {
 
         :host(.opened) ha-media-player-browse {
           height: calc(
-            100vh -
-              65px - var(--safe-area-inset-top, var(--ha-space-0)) - var(
-                --safe-area-inset-bottom,
-                var(--ha-space-0)
-              )
+            100vh - 65px - var(--safe-area-inset-y)
           );
         }
 

--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -232,15 +232,21 @@ class DialogMediaPlayerBrowse extends LitElement {
 
         ha-media-player-browse {
           --media-browser-max-height: calc(
-            100vh - 65px - var(--safe-area-inset-top, 0) -
-              var(--safe-area-inset-bottom, 0)
+            100vh -
+              65px - var(--safe-area-inset-top, var(--ha-space-0)) - var(
+                --safe-area-inset-bottom,
+                var(--ha-space-0)
+              )
           );
         }
 
         :host(.opened) ha-media-player-browse {
           height: calc(
-            100vh - 65px - var(--safe-area-inset-top, 0) -
-              var(--safe-area-inset-bottom, 0)
+            100vh -
+              65px - var(--safe-area-inset-top, var(--ha-space-0)) - var(
+                --safe-area-inset-bottom,
+                var(--ha-space-0)
+              )
           );
         }
 
@@ -252,8 +258,11 @@ class DialogMediaPlayerBrowse extends LitElement {
           ha-media-player-browse {
             position: initial;
             --media-browser-max-height: calc(
-              100vh - 145px - var(--safe-area-inset-top, 0) -
-                var(--safe-area-inset-bottom, 0)
+              100vh -
+                145px - var(--safe-area-inset-top, var(--ha-space-0)) - var(
+                  --safe-area-inset-bottom,
+                  var(--ha-space-0)
+                )
             );
             width: 700px;
           }

--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -253,7 +253,13 @@ class DialogMediaPlayerBrowse extends LitElement {
         @media (min-width: 800px) {
           ha-dialog {
             --mdc-dialog-max-width: 800px;
-            --mdc-dialog-max-height: calc(100% - 72px);
+            --mdc-dialog-max-height: calc(
+              100vh -
+                72px - var(--safe-area-inset-top, var(--ha-space-0)) - var(
+                  --safe-area-inset-bottom,
+                  var(--ha-space-0)
+                )
+            );
           }
           ha-media-player-browse {
             position: initial;

--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -231,7 +231,9 @@ class DialogMediaPlayerBrowse extends LitElement {
         }
 
         ha-media-player-browse {
-          --media-browser-max-height: calc(100vh - 65px - var(--safe-area-inset-y));
+          --media-browser-max-height: calc(
+            100vh - 65px - var(--safe-area-inset-y)
+          );
         }
 
         :host(.opened) ha-media-player-browse {

--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -231,13 +231,7 @@ class DialogMediaPlayerBrowse extends LitElement {
         }
 
         ha-media-player-browse {
-          --media-browser-max-height: calc(
-            100vh -
-              65px - var(--safe-area-inset-top, var(--ha-space-0)) - var(
-                --safe-area-inset-bottom,
-                var(--ha-space-0)
-              )
-          );
+          --media-browser-max-height: calc(100vh - 65px - var(--safe-area-inset-y));
         }
 
         :host(.opened) ha-media-player-browse {

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -50,7 +50,7 @@ import { lightSupportsFavoriteColors } from "../../data/light";
 import type { ItemType } from "../../data/search";
 import { SearchableDomains } from "../../data/search";
 import { getSensorNumericDeviceClasses } from "../../data/sensor";
-import { haStyleDialog } from "../../resources/styles";
+import { haStyleDialog, haStyleDialogFixedTop } from "../../resources/styles";
 import "../../state-summary/state-card-content";
 import type { HomeAssistant } from "../../types";
 import {
@@ -707,14 +707,9 @@ export class MoreInfoDialog extends LitElement {
   static get styles() {
     return [
       haStyleDialog,
+      haStyleDialogFixedTop,
       css`
         ha-dialog {
-          /* Set the top top of the dialog to a fixed position, so it doesnt jump when the content changes size */
-          --vertical-align-dialog: flex-start;
-          --dialog-surface-margin-top: max(
-            var(--ha-space-10),
-            var(--safe-area-inset-top, var(--ha-space-0))
-          );
           --dialog-content-padding: 0;
         }
 
@@ -735,13 +730,6 @@ export class MoreInfoDialog extends LitElement {
           padding: var(--ha-space-2) var(--ha-space-6) var(--ha-space-6)
             var(--ha-space-6);
           display: block;
-        }
-
-        @media all and (max-width: 450px), all and (max-height: 500px) {
-          /* When in fullscreen dialog should be attached to top */
-          ha-dialog {
-            --dialog-surface-margin-top: var(--ha-space-0);
-          }
         }
 
         @media all and (min-width: 600px) and (min-height: 501px) {

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -46,7 +46,11 @@ import { getPanelNameTranslationKey } from "../../data/panel";
 import type { PageNavigation } from "../../layouts/hass-tabs-subpage";
 import { configSections } from "../../panels/config/ha-panel-config";
 import { HaFuse } from "../../resources/fuse";
-import { haStyleDialog, haStyleScrollbar } from "../../resources/styles";
+import {
+  haStyleDialog,
+  haStyleDialogFixedTop,
+  haStyleScrollbar,
+} from "../../resources/styles";
 import { loadVirtualizer } from "../../resources/virtualizer";
 import type { HomeAssistant } from "../../types";
 import { brandsUrl } from "../../util/brands-url";
@@ -986,6 +990,7 @@ export class QuickBar extends LitElement {
     return [
       haStyleScrollbar,
       haStyleDialog,
+      haStyleDialogFixedTop,
       css`
         ha-list {
           position: relative;
@@ -1010,8 +1015,6 @@ export class QuickBar extends LitElement {
           ha-dialog {
             --mdc-dialog-max-width: 800px;
             --mdc-dialog-min-width: 500px;
-            --dialog-surface-position: fixed;
-            --dialog-surface-top: var(--ha-space-10);
             --mdc-dialog-max-height: calc(100% - var(--ha-space-18));
           }
         }

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -1015,7 +1015,9 @@ export class QuickBar extends LitElement {
           ha-dialog {
             --mdc-dialog-max-width: 800px;
             --mdc-dialog-min-width: 500px;
-            --mdc-dialog-max-height: calc(100% - var(--ha-space-18));
+            --mdc-dialog-max-height: calc(
+              100vh - var(--ha-space-18) - var(--safe-area-inset-y)
+            );
           }
         }
 

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -281,8 +281,12 @@ class DialogNewDashboard extends LitElement implements HassDialog {
         @media all and (min-width: 850px) {
           ha-dialog {
             --mdc-dialog-min-width: 845px;
-            --mdc-dialog-min-height: calc(100vh - 72px);
-            --mdc-dialog-max-height: calc(100vh - 72px);
+            --mdc-dialog-min-height: calc(
+              100vh - var(--ha-space-18) - var(--safe-area-inset-y)
+            );
+            --mdc-dialog-max-height: calc(
+              100vh - var(--ha-space-18) - var(--safe-area-inset-y)
+            );
           }
         }
 

--- a/src/panels/config/integrations/dialog-add-integration.ts
+++ b/src/panels/config/integrations/dialog-add-integration.ts
@@ -462,7 +462,7 @@ class AddIntegrationDialog extends LitElement {
               style=${styleMap({
                 width: `${this._width}px`,
                 height: this._narrow
-                  ? "calc(100vh - 184px - var(--safe-area-inset-top, 0px) - var(--safe-area-inset-bottom, 0px))"
+                  ? "calc(100vh - 184px - var(--safe-area-inset-top, var(--ha-space-0)) - var(--safe-area-inset-bottom, var(--ha-space-0)))"
                   : "500px",
               })}
               @click=${this._integrationPicked}
@@ -718,9 +718,6 @@ class AddIntegrationDialog extends LitElement {
         ha-dialog {
           --mdc-dialog-min-width: 500px;
         }
-      }
-      ha-dialog {
-        --dialog-content-padding: 0;
       }
       search-input {
         display: block;

--- a/src/panels/config/integrations/dialog-add-integration.ts
+++ b/src/panels/config/integrations/dialog-add-integration.ts
@@ -719,6 +719,9 @@ class AddIntegrationDialog extends LitElement {
           --mdc-dialog-min-width: 500px;
         }
       }
+      ha-dialog {
+        --dialog-content-padding: 0;
+      }
       search-input {
         display: block;
         margin: 16px 16px 0;

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-manage-zigbee-device.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-manage-zigbee-device.ts
@@ -12,7 +12,10 @@ import "../../../../../components/ha-tab-group";
 import "../../../../../components/ha-tab-group-tab";
 import type { ZHADevice, ZHAGroup } from "../../../../../data/zha";
 import { fetchBindableDevices, fetchGroups } from "../../../../../data/zha";
-import { haStyleDialog } from "../../../../../resources/styles";
+import {
+  haStyleDialog,
+  haStyleDialogFixedTop,
+} from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import { sortZHADevices, sortZHAGroups } from "./functions";
 import type {
@@ -211,11 +214,11 @@ class DialogZHAManageZigbeeDevice extends LitElement {
   static get styles(): CSSResultGroup {
     return [
       haStyleDialog,
+      haStyleDialogFixedTop,
       css`
         ha-dialog {
           --dialog-surface-position: static;
           --dialog-content-position: static;
-          --vertical-align-dialog: flex-start;
         }
 
         .content {
@@ -229,7 +232,6 @@ class DialogZHAManageZigbeeDevice extends LitElement {
           ha-dialog {
             --mdc-dialog-min-width: 560px;
             --mdc-dialog-max-width: 560px;
-            --dialog-surface-margin-top: 40px;
             --mdc-dialog-max-height: calc(100% - 72px);
           }
         }

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-manage-zigbee-device.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-manage-zigbee-device.ts
@@ -232,7 +232,9 @@ class DialogZHAManageZigbeeDevice extends LitElement {
           ha-dialog {
             --mdc-dialog-min-width: 560px;
             --mdc-dialog-max-width: 560px;
-            --mdc-dialog-max-height: calc(100% - 72px);
+            --mdc-dialog-max-height: calc(
+              100vh - var(--ha-space-18) - var(--safe-area-inset-y)
+            );
           }
         }
 

--- a/src/panels/lovelace/editor/badge-editor/hui-dialog-edit-badge.ts
+++ b/src/panels/lovelace/editor/badge-editor/hui-dialog-edit-badge.ts
@@ -21,7 +21,10 @@ import {
 } from "../../../../data/lovelace_custom_cards";
 import { showConfirmationDialog } from "../../../../dialogs/generic/show-dialog-box";
 import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
-import { haStyleDialog } from "../../../../resources/styles";
+import {
+  haStyleDialog,
+  haStyleDialogFixedTop,
+} from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import { showSaveSuccessToast } from "../../../../util/toast-saved-success";
 import "../../badges/hui-badge";
@@ -395,6 +398,7 @@ export class HuiDialogEditBadge
   static get styles(): CSSResultGroup {
     return [
       haStyleDialog,
+      haStyleDialogFixedTop,
       css`
         :host {
           --code-mirror-max-height: calc(100vh - 176px);
@@ -403,8 +407,6 @@ export class HuiDialogEditBadge
         ha-dialog {
           --mdc-dialog-max-width: 100px;
           --dialog-z-index: 6;
-          --dialog-surface-position: fixed;
-          --dialog-surface-top: 40px;
           --mdc-dialog-max-width: 90vw;
           --dialog-content-padding: 24px 12px;
         }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
@@ -187,6 +187,12 @@ export class HuiCreateDialogCard
         @media all and (min-width: 850px) {
           ha-dialog {
             --mdc-dialog-min-width: 845px;
+            --mdc-dialog-min-height: calc(
+              100vh - var(--ha-space-18) - var(--safe-area-inset-y)
+            );
+            --mdc-dialog-max-height: calc(
+              100vh - var(--ha-space-18) - var(--safe-area-inset-y)
+            );
           }
         }
 

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
@@ -184,19 +184,9 @@ export class HuiCreateDialogCard
     return [
       haStyleDialog,
       css`
-        @media all and (max-width: 450px), all and (max-height: 500px) {
-          /* overrule the ha-style-dialog max-height on small screens */
-          ha-dialog {
-            --mdc-dialog-max-height: 100%;
-            height: 100%;
-          }
-        }
-
         @media all and (min-width: 850px) {
           ha-dialog {
             --mdc-dialog-min-width: 845px;
-            --mdc-dialog-min-height: calc(100vh - 72px);
-            --mdc-dialog-max-height: calc(100vh - 72px);
           }
         }
 

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -21,7 +21,10 @@ import {
 } from "../../../../data/lovelace_custom_cards";
 import { showConfirmationDialog } from "../../../../dialogs/generic/show-dialog-box";
 import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
-import { haStyleDialog } from "../../../../resources/styles";
+import {
+  haStyleDialog,
+  haStyleDialogFixedTop,
+} from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import { showToast } from "../../../../util/toast";
 import { showSaveSuccessToast } from "../../../../util/toast-saved-success";
@@ -371,6 +374,7 @@ export class HuiDialogEditCard
   static get styles(): CSSResultGroup {
     return [
       haStyleDialog,
+      haStyleDialogFixedTop,
       css`
         :host {
           --code-mirror-max-height: calc(100vh - 176px);
@@ -379,8 +383,6 @@ export class HuiDialogEditCard
         ha-dialog {
           --mdc-dialog-max-width: 100px;
           --dialog-z-index: 6;
-          --dialog-surface-position: fixed;
-          --dialog-surface-top: 40px;
           --mdc-dialog-max-width: 90vw;
           --dialog-content-padding: 24px 12px;
         }

--- a/src/panels/lovelace/editor/dashboard-strategy-editor/dialogs/dialog-dashboard-strategy-editor.ts
+++ b/src/panels/lovelace/editor/dashboard-strategy-editor/dialogs/dialog-dashboard-strategy-editor.ts
@@ -226,8 +226,14 @@ class DialogDashboardStrategyEditor extends LitElement {
       css`
         ha-dialog {
           --dialog-content-padding: 0 24px;
-          --mdc-dialog-min-width: min(640px, calc(100% - 32px));
-          --mdc-dialog-max-width: min(640px, calc(100% - 32px));
+          --mdc-dialog-min-width: min(
+            640px,
+            calc(100vw - 32px - var(--safe-area-inset-x))
+          );
+          --mdc-dialog-max-width: min(
+            640px,
+            calc(100vw - 32px - var(--safe-area-inset-x))
+          );
           --mdc-dialog-max-height: calc(100% - 80px);
         }
 

--- a/src/panels/lovelace/editor/dashboard-strategy-editor/dialogs/dialog-dashboard-strategy-editor.ts
+++ b/src/panels/lovelace/editor/dashboard-strategy-editor/dialogs/dialog-dashboard-strategy-editor.ts
@@ -242,9 +242,12 @@ class DialogDashboardStrategyEditor extends LitElement {
           ha-dialog {
             height: 100%;
             --dialog-surface-top: 0px;
-            --mdc-dialog-min-width: 100%;
-            --mdc-dialog-max-width: 100%;
-            --mdc-dialog-max-height: 100%;
+            --mdc-dialog-min-width: 100vw;
+            --mdc-dialog-max-width: 100vw;
+            --mdc-dialog-min-height: 100vh;
+            --mdc-dialog-min-height: 100svh;
+            --mdc-dialog-max-height: 100vh;
+            --mdc-dialog-max-height: 100svh;
             --dialog-content-padding: 8px;
           }
         }

--- a/src/panels/lovelace/editor/dashboard-strategy-editor/dialogs/dialog-dashboard-strategy-editor.ts
+++ b/src/panels/lovelace/editor/dashboard-strategy-editor/dialogs/dialog-dashboard-strategy-editor.ts
@@ -226,8 +226,6 @@ class DialogDashboardStrategyEditor extends LitElement {
       css`
         ha-dialog {
           --dialog-content-padding: 0 24px;
-          --dialog-surface-position: fixed;
-          --dialog-surface-top: 40px;
           --mdc-dialog-min-width: min(640px, calc(100% - 32px));
           --mdc-dialog-max-width: min(640px, calc(100% - 32px));
           --mdc-dialog-max-height: calc(100% - 80px);

--- a/src/panels/lovelace/editor/dashboard-strategy-editor/dialogs/dialog-dashboard-strategy-editor.ts
+++ b/src/panels/lovelace/editor/dashboard-strategy-editor/dialogs/dialog-dashboard-strategy-editor.ts
@@ -234,7 +234,9 @@ class DialogDashboardStrategyEditor extends LitElement {
             640px,
             calc(100vw - var(--safe-area-inset-x))
           );
-          --mdc-dialog-max-height: calc(100% - 80px);
+          --mdc-dialog-max-height: calc(
+            100vh - var(--ha-space-20) - var(--safe-area-inset-y)
+          );
         }
 
         @media all and (max-width: 450px), all and (max-height: 500px) {

--- a/src/panels/lovelace/editor/dashboard-strategy-editor/dialogs/dialog-dashboard-strategy-editor.ts
+++ b/src/panels/lovelace/editor/dashboard-strategy-editor/dialogs/dialog-dashboard-strategy-editor.ts
@@ -17,7 +17,10 @@ import "../../../../../components/ha-dialog-header";
 import "../../../../../components/ha-icon-button";
 import "../../../../../components/ha-list-item";
 import type { LovelaceStrategyConfig } from "../../../../../data/lovelace/config/strategy";
-import { haStyleDialog } from "../../../../../resources/styles";
+import {
+  haStyleDialog,
+  haStyleDialogFixedTop,
+} from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import { showSaveSuccessToast } from "../../../../../util/toast-saved-success";
 import { cleanLegacyStrategyConfig } from "../../../strategies/legacy-strategy";
@@ -219,6 +222,7 @@ class DialogDashboardStrategyEditor extends LitElement {
   static get styles(): CSSResultGroup {
     return [
       haStyleDialog,
+      haStyleDialogFixedTop,
       css`
         ha-dialog {
           --dialog-content-padding: 0 24px;

--- a/src/panels/lovelace/editor/dashboard-strategy-editor/dialogs/dialog-dashboard-strategy-editor.ts
+++ b/src/panels/lovelace/editor/dashboard-strategy-editor/dialogs/dialog-dashboard-strategy-editor.ts
@@ -228,11 +228,11 @@ class DialogDashboardStrategyEditor extends LitElement {
           --dialog-content-padding: 0 24px;
           --mdc-dialog-min-width: min(
             640px,
-            calc(100vw - 32px - var(--safe-area-inset-x))
+            calc(100vw - var(--safe-area-inset-x))
           );
           --mdc-dialog-max-width: min(
             640px,
-            calc(100vw - 32px - var(--safe-area-inset-x))
+            calc(100vw - var(--safe-area-inset-x))
           );
           --mdc-dialog-max-height: calc(100% - 80px);
         }

--- a/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
@@ -30,7 +30,10 @@ import {
 } from "../../../../data/lovelace/config/view";
 import { showAlertDialog } from "../../../../dialogs/generic/show-dialog-box";
 import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
-import { haStyleDialog } from "../../../../resources/styles";
+import {
+  haStyleDialog,
+  haStyleDialogFixedTop,
+} from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import type { Lovelace } from "../../types";
 import { addSection, deleteSection, moveSection } from "../config-util";
@@ -418,19 +421,8 @@ export class HuiDialogEditSection
   static get styles(): CSSResultGroup {
     return [
       haStyleDialog,
+      haStyleDialogFixedTop,
       css`
-        ha-dialog {
-          /* Set the top top of the dialog to a fixed position, so it doesnt jump when the content changes size */
-          --vertical-align-dialog: flex-start;
-          --dialog-surface-margin-top: 40px;
-        }
-
-        @media all and (max-width: 450px), all and (max-height: 500px) {
-          /* When in fullscreen dialog should be attached to top */
-          ha-dialog {
-            --dialog-surface-margin-top: 0px;
-          }
-        }
         ha-dialog.yaml-mode {
           --dialog-content-padding: 0;
         }

--- a/src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts
@@ -36,7 +36,10 @@ import {
   showAlertDialog,
   showConfirmationDialog,
 } from "../../../../dialogs/generic/show-dialog-box";
-import { haStyleDialog } from "../../../../resources/styles";
+import {
+  haStyleDialog,
+  haStyleDialogFixedTop,
+} from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import "../../components/hui-entity-editor";
 import type { Lovelace } from "../../types";
@@ -631,19 +634,8 @@ export class HuiDialogEditView extends LitElement {
   static get styles(): CSSResultGroup {
     return [
       haStyleDialog,
+      haStyleDialogFixedTop,
       css`
-        ha-dialog {
-          /* Set the top top of the dialog to a fixed position, so it doesnt jump when the content changes size */
-          --vertical-align-dialog: flex-start;
-          --dialog-surface-margin-top: 40px;
-        }
-
-        @media all and (max-width: 450px), all and (max-height: 500px) {
-          /* When in fullscreen dialog should be attached to top */
-          ha-dialog {
-            --dialog-surface-margin-top: 0px;
-          }
-        }
         ha-dialog.yaml-mode {
           --dialog-content-padding: 0;
         }

--- a/src/panels/lovelace/editor/view-header/hui-dialog-edit-view-header.ts
+++ b/src/panels/lovelace/editor/view-header/hui-dialog-edit-view-header.ts
@@ -16,7 +16,10 @@ import "../../../../components/ha-yaml-editor";
 import type { HaYamlEditor } from "../../../../components/ha-yaml-editor";
 import type { LovelaceViewHeaderConfig } from "../../../../data/lovelace/config/view";
 import { showAlertDialog } from "../../../../dialogs/generic/show-dialog-box";
-import { haStyleDialog } from "../../../../resources/styles";
+import {
+  haStyleDialog,
+  haStyleDialogFixedTop,
+} from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import "./hui-view-header-settings-editor";
 import type { EditViewHeaderDialogParams } from "./show-edit-view-header-dialog";
@@ -201,19 +204,8 @@ export class HuiDialogEditViewHeader extends LitElement {
   static get styles(): CSSResultGroup {
     return [
       haStyleDialog,
+      haStyleDialogFixedTop,
       css`
-        ha-dialog {
-          /* Set the top top of the dialog to a fixed position, so it doesnt jump when the content changes size */
-          --vertical-align-dialog: flex-start;
-          --dialog-surface-margin-top: 40px;
-        }
-
-        @media all and (max-width: 450px), all and (max-height: 500px) {
-          /* When in fullscreen dialog should be attached to top */
-          ha-dialog {
-            --dialog-surface-margin-top: 0px;
-          }
-        }
         ha-dialog.yaml-mode {
           --dialog-content-padding: 0;
         }

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -142,10 +142,8 @@ export const haStyleDialog = css`
     --mdc-dialog-max-width: 600px;
     --mdc-dialog-max-width: min(600px, 95vw);
     --justify-action-buttons: space-between;
-    --dialog-container-padding: var(--safe-area-inset-top, var(--ha-space-0))
-      var(--safe-area-inset-right, var(--ha-space-0))
-      var(--safe-area-inset-bottom, var(--ha-space-0))
-      var(--safe-area-inset-left, var(--ha-space-0));
+    --dialog-container-padding: var(--safe-area-inset-x, var(--ha-space-0))
+      var(--safe-area-inset-y, var(--ha-space-0));
     --dialog-surface-padding: var(--ha-space-0);
   }
 

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -161,9 +161,10 @@ export const haStyleDialog = css`
       --mdc-dialog-min-height: 100svh;
       --mdc-dialog-max-height: 100vh;
       --mdc-dialog-max-height: 100svh;
-      --dialog-surface-padding: var(--safe-area-inset-top)
-        var(--safe-area-inset-right) var(--safe-area-inset-bottom)
-        var(--safe-area-inset-left);
+      --dialog-surface-padding: var(--safe-area-inset-top, var(--ha-space-0))
+        var(--safe-area-inset-right, var(--ha-space-0))
+        var(--safe-area-inset-bottom, var(--ha-space-0))
+        var(--safe-area-inset-left, var(--ha-space-0));
       --vertical-align-dialog: flex-end;
       --ha-dialog-border-radius: var(--ha-border-radius-square);
     }

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -186,11 +186,12 @@ export const haStyleDialogFixedTop = css`
     --vertical-align-dialog: flex-start;
     --dialog-surface-margin-top: max(
       var(--ha-space-10),
-      calc(
-        var(--safe-area-inset-top, var(--ha-space-0)) +
-          var(--safe-area-inset-bottom, var(--ha-space-0))
-      )
+      var(--safe-area-inset-top, var(--ha-space-0))
     );
+    --mdc-dialog-min-height: calc(100vh - var(--dialog-surface-margin-top));
+    --mdc-dialog-min-height: calc(100svh - var(--dialog-surface-margin-top));
+    --mdc-dialog-max-height: calc(100vh - var(--dialog-surface-margin-top));
+    --mdc-dialog-max-height: calc(100svh - var(--dialog-surface-margin-top));
   }
 
   @media all and (max-width: 450px), all and (max-height: 500px) {

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -142,6 +142,11 @@ export const haStyleDialog = css`
     --mdc-dialog-max-width: 600px;
     --mdc-dialog-max-width: min(600px, 95vw);
     --justify-action-buttons: space-between;
+    --dialog-container-padding: var(--safe-area-inset-top, var(--ha-space-0))
+      var(--safe-area-inset-right, var(--ha-space-0))
+      var(--safe-area-inset-bottom, var(--ha-space-0))
+      var(--safe-area-inset-left, var(--ha-space-0));
+    --dialog-surface-padding: var(--ha-space-0);
   }
 
   ha-dialog .form {
@@ -161,6 +166,7 @@ export const haStyleDialog = css`
       --mdc-dialog-min-height: 100svh;
       --mdc-dialog-max-height: 100vh;
       --mdc-dialog-max-height: 100svh;
+      --dialog-container-padding: var(--ha-space-0);
       --dialog-surface-padding: var(--safe-area-inset-top, var(--ha-space-0))
         var(--safe-area-inset-right, var(--ha-space-0))
         var(--safe-area-inset-bottom, var(--ha-space-0))

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -180,6 +180,24 @@ export const haStyleDialog = css`
   }
 `;
 
+export const haStyleDialogFixedTop = css`
+  ha-dialog {
+    /* Pin dialog to top so it doesn't jump when content changes size */
+    --vertical-align-dialog: flex-start;
+    --dialog-surface-margin-top: max(
+      var(--ha-space-10),
+      var(--safe-area-inset-top, var(--ha-space-0))
+    );
+  }
+
+  @media all and (max-width: 450px), all and (max-height: 500px) {
+    ha-dialog {
+      /* When in fullscreen, dialog should be attached to top */
+      --dialog-surface-margin-top: var(--ha-space-0);
+    }
+  }
+`;
+
 export const haStyleScrollbar = css`
   .ha-scrollbar::-webkit-scrollbar {
     width: 0.4rem;

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -185,10 +185,30 @@ export const haStyleDialogFixedTop = css`
     /* Pin dialog to top so it doesn't jump when content changes size */
     --vertical-align-dialog: flex-start;
     --dialog-surface-margin-top: var(--ha-space-10);
-    --mdc-dialog-min-height: calc(100vh - var(--dialog-surface-margin-top));
-    --mdc-dialog-min-height: calc(100svh - var(--dialog-surface-margin-top));
-    --mdc-dialog-max-height: calc(100vh - var(--dialog-surface-margin-top));
-    --mdc-dialog-max-height: calc(100svh - var(--dialog-surface-margin-top));
+    --mdc-dialog-min-height: calc(
+      100vh - var(--dialog-surface-margin-top) - var(
+          --safe-area-inset-top,
+          var(--ha-space-0)
+        )
+    );
+    --mdc-dialog-min-height: calc(
+      100svh - var(--dialog-surface-margin-top) - var(
+          --safe-area-inset-top,
+          var(--ha-space-0)
+        )
+    );
+    --mdc-dialog-max-height: calc(
+      100vh - var(--dialog-surface-margin-top) - var(
+          --safe-area-inset-top,
+          var(--ha-space-0)
+        )
+    );
+    --mdc-dialog-max-height: calc(
+      100svh - var(--dialog-surface-margin-top) - var(
+          --safe-area-inset-top,
+          var(--ha-space-0)
+        )
+    );
   }
 
   @media all and (max-width: 450px), all and (max-height: 500px) {

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -186,25 +186,25 @@ export const haStyleDialogFixedTop = css`
     --vertical-align-dialog: flex-start;
     --dialog-surface-margin-top: var(--ha-space-10);
     --mdc-dialog-min-height: calc(
-      100vh - var(--dialog-surface-margin-top) - var(
+      100vh - var(--dialog-surface-margin-top) - var(--ha-space-2) - var(
           --safe-area-inset-y,
           var(--ha-space-0)
         )
     );
     --mdc-dialog-min-height: calc(
-      100svh - var(--dialog-surface-margin-top) - var(
+      100svh - var(--dialog-surface-margin-top) - var(--ha-space-2) - var(
           --safe-area-inset-y,
           var(--ha-space-0)
         )
     );
     --mdc-dialog-max-height: calc(
-      100vh - var(--dialog-surface-margin-top) - var(
+      100vh - var(--dialog-surface-margin-top) - var(--ha-space-2) - var(
           --safe-area-inset-y,
           var(--ha-space-0)
         )
     );
     --mdc-dialog-max-height: calc(
-      100svh - var(--dialog-surface-margin-top) - var(
+      100svh - var(--dialog-surface-margin-top) - var(--ha-space-2) - var(
           --safe-area-inset-y,
           var(--ha-space-0)
         )

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -185,18 +185,6 @@ export const haStyleDialogFixedTop = css`
     /* Pin dialog to top so it doesn't jump when content changes size */
     --vertical-align-dialog: flex-start;
     --dialog-surface-margin-top: var(--ha-space-10);
-    --mdc-dialog-min-height: calc(
-      100vh - var(--dialog-surface-margin-top) - var(--ha-space-2) - var(
-          --safe-area-inset-y,
-          var(--ha-space-0)
-        )
-    );
-    --mdc-dialog-min-height: calc(
-      100svh - var(--dialog-surface-margin-top) - var(--ha-space-2) - var(
-          --safe-area-inset-y,
-          var(--ha-space-0)
-        )
-    );
     --mdc-dialog-max-height: calc(
       100vh - var(--dialog-surface-margin-top) - var(--ha-space-2) - var(
           --safe-area-inset-y,

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -142,8 +142,10 @@ export const haStyleDialog = css`
     --mdc-dialog-max-width: 600px;
     --mdc-dialog-max-width: min(600px, 95vw);
     --justify-action-buttons: space-between;
-    --dialog-container-padding: var(--safe-area-inset-x, var(--ha-space-0))
-      var(--safe-area-inset-y, var(--ha-space-0));
+    --dialog-container-padding: var(--safe-area-inset-top, var(--ha-space-0))
+      var(--safe-area-inset-right, var(--ha-space-0))
+      var(--safe-area-inset-bottom, var(--ha-space-0))
+      var(--safe-area-inset-left, var(--ha-space-0));
     --dialog-surface-padding: var(--ha-space-0);
   }
 
@@ -165,8 +167,10 @@ export const haStyleDialog = css`
       --mdc-dialog-max-height: 100vh;
       --mdc-dialog-max-height: 100svh;
       --dialog-container-padding: var(--ha-space-0);
-      --dialog-surface-padding: var(--safe-area-inset-x, var(--ha-space-0))
-        var(--safe-area-inset-y, var(--ha-space-0));
+      --dialog-surface-padding: var(--safe-area-inset-top, var(--ha-space-0))
+        var(--safe-area-inset-right, var(--ha-space-0))
+        var(--safe-area-inset-bottom, var(--ha-space-0))
+        var(--safe-area-inset-left, var(--ha-space-0));
       --vertical-align-dialog: flex-end;
       --ha-dialog-border-radius: var(--ha-border-radius-square);
     }
@@ -211,6 +215,10 @@ export const haStyleDialogFixedTop = css`
     ha-dialog {
       /* When in fullscreen, dialog should be attached to top */
       --dialog-surface-margin-top: var(--ha-space-0);
+      --mdc-dialog-min-height: 100vh;
+      --mdc-dialog-min-height: 100svh;
+      --mdc-dialog-max-height: 100vh;
+      --mdc-dialog-max-height: 100svh;
     }
   }
 `;

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -184,10 +184,7 @@ export const haStyleDialogFixedTop = css`
   ha-dialog {
     /* Pin dialog to top so it doesn't jump when content changes size */
     --vertical-align-dialog: flex-start;
-    --dialog-surface-margin-top: max(
-      var(--ha-space-10),
-      var(--safe-area-inset-top, var(--ha-space-0))
-    );
+    --dialog-surface-margin-top: var(--ha-space-10);
     --mdc-dialog-min-height: calc(100vh - var(--dialog-surface-margin-top));
     --mdc-dialog-min-height: calc(100svh - var(--dialog-surface-margin-top));
     --mdc-dialog-max-height: calc(100vh - var(--dialog-surface-margin-top));

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -167,10 +167,8 @@ export const haStyleDialog = css`
       --mdc-dialog-max-height: 100vh;
       --mdc-dialog-max-height: 100svh;
       --dialog-container-padding: var(--ha-space-0);
-      --dialog-surface-padding: var(--safe-area-inset-top, var(--ha-space-0))
-        var(--safe-area-inset-right, var(--ha-space-0))
-        var(--safe-area-inset-bottom, var(--ha-space-0))
-        var(--safe-area-inset-left, var(--ha-space-0));
+      --dialog-surface-padding: var(--safe-area-inset-x, var(--ha-space-0))
+        var(--safe-area-inset-y, var(--ha-space-0));
       --vertical-align-dialog: flex-end;
       --ha-dialog-border-radius: var(--ha-border-radius-square);
     }
@@ -187,25 +185,25 @@ export const haStyleDialogFixedTop = css`
     --dialog-surface-margin-top: var(--ha-space-10);
     --mdc-dialog-min-height: calc(
       100vh - var(--dialog-surface-margin-top) - var(
-          --safe-area-inset-top,
+          --safe-area-inset-y,
           var(--ha-space-0)
         )
     );
     --mdc-dialog-min-height: calc(
       100svh - var(--dialog-surface-margin-top) - var(
-          --safe-area-inset-top,
+          --safe-area-inset-y,
           var(--ha-space-0)
         )
     );
     --mdc-dialog-max-height: calc(
       100vh - var(--dialog-surface-margin-top) - var(
-          --safe-area-inset-top,
+          --safe-area-inset-y,
           var(--ha-space-0)
         )
     );
     --mdc-dialog-max-height: calc(
       100svh - var(--dialog-surface-margin-top) - var(
-          --safe-area-inset-top,
+          --safe-area-inset-y,
           var(--ha-space-0)
         )
     );

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -186,7 +186,10 @@ export const haStyleDialogFixedTop = css`
     --vertical-align-dialog: flex-start;
     --dialog-surface-margin-top: max(
       var(--ha-space-10),
-      var(--safe-area-inset-top, var(--ha-space-0))
+      calc(
+        var(--safe-area-inset-top, var(--ha-space-0)) +
+          var(--safe-area-inset-bottom, var(--ha-space-0))
+      )
     );
   }
 

--- a/src/resources/theme/main.globals.ts
+++ b/src/resources/theme/main.globals.ts
@@ -33,8 +33,8 @@ export const mainStyles = css`
     --safe-area-inset-left: var(--app-safe-area-inset-left, env(safe-area-inset-left, 0));
     --safe-area-inset-right: var(--app-safe-area-inset-right, env(safe-area-inset-right, 0));
 
-    --safe-area-inset-y: calc(var(--safe-area-inset-top, 0) + var(--safe-area-inset-bottom, 0));
-    --safe-area-inset-x: calc(var(--safe-area-inset-left, 0) + var(--safe-area-inset-right, 0));
+    --safe-area-inset-y: calc(var(--safe-area-inset-top, 0px) + var(--safe-area-inset-bottom, 0px));
+    --safe-area-inset-x: calc(var(--safe-area-inset-left, 0px) + var(--safe-area-inset-right, 0px));
   }
 `;
 

--- a/src/resources/theme/main.globals.ts
+++ b/src/resources/theme/main.globals.ts
@@ -32,6 +32,9 @@ export const mainStyles = css`
     --safe-area-inset-bottom: var(--app-safe-area-inset-bottom, env(safe-area-inset-bottom, 0));
     --safe-area-inset-left: var(--app-safe-area-inset-left, env(safe-area-inset-left, 0));
     --safe-area-inset-right: var(--app-safe-area-inset-right, env(safe-area-inset-right, 0));
+
+    --safe-area-inset-y: calc(var(--safe-area-inset-top, 0) + var(--safe-area-inset-bottom, 0));
+    --safe-area-inset-x: calc(var(--safe-area-inset-left, 0) + var(--safe-area-inset-right, 0));
   }
 `;
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Various style consolidation and fixes for ha-dialog and its usages.

Introduces a container padding to make dialogs conform to safe areas and use padding on the surface instead when on narrow layouts. Swaps between the 2 when layout changes to full mode.


https://github.com/user-attachments/assets/f7cfed44-f515-492b-a52e-43048cc67a6a

https://github.com/user-attachments/assets/5c07a5fd-14bf-433c-abe8-7fdc5e5580c5

Also moves more info dialog styles for fixed top to shared area to be reused on other dialogs like the media browser.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #27996
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
