### PR TITLE
Fix ha-card styling of .card-content when not first element but not following .card-header

### DIFF
--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -51,7 +51,10 @@ export class HaCard extends LitElement {
       font-weight: var(--ha-font-weight-normal);
     }
 
-    :host ::slotted(.card-content:not(:first-child)),
+    :host
+      ::slotted(
+        .card-content:not(:nth-child(1 of .card-content, .card-header))
+      ),
     slot:not(:first-child)::slotted(.card-content) {
       padding-top: 0;
       margin-top: calc(var(--ha-space-2) * -1);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

ha-card styling includes stying .card-content with no padding-top and negative margin-top when not first-child. This is to allow for ha-card to have a .card-header or not and style .card-content accordingly.

This can present an issue if a custom card or custom situation needs to have an elemenet prepended to ha-card light DOM which will always then make .card-content not first-child and thus clear top-padding and set negative top-margin. 

I have checked all instances of ha-card and the scenario is that the only slotted content used is .card-header and so specifically checking for nth-child(1 of .card-header, card-content) gives the same outcome without the side effect when another element may be present above in the light DOM of ha-card.

_NOTE: Frontend prettier settings updated indent styling of CSS which I think don't look so good. Will check when PR submitted as to any further Prettier issues with PR build process._

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/thomasloven/lovelace-card-mod/issues/568#issuecomment-3736618602
- Link to documentation pull request:

Specifically, custom card card-mod now (4.2.0 beta) works around a Lit issue in that Lit may remove the applied card-mod element. It will detect this scenario (details can be provided if required) and prepend card-mod. 

Card-mod could try and set a style to manage the specifics of ha-card, and a workaround is provided in the linked issue. This would not include '!important' to allow for inline and other styles to use '!important'. Rather the workaround relies on specificity, using selectors and adjacent sibling to detect the scenario and style accordingly. Other issues with this workaround could be related to various other styling that may be applied. I believe the best overall fix and most easily supported by Frontend and custom devs, is the change this PR brings.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
