### PR TITLE
Add config entry picker for Z-Wave JS panel

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-entry-picker.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-entry-picker.ts
@@ -1,0 +1,119 @@
+import type { CSSResultGroup } from "lit";
+import { LitElement, css, html } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import "../../../../../components/ha-card";
+import "../../../../../components/ha-icon-next";
+import "../../../../../components/ha-list";
+import "../../../../../components/ha-list-item";
+import "../../../../../layouts/hass-loading-screen";
+import type { ConfigEntry } from "../../../../../data/config_entries";
+import { getConfigEntries } from "../../../../../data/config_entries";
+import { haStyle } from "../../../../../resources/styles";
+import type { HomeAssistant } from "../../../../../types";
+
+@customElement("zwave_js-config-entry-picker")
+class ZWaveJSConfigEntryPicker extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ type: Boolean }) public narrow = false;
+
+  @state() private _configEntries?: ConfigEntry[];
+
+  protected async firstUpdated() {
+    await this._fetchConfigEntries();
+  }
+
+  protected render() {
+    if (!this._configEntries) {
+      return html`<hass-loading-screen></hass-loading-screen>`;
+    }
+
+    if (this._configEntries.length === 0) {
+      return html`
+        <div class="content">
+          <ha-card>
+            <div class="card-content">
+              <p>
+                ${this.hass.localize(
+                  "ui.panel.config.zwave_js.picker.no_entries"
+                )}
+              </p>
+            </div>
+          </ha-card>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="content">
+        <ha-card>
+          <h1 class="card-header">
+            ${this.hass.localize("ui.panel.config.zwave_js.picker.title")}
+          </h1>
+          <ha-list>
+            ${this._configEntries.map(
+              (entry) => html`
+                <a
+                  href="/config/zwave_js/dashboard?config_entry=${entry.entry_id}"
+                >
+                  <ha-list-item hasMeta>
+                    <span>${entry.title}</span>
+                    <ha-icon-next slot="meta"></ha-icon-next>
+                  </ha-list-item>
+                </a>
+              `
+            )}
+          </ha-list>
+        </ha-card>
+      </div>
+    `;
+  }
+
+  private async _fetchConfigEntries() {
+    const entries = await getConfigEntries(this.hass, {
+      domain: "zwave_js",
+    });
+    this._configEntries = entries;
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      css`
+        .content {
+          padding: 24px;
+          display: flex;
+          justify-content: center;
+        }
+
+        ha-card {
+          max-width: 600px;
+          width: 100%;
+        }
+
+        .card-header {
+          font-size: 20px;
+          font-weight: 500;
+          padding: 16px;
+          padding-bottom: 0;
+        }
+
+        a {
+          text-decoration: none;
+          color: inherit;
+        }
+
+        ha-list {
+          --md-list-item-leading-space: var(--ha-space-4);
+          --md-list-item-trailing-space: var(--ha-space-4);
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "zwave_js-config-entry-picker": ZWaveJSConfigEntryPicker;
+  }
+}

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-entry-picker.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-entry-picker.ts
@@ -34,11 +34,7 @@ class ZWaveJSConfigEntryPicker extends LitElement {
 
     if (this._configEntries.length === 0) {
       return html`
-        <hass-subpage
-          header="Z-Wave JS"
-          .narrow=${this.narrow}
-          .hass=${this.hass}
-        >
+        <hass-subpage header="Z-Wave" .narrow=${this.narrow} .hass=${this.hass}>
           <div class="content">
             <ha-card>
               <div class="card-content">
@@ -55,11 +51,7 @@ class ZWaveJSConfigEntryPicker extends LitElement {
     }
 
     return html`
-      <hass-subpage
-        header="Z-Wave JS"
-        .narrow=${this.narrow}
-        .hass=${this.hass}
-      >
+      <hass-subpage header="Z-Wave" .narrow=${this.narrow} .hass=${this.hass}>
         <div class="content">
           <ha-card
             .header=${this.hass.localize(

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-entry-picker.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-entry-picker.ts
@@ -1,4 +1,4 @@
-import type { CSSResultGroup } from "lit";
+import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../../../components/ha-card";
@@ -6,10 +6,13 @@ import "../../../../../components/ha-icon-next";
 import "../../../../../components/ha-list";
 import "../../../../../components/ha-list-item";
 import "../../../../../layouts/hass-loading-screen";
+import "../../../../../layouts/hass-subpage";
 import type { ConfigEntry } from "../../../../../data/config_entries";
 import { getConfigEntries } from "../../../../../data/config_entries";
 import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
+import { navigate } from "../../../../../common/navigate";
+import { caseInsensitiveStringCompare } from "../../../../../common/string/compare";
 
 @customElement("zwave_js-config-entry-picker")
 class ZWaveJSConfigEntryPicker extends LitElement {
@@ -19,7 +22,8 @@ class ZWaveJSConfigEntryPicker extends LitElement {
 
   @state() private _configEntries?: ConfigEntry[];
 
-  protected async firstUpdated() {
+  protected async firstUpdated(changedProps: PropertyValues) {
+    super.firstUpdated(changedProps);
     await this._fetchConfigEntries();
   }
 
@@ -30,42 +34,55 @@ class ZWaveJSConfigEntryPicker extends LitElement {
 
     if (this._configEntries.length === 0) {
       return html`
-        <div class="content">
-          <ha-card>
-            <div class="card-content">
-              <p>
-                ${this.hass.localize(
-                  "ui.panel.config.zwave_js.picker.no_entries"
-                )}
-              </p>
-            </div>
-          </ha-card>
-        </div>
+        <hass-subpage
+          header="Z-Wave JS"
+          .narrow=${this.narrow}
+          .hass=${this.hass}
+        >
+          <div class="content">
+            <ha-card>
+              <div class="card-content">
+                <p>
+                  ${this.hass.localize(
+                    "ui.panel.config.zwave_js.picker.no_entries"
+                  )}
+                </p>
+              </div>
+            </ha-card>
+          </div>
+        </hass-subpage>
       `;
     }
 
     return html`
-      <div class="content">
-        <ha-card>
-          <h1 class="card-header">
-            ${this.hass.localize("ui.panel.config.zwave_js.picker.title")}
-          </h1>
-          <ha-list>
-            ${this._configEntries.map(
-              (entry) => html`
-                <a
-                  href="/config/zwave_js/dashboard?config_entry=${entry.entry_id}"
-                >
-                  <ha-list-item hasMeta>
-                    <span>${entry.title}</span>
-                    <ha-icon-next slot="meta"></ha-icon-next>
-                  </ha-list-item>
-                </a>
-              `
+      <hass-subpage
+        header="Z-Wave JS"
+        .narrow=${this.narrow}
+        .hass=${this.hass}
+      >
+        <div class="content">
+          <ha-card
+            .header=${this.hass.localize(
+              "ui.panel.config.zwave_js.picker.title"
             )}
-          </ha-list>
-        </ha-card>
-      </div>
+          >
+            <ha-list>
+              ${this._configEntries.map(
+                (entry) => html`
+                  <a
+                    href="/config/zwave_js/dashboard?config_entry=${entry.entry_id}"
+                  >
+                    <ha-list-item hasMeta>
+                      <span>${entry.title}</span>
+                      <ha-icon-next slot="meta"></ha-icon-next>
+                    </ha-list-item>
+                  </a>
+                `
+              )}
+            </ha-list>
+          </ha-card>
+        </div>
+      </hass-subpage>
     `;
   }
 
@@ -73,7 +90,15 @@ class ZWaveJSConfigEntryPicker extends LitElement {
     const entries = await getConfigEntries(this.hass, {
       domain: "zwave_js",
     });
-    this._configEntries = entries;
+    this._configEntries = entries.sort((a, b) =>
+      caseInsensitiveStringCompare(a.title, b.title)
+    );
+    if (this._configEntries.length === 1) {
+      navigate(
+        `/config/zwave_js/dashboard?config_entry=${this._configEntries[0].entry_id}`,
+        { replace: true }
+      );
+    }
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-router.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-router.ts
@@ -3,6 +3,7 @@ import { customElement, property } from "lit/decorators";
 import type { RouterOptions } from "../../../../../layouts/hass-router-page";
 import { HassRouterPage } from "../../../../../layouts/hass-router-page";
 import type { HomeAssistant } from "../../../../../types";
+import { navigate } from "../../../../../common/navigate";
 import type { PageNavigation } from "../../../../../layouts/hass-tabs-subpage";
 
 export const configTabs: PageNavigation[] = [
@@ -41,13 +42,20 @@ class ZWaveJSConfigRouter extends HassRouterPage {
       const searchParams = new URLSearchParams(window.location.search);
       if (searchParams.has("config_entry")) {
         this._configEntry = searchParams.get("config_entry");
+        searchParams.delete("config_entry");
+        let url = `${this.routeTail.prefix}${this.routeTail.path}`;
+        const search = searchParams.toString();
+        if (search) {
+          url += `?${search}`;
+        }
+        navigate(url, { replace: true });
       }
 
-      if (page === "picker" && this._configEntry) {
+      if ((!page || page === "picker") && this._configEntry) {
         return "dashboard";
       }
 
-      if (page !== "picker" && !this._configEntry) {
+      if ((!page || page !== "picker") && !this._configEntry) {
         return "picker";
       }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-router.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-router.ts
@@ -39,7 +39,9 @@ class ZWaveJSConfigRouter extends HassRouterPage {
     // Make sure that we have a config entry in the URL before rendering other pages
     beforeRender: (page) => {
       const searchParams = new URLSearchParams(window.location.search);
-      this._configEntry = searchParams.get("config_entry");
+      if (searchParams.has("config_entry")) {
+        this._configEntry = searchParams.get("config_entry");
+      }
 
       if (page === "picker" && this._configEntry) {
         return "dashboard";

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-router.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-router.ts
@@ -38,9 +38,13 @@ class ZWaveJSConfigRouter extends HassRouterPage {
   );
 
   protected routerOptions: RouterOptions = {
-    defaultPage: "dashboard",
+    defaultPage: "picker",
     showLoading: true,
     routes: {
+      picker: {
+        tag: "zwave_js-config-entry-picker",
+        load: () => import("./zwave_js-config-entry-picker"),
+      },
       dashboard: {
         tag: "zwave_js-config-dashboard",
         load: () => import("./zwave_js-config-dashboard"),
@@ -78,7 +82,11 @@ class ZWaveJSConfigRouter extends HassRouterPage {
     el.hass = this.hass;
     el.isWide = this.isWide;
     el.narrow = this.narrow;
-    el.configEntryId = this._configEntry;
+
+    // Only pass configEntryId to pages that need it (not the picker)
+    if (this.routeTail.path !== "picker") {
+      el.configEntryId = this._configEntry;
+    }
 
     const searchParams = new URLSearchParams(window.location.search);
     if (this._configEntry && !searchParams.has("config_entry")) {
@@ -99,9 +107,15 @@ class ZWaveJSConfigRouter extends HassRouterPage {
     const entries = await getConfigEntries(this.hass, {
       domain: "zwave_js",
     });
-    if (entries.length) {
+    // Only auto-select if there's exactly one entry
+    if (entries.length === 1) {
       this._configEntry = entries[0].entry_id;
+      // Redirect to dashboard with the config entry
+      navigate(`/config/zwave_js/dashboard?config_entry=${this._configEntry}`, {
+        replace: true,
+      });
     }
+    // Otherwise, let the picker page handle showing the list
   }
 }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-router.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-router.ts
@@ -3,7 +3,6 @@ import { customElement, property } from "lit/decorators";
 import type { RouterOptions } from "../../../../../layouts/hass-router-page";
 import { HassRouterPage } from "../../../../../layouts/hass-router-page";
 import type { HomeAssistant } from "../../../../../types";
-import { navigate } from "../../../../../common/navigate";
 import type { PageNavigation } from "../../../../../layouts/hass-tabs-subpage";
 
 export const configTabs: PageNavigation[] = [
@@ -42,13 +41,9 @@ class ZWaveJSConfigRouter extends HassRouterPage {
       const searchParams = new URLSearchParams(window.location.search);
       if (searchParams.has("config_entry")) {
         this._configEntry = searchParams.get("config_entry");
-        searchParams.delete("config_entry");
-        let url = `${this.routeTail.prefix}${this.routeTail.path}`;
-        const search = searchParams.toString();
-        if (search) {
-          url += `?${search}`;
-        }
-        navigate(url, { replace: true });
+      } else if (page === "picker") {
+        this._configEntry = null;
+        return undefined;
       }
 
       if ((!page || page === "picker") && this._configEntry) {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-router.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-router.ts
@@ -3,9 +3,7 @@ import { customElement, property } from "lit/decorators";
 import type { RouterOptions } from "../../../../../layouts/hass-router-page";
 import { HassRouterPage } from "../../../../../layouts/hass-router-page";
 import type { HomeAssistant } from "../../../../../types";
-import { navigate } from "../../../../../common/navigate";
 import type { PageNavigation } from "../../../../../layouts/hass-tabs-subpage";
-import { getConfigEntries } from "../../../../../data/config_entries";
 
 export const configTabs: PageNavigation[] = [
   {
@@ -33,13 +31,26 @@ class ZWaveJSConfigRouter extends HassRouterPage {
 
   @property({ type: Boolean }) public narrow = false;
 
-  private _configEntry = new URLSearchParams(window.location.search).get(
-    "config_entry"
-  );
+  private _configEntry: string | null = null;
 
   protected routerOptions: RouterOptions = {
     defaultPage: "picker",
     showLoading: true,
+    // Make sure that we have a config entry in the URL before rendering other pages
+    beforeRender: (page) => {
+      const searchParams = new URLSearchParams(window.location.search);
+      this._configEntry = searchParams.get("config_entry");
+
+      if (page === "picker" && this._configEntry) {
+        return "dashboard";
+      }
+
+      if (page !== "picker" && !this._configEntry) {
+        return "picker";
+      }
+
+      return undefined;
+    },
     routes: {
       picker: {
         tag: "zwave_js-config-entry-picker",
@@ -74,7 +85,6 @@ class ZWaveJSConfigRouter extends HassRouterPage {
         load: () => import("./zwave_js-network-visualization"),
       },
     },
-    initialLoad: () => this._fetchConfigEntries(),
   };
 
   protected updatePageEl(el): void {
@@ -82,40 +92,7 @@ class ZWaveJSConfigRouter extends HassRouterPage {
     el.hass = this.hass;
     el.isWide = this.isWide;
     el.narrow = this.narrow;
-
-    // Only pass configEntryId to pages that need it (not the picker)
-    if (this.routeTail.path !== "picker") {
-      el.configEntryId = this._configEntry;
-    }
-
-    const searchParams = new URLSearchParams(window.location.search);
-    if (this._configEntry && !searchParams.has("config_entry")) {
-      searchParams.append("config_entry", this._configEntry);
-      navigate(
-        `${this.routeTail.prefix}${
-          this.routeTail.path
-        }?${searchParams.toString()}`,
-        { replace: true }
-      );
-    }
-  }
-
-  private async _fetchConfigEntries() {
-    if (this._configEntry) {
-      return;
-    }
-    const entries = await getConfigEntries(this.hass, {
-      domain: "zwave_js",
-    });
-    // Only auto-select if there's exactly one entry
-    if (entries.length === 1) {
-      this._configEntry = entries[0].entry_id;
-      // Redirect to dashboard with the config entry
-      navigate(`/config/zwave_js/dashboard?config_entry=${this._configEntry}`, {
-        replace: true,
-      });
-    }
-    // Otherwise, let the picker page handle showing the list
+    el.configEntryId = this._configEntry;
   }
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6827,6 +6827,10 @@
                 }
               }
             }
+          },
+          "picker": {
+            "title": "Select Z-Wave network",
+            "no_entries": "No Z-Wave networks configured. Please set up Z-Wave JS integration first."
           }
         },
         "matter": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6830,7 +6830,7 @@
           },
           "picker": {
             "title": "Select Z-Wave network",
-            "no_entries": "No Z-Wave networks configured. Please set up Z-Wave JS integration first."
+            "no_entries": "No Z-Wave networks configured. Set up the Z-Wave JS integration first."
           }
         },
         "matter": {


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When the Z-Wave JS panel is opened without a config entry in the URL,
users now see a picker page to select which config entry to use. The
picker displays all available Z-Wave JS config entries and uses anchor
tags to link to the correct page with the selected config entry.

Changes:
- Created new zwave_js-config-entry-picker component
- Updated zwave_js-config-router to show picker as default page
- Auto-select single config entry for backwards compatibility
- Added translation keys for picker title and no entries message


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a selection flow when the Z-Wave JS panel is opened without a `config_entry`.
> 
> - New `zwave_js-config-entry-picker` lists available Z-Wave JS config entries; auto-redirects if only one is present
> - Router now defaults to `picker` and uses `beforeRender` to require `config_entry`, redirecting between `picker` and `dashboard` as needed
> - Added i18n strings for picker title and empty-state message
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ad506f85c19780ec224b11486baa0083a849880. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->