### PR TITLE
Add area and device context to media player join dialog

### DIFF
--- a/src/components/media-player/ha-media-player-toggle.ts
+++ b/src/components/media-player/ha-media-player-toggle.ts
@@ -1,14 +1,14 @@
 import { type CSSResultGroup, LitElement, css, html } from "lit";
 import { customElement, property } from "lit/decorators";
-import { mdiSpeaker } from "@mdi/js";
+import { mdiSpeaker, mdiSpeakerPause, mdiSpeakerPlay } from "@mdi/js";
 
 import type { HomeAssistant } from "../../types";
-import { computeStateName } from "../../common/entity/compute_state_name";
+import { computeEntityNameList } from "../../common/entity/compute_entity_name_display";
+import { computeRTL } from "../../common/util/compute_rtl";
 import { fireEvent } from "../../common/dom/fire_event";
 
 import "../ha-switch";
 import "../ha-svg-icon";
-import type { MediaPlayerEntity } from "../../data/media-player";
 
 @customElement("ha-media-player-toggle")
 class HaMediaPlayerToggle extends LitElement {
@@ -22,13 +22,35 @@ class HaMediaPlayerToggle extends LitElement {
 
   protected render() {
     const stateObj = this.hass.states[this.entityId];
+
+    let icon = mdiSpeaker;
+    if (stateObj.state === "playing") {
+      icon = mdiSpeakerPlay;
+    } else if (stateObj.state === "paused") {
+      icon = mdiSpeakerPause;
+    }
+
+    const [entityName, deviceName, areaName] = computeEntityNameList(
+      stateObj,
+      [{ type: "entity" }, { type: "device" }, { type: "area" }],
+      this.hass.entities,
+      this.hass.devices,
+      this.hass.areas,
+      this.hass.floors
+    );
+
+    const isRTL = computeRTL(this.hass);
+
+    const primary = entityName || deviceName || this.entityId;
+    const secondary = [areaName, entityName ? deviceName : undefined]
+      .filter(Boolean)
+      .join(isRTL ? " ◂ " : " ▸ ");
+
     return html`<div class="list-item">
-      <ha-svg-icon .path=${mdiSpeaker}></ha-svg-icon>
+      <ha-svg-icon .path=${icon}></ha-svg-icon>
       <div class="info">
-        <div class="main-text">${computeStateName(stateObj)}</div>
-        <div class="secondary-text">
-          ${this._formatSecondaryText(stateObj as MediaPlayerEntity)}
-        </div>
+        <div class="main-text">${primary}</div>
+        <div class="secondary-text">${secondary}</div>
       </div>
       <ha-switch
         .disabled=${this.disabled}
@@ -36,16 +58,6 @@ class HaMediaPlayerToggle extends LitElement {
         @change=${this._handleChange}
       ></ha-switch>
     </div>`;
-  }
-
-  private _formatSecondaryText(stateObj: MediaPlayerEntity): string {
-    if (stateObj.state !== "playing") {
-      return this.hass.localize("ui.card.media_player.idle");
-    }
-
-    return [stateObj.attributes.media_title, stateObj.attributes.media_artist]
-      .filter((segment) => segment)
-      .join(" · ");
   }
 
   static get styles(): CSSResultGroup {

--- a/src/components/media-player/ha-media-player-toggle.ts
+++ b/src/components/media-player/ha-media-player-toggle.ts
@@ -1,6 +1,7 @@
 import { type CSSResultGroup, LitElement, css, html } from "lit";
 import { customElement, property } from "lit/decorators";
 import { mdiSpeaker, mdiSpeakerPause, mdiSpeakerPlay } from "@mdi/js";
+import memoizeOne from "memoize-one";
 
 import type { HomeAssistant } from "../../types";
 import { computeEntityNameList } from "../../common/entity/compute_entity_name_display";
@@ -20,6 +21,34 @@ class HaMediaPlayerToggle extends LitElement {
 
   @property({ type: Boolean }) public disabled = false;
 
+  private _computeDisplayData = memoizeOne(
+    (
+      entityId: string,
+      entities: HomeAssistant["entities"],
+      devices: HomeAssistant["devices"],
+      areas: HomeAssistant["areas"],
+      floors: HomeAssistant["floors"],
+      isRTL: boolean,
+      stateObj: HomeAssistant["states"][string]
+    ) => {
+      const [entityName, deviceName, areaName] = computeEntityNameList(
+        stateObj,
+        [{ type: "entity" }, { type: "device" }, { type: "area" }],
+        entities,
+        devices,
+        areas,
+        floors
+      );
+
+      const primary = entityName || deviceName || entityId;
+      const secondary = [areaName, entityName ? deviceName : undefined]
+        .filter(Boolean)
+        .join(isRTL ? " ◂ " : " ▸ ");
+
+      return { primary, secondary };
+    }
+  );
+
   protected render() {
     const stateObj = this.hass.states[this.entityId];
 
@@ -30,21 +59,17 @@ class HaMediaPlayerToggle extends LitElement {
       icon = mdiSpeakerPause;
     }
 
-    const [entityName, deviceName, areaName] = computeEntityNameList(
-      stateObj,
-      [{ type: "entity" }, { type: "device" }, { type: "area" }],
+    const isRTL = computeRTL(this.hass);
+
+    const { primary, secondary } = this._computeDisplayData(
+      this.entityId,
       this.hass.entities,
       this.hass.devices,
       this.hass.areas,
-      this.hass.floors
+      this.hass.floors,
+      isRTL,
+      stateObj
     );
-
-    const isRTL = computeRTL(this.hass);
-
-    const primary = entityName || deviceName || this.entityId;
-    const secondary = [areaName, entityName ? deviceName : undefined]
-      .filter(Boolean)
-      .join(isRTL ? " ◂ " : " ▸ ");
 
     return html`<div class="list-item">
       <ha-svg-icon .path=${icon}></ha-svg-icon>


### PR DESCRIPTION
## Proposed change

Updates the media player join dialog to display entity names with proper contextual information (device and area names), matching the entity picker's display pattern throughout Home Assistant.

**Before:** The dialog only showed entity friendly names (e.g., "Enceintes"), making it impossible to distinguish between multiple speakers with the same name in different rooms.

<img width="403" height="458" alt="CleanShot 2026-01-11 at 14 04 18" src="https://github.com/user-attachments/assets/c690d19e-dd9e-4928-9c14-e09e946ca745" />


**After:** The dialog now shows:
- **Primary text**: Entity name (or device name if they're equal)
- **Secondary text**: Area name and device name with RTL-aware separators
- **Visual state indicators**: Icons that reflect playing/paused/idle states

<img width="510" height="571" alt="CleanShot 2026-01-11 at 14 04 36" src="https://github.com/user-attachments/assets/a8c991e4-dada-4bb4-803b-72943ffadf37" />


This improvement helps users easily identify which media players to join by showing their location and current playback state.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

No configuration changes required. This enhancement works automatically with all media players that support the grouping feature.

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/28065
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io