### PR TITLE
Fix energy dashboard redirect for device-consumption-only configs

### DIFF
--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -268,8 +268,10 @@ class PanelEnergy extends LitElement {
       (source) => source.type === "gas"
     );
 
+    const hasDeviceConsumption = this._prefs.device_consumption.length > 0;
+
     const views: LovelaceViewConfig[] = [];
-    if (hasEnergy) {
+    if (hasEnergy || hasDeviceConsumption) {
       views.push(ENERGY_VIEW);
     }
     if (hasGas) {


### PR DESCRIPTION
## Summary
- Fixes energy dashboard redirecting to `/config/energy?historyBack=1` when users have only device consumption configured (no grid/solar/battery/gas/water sources)

## Problem
When users configure the energy dashboard with only device consumption tracking, navigating to `/energy` would redirect to the config page instead of showing the dashboard. This happened because `_generateLovelaceConfig()` returned an empty views array when no traditional energy sources were configured.

## Solution
Added `hasDeviceConsumption` check and included `ENERGY_VIEW` when device consumption is configured. The `energy-view-strategy` already fully supports device consumption cards (device graphs, sankey diagrams, etc.), so no additional changes were needed there.

## Test plan
- [x] Configure energy dashboard with only device consumption (no grid/solar/battery/gas/water)
- [x] Navigate to `/energy`
- [x] Verify energy dashboard displays with device consumption cards
- [ ] Verify no redirect to `/config/energy` occurs

fixes #28327