### PR TITLE
Migrate domain selection to use generic picker component

### DIFF
--- a/src/components/ha-picker-field.ts
+++ b/src/components/ha-picker-field.ts
@@ -11,13 +11,13 @@ import {
 import { customElement, property, query, state } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
 import { fireEvent } from "../common/dom/fire_event";
-import { PickerMixin } from "../mixins/picker-mixin";
 import { localizeContext } from "../data/context";
+import { PickerMixin } from "../mixins/picker-mixin";
 import type { HomeAssistant } from "../types";
 import "./ha-combo-box-item";
 import type { HaComboBoxItem } from "./ha-combo-box-item";
-import "./ha-icon-button";
 import "./ha-icon";
+import "./ha-icon-button";
 
 declare global {
   interface HASSDomEvents {
@@ -194,7 +194,10 @@ export class HaPickerField extends PickerMixin(LitElement) {
 
         .placeholder {
           color: var(--secondary-text-color);
-          padding: 0 8px;
+        }
+
+        :host([invalid]) .placeholder {
+          color: var(--mdc-theme-error, var(--error-color, #b00020));
         }
 
         .unknown {

--- a/src/panels/config/application_credentials/dialog-add-application-credential.ts
+++ b/src/panels/config/application_credentials/dialog-add-application-credential.ts
@@ -5,11 +5,12 @@ import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-alert";
 import "../../../components/ha-button";
-import "../../../components/ha-combo-box";
 import { createCloseHeading } from "../../../components/ha-dialog";
 import "../../../components/ha-fade-in";
+import "../../../components/ha-generic-picker";
 import "../../../components/ha-markdown";
 import "../../../components/ha-password-field";
+import type { PickerComboBoxItem } from "../../../components/ha-picker-combo-box";
 import "../../../components/ha-spinner";
 import "../../../components/ha-textfield";
 import type {
@@ -165,20 +166,19 @@ export class DialogAddApplicationCredential extends LitElement {
                   : nothing}
                 ${this._params.selectedDomain
                   ? nothing
-                  : html`<ha-combo-box
+                  : html`<ha-generic-picker
                       name="domain"
                       .hass=${this.hass}
                       .label=${this.hass.localize(
                         "ui.panel.config.application_credentials.editor.domain"
                       )}
                       .value=${this._domain}
-                      .items=${this._domains}
-                      item-id-path="id"
-                      item-value-path="id"
-                      item-label-path="name"
+                      .getItems=${this._getDomainItems}
                       required
+                      .disabled=${!this._domains}
+                      .valueRenderer=${this._domainRenderer}
                       @value-changed=${this._handleDomainPicked}
-                    ></ha-combo-box>`}
+                    ></ha-generic-picker>`}
                 ${this._description
                   ? html`<ha-markdown
                       breaks
@@ -327,6 +327,20 @@ export class DialogAddApplicationCredential extends LitElement {
     this._params!.applicationCredentialAddedCallback(applicationCredential);
     this.closeDialog();
   }
+
+  private _getDomainItems = (): PickerComboBoxItem[] =>
+    this._domains?.map((domain) => ({
+      id: domain.id,
+      primary: domain.name,
+      sorting_label: domain.name,
+    })) ?? [];
+
+  private _domainRenderer = (domainId: string) => {
+    const domain = this._domains?.find((d) => d.id === domainId);
+    return html`<span slot="headline"
+      >${domain ? domain.name : domainId}</span
+    >`;
+  };
 
   static get styles(): CSSResultGroup {
     return [

--- a/src/panels/config/application_credentials/dialog-add-application-credential.ts
+++ b/src/panels/config/application_credentials/dialog-add-application-credential.ts
@@ -5,7 +5,7 @@ import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-alert";
 import "../../../components/ha-button";
-import { createCloseHeading } from "../../../components/ha-dialog";
+import "../../../components/ha-dialog-footer";
 import "../../../components/ha-fade-in";
 import "../../../components/ha-generic-picker";
 import "../../../components/ha-markdown";
@@ -13,6 +13,7 @@ import "../../../components/ha-password-field";
 import type { PickerComboBoxItem } from "../../../components/ha-picker-combo-box";
 import "../../../components/ha-spinner";
 import "../../../components/ha-textfield";
+import "../../../components/ha-wa-dialog";
 import type {
   ApplicationCredential,
   ApplicationCredentialsConfig,
@@ -60,6 +61,10 @@ export class DialogAddApplicationCredential extends LitElement {
 
   @state() private _config?: ApplicationCredentialsConfig;
 
+  @state() private _open = false;
+
+  @state() private _invalid = false;
+
   public showDialog(params: AddApplicationCredentialDialogParams) {
     this._params = params;
     this._domain = params.selectedDomain;
@@ -70,6 +75,7 @@ export class DialogAddApplicationCredential extends LitElement {
     this._clientSecret = "";
     this._error = undefined;
     this._loading = false;
+    this._open = true;
     this._fetchConfig();
   }
 
@@ -91,16 +97,16 @@ export class DialogAddApplicationCredential extends LitElement {
       ? domainToName(this.hass.localize, this._domain!)
       : "";
     return html`
-      <ha-dialog
-        open
+      <ha-wa-dialog
+        .hass=${this.hass}
+        .open=${this._open}
         @closed=${this._abortDialog}
-        scrimClickAction
-        escapeKeyAction
-        .heading=${createCloseHeading(
-          this.hass,
-          this.hass.localize(
-            "ui.panel.config.application_credentials.editor.caption"
-          )
+        .preventScrimClose=${!!this._domain ||
+        !!this._name ||
+        !!this._clientId ||
+        !!this._clientSecret}
+        .headerTitle=${this.hass.localize(
+          "ui.panel.config.application_credentials.editor.caption"
         )}
       >
         ${!this._config
@@ -173,11 +179,15 @@ export class DialogAddApplicationCredential extends LitElement {
                         "ui.panel.config.application_credentials.editor.domain"
                       )}
                       .value=${this._domain}
+                      .invalid=${this._invalid && !this._domain}
                       .getItems=${this._getDomainItems}
                       required
                       .disabled=${!this._domains}
                       .valueRenderer=${this._domainRenderer}
                       @value-changed=${this._handleDomainPicked}
+                      .errorMessage=${this.hass.localize(
+                        "ui.common.error_required"
+                      )}
                     ></ha-generic-picker>`}
                 ${this._description
                   ? html`<ha-markdown
@@ -192,9 +202,10 @@ export class DialogAddApplicationCredential extends LitElement {
                     "ui.panel.config.application_credentials.editor.name"
                   )}
                   .value=${this._name}
+                  .invalid=${this._invalid && !this._name}
                   required
                   @input=${this._handleValueChanged}
-                  .validationMessage=${this.hass.localize(
+                  .errorMessage=${this.hass.localize(
                     "ui.common.error_required"
                   )}
                   dialogInitialFocus
@@ -206,9 +217,10 @@ export class DialogAddApplicationCredential extends LitElement {
                     "ui.panel.config.application_credentials.editor.client_id"
                   )}
                   .value=${this._clientId}
+                  .invalid=${this._invalid && !this._clientId}
                   required
                   @input=${this._handleValueChanged}
-                  .validationMessage=${this.hass.localize(
+                  .errorMessage=${this.hass.localize(
                     "ui.common.error_required"
                   )}
                   dialogInitialFocus
@@ -223,9 +235,10 @@ export class DialogAddApplicationCredential extends LitElement {
                   )}
                   name="clientSecret"
                   .value=${this._clientSecret}
+                  .invalid=${this._invalid && !this._clientSecret}
                   required
                   @input=${this._handleValueChanged}
-                  .validationMessage=${this.hass.localize(
+                  .errorMessage=${this.hass.localize(
                     "ui.common.error_required"
                   )}
                   .helper=${this.hass.localize(
@@ -235,28 +248,31 @@ export class DialogAddApplicationCredential extends LitElement {
                 ></ha-password-field>
               </div>
 
-              <ha-button
-                appearance="plain"
-                slot="secondaryAction"
-                @click=${this._abortDialog}
-                .disabled=${this._loading}
-              >
-                ${this.hass.localize("ui.common.cancel")}
-              </ha-button>
-              <ha-button
-                slot="primaryAction"
-                .disabled=${!this._domain ||
-                !this._clientId ||
-                !this._clientSecret}
-                @click=${this._addApplicationCredential}
-                .loading=${this._loading}
-              >
-                ${this.hass.localize(
-                  "ui.panel.config.application_credentials.editor.add"
-                )}
-              </ha-button>`}
-      </ha-dialog>
+              <ha-dialog-footer slot="footer">
+                <ha-button
+                  appearance="plain"
+                  slot="secondaryAction"
+                  @click=${this._closeDialog}
+                  .disabled=${this._loading}
+                >
+                  ${this.hass.localize("ui.common.cancel")}
+                </ha-button>
+                <ha-button
+                  slot="primaryAction"
+                  @click=${this._addApplicationCredential}
+                  .loading=${this._loading}
+                >
+                  ${this.hass.localize(
+                    "ui.panel.config.application_credentials.editor.add"
+                  )}
+                </ha-button>
+              </ha-dialog-footer>`}
+      </ha-wa-dialog>
     `;
+  }
+
+  private _closeDialog() {
+    this._open = false;
   }
 
   public closeDialog() {
@@ -303,9 +319,16 @@ export class DialogAddApplicationCredential extends LitElement {
 
   private async _addApplicationCredential(ev) {
     ev.preventDefault();
-    if (!this._domain || !this._clientId || !this._clientSecret) {
+    if (
+      !this._domain ||
+      !this._name ||
+      !this._clientId ||
+      !this._clientSecret
+    ) {
+      this._invalid = true;
       return;
     }
+    this._invalid = false;
 
     this._loading = true;
     this._error = "";

--- a/src/panels/config/application_credentials/dialog-add-application-credential.ts
+++ b/src/panels/config/application_credentials/dialog-add-application-credential.ts
@@ -352,12 +352,12 @@ export class DialogAddApplicationCredential extends LitElement {
         }
         .row {
           display: flex;
-          padding: 8px 0;
+          padding: var(--ha-space-2) 0;
         }
         ha-textfield {
           display: block;
-          margin-top: 16px;
-          margin-bottom: 16px;
+          margin-top: var(--ha-space-4);
+          margin-bottom: var(--ha-space-4);
         }
         a {
           text-decoration: none;
@@ -366,8 +366,8 @@ export class DialogAddApplicationCredential extends LitElement {
           --mdc-icon-size: 16px;
         }
         ha-markdown {
-          margin-top: 16px;
-          margin-bottom: 16px;
+          margin-top: var(--ha-space-4);
+          margin-bottom: var(--ha-space-4);
         }
         ha-fade-in {
           display: flex;

--- a/src/panels/config/application_credentials/dialog-add-application-credential.ts
+++ b/src/panels/config/application_credentials/dialog-add-application-credential.ts
@@ -354,13 +354,10 @@ export class DialogAddApplicationCredential extends LitElement {
           display: flex;
           padding: 8px 0;
         }
-        ha-combo-box {
-          display: block;
-          margin-bottom: 24px;
-        }
         ha-textfield {
           display: block;
-          margin-bottom: 24px;
+          margin-top: 16px;
+          margin-bottom: 16px;
         }
         a {
           text-decoration: none;
@@ -369,6 +366,7 @@ export class DialogAddApplicationCredential extends LitElement {
           --mdc-icon-size: 16px;
         }
         ha-markdown {
+          margin-top: 16px;
           margin-bottom: 16px;
         }
         ha-fade-in {


### PR DESCRIPTION
## Proposed change
- dialog: add-application-credential use generic picker for domain selection

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
