### PR TITLE
Replace `unload` event handler for custom panels with `pagehide`

### DIFF
--- a/src/entrypoints/custom-panel.ts
+++ b/src/entrypoints/custom-panel.ts
@@ -134,7 +134,7 @@ document.addEventListener(
   { once: true }
 );
 
-window.addEventListener("unload", () => {
+window.addEventListener("pagehide", () => {
   // allow disconnected callback to fire
   while (document.body.lastChild) {
     document.body.removeChild(document.body.lastChild);

--- a/src/entrypoints/custom-panel.ts
+++ b/src/entrypoints/custom-panel.ts
@@ -28,6 +28,7 @@ window.loadES5Adapter = () => {
 };
 
 let panelEl: HTMLElement | undefined;
+let initialized = false;
 
 function setProperties(properties) {
   if (!panelEl) {
@@ -128,13 +129,23 @@ function initialize(
   });
 }
 
-document.addEventListener(
-  "DOMContentLoaded",
-  () => window.parent.customPanel!.registerIframe(initialize, setProperties),
-  { once: true }
-);
+function handleReady() {
+  if (initialized) return;
+  initialized = true;
+  window.parent.customPanel!.registerIframe(initialize, setProperties);
+}
+
+// Initial load
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", handleReady, { once: true });
+} else {
+  handleReady();
+}
+
+window.addEventListener("pageshow", handleReady);
 
 window.addEventListener("pagehide", () => {
+  initialized = false;
   // allow disconnected callback to fire
   while (document.body.lastChild) {
     document.body.removeChild(document.body.lastChild);


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Replace the `unload` event handler for the custom panel loader with `pagehide`.

Loading a custom panel in Chrome 143 on macOS 15.6.1 with the `unload` handler yields
> [Violation] Permissions policy violation: unload is not allowed in this document.

Looking at https://web.dev/articles/bfcache?hl=de#never-use-the-unload-event and https://github.com/WICG/document-policy/issues/39 I guess replacing it with `pagehide` event should be fine. 

Disclaimer: I don't really know what this events intended use in the codebase is, so please review carefully.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
