### PR TITLE
Fix issue #28896: "Last 12 months" in the Datetime Picker selects last year

### DIFF
--- a/src/common/datetime/calc_date_range.ts
+++ b/src/common/datetime/calc_date_range.ts
@@ -93,8 +93,8 @@ export const calcDateRange = (
       ];
     case "now-12m":
       return [
-        calcDate(subMonths(today, 12), startOfMonth, hass.locale, hass.config),
-        calcDate(subMonths(today, 1), endOfMonth, hass.locale, hass.config),
+        calcDate(today, subMonths, hass.locale, hass.config, 12),
+        calcDate(today, subMonths, hass.locale, hass.config, 0),
       ];
     case "now-1h":
       return [


### PR DESCRIPTION
Fixes: https://github.com/home-assistant/frontend/issues/28896

**The Problem:**

"now-12m" was selecting the calendar year (Jan 1st to Dec 31st) instead of the last 12 months from now It used startOfMonth and endOfMonth, which snap to month boundaries.

 **The Solution:**
Changed to match the now-7d and now-30d pattern
Now uses subMonths(today, 12) for start and subMonths(today, 0) (which equals today) for end This gives exactly the last 12 months (365/366 days) ending at the current time 

**The Fix:**
```
// Before (WRONG):
calcDate(subMonths(today, 12), startOfMonth, ...)  // Jan 1st of 12 months ago
calcDate(subMonths(today, 1), endOfMonth, ...)     // Dec 31st of last month

// After (CORRECT):
calcDate(today, subMonths, hass.locale, hass.config, 12)  // 12 months ago from now
calcDate(today, subMonths, hass.locale, hass.config, 0)   // now
```
<img width="814" height="603" alt="image" src="https://github.com/user-attachments/assets/99d536c1-5f75-4ffe-b292-a1bbb5d0b8a9" />
<img width="697" height="555" alt="image" src="https://github.com/user-attachments/assets/cff3daee-24d7-4c9c-bdb4-cc55e99f11cf" />



<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


✏️ Tip: You can customize this high-level summary in your review settings.