### PR TITLE
Allow for badges to be connectedWhileHidden and for hui-badge to respond to badge-visibility-changed event

### DIFF
--- a/src/panels/lovelace/badges/hui-badge.ts
+++ b/src/panels/lovelace/badges/hui-badge.ts
@@ -67,6 +67,11 @@ export class HuiBadge extends ConditionalListenerMixin<LovelaceBadgeConfig>(
     if (this.hass) {
       this._element.hass = this.hass;
     }
+    // Update element when the visibility of the badge changes, e.g. custom badge
+    this._element.addEventListener("badge-visibility-changed", (ev: Event) => {
+      ev.stopPropagation();
+      this._updateVisibility();
+    });
     this._element.addEventListener(
       "ll-upgrade",
       (ev: Event) => {
@@ -168,7 +173,11 @@ export class HuiBadge extends ConditionalListenerMixin<LovelaceBadgeConfig>(
       fireEvent(this, "badge-visibility-changed", { value: visible });
     }
 
-    if (!visible && this._element.parentElement) {
+    if (this._element.connectedWhileHidden === true) {
+      if (!this._element.parentElement) {
+        this.appendChild(this._element);
+      }
+    } else if (!visible && this._element.parentElement) {
       this.removeChild(this._element);
     } else if (visible && !this._element.parentElement) {
       this.appendChild(this._element);

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -44,6 +44,7 @@ export interface Lovelace {
 
 export interface LovelaceBadge extends HTMLElement {
   hass?: HomeAssistant;
+  connectedWhileHidden?: boolean;
   setConfig(config: LovelaceBadgeConfig): void;
 }
 
@@ -112,7 +113,8 @@ export interface LovelaceBadgeConstructor extends Constructor<LovelaceBadge> {
   getConfigForm?: () => LovelaceConfigForm;
 }
 
-export interface LovelaceHeaderFooterConstructor extends Constructor<LovelaceHeaderFooter> {
+export interface LovelaceHeaderFooterConstructor
+  extends Constructor<LovelaceHeaderFooter> {
   getStubConfig?: (
     hass: HomeAssistant,
     entities: string[],
@@ -125,7 +127,8 @@ export interface LovelaceRowConstructor extends Constructor<LovelaceRow> {
   getConfigElement?: () => LovelaceRowEditor;
 }
 
-export interface LovelaceElementConstructor extends Constructor<LovelaceElement> {
+export interface LovelaceElementConstructor
+  extends Constructor<LovelaceElement> {
   getConfigElement?: () => LovelacePictureElementEditor;
   getStubConfig?: (
     hass: HomeAssistant,
@@ -149,7 +152,8 @@ export interface LovelaceBadgeEditor extends LovelaceGenericElementEditor {
   setConfig(config: LovelaceBadgeConfig): void;
 }
 
-export interface LovelaceHeaderFooterEditor extends LovelaceGenericElementEditor {
+export interface LovelaceHeaderFooterEditor
+  extends LovelaceGenericElementEditor {
   setConfig(config: LovelaceHeaderFooterConfig): void;
 }
 
@@ -157,7 +161,8 @@ export interface LovelaceRowEditor extends LovelaceGenericElementEditor {
   setConfig(config: LovelaceRowConfig): void;
 }
 
-export interface LovelacePictureElementEditor extends LovelaceGenericElementEditor {
+export interface LovelacePictureElementEditor
+  extends LovelaceGenericElementEditor {
   setConfig(config: LovelaceElementConfig): void;
 }
 
@@ -180,7 +185,8 @@ export interface LovelaceCardFeature extends HTMLElement {
   position?: LovelaceCardFeaturePosition;
 }
 
-export interface LovelaceCardFeatureConstructor extends Constructor<LovelaceCardFeature> {
+export interface LovelaceCardFeatureConstructor
+  extends Constructor<LovelaceCardFeature> {
   getStubConfig?: (
     hass: HomeAssistant,
     context?: LovelaceCardFeatureContext
@@ -193,7 +199,8 @@ export interface LovelaceCardFeatureConstructor extends Constructor<LovelaceCard
   isSupported?: (stateObj?: HassEntity) => boolean;
 }
 
-export interface LovelaceCardFeatureEditor extends LovelaceGenericElementEditor {
+export interface LovelaceCardFeatureEditor
+  extends LovelaceGenericElementEditor {
   setConfig(config: LovelaceCardFeatureConfig): void;
 }
 
@@ -203,7 +210,8 @@ export interface LovelaceHeadingBadge extends HTMLElement {
   setConfig(config: LovelaceHeadingBadgeConfig);
 }
 
-export interface LovelaceHeadingBadgeConstructor extends Constructor<LovelaceHeadingBadge> {
+export interface LovelaceHeadingBadgeConstructor
+  extends Constructor<LovelaceHeadingBadge> {
   getStubConfig?: (
     hass: HomeAssistant,
     stateObj?: HassEntity
@@ -215,6 +223,7 @@ export interface LovelaceHeadingBadgeConstructor extends Constructor<LovelaceHea
   };
 }
 
-export interface LovelaceHeadingBadgeEditor extends LovelaceGenericElementEditor {
+export interface LovelaceHeadingBadgeEditor
+  extends LovelaceGenericElementEditor {
   setConfig(config: LovelaceHeadingBadgeConfig): void;
 }

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -113,8 +113,7 @@ export interface LovelaceBadgeConstructor extends Constructor<LovelaceBadge> {
   getConfigForm?: () => LovelaceConfigForm;
 }
 
-export interface LovelaceHeaderFooterConstructor
-  extends Constructor<LovelaceHeaderFooter> {
+export interface LovelaceHeaderFooterConstructor extends Constructor<LovelaceHeaderFooter> {
   getStubConfig?: (
     hass: HomeAssistant,
     entities: string[],
@@ -127,8 +126,7 @@ export interface LovelaceRowConstructor extends Constructor<LovelaceRow> {
   getConfigElement?: () => LovelaceRowEditor;
 }
 
-export interface LovelaceElementConstructor
-  extends Constructor<LovelaceElement> {
+export interface LovelaceElementConstructor extends Constructor<LovelaceElement> {
   getConfigElement?: () => LovelacePictureElementEditor;
   getStubConfig?: (
     hass: HomeAssistant,
@@ -152,8 +150,7 @@ export interface LovelaceBadgeEditor extends LovelaceGenericElementEditor {
   setConfig(config: LovelaceBadgeConfig): void;
 }
 
-export interface LovelaceHeaderFooterEditor
-  extends LovelaceGenericElementEditor {
+export interface LovelaceHeaderFooterEditor extends LovelaceGenericElementEditor {
   setConfig(config: LovelaceHeaderFooterConfig): void;
 }
 
@@ -161,8 +158,7 @@ export interface LovelaceRowEditor extends LovelaceGenericElementEditor {
   setConfig(config: LovelaceRowConfig): void;
 }
 
-export interface LovelacePictureElementEditor
-  extends LovelaceGenericElementEditor {
+export interface LovelacePictureElementEditor extends LovelaceGenericElementEditor {
   setConfig(config: LovelaceElementConfig): void;
 }
 
@@ -185,8 +181,7 @@ export interface LovelaceCardFeature extends HTMLElement {
   position?: LovelaceCardFeaturePosition;
 }
 
-export interface LovelaceCardFeatureConstructor
-  extends Constructor<LovelaceCardFeature> {
+export interface LovelaceCardFeatureConstructor extends Constructor<LovelaceCardFeature> {
   getStubConfig?: (
     hass: HomeAssistant,
     context?: LovelaceCardFeatureContext
@@ -199,8 +194,7 @@ export interface LovelaceCardFeatureConstructor
   isSupported?: (stateObj?: HassEntity) => boolean;
 }
 
-export interface LovelaceCardFeatureEditor
-  extends LovelaceGenericElementEditor {
+export interface LovelaceCardFeatureEditor extends LovelaceGenericElementEditor {
   setConfig(config: LovelaceCardFeatureConfig): void;
 }
 
@@ -210,8 +204,7 @@ export interface LovelaceHeadingBadge extends HTMLElement {
   setConfig(config: LovelaceHeadingBadgeConfig);
 }
 
-export interface LovelaceHeadingBadgeConstructor
-  extends Constructor<LovelaceHeadingBadge> {
+export interface LovelaceHeadingBadgeConstructor extends Constructor<LovelaceHeadingBadge> {
   getStubConfig?: (
     hass: HomeAssistant,
     stateObj?: HassEntity
@@ -223,7 +216,6 @@ export interface LovelaceHeadingBadgeConstructor
   };
 }
 
-export interface LovelaceHeadingBadgeEditor
-  extends LovelaceGenericElementEditor {
+export interface LovelaceHeadingBadgeEditor extends LovelaceGenericElementEditor {
   setConfig(config: LovelaceHeadingBadgeConfig): void;
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Allow badges to be connectedWhileHidden and for hui-badge to respond to badge-visibility-changed event

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

cards can currently be `connectedWhileHidden` and fire the `card-visibility-changed `event, allowing them to be initially hidden via their `hidden` property but then become visible by changing the hidden property to `false` and firing `card-vibility-changed` event. This PR adds the same functionaility to badges. While no Frontend badge will use this mechanism, it will be available to custom badges.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
