### PR TITLE
Don't await intl-polyfill imports

### DIFF
--- a/src/resources/polyfills/intl-polyfill.ts
+++ b/src/resources/polyfills/intl-polyfill.ts
@@ -66,10 +66,10 @@ const polyfillIntl = async () => {
   if (polyfills.length === 0) {
     return;
   }
-  await Promise.allSettled(polyfills).then(() =>
+  Promise.all(polyfills).then(async () => {
     // Load the default language
-    polyfillLocaleData(locale)
-  );
+    await polyfillLocaleData(locale);
+  });
 };
 
 await polyfillIntl();

--- a/src/resources/polyfills/intl-polyfill.ts
+++ b/src/resources/polyfills/intl-polyfill.ts
@@ -66,7 +66,7 @@ const polyfillIntl = async () => {
   if (polyfills.length === 0) {
     return;
   }
-  Promise.all(polyfills).then(async () => {
+  Promise.allSettled(polyfills).then(async () => {
     // Load the default language
     await polyfillLocaleData(locale);
   });

--- a/src/resources/polyfills/intl-polyfill.ts
+++ b/src/resources/polyfills/intl-polyfill.ts
@@ -29,7 +29,7 @@ const polyfillIntl = async () => {
     await import("@formatjs/intl-getcanonicallocales/polyfill-force");
   }
   if (shouldPolyfillLocale()) {
-    await import("@formatjs/intl-locale/polyfill-force");
+    import("@formatjs/intl-locale/polyfill-force");
   }
   if (shouldPolyfillDateTimeFormat(locale)) {
     polyfills.push(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Awaiting `import("@formatjs/intl-displaynames/polyfill-force");` in Chrome 143 on macOS 15.6.1 never resolves and dosen't log anything when loading it as part of a config panel dependency (submodule of https://github.com/XKNX/knx-frontend). The project just doesn't load then - an empty tag is rendered instead of the panel. 

This started with f2aba45dfee7c16c2ff9cd44f6d082f09bd12823
Removing `await` here fixes this for me. 

Unfortunately I can't explain why this is happening or what exactly is going on here - and I would be happy if anyone would tell me 😃

For `polyfillLocaleData(locale)` - afaict - it doesn't make a difference if awaited or not. Both work fine.

Testing `await import("@formatjs/intl-locale/polyfill-force");` - although it wouldn't load for my version of Chrome, removing the if-check it would also block indefinitely when using await. 
`await import("@formatjs/intl-getcanonicallocales/polyfill-force");` works fine.

See also https://discord.com/channels/330944238910963714/1456944554786816154
## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
