### PR TITLE
Use non-admin endpoint to subscribe to one lab feature

### DIFF
--- a/src/components/ha-snowflakes.ts
+++ b/src/components/ha-snowflakes.ts
@@ -31,8 +31,8 @@ export class HaSnowflakes extends SubscribeMixin(LitElement) {
         this.hass!.connection,
         "frontend",
         "winter_mode",
-        (enabled) => {
-          this._enabled = enabled;
+        (feature) => {
+          this._enabled = feature.enabled;
         }
       ),
     ];

--- a/src/data/labs.ts
+++ b/src/data/labs.ts
@@ -101,22 +101,18 @@ export const subscribeLabFeatures = (
  * Subscribe to a specific lab feature
  * @param conn - The connection to the Home Assistant instance
  * @param domain - The domain of the lab feature
- * @param previewFeature - The preview feature of the lab feature
+ * @param previewFeature - The preview feature identifier
  * @param onChange - The function to call when the lab feature changes
- * @returns The unsubscribe function
+ * @returns A promise that resolves to the unsubscribe function
  */
 export const subscribeLabFeature = (
   conn: Connection,
   domain: string,
   previewFeature: string,
-  onChange: (enabled: boolean) => void
-) =>
-  subscribeLabFeatures(conn, (features) => {
-    const enabled =
-      features.find(
-        (feature) =>
-          feature.domain === domain &&
-          feature.preview_feature === previewFeature
-      )?.enabled ?? false;
-    onChange(enabled);
+  onChange: (feature: LabPreviewFeature) => void
+): Promise<() => void> =>
+  conn.subscribeMessage<LabPreviewFeature>(onChange, {
+    type: "labs/subscribe",
+    domain,
+    preview_feature: previewFeature,
   });

--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -228,7 +228,7 @@ class DialogAddAutomationElement
 
   private _unsub?: Promise<UnsubscribeFunc>;
 
-  private _unsubscribeLabFeatures?: UnsubscribeFunc;
+  private _unsubscribeLabFeatures?: Promise<UnsubscribeFunc>;
 
   private _configEntryLookup: Record<string, ConfigEntry> = {};
 
@@ -285,8 +285,8 @@ class DialogAddAutomationElement
       this.hass.connection,
       "automation",
       "new_triggers_conditions",
-      (enabled) => {
-        this._newTriggersAndConditions = enabled;
+      (feature) => {
+        this._newTriggersAndConditions = feature.enabled;
         this._tab = this._newTriggersAndConditions ? "targets" : "groups";
       }
     );
@@ -422,7 +422,7 @@ class DialogAddAutomationElement
       this._unsub = undefined;
     }
     if (this._unsubscribeLabFeatures) {
-      this._unsubscribeLabFeatures();
+      this._unsubscribeLabFeatures.then((unsub) => unsub());
       this._unsubscribeLabFeatures = undefined;
     }
   }

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -94,8 +94,8 @@ export default class HaAutomationCondition extends SubscribeMixin(LitElement) {
         this.hass!.connection,
         "automation",
         "new_triggers_conditions",
-        (enabled) => {
-          this._newTriggersAndConditions = enabled;
+        (feature) => {
+          this._newTriggersAndConditions = feature.enabled;
         }
       ),
     ];

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -89,8 +89,8 @@ export default class HaAutomationTrigger extends SubscribeMixin(LitElement) {
         this.hass!.connection,
         "automation",
         "new_triggers_conditions",
-        (enabled) => {
-          this._newTriggersAndConditions = enabled;
+        (feature) => {
+          this._newTriggersAndConditions = feature.enabled;
         }
       ),
     ];


### PR DESCRIPTION
## Proposed change

Use non-admin endpoint to subscribe to one lab feature
- Needs core : https://github.com/home-assistant/core/pull/157976

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/28332
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
