### PR TITLE
Fix disabled dashboard picker when no custom dashboard

### DIFF
--- a/src/panels/profile/ha-pick-dashboard-row.ts
+++ b/src/panels/profile/ha-pick-dashboard-row.ts
@@ -1,14 +1,17 @@
+import { mdiViewDashboard } from "@mdi/js";
 import type { PropertyValues, TemplateResult } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../components/ha-divider";
+import "../../components/ha-icon";
 import "../../components/ha-list-item";
 import "../../components/ha-select";
 import "../../components/ha-settings-row";
+import "../../components/ha-svg-icon";
 import { saveFrontendUserData } from "../../data/frontend";
 import type { LovelaceDashboard } from "../../data/lovelace/dashboard";
 import { fetchDashboards } from "../../data/lovelace/dashboard";
-import { getPanelTitle } from "../../data/panel";
+import { getPanelIcon, getPanelTitle } from "../../data/panel";
 import type { HomeAssistant, PanelInfo } from "../../types";
 import { PANEL_DASHBOARDS } from "../config/lovelace/dashboards/ha-config-lovelace-dashboards";
 
@@ -37,54 +40,57 @@ class HaPickDashboardRow extends LitElement {
         <span slot="description">
           ${this.hass.localize("ui.panel.profile.dashboard.description")}
         </span>
-        ${this._dashboards
-          ? html`<ha-select
-              .label=${this.hass.localize(
-                "ui.panel.profile.dashboard.dropdown_label"
-              )}
-              .disabled=${!this._dashboards?.length}
-              .value=${value}
-              @selected=${this._dashboardChanged}
-              naturalMenuWidth
-            >
-              <ha-list-item .value=${USE_SYSTEM_VALUE}>
-                ${this.hass.localize("ui.panel.profile.dashboard.system")}
+        <ha-select
+          .label=${this.hass.localize(
+            "ui.panel.profile.dashboard.dropdown_label"
+          )}
+          .value=${value}
+          @selected=${this._dashboardChanged}
+          naturalMenuWidth
+        >
+          <ha-list-item .value=${USE_SYSTEM_VALUE}>
+            ${this.hass.localize("ui.panel.profile.dashboard.system")}
+          </ha-list-item>
+          <ha-divider></ha-divider>
+          <ha-list-item value="lovelace" graphic="icon">
+            <ha-svg-icon slot="graphic" .path=${mdiViewDashboard}></ha-svg-icon>
+            ${this.hass.localize("ui.panel.profile.dashboard.lovelace")}
+          </ha-list-item>
+          ${PANEL_DASHBOARDS.map((panel) => {
+            const panelInfo = this.hass.panels[panel] as PanelInfo | undefined;
+            if (!panelInfo) {
+              return nothing;
+            }
+            return html`
+              <ha-list-item value=${panelInfo.url_path} graphic="icon">
+                <ha-icon
+                  slot="graphic"
+                  .icon=${getPanelIcon(panelInfo)}
+                ></ha-icon>
+                ${getPanelTitle(this.hass, panelInfo)}
               </ha-list-item>
-              <ha-divider></ha-divider>
-              <ha-list-item value="lovelace">
-                ${this.hass.localize("ui.panel.profile.dashboard.lovelace")}
-              </ha-list-item>
-              ${PANEL_DASHBOARDS.map((panel) => {
-                const panelInfo = this.hass.panels[panel] as
-                  | PanelInfo
-                  | undefined;
-                if (!panelInfo) {
-                  return nothing;
-                }
-                return html`
-                  <ha-list-item value=${panelInfo.url_path}>
-                    ${getPanelTitle(this.hass, panelInfo)}
-                  </ha-list-item>
-                `;
-              })}
-              <ha-divider></ha-divider>
-              ${this._dashboards.map((dashboard) => {
-                if (!this.hass.user!.is_admin && dashboard.require_admin) {
-                  return "";
-                }
-                return html`
-                  <ha-list-item .value=${dashboard.url_path}>
-                    ${dashboard.title}
-                  </ha-list-item>
-                `;
-              })}
-            </ha-select>`
-          : html`<ha-select
-              .label=${this.hass.localize(
-                "ui.panel.profile.dashboard.dropdown_label"
-              )}
-              disabled
-            ></ha-select>`}
+            `;
+          })}
+          ${this._dashboards?.length
+            ? html`
+                <ha-divider></ha-divider>
+                ${this._dashboards.map((dashboard) => {
+                  if (!this.hass.user!.is_admin && dashboard.require_admin) {
+                    return "";
+                  }
+                  return html`
+                    <ha-list-item .value=${dashboard.url_path} graphic="icon">
+                      <ha-icon
+                        slot="graphic"
+                        .icon=${dashboard.icon || "mdi:view-dashboard"}
+                      ></ha-icon>
+                      ${dashboard.title}
+                    </ha-list-item>
+                  `;
+                })}
+              `
+            : nothing}
+        </ha-select>
       </ha-settings-row>
     `;
   }


### PR DESCRIPTION
## Proposed change

Fix disabled dashboard picker when no custom dashboard
I also added icons in the picker

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/28153
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
