### PR TITLE
Attempt to ensure view transitions are always ran

### DIFF
--- a/src/common/util/view-transition.ts
+++ b/src/common/util/view-transition.ts
@@ -20,11 +20,30 @@
 export const withViewTransition = (
   callback: (viewTransitionAvailable: boolean) => void | Promise<void>
 ): Promise<void> => {
-  if (document.startViewTransition) {
-    return document.startViewTransition(() => callback(true)).finished;
+  // Ensure the callback is invoked exactly once and awaited, even if
+  // view transitions are unavailable or throw.
+  const runCallback = async (viewTransitionAvailable: boolean) => {
+    const result = callback(viewTransitionAvailable);
+    await (result instanceof Promise ? result : Promise.resolve());
+  };
+
+  if (!document.startViewTransition) {
+    return runCallback(false);
   }
 
-  // Fallback: Execute callback directly without transition
-  const result = callback(false);
-  return result instanceof Promise ? result : Promise.resolve();
+  let invoked = false;
+
+  try {
+    const transition = document.startViewTransition(() => {
+      invoked = true;
+      return runCallback(true);
+    });
+    return transition.finished;
+  } catch (err) {
+    if (!invoked) {
+      return runCallback(false);
+    }
+    // Callback already ran; surface the original error.
+    return Promise.reject(err);
+  }
 };

--- a/src/common/util/view-transition.ts
+++ b/src/common/util/view-transition.ts
@@ -19,10 +19,13 @@ export const withViewTransition = (
     return Promise.resolve();
   }
 
+  let callbackInvoked = false;
+
   try {
     // View Transitions require DOM updates to happen synchronously within
     // the callback. Execute the callback immediately (synchronously).
     const transition = document.startViewTransition(() => {
+      callbackInvoked = true;
       callback(true);
     });
     return transition.finished;
@@ -32,9 +35,11 @@ export const withViewTransition = (
       "View transition failed, falling back to direct execution.",
       err
     );
-    // If startViewTransition throws synchronously, the callback hasn't run yet.
-    // Fall back to executing without a transition.
-    callback(false);
-    return Promise.resolve();
+    // Make sure the callback is invoked exactly once.
+    if (!callbackInvoked) {
+      callback(false);
+      return Promise.resolve();
+    }
+    return Promise.reject(err);
   }
 };

--- a/src/common/util/view-transition.ts
+++ b/src/common/util/view-transition.ts
@@ -31,19 +31,14 @@ export const withViewTransition = (
     return runCallback(false);
   }
 
-  let invoked = false;
-
   try {
-    const transition = document.startViewTransition(() => {
-      invoked = true;
-      return runCallback(true);
-    });
+    const transition = document.startViewTransition(() => runCallback(true));
     return transition.finished;
   } catch (err) {
-    if (!invoked) {
-      return runCallback(false);
-    }
-    // Callback already ran; surface the original error.
-    return Promise.reject(err);
+    // eslint-disable-next-line no-console
+    console.warn("View transition failed", err);
+    // If startViewTransition throws synchronously, the callback hasn't run yet.
+    // Fall back to executing without a transition.
+    return runCallback(false);
   }
 };

--- a/src/common/util/view-transition.ts
+++ b/src/common/util/view-transition.ts
@@ -36,7 +36,10 @@ export const withViewTransition = (
     return transition.finished;
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.warn("View transition failed", err);
+    console.warn(
+      "View transition failed, falling back to direct execution.",
+      err
+    );
     // If startViewTransition throws synchronously, the callback hasn't run yet.
     // Fall back to executing without a transition.
     return runCallback(false);

--- a/src/common/util/view-transition.ts
+++ b/src/common/util/view-transition.ts
@@ -1,38 +1,30 @@
 /**
- * Executes a callback within a View Transition if supported, otherwise runs it directly.
+ * Executes a synchronous callback within a View Transition if supported, otherwise runs it directly.
  *
- * @param callback - Function to execute. Can be synchronous or return a Promise. The callback will be passed a boolean indicating whether the view transition is available.
+ * @param callback - Synchronous function to execute. The callback will be passed a boolean indicating whether the view transition is available.
  * @returns Promise that resolves when the transition completes (or immediately if not supported)
  *
  * @example
  * ```typescript
- * // Synchronous callback
  * withViewTransition(() => {
  *   this.large = !this.large;
- * });
- *
- * // Async callback
- * await withViewTransition(async () => {
- *   await this.updateData();
  * });
  * ```
  */
 export const withViewTransition = (
-  callback: (viewTransitionAvailable: boolean) => void | Promise<void>
+  callback: (viewTransitionAvailable: boolean) => void
 ): Promise<void> => {
-  // Ensure the callback is invoked exactly once and awaited, even if
-  // view transitions are unavailable or throw.
-  const runCallback = async (viewTransitionAvailable: boolean) => {
-    const result = callback(viewTransitionAvailable);
-    await (result instanceof Promise ? result : Promise.resolve());
-  };
-
   if (!document.startViewTransition) {
-    return runCallback(false);
+    callback(false);
+    return Promise.resolve();
   }
 
   try {
-    const transition = document.startViewTransition(() => runCallback(true));
+    // View Transitions require DOM updates to happen synchronously within
+    // the callback. Execute the callback immediately (synchronously).
+    const transition = document.startViewTransition(() => {
+      callback(true);
+    });
     return transition.finished;
   } catch (err) {
     // eslint-disable-next-line no-console
@@ -42,6 +34,7 @@ export const withViewTransition = (
     );
     // If startViewTransition throws synchronously, the callback hasn't run yet.
     // Fall back to executing without a transition.
-    return runCallback(false);
+    callback(false);
+    return Promise.resolve();
   }
 };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
- Makes sure to catch view transition errors (like the safari implementation) and always run the callback
- Removes async callback since not used and since we are working on DOM updates
- Ensures the callback is ran once

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #28321
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
