### PR TITLE
Developer Tools: Update both event fire and event listen when clicked.

### DIFF
--- a/src/panels/developer-tools/event/developer-tools-event.ts
+++ b/src/panels/developer-tools/event/developer-tools-event.ts
@@ -25,6 +25,8 @@ class HaPanelDevEvent extends LitElement {
 
   @state() private _isValid = true;
 
+  @state() private _selectedEventType = "";
+
   protected render(): TemplateResult {
     return html`
       <div
@@ -89,7 +91,10 @@ class HaPanelDevEvent extends LitElement {
             </div>
           </ha-card>
 
-          <event-subscribe-card .hass=${this.hass}></event-subscribe-card>
+          <event-subscribe-card
+            .hass=${this.hass}
+            .selectedEventType=${this._selectedEventType}
+          ></event-subscribe-card>
         </div>
 
         <div>
@@ -109,6 +114,7 @@ class HaPanelDevEvent extends LitElement {
 
   private _eventSelected(ev) {
     this._eventType = ev.detail.eventType;
+    this._selectedEventType = ev.detail.eventType;
   }
 
   private _eventTypeChanged(ev) {

--- a/src/panels/developer-tools/event/event-subscribe-card.ts
+++ b/src/panels/developer-tools/event/event-subscribe-card.ts
@@ -15,6 +15,8 @@ import type { HomeAssistant } from "../../../types";
 class EventSubscribeCard extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
+  @property({ attribute: false }) public selectedEventType = "";
+
   @state() private _eventType = "";
 
   @state() private _subscribed?: () => void;
@@ -33,6 +35,18 @@ class EventSubscribeCard extends LitElement {
     if (this._subscribed) {
       this._subscribed();
       this._subscribed = undefined;
+    }
+  }
+
+  protected willUpdate(changedProperties: Map<string, any>) {
+    super.willUpdate(changedProperties);
+
+    if (
+      changedProperties.has("selectedEventType") &&
+      this.selectedEventType &&
+      !this._subscribed
+    ) {
+      this._eventType = this.selectedEventType;
     }
   }
 


### PR DESCRIPTION
## Breaking change
Not a breaking change, adds additional functionality.


## Proposed change
When in Developer Tools, clicking an event on the right hand side would have previously filled the `event_type` field in the fire event section, but not in the listen to bit. 

This PR adds functionality to autofil the listening event field, but only if it isn't currently listening to an events.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
No additional configuration needed.

## Additional information
There isn't an issue already associated with this, I just found it annoying and after checking with a friend they did too; so I thought to fix it.

## Checklist
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

I'm not sure the best place to add tests for this, but happy to!

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

Documentation not required.

[docs-repository]: https://github.com/home-assistant/home-assistant.io
