### PR TITLE
Fix a crash when clearing energy statistic

### DIFF
--- a/src/panels/config/energy/dialogs/dialog-energy-gas-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-gas-settings.ts
@@ -339,11 +339,11 @@ export class DialogEnergyGasSettings
         ev.detail.value,
         metadata[0]
       );
+      if (isExternalStatistic(ev.detail.value) && this._costs !== "statistic") {
+        this._costs = "no-costs";
+      }
     } else {
       this._pickedDisplayUnit = undefined;
-    }
-    if (isExternalStatistic(ev.detail.value) && this._costs !== "statistic") {
-      this._costs = "no-costs";
     }
     this._source = {
       ...this._source!,

--- a/src/panels/config/energy/dialogs/dialog-energy-grid-flow-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-grid-flow-settings.ts
@@ -326,6 +326,13 @@ export class DialogEnergyGridFlowSettings
   }
 
   private async _statisticChanged(ev: CustomEvent<{ value: string }>) {
+    if (
+      ev.detail.value &&
+      isExternalStatistic(ev.detail.value) &&
+      this._costs !== "statistic"
+    ) {
+      this._costs = "no-costs";
+    }
     this._source = {
       ...this._source!,
       [this._params!.direction === "from"

--- a/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
@@ -278,7 +278,11 @@ export class DialogEnergyWaterSettings
   }
 
   private async _statisticChanged(ev: CustomEvent<{ value: string }>) {
-    if (isExternalStatistic(ev.detail.value) && this._costs !== "statistic") {
+    if (
+      ev.detail.value &&
+      isExternalStatistic(ev.detail.value) &&
+      this._costs !== "statistic"
+    ) {
       this._costs = "no-costs";
     }
     this._source = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Clearing a gas/water energy statistic in the picker throws an exception because isExternalStatistic doesn't handle `undefined`. 

Grid didn't have this problem, but only because the same feature was missing there, so copied the fixed logic there as well. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
