### PR TITLE
Add ignoreLocation option to fuseMultiTerm config

### DIFF
--- a/src/resources/fuseMultiTerm.ts
+++ b/src/resources/fuseMultiTerm.ts
@@ -17,6 +17,7 @@ const DEFAULT_OPTIONS: IFuseOptions<any> = {
   isCaseSensitive: false,
   threshold: 0.3,
   minMatchCharLength: 2,
+  ignoreLocation: true, // don't care where the pattern is
 };
 
 const DEFAULT_MIN_CHAR_LENGTH = 2;


### PR DESCRIPTION
## Proposed change
Allow to [ignore where the searched pattern is located](https://www.fusejs.io/api/options.html#ignorelocation). Otherwise the pattern is searched only in the first ([threshold `0.3` x distance `100` [by default]](https://www.fusejs.io/concepts/scoring-theory.html#distance-threshold-and-location)) = `30` characters as reported in #27832
Update: it's even worse since in datatables the threshold is `0.2`: https://github.com/home-assistant/frontend/blob/4050dd03840b3be637751384624185eb5b3a7c05/src/components/data-table/sort-filter-worker.ts#L52

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
1. create two automations with these names:
  *  Fermer certains volets les soirs froids
  * [0123456789012345678901234567890abc](https://github.com/home-assistant/frontend/issues/27832#issuecomment-3652040393)

2. open the automations dashoard
3. search for "froid" or "abc"

Expected: created automations are shown
Observed: not found whereas there's a simple exact match


Here's the proof of the issue using a local HA (running in VM). I created my automation:
<img width="1698" height="449" alt="image" src="https://github.com/user-attachments/assets/b753fd41-ae20-4509-a145-65dc74601d79" />
❌ But it cannot find it:
<img width="1654" height="369" alt="image" src="https://github.com/user-attachments/assets/6d5d25a4-0229-47a1-847c-69a1267a2b17" />

✅ And now when I switched to my dev container, with the proposed patch, it finds it:
<img width="1530" height="386" alt="image" src="https://github.com/user-attachments/assets/c94b81ae-5260-480c-bcae-a4bdc0c97ab8" />

Using the second test case, see the difference between ✅ my patched version at the top and ❌ the current code at the bottom
<img width="1440" height="1063" alt="image" src="https://github.com/user-attachments/assets/61661c45-c079-4ce6-899d-145f695ad139" />



## Additional information

- This PR fixes or closes issue: fixes #27832

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

[docs-repository]: https://github.com/home-assistant/home-assistant.io
