### PR TITLE
Entity context: voice assistants expose entities

### DIFF
--- a/src/panels/config/voice-assistants/dialog-expose-entity.ts
+++ b/src/panels/config/voice-assistants/dialog-expose-entity.ts
@@ -161,8 +161,8 @@ class DialogExposeEntity extends LitElement {
 
       for (const entity of Object.values(this.hass.states)) {
         if (
-          !this._params!.filterAssistants.some(
-            (ass) => !exposedEntities[entity.entity_id]?.[ass]
+          this._params!.filterAssistants.every(
+            (ass) => exposedEntities[entity.entity_id]?.[ass]
           )
         ) {
           continue;

--- a/src/panels/config/voice-assistants/dialog-expose-entity.ts
+++ b/src/panels/config/voice-assistants/dialog-expose-entity.ts
@@ -25,6 +25,11 @@ import type { HomeAssistant } from "../../../types";
 import "./entity-voice-settings";
 import type { ExposeEntityDialogParams } from "./show-dialog-expose-entity";
 
+interface FilteredEntity {
+  entity: HassEntity;
+  nameList: (string | undefined)[];
+}
+
 @customElement("dialog-expose-entity")
 class DialogExposeEntity extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -150,31 +155,20 @@ class DialogExposeEntity extends LitElement {
     (
       exposedEntities: Record<string, ExposeEntitySettings>,
       filter?: string
-    ) => {
+    ): FilteredEntity[] => {
       const lowerFilter = filter?.toLowerCase();
-      return Object.values(this.hass.states).filter((entity) => {
+      const result: FilteredEntity[] = [];
+
+      for (const entity of Object.values(this.hass.states)) {
         if (
           !this._params!.filterAssistants.some(
             (ass) => !exposedEntities[entity.entity_id]?.[ass]
           )
         ) {
-          return false;
+          continue;
         }
 
-        if (!lowerFilter) {
-          return true;
-        }
-
-        if (entity.entity_id.toLowerCase().includes(lowerFilter)) {
-          return true;
-        }
-
-        const entityName = computeStateName(entity);
-        if (entityName?.toLowerCase().includes(lowerFilter)) {
-          return true;
-        }
-
-        const [, deviceName, areaName] = computeEntityNameList(
+        const nameList = computeEntityNameList(
           entity,
           [{ type: "entity" }, { type: "device" }, { type: "area" }],
           this.hass.entities,
@@ -183,28 +177,42 @@ class DialogExposeEntity extends LitElement {
           this.hass.floors
         );
 
+        if (!lowerFilter) {
+          result.push({ entity, nameList });
+          continue;
+        }
+
+        if (entity.entity_id.toLowerCase().includes(lowerFilter)) {
+          result.push({ entity, nameList });
+          continue;
+        }
+
+        const entityName = computeStateName(entity);
+        if (entityName?.toLowerCase().includes(lowerFilter)) {
+          result.push({ entity, nameList });
+          continue;
+        }
+
+        const [, deviceName, areaName] = nameList;
+
         if (deviceName?.toLowerCase().includes(lowerFilter)) {
-          return true;
+          result.push({ entity, nameList });
+          continue;
         }
 
         if (areaName?.toLowerCase().includes(lowerFilter)) {
-          return true;
+          result.push({ entity, nameList });
+          continue;
         }
+      }
 
-        return false;
-      });
+      return result;
     }
   );
 
-  private _renderItem = (entityState: HassEntity) => {
-    const [entityName, deviceName, areaName] = computeEntityNameList(
-      entityState,
-      [{ type: "entity" }, { type: "device" }, { type: "area" }],
-      this.hass.entities,
-      this.hass.devices,
-      this.hass.areas,
-      this.hass.floors
-    );
+  private _renderItem = (item: FilteredEntity) => {
+    const { entity: entityState, nameList } = item;
+    const [entityName, deviceName, areaName] = nameList;
 
     const isRTL = computeRTL(this.hass);
     const primary = entityName || deviceName || entityState.entity_id;

--- a/src/panels/config/voice-assistants/dialog-expose-entity.ts
+++ b/src/panels/config/voice-assistants/dialog-expose-entity.ts
@@ -8,6 +8,8 @@ import { ifDefined } from "lit/directives/if-defined";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeStateName } from "../../../common/entity/compute_state_name";
+import { computeEntityNameList } from "../../../common/entity/compute_entity_name_display";
+import { computeRTL } from "../../../common/util/compute_rtl";
 import "../../../components/ha-check-list-item";
 import "../../../components/search-input";
 import "../../../components/ha-dialog";
@@ -143,36 +145,96 @@ class DialogExposeEntity extends LitElement {
       filter?: string
     ) => {
       const lowerFilter = filter?.toLowerCase();
-      return Object.values(this.hass.states).filter(
-        (entity) =>
-          this._params!.filterAssistants.some(
+      return Object.values(this.hass.states).filter((entity) => {
+        if (
+          !this._params!.filterAssistants.some(
             (ass) => !exposedEntities[entity.entity_id]?.[ass]
-          ) &&
-          (!lowerFilter ||
-            entity.entity_id.toLowerCase().includes(lowerFilter) ||
-            computeStateName(entity)?.toLowerCase().includes(lowerFilter))
-      );
+          )
+        ) {
+          return false;
+        }
+
+        if (!lowerFilter) {
+          return true;
+        }
+
+        if (entity.entity_id.toLowerCase().includes(lowerFilter)) {
+          return true;
+        }
+
+        const entityName = computeStateName(entity);
+        if (entityName?.toLowerCase().includes(lowerFilter)) {
+          return true;
+        }
+
+        const [, deviceName, areaName] = computeEntityNameList(
+          entity,
+          [{ type: "entity" }, { type: "device" }, { type: "area" }],
+          this.hass.entities,
+          this.hass.devices,
+          this.hass.areas,
+          this.hass.floors
+        );
+
+        if (deviceName?.toLowerCase().includes(lowerFilter)) {
+          return true;
+        }
+
+        if (areaName?.toLowerCase().includes(lowerFilter)) {
+          return true;
+        }
+
+        return false;
+      });
     }
   );
 
-  private _renderItem = (entityState: HassEntity) => html`
-    <ha-check-list-item
-      graphic="icon"
-      twoLine
-      .value=${entityState.entity_id}
-      .selected=${this._selected.includes(entityState.entity_id)}
-      @request-selected=${this._handleSelected}
-    >
-      <ha-state-icon
-        title=${ifDefined(entityState?.state)}
-        slot="graphic"
-        .hass=${this.hass}
-        .stateObj=${entityState}
-      ></ha-state-icon>
-      ${computeStateName(entityState)}
-      <span slot="secondary">${entityState.entity_id}</span>
-    </ha-check-list-item>
-  `;
+  private _renderItem = (entityState: HassEntity) => {
+    const [entityName, deviceName, areaName] = computeEntityNameList(
+      entityState,
+      [{ type: "entity" }, { type: "device" }, { type: "area" }],
+      this.hass.entities,
+      this.hass.devices,
+      this.hass.areas,
+      this.hass.floors
+    );
+
+    const isRTL = computeRTL(this.hass);
+    const primary = entityName || deviceName || entityState.entity_id;
+    const context = [areaName, entityName ? deviceName : undefined]
+      .filter(Boolean)
+      .join(isRTL ? " ◂ " : " ▸ ");
+    const showEntityId = this.hass.userData?.showEntityIdPicker;
+
+    return html`
+      <ha-check-list-item
+        graphic="icon"
+        ?twoLine=${context}
+        ?threeLine=${showEntityId}
+        .value=${entityState.entity_id}
+        .selected=${this._selected.includes(entityState.entity_id)}
+        @request-selected=${this._handleSelected}
+      >
+        <ha-state-icon
+          title=${ifDefined(entityState?.state)}
+          slot="graphic"
+          .hass=${this.hass}
+          .stateObj=${entityState}
+        ></ha-state-icon>
+        ${primary}
+        ${context || showEntityId
+          ? html`<span slot="secondary">
+              ${context}
+              ${showEntityId
+                ? html`<br /><span class="entity-id"
+                      >${entityState.entity_id}</span
+                    >`
+                : nothing}
+            </span>`
+          : nothing}
+      </ha-check-list-item>
+    `;
+  };
 
   private _expose() {
     this._params!.exposeEntities(this._selected);
@@ -198,6 +260,7 @@ class DialogExposeEntity extends LitElement {
           width: 100%;
           display: block;
           box-sizing: border-box;
+          margin-top: var(--ha-space-2);
           --text-field-suffix-padding-left: 8px;
         }
         .header {
@@ -210,7 +273,7 @@ class DialogExposeEntity extends LitElement {
           box-sizing: border-box;
           display: flex;
           flex-direction: column;
-          margin: -4px 0;
+          margin: calc(var(--ha-space-1) * -1) 0;
         }
         .subtitle {
           color: var(--secondary-text-color);
@@ -225,9 +288,17 @@ class DialogExposeEntity extends LitElement {
           width: 100%;
           height: 72px;
         }
+        ha-check-list-item[threeLine] {
+          height: 88px;
+        }
+        ha-check-list-item .entity-id {
+          line-height: var(--ha-line-height-normal);
+          padding-left: var(--ha-space-1);
+          font-size: var(--ha-font-size-xs);
+        }
         ha-check-list-item ha-state-icon {
-          margin-left: 24px;
-          margin-inline-start: 24px;
+          margin-left: var(--ha-space-6);
+          margin-inline-start: var(--ha-space-6);
           margin-inline-end: initial;
         }
         @media all and (max-height: 800px) {
@@ -262,8 +333,8 @@ class DialogExposeEntity extends LitElement {
             --text-field-suffix-padding-left: unset;
           }
           ha-check-list-item ha-state-icon {
-            margin-left: 8px;
-            margin-inline-start: 8px;
+            margin-left: var(--ha-space-2);
+            margin-inline-start: var(--ha-space-2);
             margin-inline-end: initial;
           }
         }

--- a/src/panels/config/voice-assistants/dialog-expose-entity.ts
+++ b/src/panels/config/voice-assistants/dialog-expose-entity.ts
@@ -20,6 +20,7 @@ import "../../../components/ha-list";
 import type { ExposeEntitySettings } from "../../../data/expose";
 import { voiceAssistants } from "../../../data/expose";
 import { haStyle } from "../../../resources/styles";
+import { loadVirtualizer } from "../../../resources/virtualizer";
 import type { HomeAssistant } from "../../../types";
 import "./entity-voice-settings";
 import type { ExposeEntityDialogParams } from "./show-dialog-expose-entity";
@@ -33,6 +34,12 @@ class DialogExposeEntity extends LitElement {
   @state() private _filter?: string;
 
   @state() private _selected: string[] = [];
+
+  public willUpdate(): void {
+    if (!this.hasUpdated) {
+      loadVirtualizer();
+    }
+  }
 
   public async showDialog(params: ExposeEntityDialogParams): Promise<void> {
     this._params = params;

--- a/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
+++ b/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
@@ -167,20 +167,21 @@ export class VoiceAssistantsExpose extends LitElement {
         filterable: true,
         direction: "asc",
         flex: 2,
-        template: narrow
-          ? undefined
-          : (entry) => html`
-              ${entry.name}<br />
-              <div class="secondary">${entry.entity_id}</div>
-            `,
       },
-      // For search & narrow
+      area: {
+        title: localize("ui.panel.config.voice_assistants.expose.headers.area"),
+        sortable: true,
+        groupable: true,
+        filterable: true,
+        template: (entry) => entry.area || "—",
+      },
       entity_id: {
         title: localize(
           "ui.panel.config.voice_assistants.expose.headers.entity_id"
         ),
-        hidden: !narrow,
+        sortable: true,
         filterable: true,
+        defaultHidden: true,
       },
       domain: {
         title: localize(
@@ -190,13 +191,6 @@ export class VoiceAssistantsExpose extends LitElement {
         hidden: true,
         filterable: true,
         groupable: true,
-      },
-      area: {
-        title: localize("ui.panel.config.voice_assistants.expose.headers.area"),
-        sortable: true,
-        groupable: true,
-        filterable: true,
-        template: (entry) => entry.area || "—",
       },
       assistants: {
         title: localize(
@@ -819,8 +813,8 @@ export class VoiceAssistantsExpose extends LitElement {
         }
         .selected-txt {
           font-weight: var(--ha-font-weight-bold);
-          padding-left: 16px;
-          padding-inline-start: 16px;
+          padding-left: var(--ha-space-4);
+          padding-inline-start: var(--ha-space-4);
           direction: var(--direction);
         }
         .table-header .selected-txt {
@@ -830,8 +824,8 @@ export class VoiceAssistantsExpose extends LitElement {
           font-size: var(--ha-font-size-l);
         }
         .header-toolbar .header-btns {
-          margin-right: -12px;
-          margin-inline-end: -12px;
+          margin-right: calc(var(--ha-space-3) * -1);
+          margin-inline-end: calc(var(--ha-space-3) * -1);
           direction: var(--direction);
         }
         .header-btns {
@@ -839,17 +833,17 @@ export class VoiceAssistantsExpose extends LitElement {
         }
         .header-btns > ha-button,
         .header-btns > ha-icon-button {
-          margin: 8px;
+          margin: var(--ha-space-2);
         }
         ha-button-menu {
-          margin-left: 8px;
-          margin-inline-start: 8px;
+          margin-left: var(--ha-space-2);
+          margin-inline-start: var(--ha-space-2);
           margin-inline-end: initial;
         }
         .clear {
           color: var(--primary-color);
-          padding-left: 8px;
-          padding-inline-start: 8px;
+          padding-left: var(--ha-space-2);
+          padding-inline-start: var(--ha-space-2);
           text-transform: uppercase;
           direction: var(--direction);
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
- Moved entity id on main grid to its own column, to match devices and services -> entities etc.
- Added context to secondary text
- Shows entity id if enabled on third line

<details>
<summary>Screenshots</summary>

Before:
<img width="1598" height="406" alt="image" src="https://github.com/user-attachments/assets/b124b0af-3f4c-4e6b-9b8b-2399f3f0ea6f" />

<img width="998" height="1148" alt="image" src="https://github.com/user-attachments/assets/a995c369-087e-4e59-a89c-a0199547b66d" />


After:
<img width="1035" height="1313" alt="image" src="https://github.com/user-attachments/assets/84cf8a02-1119-4a7c-a2f9-0067cc7ad882" />
<img width="3503" height="550" alt="image" src="https://github.com/user-attachments/assets/fb4e84f7-420b-484e-a2de-a521b938e30f" />

<img width="956" height="1266" alt="image" src="https://github.com/user-attachments/assets/be0a19a8-19f3-4c89-b308-65bc7a01a799" />

<img width="1005" height="1208" alt="image" src="https://github.com/user-attachments/assets/f8803ac0-245e-4fa4-b9fd-814be86c468b" />


</details>

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: resolves #28064
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
