### PR TITLE
Add Polarity Invert option to Power sensors in Energy dashboard

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -158,6 +158,7 @@ export interface SolarSourceTypeEnergyPreference {
 
   stat_energy_from: string;
   stat_rate?: string;
+  stat_rate_negate?: boolean;
   config_entry_solar_forecast: string[] | null;
 }
 

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -58,7 +58,7 @@ export const emptyFlowToGridSourceEnergyPreference =
 export const emptyGridPowerSourceEnergyPreference =
   (): GridPowerSourceEnergyPreference => ({
     stat_rate: "",
-    stat_negate: false,
+    stat_rate_negate: false,
   });
 
 export const emptyGridSourceEnergyPreference =
@@ -140,7 +140,7 @@ export interface FlowToGridSourceEnergyPreference {
 export interface GridPowerSourceEnergyPreference {
   // W meter
   stat_rate: string;
-  stat_negate?: boolean;
+  stat_rate_negate?: boolean;
 }
 
 export interface GridSourceTypeEnergyPreference {
@@ -166,7 +166,7 @@ export interface BatterySourceTypeEnergyPreference {
   stat_energy_from: string;
   stat_energy_to: string;
   stat_rate?: string;
-  stat_negate?: boolean;
+  stat_rate_negate?: boolean;
 }
 export interface GasSourceTypeEnergyPreference {
   type: "gas";

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -1373,16 +1373,21 @@ export const calculateSolarConsumedGauge = (
 /**
  * Get current power value from entity state, normalized to kW
  * @param stateObj - The entity state object to get power value from
+ * @param negateValue - Whether a bi-directional power value should be negated
  * @returns Power value in kW, or 0 if entity not found or invalid
  */
-export const getPowerFromState = (stateObj: HassEntity): number | undefined => {
+export const getPowerFromState = (
+  stateObj: HassEntity,
+  negateValue = false
+): number | undefined => {
   if (!stateObj) {
     return undefined;
   }
-  const value = parseFloat(stateObj.state);
+  let value = parseFloat(stateObj.state);
   if (isNaN(value)) {
     return undefined;
   }
+  if (negateValue) value = -value;
 
   // Normalize to kW based on unit of measurement (case-sensitive)
   // Supported units: GW, kW, MW, mW, TW, W

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -1374,15 +1374,22 @@ export const calculateSolarConsumedGauge = (
 /**
  * Get current power value from entity state, normalized to kW
  * @param stateObj - The entity state object to get power value from
+ * @param invertFlow - Whether to reverse the direction of the power flow
  * @returns Power value in kW, or 0 if entity not found or invalid
  */
-export const getPowerFromState = (stateObj: HassEntity): number | undefined => {
+export const getPowerFromState = (
+  stateObj: HassEntity,
+  invertFlow = false
+): number | undefined => {
   if (!stateObj) {
     return undefined;
   }
-  const value = parseFloat(stateObj.state);
+  let value = parseFloat(stateObj.state);
   if (isNaN(value)) {
     return undefined;
+  }
+  if (invertFlow) {
+    value = -value;
   }
 
   // Normalize to kW based on unit of measurement (case-sensitive)

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -55,6 +55,12 @@ export const emptyFlowToGridSourceEnergyPreference =
     number_energy_price: null,
   });
 
+export const emptyGridPowerSourceEnergyPreference =
+  (): GridPowerSourceEnergyPreference => ({
+    stat_rate: "",
+    stat_negate: false,
+  });
+
 export const emptyGridSourceEnergyPreference =
   (): GridSourceTypeEnergyPreference => ({
     type: "grid",
@@ -134,6 +140,7 @@ export interface FlowToGridSourceEnergyPreference {
 export interface GridPowerSourceEnergyPreference {
   // W meter
   stat_rate: string;
+  stat_negate?: boolean;
 }
 
 export interface GridSourceTypeEnergyPreference {
@@ -159,6 +166,7 @@ export interface BatterySourceTypeEnergyPreference {
   stat_energy_from: string;
   stat_energy_to: string;
   stat_rate?: string;
+  stat_negate?: boolean;
 }
 export interface GasSourceTypeEnergyPreference {
   type: "gas";

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -1374,21 +1374,16 @@ export const calculateSolarConsumedGauge = (
 /**
  * Get current power value from entity state, normalized to kW
  * @param stateObj - The entity state object to get power value from
- * @param negateValue - Whether a bi-directional power value should be negated
  * @returns Power value in kW, or 0 if entity not found or invalid
  */
-export const getPowerFromState = (
-  stateObj: HassEntity,
-  negateValue = false
-): number | undefined => {
+export const getPowerFromState = (stateObj: HassEntity): number | undefined => {
   if (!stateObj) {
     return undefined;
   }
-  let value = parseFloat(stateObj.state);
+  const value = parseFloat(stateObj.state);
   if (isNaN(value)) {
     return undefined;
   }
-  if (negateValue) value = -value;
 
   // Normalize to kW based on unit of measurement (case-sensitive)
   // Supported units: GW, kW, MW, mW, TW, W

--- a/src/panels/config/energy/dialogs/dialog-energy-battery-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-battery-settings.ts
@@ -4,8 +4,11 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-statistic-picker";
-import "../../../../components/ha-dialog";
 import "../../../../components/ha-button";
+import "../../../../components/ha-checkbox";
+import type { HaCheckbox } from "../../../../components/ha-checkbox";
+import "../../../../components/ha-dialog";
+import "../../../../components/ha-formfield";
 import type { BatterySourceTypeEnergyPreference } from "../../../../data/energy";
 import {
   emptyBatteryEnergyPreference,
@@ -148,6 +151,19 @@ export class DialogEnergyBatterySettings
             { unit: this._power_units?.join(", ") || "" }
           )}
         ></ha-statistic-picker>
+        <ha-formfield
+          .label=${html`<div style="display: flex; align-items: center;">
+            ${this.hass.localize(
+              "ui.panel.config.energy.battery.dialog.power_negate"
+            )}
+          </div>`}
+        >
+          <ha-checkbox
+            @change=${this._powerNegateChanged}
+            .checked=${!!this._source?.stat_negate}
+          >
+          </ha-checkbox>
+        </ha-formfield>
 
         <ha-button
           appearance="plain"
@@ -174,6 +190,14 @@ export class DialogEnergyBatterySettings
 
   private _statisticFromChanged(ev: CustomEvent<{ value: string }>) {
     this._source = { ...this._source!, stat_energy_from: ev.detail.value };
+  }
+
+  private _powerNegateChanged(ev) {
+    const input = ev.currentTarget as HaCheckbox;
+    this._source = {
+      ...this._source!,
+      stat_negate: input.checked,
+    };
   }
 
   private _powerChanged(ev: CustomEvent<{ value: string }>) {

--- a/src/panels/config/energy/dialogs/dialog-energy-battery-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-battery-settings.ts
@@ -160,7 +160,7 @@ export class DialogEnergyBatterySettings
         >
           <ha-checkbox
             @change=${this._powerNegateChanged}
-            .checked=${!!this._source?.stat_negate}
+            .checked=${!!this._source?.stat_rate_negate}
           >
           </ha-checkbox>
         </ha-formfield>
@@ -196,7 +196,7 @@ export class DialogEnergyBatterySettings
     const input = ev.currentTarget as HaCheckbox;
     this._source = {
       ...this._source!,
-      stat_negate: input.checked,
+      stat_rate_negate: input.checked,
     };
   }
 

--- a/src/panels/config/energy/dialogs/dialog-energy-grid-power-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-grid-power-settings.ts
@@ -4,10 +4,16 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-statistic-picker";
-import "../../../../components/ha-dialog";
 import "../../../../components/ha-button";
+import "../../../../components/ha-checkbox";
+import type { HaCheckbox } from "../../../../components/ha-checkbox";
+import "../../../../components/ha-dialog";
+import "../../../../components/ha-formfield";
 import type { GridPowerSourceEnergyPreference } from "../../../../data/energy";
-import { energyStatisticHelpUrl } from "../../../../data/energy";
+import {
+  energyStatisticHelpUrl,
+  emptyGridPowerSourceEnergyPreference,
+} from "../../../../data/energy";
 import { getSensorDeviceClassConvertibleUnits } from "../../../../data/sensor";
 import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
 import { haStyleDialog } from "../../../../resources/styles";
@@ -97,7 +103,19 @@ export class DialogEnergyGridPowerSettings
           )}
           dialogInitialFocus
         ></ha-statistic-picker>
-
+        <ha-formfield
+          .label=${html`<div style="display: flex; align-items: center;">
+            ${this.hass.localize(
+              "ui.panel.config.energy.grid.power_dialog.power_negate"
+            )}
+          </div>`}
+        >
+          <ha-checkbox
+            @change=${this._powerNegateChanged}
+            .checked=${!!this._source?.stat_negate}
+          >
+          </ha-checkbox>
+        </ha-formfield>
         <ha-button
           appearance="plain"
           @click=${this.closeDialog}
@@ -114,6 +132,14 @@ export class DialogEnergyGridPowerSettings
         </ha-button>
       </ha-dialog>
     `;
+  }
+
+  private _powerNegateChanged(ev) {
+    const input = ev.currentTarget as HaCheckbox;
+    this._source = {
+      ...this._source!,
+      stat_negate: input.checked,
+    };
   }
 
   private _powerStatisticChanged(ev: CustomEvent<{ value: string }>) {

--- a/src/panels/config/energy/dialogs/dialog-energy-grid-power-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-grid-power-settings.ts
@@ -37,7 +37,9 @@ export class DialogEnergyGridPowerSettings
     params: EnergySettingsGridPowerDialogParams
   ): Promise<void> {
     this._params = params;
-    this._source = params.source ? { ...params.source } : { stat_rate: "" };
+    this._source = params.source
+      ? { ...params.source }
+      : emptyGridPowerSourceEnergyPreference();
 
     const initialSourceIdPower = this._source.stat_rate;
 

--- a/src/panels/config/energy/dialogs/dialog-energy-grid-power-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-grid-power-settings.ts
@@ -112,7 +112,7 @@ export class DialogEnergyGridPowerSettings
         >
           <ha-checkbox
             @change=${this._powerNegateChanged}
-            .checked=${!!this._source?.stat_negate}
+            .checked=${!!this._source?.stat_rate_negate}
           >
           </ha-checkbox>
         </ha-formfield>
@@ -138,7 +138,7 @@ export class DialogEnergyGridPowerSettings
     const input = ev.currentTarget as HaCheckbox;
     this._source = {
       ...this._source!,
-      stat_negate: input.checked,
+      stat_rate_negate: input.checked,
     };
   }
 

--- a/src/panels/config/energy/dialogs/dialog-energy-solar-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-solar-settings.ts
@@ -135,6 +135,19 @@ export class DialogEnergySolarSettings
             { unit: this._power_units?.join(", ") || "" }
           )}
         ></ha-statistic-picker>
+        <ha-formfield
+          .label=${html`<div style="display: flex; align-items: center;">
+            ${this.hass.localize(
+              "ui.panel.config.energy.solar.dialog.solar_production_power_negate"
+            )}
+          </div>`}
+        >
+          <ha-checkbox
+            @change=${this._powerNegateChanged}
+            .checked=${!!this._source?.stat_rate_negate}
+          >
+          </ha-checkbox>
+        </ha-formfield>
 
         <h3>
           ${this.hass.localize(
@@ -291,6 +304,14 @@ export class DialogEnergySolarSettings
 
   private _powerStatisticChanged(ev: CustomEvent<{ value: string }>) {
     this._source = { ...this._source!, stat_rate: ev.detail.value };
+  }
+
+  private _powerNegateChanged(ev) {
+    const input = ev.currentTarget as HaCheckbox;
+    this._source = {
+      ...this._source!,
+      stat_rate_negate: input.checked,
+    };
   }
 
   private async _save() {

--- a/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
@@ -507,7 +507,10 @@ class HuiPowerSankeyCard
       .forEach((source) => {
         if (source.type === "grid" && source.power) {
           source.power.forEach((powerSource) => {
-            const value = this._getCurrentPower(powerSource.stat_rate);
+            const value = this._getCurrentPower(
+              powerSource.stat_rate,
+              !!powerSource.stat_negate
+            );
             if (value > 0) {
               from_grid += value;
             } else if (value < 0) {
@@ -522,7 +525,10 @@ class HuiPowerSankeyCard
       .filter((source) => source.type === "battery")
       .forEach((source) => {
         if (source.type === "battery" && source.stat_rate) {
-          const value = this._getCurrentPower(source.stat_rate);
+          const value = this._getCurrentPower(
+            source.stat_rate,
+            !!source.stat_negate
+          );
           if (value > 0) {
             from_battery += value;
           } else if (value < 0) {
@@ -723,11 +729,11 @@ class HuiPowerSankeyCard
    * @param entityId - The entity ID to get power value from
    * @returns Power value in kW, or 0 if entity not found or invalid
    */
-  private _getCurrentPower(entityId: string): number {
+  private _getCurrentPower(entityId: string, negateValue = false): number {
     // Track this entity for state change detection
     this._entities.add(entityId);
 
-    return getPowerFromState(this.hass.states[entityId]) ?? 0;
+    return getPowerFromState(this.hass.states[entityId], negateValue) ?? 0;
   }
 
   /**

--- a/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
@@ -494,7 +494,10 @@ class HuiPowerSankeyCard
       .filter((source) => source.type === "solar")
       .forEach((source) => {
         if (source.type === "solar" && source.stat_rate) {
-          const value = this._getCurrentPower(source.stat_rate);
+          const value = this._getCurrentPower(
+            source.stat_rate,
+            !!source.stat_rate_negate
+          );
           if (value > 0) {
             solar += value;
           }

--- a/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
@@ -736,7 +736,9 @@ class HuiPowerSankeyCard
     // Track this entity for state change detection
     this._entities.add(entityId);
 
-    return getPowerFromState(this.hass.states[entityId], negateValue) ?? 0;
+    let value = getPowerFromState(this.hass.states[entityId]) ?? 0;
+    if (negateValue) value = -value;
+    return value;
   }
 
   /**

--- a/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
@@ -730,15 +730,14 @@ class HuiPowerSankeyCard
   /**
    * Get current power value from entity state, normalized to kW
    * @param entityId - The entity ID to get power value from
+   * @param invertFlow - Whether to reverse the direction of the power flow
    * @returns Power value in kW, or 0 if entity not found or invalid
    */
-  private _getCurrentPower(entityId: string, negateValue = false): number {
+  private _getCurrentPower(entityId: string, invertFlow = false): number {
     // Track this entity for state change detection
     this._entities.add(entityId);
 
-    let value = getPowerFromState(this.hass.states[entityId]) ?? 0;
-    if (negateValue) value = -value;
-    return value;
+    return getPowerFromState(this.hass.states[entityId], invertFlow) ?? 0;
   }
 
   /**

--- a/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
@@ -509,7 +509,7 @@ class HuiPowerSankeyCard
           source.power.forEach((powerSource) => {
             const value = this._getCurrentPower(
               powerSource.stat_rate,
-              !!powerSource.stat_negate
+              !!powerSource.stat_rate_negate
             );
             if (value > 0) {
               from_grid += value;
@@ -527,7 +527,7 @@ class HuiPowerSankeyCard
         if (source.type === "battery" && source.stat_rate) {
           const value = this._getCurrentPower(
             source.stat_rate,
-            !!source.stat_negate
+            !!source.stat_rate_negate
           );
           if (value > 0) {
             from_battery += value;

--- a/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
@@ -226,10 +226,6 @@ export class HuiPowerSourcesGraphCard
         const { positive, negative } = this._processData(
           statIds[key].stats.map((stat: StatsArgs) => {
             let stats = energyData.stats[stat.id] ?? [];
-            const currentState = getPowerFromState(this.hass.states[stat.id]);
-            if (currentState !== undefined) {
-              stats.push({ start: now, end: now, mean: currentState });
-            }
             if (stat.negate) {
               stats = stats.map((point) => {
                 if (point.mean)
@@ -240,6 +236,13 @@ export class HuiPowerSourcesGraphCard
                   };
                 return point;
               });
+            }
+            const currentState = getPowerFromState(
+              this.hass.states[stat.id],
+              !!stat.negate
+            );
+            if (currentState !== undefined) {
+              stats.push({ start: now, end: now, mean: currentState });
             }
             return stats;
           })

--- a/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
@@ -187,7 +187,10 @@ export class HuiPowerSourcesGraphCard
 
       if (source.type === "battery") {
         if (source.stat_rate) {
-          statIds.battery.stats.push({ id: source.stat_rate });
+          statIds.battery.stats.push({
+            id: source.stat_rate,
+            negate: !!source.stat_rate_negate,
+          });
         }
         continue;
       }

--- a/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
@@ -146,23 +146,28 @@ export class HuiPowerSourcesGraphCard
     const datasets: LineSeriesOption[] = [];
     this._legendData = [];
 
+    interface StatsArgs {
+      id: string;
+      negate?: boolean;
+    }
+
     const statIds = {
       solar: {
-        stats: [] as string[],
+        stats: [] as StatsArgs[],
         color: "--energy-solar-color",
         name: this.hass.localize(
           "ui.panel.lovelace.cards.energy.power_graph.solar"
         ),
       },
       grid: {
-        stats: [] as string[],
+        stats: [] as StatsArgs[],
         color: "--energy-grid-consumption-color",
         name: this.hass.localize(
           "ui.panel.lovelace.cards.energy.power_graph.grid"
         ),
       },
       battery: {
-        stats: [] as string[],
+        stats: [] as StatsArgs[],
         color: "--energy-battery-out-color",
         name: this.hass.localize(
           "ui.panel.lovelace.cards.energy.power_graph.battery"
@@ -175,20 +180,25 @@ export class HuiPowerSourcesGraphCard
     for (const source of energyData.prefs.energy_sources) {
       if (source.type === "solar") {
         if (source.stat_rate) {
-          statIds.solar.stats.push(source.stat_rate);
+          statIds.solar.stats.push({ id: source.stat_rate });
         }
         continue;
       }
 
       if (source.type === "battery") {
         if (source.stat_rate) {
-          statIds.battery.stats.push(source.stat_rate);
+          statIds.battery.stats.push({ id: source.stat_rate });
         }
         continue;
       }
 
       if (source.type === "grid" && source.power) {
-        statIds.grid.stats.push(...source.power.map((p) => p.stat_rate));
+        statIds.grid.stats.push(
+          ...source.power.map((power) => ({
+            id: power.stat_rate,
+            negate: !!power.stat_negate,
+          }))
+        );
       }
     }
     const commonSeriesOptions: LineSeriesOption = {
@@ -208,9 +218,12 @@ export class HuiPowerSourcesGraphCard
         // Echarts is supposed to handle that but it is bugged when you use it together with stacking.
         // The interpolation breaks the stacking, so this positive/negative is a workaround
         const { positive, negative } = this._processData(
-          statIds[key].stats.map((id: string) => {
-            const stats = energyData.stats[id] ?? [];
-            const currentState = getPowerFromState(this.hass.states[id]);
+          statIds[key].stats.map((stat: StatsArgs) => {
+            const stats = energyData.stats[stat.id] ?? [];
+            const currentState = getPowerFromState(
+              this.hass.states[stat.id],
+              !!stat.negate
+            );
             if (currentState !== undefined) {
               stats.push({ start: now, end: now, mean: currentState });
             }

--- a/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
@@ -196,7 +196,7 @@ export class HuiPowerSourcesGraphCard
         statIds.grid.stats.push(
           ...source.power.map((power) => ({
             id: power.stat_rate,
-            negate: !!power.stat_negate,
+            negate: !!power.stat_rate_negate,
           }))
         );
       }

--- a/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
@@ -180,7 +180,10 @@ export class HuiPowerSourcesGraphCard
     for (const source of energyData.prefs.energy_sources) {
       if (source.type === "solar") {
         if (source.stat_rate) {
-          statIds.solar.stats.push({ id: source.stat_rate });
+          statIds.solar.stats.push({
+            id: source.stat_rate,
+            negate: !!source.stat_rate_negate,
+          });
         }
         continue;
       }

--- a/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
@@ -225,13 +225,21 @@ export class HuiPowerSourcesGraphCard
         // The interpolation breaks the stacking, so this positive/negative is a workaround
         const { positive, negative } = this._processData(
           statIds[key].stats.map((stat: StatsArgs) => {
-            const stats = energyData.stats[stat.id] ?? [];
-            const currentState = getPowerFromState(
-              this.hass.states[stat.id],
-              !!stat.negate
-            );
+            let stats = energyData.stats[stat.id] ?? [];
+            const currentState = getPowerFromState(this.hass.states[stat.id]);
             if (currentState !== undefined) {
               stats.push({ start: now, end: now, mean: currentState });
+            }
+            if (stat.negate) {
+              stats = stats.map((point) => {
+                if (point.mean)
+                  return {
+                    start: point.start,
+                    end: point.end,
+                    mean: -point.mean,
+                  };
+                return point;
+              });
             }
             return stats;
           })

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3112,7 +3112,7 @@
             "power_dialog": {
               "header": "Configure grid power",
               "power_stat": "Power sensor",
-              "power_negate": "Invert bi-directional power sensor polarity",
+              "power_negate": "Invert power sensor polarity",
               "power_helper": "Pick a sensor which measures grid power in either of {unit}. Positive values indicate importing electricity from the grid, negative values indicate exporting electricity to the grid. Polarity can optionally be inverted."
             },
             "flow_dialog": {
@@ -3185,7 +3185,7 @@
               "energy_into_battery": "Energy charged into the battery",
               "energy_out_of_battery": "Energy discharged from the battery",
               "power": "Battery power",
-              "power_negate": "Invert bi-directional power sensor polarity",
+              "power_negate": "Invert power sensor polarity",
               "power_helper": "Pick a sensor which measures the electricity flowing into and out of the battery in either of {unit}. Positive values indicate discharging the battery, negative values indicate charging the battery. Polarity can optionally be inverted."
             }
           },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3112,7 +3112,8 @@
             "power_dialog": {
               "header": "Configure grid power",
               "power_stat": "Power sensor",
-              "power_helper": "Pick a sensor which measures grid power in either of {unit}. Positive values indicate importing electricity from the grid, negative values indicate exporting electricity to the grid."
+              "power_negate": "Invert bi-directional power sensor polarity",
+              "power_helper": "Pick a sensor which measures grid power in either of {unit}. Positive values indicate importing electricity from the grid, negative values indicate exporting electricity to the grid. Polarity can optionally be inverted."
             },
             "flow_dialog": {
               "cost_entity_helper": "Any sensor with a unit of `{currency}/(valid energy unit)` (e.g. `{currency}/Wh` or `{currency}/kWh`) may be used and will be automatically converted.",
@@ -3184,7 +3185,8 @@
               "energy_into_battery": "Energy charged into the battery",
               "energy_out_of_battery": "Energy discharged from the battery",
               "power": "Battery power",
-              "power_helper": "Pick a sensor which measures the electricity flowing into and out of the battery in either of {unit}. Positive values indicate discharging the battery, negative values indicate charging the battery."
+              "power_negate": "Invert bi-directional power sensor polarity",
+              "power_helper": "Pick a sensor which measures the electricity flowing into and out of the battery in either of {unit}. Positive values indicate discharging the battery, negative values indicate charging the battery. Polarity can optionally be inverted."
             }
           },
           "gas": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3163,6 +3163,7 @@
               "entity_para": "Pick a sensor which measures solar production in either of {unit}.",
               "solar_production_energy": "Solar production energy",
               "solar_production_power": "Solar production power",
+              "solar_production_power_negate": "Invert power sensor polarity",
               "solar_production_forecast": "Solar production forecast",
               "solar_production_forecast_description": "Adding solar production forecast information will allow you to quickly see your expected production for today.",
               "dont_forecast_production": "Don't forecast production",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

In #27373 the option to track power as well as energy was added. In the case of the Grid and Battery power sources, these are added as a single bi-directional sensor which requires a specific polarity to be meaningful. However not all integrations or hardware use the expected polarity meaning additional template sensors would need to be created to negate these values before they could be used with the energy dashboard.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

In this PR, and the associated core PR, we add the option to invert the polarity of a power sensor used for grid/battery/solar power data. This is saved in the preferences as stat_rate_negate alongside with the stat_rate entity id.

In the dialog entries, a check-box is added to select whether to invert the polarity.

<img width="300" alt="Battery power with checked invert option" src="https://github.com/user-attachments/assets/589d53e9-0177-4d23-947d-ccb1fbb2e390" />
<img width="300" alt="Solar power with unchecked invert option" src="https://github.com/user-attachments/assets/47a6f185-5d99-451e-89a7-01469cd30b69" />
<img width="300" alt="Grid power with unchecked invert option" src="https://github.com/user-attachments/assets/e9140c13-544c-4b5a-8cdc-41c7cd890f12" />

The scope was limited to these two sources as they are likely to be bidirectional. Solar and individual loads are unlikely to need inverting, though that could be added at a later date.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Core pull request: https://github.com/home-assistant/core/pull/158142
- This PR fixes or closes issue: 
  #28409 
  https://github.com/wills106/homeassistant-solax-modbus/issues/1751
  https://github.com/WillCodeForCats/solaredge-modbus-multi/issues/927
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/1915
- Link to documentation pull request:

There was a similar proposal to add a direction toggle in the comments of the original PR: https://github.com/home-assistant/core/pull/153809#issuecomment-3401538017

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
