### PR TITLE
Update HaGenericPicker unknown value check to handle null and empty strings

### DIFF
--- a/src/components/ha-generic-picker.ts
+++ b/src/components/ha-generic-picker.ts
@@ -246,7 +246,7 @@ export class HaGenericPicker extends LitElement {
 
   private _unknownValue = memoizeOne(
     (value?: string, items?: (PickerComboBoxItem | string)[]) => {
-      if (value === undefined || !items) {
+      if (value === undefined || value === null || value === "" || !items) {
         return false;
       }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The changes in #28372 caused unset values such as those in `entity-registry-settings-editor` where no device area is used (helpers, non-device area etc.) to show the invalid warning:
<img width="885" height="1066" alt="image" src="https://github.com/user-attachments/assets/6d4833bb-4871-4779-85c4-b71a6d3a3be4" />

This fixes that issue by allowing null or undefined values before showing warning:
<img width="901" height="1088" alt="image" src="https://github.com/user-attachments/assets/6150900e-2c9e-438e-869d-73a5d023e6bf" />

Invalid values still show warning:
<img width="1208" height="895" alt="image" src="https://github.com/user-attachments/assets/7af8af3f-345e-4b61-8688-e5cc27a503b5" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
