### PR TITLE
Fix hide sidebar tooltip on touchend events

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -626,6 +626,7 @@ class HaSidebar extends SubscribeMixin(LitElement) {
   private _listboxTouchend() {
     clearTimeout(this._touchendTimeout);
     this._touchendTimeout = window.setTimeout(() => {
+      // Allow 1 second for users to read the tooltip on touch devices
       this._hideTooltip();
     }, 1000);
   }

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -239,6 +239,18 @@ class HaSidebar extends SubscribeMixin(LitElement) {
     ];
   }
 
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    // clear timeouts
+    clearTimeout(this._mouseLeaveTimeout);
+    clearTimeout(this._tooltipHideTimeout);
+    clearTimeout(this._touchendTimeout);
+    // set undefined values
+    this._mouseLeaveTimeout = undefined;
+    this._tooltipHideTimeout = undefined;
+    this._touchendTimeout = undefined;
+  }
+
   protected render() {
     if (!this.hass) {
       return nothing;

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -197,6 +197,8 @@ class HaSidebar extends SubscribeMixin(LitElement) {
 
   private _mouseLeaveTimeout?: number;
 
+  private _touchendTimeout?: number;
+
   private _tooltipHideTimeout?: number;
 
   private _recentKeydownActiveUntil = 0;
@@ -406,6 +408,7 @@ class HaSidebar extends SubscribeMixin(LitElement) {
         class="ha-scrollbar"
         @focusin=${this._listboxFocusIn}
         @focusout=${this._listboxFocusOut}
+        @touchend=${this._listboxTouchend}
         @scroll=${this._listboxScroll}
         @keydown=${this._listboxKeydown}
       >
@@ -618,6 +621,13 @@ class HaSidebar extends SubscribeMixin(LitElement) {
 
   private _listboxFocusOut() {
     this._hideTooltip();
+  }
+
+  private _listboxTouchend() {
+    clearTimeout(this._touchendTimeout);
+    this._touchendTimeout = window.setTimeout(() => {
+      this._hideTooltip();
+    }, 1000);
   }
 
   @eventOptions({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The sidebar's tooltips do not disappear in touch devices (reported [here](https://community.home-assistant.io/t/make-tooltips-for-sidebar-items-auto-disappear/802230/3?u=elchininet) and [here](https://www.reddit.com/r/homeassistant/comments/1o3v0o6/hide_sidebar_tooltip_on_tablet_dashboard/)). After tapping on an item the relative tooltip appears and it doesn't disappear until one taps on another part of the screen. This is due to the fact that tooltips appear on `focusin` and `mouseenter` events and are removed on `focusout` and `mouseleave` events. In desktop devices, this is not an issue because once one moves the mouse out of the item, the respective tooltip disappears. But in touch devices (mainly tablets because in mobile devices the sidebar gets hidden), the items get focus once tapped but they do not lose the focus until one taps in another part of the screen and there is no `mouseleave` in these devices.

In this pull request this is fixed adding a `touchend` event to the `ha-md-list` element which executes the removal of the tooltip. The removal of the tooltip is done with a delay to allow its text to be read.

### Before

https://github.com/user-attachments/assets/547b3a86-9bde-482f-907a-c98b4852702b

### After

https://github.com/user-attachments/assets/336e2a03-a053-459e-a1a5-d37ff3c5adde

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
