### PR TITLE
Support legacy table styles in markdown

### DIFF
--- a/src/components/ha-assist-chat.ts
+++ b/src/components/ha-assist-chat.ts
@@ -659,7 +659,7 @@ export class HaAssistChat extends LitElement {
       --markdown-table-border-color: var(--divider-color);
       --markdown-code-background-color: var(--primary-background-color);
       --markdown-code-text-color: var(--primary-text-color);
-      --markdown-list-indent: 1rem;
+      --markdown-list-indent: 1.15em;
       &:not(:has(ha-markdown-element)) {
         min-height: 1lh;
         min-width: 1lh;

--- a/src/components/ha-assist-chat.ts
+++ b/src/components/ha-assist-chat.ts
@@ -134,7 +134,6 @@ export class HaAssistChat extends LitElement {
               })}"
               breaks
               cache
-              assist
               .content=${message.text}
             >
             </ha-markdown>

--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -70,11 +70,6 @@ export class HaMarkdown extends LitElement {
     a {
       color: var(--markdown-link-color, var(--primary-color));
     }
-    :host([assist]) img {
-      height: auto;
-      width: auto;
-      transition: height 0.2s ease-in-out;
-    }
     img {
       background-color: var(--markdown-image-background-color);
       border-radius: var(--markdown-image-border-radius);

--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -81,8 +81,7 @@ export class HaMarkdown extends LitElement {
     p:first-child > img:last-child {
       vertical-align: top;
     }
-    :host > ul,
-    :host > ol {
+    ha-markdown-element > :is(ol, ul) {
       padding-inline-start: var(--markdown-list-indent, revert);
     }
     li {

--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -132,6 +132,18 @@ export class HaMarkdown extends LitElement {
       border-bottom: none;
       margin: var(--ha-space-4) 0;
     }
+    table[role="presentation"] {
+      --markdown-table-border-collapse: separate;
+      --markdown-table-border-width: attr(border, 0);
+      --markdown-table-padding-inline: 0;
+      --markdown-table-padding-block: 0;
+      th {
+        vertical-align: attr(align, center);
+      }
+      td {
+        vertical-align: attr(align, left);
+      }
+    }
     table {
       border-collapse: var(--markdown-table-border-collapse, collapse);
     }
@@ -139,14 +151,15 @@ export class HaMarkdown extends LitElement {
       overflow: auto;
     }
     th {
-      text-align: start;
+      text-align: var(--markdown-table-text-align, start);
     }
     td,
     th {
       border-width: var(--markdown-table-border-width, 1px);
       border-style: var(--markdown-table-border-style, solid);
       border-color: var(--markdown-table-border-color, var(--divider-color));
-      padding: 0.25em 0.5em;
+      padding-inline: var(--markdown-table-padding-inline, 0.5em);
+      padding-block: var(--markdown-table-padding-block, 0.25em);
     }
     blockquote {
       border-left: 4px solid var(--divider-color);

--- a/src/resources/markdown-worker.ts
+++ b/src/resources/markdown-worker.ts
@@ -19,6 +19,7 @@ const renderMarkdown = async (
   if (!whiteListNormal) {
     whiteListNormal = {
       ...getDefaultWhiteList(),
+      table: [...(getDefaultWhiteList().table ?? []), "role"],
       input: ["type", "disabled", "checked"],
       "ha-icon": ["icon"],
       "ha-svg-icon": ["path"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

It seems like there is a group of users who rely on the rendering behavior of the markdown card to build layouts with html tables ([#28343](https://github.com/home-assistant/frontend/issues/28343)). While the use of tables for layouts is [highly discouraged](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics#when_should_you_avoid_html_tables) and the used attributes are [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableElement#obsolete_properties), many users are frustrated by changes to the default table styles because Home Assistant does not provide an easy way to add custom styles.

In some cases users want to use them as actual data tables but are bothered by the newly added padding, which is not customizable via css variables.

_Idea (not implemented):_
Most of the negative feedback originated because borders where added to the table styles. While borderless tables are mostly a personal preference, there is a case for consistency. Maybe borders for columns should be removed and only applied for rows, like in all the other tables in the HA UI?

## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
- Let users opt out of the default theme styles for table layouts by adding the attribute role="presentation" based on [W3Cs recommendation](https://www.w3.org/TR/2014/REC-html5-20141028/tabular-data.html#:~:text=If%20a%20table%20is%20to%20be%20used%20for%20layout%20it%20must%20be%20marked%20with%20the%20attribute%20role%3D%22presentation%22).
- Add customization options for cell padding and text alignment
- Fix css selectors for list indentation
- Remove styles for images in assist because theres no realistic use case for them.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
