### PR TITLE
Automation editor target in row improve configEntry subscription

### DIFF
--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -96,6 +96,22 @@ export interface ConfigEntryUpdate {
   entry: ConfigEntry;
 }
 
+export const subscribeAndProcessConfigEntries = (
+  hass: HomeAssistant,
+  callbackFunction: (entries: ConfigEntry[]) => void,
+  filters?: {
+    type?: IntegrationType[];
+    domain?: string;
+  }
+): Promise<UnsubscribeFunc> => {
+  const stream = new ConfigEntryStream();
+  const processCallback = (messages: ConfigEntryUpdate[]) => {
+    callbackFunction(stream.processMessage(messages));
+  };
+
+  return subscribeConfigEntries(hass, processCallback, filters);
+};
+
 export const subscribeConfigEntries = (
   hass: HomeAssistant,
   callbackFunction: (message: ConfigEntryUpdate[]) => void,
@@ -110,10 +126,9 @@ export const subscribeConfigEntries = (
   if (filters && filters.type) {
     params.type_filter = filters.type;
   }
-  return hass.connection.subscribeMessage<ConfigEntryUpdate[]>(
-    (message) => callbackFunction(message),
-    params
-  );
+  return hass.connection.subscribeMessage<ConfigEntryUpdate[]>((message) => {
+    callbackFunction(message);
+  }, params);
 };
 
 export const getConfigEntries = (
@@ -207,28 +222,28 @@ export const sortConfigEntries = (
   return [primaryEntry, ...otherEntries];
 };
 
-export const handleConfigEntrySubscriptionMessages = (
-  currentEntries: ConfigEntry[],
-  messages: ConfigEntryUpdate[]
-): ConfigEntry[] => {
-  let entries = [...currentEntries];
-  messages.forEach((message) => {
-    if (message.type === null || message.type === "added") {
-      entries.push(message.entry);
-      return;
-    }
-    if (message.type === "removed") {
-      entries = entries.filter(
-        (entry) => entry.entry_id !== message.entry.entry_id
-      );
-      return;
-    }
-    if (message.type === "updated") {
-      const newEntry = message.entry;
-      entries = entries.map((entry) =>
-        entry.entry_id === newEntry.entry_id ? newEntry : entry
-      );
-    }
-  });
-  return entries;
-};
+export class ConfigEntryStream {
+  private _entries: ConfigEntry[] = [];
+
+  processMessage(message: ConfigEntryUpdate[]) {
+    message.forEach((configEntry) => {
+      if (configEntry.type === null || configEntry.type === "added") {
+        this._entries.push(configEntry.entry);
+        return;
+      }
+      if (configEntry.type === "removed") {
+        this._entries = this._entries.filter(
+          (entry) => entry.entry_id !== configEntry.entry.entry_id
+        );
+        return;
+      }
+      if (configEntry.type === "updated") {
+        const newEntry = configEntry.entry;
+        this._entries = this._entries.map((entry) =>
+          entry.entry_id === newEntry.entry_id ? newEntry : entry
+        );
+      }
+    });
+    return this._entries;
+  }
+}

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -206,3 +206,29 @@ export const sortConfigEntries = (
   );
   return [primaryEntry, ...otherEntries];
 };
+
+export const handleConfigEntrySubscriptionMessages = (
+  currentEntries: ConfigEntry[],
+  messages: ConfigEntryUpdate[]
+): ConfigEntry[] => {
+  let entries = [...currentEntries];
+  messages.forEach((message) => {
+    if (message.type === null || message.type === "added") {
+      entries.push(message.entry);
+      return;
+    }
+    if (message.type === "removed") {
+      entries = entries.filter(
+        (entry) => entry.entry_id !== message.entry.entry_id
+      );
+      return;
+    }
+    if (message.type === "updated") {
+      const newEntry = message.entry;
+      entries = entries.map((entry) =>
+        entry.entry_id === newEntry.entry_id ? newEntry : entry
+      );
+    }
+  });
+  return entries;
+};

--- a/src/data/context.ts
+++ b/src/data/context.ts
@@ -3,6 +3,7 @@ import type { HassConfig } from "home-assistant-js-websocket";
 import type { HomeAssistant } from "../types";
 import type { EntityRegistryEntry } from "./entity/entity_registry";
 import type { LabelRegistryEntry } from "./label/label_registry";
+import type { ConfigEntry } from "./config_entries";
 
 export const connectionContext =
   createContext<HomeAssistant["connection"]>("connection");
@@ -30,3 +31,5 @@ export const fullEntitiesContext =
 export const floorsContext = createContext<HomeAssistant["floors"]>("floors");
 
 export const labelsContext = createContext<LabelRegistryEntry[]>("labels");
+
+export const configEntries = createContext<ConfigEntry[]>("configEntries");

--- a/src/data/context.ts
+++ b/src/data/context.ts
@@ -1,9 +1,9 @@
 import { createContext } from "@lit/context";
 import type { HassConfig } from "home-assistant-js-websocket";
 import type { HomeAssistant } from "../types";
+import type { ConfigEntry } from "./config_entries";
 import type { EntityRegistryEntry } from "./entity/entity_registry";
 import type { LabelRegistryEntry } from "./label/label_registry";
-import type { ConfigEntry } from "./config_entries";
 
 export const connectionContext =
   createContext<HomeAssistant["connection"]>("connection");
@@ -32,4 +32,5 @@ export const floorsContext = createContext<HomeAssistant["floors"]>("floors");
 
 export const labelsContext = createContext<LabelRegistryEntry[]>("labels");
 
-export const configEntries = createContext<ConfigEntry[]>("configEntries");
+export const configEntriesContext =
+  createContext<ConfigEntry[]>("configEntries");

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -48,10 +48,10 @@ import {
   normalizeAutomationConfig,
 } from "../../../data/automation";
 import {
-  handleConfigEntrySubscriptionMessages,
-  subscribeConfigEntries,
+  subscribeAndProcessConfigEntries,
+  type ConfigEntry,
 } from "../../../data/config_entries";
-import { configEntries } from "../../../data/context";
+import { configEntriesContext } from "../../../data/context";
 import { getActionType, type Action } from "../../../data/script";
 import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import type { HomeAssistant } from "../../../types";
@@ -125,7 +125,7 @@ export class HaManualAutomationEditor extends SubscribeMixin(LitElement) {
   >;
 
   private _configEntries = new ContextProvider(this, {
-    context: configEntries,
+    context: configEntriesContext,
     initialValue: [],
   });
 
@@ -138,14 +138,13 @@ export class HaManualAutomationEditor extends SubscribeMixin(LitElement) {
 
   public hassSubscribe(): Promise<UnsubscribeFunc>[] {
     return [
-      subscribeConfigEntries(this.hass, (messages) => {
-        this._configEntries.setValue(
-          handleConfigEntrySubscriptionMessages(
-            this._configEntries.value,
-            messages
-          )
-        );
-      }),
+      subscribeAndProcessConfigEntries(
+        this.hass,
+        (message: ConfigEntry[]) => {
+          this._configEntries.setValue(message);
+        },
+        undefined
+      ),
     ];
   }
 

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -1,5 +1,6 @@
+import { ContextProvider } from "@lit/context";
 import { mdiContentSave, mdiHelpCircle } from "@mdi/js";
-import type { HassEntity } from "home-assistant-js-websocket";
+import type { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
 import { load } from "js-yaml";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
@@ -46,7 +47,13 @@ import {
   isTrigger,
   normalizeAutomationConfig,
 } from "../../../data/automation";
+import {
+  handleConfigEntrySubscriptionMessages,
+  subscribeConfigEntries,
+} from "../../../data/config_entries";
+import { configEntries } from "../../../data/context";
 import { getActionType, type Action } from "../../../data/script";
+import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import type { HomeAssistant } from "../../../types";
 import { documentationUrl } from "../../../util/documentation-url";
 import { showToast } from "../../../util/toast";
@@ -80,7 +87,7 @@ const automationConfigStruct = union([
 export const SIDEBAR_DEFAULT_WIDTH = 500;
 
 @customElement("manual-automation-editor")
-export class HaManualAutomationEditor extends LitElement {
+export class HaManualAutomationEditor extends SubscribeMixin(LitElement) {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: "is-wide", type: Boolean }) public isWide = false;
@@ -117,11 +124,29 @@ export class HaManualAutomationEditor extends LitElement {
     HaAutomationAction | HaAutomationCondition
   >;
 
+  private _configEntries = new ContextProvider(this, {
+    context: configEntries,
+    initialValue: [],
+  });
+
   private _prevSidebarWidthPx?: number;
 
   public connectedCallback() {
     super.connectedCallback();
     window.addEventListener("paste", this._handlePaste);
+  }
+
+  public hassSubscribe(): Promise<UnsubscribeFunc>[] {
+    return [
+      subscribeConfigEntries(this.hass, (messages) => {
+        this._configEntries.setValue(
+          handleConfigEntrySubscriptionMessages(
+            this._configEntries.value,
+            messages
+          )
+        );
+      }),
+    ];
   }
 
   public disconnectedCallback() {

--- a/src/panels/config/automation/target/ha-automation-row-targets.ts
+++ b/src/panels/config/automation/target/ha-automation-row-targets.ts
@@ -9,7 +9,7 @@ import "../../../../components/ha-svg-icon";
 import type { ConfigEntry } from "../../../../data/config_entries";
 import {
   areasContext,
-  configEntries,
+  configEntriesContext,
   devicesContext,
   floorsContext,
   labelsContext,
@@ -54,7 +54,7 @@ export class HaAutomationRowTargets extends LitElement {
   private _labelRegistry!: LabelRegistryEntry[];
 
   @state()
-  @consume({ context: configEntries, subscribe: true })
+  @consume({ context: configEntriesContext, subscribe: true })
   @transform<ConfigEntry[], Record<string, ConfigEntry>>({
     transformer: function (value) {
       return Object.fromEntries(value.map((entry) => [entry.entry_id, entry]));

--- a/src/panels/config/automation/target/ha-automation-row-targets.ts
+++ b/src/panels/config/automation/target/ha-automation-row-targets.ts
@@ -1,17 +1,15 @@
 import { consume } from "@lit/context";
 import { mdiAlert, mdiFormatListBulleted, mdiShape } from "@mdi/js";
 import type { HassServiceTarget } from "home-assistant-js-websocket";
-import { LitElement, css, html, nothing, type TemplateResult } from "lit";
+import { css, html, LitElement, type nothing, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { until } from "lit/directives/until";
 import { ensureArray } from "../../../../common/array/ensure-array";
+import { transform } from "../../../../common/decorators/transform";
 import "../../../../components/ha-svg-icon";
-import {
-  getConfigEntries,
-  type ConfigEntry,
-} from "../../../../data/config_entries";
+import type { ConfigEntry } from "../../../../data/config_entries";
 import {
   areasContext,
+  configEntries,
   devicesContext,
   floorsContext,
   labelsContext,
@@ -55,6 +53,13 @@ export class HaAutomationRowTargets extends LitElement {
   @consume({ context: labelsContext, subscribe: true })
   private _labelRegistry!: LabelRegistryEntry[];
 
+  @state()
+  @consume({ context: configEntries, subscribe: true })
+  @transform<ConfigEntry[], Record<string, ConfigEntry>>({
+    transformer: function (value) {
+      return Object.fromEntries(value.map((entry) => [entry.entry_id, entry]));
+    },
+  })
   private _configEntryLookup?: Record<string, ConfigEntry>;
 
   protected render() {
@@ -149,13 +154,6 @@ export class HaAutomationRowTargets extends LitElement {
     </div>`;
   }
 
-  private async _loadConfigEntries() {
-    const configEntries = await getConfigEntries(this.hass);
-    this._configEntryLookup = Object.fromEntries(
-      configEntries.map((entry) => [entry.entry_id, entry])
-    );
-  }
-
   private _renderTarget(
     targetType: "floor" | "area" | "device" | "entity" | "label",
     targetId: string
@@ -176,22 +174,6 @@ export class HaAutomationRowTargets extends LitElement {
         getTargetText(this.hass, targetType, targetId, this._getLabel),
         true
       );
-    }
-
-    if (targetType === "device" && !this._configEntryLookup) {
-      const loadConfigEntries = this._loadConfigEntries().then(() =>
-        this._renderTargetBadge(
-          getTargetIcon(
-            this.hass,
-            targetType,
-            targetId,
-            this._configEntryLookup!
-          ),
-          getTargetText(this.hass, targetType, targetId)
-        )
-      );
-
-      return html`${until(loadConfigEntries, nothing)}`;
     }
 
     return this._renderTargetBadge(

--- a/src/panels/config/script/manual-script-editor.ts
+++ b/src/panels/config/script/manual-script-editor.ts
@@ -1,4 +1,6 @@
+import { ContextProvider } from "@lit/context";
 import { mdiContentSave, mdiHelpCircle } from "@mdi/js";
+import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { load } from "js-yaml";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
@@ -35,6 +37,11 @@ import type {
   ActionSidebarConfig,
   SidebarConfig,
 } from "../../../data/automation";
+import {
+  handleConfigEntrySubscriptionMessages,
+  subscribeConfigEntries,
+} from "../../../data/config_entries";
+import { configEntries } from "../../../data/context";
 import type {
   Action,
   Fields,
@@ -46,6 +53,7 @@ import {
   MODES,
   normalizeScriptConfig,
 } from "../../../data/script";
+import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import type { HomeAssistant } from "../../../types";
 import { documentationUrl } from "../../../util/documentation-url";
 import { showToast } from "../../../util/toast";
@@ -70,7 +78,7 @@ const scriptConfigStruct = object({
 });
 
 @customElement("manual-script-editor")
-export class HaManualScriptEditor extends LitElement {
+export class HaManualScriptEditor extends SubscribeMixin(LitElement) {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: "is-wide", type: Boolean }) public isWide = false;
@@ -108,6 +116,11 @@ export class HaManualScriptEditor extends LitElement {
     HaAutomationAction | HaScriptFields
   >;
 
+  private _configEntries = new ContextProvider(this, {
+    context: configEntries,
+    initialValue: [],
+  });
+
   private _openFields = false;
 
   private _prevSidebarWidthPx?: number;
@@ -127,6 +140,19 @@ export class HaManualScriptEditor extends LitElement {
         },
       },
     });
+  }
+
+  public hassSubscribe(): Promise<UnsubscribeFunc>[] {
+    return [
+      subscribeConfigEntries(this.hass, (messages) => {
+        this._configEntries.setValue(
+          handleConfigEntrySubscriptionMessages(
+            this._configEntries.value,
+            messages
+          )
+        );
+      }),
+    ];
   }
 
   protected updated(changedProps) {

--- a/src/panels/config/script/manual-script-editor.ts
+++ b/src/panels/config/script/manual-script-editor.ts
@@ -37,11 +37,8 @@ import type {
   ActionSidebarConfig,
   SidebarConfig,
 } from "../../../data/automation";
-import {
-  handleConfigEntrySubscriptionMessages,
-  subscribeConfigEntries,
-} from "../../../data/config_entries";
-import { configEntries } from "../../../data/context";
+import { subscribeAndProcessConfigEntries } from "../../../data/config_entries";
+import { configEntriesContext } from "../../../data/context";
 import type {
   Action,
   Fields,
@@ -117,7 +114,7 @@ export class HaManualScriptEditor extends SubscribeMixin(LitElement) {
   >;
 
   private _configEntries = new ContextProvider(this, {
-    context: configEntries,
+    context: configEntriesContext,
     initialValue: [],
   });
 
@@ -144,13 +141,8 @@ export class HaManualScriptEditor extends SubscribeMixin(LitElement) {
 
   public hassSubscribe(): Promise<UnsubscribeFunc>[] {
     return [
-      subscribeConfigEntries(this.hass, (messages) => {
-        this._configEntries.setValue(
-          handleConfigEntrySubscriptionMessages(
-            this._configEntries.value,
-            messages
-          )
-        );
+      subscribeAndProcessConfigEntries(this.hass, (configEntries) => {
+        this._configEntries.setValue(configEntries);
       }),
     ];
   }


### PR DESCRIPTION
## Proposed change
- Subscribe config entries in automation/script editor and consume the context for each target badge.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
