### PR TITLE
ha-label-picker, ha-category-picker: fix icon for "no items available"

### DIFF
--- a/src/components/ha-label-picker.ts
+++ b/src/components/ha-label-picker.ts
@@ -1,4 +1,4 @@
-import { mdiPlus } from "@mdi/js";
+import { mdiLabel, mdiPlus } from "@mdi/js";
 import type { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { TemplateResult } from "lit";
 import { LitElement, html } from "lit";

--- a/src/components/ha-label-picker.ts
+++ b/src/components/ha-label-picker.ts
@@ -1,4 +1,4 @@
-import { mdiLabel, mdiPlus } from "@mdi/js";
+import { mdiPlus } from "@mdi/js";
 import type { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { TemplateResult } from "lit";
 import { LitElement, html } from "lit";
@@ -29,7 +29,6 @@ import type { PickerValueRenderer } from "./ha-picker-field";
 import "./ha-svg-icon";
 
 const ADD_NEW_ID = "___ADD_NEW___";
-const NO_LABELS = "___NO_LABELS___";
 
 @customElement("ha-label-picker")
 export class HaLabelPicker extends SubscribeMixin(LitElement) {
@@ -142,18 +141,8 @@ export class HaLabelPicker extends SubscribeMixin(LitElement) {
 
   private _getLabelsMemoized = memoizeOne(getLabels);
 
-  private _getItems = () => {
-    if (!this._labels || this._labels.length === 0) {
-      return [
-        {
-          id: NO_LABELS,
-          primary: this.hass.localize("ui.components.label-picker.no_labels"),
-          icon_path: mdiLabel,
-        },
-      ];
-    }
-
-    return this._getLabelsMemoized(
+  private _getItems = () =>
+    this._getLabelsMemoized(
       this.hass.states,
       this.hass.areas,
       this.hass.devices,
@@ -166,7 +155,6 @@ export class HaLabelPicker extends SubscribeMixin(LitElement) {
       this.entityFilter,
       this.excludeLabels
     );
-  };
 
   private _allLabelNames = memoizeOne((labels?: LabelRegistryEntry[]) => {
     if (!labels) {
@@ -250,10 +238,6 @@ export class HaLabelPicker extends SubscribeMixin(LitElement) {
     ev.stopPropagation();
 
     const value = ev.detail.value;
-
-    if (value === NO_LABELS) {
-      return;
-    }
 
     if (!value) {
       this._setValue(undefined);

--- a/src/panels/config/category/ha-category-picker.ts
+++ b/src/panels/config/category/ha-category-picker.ts
@@ -20,7 +20,6 @@ import type { HomeAssistant, ValueChangedEvent } from "../../../types";
 import { showCategoryRegistryDetailDialog } from "./show-dialog-category-registry-detail";
 
 const ADD_NEW_ID = "___ADD_NEW___";
-const NO_CATEGORIES_ID = "___NO_CATEGORIES___";
 
 @customElement("ha-category-picker")
 export class HaCategoryPicker extends SubscribeMixin(LitElement) {
@@ -106,18 +105,6 @@ export class HaCategoryPicker extends SubscribeMixin(LitElement) {
     ): PickerComboBoxItem[] | undefined => {
       if (!categories) {
         return undefined;
-      }
-
-      if (!categories || categories.length === 0) {
-        return [
-          {
-            id: NO_CATEGORIES_ID,
-            primary: this.hass.localize(
-              "ui.components.category-picker.no_categories"
-            ),
-            icon_path: mdiTag,
-          },
-        ];
       }
 
       const items = categories.map<PickerComboBoxItem>((category) => ({
@@ -215,10 +202,6 @@ export class HaCategoryPicker extends SubscribeMixin(LitElement) {
     ev.stopPropagation();
 
     const value = ev.detail.value;
-
-    if (value === NO_CATEGORIES_ID) {
-      return;
-    }
 
     if (!value) {
       this._setValue(undefined);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Currently in `ha-label-picker`, if no labels are created, we see a "No labels available" text with some icon.
When a new label is created & then a user wants to add one more label, the same text is shown with `mdiMinusBoxOutline` icon (which is expected for such cases):

<img width="1135" height="490" alt="image" src="https://github.com/user-attachments/assets/00bc192b-1877-4b39-bdb3-650ee5c21e6b" />

Similarly it happens in `ha-category-picker`:

<img width="413" height="549" alt="image" src="https://github.com/user-attachments/assets/514fd022-44c8-47bd-a420-cf6f2d78498a" />


After the fix:

<img width="1117" height="478" alt="image" src="https://github.com/user-attachments/assets/6173f9de-ddf5-4cde-b1b3-e9b3de963570" />

<img width="415" height="549" alt="image" src="https://github.com/user-attachments/assets/6a36ef0f-017f-4332-95b9-dab5151c5507" />




## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
