### PR TITLE
Fix trace download truncation with Jinja comments

### DIFF
--- a/src/panels/config/automation/ha-automation-trace.ts
+++ b/src/panels/config/automation/ha-automation-trace.ts
@@ -46,6 +46,7 @@ import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-subpage";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant, Route } from "../../../types";
+import { fileDownload } from "../../../util/file_download";
 
 const TABS = ["details", "timeline", "logbook", "automation_config"] as const;
 
@@ -444,21 +445,21 @@ export class HaAutomationTrace extends LitElement {
   }
 
   private _downloadTrace() {
-    const aEl = document.createElement("a");
-    aEl.download = `trace ${this._entityId} ${
-      this._trace!.timestamp.start
-    }.json`;
-    aEl.href = `data:application/json;charset=utf-8,${encodeURI(
-      JSON.stringify(
-        {
-          trace: this._trace,
-          logbookEntries: this._logbookEntries,
-        },
-        undefined,
-        2
-      )
-    )}`;
-    aEl.click();
+    const json = JSON.stringify(
+      {
+        trace: this._trace,
+        logbookEntries: this._logbookEntries,
+      },
+      undefined,
+      2
+    );
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    fileDownload(
+      url,
+      `trace ${this._entityId} ${this._trace!.timestamp.start}.json`
+    );
+    URL.revokeObjectURL(url);
   }
 
   private _importTrace() {

--- a/src/panels/config/script/ha-script-trace.ts
+++ b/src/panels/config/script/ha-script-trace.ts
@@ -43,6 +43,7 @@ import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-subpage";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant, Route } from "../../../types";
+import { fileDownload } from "../../../util/file_download";
 
 @customElement("ha-script-trace")
 export class HaScriptTrace extends LitElement {
@@ -455,21 +456,21 @@ export class HaScriptTrace extends LitElement {
   }
 
   private _downloadTrace() {
-    const aEl = document.createElement("a");
-    aEl.download = `trace ${this._entityId} ${
-      this._trace!.timestamp.start
-    }.json`;
-    aEl.href = `data:application/json;charset=utf-8,${encodeURI(
-      JSON.stringify(
-        {
-          trace: this._trace,
-          logbookEntries: this._logbookEntries,
-        },
-        undefined,
-        2
-      )
-    )}`;
-    aEl.click();
+    const json = JSON.stringify(
+      {
+        trace: this._trace,
+        logbookEntries: this._logbookEntries,
+      },
+      undefined,
+      2
+    );
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    fileDownload(
+      url,
+      `trace ${this._entityId} ${this._trace!.timestamp.start}.json`
+    );
+    URL.revokeObjectURL(url);
   }
 
   private _importTrace() {


### PR DESCRIPTION
## Breaking change

(removed — not a breaking change)

## Proposed change

Fix trace download truncation when the trace JSON contains Jinja comments like {# ... #} (the # was treated as a URL fragment delimiter when using a data: URL). The trace
download now uses a Blob + URL.createObjectURL() to generate the download reliably.

Note: This code fix was made by codex.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

# No configuration needed.

Reproduction:
* add a Jinja `{# comment #}` inside a script/automation template (see [this](https://github.com/home-assistant/core/issues/146760#issuecomment-3646379621) for an example)
* run it, then download the trace
* observe the downloaded json file was truncated before this fix

## Additional information

- This PR fixes or closes issue: fixes home-assistant/core#146760
- This PR is related to issue or discussion: https://github.com/home-assistant/core/issues/146760#issuecomment-3646379621
- Link to documentation pull request:

## Checklist

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]