### PR TITLE
Fix days to show form field missing

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -387,6 +387,7 @@ export class HuiStatisticsGraphCardEditor
     switch (schema.name) {
       case "chart_type":
       case "stat_types":
+      case "days_to_show":
       case "period":
       case "unit":
       case "hide_legend":

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8045,6 +8045,7 @@
             "statistics-graph": {
               "name": "Statistics graph",
               "description": "The Statistics graph card allows you to display a graph of the statistics for each of the entities listed.",
+              "days_to_show": "Days to show",
               "period": "Period",
               "unit": "Unit",
               "stat_types": "Show stat types",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR fixes a bug in the Statistics Graph card editor where the "Days to show" field was missing a label, causing it to be hidden. 

The fix involves:
1.  Adding the missing translation key `days_to_show` to `src/translations/en.json`.
2.  Updating `src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts` to explicitly handle the `days_to_show` case in `_computeLabelCallback`.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: statistics-graph
entities:
  - sensor.energy_consumption
days_to_show: 30
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
