### PR TITLE
Remove box-shadow from automation dialog "Show more" button (#28945)

### DIFF
--- a/src/panels/config/automation/add-automation-element/ha-automation-add-from-target.ts
+++ b/src/panels/config/automation/add-automation-element/ha-automation-add-from-target.ts
@@ -1506,14 +1506,6 @@ export default class HaAutomationAddFromTarget extends LitElement {
         var(--ha-shadow-spread-lg) var(--ha-color-shadow-light);
     }
 
-    @media (prefers-color-scheme: dark) {
-      .targets-show-more {
-        box-shadow: inset var(--ha-shadow-offset-x-lg)
-          calc(var(--ha-shadow-offset-y-lg) * -1) var(--ha-shadow-blur-lg)
-          var(--ha-shadow-spread-lg) var(--ha-color-shadow-dark);
-      }
-    }
-
     @media all and (max-width: 870px), all and (max-height: 500px) {
       :host {
         max-height: var(--max-height, 50%);


### PR DESCRIPTION
## Summary

Removes the `@media (prefers-color-scheme: dark)` media query from the "Show more" button shadow in the automation add trigger/condition/action dialog.

The media query was using `prefers-color-scheme: dark` which follows the OS preference rather than Home Assistant's theme system. This caused a double shadow effect when there's a mismatch between OS dark mode and HA theme settings.

Fixes #28945

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Video

<!--
If applicable, add screenshots or video of the changes.
-->

## Checklist

- [x] This PR fixes a bug reported in an issue.
- [x] I have followed the [contribution guidelines](https://github.com/home-assistant/frontend/blob/dev/CONTRIBUTING.md).