### PR TITLE
Add browser back button protection to prevent-unsaved-mixin

### DIFF
--- a/src/mixins/prevent-unsaved-mixin.ts
+++ b/src/mixins/prevent-unsaved-mixin.ts
@@ -6,13 +6,21 @@ export const PreventUnsavedMixin = <T extends Constructor<LitElement>>(
   superClass: T
 ) =>
   class extends superClass {
+    private _historyState: string | null = null;
+
+    private _listenersAttached = false;
+
+    private _isNavigating = false;
+
     private _handleClick = async (e: MouseEvent) => {
-      // get the right target, otherwise the composedPath would return <home-assistant> in the new event
-      const target = e.composedPath()[0];
-      if (!isNavigationClick(e)) {
+      const href = isNavigationClick(e);
+      if (!href) {
         return;
       }
 
+      const target = e.composedPath()[0];
+
+      this._isNavigating = true;
       const result = await this.promptDiscardChanges();
       if (result) {
         this._removeListeners();
@@ -20,24 +28,64 @@ export const PreventUnsavedMixin = <T extends Constructor<LitElement>>(
           const newEvent = new MouseEvent(e.type, e);
           target.dispatchEvent(newEvent);
         }
+      } else {
+        this._isNavigating = false;
       }
     };
 
     private _handleUnload = (e: BeforeUnloadEvent) => e.preventDefault();
 
+    private _handlePopState = async () => {
+      // Ignore popstate events triggered by dialog state management
+      if (window.history.state?.opensDialog) {
+        return;
+      }
+
+      const result = await this.promptDiscardChanges();
+      if (!result) {
+        window.history.pushState(null, "", this._historyState);
+      } else {
+        this._removeListeners();
+      }
+    };
+
     private _removeListeners() {
       window.removeEventListener("click", this._handleClick, true);
       window.removeEventListener("beforeunload", this._handleUnload);
+      window.removeEventListener("popstate", this._handlePopState);
+      this._listenersAttached = false;
+    }
+
+    protected shouldUpdate(changedProperties: PropertyValues): boolean {
+      if (this._isNavigating) {
+        return false;
+      }
+      return super.shouldUpdate(changedProperties);
     }
 
     protected willUpdate(changedProperties: PropertyValues): void {
       super.willUpdate(changedProperties);
 
+      if (this._isNavigating) {
+        return;
+      }
+
       if (this.isDirty) {
-        window.addEventListener("click", this._handleClick, true);
-        window.addEventListener("beforeunload", this._handleUnload);
+        if (!this._listenersAttached) {
+          window.addEventListener("popstate", this._handlePopState);
+          window.addEventListener("click", this._handleClick, true);
+          window.addEventListener("beforeunload", this._handleUnload);
+          this._listenersAttached = true;
+        }
+        if (!this._historyState) {
+          this._historyState =
+            window.location.pathname + window.location.search;
+          // Push a state to enable back button detection
+          window.history.pushState(null, "", this._historyState);
+        }
       } else {
         this._removeListeners();
+        this._historyState = null;
       }
     }
 

--- a/src/mixins/prevent-unsaved-mixin.ts
+++ b/src/mixins/prevent-unsaved-mixin.ts
@@ -18,6 +18,10 @@ export const PreventUnsavedMixin = <T extends Constructor<LitElement>>(
         return;
       }
 
+      if (!isNavigationClick(e)) {
+        return;
+      }
+      // get the right target, otherwise the composedPath would return <home-assistant> in the new event
       const target = e.composedPath()[0];
 
       this._isNavigating = true;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Enhance the prevent-unsaved-mixin to intercept browser back/forward button navigation and prompt users before discarding unsaved changes.

https://github.com/user-attachments/assets/ae911489-9cd6-4977-a2c2-cbd0a11fbe8f

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #27769 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
