### PR TITLE
Handling empty history

### DIFF
--- a/src/panels/lovelace/common/graph/coordinates.ts
+++ b/src/panels/lovelace/common/graph/coordinates.ts
@@ -7,6 +7,11 @@ const calcPoints = (
   height: number,
   limits?: { minX?: number; maxX?: number; minY?: number; maxY?: number }
 ) => {
+  // handling empty history (for example unavailable for long time)
+  if (history.length === 0) {
+    return { points: [], yAxisOrigin: height };
+  }
+
   let yAxisOrigin = height;
   let minY = limits?.minY ?? history[0][1];
   let maxY = limits?.maxY ?? history[0][1];


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Using the lovelace card with a history line and the sensor is unavailable (for a long time) results in `TypeError: can't access property 1, history[0] is undefined` originating from calcPoints(). This leads to an endless spinning progress indicator in the card.
<img width="269" height="141" alt="BeforeFix" src="https://github.com/user-attachments/assets/91061fc7-c86d-4b58-925a-b3e74f09e59d" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
graph: line
type: sensor
detail: 1
hours_to_show: 0.01
entity: sensor.unavailablesensor
```
Note: the small `hours_to_show` value is just for easier reproduction. The same issue can be observed for larger values (e.g. 8 hours on my productive system).

## Additional information
To reproduce the bug:
1. Create a template sensor `UnavailableSensor` with state unavailable. 
2. Add the card from the example configuration to the dashboard
3. In the developer tools, set the state of `UnavailableSensor` to `unavailable`.
4. Refresh the dashboard (Ctrl + Shift + R). You might need to refresh it a few times (coming from the hours_to_show).

Applying the changes correctly renders the card:

<img width="261" height="139" alt="AfterFix" src="https://github.com/user-attachments/assets/98cba8a6-1c0b-4f8a-95b3-d6e4915738bb" />


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
