### PR TITLE
Migrate addon-picker to generic-picker

### DIFF
--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -278,6 +278,7 @@ export class HaEntityPicker extends LitElement {
         .autofocus=${this.autofocus}
         .allowCustomValue=${this.allowCustomEntity}
         .label=${this.label}
+        .required=${this.required}
         .helper=${this.helper}
         .searchLabel=${this.searchLabel}
         .notFoundLabel=${this._notFoundLabel}

--- a/src/components/ha-addon-picker.ts
+++ b/src/components/ha-addon-picker.ts
@@ -1,29 +1,29 @@
-import type { ComboBoxLitRenderer } from "@vaadin/combo-box/lit";
-import { html, LitElement, nothing } from "lit";
+import type { RenderItemFunction } from "@lit-labs/virtualizer/virtualize";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { isComponentLoaded } from "../common/config/is_component_loaded";
 import { fireEvent } from "../common/dom/fire_event";
-import { stringCompare } from "../common/string/compare";
-import type { HassioAddonInfo } from "../data/hassio/addon";
 import { fetchHassioAddonsInfo } from "../data/hassio/addon";
 import type { HomeAssistant, ValueChangedEvent } from "../types";
 import "./ha-alert";
-import "./ha-combo-box";
-import type { HaComboBox } from "./ha-combo-box";
 import "./ha-combo-box-item";
+import "./ha-generic-picker";
+import type { HaGenericPicker } from "./ha-generic-picker";
+import type { PickerComboBoxItem } from "./ha-picker-combo-box";
 
-const rowRenderer: ComboBoxLitRenderer<HassioAddonInfo> = (item) => html`
+const SEARCH_KEYS = [
+  { name: "primary", weight: 10 },
+  { name: "secondary", weight: 8 },
+  { name: "search_labels.description", weight: 6 },
+  { name: "search_labels.repository", weight: 5 },
+];
+
+const rowRenderer: RenderItemFunction<PickerComboBoxItem> = (item) => html`
   <ha-combo-box-item type="button">
-    <span slot="headline">${item.name}</span>
-    <span slot="supporting-text">${item.slug}</span>
+    <span slot="headline">${item.primary}</span>
+    <span slot="supporting-text">${item.secondary}</span>
     ${item.icon
-      ? html`
-          <img
-            alt=""
-            slot="start"
-            .src="/api/hassio/addons/${item.slug}/icon"
-          />
-        `
+      ? html` <img alt="" slot="start" .src=${item.icon} /> `
       : nothing}
   </ha-combo-box-item>
 `;
@@ -38,22 +38,22 @@ class HaAddonPicker extends LitElement {
 
   @property() public helper?: string;
 
-  @state() private _addons?: HassioAddonInfo[];
+  @state() private _addons?: PickerComboBoxItem[];
 
   @property({ type: Boolean }) public disabled = false;
 
   @property({ type: Boolean }) public required = false;
 
-  @query("ha-combo-box") private _comboBox!: HaComboBox;
+  @query("ha-generic-picker") private _genericPicker!: HaGenericPicker;
 
   @state() private _error?: string;
 
   public open() {
-    this._comboBox?.open();
+    this._genericPicker?.open();
   }
 
   public focus() {
-    this._comboBox?.focus();
+    this._genericPicker?.focus();
   }
 
   protected firstUpdated() {
@@ -67,23 +67,26 @@ class HaAddonPicker extends LitElement {
     if (!this._addons) {
       return nothing;
     }
+
     return html`
-      <ha-combo-box
+      <ha-generic-picker
         .hass=${this.hass}
-        .label=${this.label === undefined && this.hass
+        .autofocus=${this.autofocus}
+        .placeholder=${this.label === undefined && this.hass
           ? this.hass.localize("ui.components.addon-picker.addon")
           : this.label}
-        .value=${this._value}
-        .required=${this.required}
-        .disabled=${this.disabled}
+        .valueRenderer=${this._valueRenderer}
         .helper=${this.helper}
-        .renderer=${rowRenderer}
-        .items=${this._addons}
-        item-value-path="slug"
-        item-id-path="slug"
-        item-label-path="name"
+        .disabled=${this.disabled}
+        .required=${this.required}
+        show-label
+        .value=${this.value}
+        .getItems=${this._getItems}
+        .searchKeys=${SEARCH_KEYS}
+        .rowRenderer=${rowRenderer}
         @value-changed=${this._addonChanged}
-      ></ha-combo-box>
+      >
+      </ha-generic-picker>
     `;
   }
 
@@ -93,9 +96,19 @@ class HaAddonPicker extends LitElement {
         const addonsInfo = await fetchHassioAddonsInfo(this.hass);
         this._addons = addonsInfo.addons
           .filter((addon) => addon.version)
-          .sort((a, b) =>
-            stringCompare(a.name, b.name, this.hass.locale.language)
-          );
+          .map((addon) => ({
+            id: addon.slug,
+            primary: addon.name,
+            secondary: addon.slug,
+            icon: addon.icon
+              ? `/api/hassio/addons/${addon.slug}/icon`
+              : undefined,
+            search_labels: {
+              description: addon.description || null,
+              repository: addon.repository || null,
+            },
+            sorting_label: [addon.name, addon.slug].filter(Boolean).join("_"),
+          }));
       } else {
         this._error = this.hass.localize(
           "ui.components.addon-picker.error.no_supervisor"
@@ -107,6 +120,8 @@ class HaAddonPicker extends LitElement {
       );
     }
   }
+
+  private _getItems = () => this._addons!;
 
   private get _value() {
     return this.value || "";
@@ -128,6 +143,28 @@ class HaAddonPicker extends LitElement {
       fireEvent(this, "change");
     }, 0);
   }
+
+  private _valueRenderer = (itemId: string) => {
+    const item = this._addons!.find((addon) => addon.id === itemId);
+    return html`<span
+      style="display: flex; align-items: center; gap: 8px;"
+      slot="headline"
+      >${item?.icon
+        ? html`<img style="width: 32px;" alt="" .src=${item.icon} /> `
+        : nothing}${item?.primary || "Unknown"}</span
+    >`;
+  };
+
+  static styles = css`
+    .headline {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .headline img {
+      width: 32px;
+    }
+  `;
 }
 
 declare global {

--- a/src/components/ha-addon-picker.ts
+++ b/src/components/ha-addon-picker.ts
@@ -146,13 +146,13 @@ class HaAddonPicker extends LitElement {
 
   private _valueRenderer = (itemId: string) => {
     const item = this._addons!.find((addon) => addon.id === itemId);
-    return html`<span
-      style="display: flex; align-items: center; gap: 8px;"
-      slot="headline"
-      >${item?.icon
-        ? html`<img style="width: 32px;" alt="" .src=${item.icon} /> `
-        : nothing}${item?.primary || "Unknown"}</span
-    >`;
+    return html`${item?.icon
+        ? html`<img
+            slot="start"
+            alt=${item.primary ?? "Unknown"}
+            .src=${item.icon}
+          />`
+        : nothing}<span slot="headline">${item?.primary || "Unknown"}</span>`;
   };
 }
 

--- a/src/components/ha-addon-picker.ts
+++ b/src/components/ha-addon-picker.ts
@@ -1,5 +1,5 @@
 import type { RenderItemFunction } from "@lit-labs/virtualizer/virtualize";
-import { css, html, LitElement, nothing } from "lit";
+import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { isComponentLoaded } from "../common/config/is_component_loaded";
 import { fireEvent } from "../common/dom/fire_event";
@@ -154,17 +154,6 @@ class HaAddonPicker extends LitElement {
         : nothing}${item?.primary || "Unknown"}</span
     >`;
   };
-
-  static styles = css`
-    .headline {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-    .headline img {
-      width: 32px;
-    }
-  `;
 }
 
 declare global {

--- a/src/components/ha-picker-field.ts
+++ b/src/components/ha-picker-field.ts
@@ -73,7 +73,9 @@ export class HaPickerField extends LitElement {
 
     const overlineLabel =
       this.showLabel && hasValue && this.placeholder
-        ? html`<span slot="overline">${this.placeholder}</span>`
+        ? html`<span slot="overline"
+            >${this.placeholder}${this.required ? " *" : ""}</span
+          >`
         : nothing;
 
     const headlineContent = hasValue
@@ -82,7 +84,7 @@ export class HaPickerField extends LitElement {
         : html`<span slot="headline">${this.value}</span>`
       : this.placeholder
         ? html`<span slot="headline" class="placeholder">
-            ${this.placeholder}
+            ${this.placeholder}${this.required ? " *" : ""}
           </span>`
         : nothing;
 


### PR DESCRIPTION
## Proposed change
- Migrate addon-picker to use `generic-picker`
- add `*` to requried labels in `generic-picker`
- use `required` attribute in `entity-picker`


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
