### PR TITLE
Update energy summary visibility condition

### DIFF
--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -314,7 +314,7 @@ class PanelEnergy extends LitElement {
     if (hasPower) {
       views.push(POWER_VIEW);
     }
-    if (views.length > 1) {
+    if ([hasEnergy, hasGas, hasWater].filter(Boolean).length > 1) {
       views.unshift(OVERVIEW_VIEW);
     }
     return {

--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -283,13 +283,18 @@ class PanelEnergy extends LitElement {
       ["grid", "solar", "battery"].includes(source.type)
     );
 
-    const hasPower =
-      this._prefs.energy_sources.some(
-        (source) =>
-          (source.type === "solar" && source.stat_rate) ||
-          (source.type === "battery" && source.stat_rate) ||
-          (source.type === "grid" && source.power?.length)
-      ) || this._prefs.device_consumption.some((device) => device.stat_rate);
+    const hasPowerSource = this._prefs.energy_sources.some(
+      (source) =>
+        (source.type === "solar" && source.stat_rate) ||
+        (source.type === "battery" && source.stat_rate) ||
+        (source.type === "grid" && source.power?.length)
+    );
+
+    const hasDevicePower = this._prefs.device_consumption.some(
+      (device) => device.stat_rate
+    );
+
+    const hasPower = hasPowerSource || hasDevicePower;
 
     const hasWater =
       this._prefs.energy_sources.some((source) => source.type === "water") ||
@@ -314,7 +319,9 @@ class PanelEnergy extends LitElement {
     if (hasPower) {
       views.push(POWER_VIEW);
     }
-    if ([hasEnergy, hasGas, hasWater].filter(Boolean).length > 1) {
+    if (
+      [hasEnergy, hasGas, hasWater, hasPowerSource].filter(Boolean).length > 1
+    ) {
       views.unshift(OVERVIEW_VIEW);
     }
     return {

--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -320,7 +320,8 @@ class PanelEnergy extends LitElement {
       views.push(POWER_VIEW);
     }
     if (
-      [hasEnergy, hasGas, hasWater, hasPowerSource].filter(Boolean).length > 1
+      hasPowerSource ||
+      [hasEnergy, hasGas, hasWater].filter(Boolean).length > 1
     ) {
       views.unshift(OVERVIEW_VIEW);
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The logic for the energy summary panel is not quite right. 

If user has only individual devices & individual devices power: We show summary panel, but it is completely blank, as neither of those sources are shown in the summary. That seems like it obviously needs to be fixed. 

If user has one summarized source (e.g. gas), and individual devices: We show a summary panel, and it has only gas. Then we also show the detailed gas panel, which is just the same information as summary repeated again. I don't really think we want both of these?

Same if you have grid energy, individual devices, and devices power. We show the summary (which is grid energy only), then the energy panel (more information, but in a different layout), and power. I'm not entirely sure if we want the summary in this configuration or not. This PR removes it, but I'm open to other opinions if we think we want to keep both?

In summary this tries to only show the summary panel when we have >1 thing which is summarized on that panel. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
