### PR TITLE
Continue on error UI

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -616,6 +616,7 @@ export interface ActionSidebarConfig extends BaseSidebarConfig {
   save: (value: Action) => void;
   rename: () => void;
   disable: () => void;
+  continueOnError: () => void;
   duplicate: () => void;
   cut: () => void;
   copy: () => void;

--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -1,6 +1,7 @@
 import { consume } from "@lit/context";
 import {
   mdiAlertCircleCheck,
+  mdiAlertCircleCheckOutline,
   mdiAppleKeyboardCommand,
   mdiArrowDown,
   mdiArrowUp,
@@ -444,6 +445,28 @@ export default class HaAutomationActionRow extends LitElement {
             )
           )}
         </ha-md-menu-item>
+        ${type !== "condition"
+          ? html`
+              <ha-md-menu-item
+                .clickAction=${this._onContinueOnError}
+                .disabled=${this.disabled}
+              >
+                <ha-svg-icon
+                  slot="start"
+                  .path=${(this.action as NonConditionAction)
+                    .continue_on_error === true
+                    ? mdiAlertCircleCheck
+                    : mdiAlertCircleCheckOutline}
+                ></ha-svg-icon>
+
+                ${this._renderOverflowLabel(
+                  this.hass.localize(
+                    "ui.panel.config.automation.editor.actions.continue_on_error"
+                  )
+                )}
+              </ha-md-menu-item>
+            `
+          : nothing}
         <ha-md-menu-item
           class="warning"
           .clickAction=${this._onDelete}
@@ -602,6 +625,27 @@ export default class HaAutomationActionRow extends LitElement {
 
     if (this._selected && this.optionsInSidebar) {
       this.openSidebar(value); // refresh sidebar
+    }
+
+    if (this._yamlMode && !this.optionsInSidebar) {
+      this._actionEditor?.yamlEditor?.setValue(value);
+    }
+  };
+
+  private _onContinueOnError = () => {
+    const continueOnError = !(
+      (this.action as NonConditionAction).continue_on_error ?? false
+    );
+    const value = continueOnError
+      ? { ...this.action, continue_on_error: true }
+      : { ...this.action };
+    if (!continueOnError) {
+      delete (value as NonConditionAction).continue_on_error;
+    }
+    fireEvent(this, "value-changed", { value });
+
+    if (this._selected && this.optionsInSidebar) {
+      this.openSidebar(value);
     }
 
     if (this._yamlMode && !this.optionsInSidebar) {
@@ -818,6 +862,7 @@ export default class HaAutomationActionRow extends LitElement {
         this.openSidebar();
       },
       disable: this._onDisable,
+      continueOnError: this._onContinueOnError,
       delete: this._onDelete,
       copy: this._copyAction,
       cut: this._cutAction,

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
@@ -1,4 +1,6 @@
 import {
+  mdiAlertCircleCheck,
+  mdiAlertCircleCheckOutline,
   mdiAppleKeyboardCommand,
   mdiContentCopy,
   mdiContentCut,
@@ -21,7 +23,11 @@ import "../../../../components/ha-md-menu-item";
 import { ACTION_BUILDING_BLOCKS } from "../../../../data/action";
 import type { ActionSidebarConfig } from "../../../../data/automation";
 import { domainToName } from "../../../../data/integration";
-import type { RepeatAction, ServiceAction } from "../../../../data/script";
+import type {
+  NonConditionAction,
+  RepeatAction,
+  ServiceAction,
+} from "../../../../data/script";
 import type { HomeAssistant } from "../../../../types";
 import { isMac } from "../../../../util/is_mac";
 import type HaAutomationConditionEditor from "../action/ha-automation-action-editor";
@@ -249,6 +255,29 @@ export default class HaAutomationSidebarAction extends LitElement {
           <span class="shortcut-placeholder ${isMac ? "mac" : ""}"></span>
         </div>
       </ha-md-menu-item>
+      ${actionType !== "condition"
+        ? html`
+            <ha-md-menu-item
+              slot="menu-items"
+              .clickAction=${this.config.continueOnError}
+              .disabled=${this.disabled}
+            >
+              <ha-svg-icon
+                slot="start"
+                .path=${(actionConfig as NonConditionAction)
+                  .continue_on_error === true
+                  ? mdiAlertCircleCheck
+                  : mdiAlertCircleCheckOutline}
+              ></ha-svg-icon>
+              <div class="overflow-label">
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.actions.continue_on_error"
+                )}
+                <span class="shortcut-placeholder ${isMac ? "mac" : ""}"></span>
+              </div>
+            </ha-md-menu-item>
+          `
+        : nothing}
       <ha-md-menu-item
         slot="menu-items"
         .clickAction=${this.config.delete}

--- a/test/panels/config/automation/action/continue-on-error-toggle.test.ts
+++ b/test/panels/config/automation/action/continue-on-error-toggle.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import type { NonConditionAction } from "../../../../../src/data/script";
+
+/**
+ * Helper function that mirrors the toggle logic from ha-automation-action-row.ts
+ * This tests the core logic without needing to instantiate the full component.
+ */
+function toggleContinueOnError(action: NonConditionAction): NonConditionAction {
+  const continueOnError = !(action.continue_on_error ?? false);
+  if (continueOnError) {
+    return { ...action, continue_on_error: true };
+  }
+  const result = { ...action };
+  delete result.continue_on_error;
+  return result;
+}
+
+describe("continue_on_error toggle", () => {
+  it("should enable continue_on_error when currently undefined", () => {
+    const action: NonConditionAction = {
+      action: "light.turn_on",
+      target: { entity_id: "light.bedroom" },
+    };
+
+    const result = toggleContinueOnError(action);
+
+    expect(result.continue_on_error).toBe(true);
+    expect(result.action).toBe("light.turn_on");
+  });
+
+  it("should enable continue_on_error when currently false", () => {
+    const action: NonConditionAction = {
+      action: "light.turn_on",
+      continue_on_error: false,
+    };
+
+    const result = toggleContinueOnError(action);
+
+    expect(result.continue_on_error).toBe(true);
+  });
+
+  it("should remove continue_on_error when currently true", () => {
+    const action: NonConditionAction = {
+      action: "light.turn_on",
+      target: { entity_id: "light.bedroom" },
+      continue_on_error: true,
+    };
+
+    const result = toggleContinueOnError(action);
+
+    expect(result.continue_on_error).toBeUndefined();
+    expect(result.action).toBe("light.turn_on");
+    expect(result.target).toEqual({ entity_id: "light.bedroom" });
+  });
+
+  it("should preserve other action properties when toggling on", () => {
+    const action: NonConditionAction = {
+      alias: "Turn on bedroom light",
+      action: "light.turn_on",
+      target: { entity_id: "light.bedroom" },
+      data: { brightness: 255 },
+      enabled: true,
+    };
+
+    const result = toggleContinueOnError(action);
+
+    expect(result.continue_on_error).toBe(true);
+    expect(result.alias).toBe("Turn on bedroom light");
+    expect(result.action).toBe("light.turn_on");
+    expect(result.target).toEqual({ entity_id: "light.bedroom" });
+    expect(result.data).toEqual({ brightness: 255 });
+    expect(result.enabled).toBe(true);
+  });
+
+  it("should preserve other action properties when toggling off", () => {
+    const action: NonConditionAction = {
+      alias: "Turn on bedroom light",
+      action: "light.turn_on",
+      target: { entity_id: "light.bedroom" },
+      continue_on_error: true,
+      enabled: false,
+    };
+
+    const result = toggleContinueOnError(action);
+
+    expect(result.continue_on_error).toBeUndefined();
+    expect(result.alias).toBe("Turn on bedroom light");
+    expect(result.enabled).toBe(false);
+  });
+
+  it("should work with delay action", () => {
+    const action: NonConditionAction = {
+      delay: "00:00:05",
+    };
+
+    const result = toggleContinueOnError(action);
+
+    expect(result.continue_on_error).toBe(true);
+    expect((result as any).delay).toBe("00:00:05");
+  });
+
+  it("should work with event action", () => {
+    const action: NonConditionAction = {
+      event: "custom_event",
+      event_data: { key: "value" },
+    };
+
+    const result = toggleContinueOnError(action);
+
+    expect(result.continue_on_error).toBe(true);
+    expect((result as any).event).toBe("custom_event");
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
In Home Assistant's YAML configuration, you can add continue_on_error: true to any action in an automation. This prevents the whole automation from crashing if one light bulb is unreachable. However, this option is invisible in the Visual Editor. If a user wants to use it, they have to switch to YAML mode, adding friction for non-technical users.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature-ish (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

NOTE: If the added test is undesired, feel free to drop that specific commit.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

NOTE: I think the documentation isn't needed for this small change. If asked, I can update this page or another one: https://www.home-assistant.io/docs/automation/editor/

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
