### PR TITLE
Add theme color to the word "Blocks" when adding automation

### DIFF
--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -2053,6 +2053,10 @@ class DialogAddAutomationElement
             0;
         }
 
+        ha-button-toggle-group button {
+          color: var(--ha-color-on-surface-variant);
+        }
+
         .content {
           flex: 1;
           min-height: 0;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

Add color control to the items-title of the "Blocks" tab when adding conditions or actions to an automation.  As far as I could tell, the word "Blocks" is stuck black (see picture below).

I am uncertain about a number of things here though:

1. Is this the correct place and method to add color?  It is not at all obvious - everything about this is so convoluted
3. Is this the correct color variable to use for this?


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests



## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.


<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io

<img width="1199" height="835" alt="image" src="https://github.com/user-attachments/assets/eeaf6867-c250-4fec-bbd7-a5ce723f4a7a" />

