### PR TITLE
Fix tree view heading overlapping Show more button (#28872)

### DIFF
--- a/src/panels/config/automation/add-automation-element/ha-automation-add-from-target.ts
+++ b/src/panels/config/automation/add-automation-element/ha-automation-add-from-target.ts
@@ -1504,6 +1504,7 @@ export default class HaAutomationAddFromTarget extends LitElement {
       box-shadow: inset var(--ha-shadow-offset-x-lg)
         calc(var(--ha-shadow-offset-y-lg) * -1) var(--ha-shadow-blur-lg)
         var(--ha-shadow-spread-lg) var(--ha-color-shadow-light);
+      z-index: 2;
     }
 
     @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Proposed change

Fix the "Show more" button being hidden behind sticky section headings in the automation trigger tree view when they overlap.

The sticky section headings (`ha-section-title`) had `z-index: 1`, while the "Show more" button had no z-index specified. This caused the headings to appear on top of the button when scrolling in narrow view.

Added `z-index: 2` to `.targets-show-more` to ensure the button always appears above the sticky headings.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml
```

Additional information

- This PR fixes or closes issue: fixes #28872
- This PR is related to issue or discussion:
- Link to documentation pull request:

Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.