### PR TITLE
Add API in energy integration for fetching power data

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -268,6 +268,23 @@ export const getFossilEnergyConsumption = async (
     period,
   });
 
+export const getPowerStatistics = async (
+  hass: HomeAssistant,
+  startTime: Date,
+  endTime?: Date,
+  statistic_ids?: string[],
+  period: "5minute" | "hour" | "day" | "month" = "hour",
+  units?: StatisticsUnitConfiguration
+) =>
+  hass.callWS<Statistics>({
+    type: "energy/get_power_statistics",
+    start_time: startTime.toISOString(),
+    end_time: endTime?.toISOString(),
+    statistic_ids,
+    period,
+    units,
+  });
+
 export interface EnergySourceByType {
   grid?: GridSourceTypeEnergyPreference[];
   solar?: SolarSourceTypeEnergyPreference[];
@@ -494,9 +511,14 @@ const getEnergyData = async (
       ])
     : {};
   const _powerStats: Statistics | Promise<Statistics> = powerStatIds.length
-    ? fetchStatistics(hass!, start, end, powerStatIds, finePeriod, powerUnits, [
-        "mean",
-      ])
+    ? getPowerStatistics(
+        hass!,
+        start,
+        end,
+        powerStatIds,
+        finePeriod,
+        powerUnits
+      )
     : {};
 
   const _waterStats: Statistics | Promise<Statistics> = waterStatIds.length


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Rather than requesting power data directly from the recorder, a new web API is added to the energy integration which provides access to the power data. Update the frontend to use that.

The new API allows performing more complex operations in the backend when fetching power data. Initially this is set up to mix in long-term statistics data if short term statistics data is requested but not available due to age.

Refer to the corresponding core PR https://github.com/home-assistant/core/pull/160000

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This suggested approach also opens a future possibility to correct for power data having the wrong polarity in the future - polarity correction could be performed as part of the new API in the back-end rather than the front-end.

- This PR fixes or closes issue: fixes #28737
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/1915#discussioncomment-15296701
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
