### PR TITLE
Fix statistic-graph-card cutoff w/ energy date picker

### DIFF
--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -16,16 +16,7 @@ export interface RecorderInfo {
 
 export type StatisticType = "change" | "state" | "sum" | "min" | "max" | "mean";
 
-export const STATISTIC_PERIOD = {
-  FIVE_MINUTE: "5minute",
-  HOUR: "hour",
-  DAY: "day",
-  WEEK: "week",
-  MONTH: "month",
-} as const;
-
-export type StatisticPeriod =
-  (typeof STATISTIC_PERIOD)[keyof typeof STATISTIC_PERIOD];
+export type StatisticPeriod = "5minute" | "hour" | "day" | "week" | "month";
 
 export type Statistics = Record<string, StatisticValue[]>;
 

--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -16,6 +16,17 @@ export interface RecorderInfo {
 
 export type StatisticType = "change" | "state" | "sum" | "min" | "max" | "mean";
 
+export const STATISTIC_PERIOD = {
+  FIVE_MINUTE: "5minute",
+  HOUR: "hour",
+  DAY: "day",
+  WEEK: "week",
+  MONTH: "month",
+} as const;
+
+export type StatisticPeriod =
+  (typeof STATISTIC_PERIOD)[keyof typeof STATISTIC_PERIOD];
+
 export type Statistics = Record<string, StatisticValue[]>;
 
 export interface StatisticValue {
@@ -174,7 +185,7 @@ export const fetchStatistics = (
   startTime: Date,
   endTime?: Date,
   statistic_ids?: string[],
-  period: "5minute" | "hour" | "day" | "week" | "month" = "hour",
+  period: StatisticPeriod = "hour",
   units?: StatisticsUnitConfiguration,
   types?: StatisticsTypes
 ) =>

--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -46,12 +46,12 @@ export function getSuggestedMax(
 
   if (!detailedDailyData) {
     suggestedMax.setMinutes(0, 0, 0);
-  }
-  if (dayDifference > 35) {
-    suggestedMax.setDate(1);
-  }
-  if (dayDifference > 2) {
-    suggestedMax.setHours(0);
+    if (dayDifference > 35) {
+      suggestedMax.setDate(1);
+    }
+    if (dayDifference > 2) {
+      suggestedMax.setHours(0);
+    }
   }
   return suggestedMax.getTime();
 }

--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -30,19 +30,16 @@ import {
 import { formatTime } from "../../../../../common/datetime/format_time";
 import type { ECOption } from "../../../../../resources/echarts/echarts";
 import { filterXSS } from "../../../../../common/util/xss";
-import {
-  STATISTIC_PERIOD,
-  type StatisticPeriod,
-} from "../../../../../data/recorder";
+import type { StatisticPeriod } from "../../../../../data/recorder";
 
 export function getSuggestedMax(period: StatisticPeriod, end: Date): number {
   let suggestedMax = new Date(end);
 
-  if (period === STATISTIC_PERIOD.FIVE_MINUTE) {
+  if (period === "5minute") {
     return suggestedMax.getTime();
   }
   suggestedMax.setMinutes(0, 0, 0);
-  if (period === STATISTIC_PERIOD.HOUR) {
+  if (period === "hour") {
     return suggestedMax.getTime();
   }
   // Sometimes around DST we get a time of 0:59 instead of 23:59 as expected.
@@ -51,7 +48,7 @@ export function getSuggestedMax(period: StatisticPeriod, end: Date): number {
     suggestedMax = subHours(suggestedMax, 1);
   }
   suggestedMax.setHours(0);
-  if (period === STATISTIC_PERIOD.DAY || period === STATISTIC_PERIOD.WEEK) {
+  if (period === "day" || period === "week") {
     return suggestedMax.getTime();
   }
   // period === month
@@ -60,11 +57,7 @@ export function getSuggestedMax(period: StatisticPeriod, end: Date): number {
 }
 
 export function getSuggestedPeriod(dayDifference: number): StatisticPeriod {
-  return dayDifference > 35
-    ? STATISTIC_PERIOD.MONTH
-    : dayDifference > 2
-      ? STATISTIC_PERIOD.DAY
-      : STATISTIC_PERIOD.HOUR;
+  return dayDifference > 35 ? "month" : dayDifference > 2 ? "day" : "hour";
 }
 
 function createYAxisLabelFormatter(locale: FrontendLocaleData) {
@@ -102,9 +95,7 @@ export function getCommonOptions(
       type: "time",
       min: start,
       max: getSuggestedMax(
-        detailedDailyData
-          ? STATISTIC_PERIOD.FIVE_MINUTE
-          : getSuggestedPeriod(dayDifference),
+        detailedDailyData ? "5minute" : getSuggestedPeriod(dayDifference),
         end
       ),
     },

--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -30,36 +30,41 @@ import {
 import { formatTime } from "../../../../../common/datetime/format_time";
 import type { ECOption } from "../../../../../resources/echarts/echarts";
 import { filterXSS } from "../../../../../common/util/xss";
+import {
+  STATISTIC_PERIOD,
+  type StatisticPeriod,
+} from "../../../../../data/recorder";
 
-export function getSuggestedMax(
-  dayDifference: number,
-  end: Date,
-  detailedDailyData = false
-): number {
+export function getSuggestedMax(period: StatisticPeriod, end: Date): number {
   let suggestedMax = new Date(end);
 
+  if (period === STATISTIC_PERIOD.FIVE_MINUTE) {
+    return suggestedMax.getTime();
+  }
+  suggestedMax.setMinutes(0, 0, 0);
+  if (period === STATISTIC_PERIOD.HOUR) {
+    return suggestedMax.getTime();
+  }
   // Sometimes around DST we get a time of 0:59 instead of 23:59 as expected.
   // Correct for this when showing days/months so we don't get an extra day.
-  if (dayDifference > 2 && suggestedMax.getHours() === 0) {
+  if (suggestedMax.getHours() === 0) {
     suggestedMax = subHours(suggestedMax, 1);
   }
-
-  if (!detailedDailyData) {
-    suggestedMax.setMinutes(0, 0, 0);
-    if (dayDifference > 35) {
-      suggestedMax.setDate(1);
-    }
-    if (dayDifference > 2) {
-      suggestedMax.setHours(0);
-    }
+  suggestedMax.setHours(0);
+  if (period === STATISTIC_PERIOD.DAY || period === STATISTIC_PERIOD.WEEK) {
+    return suggestedMax.getTime();
   }
+  // period === month
+  suggestedMax.setDate(1);
   return suggestedMax.getTime();
 }
 
-export function getSuggestedPeriod(
-  dayDifference: number
-): "month" | "day" | "hour" {
-  return dayDifference > 35 ? "month" : dayDifference > 2 ? "day" : "hour";
+export function getSuggestedPeriod(dayDifference: number): StatisticPeriod {
+  return dayDifference > 35
+    ? STATISTIC_PERIOD.MONTH
+    : dayDifference > 2
+      ? STATISTIC_PERIOD.DAY
+      : STATISTIC_PERIOD.HOUR;
 }
 
 function createYAxisLabelFormatter(locale: FrontendLocaleData) {
@@ -96,7 +101,12 @@ export function getCommonOptions(
     xAxis: {
       type: "time",
       min: start,
-      max: getSuggestedMax(dayDifference, end, detailedDailyData),
+      max: getSuggestedMax(
+        detailedDailyData
+          ? STATISTIC_PERIOD.FIVE_MINUTE
+          : getSuggestedPeriod(dayDifference),
+        end
+      ),
     },
     yAxis: {
       type: "value",

--- a/src/panels/lovelace/cards/hui-statistics-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-statistics-graph-card.ts
@@ -334,11 +334,7 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
             .maxYAxis=${this._config.max_y_axis}
             .startTime=${this._energyStart}
             .endTime=${this._energyEnd && this._energyStart
-              ? getSuggestedMax(
-                  differenceInDays(this._energyEnd, this._energyStart),
-                  this._energyEnd,
-                  this._config?.period === "5minute"
-                )
+              ? getSuggestedMax(this._period!, this._energyEnd)
               : undefined}
             .fitYData=${this._config.fit_y_data || false}
             .hideLegend=${this._config.hide_legend || false}

--- a/src/panels/lovelace/cards/hui-statistics-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-statistics-graph-card.ts
@@ -336,7 +336,8 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
             .endTime=${this._energyEnd && this._energyStart
               ? getSuggestedMax(
                   differenceInDays(this._energyEnd, this._energyStart),
-                  this._energyEnd
+                  this._energyEnd,
+                  this._config?.period === "5minute"
                 )
               : undefined}
             .fitYData=${this._config.fit_y_data || false}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The statistic graph card suffered from the same issue as the energy power graph where it cutoff the last hour when using 5-minute resolution, as well as other similar issues when using a period that was not the default period based on the dayDifference (cutoff the month of december if you select "days" period and display the entire year. 

Looking at the `getSuggestedMax` function where the previous fix was applied, I realized that passing the dayDifference here was really the wrong thing, what it really wants is to know is the display period, it was just internally trying to guess the period from the dayDifference, but the dayDifference itself didn't actually matter. 

By changing this function to explictly take the period, we can generate the right value even when the period/dayDifference is not the default setting. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #28766 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
