### PR TITLE
Add select-all to media management dialog, design update, migrate to wa

### DIFF
--- a/src/components/media-player/dialog-media-manage.ts
+++ b/src/components/media-player/dialog-media-manage.ts
@@ -29,6 +29,7 @@ import "../ha-check-list-item";
 import "../ha-wa-dialog";
 import "../ha-dialog-header";
 import "../ha-dialog-footer";
+import "../ha-icon-button";
 import "../ha-list";
 import "../ha-spinner";
 import "../ha-svg-icon";

--- a/src/components/media-player/dialog-media-manage.ts
+++ b/src/components/media-player/dialog-media-manage.ts
@@ -1,13 +1,17 @@
 import { animate } from "@lit-labs/motion";
 
-import { mdiClose, mdiDelete } from "@mdi/js";
+import {
+  mdiClose,
+  mdiDelete,
+  mdiCheckboxBlankOutline,
+  mdiCheckboxMarkedOutline,
+} from "@mdi/js";
 import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import { fireEvent } from "../../common/dom/fire_event";
-import { computeRTLDirection } from "../../common/util/compute_rtl";
 import { deleteImage, getIdFromUrl } from "../../data/image_upload";
 import type { MediaPlayerItem } from "../../data/media-player";
 import { MediaClassBrowserSettings } from "../../data/media-player";
@@ -22,8 +26,9 @@ import { haStyleDialog, haStyleDialogFixedTop } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import "../ha-button";
 import "../ha-check-list-item";
-import "../ha-dialog";
+import "../ha-wa-dialog";
 import "../ha-dialog-header";
+import "../ha-dialog-footer";
 import "../ha-list";
 import "../ha-spinner";
 import "../ha-svg-icon";
@@ -46,14 +51,24 @@ class DialogMediaManage extends LitElement {
 
   @state() private _selected = new Set<number>();
 
+  @state() private _open = false;
+
+  @state() private _filteredChildren: MediaPlayerItem[] = [];
+
   private _filesChanged = false;
 
   public showDialog(params: MediaManageDialogParams): void {
     this._params = params;
     this._refreshMedia();
+    this._open = true;
   }
 
   public closeDialog() {
+    this._open = false;
+    return true;
+  }
+
+  private _dialogClosed(): void {
     if (this._filesChanged && this._params!.onClose) {
       this._params!.onClose();
     }
@@ -65,88 +80,68 @@ class DialogMediaManage extends LitElement {
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
+  protected willUpdate() {
+    this._filteredChildren =
+      this._currentItem?.children?.filter((child) => !child.can_expand) || [];
+    if (this._filteredChildren.length === 0 && this._selected.size !== 0) {
+      // When running delete all, sometimes the list can throw off a spurious
+      // select event that makes it think that 1 item is still selected. Clear selected
+      // if nothing can be selected.
+      this._selected = new Set();
+    }
+  }
+
   protected render() {
     if (!this._params) {
       return nothing;
     }
 
-    const children =
-      this._currentItem?.children?.filter((child) => !child.can_expand) || [];
-
     let fileIndex = 0;
 
     return html`
-      <ha-dialog
-        open
-        scrimClickAction
-        escapeKeyAction
-        hideActions
-        flexContent
-        .heading=${this._params.currentItem.title}
-        @closed=${this.closeDialog}
+      <ha-wa-dialog
+        .hass=${this.hass}
+        .open=${this._open}
+        ?prevent-scrim-close=${this._uploading || this._deleting}
+        @closed=${this._dialogClosed}
       >
-        <ha-dialog-header slot="heading">
+        <ha-dialog-header slot="header">
+          ${!(this._uploading || this._deleting)
+            ? html`<slot name="headerNavigationIcon" slot="navigationIcon">
+                <ha-icon-button
+                  data-dialog="close"
+                  .label=${this.hass?.localize("ui.common.close") ?? "Close"}
+                  .path=${mdiClose}
+                ></ha-icon-button
+              ></slot>`
+            : nothing}
+          <span class="title" slot="title" id="dialog-box-title">
+            ${this.hass.localize(
+              "ui.components.media-browser.file_management.title"
+            )}
+          </span>
           ${this._selected.size === 0
-            ? html`
-                <span slot="title">
-                  ${this.hass.localize(
-                    "ui.components.media-browser.file_management.title"
-                  )}
-                </span>
-
-                <ha-media-upload-button
-                  .disabled=${this._deleting}
-                  .hass=${this.hass}
-                  .currentItem=${this._params.currentItem}
-                  @uploading=${this._startUploading}
-                  @media-refresh=${this._doneUploading}
-                  slot="actionItems"
-                ></ha-media-upload-button>
-                ${this._uploading
-                  ? ""
-                  : html`
-                      <ha-icon-button
-                        .label=${this.hass.localize("ui.common.close")}
-                        .path=${mdiClose}
-                        dialogAction="close"
-                        slot="navigationIcon"
-                        dir=${computeRTLDirection(this.hass)}
-                      ></ha-icon-button>
-                    `}
-              `
-            : html`
-                <ha-button
-                  variant="danger"
-                  slot="navigationIcon"
-                  .disabled=${this._deleting}
-                  @click=${this._handleDelete}
-                >
-                  <ha-svg-icon .path=${mdiDelete} slot="start"></ha-svg-icon>
-                  ${this.hass.localize(
-                    `ui.components.media-browser.file_management.${
-                      this._deleting ? "deleting" : "delete"
-                    }`,
-                    { count: this._selected.size }
-                  )}
-                </ha-button>
-
-                ${this._deleting
-                  ? ""
-                  : html`
-                      <ha-button
-                        slot="actionItems"
-                        @click=${this._handleDeselectAll}
-                      >
-                        <ha-svg-icon
-                          .path=${mdiClose}
-                          slot="start"
-                        ></ha-svg-icon>
-                        ${this.hass.localize(
-                          `ui.components.media-browser.file_management.deselect_all`
-                        )}
-                      </ha-button>
-                    `}
-              `}
+            ? html`<ha-media-upload-button
+                .hass=${this.hass}
+                .currentItem=${this._params.currentItem}
+                @uploading=${this._startUploading}
+                @media-refresh=${this._doneUploading}
+                slot="actionItems"
+              ></ha-media-upload-button>`
+            : html`<ha-button
+                variant="danger"
+                slot="actionItems"
+                .disabled=${this._deleting}
+                @click=${this._handleDelete}
+              >
+                <ha-svg-icon .path=${mdiDelete} slot="start"></ha-svg-icon>
+                ${this.hass.localize(
+                  `ui.components.media-browser.file_management.${
+                    this._deleting ? "deleting" : "delete"
+                  }`,
+                  { count: this._selected.size }
+                )}
+              </ha-button>`}
         </ha-dialog-header>
         ${!this._currentItem
           ? html`
@@ -154,7 +149,7 @@ class DialogMediaManage extends LitElement {
                 <ha-spinner></ha-spinner>
               </div>
             `
-          : !children.length
+          : !this._filteredChildren.length
             ? html`<div class="no-items">
                 <p>
                   ${this.hass.localize(
@@ -170,9 +165,38 @@ class DialogMediaManage extends LitElement {
                   : ""}
               </div>`
             : html`
+                <div class="buttons" slot="footer">
+                  <ha-button
+                    appearance="filled"
+                    @click=${this._handleDeselectAll}
+                    .disabled=${this._selected.size === 0}
+                  >
+                    <ha-svg-icon
+                      .path=${mdiCheckboxBlankOutline}
+                      slot="start"
+                    ></ha-svg-icon>
+                    ${this.hass.localize(
+                      `ui.components.media-browser.file_management.deselect_all`
+                    )}
+                  </ha-button>
+                  <ha-button
+                    appearance="filled"
+                    @click=${this._handleSelectAll}
+                    .disabled=${this._selected.size ===
+                    this._filteredChildren.length}
+                  >
+                    <ha-svg-icon
+                      .path=${mdiCheckboxMarkedOutline}
+                      slot="start"
+                    ></ha-svg-icon>
+                    ${this.hass.localize(
+                      `ui.components.media-browser.file_management.select_all`
+                    )}
+                  </ha-button>
+                </div>
                 <ha-list multi @selected=${this._handleSelected}>
                   ${repeat(
-                    children,
+                    this._filteredChildren,
                     (item) => item.media_content_id,
                     (item) => {
                       const icon = html`
@@ -220,7 +244,7 @@ class DialogMediaManage extends LitElement {
               )}
             </ha-tip>`
           : nothing}
-      </ha-dialog>
+      </ha-wa-dialog>
     `;
   }
 
@@ -242,6 +266,10 @@ class DialogMediaManage extends LitElement {
     if (this._selected.size) {
       this._selected = new Set();
     }
+  }
+
+  private _handleSelectAll() {
+    this._selected = new Set([...Array(this._filteredChildren.length).keys()]);
   }
 
   private async _handleDelete() {
@@ -338,7 +366,11 @@ class DialogMediaManage extends LitElement {
           justify-content: center;
           align-items: center;
         }
-
+        .buttons {
+          display: flex;
+          justify-content: center;
+          width: 100%;
+        }
         .no-items {
           text-align: center;
           padding: 16px;

--- a/src/components/media-player/dialog-media-manage.ts
+++ b/src/components/media-player/dialog-media-manage.ts
@@ -22,7 +22,6 @@ import {
   removeLocalMedia,
 } from "../../data/media_source";
 import { showConfirmationDialog } from "../../dialogs/generic/show-dialog-box";
-import { haStyleDialog, haStyleDialogFixedTop } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import "../ha-button";
 import "../ha-check-list-item";
@@ -333,23 +332,7 @@ class DialogMediaManage extends LitElement {
 
   static get styles(): CSSResultGroup {
     return [
-      haStyleDialog,
-      haStyleDialogFixedTop,
       css`
-        ha-dialog {
-          --dialog-z-index: 9;
-          --dialog-content-padding: 0;
-        }
-
-        @media (min-width: 800px) {
-          ha-dialog {
-            --mdc-dialog-max-width: 800px;
-            --mdc-dialog-max-height: calc(
-              100vh - var(--ha-space-18) - var(--safe-area-inset-y)
-            );
-          }
-        }
-
         ha-dialog-header ha-media-upload-button,
         ha-dialog-header ha-button {
           --mdc-theme-primary: var(--primary-text-color);

--- a/src/components/media-player/dialog-media-manage.ts
+++ b/src/components/media-player/dialog-media-manage.ts
@@ -333,6 +333,9 @@ class DialogMediaManage extends LitElement {
   static get styles(): CSSResultGroup {
     return [
       css`
+        ha-wa-dialog {
+          --dialog-content-padding: 0;
+        }
         ha-dialog-header ha-media-upload-button,
         ha-dialog-header ha-button {
           --mdc-theme-primary: var(--primary-text-color);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1099,6 +1099,7 @@
           "delete": "Delete {count}",
           "deleting": "Deleting {count}",
           "deselect_all": "Deselect all",
+          "select_all": "[%key:ui::components::subpage-data-table::select_all%]",
           "tip_media_storage": "[%key:ui::panel::config::tips::media_storage%]",
           "tip_storage_panel": "storage"
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Added a select all button, update dialog to ha-wa-dialog, and move around some of the buttons. 

Previous dialog crammed all its UI elements into the dialog header, which is a little non-standard, and doesn't really leave any room to allow a select all button. 

<img width="647" height="203" alt="image" src="https://github.com/user-attachments/assets/ae3c4f87-db03-49fb-92b5-ef56d59a044a" />
<img width="522" height="147" alt="image" src="https://github.com/user-attachments/assets/761ceae0-860c-40ae-9001-06b7e7168da7" />


I propose a change where we can add select all by keep upload/delete in the top right, and move select/deselect all to the footer. This also allows for keeping the close button and title always visible, which was previously hidden when an item was selected. 

<img width="585" height="298" alt="image" src="https://github.com/user-attachments/assets/425aa5fa-d62b-4e21-bcc1-a07d850af4c1" />
<img width="585" height="296" alt="image" src="https://github.com/user-attachments/assets/c6c87cb3-af74-47fb-a39b-c35334f77aeb" />




## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/1299 https://github.com/home-assistant/frontend/discussions/14944 https://github.com/home-assistant/frontend/discussions/24216
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
