### PR TITLE
Add history link to statistics graph card

### DIFF
--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -8,6 +8,7 @@ import "../../../components/chart/state-history-charts";
 import "../../../components/ha-alert";
 import "../../../components/ha-card";
 import "../../../components/ha-icon-next";
+import "../../../components/ha-tooltip";
 import {
   computeHistory,
   convertStatisticsToHistory,
@@ -54,6 +55,8 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
   private _entityIds: string[] = [];
 
   private _entities: EntityConfig[] = [];
+
+  private _historyLinkId = `history-${Math.random().toString(36).substring(2, 9)}`;
 
   private _hoursToShow = DEFAULT_HOURS_TO_SHOW;
 
@@ -288,7 +291,16 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
           ? html`
               <h1 class="card-header">
                 ${this._config.title}
-                <a href=${configUrl}><ha-icon-next></ha-icon-next></a>
+                <a
+                  id=${this._historyLinkId}
+                  href=${configUrl}
+                  aria-label=${this.hass.localize("panel.history")}
+                >
+                  <ha-icon-next></ha-icon-next>
+                </a>
+                <ha-tooltip for=${this._historyLinkId} placement="left">
+                  ${this.hass.localize("panel.history")}
+                </ha-tooltip>
               </h1>
             `
           : nothing}

--- a/src/panels/lovelace/cards/hui-statistics-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-statistics-graph-card.ts
@@ -76,8 +76,6 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
 
   private _entityIds: string[] = [];
 
-  private _hoursToShow = DEFAULT_DAYS_TO_SHOW;
-
   private _historyLinkId = `history-${Math.random().toString(36).substring(2, 9)}`;
 
   private _names: Record<string, string> = {};

--- a/src/panels/lovelace/cards/hui-statistics-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-statistics-graph-card.ts
@@ -7,6 +7,7 @@ import { classMap } from "lit/directives/class-map";
 import { createSearchParam } from "../../../common/url/search-params";
 import "../../../components/ha-card";
 import "../../../components/ha-icon-next";
+import "../../../components/ha-tooltip";
 import { getEnergyDataCollection } from "../../../data/energy";
 import type {
   Statistics,
@@ -74,6 +75,10 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
   private _entities: EntityConfig[] = [];
 
   private _entityIds: string[] = [];
+
+  private _hoursToShow = DEFAULT_DAYS_TO_SHOW;
+
+  private _historyLinkId = `history-${Math.random().toString(36).substring(2, 9)}`;
 
   private _names: Record<string, string> = {};
 
@@ -298,7 +303,16 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
           ? html`
               <h1 class="card-header">
                 ${this._config.title}
-                <a href=${configUrl}><ha-icon-next></ha-icon-next></a>
+                <a
+                  id=${this._historyLinkId}
+                  href=${configUrl}
+                  aria-label=${this.hass.localize("panel.history")}
+                >
+                  <ha-icon-next></ha-icon-next>
+                </a>
+                <ha-tooltip for=${this._historyLinkId} placement="left">
+                  ${this.hass.localize("panel.history")}
+                </ha-tooltip>
               </h1>
             `
           : nothing}

--- a/src/panels/lovelace/cards/hui-statistics-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-statistics-graph-card.ts
@@ -4,7 +4,9 @@ import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import { createSearchParam } from "../../../common/url/search-params";
 import "../../../components/ha-card";
+import "../../../components/ha-icon-next";
 import { getEnergyDataCollection } from "../../../data/energy";
 import type {
   Statistics,
@@ -277,10 +279,28 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
 
     const hasFixedHeight = typeof this._config.grid_options?.rows === "number";
 
+    const daysToShow =
+      this._energyStart && this._energyEnd
+        ? differenceInDays(this._energyEnd, this._energyStart)
+        : this._config.days_to_show || DEFAULT_DAYS_TO_SHOW;
+
+    const start =
+      this._energyStart || subHours(new Date(), 24 * daysToShow + 1);
+
+    const configUrl = `/history?${createSearchParam({
+      entity_id: this._entityIds.join(","),
+      start_date: start.toISOString(),
+    })}`;
+
     return html`
       <ha-card>
         ${this._config.title
-          ? html`<h1 class="card-header">${this._config.title}</h1>`
+          ? html`
+              <h1 class="card-header">
+                ${this._config.title}
+                <a href=${configUrl}><ha-icon-next></ha-icon-next></a>
+              </h1>
+            `
           : nothing}
         <div
           class="content ${classMap({
@@ -310,9 +330,7 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
             .fitYData=${this._config.fit_y_data || false}
             .hideLegend=${this._config.hide_legend || false}
             .logarithmicScale=${this._config.logarithmic_scale || false}
-            .daysToShow=${this._energyStart && this._energyEnd
-              ? differenceInDays(this._energyEnd, this._energyStart)
-              : this._config.days_to_show || DEFAULT_DAYS_TO_SHOW}
+            .daysToShow=${daysToShow}
             .height=${hasFixedHeight ? "100%" : undefined}
             .expandLegend=${this._config.expand_legend}
           ></statistics-chart>
@@ -396,7 +414,14 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
       height: 100%;
     }
     .card-header {
+      justify-content: space-between;
+      display: flex;
       padding-bottom: 0;
+    }
+    .card-header ha-icon-next {
+      --mdc-icon-button-size: 24px;
+      line-height: 24px;
+      color: var(--primary-text-color);
     }
     .content {
       padding: 16px;


### PR DESCRIPTION
## Proposed change

This PR adds a "next" icon link to the header of the **Statistics Graph card**. 

Clicking this link navigates the user directly to the **History panel**, with the same entities and time range pre-selected. This improves the user experience by providing a quick way to transition from high-level statistics to detailed history data.

This PR makes the behavior consistent between history and statistics cards. Currently, only the history card shows a link to the history.

Additionally, this PR improves on the accessibility, adding `aria-label` and a tooltip in both cards for this link.

(The top item is a statistics card, which did not have a history link. The bottom item is a history card, which already has one.)

<img width="402" height="601" alt="Screenshot 2025-12-22 at 16 24 36" src="https://github.com/user-attachments/assets/8012c503-48c7-48c2-850a-1c539dc5cb7d" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

N/A (Uses existing Statistics Graph card configuration)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io