### PR TITLE
fix read-only fields in config flow expandables

### DIFF
--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -51,7 +51,7 @@ class StepFlowForm extends LitElement {
   }
 
   private handleReadOnlyFields = memoizeOne((schema) => {
-    function handleReadOnlyField(field) {
+    function handleReadOnlyField(field: HaFormSchema) {
       return {
         ...field,
         ...(Object.values((field as HaFormSelector)?.selector ?? {})[0]
@@ -60,7 +60,7 @@ class StepFlowForm extends LitElement {
           : {}),
       };
     }
-    return schema?.map((field) =>
+    return schema?.map((field: HaFormSchema) =>
       field.type === "expandable" && field.schema
         ? {
             ...field,

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -50,14 +50,27 @@ class StepFlowForm extends LitElement {
     this.removeEventListener("keydown", this._handleKeyDown);
   }
 
-  private handleReadOnlyFields = memoizeOne((schema) =>
-    schema?.map((field) => ({
-      ...field,
-      ...(Object.values((field as HaFormSelector)?.selector ?? {})[0]?.read_only
-        ? { disabled: true }
-        : {}),
-    }))
-  );
+  private handleReadOnlyFields = memoizeOne((schema) => {
+    function handleReadOnlyField(field) {
+      return {
+        ...field,
+        ...(Object.values((field as HaFormSelector)?.selector ?? {})[0]
+          ?.read_only
+          ? { disabled: true }
+          : {}),
+      };
+    }
+    return schema?.map((field) =>
+      field.type === "expandable" && field.schema
+        ? {
+            ...field,
+            schema: field.schema.map((sectionField) =>
+              handleReadOnlyField(sectionField)
+            ),
+          }
+        : handleReadOnlyField(field)
+    );
+  });
 
   protected render(): TemplateResult {
     const step = this.step;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
read_only property was not honored inside expandable config_flow sections

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #28578 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
