### PR TITLE
Don't suggest entity autocomplete for actions

### DIFF
--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -651,6 +651,18 @@ export class HaCodeEditor extends ReactiveElement {
           }
         }
       }
+
+      // Properties that should never suggest entities
+      const negativeProperties = ["action"];
+
+      // Create regex pattern for negative properties
+      const negativePropertyPattern = negativeProperties.join("|");
+      const negativeEntityFieldRegex = new RegExp(
+        `^\\s*(-\\s+)?(${negativePropertyPattern}):\\s*`
+      );
+      if (lineText.match(negativeEntityFieldRegex)) {
+        return null;
+      }
     }
 
     // Original entity completion logic for non-YAML or when not in entity_id field


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When entering an action in yaml, don't suggest entities for autocompletion, e.g. after `action: light.`, we're looking for `light.turn_on` or `light.turn_off`, not a suggestion of all the light entities in your system.

We can probably get it to popup actions to autocomplete instead, but for a first step just get the entities out of the way. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
