### PR TITLE
Add button to heading card

### DIFF
--- a/src/panels/lovelace/cards/hui-heading-card.ts
+++ b/src/panels/lovelace/cards/hui-heading-card.ts
@@ -153,7 +153,7 @@ export class HuiHeadingCard extends LitElement implements LovelaceCard {
       flex-direction: row;
       justify-content: space-between;
       align-items: center;
-      overflow: hidden;
+      overflow: visible;
       gap: var(--ha-space-2);
     }
     .content:hover ha-icon-next {

--- a/src/panels/lovelace/create-element/create-heading-badge-element.ts
+++ b/src/panels/lovelace/create-element/create-heading-badge-element.ts
@@ -1,3 +1,4 @@
+import "../heading-badges/hui-button-heading-badge";
 import "../heading-badges/hui-entity-heading-badge";
 
 import {
@@ -6,7 +7,7 @@ import {
 } from "./create-element-base";
 import type { LovelaceHeadingBadgeConfig } from "../heading-badges/types";
 
-const ALWAYS_LOADED_TYPES = new Set(["error", "entity"]);
+const ALWAYS_LOADED_TYPES = new Set(["error", "entity", "button"]);
 
 export const createHeadingBadgeElement = (config: LovelaceHeadingBadgeConfig) =>
   createLovelaceElement(

--- a/src/panels/lovelace/editor/config-elements/hui-heading-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-heading-card-editor.ts
@@ -140,7 +140,7 @@ export class HuiHeadingCardEditor
         <ha-svg-icon slot="leading-icon" .path=${mdiListBox}></ha-svg-icon>
         <h3 slot="header">
           ${this.hass!.localize(
-            "ui.panel.lovelace.editor.card.heading.entities"
+            "ui.panel.lovelace.editor.card.heading.badges"
           )}
         </h3>
         <div class="content">

--- a/src/panels/lovelace/editor/config-elements/hui-heading-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-heading-card-editor.ts
@@ -139,9 +139,7 @@ export class HuiHeadingCardEditor
       <ha-expansion-panel outlined>
         <ha-svg-icon slot="leading-icon" .path=${mdiListBox}></ha-svg-icon>
         <h3 slot="header">
-          ${this.hass!.localize(
-            "ui.panel.lovelace.editor.card.heading.badges"
-          )}
+          ${this.hass!.localize("ui.panel.lovelace.editor.card.heading.badges")}
         </h3>
         <div class="content">
           <hui-heading-badges-editor

--- a/src/panels/lovelace/editor/heading-badge-editor/hui-button-heading-badge-editor.ts
+++ b/src/panels/lovelace/editor/heading-badge-editor/hui-button-heading-badge-editor.ts
@@ -1,0 +1,218 @@
+import { mdiEye, mdiGestureTap } from "@mdi/js";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { any, array, assert, object, optional, string } from "superstruct";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-expansion-panel";
+import "../../../../components/ha-form/ha-form";
+import type {
+  HaFormSchema,
+  SchemaUnion,
+} from "../../../../components/ha-form/types";
+import type { HomeAssistant } from "../../../../types";
+import type { Condition } from "../../common/validate-condition";
+import type { ButtonHeadingBadgeConfig } from "../../heading-badges/types";
+import type { LovelaceGenericElementEditor } from "../../types";
+import "../conditions/ha-card-conditions-editor";
+import { configElementStyle } from "../config-elements/config-elements-style";
+import { actionConfigStruct } from "../structs/action-struct";
+
+const buttonConfigStruct = object({
+  type: optional(string()),
+  content: optional(string()),
+  icon: optional(string()),
+  color: optional(string()),
+  tap_action: optional(actionConfigStruct),
+  hold_action: optional(actionConfigStruct),
+  double_tap_action: optional(actionConfigStruct),
+  visibility: optional(array(any())),
+});
+
+@customElement("hui-button-heading-badge-editor")
+export class HuiButtonHeadingBadgeEditor
+  extends LitElement
+  implements LovelaceGenericElementEditor
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ type: Boolean }) public preview = false;
+
+  @state() private _config?: ButtonHeadingBadgeConfig;
+
+  public setConfig(config: ButtonHeadingBadgeConfig): void {
+    assert(config, buttonConfigStruct);
+    this._config = config;
+  }
+
+  private _schema = memoizeOne(
+    () =>
+      [
+        {
+          name: "",
+          type: "grid",
+          schema: [
+            {
+              name: "content",
+              selector: { text: {} },
+            },
+            {
+              name: "icon",
+              selector: { icon: {} },
+            },
+            {
+              name: "color",
+              selector: {
+                ui_color: {},
+              },
+            },
+          ],
+        },
+        {
+          name: "interactions",
+          type: "expandable",
+          flatten: true,
+          iconPath: mdiGestureTap,
+          schema: [
+            {
+              name: "tap_action",
+              selector: {
+                ui_action: {
+                  default_action: "none",
+                },
+              },
+            },
+            {
+              name: "",
+              type: "optional_actions",
+              flatten: true,
+              schema: (["hold_action", "double_tap_action"] as const).map(
+                (action) => ({
+                  name: action,
+                  selector: {
+                    ui_action: {
+                      default_action: "none" as const,
+                    },
+                  },
+                })
+              ),
+            },
+          ],
+        },
+      ] as const satisfies readonly HaFormSchema[]
+  );
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    const schema = this._schema();
+
+    const conditions = this._config.visibility ?? [];
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${this._config}
+        .schema=${schema}
+        .computeLabel=${this._computeLabelCallback}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+      <ha-expansion-panel outlined>
+        <ha-svg-icon slot="leading-icon" .path=${mdiEye}></ha-svg-icon>
+        <h3 slot="header">
+          ${this.hass!.localize(
+            "ui.panel.lovelace.editor.card.heading.button_config.visibility"
+          )}
+        </h3>
+        <div class="content">
+          <p class="intro">
+            ${this.hass.localize(
+              "ui.panel.lovelace.editor.card.heading.button_config.visibility_explanation"
+            )}
+          </p>
+          <ha-card-conditions-editor
+            .hass=${this.hass}
+            .conditions=${conditions}
+            @value-changed=${this._conditionChanged}
+          >
+          </ha-card-conditions-editor>
+        </div>
+      </ha-expansion-panel>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    if (!this._config || !this.hass) {
+      return;
+    }
+
+    const config = ev.detail.value as ButtonHeadingBadgeConfig;
+
+    fireEvent(this, "config-changed", { config });
+  }
+
+  private _conditionChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    if (!this._config || !this.hass) {
+      return;
+    }
+
+    const conditions = ev.detail.value as Condition[];
+
+    const newConfig: ButtonHeadingBadgeConfig = {
+      ...this._config,
+      visibility: conditions,
+    };
+    if (newConfig.visibility?.length === 0) {
+      delete newConfig.visibility;
+    }
+
+    fireEvent(this, "config-changed", { config: newConfig });
+  }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
+    switch (schema.name) {
+      case "content":
+      case "color":
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.heading.button_config.${schema.name}`
+        );
+      default:
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.generic.${schema.name}`
+        );
+    }
+  };
+
+  static get styles() {
+    return [
+      configElementStyle,
+      css`
+        .container {
+          display: flex;
+          flex-direction: column;
+        }
+        ha-form {
+          display: block;
+          margin-bottom: 24px;
+        }
+        .intro {
+          margin: 0;
+          color: var(--secondary-text-color);
+          margin-bottom: 8px;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-button-heading-badge-editor": HuiButtonHeadingBadgeEditor;
+  }
+}

--- a/src/panels/lovelace/editor/heading-badge-editor/hui-button-heading-badge-editor.ts
+++ b/src/panels/lovelace/editor/heading-badge-editor/hui-button-heading-badge-editor.ts
@@ -20,7 +20,7 @@ import { actionConfigStruct } from "../structs/action-struct";
 
 const buttonConfigStruct = object({
   type: optional(string()),
-  content: optional(string()),
+  text: optional(string()),
   icon: optional(string()),
   color: optional(string()),
   tap_action: optional(actionConfigStruct),
@@ -49,13 +49,13 @@ export class HuiButtonHeadingBadgeEditor
     () =>
       [
         {
+          name: "text",
+          selector: { text: {} },
+        },
+        {
           name: "",
           type: "grid",
           schema: [
-            {
-              name: "content",
-              selector: { text: {} },
-            },
             {
               name: "icon",
               selector: { icon: {} },
@@ -177,7 +177,7 @@ export class HuiButtonHeadingBadgeEditor
     schema: SchemaUnion<ReturnType<typeof this._schema>>
   ) => {
     switch (schema.name) {
-      case "content":
+      case "text":
       case "color":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.heading.button_config.${schema.name}`

--- a/src/panels/lovelace/heading-badges/hui-button-heading-badge.ts
+++ b/src/panels/lovelace/heading-badges/hui-button-heading-badge.ts
@@ -35,6 +35,13 @@ export class HuiButtonHeadingBadge
     return document.createElement("hui-button-heading-badge-editor");
   }
 
+  public static getStubConfig(): ButtonHeadingBadgeConfig {
+    return {
+      type: "button",
+      icon: "mdi:gesture-tap-button",
+    };
+  }
+
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: ButtonHeadingBadgeConfig;

--- a/src/panels/lovelace/heading-badges/hui-button-heading-badge.ts
+++ b/src/panels/lovelace/heading-badges/hui-button-heading-badge.ts
@@ -1,0 +1,120 @@
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
+import { computeCssColor } from "../../../common/color/compute-color";
+import "../../../components/ha-control-button";
+import "../../../components/ha-icon";
+import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
+import type { HomeAssistant } from "../../../types";
+import { actionHandler } from "../common/directives/action-handler-directive";
+import { handleAction } from "../common/handle-action";
+import { hasAction } from "../common/has-action";
+import type {
+  LovelaceHeadingBadge,
+  LovelaceHeadingBadgeEditor,
+} from "../types";
+import type { ButtonHeadingBadgeConfig } from "./types";
+
+const DEFAULT_ACTIONS: Pick<
+  ButtonHeadingBadgeConfig,
+  "tap_action" | "hold_action" | "double_tap_action"
+> = {
+  tap_action: { action: "none" },
+  hold_action: { action: "none" },
+  double_tap_action: { action: "none" },
+};
+
+@customElement("hui-button-heading-badge")
+export class HuiButtonHeadingBadge
+  extends LitElement
+  implements LovelaceHeadingBadge
+{
+  public static async getConfigElement(): Promise<LovelaceHeadingBadgeEditor> {
+    await import("../editor/heading-badge-editor/hui-button-heading-badge-editor");
+    return document.createElement("hui-button-heading-badge-editor");
+  }
+
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @state() private _config?: ButtonHeadingBadgeConfig;
+
+  @property({ type: Boolean }) public preview = false;
+
+  public setConfig(config: ButtonHeadingBadgeConfig): void {
+    this._config = {
+      ...DEFAULT_ACTIONS,
+      ...config,
+    };
+  }
+
+  get hasAction() {
+    return (
+      hasAction(this._config?.tap_action) ||
+      hasAction(this._config?.hold_action) ||
+      hasAction(this._config?.double_tap_action)
+    );
+  }
+
+  private _handleAction(ev: ActionHandlerEvent) {
+    handleAction(this, this.hass!, this._config!, ev.detail.action!);
+  }
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    const config = this._config;
+
+    const color = config.color ? computeCssColor(config.color) : undefined;
+
+    const style = {
+      "--control-button-icon-color": color,
+      "--control-button-background-color": color,
+    };
+
+    return html`
+      <ha-control-button
+        @action=${this._handleAction}
+        .actionHandler=${actionHandler({
+          hasHold: hasAction(this._config!.hold_action),
+          hasDoubleClick: hasAction(this._config!.double_tap_action),
+        })}
+        style=${styleMap(style)}
+        .label=${config.content}
+      >
+        <span class="content">
+          ${config.icon
+            ? html`<ha-icon .icon=${config.icon}></ha-icon>`
+            : nothing}
+          ${config.content}
+        </span>
+      </ha-control-button>
+    `;
+  }
+
+  static styles = css`
+    ha-control-button {
+      --control-button-border-radius: var(--ha-border-radius-md);
+      --control-button-padding: 0 var(--ha-space-1);
+      --mdc-icon-size: var(--ha-heading-badge-icon-size, 16px);
+      width: auto;
+      height: var(--ha-heading-badge-height, 24px);
+      min-width: var(--ha-heading-badge-height, 24px);
+      font-size: var(--ha-font-size-s);
+    }
+    .content {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: var(--ha-space-1);
+      white-space: nowrap;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-button-heading-badge": HuiButtonHeadingBadge;
+  }
+}

--- a/src/panels/lovelace/heading-badges/hui-button-heading-badge.ts
+++ b/src/panels/lovelace/heading-badges/hui-button-heading-badge.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
+import { classMap } from "lit/directives/class-map";
 import { computeCssColor } from "../../../common/color/compute-color";
 import "../../../components/ha-control-button";
 import "../../../components/ha-icon";
@@ -68,10 +69,7 @@ export class HuiButtonHeadingBadge
 
     const color = config.color ? computeCssColor(config.color) : undefined;
 
-    const style = {
-      "--control-button-icon-color": color,
-      "--control-button-background-color": color,
-    };
+    const style = { "--color": color };
 
     return html`
       <ha-control-button
@@ -81,13 +79,16 @@ export class HuiButtonHeadingBadge
           hasDoubleClick: hasAction(this._config!.double_tap_action),
         })}
         style=${styleMap(style)}
-        .label=${config.content}
+        .label=${config.text}
+        class=${classMap({ colored: !!color, "with-text": !!config.text })}
       >
         <span class="content">
           ${config.icon
             ? html`<ha-icon .icon=${config.icon}></ha-icon>`
             : nothing}
-          ${config.content}
+          ${config.text
+            ? html`<span class="text">${config.text}</span>`
+            : nothing}
         </span>
       </ha-control-button>
     `;
@@ -95,20 +96,35 @@ export class HuiButtonHeadingBadge
 
   static styles = css`
     ha-control-button {
-      --control-button-border-radius: var(--ha-border-radius-md);
-      --control-button-padding: 0 var(--ha-space-1);
-      --mdc-icon-size: var(--ha-heading-badge-icon-size, 16px);
+      --control-button-border-radius: var(
+        --ha-heading-badge-border-radius,
+        var(--ha-border-radius-pill)
+      );
+      --control-button-padding: 0;
+      --mdc-icon-size: var(--ha-heading-badge-icon-size, 14px);
       width: auto;
-      height: var(--ha-heading-badge-height, 24px);
-      min-width: var(--ha-heading-badge-height, 24px);
+      height: var(--ha-heading-badge-size, 26px);
+      min-width: var(--ha-heading-badge-size, 26px);
       font-size: var(--ha-font-size-s);
+    }
+    ha-control-button.with-text {
+      --control-button-padding: 0 var(--ha-space-2);
+    }
+    ha-control-button.colored {
+      --control-button-icon-color: var(--color);
+      --control-button-background-color: var(--color);
+      --control-button-focus-color: var(--color);
+      --ha-ripple-color: var(--color);
     }
     .content {
       display: flex;
       flex-direction: row;
       align-items: center;
-      gap: var(--ha-space-1);
       white-space: nowrap;
+    }
+    .text {
+      padding: 0 var(--ha-space-1);
+      line-height: 1;
     }
   `;
 }

--- a/src/panels/lovelace/heading-badges/hui-entity-heading-badge.ts
+++ b/src/panels/lovelace/heading-badges/hui-entity-heading-badge.ts
@@ -16,6 +16,7 @@ import "../../../state-display/state-display";
 import type { HomeAssistant } from "../../../types";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { computeLovelaceEntityName } from "../common/entity/compute-lovelace-entity-name";
+import { findEntities } from "../common/find-entities";
 import { handleAction } from "../common/handle-action";
 import { hasAction } from "../common/has-action";
 import { DEFAULT_CONFIG } from "../editor/heading-badge-editor/hui-entity-heading-badge-editor";
@@ -41,6 +42,24 @@ export class HuiEntityHeadingBadge
   public static async getConfigElement(): Promise<LovelaceHeadingBadgeEditor> {
     await import("../editor/heading-badge-editor/hui-entity-heading-badge-editor");
     return document.createElement("hui-heading-entity-editor");
+  }
+
+  public static getStubConfig(hass: HomeAssistant): EntityHeadingBadgeConfig {
+    const includeDomains = ["sensor", "light", "switch"];
+    const maxEntities = 1;
+    const entities = Object.keys(hass.states);
+    const foundEntities = findEntities(
+      hass,
+      maxEntities,
+      entities,
+      [],
+      includeDomains
+    );
+
+    return {
+      type: "entity",
+      entity: foundEntities[0] || "",
+    };
   }
 
   @property({ attribute: false }) public hass?: HomeAssistant;

--- a/src/panels/lovelace/heading-badges/types.ts
+++ b/src/panels/lovelace/heading-badges/types.ts
@@ -26,3 +26,13 @@ export interface EntityHeadingBadgeConfig extends LovelaceHeadingBadgeConfig {
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
 }
+
+export interface ButtonHeadingBadgeConfig extends LovelaceHeadingBadgeConfig {
+  type: "button";
+  content?: string;
+  icon?: string;
+  color?: string;
+  tap_action?: ActionConfig;
+  hold_action?: ActionConfig;
+  double_tap_action?: ActionConfig;
+}

--- a/src/panels/lovelace/heading-badges/types.ts
+++ b/src/panels/lovelace/heading-badges/types.ts
@@ -29,7 +29,7 @@ export interface EntityHeadingBadgeConfig extends LovelaceHeadingBadgeConfig {
 
 export interface ButtonHeadingBadgeConfig extends LovelaceHeadingBadgeConfig {
   type: "button";
-  content?: string;
+  text?: string;
   icon?: string;
   color?: string;
   tap_action?: ActionConfig;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8480,7 +8480,7 @@
                 "title": "Title",
                 "subtitle": "Subtitle"
               },
-              "entities": "Entities",
+              "badges": "Badges",
               "entity_config": {
                 "color": "[%key:ui::panel::lovelace::editor::card::tile::color%]",
                 "color_helper": "[%key:ui::panel::lovelace::editor::card::tile::color_helper%]",
@@ -8496,7 +8496,7 @@
                 }
               },
               "button_config": {
-                "Text": "Text",
+                "text": "Text",
                 "color": "Color",
                 "visibility": "Visibility",
                 "visibility_explanation": "The button will be shown when ALL conditions below are fulfilled. If no conditions are set, the button will always be shown."
@@ -8778,6 +8778,11 @@
             "remove": "Remove entity",
             "form-label": "Edit entity"
           },
+          "badges": {
+            "name": "Badges",
+            "edit": "Edit badge",
+            "remove": "Remove badge"
+          },
           "features": {
             "name": "Features",
             "not_compatible": "Not compatible",
@@ -9029,6 +9034,19 @@
               "trend-graph": {
                 "label": "Trend graph",
                 "detail": "Show more detail"
+              }
+            }
+          },
+          "heading-badges": {
+            "add": "Add badge",
+            "no_entity": "No entity selected",
+            "entity_not_found": "Entity not found",
+            "types": {
+              "entity": {
+                "label": "Entity"
+              },
+              "button": {
+                "label": "Button"
               }
             }
           },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8495,6 +8495,12 @@
                   "state": "[%key:ui::panel::lovelace::editor::badge::entity::displayed_elements_options::state%]"
                 }
               },
+              "button_config": {
+                "content": "Content",
+                "color": "Icon color",
+                "visibility": "Visibility",
+                "visibility_explanation": "The button will be shown when ALL conditions below are fulfilled. If no conditions are set, the button will always be shown."
+              },
               "default_heading": "Kitchen"
             },
             "map": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8496,8 +8496,8 @@
                 }
               },
               "button_config": {
-                "content": "Content",
-                "color": "Icon color",
+                "Text": "Text",
+                "color": "Color",
                 "visibility": "Visibility",
                 "visibility_explanation": "The button will be shown when ALL conditions below are fulfilled. If no conditions are set, the button will always be shown."
               },


### PR DESCRIPTION
## Proposed change

Add a new button heading badge type for heading cards. This badge allows users to add customizable buttons alongside their heading card content.

The editor has also been updated to support other type of badges.

The button will be used in the home dashboard to quickly assign to area to device without area (it will be another PR)

**Dashboard**

<img width="452" height="131" alt="CleanShot 2026-01-14 at 15 13 08" src="https://github.com/user-attachments/assets/b8d26217-7ff8-4aa3-91bd-19a7890f9978" />

**Badges editor**

<img width="505" height="353" alt="CleanShot 2026-01-19 at 15 37 11" src="https://github.com/user-attachments/assets/74fccf7b-5be8-4119-bfbf-825203f33b37" />

**Features**
- Display text and/or icon
- Customizable color
- Support for tap, hold, and double-tap actions
- Visibility conditions to show/hide based on states

**Configuration example**

```yaml
type: heading
icon: mdi:vacuum
heading: Vacuum
heading_style: title
badges:
  - type: entity
    entity: sensor.sonos_move_battery
  - type: button
    icon: mdi:sofa
    text: Assign area
    color: primary
  - type: button
    icon: mdi:lightbulb-off
  - type: button
    text: Restart
```

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
