### PR TITLE
Use entity name for activity/logbook renderer

### DIFF
--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -11,6 +11,7 @@ import { formatTimeWithSeconds } from "../../common/datetime/format_time";
 import { restoreScroll } from "../../common/decorators/restore-scroll";
 import { fireEvent } from "../../common/dom/fire_event";
 import { computeDomain } from "../../common/entity/compute_domain";
+import { DEFAULT_ENTITY_NAME } from "../../common/entity/compute_entity_name_display";
 import { navigate } from "../../common/navigate";
 import { computeTimelineColor } from "../../components/chart/timeline-color";
 import "../../components/entity/state-badge";
@@ -463,15 +464,24 @@ class HaLogbookRenderer extends LitElement {
     entityName: string | undefined,
     noLink?: boolean
   ) {
-    const hasState = entityId && entityId in this.hass.states;
-    const displayName =
-      entityName ||
-      (hasState
-        ? this.hass.states[entityId].attributes.friendly_name || entityId
-        : entityId);
+    if (!entityId) {
+      return entityName || "";
+    }
+
+    const stateObj = this.hass.states[entityId];
+    const hasState = Boolean(stateObj);
+
+    const displayName = hasState
+      ? this.hass.formatEntityName(stateObj, DEFAULT_ENTITY_NAME) ||
+        entityName ||
+        stateObj.attributes.friendly_name ||
+        entityId
+      : entityName || entityId;
+
     if (!hasState) {
       return displayName;
     }
+
     return noLink
       ? displayName
       : html`<button


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Makes activity/logbook entity rendering use contextual naming format (device/area/entity) 

Before:
<img width="1898" height="733" alt="image" src="https://github.com/user-attachments/assets/6eeaf3d4-fe54-4559-bc82-94cc27fbc759" />

After:
<img width="1970" height="550" alt="image" src="https://github.com/user-attachments/assets/93f0c10a-06f3-457d-b343-ddf2aa00b96a" />

This is how this entity is named in this example:
 
<img width="1048" height="543" alt="image" src="https://github.com/user-attachments/assets/7480d0ca-c4bb-428e-b63c-453c9cc00b80" />

<img width="1616" height="550" alt="image" src="https://github.com/user-attachments/assets/4ef6d445-ee16-44eb-b459-078b1ae0abf4" />

Other entity:

<img width="898" height="528" alt="image" src="https://github.com/user-attachments/assets/6771504c-8aa3-4719-a419-e46cc1405b95" />

<img width="1676" height="736" alt="image" src="https://github.com/user-attachments/assets/59839259-5a83-4b15-a1e7-8e54d432c8d8" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: resolves #28067
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
