### PR TITLE
Improve shadow and border for energy date picker

### DIFF
--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -670,12 +670,12 @@ class PanelEnergy extends LitElement {
           justify-content: center;
         }
         hui-root.has-period-selector {
-          --view-container-padding-bottom: var(--ha-space-14);
+          --view-container-padding-bottom: var(--ha-space-18);
         }
         .period-selector {
           position: fixed;
           z-index: 4;
-          bottom: max(var(--ha-space-2), var(--safe-area-inset-bottom, 0px));
+          bottom: max(var(--ha-space-4), var(--safe-area-inset-bottom, 0px));
           left: max(
             var(--mdc-drawer-width, 0px),
             var(--safe-area-inset-left, 0px)
@@ -700,12 +700,12 @@ class PanelEnergy extends LitElement {
           --ha-card-border-color: var(--divider-color);
           --ha-card-border-width: var(--ha-card-border-width, 1px);
         }
-        @media (min-width: 600px) {
+        @media all and (max-width: 450px), all and (max-height: 500px) {
           hui-root.has-period-selector {
-            --view-container-padding-bottom: var(--ha-space-18);
+            --view-container-padding-bottom: var(--ha-space-14);
           }
           .period-selector {
-            bottom: max(var(--ha-space-4), var(--safe-area-inset-bottom, 0px));
+            bottom: max(var(--ha-space-2), var(--safe-area-inset-bottom, 0px));
           }
         }
       `,

--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -670,26 +670,28 @@ class PanelEnergy extends LitElement {
           justify-content: center;
         }
         hui-root.has-period-selector {
-          --view-container-padding-bottom: var(--ha-space-16);
+          --view-container-padding-bottom: var(--ha-space-14);
         }
         .period-selector {
           position: fixed;
           z-index: 4;
-          bottom: calc(var(--ha-space-2) + var(--safe-area-inset-bottom, 0px));
-          left: var(--mdc-drawer-width, 0);
-          right: var(--safe-area-inset-right, 0px);
-          inset-inline-start: var(--mdc-drawer-width, 0);
-          inset-inline-end: var(--safe-area-inset-right, 0px);
-          margin: var(--ha-space-2) auto;
+          bottom: max(var(--ha-space-2), var(--safe-area-inset-bottom, 0px));
+          left: max(
+            var(--mdc-drawer-width, 0px),
+            var(--safe-area-inset-left, 0px)
+          );
+          right: var(--safe-area-inset-right, 0);
+          inset-inline-start: max(
+            var(--mdc-drawer-width, 0px),
+            var(--safe-area-inset-left, 0px)
+          );
+          inset-inline-end: var(--safe-area-inset-right, 0);
+          margin: 0 auto;
           max-width: calc(min(450px, 100% - var(--ha-space-4)));
           box-sizing: border-box;
-          padding-left: calc(
-            var(--ha-space-4) + var(--safe-area-inset-left, 0px)
-          );
+          padding-left: var(--ha-space-2);
           padding-right: 0;
-          padding-inline-start: calc(
-            var(--ha-space-4) + var(--safe-area-inset-left, 0px)
-          );
+          padding-inline-start: var(--ha-space-4);
           padding-inline-end: 0;
           --ha-card-box-shadow:
             0px 3px 5px -1px rgba(0, 0, 0, 0.2),
@@ -697,6 +699,14 @@ class PanelEnergy extends LitElement {
             0px 1px 18px 0px rgba(0, 0, 0, 0.12);
           --ha-card-border-color: var(--divider-color);
           --ha-card-border-width: var(--ha-card-border-width, 1px);
+        }
+        @media (min-width: 600px) {
+          hui-root.has-period-selector {
+            --view-container-padding-bottom: var(--ha-space-18);
+          }
+          .period-selector {
+            bottom: max(var(--ha-space-4), var(--safe-area-inset-bottom, 0px));
+          }
         }
       `,
     ];

--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -255,7 +255,7 @@ class PanelEnergy extends LitElement {
       </hui-root>
       ${showEnergySelector
         ? html`
-            <ha-card raised class="period-selector">
+            <ha-card class="period-selector">
               <hui-energy-period-selector
                 .hass=${this.hass}
                 .collectionKey=${DEFAULT_ENERGY_COLLECTION_KEY}
@@ -674,6 +674,7 @@ class PanelEnergy extends LitElement {
         }
         .period-selector {
           position: fixed;
+          z-index: 1;
           bottom: calc(var(--ha-space-2) + var(--safe-area-inset-bottom, 0px));
           left: var(--mdc-drawer-width, 0);
           right: var(--safe-area-inset-right, 0px);
@@ -690,6 +691,12 @@ class PanelEnergy extends LitElement {
             var(--ha-space-4) + var(--safe-area-inset-left, 0px)
           );
           padding-inline-end: 0;
+          --ha-card-box-shadow:
+            0px 3px 5px -1px rgba(0, 0, 0, 0.2),
+            0px 6px 10px 0px rgba(0, 0, 0, 0.14),
+            0px 1px 18px 0px rgba(0, 0, 0, 0.12);
+          --ha-card-border-color: var(--divider-color);
+          --ha-card-border-width: 1px;
         }
       `,
     ];

--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -674,7 +674,7 @@ class PanelEnergy extends LitElement {
         }
         .period-selector {
           position: fixed;
-          z-index: 1;
+          z-index: 4;
           bottom: calc(var(--ha-space-2) + var(--safe-area-inset-bottom, 0px));
           left: var(--mdc-drawer-width, 0);
           right: var(--safe-area-inset-right, 0px);

--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -696,7 +696,7 @@ class PanelEnergy extends LitElement {
             0px 6px 10px 0px rgba(0, 0, 0, 0.14),
             0px 1px 18px 0px rgba(0, 0, 0, 0.12);
           --ha-card-border-color: var(--divider-color);
-          --ha-card-border-width: 1px;
+          --ha-card-border-width: var(--ha-card-border-width, 1px);
         }
       `,
     ];


### PR DESCRIPTION
## Proposed change

Improve shadow and border for energy date picker as the style from raised card was not enough. I also fixed a z-index issue with graph legend.

### Before

<img width="578" height="789" alt="CleanShot 2025-12-16 at 11 35 34" src="https://github.com/user-attachments/assets/aa51ed4b-b6a3-4c1e-8ebe-f929184e4956" />
<img width="578" height="789" alt="CleanShot 2025-12-16 at 11 35 54" src="https://github.com/user-attachments/assets/6f932740-96f7-4e39-b636-85635e5a39f3" />

### After

<img width="578" height="789" alt="CleanShot 2025-12-16 at 11 35 22" src="https://github.com/user-attachments/assets/f2a5090c-8fb2-4907-9de1-24a1806e7e00" />
<img width="577" height="789" alt="CleanShot 2025-12-16 at 11 35 13" src="https://github.com/user-attachments/assets/b67f6155-1bd5-40f7-be56-138802f0e0bd" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
