### PR TITLE
Show encryption key in actions for esphome device

### DIFF
--- a/src/data/esphome.ts
+++ b/src/data/esphome.ts
@@ -1,0 +1,14 @@
+import type { HomeAssistant } from "../types";
+
+export interface ESPHomeEncryptionKey {
+  encryption_key: string;
+}
+
+export const fetchESPHomeEncryptionKey = (
+  hass: HomeAssistant,
+  entry_id: string
+): Promise<ESPHomeEncryptionKey> =>
+  hass.callWS({
+    type: "esphome/get_encryption_key",
+    entry_id,
+  });

--- a/src/panels/config/devices/device-detail/integration-elements/esphome/device-actions.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/esphome/device-actions.ts
@@ -1,0 +1,52 @@
+import { mdiKey } from "@mdi/js";
+import { getConfigEntries } from "../../../../../../data/config_entries";
+import type { DeviceRegistryEntry } from "../../../../../../data/device_registry";
+import { fetchESPHomeEncryptionKey } from "../../../../../../data/esphome";
+import type { HomeAssistant } from "../../../../../../types";
+import { showESPHomeEncryptionKeyDialog } from "../../../../integrations/integration-panels/esphome/show-dialog-esphome-encryption-key";
+import type { DeviceAction } from "../../../ha-config-device-page";
+
+export const getESPHomeDeviceActions = async (
+  el: HTMLElement,
+  hass: HomeAssistant,
+  device: DeviceRegistryEntry
+): Promise<DeviceAction[]> => {
+  const actions: DeviceAction[] = [];
+
+  const configEntries = await getConfigEntries(hass, {
+    domain: "esphome",
+  });
+
+  const configEntry = configEntries.find((entry) =>
+    device.config_entries.includes(entry.entry_id)
+  );
+
+  if (!configEntry) {
+    return [];
+  }
+
+  const entryId = configEntry.entry_id;
+
+  try {
+    const encryptionKey = await fetchESPHomeEncryptionKey(hass, entryId);
+
+    if (encryptionKey.encryption_key) {
+      actions.push({
+        label: hass.localize(
+          "ui.panel.config.devices.esphome.show_encryption_key"
+        ),
+        icon: mdiKey,
+        action: () =>
+          showESPHomeEncryptionKeyDialog(el, {
+            entry_id: entryId,
+            encryption_key: encryptionKey.encryption_key,
+          }),
+      });
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("Failed to fetch ESPHome encryption key:", err);
+  }
+
+  return actions;
+};

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -1162,6 +1162,17 @@ export class HaConfigDevicePage extends LitElement {
       );
       deviceActions.push(...actions);
     }
+    if (domains.includes("esphome")) {
+      const esphome = await import(
+        "./device-detail/integration-elements/esphome/device-actions"
+      );
+      const actions = await esphome.getESPHomeDeviceActions(
+        this,
+        this.hass,
+        device
+      );
+      deviceActions.push(...actions);
+    }
     if (domains.includes("matter")) {
       const matter = await import(
         "./device-detail/integration-elements/matter/device-actions"

--- a/src/panels/config/integrations/integration-panels/esphome/dialog-esphome-encryption-key.ts
+++ b/src/panels/config/integrations/integration-panels/esphome/dialog-esphome-encryption-key.ts
@@ -1,0 +1,136 @@
+import { mdiClose, mdiContentCopy } from "@mdi/js";
+import type { CSSResultGroup } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import { copyToClipboard } from "../../../../../common/util/copy-clipboard";
+import "../../../../../components/ha-dialog";
+import "../../../../../components/ha-dialog-header";
+import "../../../../../components/ha-icon-button";
+import { haStyleDialog } from "../../../../../resources/styles";
+import type { HomeAssistant } from "../../../../../types";
+import { showToast } from "../../../../../util/toast";
+import type { ESPHomeEncryptionKeyDialogParams } from "./show-dialog-esphome-encryption-key";
+
+@customElement("dialog-esphome-encryption-key")
+class DialogESPHomeEncryptionKey extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _params?: ESPHomeEncryptionKeyDialogParams;
+
+  public async showDialog(
+    params: ESPHomeEncryptionKeyDialogParams
+  ): Promise<void> {
+    this._params = params;
+  }
+
+  public closeDialog(): void {
+    this._params = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render() {
+    if (!this._params) {
+      return nothing;
+    }
+
+    return html`
+      <ha-dialog
+        open
+        @closed=${this.closeDialog}
+        hideActions
+        .heading=${this.hass.localize(
+          "ui.panel.config.devices.esphome.encryption_key_title"
+        )}
+      >
+        <ha-dialog-header slot="heading">
+          <ha-icon-button
+            slot="navigationIcon"
+            dialogAction="cancel"
+            .label=${this.hass.localize("ui.common.close")}
+            .path=${mdiClose}
+          ></ha-icon-button>
+          <span slot="title">
+            ${this.hass.localize(
+              "ui.panel.config.devices.esphome.encryption_key_title"
+            )}
+          </span>
+        </ha-dialog-header>
+
+        <div class="content">
+          <p>
+            ${this.hass.localize(
+              "ui.panel.config.devices.esphome.encryption_key_description"
+            )}
+          </p>
+          <div class="key-row">
+            <div class="key-container">
+              <code>${this._params.encryption_key}</code>
+            </div>
+            <ha-icon-button
+              @click=${this._copyToClipboard}
+              .label=${this.hass.localize("ui.common.copy")}
+              .path=${mdiContentCopy}
+            ></ha-icon-button>
+          </div>
+        </div>
+      </ha-dialog>
+    `;
+  }
+
+  private async _copyToClipboard(): Promise<void> {
+    if (!this._params?.encryption_key) {
+      return;
+    }
+
+    await copyToClipboard(this._params.encryption_key);
+    showToast(this, {
+      message: this.hass.localize("ui.common.copied_clipboard"),
+    });
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyleDialog,
+      css`
+        ha-dialog {
+          --dialog-content-padding: 0 24px 24px 24px;
+          --mdc-dialog-max-width: 500px;
+        }
+
+        .content {
+          display: flex;
+          flex-direction: column;
+          gap: 24px;
+          margin-bottom: 24px;
+        }
+
+        .key-row {
+          display: flex;
+          gap: 8px;
+          align-items: center;
+        }
+
+        .key-container {
+          flex: 1;
+          border-radius: 8px;
+          border: 1px solid var(--divider-color);
+          background-color: var(--code-editor-background-color, #f8f8f8);
+          padding: 12px;
+          overflow: hidden;
+        }
+
+        p {
+          margin: 0;
+          color: var(--secondary-text-color);
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-esphome-encryption-key": DialogESPHomeEncryptionKey;
+  }
+}

--- a/src/panels/config/integrations/integration-panels/esphome/dialog-esphome-encryption-key.ts
+++ b/src/panels/config/integrations/integration-panels/esphome/dialog-esphome-encryption-key.ts
@@ -113,7 +113,10 @@ class DialogESPHomeEncryptionKey extends LitElement {
           flex: 1;
           border-radius: var(--ha-space-2);
           border: 1px solid var(--divider-color);
-          background-color: var(--code-editor-background-color, #f8f8f8);
+          background-color: var(
+            --code-editor-background-color,
+            var(--secondary-background-color)
+          );
           padding: var(--ha-space-3);
           overflow: hidden;
         }

--- a/src/panels/config/integrations/integration-panels/esphome/dialog-esphome-encryption-key.ts
+++ b/src/panels/config/integrations/integration-panels/esphome/dialog-esphome-encryption-key.ts
@@ -4,9 +4,9 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { copyToClipboard } from "../../../../../common/util/copy-clipboard";
-import "../../../../../components/ha-dialog";
 import "../../../../../components/ha-dialog-header";
 import "../../../../../components/ha-icon-button";
+import "../../../../../components/ha-wa-dialog";
 import { haStyleDialog } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import { showToast } from "../../../../../util/toast";
@@ -35,11 +35,11 @@ class DialogESPHomeEncryptionKey extends LitElement {
     }
 
     return html`
-      <ha-dialog
+      <ha-wa-dialog
         open
         @closed=${this.closeDialog}
         hideActions
-        .heading=${this.hass.localize(
+        header-title=${this.hass.localize(
           "ui.panel.config.devices.esphome.encryption_key_title"
         )}
       >
@@ -74,7 +74,7 @@ class DialogESPHomeEncryptionKey extends LitElement {
             ></ha-icon-button>
           </div>
         </div>
-      </ha-dialog>
+      </ha-wa-dialog>
     `;
   }
 
@@ -94,35 +94,34 @@ class DialogESPHomeEncryptionKey extends LitElement {
       haStyleDialog,
       css`
         ha-dialog {
-          --dialog-content-padding: 0 24px 24px 24px;
           --mdc-dialog-max-width: 500px;
         }
 
         .content {
           display: flex;
           flex-direction: column;
-          gap: 24px;
-          margin-bottom: 24px;
+          gap: var(--ha-space-6);
         }
 
         .key-row {
           display: flex;
-          gap: 8px;
+          gap: var(--ha-space-2);
           align-items: center;
         }
 
         .key-container {
           flex: 1;
-          border-radius: 8px;
+          border-radius: var(--ha-space-2);
           border: 1px solid var(--divider-color);
           background-color: var(--code-editor-background-color, #f8f8f8);
-          padding: 12px;
+          padding: var(--ha-space-3);
           overflow: hidden;
         }
 
         p {
           margin: 0;
           color: var(--secondary-text-color);
+          line-height: var(--ha-line-height-condensed);
         }
       `,
     ];

--- a/src/panels/config/integrations/integration-panels/esphome/dialog-esphome-encryption-key.ts
+++ b/src/panels/config/integrations/integration-panels/esphome/dialog-esphome-encryption-key.ts
@@ -96,7 +96,6 @@ class DialogESPHomeEncryptionKey extends LitElement {
         ha-dialog {
           --mdc-dialog-max-width: 500px;
         }
-
         .content {
           display: flex;
           flex-direction: column;

--- a/src/panels/config/integrations/integration-panels/esphome/dialog-esphome-encryption-key.ts
+++ b/src/panels/config/integrations/integration-panels/esphome/dialog-esphome-encryption-key.ts
@@ -4,6 +4,8 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { copyToClipboard } from "../../../../../common/util/copy-clipboard";
+import "../../../../../components/ha-button";
+import "../../../../../components/ha-dialog-footer";
 import "../../../../../components/ha-dialog-header";
 import "../../../../../components/ha-icon-button";
 import "../../../../../components/ha-wa-dialog";
@@ -38,7 +40,6 @@ class DialogESPHomeEncryptionKey extends LitElement {
       <ha-wa-dialog
         open
         @closed=${this.closeDialog}
-        hideActions
         header-title=${this.hass.localize(
           "ui.panel.config.devices.esphome.encryption_key_title"
         )}
@@ -74,6 +75,11 @@ class DialogESPHomeEncryptionKey extends LitElement {
             ></ha-icon-button>
           </div>
         </div>
+        <ha-dialog-footer slot="footer">
+          <ha-button slot="primaryAction" data-dialog="close">
+            ${this.hass.localize("ui.common.close")}
+          </ha-button>
+        </ha-dialog-footer>
       </ha-wa-dialog>
     `;
   }
@@ -93,9 +99,6 @@ class DialogESPHomeEncryptionKey extends LitElement {
     return [
       haStyleDialog,
       css`
-        ha-dialog {
-          --mdc-dialog-max-width: 500px;
-        }
         .content {
           display: flex;
           flex-direction: column;

--- a/src/panels/config/integrations/integration-panels/esphome/dialog-esphome-encryption-key.ts
+++ b/src/panels/config/integrations/integration-panels/esphome/dialog-esphome-encryption-key.ts
@@ -118,7 +118,7 @@ class DialogESPHomeEncryptionKey extends LitElement {
             var(--secondary-background-color)
           );
           padding: var(--ha-space-3);
-          overflow: hidden;
+          overflow: auto;
         }
 
         p {

--- a/src/panels/config/integrations/integration-panels/esphome/show-dialog-esphome-encryption-key.ts
+++ b/src/panels/config/integrations/integration-panels/esphome/show-dialog-esphome-encryption-key.ts
@@ -1,0 +1,20 @@
+import { fireEvent } from "../../../../../common/dom/fire_event";
+
+export interface ESPHomeEncryptionKeyDialogParams {
+  entry_id: string;
+  encryption_key: string;
+}
+
+export const loadESPHomeEncryptionKeyDialog = () =>
+  import("./dialog-esphome-encryption-key");
+
+export const showESPHomeEncryptionKeyDialog = (
+  element: HTMLElement,
+  dialogParams: ESPHomeEncryptionKeyDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-esphome-encryption-key",
+    dialogImport: loadESPHomeEncryptionKeyDialog,
+    dialogParams,
+  });
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5400,6 +5400,11 @@
                 "partial_failure": "Some devices failed to delete successfully. Check system logs for more information."
               }
             }
+          },
+          "esphome": {
+            "show_encryption_key": "Show encryption key",
+            "encryption_key_title": "ESPHome Encryption Key",
+            "encryption_key_description": "This is the encryption key for your ESPHome device. Keep it in a safe place, as you may need it when transferring devices between Home Assistant instances."
           }
         },
         "entities": {


### PR DESCRIPTION
## Proposed change
Show encryption key in actions for esphome device in a dialog. You are able to copy it.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR is related to issue or discussion: https://github.com/esphome/backlog/issues/69
- This PR need the core PR: https://github.com/home-assistant/core/pull/154058

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
