### PR TITLE
ha-config-voice-assistants-expose: simplify "template" for "assistants"

### DIFF
--- a/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
+++ b/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
@@ -6,7 +6,7 @@ import {
   mdiPlusBoxMultiple,
 } from "@mdi/js";
 import type { CSSResultGroup, PropertyValues } from "lit";
-import { LitElement, css, html } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
 import memoize from "memoize-one";
@@ -209,7 +209,7 @@ export class VoiceAssistantsExpose extends LitElement {
         maxWidth: "160px",
         type: "flex",
         template: (entry) =>
-          html`${availableAssistants.map((key) => {
+          availableAssistants.map((key) => {
             const supported =
               !supportedEntities?.[key] ||
               supportedEntities[key].includes(entry.entity_id);
@@ -224,8 +224,8 @@ export class VoiceAssistantsExpose extends LitElement {
                   >
                   </voice-assistants-expose-assistant-icon>
                 `
-              : html`<div style="width: 40px;"></div>`;
-          })}`,
+              : nothing;
+          }),
       },
       aliases: {
         title: localize(

--- a/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
+++ b/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
@@ -209,7 +209,7 @@ export class VoiceAssistantsExpose extends LitElement {
         maxWidth: "160px",
         type: "flex",
         template: (entry) =>
-          availableAssistants.map((key) => {
+          html`${availableAssistants.map((key) => {
             const supported =
               !supportedEntities?.[key] ||
               supportedEntities[key].includes(entry.entity_id);
@@ -225,7 +225,7 @@ export class VoiceAssistantsExpose extends LitElement {
                   </voice-assistants-expose-assistant-icon>
                 `
               : nothing;
-          }),
+          })}`,
       },
       aliases: {
         title: localize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Simplification for "assistants" column.

Before - icons are shown on fixed places:
<img width="176" height="540" alt="image" src="https://github.com/user-attachments/assets/308a9da3-9b4e-45c9-a94e-6c8529a4b1aa" />

After - icons are shown one by one:
<img width="190" height="440" alt="image" src="https://github.com/user-attachments/assets/b28a492f-efdd-49b7-956e-98cfdad9841e" />

Reason: there is a chance that the 1st assistant is not used - hence the 1st "cell" will be empty for all entities, not nice...



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
