### PR TITLE
Always use fallback for brands URL

### DIFF
--- a/src/components/ha-related-items.ts
+++ b/src/components/ha-related-items.ts
@@ -223,7 +223,6 @@ export class HaRelatedItems extends LitElement {
                         .src=${brandsUrl({
                           domain: entry.domain,
                           type: "icon",
-                          useFallback: true,
                           darkOptimized: this.hass.themes?.darkMode,
                         })}
                         crossorigin="anonymous"
@@ -249,7 +248,6 @@ export class HaRelatedItems extends LitElement {
                           .src=${brandsUrl({
                             domain: integration,
                             type: "icon",
-                            useFallback: true,
                             darkOptimized: this.hass.themes?.darkMode,
                           })}
                           crossorigin="anonymous"

--- a/src/components/ha-selector/ha-selector-media.ts
+++ b/src/components/ha-selector/ha-selector-media.ts
@@ -87,7 +87,6 @@ export class HaMediaSelector extends LitElement {
         this._thumbnailUrl = brandsUrl({
           domain: extractDomainFromBrandUrl(thumbnail),
           type: "icon",
-          useFallback: true,
           darkOptimized: this.hass.themes?.darkMode,
         });
       } else {

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -793,7 +793,6 @@ export class HaMediaPlayerBrowse extends LitElement {
       thumbnailUrl = brandsUrl({
         domain: extractDomainFromBrandUrl(thumbnailUrl),
         type: "icon",
-        useFallback: true,
         darkOptimized: this.hass.themes?.darkMode,
       });
     }

--- a/src/panels/config/backup/components/config/ha-backup-config-agents.ts
+++ b/src/panels/config/backup/components/config/ha-backup-config-agents.ts
@@ -152,7 +152,6 @@ class HaBackupConfigAgents extends LitElement {
         .src=${brandsUrl({
           domain,
           type: "icon",
-          useFallback: true,
           darkOptimized: this.hass.themes?.darkMode,
         })}
         crossorigin="anonymous"

--- a/src/panels/config/backup/components/ha-backup-agents-picker.ts
+++ b/src/panels/config/backup/components/ha-backup-agents-picker.ts
@@ -66,7 +66,6 @@ class HaBackupAgentsPicker extends LitElement {
                     .src=${brandsUrl({
                       domain,
                       type: "icon",
-                      useFallback: true,
                       darkOptimized: this.hass.themes?.darkMode,
                     })}
                     crossorigin="anonymous"

--- a/src/panels/config/backup/ha-config-backup-backups.ts
+++ b/src/panels/config/backup/ha-config-backup-backups.ts
@@ -226,7 +226,6 @@ class HaConfigBackupBackups extends SubscribeMixin(LitElement) {
                     .src=${brandsUrl({
                       domain,
                       type: "icon",
-                      useFallback: true,
                       darkOptimized: this.hass.themes?.darkMode,
                     })}
                     height="24"

--- a/src/panels/config/backup/ha-config-backup-details.ts
+++ b/src/panels/config/backup/ha-config-backup-details.ts
@@ -207,7 +207,6 @@ class HaConfigBackupDetails extends LitElement {
                                           .src=${brandsUrl({
                                             domain,
                                             type: "icon",
-                                            useFallback: true,
                                             darkOptimized:
                                               this.hass.themes?.darkMode,
                                           })}

--- a/src/panels/config/backup/ha-config-backup-settings.ts
+++ b/src/panels/config/backup/ha-config-backup-settings.ts
@@ -252,7 +252,6 @@ class HaConfigBackupSettings extends LitElement {
                       .src=${brandsUrl({
                         domain: "cloud",
                         type: "icon",
-                        useFallback: true,
                         darkOptimized: this.hass.themes?.darkMode,
                       })}
                       crossorigin="anonymous"

--- a/src/panels/config/helpers/dialog-helper-detail.ts
+++ b/src/panels/config/helpers/dialog-helper-detail.ts
@@ -227,7 +227,6 @@ export class DialogHelperDetail extends LitElement {
                   src=${brandsUrl({
                     domain,
                     type: "icon",
-                    useFallback: true,
                     darkOptimized: this.hass.themes?.darkMode,
                   })}
                   crossorigin="anonymous"

--- a/src/panels/config/integrations/ha-domain-integrations.ts
+++ b/src/panels/config/integrations/ha-domain-integrations.ts
@@ -60,7 +60,6 @@ class HaDomainIntegrations extends LitElement {
                     src=${brandsUrl({
                       domain: flow.handler,
                       type: "icon",
-                      useFallback: true,
                       darkOptimized: this.hass.themes?.darkMode,
                     })}
                     crossorigin="anonymous"
@@ -106,7 +105,6 @@ class HaDomainIntegrations extends LitElement {
                   src=${brandsUrl({
                     domain,
                     type: "icon",
-                    useFallback: true,
                     darkOptimized: this.hass.themes?.darkMode,
                   })}
                   crossorigin="anonymous"
@@ -170,7 +168,6 @@ class HaDomainIntegrations extends LitElement {
               src=${brandsUrl({
                 domain: this.domain,
                 type: "icon",
-                useFallback: true,
                 darkOptimized: this.hass.themes?.darkMode,
               })}
               crossorigin="anonymous"

--- a/src/panels/config/integrations/ha-integration-list-item.ts
+++ b/src/panels/config/integrations/ha-integration-list-item.ts
@@ -57,7 +57,6 @@ export class HaIntegrationListItem extends ListItemBase {
         src=${brandsUrl({
           domain: this.integration.domain,
           type: "icon",
-          useFallback: true,
           darkOptimized: this.hass.themes?.darkMode,
           brand: this.brand,
         })}

--- a/src/panels/config/labs/ha-config-labs.ts
+++ b/src/panels/config/labs/ha-config-labs.ts
@@ -203,7 +203,6 @@ class HaConfigLabs extends SubscribeMixin(LitElement) {
               src=${brandsUrl({
                 domain: preview_feature.domain,
                 type: "icon",
-                useFallback: true,
                 darkOptimized: this.hass.themes?.darkMode,
               })}
               crossorigin="anonymous"

--- a/src/panels/config/repairs/ha-config-repairs.ts
+++ b/src/panels/config/repairs/ha-config-repairs.ts
@@ -75,7 +75,6 @@ class HaConfigRepairs extends LitElement {
                 src=${brandsUrl({
                   domain: issue.issue_domain || issue.domain,
                   type: "icon",
-                  useFallback: true,
                   darkOptimized: this.hass.themes?.darkMode,
                 })}
                 .title=${domainName}

--- a/src/panels/config/repairs/integrations-startup-time.ts
+++ b/src/panels/config/repairs/integrations-startup-time.ts
@@ -58,7 +58,6 @@ class IntegrationsStartupTime extends LitElement {
                 src=${brandsUrl({
                   domain: setup.domain,
                   type: "icon",
-                  useFallback: true,
                   darkOptimized: this.hass.themes?.darkMode,
                 })}
                 crossorigin="anonymous"

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -160,7 +160,6 @@ class HaLogbookRenderer extends LitElement {
         ? brandsUrl({
             domain: domain!,
             type: "icon",
-            useFallback: true,
             darkOptimized: this.hass.themes?.darkMode,
           })
         : undefined;

--- a/src/util/brands-url.ts
+++ b/src/util/brands-url.ts
@@ -1,7 +1,6 @@
 export interface BrandsOptions {
   domain: string;
   type: "icon" | "logo" | "icon@2x" | "logo@2x";
-  useFallback?: boolean;
   darkOptimized?: boolean;
   brand?: boolean;
 }
@@ -14,11 +13,9 @@ export interface HardwareBrandsOptions {
 }
 
 export const brandsUrl = (options: BrandsOptions): string =>
-  `https://brands.home-assistant.io/${options.brand ? "brands/" : ""}${
-    options.useFallback ? "_/" : ""
-  }${options.domain}/${options.darkOptimized ? "dark_" : ""}${
-    options.type
-  }.png`;
+  `https://brands.home-assistant.io/${options.brand ? "brands/" : ""}_/${options.domain}/${
+    options.darkOptimized ? "dark_" : ""
+  }${options.type}.png`;
 
 export const hardwareBrandsUrl = (options: HardwareBrandsOptions): string =>
   `https://brands.home-assistant.io/hardware/${options.category}/${

--- a/test/util/generate-brands-url.test.ts
+++ b/test/util/generate-brands-url.test.ts
@@ -2,40 +2,26 @@ import { assert, describe, it } from "vitest";
 import { brandsUrl } from "../../src/util/brands-url";
 
 describe("Generate brands Url", () => {
-  it("Generate logo brands url for cloud component without fallback", () => {
+  it("Generate logo brands url for cloud component", () => {
     assert.strictEqual(
       // @ts-ignore
       brandsUrl({ domain: "cloud", type: "logo" }),
-      "https://brands.home-assistant.io/cloud/logo.png"
-    );
-  });
-  it("Generate icon brands url for cloud component without fallback", () => {
-    assert.strictEqual(
-      // @ts-ignore
-      brandsUrl({ domain: "cloud", type: "icon" }),
-      "https://brands.home-assistant.io/cloud/icon.png"
-    );
-  });
-  it("Generate logo brands url for cloud component with fallback", () => {
-    assert.strictEqual(
-      // @ts-ignore
-      brandsUrl({ domain: "cloud", type: "logo", useFallback: true }),
       "https://brands.home-assistant.io/_/cloud/logo.png"
     );
   });
-  it("Generate icon brands url for cloud component with fallback", () => {
+  it("Generate icon brands url for cloud component", () => {
     assert.strictEqual(
       // @ts-ignore
-      brandsUrl({ domain: "cloud", type: "icon", useFallback: true }),
+      brandsUrl({ domain: "cloud", type: "icon" }),
       "https://brands.home-assistant.io/_/cloud/icon.png"
     );
   });
 
-  it("Generate dark theme optimized logo brands url for cloud component without fallback", () => {
+  it("Generate dark theme optimized logo brands url for cloud component", () => {
     assert.strictEqual(
       // @ts-ignore
       brandsUrl({ domain: "cloud", type: "logo", darkOptimized: true }),
-      "https://brands.home-assistant.io/cloud/dark_logo.png"
+      "https://brands.home-assistant.io/_/cloud/dark_logo.png"
     );
   });
 });


### PR DESCRIPTION
The `useFallback` option has been removed from the `brandsUrl` utility. The URL generation will now always use the fallback path (`_/`).

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18106 
- This PR is related to issue or discussion: https://github.com/home-assistant/brands/pull/8742
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
