### PR TITLE
Don't set history redraw timer when not connected

### DIFF
--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -212,7 +212,9 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
   private _setRedrawTimer() {
     // redraw the graph every minute to update the time axis
     clearInterval(this._interval);
-    this._interval = window.setInterval(() => this._redrawGraph(), 1000 * 60);
+    if (this.isConnected) {
+      this._interval = window.setInterval(() => this._redrawGraph(), 1000 * 60);
+    }
   }
 
   private _unsubscribeHistory() {

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -164,7 +164,9 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
 
     await this._fetchStatistics(sensorNumericDeviceClasses);
 
-    this._setRedrawTimer();
+    if (this.isConnected) {
+      this._setRedrawTimer();
+    }
   }
 
   private _mergeHistory() {

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -164,9 +164,7 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
 
     await this._fetchStatistics(sensorNumericDeviceClasses);
 
-    if (this.isConnected) {
-      this._setRedrawTimer();
-    }
+    this._setRedrawTimer();
   }
 
   private _mergeHistory() {

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -135,6 +135,10 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
     const { numeric_device_classes: sensorNumericDeviceClasses } =
       await getSensorNumericDeviceClasses(this.hass!);
 
+    if (!this.isConnected) {
+      return; // Skip subscribe if we already disconnected while awaiting
+    }
+
     this._subscribed = subscribeHistoryStatesTimeWindow(
       this.hass!,
       (combinedHistory) => {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Somehow in development I keep ending up getting spams of this error, even when I'm in config pages with no history graphs at all:

```
hex.ts:12 Uncaught (in promise) Error: Invalid hex color: 
    at expandHex (hex.ts:12:1)
    at hex2rgb (convert-color.ts:12:1)
    at eval (state-history-chart-timeline.ts:325:1)
    at Array.forEach (<anonymous>)
    at eval (state-history-chart-timeline.ts:301:1)
    at Array.forEach (<anonymous>)
    at StateHistoryChartTimeline._generateData (state-history-chart-timeline.ts:291:1)
    at StateHistoryChartTimeline.willUpdate (state-history-chart-timeline.ts:178:1)
    at StateHistoryChartTimeline.performUpdate (reactive-element.ts:1502:1)
    at StateHistoryChartTimeline.scheduleUpdate (reactive-element.ts:1400:1)
 ```
 
I looked into the history card and I think what is happening is that if we connect, subscribe, and disconnect before the subscribe is finished (like while we are awaiting getStatistics), then we set the redraw timer on a disconnected card. Since the card is already disconnected, it just spins in the background forever keep rescheduling its redraw timer. Normally the timer is cancelled on disconnect, but if we setup the timer when we're already disconnected, it will just run forever. 



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
