### PR TITLE
feat: Open more-info on statistics graph legend click

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -74,6 +74,9 @@ export class HaChartBase extends LitElement {
   @consume({ context: themesContext, subscribe: true })
   _themes!: Themes;
 
+  @property({ attribute: "external-hidden-state", type: Boolean })
+  public externalHiddenState = false;
+
   @state() private _isZoomed = false;
 
   @state() private _zoomRatio = 1;
@@ -966,6 +969,10 @@ export class HaChartBase extends LitElement {
       return;
     }
     const id = ev.currentTarget?.id;
+    if (this.externalHiddenState) {
+      fireEvent(this, "chart-legend-click", { id });
+      return;
+    }
     if (this._hiddenDatasets.has(id)) {
       this._getAllIdsFromLegend(this.options, id).forEach((i) =>
         this._hiddenDatasets.delete(i)
@@ -1143,6 +1150,7 @@ declare global {
     "dataset-hidden": { id: string };
     "dataset-unhidden": { id: string };
     "chart-click": ECElementEvent;
+    "chart-legend-click": { id: string };
     "chart-zoom": {
       start: number;
       end: number;

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -10,6 +10,7 @@ import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
 import { getGraphColorByIndex } from "../../common/color/colors";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
+import { fireEvent } from "../../common/dom/fire_event";
 
 import { formatDateTimeWithSeconds } from "../../common/datetime/format_date_time";
 import {
@@ -179,6 +180,8 @@ export class StatisticsChart extends LitElement {
         @dataset-hidden=${this._datasetHidden}
         @dataset-unhidden=${this._datasetUnhidden}
         .expandLegend=${this.expandLegend}
+        .externalHiddenState=${this.clickForMoreInfo}
+        @chart-legend-click=${this._handleLegendClick}
       ></ha-chart-base>
     `;
   }
@@ -197,6 +200,10 @@ export class StatisticsChart extends LitElement {
     }
     this._hiddenStats.delete(ev.detail.id);
     this.requestUpdate("_hiddenStats");
+  }
+
+  private _handleLegendClick(ev: CustomEvent) {
+    fireEvent(this, "hass-more-info", { entityId: ev.detail.id });
   }
 
   private _renderTooltip = (params: any) => {


### PR DESCRIPTION
Statistics Graph: Open more-info on legend click
Description
This PR changes the behavior of the legend in the Statistics Graph card. Clicking on a legend item now opens the "more-info" dialog for the corresponding entity instead of toggling the visibility of the data series.

Motivation and Context
Users often want to quickly access details about the entity displayed in the graph. The default behavior of hiding the series is less useful in the context of the Statistics Graph, where users expect to interact with the entities.

implementation Details
ha-chart-base: Added externalHiddenState property to allow consumers to override the default toggle behavior and receive a chart-legend-click event instead.
statistics-chart: Enabled externalHiddenState and implemented the event listener to fire hass-more-info.
How Has This Been Tested?
 Manual verification: Clicked legend items in a statistics graph card and verified the more-info dialog opens and the series visibility does not toggle.
Checklist:
 The code change is tested and works locally.
 Local tests pass.