### PR TITLE
Make exclusion reason available in statistic-picker

### DIFF
--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -2,7 +2,7 @@ import type { RenderItemFunction } from "@lit-labs/virtualizer/virtualize";
 import { mdiChartLine, mdiHelpCircle, mdiShape } from "@mdi/js";
 import type { HassEntity } from "home-assistant-js-websocket";
 import { html, LitElement, nothing, type PropertyValues } from "lit";
-import { customElement, property, query } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { ensureArray } from "../../common/array/ensure-array";
 import { fireEvent } from "../../common/dom/fire_event";
@@ -40,6 +40,7 @@ interface StatisticComboBoxItem extends PickerComboBoxItem {
   stateObj?: HassEntity;
   domainName?: string;
   type?: StatisticItemType;
+  disabledText?: string;
 }
 
 const SEARCH_KEYS = [
@@ -125,10 +126,15 @@ export class HaStatisticPicker extends LitElement {
   @property({ type: Array, attribute: "exclude-statistics" })
   public excludeStatistics?: string[];
 
+  @property({ attribute: "exclude-reason" })
+  public excludeReason?: string;
+
   @property({ attribute: "hide-clear-icon", type: Boolean })
   public hideClearIcon = false;
 
   @query("ha-generic-picker") private _picker?: HaGenericPicker;
+
+  @state() private _showExcluded = false;
 
   public willUpdate(changedProps: PropertyValues) {
     if (
@@ -146,6 +152,7 @@ export class HaStatisticPicker extends LitElement {
   private _getItems = () =>
     this._getStatisticsItems(
       this.hass,
+      this._showExcluded,
       this.statisticIds,
       this.includeStatisticsUnitOfMeasurement,
       this.includeUnitClass,
@@ -155,21 +162,27 @@ export class HaStatisticPicker extends LitElement {
       this.value
     );
 
-  private _getAdditionalItems(): StatisticComboBoxItem[] {
-    return [
-      {
-        id: MISSING_ID,
-        primary: this.hass.localize(
-          "ui.components.statistic-picker.missing_entity"
-        ),
-        icon_path: mdiHelpCircle,
-      },
-    ];
-  }
+  private _getAdditionalItems = (): StatisticComboBoxItem[] => [
+    {
+      id: MISSING_ID,
+      primary: this.hass.localize(
+        "ui.components.statistic-picker.missing_entity"
+      ),
+      ...(!this._showExcluded
+        ? {
+            secondary: this.hass.localize(
+              "ui.components.statistic-picker.show_incompatible"
+            ),
+          }
+        : {}),
+      icon_path: mdiHelpCircle,
+    },
+  ];
 
   private _getStatisticsItems = memoizeOne(
     (
       hass: HomeAssistant,
+      showExcluded: boolean,
       statisticIds?: StatisticsMetaData[],
       includeStatisticsUnitOfMeasurement?: string | string[],
       includeUnitClass?: string | string[],
@@ -181,26 +194,60 @@ export class HaStatisticPicker extends LitElement {
       if (!statisticIds) {
         return [];
       }
+      const excluded: Record<string, string> = {};
 
       if (includeStatisticsUnitOfMeasurement) {
         const includeUnits: (string | null)[] = ensureArray(
           includeStatisticsUnitOfMeasurement
         );
-        statisticIds = statisticIds.filter((meta) =>
-          includeUnits.includes(meta.statistics_unit_of_measurement)
-        );
+        if (showExcluded) {
+          statisticIds
+            .filter(
+              (meta) =>
+                !includeUnits.includes(meta.statistics_unit_of_measurement)
+            )
+            .reduce((acc, meta) => {
+              if (!(meta.statistic_id in acc)) {
+                const uom = meta.statistics_unit_of_measurement;
+                acc[meta.statistic_id] = this.hass.localize(
+                  "ui.components.statistic-picker.incompatible_unit",
+                  { unit: uom }
+                );
+              }
+              return acc;
+            }, excluded);
+        } else {
+          statisticIds = statisticIds.filter((meta) =>
+            includeUnits.includes(meta.statistics_unit_of_measurement)
+          );
+        }
       }
       if (includeUnitClass) {
         const includeUnitClasses: (string | null)[] =
           ensureArray(includeUnitClass);
-        statisticIds = statisticIds.filter((meta) =>
-          includeUnitClasses.includes(meta.unit_class)
-        );
+
+        if (showExcluded) {
+          statisticIds
+            .filter((meta) => !includeUnitClasses.includes(meta.unit_class))
+            .reduce((acc, meta) => {
+              if (!(meta.statistic_id in acc)) {
+                const uom = meta.statistics_unit_of_measurement;
+                const unit_class = `${meta.unit_class ?? "none"} ${uom ? ` (${uom})` : ""}`;
+                acc[meta.statistic_id] = this.hass.localize(
+                  "ui.components.statistic-picker.incompatible_unit_class",
+                  { unit_class }
+                );
+              }
+              return acc;
+            }, excluded);
+        } else {
+          statisticIds = statisticIds.filter((meta) =>
+            includeUnitClasses.includes(meta.unit_class)
+          );
+        }
       }
       if (includeDeviceClass) {
-        const includeDeviceClasses: (string | null)[] =
-          ensureArray(includeDeviceClass);
-        statisticIds = statisticIds.filter((meta) => {
+        const compatibleDeviceClass = (meta: StatisticsMetaData): boolean => {
           const stateObj = this.hass.states[meta.statistic_id];
           if (!stateObj) {
             return true;
@@ -208,64 +255,61 @@ export class HaStatisticPicker extends LitElement {
           return includeDeviceClasses.includes(
             stateObj.attributes.device_class || ""
           );
-        });
+        };
+
+        const includeDeviceClasses: (string | null)[] =
+          ensureArray(includeDeviceClass);
+        if (showExcluded) {
+          statisticIds
+            .filter((meta) => !compatibleDeviceClass(meta))
+            .reduce((acc, meta) => {
+              if (!(meta.statistic_id in acc)) {
+                const stateObj = this.hass.states[meta.statistic_id]!;
+                acc[meta.statistic_id] = this.hass.localize(
+                  "ui.components.statistic-picker.incompatible_device_class",
+                  { device_class: stateObj.attributes.device_class || "none" }
+                );
+              }
+              return acc;
+            }, excluded);
+        } else {
+          statisticIds = statisticIds.filter((meta) =>
+            compatibleDeviceClass(meta)
+          );
+        }
+      }
+
+      if (excludeStatistics) {
+        const isExcluded = (meta: StatisticsMetaData): boolean =>
+          meta.statistic_id !== value &&
+          excludeStatistics.includes(meta.statistic_id);
+        if (showExcluded) {
+          statisticIds
+            .filter((meta) => isExcluded(meta))
+            .reduce((acc, meta) => {
+              if (!(meta.statistic_id in acc)) {
+                acc[meta.statistic_id] =
+                  this.excludeReason ||
+                  this.hass.localize(
+                    "ui.components.statistic-picker.manually_excluded"
+                  );
+              }
+              return acc;
+            }, excluded);
+        } else {
+          statisticIds = statisticIds.filter((meta) => !isExcluded(meta));
+        }
       }
 
       const isRTL = computeRTL(hass);
 
       const output: StatisticComboBoxItem[] = [];
 
-      statisticIds.forEach((meta) => {
-        if (
-          excludeStatistics &&
-          meta.statistic_id !== value &&
-          excludeStatistics.includes(meta.statistic_id)
-        ) {
-          return;
-        }
-        const stateObj = this.hass.states[meta.statistic_id];
-
-        if (!stateObj) {
-          if (!entitiesOnly) {
-            const id = meta.statistic_id;
-            const label = getStatisticLabel(this.hass, meta.statistic_id, meta);
-            const type =
-              meta.statistic_id.includes(":") &&
-              !meta.statistic_id.includes(".")
-                ? "external"
-                : "no_state";
-
-            const sortingPrefix = `${TYPE_ORDER.indexOf(type)}`;
-            if (type === "no_state") {
-              output.push({
-                id,
-                primary: label,
-                secondary: this.hass.localize(
-                  "ui.components.statistic-picker.no_state"
-                ),
-                type,
-                sorting_label: [sortingPrefix, label].join("_"),
-                icon_path: mdiShape,
-              });
-            } else if (type === "external") {
-              const domain = id.split(":")[0];
-              const domainName = domainToName(this.hass.localize, domain);
-              output.push({
-                id,
-                statistic_id: id,
-                primary: label,
-                secondary: domainName,
-                type,
-                sorting_label: [sortingPrefix, label].join("_"),
-                search_labels: { label, domainName },
-                icon_path: mdiChartLine,
-              });
-            }
-          }
-          return;
-        }
-        const id = meta.statistic_id;
-
+      const formatOutputByStateObj = (
+        stateObj,
+        disabledText: string
+      ): StatisticComboBoxItem => {
+        const id = stateObj.entity_id;
         const friendlyName = computeStateName(stateObj); // Keep this for search
 
         const [entityName, deviceName, areaName] = computeEntityNameList(
@@ -283,11 +327,13 @@ export class HaStatisticPicker extends LitElement {
           .join(isRTL ? " ◂ " : " ▸ ");
 
         const sortingPrefix = `${TYPE_ORDER.indexOf("entity")}`;
-        output.push({
+        return {
           id,
-          statistic_id: id,
           primary,
           secondary,
+          disabled: !!disabledText,
+          disabledText,
+          statistic_id: id,
           stateObj: stateObj,
           type: "entity",
           sorting_label: [sortingPrefix, deviceName, entityName].join("_"),
@@ -297,8 +343,70 @@ export class HaStatisticPicker extends LitElement {
             areaName: areaName || null,
             friendlyName,
           },
-        });
+        };
+      };
+
+      statisticIds.forEach((meta) => {
+        const id = meta.statistic_id;
+        const stateObj = this.hass.states[id];
+        const disabledText = excluded[id];
+        if (!stateObj) {
+          if (!entitiesOnly) {
+            const label = getStatisticLabel(this.hass, id, meta);
+            const type =
+              id.includes(":") && !id.includes(".") ? "external" : "no_state";
+
+            const sortingPrefix = `${TYPE_ORDER.indexOf(type)}`;
+            if (type === "no_state") {
+              output.push({
+                id,
+                disabled: !!disabledText,
+                disabledText,
+                primary: label,
+                secondary: this.hass.localize(
+                  "ui.components.statistic-picker.no_state"
+                ),
+                type,
+                sorting_label: [sortingPrefix, label].join("_"),
+                icon_path: mdiShape,
+              });
+            } else if (type === "external") {
+              const domain = id.split(":")[0];
+              const domainName = domainToName(this.hass.localize, domain);
+              output.push({
+                id,
+                disabled: !!disabledText,
+                disabledText,
+                statistic_id: id,
+                primary: label,
+                secondary: domainName,
+                type,
+                sorting_label: [sortingPrefix, label].join("_"),
+                search_labels: { label, domainName },
+                icon_path: mdiChartLine,
+              });
+            }
+          }
+          return;
+        }
+        output.push(formatOutputByStateObj(stateObj, disabledText));
       });
+
+      if (this._showExcluded) {
+        const ids = statisticIds.map((meta) => meta.statistic_id);
+        Object.values(this.hass.states)
+          .filter((exState) => !ids.includes(exState.entity_id))
+          .forEach((exState) => {
+            output.push(
+              formatOutputByStateObj(
+                exState,
+                this.hass.localize(
+                  "ui.components.statistic-picker.no_statistics"
+                )
+              )
+            );
+          });
+      }
 
       return output;
     }
@@ -430,7 +538,12 @@ export class HaStatisticPicker extends LitElement {
   ) => {
     const showEntityId = this.hass.userData?.showEntityIdPicker;
     return html`
-      <ha-combo-box-item type="button" compact .borderTop=${index !== 0}>
+      <ha-combo-box-item
+        type="button"
+        compact
+        .borderTop=${index !== 0}
+        .disabled=${item.disabled}
+      >
         ${item.icon_path
           ? html`
               <ha-svg-icon
@@ -456,6 +569,9 @@ export class HaStatisticPicker extends LitElement {
           ? html`<span slot="supporting-text" class="code">
               ${item.statistic_id}
             </span>`
+          : nothing}
+        ${item.disabled
+          ? html`<span slot="supporting-text">${item.disabledText}</span>`
           : nothing}
       </ha-combo-box-item>
     `;
@@ -519,10 +635,14 @@ export class HaStatisticPicker extends LitElement {
     const value = ev.detail.value;
 
     if (value === MISSING_ID) {
-      window.open(
-        documentationUrl(this.hass, this.helpMissingEntityUrl),
-        "_blank"
-      );
+      if (!this._showExcluded) {
+        this._showExcluded = true;
+      } else {
+        window.open(
+          documentationUrl(this.hass, this.helpMissingEntityUrl),
+          "_blank"
+        );
+      }
       return;
     }
 

--- a/src/components/entity/ha-statistics-picker.ts
+++ b/src/components/entity/ha-statistics-picker.ts
@@ -98,6 +98,9 @@ class HaStatisticsPicker extends LitElement {
               .statisticTypes=${includeStatisticTypesCurrent}
               .statisticIds=${this.statisticIds}
               .excludeStatistics=${this.value}
+              .excludeReason=${this.hass?.localize(
+                "ui.components.statistic-picker.already_selected"
+              )}
               .allowCustomEntity=${this.allowCustomEntity}
               @value-changed=${this._statisticChanged}
             ></ha-statistic-picker>
@@ -115,6 +118,9 @@ class HaStatisticsPicker extends LitElement {
           .statisticIds=${this.statisticIds}
           .placeholder=${this.placeholder}
           .excludeStatistics=${this.value}
+          .excludeReason=${this.hass?.localize(
+            "ui.components.statistic-picker.already_selected"
+          )}
           .allowCustomEntity=${this.allowCustomEntity}
           @value-changed=${this._addStatistic}
         ></ha-statistic-picker>

--- a/src/components/ha-picker-combo-box.ts
+++ b/src/components/ha-picker-combo-box.ts
@@ -52,6 +52,7 @@ export interface PickerComboBoxItem {
   sorting_label?: string;
   icon_path?: string;
   icon?: string;
+  disabled?: boolean;
 }
 
 export const NO_ITEMS_AVAILABLE_ID = "___no_items_available___";
@@ -376,6 +377,7 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
       id=${`list-item-${index}`}
       class="combo-box-row ${this._value === item.id ? "current-value" : ""}"
       .value=${item.id}
+      .disabled=${item.disabled}
       .index=${index}
       @click=${this._valueSelected}
     >
@@ -395,10 +397,12 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
 
   private _valueSelected = (ev: Event) => {
     ev.stopPropagation();
-    const value = (ev.currentTarget as any).value as string;
-    const newValue = value?.trim();
-
-    fireEvent(this, "value-changed", { value: newValue });
+    const target = ev.currentTarget as any;
+    if (!target.disabled) {
+      const value = target.value as string;
+      const newValue = value?.trim();
+      fireEvent(this, "value-changed", { value: newValue });
+    }
   };
 
   private _fuseIndex = memoizeOne(

--- a/src/panels/config/energy/dialogs/dialog-energy-battery-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-battery-settings.ts
@@ -107,6 +107,9 @@ export class DialogEnergyBatterySettings
             ...(this._excludeList || []),
             this._source.stat_energy_from,
           ]}
+          .excludeReason=${this.hass?.localize(
+            "ui.components.statistic-picker.already_selected"
+          )}
           @value-changed=${this._statisticToChanged}
           .helper=${this.hass.localize(
             "ui.panel.config.energy.battery.dialog.energy_helper_into",
@@ -127,6 +130,9 @@ export class DialogEnergyBatterySettings
             ...(this._excludeList || []),
             this._source.stat_energy_to,
           ]}
+          .excludeReason=${this.hass?.localize(
+            "ui.components.statistic-picker.already_selected"
+          )}
           @value-changed=${this._statisticFromChanged}
           .helper=${this.hass.localize(
             "ui.panel.config.energy.battery.dialog.energy_helper_out",
@@ -142,6 +148,9 @@ export class DialogEnergyBatterySettings
             "ui.panel.config.energy.battery.dialog.power"
           )}
           .excludeStatistics=${this._excludeListPower}
+          .excludeReason=${this.hass?.localize(
+            "ui.components.statistic-picker.already_selected"
+          )}
           @value-changed=${this._powerChanged}
           .helper=${this.hass.localize(
             "ui.panel.config.energy.battery.dialog.power_helper",

--- a/src/panels/config/energy/dialogs/dialog-energy-device-settings-water.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-device-settings-water.ts
@@ -124,6 +124,9 @@ export class DialogEnergyDeviceSettingsWater
             "ui.panel.config.energy.device_consumption_water.dialog.device_consumption_water"
           )}
           .excludeStatistics=${this._excludeList}
+          .excludeReason=${this.hass?.localize(
+            "ui.components.statistic-picker.already_selected"
+          )}
           @value-changed=${this._statisticChanged}
           dialogInitialFocus
         ></ha-statistic-picker>

--- a/src/panels/config/energy/dialogs/dialog-energy-device-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-device-settings.ts
@@ -127,6 +127,9 @@ export class DialogEnergyDeviceSettings
             "ui.panel.config.energy.device_consumption.dialog.device_consumption_energy"
           )}
           .excludeStatistics=${this._excludeList}
+          .excludeReason=${this.hass?.localize(
+            "ui.components.statistic-picker.already_selected"
+          )}
           @value-changed=${this._statisticChanged}
           .helper=${this.hass.localize(
             "ui.panel.config.energy.device_consumption.dialog.selected_stat_intro",
@@ -143,6 +146,9 @@ export class DialogEnergyDeviceSettings
             "ui.panel.config.energy.device_consumption.dialog.device_consumption_power"
           )}
           .excludeStatistics=${this._excludeListPower}
+          .excludeReason=${this.hass?.localize(
+            "ui.components.statistic-picker.already_selected"
+          )}
           @value-changed=${this._powerStatisticChanged}
           .helper=${this.hass.localize(
             "ui.panel.config.energy.device_consumption.dialog.selected_stat_intro",

--- a/src/panels/config/energy/dialogs/dialog-energy-gas-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-gas-settings.ts
@@ -160,6 +160,9 @@ export class DialogEnergyGasSettings
             "ui.panel.config.energy.gas.dialog.gas_usage"
           )}
           .excludeStatistics=${this._excludeList}
+          .excludeReason=${this.hass?.localize(
+            "ui.components.statistic-picker.already_selected"
+          )}
           @value-changed=${this._statisticChanged}
           dialogInitialFocus
         ></ha-statistic-picker>

--- a/src/panels/config/energy/dialogs/dialog-energy-grid-flow-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-grid-flow-settings.ts
@@ -152,6 +152,9 @@ export class DialogEnergyGridFlowSettings
             `ui.panel.config.energy.grid.flow_dialog.${this._params.direction}.energy_stat`
           )}
           .excludeStatistics=${this._excludeList}
+          .excludeReason=${this.hass?.localize(
+            "ui.components.statistic-picker.already_selected"
+          )}
           @value-changed=${this._statisticChanged}
           .helper=${this.hass.localize(
             `ui.panel.config.energy.grid.flow_dialog.${this._params.direction}.entity_para`,

--- a/src/panels/config/energy/dialogs/dialog-energy-grid-power-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-grid-power-settings.ts
@@ -88,6 +88,9 @@ export class DialogEnergyGridPowerSettings
             "ui.panel.config.energy.grid.power_dialog.power_stat"
           )}
           .excludeStatistics=${this._excludeListPower}
+          .excludeReason=${this.hass?.localize(
+            "ui.components.statistic-picker.already_selected"
+          )}
           @value-changed=${this._powerStatisticChanged}
           .helper=${this.hass.localize(
             "ui.panel.config.energy.grid.power_dialog.power_helper",

--- a/src/panels/config/energy/dialogs/dialog-energy-solar-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-solar-settings.ts
@@ -113,6 +113,9 @@ export class DialogEnergySolarSettings
             "ui.panel.config.energy.solar.dialog.solar_production_energy"
           )}
           .excludeStatistics=${this._excludeList}
+          .excludeReason=${this.hass?.localize(
+            "ui.components.statistic-picker.already_selected"
+          )}
           @value-changed=${this._statisticChanged}
           .helper=${this.hass.localize(
             "ui.panel.config.energy.solar.dialog.entity_para",
@@ -129,6 +132,9 @@ export class DialogEnergySolarSettings
             "ui.panel.config.energy.solar.dialog.solar_production_power"
           )}
           .excludeStatistics=${this._excludeListPower}
+          .excludeReason=${this.hass?.localize(
+            "ui.components.statistic-picker.already_selected"
+          )}
           @value-changed=${this._powerStatisticChanged}
           .helper=${this.hass.localize(
             "ui.panel.config.energy.solar.dialog.entity_para",

--- a/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
@@ -124,6 +124,9 @@ export class DialogEnergyWaterSettings
             "ui.panel.config.energy.water.dialog.water_usage"
           )}
           .excludeStatistics=${this._excludeList}
+          .excludeReason=${this.hass?.localize(
+            "ui.components.statistic-picker.already_selected"
+          )}
           @value-changed=${this._statisticChanged}
           dialogInitialFocus
         ></ha-statistic-picker>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -871,7 +871,13 @@
         "no_state": "Entity without state",
         "missing_entity": "Why is my entity not listed?",
         "learn_more": "Learn more about statistics",
-        "unknown": "Unknown statistic selected"
+        "unknown": "Unknown statistic selected",
+        "already_selected": "Already selected",
+        "show_incompatible": "Click to explore incompatible statistics",
+        "incompatible_unit": "Incompatible unit of measurement: {unit}",
+        "incompatible_unit_class": "Incompatible unit class: {unit_class}",
+        "incompatible_device_class": "Incompatible device class: {device_class}",
+        "manually_excluded": "Manually excluded"
       },
       "addon-picker": {
         "addon": "Add-on",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Was thinking about ways to help with statistic selection and a lot of users struggle when their entities unexpectedly don't show up for picking. I was thinking maybe we can have a way to better surface why entities don't appear in specific pickers. 

This change is such that everything appars normal originally (excluded entities are hidden), but when you click the "Why isn't my entity listed" button in the statistic picker, instead of linking to a website, we simply reload the picker but this time showing all entities and incompatible statistics, but then show the reason why we exclude them (entity is already selected, wrong device class, wrong unit, or entity doesn't have statistics). If you then select the "Why" button again it still goes to the original doc website. 

<img width="412" height="390" alt="image" src="https://github.com/user-attachments/assets/aaa000da-cc33-4540-8eb8-0c0b68866398" />

Not entirely convinced this is necessary, but will put it out for opinions. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
