### PR TITLE
Add new app panel

### DIFF
--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -205,6 +205,7 @@ const createRspackConfig = ({
         "lit/decorators$": "lit/decorators.js",
         "lit/directive$": "lit/directive.js",
         "lit/directives/until$": "lit/directives/until.js",
+        "lit/directives/ref$": "lit/directives/ref.js",
         "lit/directives/class-map$": "lit/directives/class-map.js",
         "lit/directives/style-map$": "lit/directives/style-map.js",
         "lit/directives/if-defined$": "lit/directives/if-defined.js",

--- a/src/common/url/route.ts
+++ b/src/common/url/route.ts
@@ -1,4 +1,4 @@
-import type { Route } from "../types";
+import type { Route } from "../../types";
 
 export const computeRouteTail = (route: Route) => {
   const dividerPos = route.path.indexOf("/", 1);
@@ -8,7 +8,7 @@ export const computeRouteTail = (route: Route) => {
         path: "",
       }
     : {
-        prefix: route.prefix + route.path. substring(0, dividerPos),
-        path: route.path. substring(dividerPos),
+        prefix: route.prefix + route.path.substring(0, dividerPos),
+        path: route.path.substring(dividerPos),
       };
 };

--- a/src/data/route.ts
+++ b/src/data/route.ts
@@ -1,0 +1,14 @@
+import type { Route } from "../types";
+
+export const computeRouteTail = (route: Route) => {
+  const dividerPos = route.path.indexOf("/", 1);
+  return dividerPos === -1
+    ? {
+        prefix: route.prefix + route.path,
+        path: "",
+      }
+    : {
+        prefix: route.prefix + route.path.substr(0, dividerPos),
+        path: route.path.substr(dividerPos),
+      };
+};

--- a/src/data/route.ts
+++ b/src/data/route.ts
@@ -8,7 +8,7 @@ export const computeRouteTail = (route: Route) => {
         path: "",
       }
     : {
-        prefix: route.prefix + route.path.substr(0, dividerPos),
-        path: route.path.substr(dividerPos),
+        prefix: route.prefix + route.path. substring(0, dividerPos),
+        path: route.path. substring(dividerPos),
       };
 };

--- a/src/layouts/hass-router-page.ts
+++ b/src/layouts/hass-router-page.ts
@@ -4,6 +4,7 @@ import { property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { navigate } from "../common/navigate";
 import type { Route } from "../types";
+import { computeRouteTail } from "../data/route";
 
 const extractPage = (path: string, defaultPage: string) => {
   if (path === "") {
@@ -56,18 +57,7 @@ export class HassRouterPage extends ReactiveElement {
 
   private _initialLoadDone = false;
 
-  private _computeTail = memoizeOne((route: Route) => {
-    const dividerPos = route.path.indexOf("/", 1);
-    return dividerPos === -1
-      ? {
-          prefix: route.prefix + route.path,
-          path: "",
-        }
-      : {
-          prefix: route.prefix + route.path.substr(0, dividerPos),
-          path: route.path.substr(dividerPos),
-        };
-  });
+  private _computeTail = memoizeOne(computeRouteTail);
 
   protected createRenderRoot() {
     return this;

--- a/src/layouts/hass-router-page.ts
+++ b/src/layouts/hass-router-page.ts
@@ -3,8 +3,8 @@ import { ReactiveElement } from "lit";
 import { property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { navigate } from "../common/navigate";
+import { computeRouteTail } from "../common/url/route";
 import type { Route } from "../types";
-import { computeRouteTail } from "../data/route";
 
 const extractPage = (path: string, defaultPage: string) => {
   if (path === "") {

--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -16,6 +16,7 @@ import { HassRouterPage } from "./hass-router-page";
 
 const CACHE_URL_PATHS = ["lovelace", "developer-tools"];
 const COMPONENTS = {
+  app: () => import("../panels/app/ha-panel-app"),
   energy: () => import("../panels/energy/ha-panel-energy"),
   calendar: () => import("../panels/calendar/ha-panel-calendar"),
   config: () => import("../panels/config/ha-panel-config"),
@@ -155,6 +156,7 @@ class PartialPanelResolver extends HassRouterPage {
         // iFrames will lose their state when disconnected
         // Do not disconnect any iframe panel
         curPanel.component_name !== "iframe" &&
+        curPanel.component_name !== "app" &&
         // Do not disconnect any custom panel that embeds into iframe (ie hassio)
         (curPanel.component_name !== "custom" ||
           !(curPanel as CustomPanelInfo).config._panel_custom.embed_iframe)

--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -127,7 +127,11 @@ class HaPanelApp extends LitElement {
     }
     // Fall back to route path (e.g., /app/core_configurator)
     if (route?.path) {
-      const slug = route.path.substring(1);
+      const dividerPos = route.path.indexOf("/", 1);
+      const slug =
+        dividerPos === -1
+          ? route.path.substring(1)
+          : route.path.substring(1, dividerPos);
       if (slug) {
         return slug;
       }

--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -192,6 +192,13 @@ class HaPanelApp extends LitElement {
     return undefined;
   }
 
+  private async _showErrorAndNavigateHome(title: string, text: string) {
+    await this.updateComplete;
+    await showAlertDialog(this, { title, text });
+    await nextRender();
+    navigate("/", { replace: true });
+  }
+
   private async _fetchData(addonSlug: string) {
     const createSessionPromise = createHassioSession(this.hass);
 
@@ -200,35 +207,26 @@ class HaPanelApp extends LitElement {
     try {
       addon = await fetchHassioAddonInfo(this.hass, addonSlug);
     } catch (err: any) {
-      await this.updateComplete;
-      await showAlertDialog(this, {
-        text: extractApiErrorMessage(err),
-        title: addonSlug,
-      });
-      await nextRender();
-      navigate("/", { replace: true });
+      await this._showErrorAndNavigateHome(
+        addonSlug,
+        extractApiErrorMessage(err)
+      );
       return;
     }
 
     if (!addon.version) {
-      await this.updateComplete;
-      await showAlertDialog(this, {
-        text: this.hass.localize("ui.panel.app.error_app_not_installed"),
-        title: addon.name,
-      });
-      await nextRender();
-      navigate("/", { replace: true });
+      await this._showErrorAndNavigateHome(
+        addon.name,
+        this.hass.localize("ui.panel.app.error_app_not_installed")
+      );
       return;
     }
 
     if (!addon.ingress_url) {
-      await this.updateComplete;
-      await showAlertDialog(this, {
-        text: this.hass.localize("ui.panel.app.error_app_no_ingress"),
-        title: addon.name,
-      });
-      await nextRender();
-      navigate("/", { replace: true });
+      await this._showErrorAndNavigateHome(
+        addon.name,
+        this.hass.localize("ui.panel.app.error_app_no_ingress")
+      );
       return;
     }
 
@@ -251,12 +249,10 @@ class HaPanelApp extends LitElement {
           this._fetchData(addonSlug);
           return;
         } catch (_err) {
-          await showAlertDialog(this, {
-            text: this.hass.localize("ui.panel.app.error_starting_app"),
-            title: addon.name,
-          });
-          await nextRender();
-          navigate("/", { replace: true });
+          await this._showErrorAndNavigateHome(
+            addon.name,
+            this.hass.localize("ui.panel.app.error_starting_app")
+          );
           return;
         }
       } else {
@@ -295,12 +291,10 @@ class HaPanelApp extends LitElement {
       if (this._sessionKeepAlive) {
         clearInterval(this._sessionKeepAlive);
       }
-      await showAlertDialog(this, {
-        text: this.hass.localize("ui.panel.app.error_creating_session"),
-        title: addon.name,
-      });
-      await nextRender();
-      navigate("/", { replace: true });
+      await this._showErrorAndNavigateHome(
+        addon.name,
+        this.hass.localize("ui.panel.app.error_creating_session")
+      );
       return;
     }
 

--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -23,8 +23,8 @@ import {
   showConfirmationDialog,
 } from "../../dialogs/generic/show-dialog-box";
 import "../../layouts/hass-loading-screen";
+import { computeRouteTail } from "../../common/url/route";
 import type { HomeAssistant, PanelInfo, Route } from "../../types";
-import { computeRouteTail } from "../../data/route";
 
 interface AppPanelConfig {
   addon?: string;

--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -142,6 +142,9 @@ class HaPanelApp extends LitElement {
 
     if (addon && addon !== oldAddon) {
       this._loadingMessage = undefined;
+      // Reset iframe subscription state when switching addons
+      this._hideToolbar = false;
+      this._iframeSubscribeUpdates = false;
       this._fetchData(addon);
     }
   }
@@ -294,6 +297,11 @@ class HaPanelApp extends LitElement {
         session = await createHassioSession(this.hass);
       }
     }, 60000);
+
+    // Check if user navigated away while we were fetching
+    if (this._getAddonSlug() !== addonSlug) {
+      return;
+    }
 
     this._addon = addon;
   }

--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -23,7 +23,6 @@ import {
   showConfirmationDialog,
 } from "../../dialogs/generic/show-dialog-box";
 import "../../layouts/hass-loading-screen";
-import "../../layouts/hass-subpage";
 import type { HomeAssistant, PanelInfo, Route } from "../../types";
 import { computeRouteTail } from "../../data/route";
 
@@ -142,9 +141,10 @@ class HaPanelApp extends LitElement {
 
     if (addon && addon !== oldAddon) {
       this._loadingMessage = undefined;
-      // Reset iframe subscription state when switching addons
+      // Reset state when switching addons
       this._hideToolbar = false;
       this._iframeSubscribeUpdates = false;
+      this._autoRetryUntil = undefined;
       this._fetchData(addon);
     }
   }
@@ -287,6 +287,11 @@ class HaPanelApp extends LitElement {
       return;
     }
 
+    // Check if user navigated away while we were fetching
+    if (this._getAddonSlug() !== addonSlug) {
+      return;
+    }
+
     if (this._sessionKeepAlive) {
       clearInterval(this._sessionKeepAlive);
     }
@@ -298,18 +303,14 @@ class HaPanelApp extends LitElement {
       }
     }, 60000);
 
-    // Check if user navigated away while we were fetching
-    if (this._getAddonSlug() !== addonSlug) {
-      return;
-    }
-
     this._addon = addon;
   }
 
-  private async _checkLoaded(ev): Promise<void> {
+  private async _checkLoaded(ev: Event): Promise<void> {
+    const iframe = ev.target as HTMLIFrameElement;
     if (
       !this._addon ||
-      ev.target.contentDocument.body.textContent !== "502: Bad Gateway"
+      iframe.contentDocument?.body.textContent !== "502: Bad Gateway"
     ) {
       return;
     }

--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -1,6 +1,7 @@
 import { mdiMenu } from "@mdi/js";
 import type { PropertyValues, TemplateResult } from "lit";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { createRef, ref } from "lit/directives/ref";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
 import { navigate } from "../../common/navigate";
@@ -23,6 +24,7 @@ import {
 import "../../layouts/hass-loading-screen";
 import "../../layouts/hass-subpage";
 import type { HomeAssistant, PanelInfo, Route } from "../../types";
+import { computeRouteTail } from "../../data/route";
 
 interface AppPanelConfig {
   addon?: string;
@@ -46,14 +48,41 @@ class HaPanelApp extends LitElement {
 
   @state() private _loadingMessage?: string;
 
+  @state() private _hideToolbar = false;
+
   private _sessionKeepAlive?: number;
 
   private _fetchDataTimeout?: number;
 
   private _autoRetryUntil?: number;
 
+  private _iframeRef = createRef<HTMLIFrameElement>();
+
+  /**
+   * iFrames can subscribe to Home Assistant specific updates
+   */
+  private _iframeSubscribeUpdates = false;
+
+  protected updated(changedProps: PropertyValues) {
+    super.updated(changedProps);
+
+    // Send property updates to iframe when narrow or route changes
+    if (
+      this._iframeSubscribeUpdates &&
+      (changedProps.has("narrow") || changedProps.has("route"))
+    ) {
+      this._sendPropertiesToIframe();
+    }
+  }
+
+  public connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener("message", this._handleIframeMessage);
+  }
+
   public disconnectedCallback() {
     super.disconnectedCallback();
+    window.removeEventListener("message", this._handleIframeMessage);
 
     if (this._sessionKeepAlive) {
       clearInterval(this._sessionKeepAlive);
@@ -72,26 +101,29 @@ class HaPanelApp extends LitElement {
       ></hass-loading-screen>`;
     }
 
-    const iframe = html`<iframe
-      title=${this._addon.name}
-      src=${this._addon.ingress_url!}
-      @load=${this._checkLoaded}
-    >
-    </iframe>`;
-
-    return this.narrow || this.hass.dockedSidebar === "always_hidden"
-      ? html`
-          <div class="header">
-            <ha-icon-button
-              .label=${this.hass.localize("ui.sidebar.sidebar_toggle")}
-              .path=${mdiMenu}
-              @click=${this._toggleMenu}
-            ></ha-icon-button>
-            <div class="main-title">${this._addon.name}</div>
-          </div>
-          ${iframe}
-        `
-      : iframe;
+    // Make sure this all is 1 template so hiding toolbar doesn't reload iframe
+    return html`
+      ${!this._hideToolbar &&
+      (this.narrow || this.hass.dockedSidebar === "always_hidden")
+        ? html`
+            <div class="header">
+              <ha-icon-button
+                .label=${this.hass.localize("ui.sidebar.sidebar_toggle")}
+                .path=${mdiMenu}
+                @click=${this._toggleMenu}
+              ></ha-icon-button>
+              <div class="main-title">${this._addon.name}</div>
+            </div>
+          `
+        : nothing}
+      <iframe
+        title=${this._addon.name}
+        src=${this._addon.ingress_url!}
+        @load=${this._checkLoaded}
+        ${ref(this._iframeRef)}
+      >
+      </iframe>
+    `;
   }
 
   protected willUpdate(changedProps: PropertyValues) {
@@ -310,6 +342,49 @@ class HaPanelApp extends LitElement {
 
   private _toggleMenu(): void {
     fireEvent(this, "hass-toggle-menu");
+  }
+
+  private _handleIframeMessage = (event: MessageEvent) => {
+    if (event.source !== this._iframeRef.value?.contentWindow) {
+      return;
+    }
+    const { type, ...data } = event.data;
+
+    switch (type) {
+      case "home-assistant/navigate":
+        navigate(data.path, data.options);
+        break;
+
+      case "home-assistant/toggle-menu":
+        this._toggleMenu();
+        break;
+
+      case "home-assistant/subscribe-properties":
+        this._iframeSubscribeUpdates = true;
+        this._hideToolbar = data.hideToolbar ?? false;
+        this._sendPropertiesToIframe();
+        break;
+
+      case "home-assistant/unsubscribe-properties":
+        this._iframeSubscribeUpdates = false;
+        this._hideToolbar = false;
+        break;
+    }
+  };
+
+  private _sendPropertiesToIframe() {
+    if (!this._iframeRef.value?.contentWindow) {
+      return;
+    }
+
+    this._iframeRef.value.contentWindow.postMessage(
+      {
+        type: "home-assistant/properties",
+        narrow: this.narrow,
+        route: computeRouteTail(this.route),
+      },
+      "*"
+    );
   }
 
   static styles = css`

--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -3,6 +3,7 @@ import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { createRef, ref } from "lit/directives/ref";
 import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
 import { fireEvent } from "../../common/dom/fire_event";
 import { navigate } from "../../common/navigate";
 import { nextRender } from "../../common/util/render-status";
@@ -381,11 +382,13 @@ class HaPanelApp extends LitElement {
       {
         type: "home-assistant/properties",
         narrow: this.narrow,
-        route: computeRouteTail(this.route),
+        route: this._computeRouteTail(this.route),
       },
       "*"
     );
   }
+
+  private _computeRouteTail = memoizeOne(computeRouteTail);
 
   static styles = css`
     :host {

--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -90,7 +90,7 @@ class HaPanelApp extends LitElement {
       this._sessionKeepAlive = undefined;
     }
     if (this._fetchDataTimeout) {
-      clearInterval(this._fetchDataTimeout);
+      clearTimeout(this._fetchDataTimeout);
       this._fetchDataTimeout = undefined;
     }
   }
@@ -263,7 +263,7 @@ class HaPanelApp extends LitElement {
     this._loadingMessage = undefined;
 
     if (this._fetchDataTimeout) {
-      clearInterval(this._fetchDataTimeout);
+      clearTimeout(this._fetchDataTimeout);
       this._fetchDataTimeout = undefined;
     }
 

--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -28,6 +28,10 @@ interface AppPanelConfig {
   addon?: string;
 }
 
+// Time to wait for app to start before we ask the user if we should try again
+const START_WAIT_TIME = 20000; // ms
+const RETRY_START_WAIT_TIME = 5000; // ms
+
 @customElement("ha-panel-app")
 class HaPanelApp extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -45,6 +49,8 @@ class HaPanelApp extends LitElement {
   private _sessionKeepAlive?: number;
 
   private _fetchDataTimeout?: number;
+
+  private _autoRetryUntil?: number;
 
   public disconnectedCallback() {
     super.disconnectedCallback();
@@ -182,6 +188,8 @@ class HaPanelApp extends LitElement {
           this._loadingMessage = this.hass.localize(
             "ui.panel.app.app_starting"
           );
+          // Set auto-retry window for after starting the app
+          this._autoRetryUntil = Date.now() + START_WAIT_TIME;
           await startHassioAddon(this.hass, addonSlug);
           this._fetchData(addonSlug);
           return;
@@ -254,29 +262,46 @@ class HaPanelApp extends LitElement {
   }
 
   private async _checkLoaded(ev): Promise<void> {
-    if (!this._addon) {
+    if (
+      !this._addon ||
+      ev.target.contentDocument.body.textContent !== "502: Bad Gateway"
+    ) {
       return;
     }
-    if (ev.target.contentDocument.body.textContent === "502: Bad Gateway") {
-      await this.updateComplete;
-      showConfirmationDialog(this, {
-        text: this.hass.localize("ui.panel.app.error_app_not_ready"),
-        title: this._addon.name,
-        confirmText: this.hass.localize("ui.panel.app.retry"),
-        dismissText: this.hass.localize("ui.common.no"),
-        confirm: async () => {
-          const addon = this._addon;
-          this._addon = undefined;
-          await Promise.all([
-            this.updateComplete,
-            new Promise((resolve) => {
-              setTimeout(resolve, 500);
-            }),
-          ]);
-          this._addon = addon;
-        },
-      });
+
+    // Auto-retry if within the retry window
+    if (this._autoRetryUntil && Date.now() < this._autoRetryUntil) {
+      this._reloadIframe();
+      return;
     }
+
+    // Clear auto-retry window and show dialog
+    this._autoRetryUntil = undefined;
+
+    await this.updateComplete;
+    showConfirmationDialog(this, {
+      text: this.hass.localize("ui.panel.app.error_app_not_ready"),
+      title: this._addon.name,
+      confirmText: this.hass.localize("ui.panel.app.retry"),
+      dismissText: this.hass.localize("ui.common.no"),
+      confirm: () => {
+        // Set auto-retry window for a bit more time.
+        this._autoRetryUntil = Date.now() + RETRY_START_WAIT_TIME;
+        this._reloadIframe();
+      },
+    });
+  }
+
+  private async _reloadIframe(): Promise<void> {
+    const addon = this._addon;
+    this._addon = undefined;
+    await Promise.all([
+      this.updateComplete,
+      new Promise((resolve) => {
+        setTimeout(resolve, 1000);
+      }),
+    ]);
+    this._addon = addon;
   }
 
   private _toggleMenu(): void {

--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -1,0 +1,334 @@
+import { mdiMenu } from "@mdi/js";
+import type { PropertyValues, TemplateResult } from "lit";
+import { css, html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../common/dom/fire_event";
+import { navigate } from "../../common/navigate";
+import { nextRender } from "../../common/util/render-status";
+import "../../components/ha-icon-button";
+import type { HassioAddonDetails } from "../../data/hassio/addon";
+import {
+  fetchHassioAddonInfo,
+  startHassioAddon,
+} from "../../data/hassio/addon";
+import { extractApiErrorMessage } from "../../data/hassio/common";
+import {
+  createHassioSession,
+  validateHassioSession,
+} from "../../data/hassio/ingress";
+import {
+  showAlertDialog,
+  showConfirmationDialog,
+} from "../../dialogs/generic/show-dialog-box";
+import "../../layouts/hass-loading-screen";
+import "../../layouts/hass-subpage";
+import type { HomeAssistant, PanelInfo, Route } from "../../types";
+
+interface AppPanelConfig {
+  addon?: string;
+}
+
+@customElement("ha-panel-app")
+class HaPanelApp extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public route!: Route;
+
+  @property({ attribute: false }) public panel!: PanelInfo<AppPanelConfig>;
+
+  @property({ type: Boolean }) public narrow = false;
+
+  @state() private _addon?: HassioAddonDetails;
+
+  @state() private _loadingMessage?: string;
+
+  private _sessionKeepAlive?: number;
+
+  private _fetchDataTimeout?: number;
+
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+
+    if (this._sessionKeepAlive) {
+      clearInterval(this._sessionKeepAlive);
+      this._sessionKeepAlive = undefined;
+    }
+    if (this._fetchDataTimeout) {
+      clearInterval(this._fetchDataTimeout);
+      this._fetchDataTimeout = undefined;
+    }
+  }
+
+  protected render(): TemplateResult {
+    if (!this._addon) {
+      return html`<hass-loading-screen
+        .message=${this._loadingMessage}
+      ></hass-loading-screen>`;
+    }
+
+    const iframe = html`<iframe
+      title=${this._addon.name}
+      src=${this._addon.ingress_url!}
+      @load=${this._checkLoaded}
+    >
+    </iframe>`;
+
+    return this.narrow || this.hass.dockedSidebar === "always_hidden"
+      ? html`
+          <div class="header">
+            <ha-icon-button
+              .label=${this.hass.localize("ui.sidebar.sidebar_toggle")}
+              .path=${mdiMenu}
+              @click=${this._toggleMenu}
+            ></ha-icon-button>
+            <div class="main-title">${this._addon.name}</div>
+          </div>
+          ${iframe}
+        `
+      : iframe;
+  }
+
+  protected willUpdate(changedProps: PropertyValues) {
+    super.willUpdate(changedProps);
+
+    if (!changedProps.has("route") && !changedProps.has("panel")) {
+      return;
+    }
+
+    const addon = this._getAddonSlug();
+
+    const oldRoute = changedProps.get("route") as this["route"] | undefined;
+    const oldPanel = changedProps.get("panel") as this["panel"] | undefined;
+    const oldAddon = this._getAddonSlugFromRoutePanel(oldRoute, oldPanel);
+
+    if (addon && addon !== oldAddon) {
+      this._loadingMessage = undefined;
+      this._fetchData(addon);
+    }
+  }
+
+  private _getAddonSlug(): string | undefined {
+    return this._getAddonSlugFromRoutePanel(this.route, this.panel);
+  }
+
+  private _getAddonSlugFromRoutePanel(
+    route?: Route,
+    panel?: PanelInfo<AppPanelConfig>
+  ): string | undefined {
+    // First check panel config (for dedicated add-on panels)
+    if (panel?.config?.addon) {
+      return panel.config.addon;
+    }
+    // Fall back to route path (e.g., /app/core_configurator)
+    if (route?.path) {
+      const slug = route.path.substring(1);
+      if (slug) {
+        return slug;
+      }
+    }
+    return undefined;
+  }
+
+  private async _fetchData(addonSlug: string) {
+    const createSessionPromise = createHassioSession(this.hass);
+
+    let addon: HassioAddonDetails;
+
+    try {
+      addon = await fetchHassioAddonInfo(this.hass, addonSlug);
+    } catch (err: any) {
+      await this.updateComplete;
+      await showAlertDialog(this, {
+        text: extractApiErrorMessage(err),
+        title: addonSlug,
+      });
+      await nextRender();
+      navigate("/", { replace: true });
+      return;
+    }
+
+    if (!addon.version) {
+      await this.updateComplete;
+      await showAlertDialog(this, {
+        text: this.hass.localize("ui.panel.app.error_app_not_installed"),
+        title: addon.name,
+      });
+      await nextRender();
+      navigate("/", { replace: true });
+      return;
+    }
+
+    if (!addon.ingress_url) {
+      await this.updateComplete;
+      await showAlertDialog(this, {
+        text: this.hass.localize("ui.panel.app.error_app_no_ingress"),
+        title: addon.name,
+      });
+      await nextRender();
+      navigate("/", { replace: true });
+      return;
+    }
+
+    if (!addon.state || !["startup", "started"].includes(addon.state)) {
+      await this.updateComplete;
+      const confirm = await showConfirmationDialog(this, {
+        text: this.hass.localize("ui.panel.app.error_app_not_running"),
+        title: addon.name,
+        confirmText: this.hass.localize("ui.panel.app.start_app"),
+        dismissText: this.hass.localize("ui.common.no"),
+      });
+      if (confirm) {
+        try {
+          this._loadingMessage = this.hass.localize(
+            "ui.panel.app.app_starting"
+          );
+          await startHassioAddon(this.hass, addonSlug);
+          this._fetchData(addonSlug);
+          return;
+        } catch (_err) {
+          await showAlertDialog(this, {
+            text: this.hass.localize("ui.panel.app.error_starting_app"),
+            title: addon.name,
+          });
+          await nextRender();
+          navigate("/", { replace: true });
+          return;
+        }
+      } else {
+        await nextRender();
+        navigate("/", { replace: true });
+        return;
+      }
+    }
+
+    if (addon.state === "startup") {
+      // Addon is starting up, wait for it to start
+      this._loadingMessage = this.hass.localize("ui.panel.app.app_starting");
+
+      this._fetchDataTimeout = window.setTimeout(() => {
+        this._fetchData(addonSlug);
+      }, 500);
+      return;
+    }
+
+    if (addon.state !== "started") {
+      return;
+    }
+
+    this._loadingMessage = undefined;
+
+    if (this._fetchDataTimeout) {
+      clearInterval(this._fetchDataTimeout);
+      this._fetchDataTimeout = undefined;
+    }
+
+    let session: string;
+
+    try {
+      session = await createSessionPromise;
+    } catch (_err: any) {
+      if (this._sessionKeepAlive) {
+        clearInterval(this._sessionKeepAlive);
+      }
+      await showAlertDialog(this, {
+        text: this.hass.localize("ui.panel.app.error_creating_session"),
+        title: addon.name,
+      });
+      await nextRender();
+      navigate("/", { replace: true });
+      return;
+    }
+
+    if (this._sessionKeepAlive) {
+      clearInterval(this._sessionKeepAlive);
+    }
+    this._sessionKeepAlive = window.setInterval(async () => {
+      try {
+        await validateHassioSession(this.hass, session);
+      } catch (_err: any) {
+        session = await createHassioSession(this.hass);
+      }
+    }, 60000);
+
+    this._addon = addon;
+  }
+
+  private async _checkLoaded(ev): Promise<void> {
+    if (!this._addon) {
+      return;
+    }
+    if (ev.target.contentDocument.body.textContent === "502: Bad Gateway") {
+      await this.updateComplete;
+      showConfirmationDialog(this, {
+        text: this.hass.localize("ui.panel.app.error_app_not_ready"),
+        title: this._addon.name,
+        confirmText: this.hass.localize("ui.panel.app.retry"),
+        dismissText: this.hass.localize("ui.common.no"),
+        confirm: async () => {
+          const addon = this._addon;
+          this._addon = undefined;
+          await Promise.all([
+            this.updateComplete,
+            new Promise((resolve) => {
+              setTimeout(resolve, 500);
+            }),
+          ]);
+          this._addon = addon;
+        },
+      });
+    }
+  }
+
+  private _toggleMenu(): void {
+    fireEvent(this, "hass-toggle-menu");
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+      height: 100%;
+    }
+
+    iframe {
+      display: block;
+      width: 100%;
+      height: 100%;
+      border: 0;
+    }
+
+    .header + iframe {
+      height: calc(100% - 40px);
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      font-size: var(--ha-font-size-l);
+      height: 40px;
+      padding: 0 16px;
+      pointer-events: none;
+      background-color: var(--app-header-background-color);
+      font-weight: var(--ha-font-weight-normal);
+      color: var(--app-header-text-color, white);
+      border-bottom: var(--app-header-border-bottom, none);
+      box-sizing: border-box;
+      --mdc-icon-size: 20px;
+    }
+
+    .main-title {
+      margin: var(--margin-title);
+      line-height: var(--ha-line-height-condensed);
+      flex-grow: 1;
+    }
+
+    ha-icon-button {
+      pointer-events: auto;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-panel-app": HaPanelApp;
+  }
+}

--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -135,8 +135,12 @@ class HaPanelApp extends LitElement {
 
     const addon = this._getAddonSlug();
 
-    const oldRoute = changedProps.get("route") as this["route"] | undefined;
-    const oldPanel = changedProps.get("panel") as this["panel"] | undefined;
+    const oldRoute = changedProps.has("route")
+      ? (changedProps.get("route") as this["route"] | undefined)
+      : this.route;
+    const oldPanel = changedProps.has("panel")
+      ? (changedProps.get("panel") as this["panel"] | undefined)
+      : this.panel;
     const oldAddon = this._getAddonSlugFromRoutePanel(oldRoute, oldPanel);
 
     if (addon && addon !== oldAddon) {
@@ -339,7 +343,7 @@ class HaPanelApp extends LitElement {
   }
 
   private async _reloadIframe(): Promise<void> {
-    const addon = this._addon;
+    const addonSlug = this._addon!.slug;
     this._addon = undefined;
     await Promise.all([
       this.updateComplete,
@@ -347,7 +351,10 @@ class HaPanelApp extends LitElement {
         setTimeout(resolve, 1000);
       }),
     ]);
-    this._addon = addon;
+    // Guard for user navigating away during the delay
+    if (this._getAddonSlug() === addonSlug) {
+      this._fetchData(addonSlug);
+    }
   }
 
   private _toggleMenu(): void {

--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -48,7 +48,7 @@ class HaPanelApp extends LitElement {
 
   @state() private _loadingMessage?: string;
 
-  @state() private _hideToolbar = false;
+  @state() private _kioskMode = false;
 
   private _sessionKeepAlive?: number;
 
@@ -103,7 +103,7 @@ class HaPanelApp extends LitElement {
 
     // Make sure this all is 1 template so hiding toolbar doesn't reload iframe
     return html`
-      ${!this._hideToolbar &&
+      ${!this._kioskMode &&
       (this.narrow || this.hass.dockedSidebar === "always_hidden")
         ? html`
             <div class="header">
@@ -146,7 +146,7 @@ class HaPanelApp extends LitElement {
     if (addon && addon !== oldAddon) {
       this._loadingMessage = undefined;
       // Reset state when switching addons
-      this._hideToolbar = false;
+      this._kioskMode = false;
       this._iframeSubscribeUpdates = false;
       this._autoRetryUntil = undefined;
       this._fetchData(addon);
@@ -378,13 +378,13 @@ class HaPanelApp extends LitElement {
 
       case "home-assistant/subscribe-properties":
         this._iframeSubscribeUpdates = true;
-        this._hideToolbar = data.hideToolbar ?? false;
+        this._kioskMode = data.kioskMode ?? false;
         this._sendPropertiesToIframe();
         break;
 
       case "home-assistant/unsubscribe-properties":
         this._iframeSubscribeUpdates = false;
-        this._hideToolbar = false;
+        this._kioskMode = false;
         break;
     }
   };

--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -50,6 +50,8 @@ class HaPanelApp extends LitElement {
 
   @state() private _kioskMode = false;
 
+  private _enabledKioskMode = false;
+
   private _sessionKeepAlive?: number;
 
   private _fetchDataTimeout?: number;
@@ -73,6 +75,11 @@ class HaPanelApp extends LitElement {
     ) {
       this._sendPropertiesToIframe();
     }
+
+    const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+    if (oldHass && oldHass.kioskMode !== this.hass.kioskMode) {
+      this._kioskMode = this.hass.kioskMode;
+    }
   }
 
   public connectedCallback() {
@@ -91,6 +98,9 @@ class HaPanelApp extends LitElement {
     if (this._fetchDataTimeout) {
       clearTimeout(this._fetchDataTimeout);
       this._fetchDataTimeout = undefined;
+    }
+    if (this._enabledKioskMode) {
+      fireEvent(window, "hass-kiosk-mode", { enable: false });
     }
   }
 
@@ -146,7 +156,10 @@ class HaPanelApp extends LitElement {
     if (addon && addon !== oldAddon) {
       this._loadingMessage = undefined;
       // Reset state when switching addons
-      this._kioskMode = false;
+      if (this._enabledKioskMode) {
+        fireEvent(window, "hass-kiosk-mode", { enable: false });
+        this._enabledKioskMode = false;
+      }
       this._iframeSubscribeUpdates = false;
       this._autoRetryUntil = undefined;
       this._fetchData(addon);
@@ -378,13 +391,19 @@ class HaPanelApp extends LitElement {
 
       case "home-assistant/subscribe-properties":
         this._iframeSubscribeUpdates = true;
-        this._kioskMode = data.kioskMode ?? false;
         this._sendPropertiesToIframe();
+        if (data.kioskMode && !this.hass.kioskMode) {
+          this._enabledKioskMode = true;
+          fireEvent(window, "hass-kiosk-mode", { enable: true });
+        }
         break;
 
       case "home-assistant/unsubscribe-properties":
         this._iframeSubscribeUpdates = false;
-        this._kioskMode = false;
+        if (this._enabledKioskMode) {
+          fireEvent(window, "hass-kiosk-mode", { enable: false });
+          this._enabledKioskMode = false;
+        }
         break;
     }
   };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2249,6 +2249,17 @@
       "reset_confirmation": "Are you sure you want to reset the sidebar to its default configuration? This will restore the original order and visibility of all panels."
     },
     "panel": {
+      "app": {
+        "error_app_not_installed": "The app is not installed. Please install it first.",
+        "error_app_no_ingress": "This app does not support ingress.",
+        "error_app_not_running": "The app is not running. Do you want to start it now?",
+        "start_app": "Start app",
+        "app_starting": "The app is starting, this can take some time...",
+        "error_starting_app": "Error starting the app",
+        "error_creating_session": "Unable to create an ingress session",
+        "error_app_not_ready": "The app seems to not be ready, it might still be starting. Do you want to try again?",
+        "retry": "Retry"
+      },
       "home": {
         "editor": {
           "title": "Edit home page",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Currently the ingress logic still lives in the  panel hosted by the supervisor. This PR makes it available inside Home Assistant without needing the `hassio` JavaScript or iframe inside an iframe.

As we're having an architecture discussion to rename add-ons to apps, I have named the panel app.

Also added the option to configure the add-on in the panel config, so backend can choose to register panels directly (debug UIs of Z-Wave, Matter, MQTT come to mind).

<img width="2744" height="2194" alt="CleanShot 2025-11-29 at 16 21 10@2x" src="https://github.com/user-attachments/assets/021933f3-19c5-48be-bb89-01e1f07f07cc" />

There is also an option for Home Assistant aware apps to subscribe to the narrow property, to allow hiding the toolbar on mobile, and provide their own interface. To do so, they can call the following functions from their embedded website:

```ts
export function toggleHomeAssistantMenu() {
  window.parent.postMessage({ type: "home-assistant/toggle-menu" }, "*");
}
export function subscribeHomeAssistantProperties(callback) {
  const handler = (event) => {
    if (event.data.type === "home-assistant/properties") {
      callback(event.data);
    }
  };
  window.addEventListener("message", handler);
  window.parent.postMessage({ type: "home-assistant/subscribe-properties", kioskMode: true }, "*");
  return () => {
    window.removeEventListener("message", handler);
    window.parent.postMessage({ type: "home-assistant/unsubscribe-properties" }, "*");
  }
}
export function navigateHomeAssistant(path, options = {}) {
  window.parent.postMessage({ type: "home-assistant/navigate", path, options }, "*");
}
```

And a test HTML I used for local testing:

```html
<html>
  <button id="toggleMenu">Toggle Menu</button>
  <button id="navigate">Navigate</button><br />
  <button id="unsubscribe">Unsubscribe</button><br />
  Narrow: <span id="narrow"></span><br />
  Route: <span id="route"></span><br />
  <script>
    // Raw commands:
    document.getElementById("toggleMenu").addEventListener("click", () => {
      window.parent.postMessage({ type: "home-assistant/toggle-menu" }, "*");
    });
    document.getElementById("navigate").addEventListener("click", () => {
      window.parent.postMessage({ type: "home-assistant/navigate", path: "/app/d5369777_music_assistant_beta/" + Math.random() }, "*");
    });
    window.addEventListener("message", (event) => {
      if (event.data.type === "home-assistant/properties") {
        document.getElementById("narrow").textContent = event.data.narrow;
        document.getElementById("route").textContent = JSON.stringify(event.data.route);
      }
    });
    window.parent.postMessage({ type: "home-assistant/subscribe-properties", kioskMode: true }, "*");
    document.getElementById("unsubscribe").addEventListener("click", () => {
      window.parent.postMessage({ type: "home-assistant/unsubscribe-properties" }, "*");
    });
  </script>
</html>
```

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an App panel that embeds add-on ingress with session handling and messaging, extracts route-tail util, wires panel into router, updates build alias, and adds i18n strings.
> 
> - **Panels**:
>   - `src/panels/app/ha-panel-app.ts`: New App panel embedding add-on ingress in an iframe with session creation/keepalive, auto-start/retry flow, narrow toolbar handling, and postMessage API (`navigate`, `toggle-menu`, subscribe/unsubscribe to `narrow`/`route`).
> - **Routing/Layout**:
>   - Extract `computeRouteTail` to `src/data/route.ts` and reuse in `hass-router-page` and App panel.
>   - `partial-panel-resolver`: Register `app` component and prevent disconnecting `app` panels when hidden.
> - **Build**:
>   - `build-scripts/rspack.cjs`: Add alias for `lit/directives/ref`.
> - **i18n**:
>   - `src/translations/en.json`: Add `ui.panel.app.*` strings for errors, start/retry text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 974ea2663f41424f590a51e91c665ada0ba61a03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->