### PR TITLE
HA-Automation-Row Component: Change Collapsible Expander Chevron direction

### DIFF
--- a/src/components/ha-automation-row.ts
+++ b/src/components/ha-automation-row.ts
@@ -1,4 +1,4 @@
-import { mdiChevronUp } from "@mdi/js";
+import { mdiChevronRight } from "@mdi/js";
 import type { TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query } from "lit/decorators";
@@ -42,7 +42,7 @@ export class HaAutomationRow extends LitElement {
           ? html`
               <ha-icon-button
                 class="expand-button"
-                .path=${mdiChevronUp}
+                .path=${mdiChevronRight}
                 @click=${this._handleExpand}
                 @keydown=${this._handleExpand}
               ></ha-icon-button>
@@ -158,8 +158,8 @@ export class HaAutomationRow extends LitElement {
       color: var(--white-color);
       transform: rotate(-45deg);
     }
-    :host([collapsed]) .expand-button {
-      transform: rotate(180deg);
+    :host(:not([collapsed])) .expand-button {
+      transform: rotate(90deg);
     }
     :host([selected]) .row,
     :host([selected]) .row:focus {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Change Collapsible Automation Row Chevron Direction to align with html `<details>` behaviour and intuition for Expanding Icons *on the left of the Summary text*. 
<details><summary>Points right when closed and down when expanded. (CLICK ME)</summary>
Very common design for collapsible sections with their indicator icon on the LEFT of the text.

RIGHT side Indicators left untouched.
</details>

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

(Visual / User experience)

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
Editing any nestable Automation block (AND, IF, OR) via the UI automation configurator.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Sorry, if this seems like a bit of a low-effort type of PR but I felt visceral disgust when I noticed that the expander-icon in automation blocks works completely differently to any other expanding section I've ever seen online.
I only changed this occurance because in the automation-row the indicator is on the left and for any other expandables I stumbled upon, the icon was on the right, which was totally fine with my expectance and gut feeling.

If you want I can scour the frontend for more of left-aligned chevrons so there's at least *some* effort :P

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works. (none needed)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] 
(Not needed)

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
