### PR TITLE
Add API to allow HA-aware add-ons to interact with HA

### DIFF
--- a/hass-app-integrate.js
+++ b/hass-app-integrate.js
@@ -1,0 +1,137 @@
+/**
+ * Home Assistant App Integration Library
+ *
+ * This library enables add-ons running in ingress iframes to communicate
+ * with Home Assistant using postMessage.
+ *
+ * Usage:
+ *   <script src="/local/hass-app-integrate.js"></script>
+ *   <script>
+ *     const hassApp = new HassAppIntegrate();
+ *
+ *     // Subscribe to property changes
+ *     const unsubscribe = hassApp.subscribe(({ narrow, route }) => {
+ *       if (narrow) {
+ *         // Show mobile layout
+ *       } else {
+ *         // Show desktop layout
+ *       }
+ *     }, { hideToolbar: true });
+ *
+ *     // Navigate to a different page
+ *     hassApp.navigate('/lovelace/dashboard');
+ *
+ *     // Toggle the sidebar menu
+ *     hassApp.toggleMenu();
+ *
+ *     // Clean up when done
+ *     unsubscribe();
+ *   </script>
+ */
+
+(function () {
+  "use strict";
+
+  class HassAppIntegrate {
+    constructor() {
+      this._subscribeCallback = null;
+      this._boundMessageHandler = this.handleMessage.bind(this);
+      window.addEventListener("message", this._boundMessageHandler);
+    }
+
+    /**
+     * Subscribe to property changes from Home Assistant
+     * @param {Function} callback - Called with { narrow, route } when properties change
+     * @param {Object} options - Options object
+     * @param {boolean} options.hideToolbar - If true, Home Assistant hides its toolbar
+     * @returns {Function} Unsubscribe function
+     */
+    subscribe(callback, options = {}) {
+      this._subscribeCallback = callback;
+
+      // Send subscribe message to parent
+      window.parent.postMessage(
+        {
+          type: "hass-app/subscribe",
+          hideToolbar: options.hideToolbar || false,
+        },
+        "*"
+      );
+
+      // Return unsubscribe function
+      return () => {
+        this._subscribeCallback = null;
+        window.parent.postMessage(
+          {
+            type: "hass-app/unsubscribe",
+          },
+          "*"
+        );
+      };
+    }
+
+    /**
+     * Navigate to a different page in Home Assistant
+     * @param {string} path - The path to navigate to (e.g., '/lovelace/dashboard')
+     * @param {Object} options - Navigation options (replace, etc.)
+     */
+    navigate(path, options) {
+      window.parent.postMessage(
+        {
+          type: "hass-app/navigate",
+          path: path,
+          options: options,
+        },
+        "*"
+      );
+    }
+
+    /**
+     * Toggle the Home Assistant sidebar menu
+     */
+    toggleMenu() {
+      window.parent.postMessage(
+        {
+          type: "hass-app/toggle-menu",
+        },
+        "*"
+      );
+    }
+
+    /**
+     * Clean up event listeners
+     */
+    destroy() {
+      window.removeEventListener("message", this._boundMessageHandler);
+      this._subscribeCallback = null;
+    }
+
+    /**
+     * Handle messages from Home Assistant
+     * @private
+     */
+    handleMessage(event) {
+      // Only process messages from parent window
+      if (event.source !== window.parent) {
+        return;
+      }
+
+      const { type, ...data } = event.data;
+
+      if (type === "hass-app/properties" && this._subscribeCallback) {
+        this._subscribeCallback({
+          narrow: data.narrow,
+          route: data.route,
+        });
+      }
+    }
+  }
+
+  // Export for use in modules and global scope
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = HassAppIntegrate;
+  }
+  if (typeof window !== "undefined") {
+    window.HassAppIntegrate = HassAppIntegrate;
+  }
+})();

--- a/hassio/src/ingress-view/hassio-ingress-view.ts
+++ b/hassio/src/ingress-view/hassio-ingress-view.ts
@@ -2,6 +2,7 @@ import { mdiMenu } from "@mdi/js";
 import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { ref } from "lit/directives/ref";
 import { fireEvent } from "../../../src/common/dom/fire_event";
 import { goBack, navigate } from "../../../src/common/navigate";
 import { extractSearchParam } from "../../../src/common/url/search-params";
@@ -42,12 +43,24 @@ class HassioIngressView extends LitElement {
 
   @state() private _loadingMessage?: string;
 
+  @state() private _hideToolbar = false;
+
   private _sessionKeepAlive?: number;
 
   private _fetchDataTimeout?: number;
 
+  private _iframe?: HTMLIFrameElement;
+
+  private _boundMessageHandler = this._handleMessage.bind(this);
+
+  public connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener("message", this._boundMessageHandler);
+  }
+
   public disconnectedCallback() {
     super.disconnectedCallback();
+    window.removeEventListener("message", this._boundMessageHandler);
 
     if (this._sessionKeepAlive) {
       clearInterval(this._sessionKeepAlive);
@@ -59,6 +72,50 @@ class HassioIngressView extends LitElement {
     }
   }
 
+  private _handleMessage(event: MessageEvent) {
+    // Only accept messages from our iframe
+    if (!this._iframe || event.source !== this._iframe.contentWindow) {
+      return;
+    }
+
+    const { type, ...data } = event.data;
+
+    switch (type) {
+      case "hass-app/subscribe":
+        this._hideToolbar = data.hideToolbar ?? false;
+        this._sendPropertiesToIframe();
+        break;
+      case "hass-app/unsubscribe":
+        this._hideToolbar = false;
+        break;
+      case "hass-app/navigate":
+        navigate(data.path, data.options);
+        break;
+      case "hass-app/toggle-menu":
+        this._toggleMenu();
+        break;
+    }
+  }
+
+  private _sendPropertiesToIframe() {
+    if (!this._iframe?.contentWindow) {
+      return;
+    }
+
+    this._iframe.contentWindow.postMessage(
+      {
+        type: "hass-app/properties",
+        narrow: this.narrow,
+        route: this.route,
+      },
+      "*"
+    );
+  }
+
+  private _handleIframeRef = (el: Element | undefined) => {
+    this._iframe = el as HTMLIFrameElement;
+  };
+
   protected render(): TemplateResult {
     if (!this._addon) {
       return html`<hass-loading-screen
@@ -69,7 +126,9 @@ class HassioIngressView extends LitElement {
     const iframe = html`<iframe
       title=${this._addon.name}
       src=${this._addon.ingress_url!}
-      @load=${this._checkLoaded}
+      sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation"
+      @load=${this._handleIframeLoad}
+      ${ref(this._handleIframeRef)}
     >
     </iframe>`;
 
@@ -83,7 +142,10 @@ class HassioIngressView extends LitElement {
       </hass-subpage>`;
     }
 
-    return html`${this.narrow || this.hass.dockedSidebar === "always_hidden"
+    // Only show header if narrow/sidebar hidden AND add-on hasn't opted to hide toolbar
+    return html`${(this.narrow ||
+      this.hass.dockedSidebar === "always_hidden") &&
+    !this._hideToolbar
       ? html`<div class="header">
             <ha-icon-button
               .label=${this.hass.localize("ui.sidebar.sidebar_toggle")}
@@ -148,6 +210,18 @@ class HassioIngressView extends LitElement {
     if (addon && addon !== oldAddon) {
       this._loadingMessage = undefined;
       this._fetchData(addon);
+    }
+  }
+
+  protected updated(changedProps: PropertyValues) {
+    super.updated(changedProps);
+
+    // Send property updates to iframe when narrow or route changes
+    if (
+      this._hideToolbar &&
+      (changedProps.has("narrow") || changedProps.has("route"))
+    ) {
+      this._sendPropertiesToIframe();
     }
   }
 
@@ -293,7 +367,7 @@ class HassioIngressView extends LitElement {
     this._addon = addon;
   }
 
-  private async _checkLoaded(ev): Promise<void> {
+  private async _handleIframeLoad(ev): Promise<void> {
     if (!this._addon) {
       return;
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This adds an API for add-ons served via Ingress similar to how we offer one for custom panels inside their iframe.

Add-ons can do the following things:

```
// Subscribe to layout changes
const unsubscribe = window.parent.hassIngress.subscribe(({ narrow, route }) => {
  if (narrow) {
    showMobileLayout();
    showMenuButton(); // Add-on renders its own menu button
  } else {
    showDesktopLayout();
  }
  
  console.log('Current path:', route.path);
}, {
  // optional options
  hideToolbar: true
});

// Navigate to a page
window.parent.hassIngress.navigate('/lovelace/dashboard');

// Show sidebar of Home Assistant (for in narrow mode)
window.parent.hassIngress.toggleMenu();
```


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `window.hassIngress` API (navigate, toggleMenu, subscribe) and optional toolbar hiding for ingress add-ons, with lifecycle integration and reactive updates.
> 
> - **Ingress add-on API**:
>   - Expose `window.hassIngress` with:
>     - `navigate(path, options?)`, `toggleMenu()`
>     - Reactive `narrow` and `route` properties
>     - `subscribe(({ narrow, route }, { hideToolbar? }) => unsubscribe)` with immediate emit and unsubscribe handling
>   - Keep API in sync on `narrow`/`route` changes and clean up on disconnect
> - **UI behavior**:
>   - Header/menu button hidden when `(narrow || sidebar always_hidden)` and add-on sets `hideToolbar=true`; add-ons can render their own menu button
> - **Internals**:
>   - Add `_hideToolbar` and `_propertyCallback` state, setup/cleanup helpers for API lifecycle
>   - Minor imports and type additions (`NavigateOptions`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e72d326f0e434b7820ceb5e9218fe8c726f5471e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->