### PR TITLE
fix stacking of multiple power sources

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
@@ -323,9 +323,9 @@ export class HuiPowerSourcesGraphCard
     const negative: [number, number][] = [];
     Object.entries(data).forEach(([x, y]) => {
       const ts = Number(x);
-      const meanY = y.reduce((a, b) => a + b, 0) / y.length;
-      positive.push([ts, Math.max(0, meanY)]);
-      negative.push([ts, Math.min(0, meanY)]);
+      const sumY = y.reduce((a, b) => a + b, 0);
+      positive.push([ts, Math.max(0, sumY)]);
+      negative.push([ts, Math.min(0, sumY)]);
     });
     return { positive, negative };
   }


### PR DESCRIPTION
## Proposed change
The power sources should be stacked and thus added, not averaged. This allows for multiple power sources per category (solar, battery, grid).


## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
