### PR TITLE
Fix navigate action after confirm

### DIFF
--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -39,6 +39,10 @@ class DialogBox extends LitElement {
   }
 
   public closeDialog(): boolean {
+    if (!this._open) {
+      // Dialog is already closing
+      return true;
+    }
     if (this._params?.confirmation || this._params?.prompt) {
       return false;
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Fix https://github.com/home-assistant/frontend/issues/28430

What happens on confirm of a confirmation dialog is that the dialog resolves its promise and begins the closing process. The thread then switches back to the action handler which attempts the navigate, which calls `closeAllDialogs`. As the confirmation dialog is still not finished closing, the dialog manager calls closeDialog() again on the confirmation dialog. 

The current logic says that a dialog which has confirmation param must reject external attempts to close, and so the navigate is rejected and stops. 

However this doesn't count for the case where the dialog was already in a closing process when closeDialog was called. If the dialog is already closing, I think we can just trivially return true to closeDialog, since the next step is a wait for all closing dialogs to be closed, before continuing. 

A bit nervous of unintended side effects here, but based on my reading of the code I think it seems allright...

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #28430
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
