### PR TITLE
Add "invert: false" option to cover position feature

### DIFF
--- a/src/panels/lovelace/card-features/hui-cover-position-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-cover-position-card-feature.ts
@@ -103,7 +103,7 @@ class HuiCoverPositionCardFeature
         min="0"
         max="100"
         step="1"
-        inverted
+        ?inverted=${this._config?.invert !== false}
         show-handle
         @value-changed=${this._valueChanged}
         .label=${computeAttributeNameDisplay(

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -16,6 +16,7 @@ export interface CoverOpenCloseCardFeatureConfig {
 
 export interface CoverPositionCardFeatureConfig {
   type: "cover-position";
+  invert?: boolean;
 }
 
 export interface CoverTiltCardFeatureConfig {


### PR DESCRIPTION
## Proposed change

The feature for cover position has the slider "inverted". I understand the reason of this decision, but this is driving me crazy since the beginning and I'm not the only one: https://community.home-assistant.io/t/reverse-slider-display/746748 so I decided to add an "optional" parameter to disable the inversion.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Simply a new optional `invert` option is available. If false, then the inversion disappears.
```yaml
features:
  - type: "cover-position"
    invert: false
```

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://community.home-assistant.io/t/reverse-slider-display/746748
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/42348

## Checklist

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
