### PR TITLE
Fix language not updating immediately when changed in general settings

### DIFF
--- a/src/panels/config/core/ha-config-section-general.ts
+++ b/src/panels/config/core/ha-config-section-general.ts
@@ -2,6 +2,7 @@ import type { TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state, query } from "lit/decorators";
 import { UNIT_C } from "../../../common/const";
+import { fireEvent } from "../../../common/dom/fire_event";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { navigate } from "../../../common/navigate";
 import "../../../components/buttons/ha-progress-button";
@@ -363,6 +364,8 @@ class HaConfigSectionGeneral extends LitElement {
 
     this._error = undefined;
 
+    const languageChanged = this._language !== this.hass.language;
+
     try {
       await saveCoreConfig(this.hass, {
         currency: this._currency,
@@ -376,6 +379,9 @@ class HaConfigSectionGeneral extends LitElement {
         ...locationConfig,
       });
       button.actionSuccess();
+      if (languageChanged && this._language) {
+        fireEvent(this, "hass-language-select", this._language);
+      }
     } catch (err: any) {
       button.actionError();
       this._error = err.message;

--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -34,9 +34,7 @@ import type { HassBaseEl } from "./hass-base-mixin";
 declare global {
   // for fire event
   interface HASSDomEvents {
-    "hass-language-select": {
-      language: string;
-    };
+    "hass-language-select": string;
     "hass-number-format-select": {
       number_format: NumberFormat;
     };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Fix language not updating immediately when changed in general settings.

Previously, changing the language in Settings > System > General required a page refresh to take effect. This PR fires the `hass-language-select` event after saving, so the UI updates immediately.

## Related issue

Fixes #28939

## Changes

### `src/panels/config/core/ha-config-section-general.ts`

- Detect when language has changed before saving
- Fire `hass-language-select` event after successful save if language changed

## Test plan

- [ ] Go to Settings > System > General
- [ ] Change the language to a different option
- [ ] Click Save
- [ ] Verify the UI language updates immediately without refresh
- [ ] Verify other settings (currency, timezone, etc.) still save correctly
- [ ] Verify changing language back works immediately as well


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io