### PR TITLE
Always store token when using develop and serve

### DIFF
--- a/src/common/auth/token_storage.ts
+++ b/src/common/auth/token_storage.ts
@@ -1,5 +1,6 @@
 import type { AuthData } from "home-assistant-js-websocket";
 import { extractSearchParam } from "../url/search-params";
+import { hassUrl } from "../../data/auth";
 
 declare global {
   interface Window {
@@ -33,7 +34,7 @@ export function saveTokens(tokens: AuthData | null) {
   if (
     !tokenCache.writeEnabled &&
     (extractSearchParam("storeToken") === "true" ||
-      __HASS_URL__ !== `${location.protocol}//${location.host}`)
+      hassUrl !== `${location.protocol}//${location.host}`)
   ) {
     tokenCache.writeEnabled = true;
   }

--- a/src/common/auth/token_storage.ts
+++ b/src/common/auth/token_storage.ts
@@ -30,7 +30,11 @@ export function askWrite() {
 export function saveTokens(tokens: AuthData | null) {
   tokenCache.tokens = tokens;
 
-  if (!tokenCache.writeEnabled && extractSearchParam("storeToken") === "true") {
+  if (
+    !tokenCache.writeEnabled &&
+    (extractSearchParam("storeToken") === "true" ||
+      __HASS_URL__ !== `${location.protocol}//${location.host}`)
+  ) {
     tokenCache.writeEnabled = true;
   }
 

--- a/test/common/auth/token_storage/askWrite.test.ts
+++ b/test/common/auth/token_storage/askWrite.test.ts
@@ -1,8 +1,14 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 let askWrite;
 
+const HASS_URL = `${location.protocol}//${location.host}`;
+
 describe("token_storage.askWrite", () => {
+  beforeEach(() => {
+    vi.stubGlobal("__HASS_URL__", HASS_URL);
+  });
+
   afterEach(() => {
     vi.resetModules();
   });

--- a/test/common/auth/token_storage/saveTokens.test.ts
+++ b/test/common/auth/token_storage/saveTokens.test.ts
@@ -4,6 +4,8 @@ import { FallbackStorage } from "../../../test_helper/local-storage-fallback";
 
 let saveTokens;
 
+const HASS_URL = `${location.protocol}//${location.host}`;
+
 describe("token_storage.saveTokens", () => {
   beforeEach(() => {
     window.localStorage = new FallbackStorage();
@@ -32,6 +34,8 @@ describe("token_storage.saveTokens", () => {
       })
     );
 
+    vi.stubGlobal("__HASS_URL__", HASS_URL);
+
     ({ saveTokens } = await import(
       "../../../../src/common/auth/token_storage"
     ));
@@ -56,6 +60,8 @@ describe("token_storage.saveTokens", () => {
         writeEnabled: undefined,
       })
     );
+
+    vi.stubGlobal("__HASS_URL__", HASS_URL);
 
     const extractSearchParamSpy = vi.fn().mockReturnValue("true");
 
@@ -97,6 +103,8 @@ describe("token_storage.saveTokens", () => {
         writeEnabled: true,
       })
     );
+
+    vi.stubGlobal("__HASS_URL__", HASS_URL);
 
     const extractSearchParamSpy = vi.fn();
 

--- a/test/common/auth/token_storage/saveTokens.test.ts
+++ b/test/common/auth/token_storage/saveTokens.test.ts
@@ -9,6 +9,7 @@ const HASS_URL = `${location.protocol}//${location.host}`;
 describe("token_storage.saveTokens", () => {
   beforeEach(() => {
     window.localStorage = new FallbackStorage();
+    vi.stubGlobal("__HASS_URL__", HASS_URL);
   });
 
   afterEach(() => {
@@ -34,8 +35,6 @@ describe("token_storage.saveTokens", () => {
       })
     );
 
-    vi.stubGlobal("__HASS_URL__", HASS_URL);
-
     ({ saveTokens } = await import(
       "../../../../src/common/auth/token_storage"
     ));
@@ -60,8 +59,6 @@ describe("token_storage.saveTokens", () => {
         writeEnabled: undefined,
       })
     );
-
-    vi.stubGlobal("__HASS_URL__", HASS_URL);
 
     const extractSearchParamSpy = vi.fn().mockReturnValue("true");
 
@@ -103,8 +100,6 @@ describe("token_storage.saveTokens", () => {
         writeEnabled: true,
       })
     );
-
-    vi.stubGlobal("__HASS_URL__", HASS_URL);
 
     const extractSearchParamSpy = vi.fn();
 

--- a/test/common/auth/token_storage/token_storage.test.ts
+++ b/test/common/auth/token_storage/token_storage.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, test, vi, afterEach, beforeEach } from "vitest";
 import type { AuthData } from "home-assistant-js-websocket";
 import { FallbackStorage } from "../../../test_helper/local-storage-fallback";
 
+const HASS_URL = `${location.protocol}//${location.host}`;
+
 describe("token_storage", () => {
   beforeEach(() => {
     vi.stubGlobal(
@@ -11,6 +13,7 @@ describe("token_storage", () => {
         writeEnabled: undefined,
       })
     );
+    vi.stubGlobal("__HASS_URL__", HASS_URL);
     window.localStorage = new FallbackStorage();
   });
 


### PR DESCRIPTION



## Proposed change

When using develop and serve you can not choose to store the token as you use an external system for auth, so we always store the token.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
