### PR TITLE
Add entity context to Expose entities to Assist dialog

### DIFF
--- a/src/panels/config/voice-assistants/dialog-expose-entity.ts
+++ b/src/panels/config/voice-assistants/dialog-expose-entity.ts
@@ -302,6 +302,7 @@ class DialogExposeEntity extends LitElement {
           height: 88px;
         }
         ha-check-list-item .code {
+          display: block;
           font-family: var(--code-font-family, monospace);
           font-size: var(--ha-font-size-s, 12px);
           direction: ltr;

--- a/src/panels/config/voice-assistants/dialog-expose-entity.ts
+++ b/src/panels/config/voice-assistants/dialog-expose-entity.ts
@@ -218,14 +218,10 @@ class DialogExposeEntity extends LitElement {
   }) => {
     const entityId = item.entity.entity_id;
 
-    // Check if user wants to see entity IDs (user preference)
-    const showEntityId = this.hass.userData?.showEntityIdPicker;
-
     return html`
       <ha-check-list-item
         graphic="icon"
-        ?twoLine=${item.secondary || showEntityId}
-        class=${showEntityId ? "three-line" : ""}
+        ?twoLine=${item.secondary}
         .value=${entityId}
         .selected=${this._selected.includes(entityId)}
         @request-selected=${this._handleSelected}
@@ -239,9 +235,6 @@ class DialogExposeEntity extends LitElement {
         ${item.primary}
         ${item.secondary
           ? html`<span slot="secondary">${item.secondary}</span>`
-          : nothing}
-        ${showEntityId
-          ? html`<span slot="secondary" class="code">${entityId}</span>`
           : nothing}
       </ha-check-list-item>
     `;
@@ -297,15 +290,6 @@ class DialogExposeEntity extends LitElement {
         ha-check-list-item {
           width: 100%;
           height: 72px;
-        }
-        ha-check-list-item.three-line {
-          height: 88px;
-        }
-        ha-check-list-item .code {
-          display: block;
-          font-family: var(--code-font-family, monospace);
-          font-size: var(--ha-font-size-s, 12px);
-          direction: ltr;
         }
         ha-check-list-item ha-state-icon {
           margin-left: 24px;

--- a/src/panels/config/voice-assistants/dialog-expose-entity.ts
+++ b/src/panels/config/voice-assistants/dialog-expose-entity.ts
@@ -201,21 +201,13 @@ class DialogExposeEntity extends LitElement {
       // Use the SAME fuzzy search as ha-entity-picker (reusing existing infrastructure)
       // Creates Fuse index and performs multi-term weighted fuzzy search
       const fuseIndex = this._fuseIndex(itemsWithContext);
-      const results = multiTermSortedSearch(
+      return multiTermSortedSearch(
         itemsWithContext,
         filter,
         entityComboBoxKeys, // Same weighted keys as entity picker
         (item) => item.id,
         fuseIndex
       );
-
-      // Debug logging for testing
-      // eslint-disable-next-line no-console
-      console.log(
-        `[Fuzzy Search] Query: "${filter}", Results: ${results.length}/${itemsWithContext.length}`
-      );
-
-      return results;
     }
   );
 

--- a/src/panels/config/voice-assistants/dialog-expose-entity.ts
+++ b/src/panels/config/voice-assistants/dialog-expose-entity.ts
@@ -6,10 +6,13 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
 import memoizeOne from "memoize-one";
+import Fuse from "fuse.js";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import { computeEntityNameList } from "../../../common/entity/compute_entity_name_display";
 import { computeRTL } from "../../../common/util/compute_rtl";
+import { multiTermSortedSearch } from "../../../resources/fuseMultiTerm";
+import { entityComboBoxKeys } from "../../../data/entity/entity_picker";
 import "../../../components/ha-check-list-item";
 import "../../../components/search-input";
 import "../../../components/ha-dialog";
@@ -33,6 +36,12 @@ class DialogExposeEntity extends LitElement {
   @state() private _filter?: string;
 
   @state() private _selected: string[] = [];
+
+  // Memoized Fuse index for fuzzy search (matches ha-entity-picker pattern)
+  private _fuseIndex = memoizeOne(
+    (items: { id: string; search_labels: any }[]) =>
+      Fuse.createIndex(entityComboBoxKeys, items)
+  );
 
   public async showDialog(params: ExposeEntityDialogParams): Promise<void> {
     this._params = params;
@@ -170,6 +179,7 @@ class DialogExposeEntity extends LitElement {
             .join(isRTL ? " ◂ " : " ▸ ");
 
           return {
+            id: entity.entity_id, // Required by multiTermSortedSearch
             entity,
             primary,
             secondary,
@@ -188,23 +198,24 @@ class DialogExposeEntity extends LitElement {
         return itemsWithContext;
       }
 
-      // Multi-word search: split by spaces and require ALL terms to match
-      const terms = filter
-        .toLowerCase()
-        .split(" ")
-        .filter((t) => t.trim());
-
-      return itemsWithContext.filter((item) =>
-        // Each term must match in at least one searchable field
-        terms.every(
-          (term) =>
-            item.search_labels.entityId.toLowerCase().includes(term) ||
-            item.search_labels.entityName?.toLowerCase().includes(term) ||
-            item.search_labels.friendlyName?.toLowerCase().includes(term) ||
-            item.search_labels.deviceName?.toLowerCase().includes(term) ||
-            item.search_labels.areaName?.toLowerCase().includes(term)
-        )
+      // Use the SAME fuzzy search as ha-entity-picker (reusing existing infrastructure)
+      // Creates Fuse index and performs multi-term weighted fuzzy search
+      const fuseIndex = this._fuseIndex(itemsWithContext);
+      const results = multiTermSortedSearch(
+        itemsWithContext,
+        filter,
+        entityComboBoxKeys, // Same weighted keys as entity picker
+        (item) => item.id,
+        fuseIndex
       );
+
+      // Debug logging for testing
+      // eslint-disable-next-line no-console
+      console.log(
+        `[Fuzzy Search] Query: "${filter}", Results: ${results.length}/${itemsWithContext.length}`
+      );
+
+      return results;
     }
   );
 

--- a/src/panels/config/voice-assistants/dialog-expose-entity.ts
+++ b/src/panels/config/voice-assistants/dialog-expose-entity.ts
@@ -8,6 +8,8 @@ import { ifDefined } from "lit/directives/if-defined";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeStateName } from "../../../common/entity/compute_state_name";
+import { computeEntityNameList } from "../../../common/entity/compute_entity_name_display";
+import { computeRTL } from "../../../common/util/compute_rtl";
 import "../../../components/ha-check-list-item";
 import "../../../components/search-input";
 import "../../../components/ha-dialog";
@@ -142,37 +144,105 @@ class DialogExposeEntity extends LitElement {
       exposedEntities: Record<string, ExposeEntitySettings>,
       filter?: string
     ) => {
-      const lowerFilter = filter?.toLowerCase();
-      return Object.values(this.hass.states).filter(
-        (entity) =>
+      const isRTL = computeRTL(this.hass);
+
+      // First filter by exposure and pre-compute all entity context
+      const itemsWithContext = Object.values(this.hass.states)
+        .filter((entity) =>
           this._params!.filterAssistants.some(
             (ass) => !exposedEntities[entity.entity_id]?.[ass]
-          ) &&
-          (!lowerFilter ||
-            entity.entity_id.toLowerCase().includes(lowerFilter) ||
-            computeStateName(entity)?.toLowerCase().includes(lowerFilter))
+          )
+        )
+        .map((entity) => {
+          // Pre-compute entity context (following entity_picker.ts pattern)
+          const [entityName, deviceName, areaName] = computeEntityNameList(
+            entity,
+            [{ type: "entity" }, { type: "device" }, { type: "area" }],
+            this.hass.entities,
+            this.hass.devices,
+            this.hass.areas,
+            this.hass.floors
+          );
+
+          const primary = entityName || deviceName || entity.entity_id;
+          const secondary = [areaName, entityName ? deviceName : undefined]
+            .filter(Boolean)
+            .join(isRTL ? " ◂ " : " ▸ ");
+
+          return {
+            entity,
+            primary,
+            secondary,
+            search_labels: {
+              entityName: entityName || null,
+              deviceName: deviceName || null,
+              areaName: areaName || null,
+              friendlyName: computeStateName(entity) || null,
+              entityId: entity.entity_id,
+            },
+          };
+        });
+
+      // If no search filter, return all items
+      if (!filter?.trim()) {
+        return itemsWithContext;
+      }
+
+      // Multi-word search: split by spaces and require ALL terms to match
+      const terms = filter
+        .toLowerCase()
+        .split(" ")
+        .filter((t) => t.trim());
+
+      return itemsWithContext.filter((item) =>
+        // Each term must match in at least one searchable field
+        terms.every(
+          (term) =>
+            item.search_labels.entityId.toLowerCase().includes(term) ||
+            item.search_labels.entityName?.toLowerCase().includes(term) ||
+            item.search_labels.friendlyName?.toLowerCase().includes(term) ||
+            item.search_labels.deviceName?.toLowerCase().includes(term) ||
+            item.search_labels.areaName?.toLowerCase().includes(term)
+        )
       );
     }
   );
 
-  private _renderItem = (entityState: HassEntity) => html`
-    <ha-check-list-item
-      graphic="icon"
-      twoLine
-      .value=${entityState.entity_id}
-      .selected=${this._selected.includes(entityState.entity_id)}
-      @request-selected=${this._handleSelected}
-    >
-      <ha-state-icon
-        title=${ifDefined(entityState?.state)}
-        slot="graphic"
-        .hass=${this.hass}
-        .stateObj=${entityState}
-      ></ha-state-icon>
-      ${computeStateName(entityState)}
-      <span slot="secondary">${entityState.entity_id}</span>
-    </ha-check-list-item>
-  `;
+  private _renderItem = (item: {
+    entity: HassEntity;
+    primary: string;
+    secondary: string;
+  }) => {
+    const entityId = item.entity.entity_id;
+
+    // Check if user wants to see entity IDs (user preference)
+    const showEntityId = this.hass.userData?.showEntityIdPicker;
+
+    return html`
+      <ha-check-list-item
+        graphic="icon"
+        ?twoLine=${item.secondary || showEntityId}
+        class=${showEntityId ? "three-line" : ""}
+        .value=${entityId}
+        .selected=${this._selected.includes(entityId)}
+        @request-selected=${this._handleSelected}
+      >
+        <ha-state-icon
+          title=${ifDefined(item.entity?.state)}
+          slot="graphic"
+          .hass=${this.hass}
+          .stateObj=${item.entity}
+        ></ha-state-icon>
+        ${item.primary}
+        ${item.secondary
+          ? html`<span slot="secondary">${item.secondary}</span>`
+          : nothing}
+        ${showEntityId
+          ? html`<span slot="secondary" class="code">${entityId}</span>`
+          : nothing}
+      </ha-check-list-item>
+    `;
+  };
 
   private _expose() {
     this._params!.exposeEntities(this._selected);
@@ -224,6 +294,14 @@ class DialogExposeEntity extends LitElement {
         ha-check-list-item {
           width: 100%;
           height: 72px;
+        }
+        ha-check-list-item.three-line {
+          height: 88px;
+        }
+        ha-check-list-item .code {
+          font-family: var(--code-font-family, monospace);
+          font-size: var(--ha-font-size-s, 12px);
+          direction: ltr;
         }
         ha-check-list-item ha-state-icon {
           margin-left: 24px;

--- a/test/resources/fuse-multi-term.test.ts
+++ b/test/resources/fuse-multi-term.test.ts
@@ -7,39 +7,39 @@ describe("Fuzzy search (multiTermSortedSearch) tests", () => {
   // Sample data matching the structure used in dialog-expose-entity.ts
   const sampleEntities = [
     {
-      id: "binary_sensor.microphone_bureau",
+      id: "binary_sensor.microphone_office",
       primary: "Microphone",
-      secondary: "Bureau ▸ Assistant vocal",
+      secondary: "Office ▸ Voice Assistant",
       search_labels: {
         entityName: "Microphone",
-        deviceName: "Assistant vocal",
-        areaName: "Bureau",
+        deviceName: "Voice Assistant",
+        areaName: "Office",
         friendlyName: "Microphone",
-        entityId: "binary_sensor.microphone_bureau",
+        entityId: "binary_sensor.microphone_office",
       },
     },
     {
-      id: "binary_sensor.microphone_chambre",
+      id: "binary_sensor.microphone_bedroom",
       primary: "Microphone",
-      secondary: "Chambre ▸ Assistant vocal",
+      secondary: "Bedroom ▸ Voice Assistant",
       search_labels: {
         entityName: "Microphone",
-        deviceName: "Assistant vocal",
-        areaName: "Chambre",
+        deviceName: "Voice Assistant",
+        areaName: "Bedroom",
         friendlyName: "Microphone",
-        entityId: "binary_sensor.microphone_chambre",
+        entityId: "binary_sensor.microphone_bedroom",
       },
     },
     {
-      id: "binary_sensor.microphone_salon",
+      id: "binary_sensor.microphone_living_room",
       primary: "Microphone",
-      secondary: "Salon ▸ Assistant vocal",
+      secondary: "Living Room ▸ Voice Assistant",
       search_labels: {
         entityName: "Microphone",
-        deviceName: "Assistant vocal",
-        areaName: "Salon",
+        deviceName: "Voice Assistant",
+        areaName: "Living Room",
         friendlyName: "Microphone",
-        entityId: "binary_sensor.microphone_salon",
+        entityId: "binary_sensor.microphone_living_room",
       },
     },
     {
@@ -67,15 +67,15 @@ describe("Fuzzy search (multiTermSortedSearch) tests", () => {
       },
     },
     {
-      id: "switch.assistants_vocaux",
-      primary: "Assistants vocaux",
+      id: "switch.voice_assistants",
+      primary: "Voice Assistants",
       secondary: "",
       search_labels: {
         entityName: null,
         deviceName: null,
         areaName: null,
-        friendlyName: "Assistants vocaux",
-        entityId: "switch.assistants_vocaux",
+        friendlyName: "Voice Assistants",
+        entityId: "switch.voice_assistants",
       },
     },
   ];
@@ -99,10 +99,10 @@ describe("Fuzzy search (multiTermSortedSearch) tests", () => {
     );
   });
 
-  it("Multi-word search: 'microphone bureau' requires BOTH terms to match", () => {
+  it("Multi-word search: 'microphone office' requires BOTH terms to match", () => {
     const results = multiTermSortedSearch(
       sampleEntities,
-      "microphone bureau",
+      "microphone office",
       entityComboBoxKeys,
       (item) => item.id,
       fuseIndex
@@ -115,8 +115,8 @@ describe("Fuzzy search (multiTermSortedSearch) tests", () => {
     );
     assert.strictEqual(
       results[0].id,
-      "binary_sensor.microphone_bureau",
-      "Should find the microphone in Bureau area"
+      "binary_sensor.microphone_office",
+      "Should find the microphone in Office area"
     );
   });
 
@@ -312,20 +312,20 @@ describe("Fuzzy search (multiTermSortedSearch) tests", () => {
     );
   });
 
-  it("Search by area name: 'bureau' finds entities in Bureau area", () => {
+  it("Search by area name: 'office' finds entities in Office area", () => {
     const results = multiTermSortedSearch(
       sampleEntities,
-      "bureau",
+      "office",
       entityComboBoxKeys,
       (item) => item.id,
       fuseIndex
     );
 
-    assert.isTrue(results.length > 0, "Should find entities in Bureau area");
+    assert.isTrue(results.length > 0, "Should find entities in Office area");
     assert.strictEqual(
       results[0].search_labels.areaName,
-      "Bureau",
-      "Should find entity in Bureau area"
+      "Office",
+      "Should find entity in Office area"
     );
   });
 
@@ -352,7 +352,7 @@ describe("Fuzzy search (multiTermSortedSearch) tests", () => {
   it("Search by entity_id: exact match by entity ID works", () => {
     const results = multiTermSortedSearch(
       sampleEntities,
-      "switch.assistants_vocaux",
+      "switch.voice_assistants",
       entityComboBoxKeys,
       (item) => item.id,
       fuseIndex
@@ -365,7 +365,7 @@ describe("Fuzzy search (multiTermSortedSearch) tests", () => {
     );
     assert.strictEqual(
       results[0].id,
-      "switch.assistants_vocaux",
+      "switch.voice_assistants",
       "Should find the exact entity by ID"
     );
   });

--- a/test/resources/fuse-multi-term.test.ts
+++ b/test/resources/fuse-multi-term.test.ts
@@ -1,0 +1,372 @@
+import { assert, describe, it } from "vitest";
+import Fuse from "fuse.js";
+import { multiTermSortedSearch } from "../../src/resources/fuseMultiTerm";
+import { entityComboBoxKeys } from "../../src/data/entity/entity_picker";
+
+describe("Fuzzy search (multiTermSortedSearch) tests", () => {
+  // Sample data matching the structure used in dialog-expose-entity.ts
+  const sampleEntities = [
+    {
+      id: "binary_sensor.microphone_bureau",
+      primary: "Microphone",
+      secondary: "Bureau ▸ Assistant vocal",
+      search_labels: {
+        entityName: "Microphone",
+        deviceName: "Assistant vocal",
+        areaName: "Bureau",
+        friendlyName: "Microphone",
+        entityId: "binary_sensor.microphone_bureau",
+      },
+    },
+    {
+      id: "binary_sensor.microphone_chambre",
+      primary: "Microphone",
+      secondary: "Chambre ▸ Assistant vocal",
+      search_labels: {
+        entityName: "Microphone",
+        deviceName: "Assistant vocal",
+        areaName: "Chambre",
+        friendlyName: "Microphone",
+        entityId: "binary_sensor.microphone_chambre",
+      },
+    },
+    {
+      id: "binary_sensor.microphone_salon",
+      primary: "Microphone",
+      secondary: "Salon ▸ Assistant vocal",
+      search_labels: {
+        entityName: "Microphone",
+        deviceName: "Assistant vocal",
+        areaName: "Salon",
+        friendlyName: "Microphone",
+        entityId: "binary_sensor.microphone_salon",
+      },
+    },
+    {
+      id: "light.kitchen_brightness",
+      primary: "Brightness",
+      secondary: "Kitchen ▸ Smart Light",
+      search_labels: {
+        entityName: "Brightness",
+        deviceName: "Smart Light",
+        areaName: "Kitchen",
+        friendlyName: "Kitchen Brightness",
+        entityId: "light.kitchen_brightness",
+      },
+    },
+    {
+      id: "light.bedroom_brightness",
+      primary: "Brightness",
+      secondary: "Bedroom ▸ Smart Light",
+      search_labels: {
+        entityName: "Brightness",
+        deviceName: "Smart Light",
+        areaName: "Bedroom",
+        friendlyName: "Bedroom Brightness",
+        entityId: "light.bedroom_brightness",
+      },
+    },
+    {
+      id: "switch.assistants_vocaux",
+      primary: "Assistants vocaux",
+      secondary: "",
+      search_labels: {
+        entityName: null,
+        deviceName: null,
+        areaName: null,
+        friendlyName: "Assistants vocaux",
+        entityId: "switch.assistants_vocaux",
+      },
+    },
+  ];
+
+  // Create Fuse index once for all tests (mimics memoization in component)
+  const fuseIndex = Fuse.createIndex(entityComboBoxKeys, sampleEntities);
+
+  it("Single word search: finds all entities with 'microphone' in any field", () => {
+    const results = multiTermSortedSearch(
+      sampleEntities,
+      "microphone",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.strictEqual(results.length, 3, "Should find 3 microphone entities");
+    assert.isTrue(
+      results.every((item) => item.id.includes("microphone")),
+      "All results should contain 'microphone' in entity_id"
+    );
+  });
+
+  it("Multi-word search: 'microphone bureau' requires BOTH terms to match", () => {
+    const results = multiTermSortedSearch(
+      sampleEntities,
+      "microphone bureau",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.strictEqual(
+      results.length,
+      1,
+      "Should find only 1 entity matching both terms"
+    );
+    assert.strictEqual(
+      results[0].id,
+      "binary_sensor.microphone_bureau",
+      "Should find the microphone in Bureau area"
+    );
+  });
+
+  it("Multi-word search: 'light kitchen' finds lights in Kitchen only", () => {
+    const results = multiTermSortedSearch(
+      sampleEntities,
+      "light kitchen",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.strictEqual(
+      results.length,
+      1,
+      "Should find only 1 light in Kitchen"
+    );
+    assert.strictEqual(
+      results[0].id,
+      "light.kitchen_brightness",
+      "Should find kitchen light, not bedroom light"
+    );
+  });
+
+  it("Multi-word search: 'light bedroom' finds lights in Bedroom only", () => {
+    const results = multiTermSortedSearch(
+      sampleEntities,
+      "light bedroom",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.strictEqual(
+      results.length,
+      1,
+      "Should find only 1 light in Bedroom"
+    );
+    assert.strictEqual(
+      results[0].id,
+      "light.bedroom_brightness",
+      "Should find bedroom light, not kitchen light"
+    );
+  });
+
+  it("Fuzzy matching: 'microfone' (typo) still finds 'microphone' entities", () => {
+    const results = multiTermSortedSearch(
+      sampleEntities,
+      "microfone", // 1 character typo
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.isTrue(
+      results.length > 0,
+      "Fuzzy search should find results despite typo"
+    );
+    assert.isTrue(
+      results.some((item) => item.id.includes("microphone")),
+      "Should find microphone entities despite typo"
+    );
+  });
+
+  it("Fuzzy matching: 'asistant' (typo) finds 'assistant' entities", () => {
+    const results = multiTermSortedSearch(
+      sampleEntities,
+      "asistant", // Missing 's' typo
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.isTrue(
+      results.length > 0,
+      "Fuzzy search should find results despite typo"
+    );
+    assert.isTrue(
+      results.some((item) =>
+        item.search_labels.friendlyName?.includes("Assistant")
+      ),
+      "Should find assistant entities despite typo"
+    );
+  });
+
+  it("All terms required: 'microphone kitchen' finds nothing (no entity matches both)", () => {
+    const results = multiTermSortedSearch(
+      sampleEntities,
+      "microphone kitchen",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.strictEqual(
+      results.length,
+      0,
+      "Should find nothing when no entity matches ALL terms"
+    );
+  });
+
+  it("Case insensitive: 'MICROPHONE' same results as 'microphone'", () => {
+    const resultsLower = multiTermSortedSearch(
+      sampleEntities,
+      "microphone",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    const resultsUpper = multiTermSortedSearch(
+      sampleEntities,
+      "MICROPHONE",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.strictEqual(
+      resultsLower.length,
+      resultsUpper.length,
+      "Case should not matter"
+    );
+    assert.strictEqual(
+      resultsLower[0].id,
+      resultsUpper[0].id,
+      "Should return same results regardless of case"
+    );
+  });
+
+  it("Case insensitive: 'MiCrOpHoNe' same results as 'microphone'", () => {
+    const resultsLower = multiTermSortedSearch(
+      sampleEntities,
+      "microphone",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    const resultsMixed = multiTermSortedSearch(
+      sampleEntities,
+      "MiCrOpHoNe",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.strictEqual(
+      resultsLower.length,
+      resultsMixed.length,
+      "Mixed case should work"
+    );
+  });
+
+  it("Empty/no match: nonsense search returns empty array", () => {
+    const results = multiTermSortedSearch(
+      sampleEntities,
+      "zzzzzzzzz",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.strictEqual(
+      results.length,
+      0,
+      "Nonsense search should return no results"
+    );
+  });
+
+  it("Weighted relevance: results are sorted by relevance", () => {
+    const results = multiTermSortedSearch(
+      sampleEntities,
+      "brightness",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.isTrue(results.length > 0, "Should find brightness entities");
+
+    // Results should be sorted by relevance (no specific order assertion,
+    // but just verify they exist and are ordered consistently)
+    const firstResult = results[0];
+    assert.isTrue(
+      firstResult.search_labels.entityName
+        ?.toLowerCase()
+        .includes("brightness") ||
+        firstResult.search_labels.friendlyName
+          ?.toLowerCase()
+          .includes("brightness"),
+      "First result should match 'brightness'"
+    );
+  });
+
+  it("Search by area name: 'bureau' finds entities in Bureau area", () => {
+    const results = multiTermSortedSearch(
+      sampleEntities,
+      "bureau",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.isTrue(results.length > 0, "Should find entities in Bureau area");
+    assert.strictEqual(
+      results[0].search_labels.areaName,
+      "Bureau",
+      "Should find entity in Bureau area"
+    );
+  });
+
+  it("Search by device name: 'smart light' finds entities with Smart Light device", () => {
+    const results = multiTermSortedSearch(
+      sampleEntities,
+      "smart light",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.strictEqual(
+      results.length,
+      2,
+      "Should find 2 entities with Smart Light device"
+    );
+    assert.isTrue(
+      results.every((item) => item.search_labels.deviceName === "Smart Light"),
+      "All results should have Smart Light as device"
+    );
+  });
+
+  it("Search by entity_id: exact match by entity ID works", () => {
+    const results = multiTermSortedSearch(
+      sampleEntities,
+      "switch.assistants_vocaux",
+      entityComboBoxKeys,
+      (item) => item.id,
+      fuseIndex
+    );
+
+    assert.strictEqual(
+      results.length,
+      1,
+      "Should find exactly 1 entity by exact entity_id"
+    );
+    assert.strictEqual(
+      results[0].id,
+      "switch.assistants_vocaux",
+      "Should find the exact entity by ID"
+    );
+  });
+});


### PR DESCRIPTION
## Proposed change

This PR enhances the "Expose entities" dialog in Voice Assistant settings to display contextual information (device name, area name) and implement fuzzy search functionality, matching the behavior of the entity picker.

**Key improvements:**
1. **Entity context display**: Shows area and device names in secondary text to help distinguish entities with similar names across different locations
2. **Fuzzy search**: Implements the same fuzzy search infrastructure used by `ha-entity-picker`, supporting multi-word search and typo tolerance
3. **Two-line layout**: Simplified to show entity name + context only (entity IDs are never displayed)

**Implementation details:**
- Reuses existing `computeEntityNameList()` utility for consistent entity display logic
- Reuses existing `multiTermSortedSearch()` and `entityComboBoxKeys` for search (no custom implementation)
- Uses memoization for performance with large entity lists
- Supports RTL languages with appropriate separators

**Example:**
Before:
<img width="556" height="618" alt="CleanShot 2026-01-12 at 20 55 23" src="https://github.com/user-attachments/assets/55abec58-3515-4e20-9dd7-b41e4699ac54" />

After:
<img width="556" height="588" alt="CleanShot 2026-01-12 at 20 56 03" src="https://github.com/user-attachments/assets/04e8930c-2594-4b56-92c6-9947d80c6de1" />

⚠️ Note: It was really hard to add the third line for `entity_id` if the user profile setting is turned on, mostly because the list does not use the same underlying component as our entity picker.
I would say that as we are moving further and further away from `entitiy_id`, I think it is fine.

## Type of change

- [x] New feature (thank you!)

## Example configuration

```yaml
# No configuration changes required
# This enhancement works with existing Voice Assistant setup
```

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: 
- Link to documentation pull request: N/A (no user-facing configuration changes)

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] (N/A - no configuration changes)

[docs-repository]: https://github.com/home-assistant/home-assistant.io