### PR TITLE
Fixed modal visibility issue in settings -> areas -> edit room

### DIFF
--- a/src/components/ha-wa-dialog.ts
+++ b/src/components/ha-wa-dialog.ts
@@ -49,7 +49,6 @@ export type DialogWidth = "small" | "medium" | "large" | "full";
  * @cssprop --ha-dialog-hide-duration - Hide animation duration.
  * @cssprop --ha-dialog-surface-background - Dialog background color.
  * @cssprop --ha-dialog-border-radius - Border radius of the dialog surface.
- * @cssprop --dialog-z-index - Z-index for the dialog.
  * @cssprop --dialog-surface-margin-top - Top margin for the dialog surface.
  *
  * @attr {boolean} open - Controls the dialog open state.
@@ -250,7 +249,6 @@ export class HaWaDialog extends ScrollableFadeMixin(LitElement) {
             var(--ha-border-radius-3xl)
           );
           max-width: var(--ha-dialog-max-width, var(--safe-width));
-          z-index: var(--dialog-z-index, 8);
         }
         @media (prefers-reduced-motion: reduce) {
           wa-dialog {

--- a/src/components/ha-wa-dialog.ts
+++ b/src/components/ha-wa-dialog.ts
@@ -250,6 +250,7 @@ export class HaWaDialog extends ScrollableFadeMixin(LitElement) {
             var(--ha-border-radius-3xl)
           );
           max-width: var(--ha-dialog-max-width, var(--safe-width));
+          z-index: var(--dialog-z-index, 8);
         }
         @media (prefers-reduced-motion: reduce) {
           wa-dialog {

--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -44,6 +44,8 @@ class DialogMediaPlayerBrowse extends LitElement {
 
   @state() _preferredLayout: MediaPlayerLayoutType = "auto";
 
+  @state() private _open = false;
+
   @query("ha-media-player-browse") private _browser!: HaMediaPlayerBrowse;
 
   public showDialog(params: MediaPlayerBrowseDialogParams): void {
@@ -54,9 +56,11 @@ class DialogMediaPlayerBrowse extends LitElement {
         media_content_type: undefined,
       },
     ];
+    this._open = true;
   }
 
   public closeDialog() {
+    this._open = false;
     this._params = undefined;
     this._navigateIds = undefined;
     this._currentItem = undefined;
@@ -73,7 +77,7 @@ class DialogMediaPlayerBrowse extends LitElement {
     return html`
       <ha-wa-dialog
         .hass=${this.hass}
-        .open=${true}
+        .open=${this._open}
         flexcontent
         @closed=${this.closeDialog}
         @opened=${this._dialogOpened}
@@ -219,7 +223,6 @@ class DialogMediaPlayerBrowse extends LitElement {
       haStyleDialogFixedTop,
       css`
         ha-wa-dialog {
-          --dialog-z-index: 9;
           --dialog-content-padding: 0;
         }
 

--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -21,7 +21,7 @@ import type {
 } from "../../data/media-player";
 import { haStyleDialog, haStyleDialogFixedTop } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
-import "../ha-dialog";
+import "../ha-wa-dialog";
 import "../ha-dialog-header";
 import "../ha-list-item";
 import "./ha-media-manage-button";
@@ -71,21 +71,14 @@ class DialogMediaPlayerBrowse extends LitElement {
     }
 
     return html`
-      <ha-dialog
-        open
-        scrimClickAction
-        escapeKeyAction
-        hideActions
-        flexContent
-        .heading=${!this._currentItem
-          ? this.hass.localize(
-              "ui.components.media-browser.media-player-browser"
-            )
-          : this._currentItem.title}
+      <ha-wa-dialog
+        .hass=${this.hass}
+        .open=${true}
+        flexcontent
         @closed=${this.closeDialog}
         @opened=${this._dialogOpened}
       >
-        <ha-dialog-header show-border slot="heading">
+        <ha-dialog-header show-border slot="header">
           ${this._navigateIds.length > (this._params.minimumNavigateLevel ?? 1)
             ? html`
                 <ha-icon-button
@@ -153,7 +146,7 @@ class DialogMediaPlayerBrowse extends LitElement {
           <ha-icon-button
             .label=${this.hass.localize("ui.common.close")}
             .path=${mdiClose}
-            dialogAction="close"
+            data-dialog="close"
             slot="actionItems"
           ></ha-icon-button>
         </ha-dialog-header>
@@ -173,7 +166,7 @@ class DialogMediaPlayerBrowse extends LitElement {
           @media-picked=${this._mediaPicked}
           @media-browsed=${this._mediaBrowsed}
         ></ha-media-player-browse>
-      </ha-dialog>
+      </ha-wa-dialog>
     `;
   }
 
@@ -225,7 +218,7 @@ class DialogMediaPlayerBrowse extends LitElement {
       haStyleDialog,
       haStyleDialogFixedTop,
       css`
-        ha-dialog {
+        ha-wa-dialog {
           --dialog-z-index: 9;
           --dialog-content-padding: 0;
         }
@@ -241,9 +234,9 @@ class DialogMediaPlayerBrowse extends LitElement {
         }
 
         @media (min-width: 800px) {
-          ha-dialog {
-            --mdc-dialog-max-width: 800px;
-            --mdc-dialog-max-height: calc(
+          ha-wa-dialog {
+            --ha-dialog-max-width: 800px;
+            --ha-dialog-max-height: calc(
               100vh - var(--ha-space-18) - var(--safe-area-inset-y)
             );
           }

--- a/src/panels/config/areas/dialog-area-registry-detail.ts
+++ b/src/panels/config/areas/dialog-area-registry-detail.ts
@@ -8,6 +8,7 @@ import type { HaEntityPicker } from "../../../components/entity/ha-entity-picker
 import "../../../components/ha-alert";
 import "../../../components/ha-aliases-editor";
 import "../../../components/ha-button";
+import "../../../components/ha-dialog-footer";
 import "../../../components/ha-expansion-panel";
 import "../../../components/ha-floor-picker";
 import "../../../components/ha-icon-picker";
@@ -16,7 +17,7 @@ import "../../../components/ha-picture-upload";
 import type { HaPictureUpload } from "../../../components/ha-picture-upload";
 import "../../../components/ha-settings-row";
 import "../../../components/ha-textfield";
-import "../../../components/ha-dialog";
+import "../../../components/ha-wa-dialog";
 import type {
   AreaRegistryEntry,
   AreaRegistryEntryMutableParams,
@@ -250,9 +251,10 @@ class DialogAreaDetail
     const isNew = !entry;
 
     return html`
-      <ha-dialog
+      <ha-wa-dialog
+        .hass=${this.hass}
         .open=${this._open}
-        .heading=${entry
+        header-title=${entry
           ? this.hass.localize("ui.panel.config.areas.editor.update_area")
           : this.hass.localize("ui.panel.config.areas.editor.create_area")}
         @closed=${this._dialogClosed}
@@ -266,28 +268,31 @@ class DialogAreaDetail
             ${!isNew ? this._renderRelatedEntitiesExpansion() : nothing}
           </div>
         </div>
-        ${!isNew
-          ? html`
-              <ha-button
-                slot="primaryAction"
-                appearance="plain"
-                @click=${this._deleteArea}
-                .disabled=${this._submitting}
-              >
-                ${this.hass.localize("ui.common.delete")}
-              </ha-button>
-            `
-          : nothing}
-        <ha-button
-          slot="primaryAction"
-          @click=${this._updateEntry}
-          .disabled=${nameInvalid || !!this._submitting}
-        >
-          ${entry
-            ? this.hass.localize("ui.common.save")
-            : this.hass.localize("ui.common.create")}
-        </ha-button>
-      </ha-dialog>
+        <ha-dialog-footer slot="footer">
+          ${!isNew
+            ? html`
+                <ha-button
+                  slot="secondaryAction"
+                  variant="danger"
+                  appearance="plain"
+                  @click=${this._deleteArea}
+                  .disabled=${this._submitting}
+                >
+                  ${this.hass.localize("ui.common.delete")}
+                </ha-button>
+              `
+            : nothing}
+          <ha-button
+            slot="primaryAction"
+            @click=${this._updateEntry}
+            .disabled=${nameInvalid || !!this._submitting}
+          >
+            ${entry
+              ? this.hass.localize("ui.common.save")
+              : this.hass.localize("ui.common.create")}
+          </ha-button>
+        </ha-dialog-footer>
+      </ha-wa-dialog>
     `;
   }
 
@@ -404,7 +409,7 @@ class DialogAreaDetail
     return [
       haStyleDialog,
       css`
-        ha-dialog {
+        ha-wa-dialog {
           --dialog-z-index: 8;
         }
         ha-textfield {

--- a/src/panels/config/areas/dialog-area-registry-detail.ts
+++ b/src/panels/config/areas/dialog-area-registry-detail.ts
@@ -8,7 +8,6 @@ import type { HaEntityPicker } from "../../../components/entity/ha-entity-picker
 import "../../../components/ha-alert";
 import "../../../components/ha-aliases-editor";
 import "../../../components/ha-button";
-import "../../../components/ha-dialog-footer";
 import "../../../components/ha-expansion-panel";
 import "../../../components/ha-floor-picker";
 import "../../../components/ha-icon-picker";
@@ -17,7 +16,7 @@ import "../../../components/ha-picture-upload";
 import type { HaPictureUpload } from "../../../components/ha-picture-upload";
 import "../../../components/ha-settings-row";
 import "../../../components/ha-textfield";
-import "../../../components/ha-wa-dialog";
+import "../../../components/ha-dialog";
 import type {
   AreaRegistryEntry,
   AreaRegistryEntryMutableParams,
@@ -251,10 +250,9 @@ class DialogAreaDetail
     const isNew = !entry;
 
     return html`
-      <ha-wa-dialog
-        .hass=${this.hass}
+      <ha-dialog
         .open=${this._open}
-        header-title=${entry
+        .heading=${entry
           ? this.hass.localize("ui.panel.config.areas.editor.update_area")
           : this.hass.localize("ui.panel.config.areas.editor.create_area")}
         @closed=${this._dialogClosed}
@@ -268,31 +266,28 @@ class DialogAreaDetail
             ${!isNew ? this._renderRelatedEntitiesExpansion() : nothing}
           </div>
         </div>
-        <ha-dialog-footer slot="footer">
-          ${!isNew
-            ? html`
-                <ha-button
-                  slot="secondaryAction"
-                  variant="danger"
-                  appearance="plain"
-                  @click=${this._deleteArea}
-                  .disabled=${this._submitting}
-                >
-                  ${this.hass.localize("ui.common.delete")}
-                </ha-button>
-              `
-            : nothing}
-          <ha-button
-            slot="primaryAction"
-            @click=${this._updateEntry}
-            .disabled=${nameInvalid || !!this._submitting}
-          >
-            ${entry
-              ? this.hass.localize("ui.common.save")
-              : this.hass.localize("ui.common.create")}
-          </ha-button>
-        </ha-dialog-footer>
-      </ha-wa-dialog>
+        ${!isNew
+          ? html`
+              <ha-button
+                slot="primaryAction"
+                appearance="plain"
+                @click=${this._deleteArea}
+                .disabled=${this._submitting}
+              >
+                ${this.hass.localize("ui.common.delete")}
+              </ha-button>
+            `
+          : nothing}
+        <ha-button
+          slot="primaryAction"
+          @click=${this._updateEntry}
+          .disabled=${nameInvalid || !!this._submitting}
+        >
+          ${entry
+            ? this.hass.localize("ui.common.save")
+            : this.hass.localize("ui.common.create")}
+        </ha-button>
+      </ha-dialog>
     `;
   }
 
@@ -409,6 +404,9 @@ class DialogAreaDetail
     return [
       haStyleDialog,
       css`
+        ha-dialog {
+          --dialog-z-index: 8;
+        }
         ha-textfield {
           display: block;
         }

--- a/src/panels/config/areas/dialog-area-registry-detail.ts
+++ b/src/panels/config/areas/dialog-area-registry-detail.ts
@@ -409,9 +409,6 @@ class DialogAreaDetail
     return [
       haStyleDialog,
       css`
-        ha-wa-dialog {
-          --dialog-z-index: 8;
-        }
         ha-textfield {
           display: block;
         }


### PR DESCRIPTION
Fixes: https://github.com/home-assistant/frontend/issues/28904

## Proposed change
_Root Cause:_ ha-dialog (Material Design) and ha-wa-dialog (Web Awesome with native <dialog>) use incompatible stacking systems. The native dialog element's "top layer" always appears above regular DOM, making z-index ineffective.

_Solution Applied:_
~~Converted dialog-area-registry-detail from ha-wa-dialog to ha-dialog - both dialogs now use the same Material Design system~~
- Z-index configuration:
    Media player dialog: z-index: 9 (will be on top)
    Area registry dialog: z-index: 8 (will be below)
Updated dialog structure to use ha-dialog slots and actions pattern


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information

  The ha-dialog component uses a different structure than ha-wa-dialog. 
For ha-dialog (Material Design based), buttons should be placed directly with slot="primaryAction" or slot="secondaryAction" without wrapping them in ha-dialog-footer. The ha-dialog-footer component is only used with ha-wa-dialog.


- This PR fixes or closes issue: fixes #https://github.com/home-assistant/frontend/issues/28904

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

**Before fix:**
<img width="837" height="896" alt="image" src="https://github.com/user-attachments/assets/09ec33a4-2627-4d49-a196-6f0a962dc338" />

**After fix**
<img width="757" height="869" alt="image" src="https://github.com/user-attachments/assets/51cb85f3-fb22-4bf0-adf6-f4cdb8c456a4" />


[docs-repository]: https://github.com/home-assistant/home-assistant.io