### PR TITLE
Allow to add context to tile card secondary line

### DIFF
--- a/src/components/ha-selector/ha-selector-ui-state-content.ts
+++ b/src/components/ha-selector/ha-selector-ui-state-content.ts
@@ -37,6 +37,7 @@ export class HaSelectorUiStateContent extends SubscribeMixin(LitElement) {
         .disabled=${this.disabled}
         .required=${this.required}
         .allowName=${this.selector.ui_state_content?.allow_name || false}
+        .allowContext=${this.selector.ui_state_content?.allow_context || false}
       ></ha-entity-state-content-picker>
     `;
   }

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -501,6 +501,7 @@ export interface UiStateContentSelector {
   ui_state_content: {
     entity_id?: string;
     allow_name?: boolean;
+    allow_context?: boolean;
   } | null;
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -144,7 +144,9 @@ export class HuiTileCardEditor
                   {
                     name: "state_content",
                     selector: {
-                      ui_state_content: {},
+                      ui_state_content: {
+                        allow_context: true,
+                      },
                     },
                     context: {
                       filter_entity: "entity",

--- a/src/panels/lovelace/strategies/usage_prediction/common-controls-section-strategy.ts
+++ b/src/panels/lovelace/strategies/usage_prediction/common-controls-section-strategy.ts
@@ -83,6 +83,15 @@ export class CommonControlsSectionStrategy extends ReactiveElement {
             ({
               type: "tile",
               entity: entityId,
+              name: [
+                {
+                  type: "device",
+                },
+                {
+                  type: "entity",
+                },
+              ],
+              state_content: ["state", "area_name"],
               show_entity_picture: true,
             }) satisfies TileCardConfig
         )

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -103,6 +103,15 @@ class StateDisplay extends LitElement {
       return html`${this.name}`;
     }
 
+    if (
+      content === "device_name" ||
+      content === "area_name" ||
+      content === "floor_name"
+    ) {
+      const type = content.replace("_name", "") as "device" | "area" | "floor";
+      return this.hass.formatEntityName(stateObj, { type }) || undefined;
+    }
+
     let relativeDateTime: string | Date | undefined;
 
     // Check last-changed for backwards compatibility

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1298,7 +1298,10 @@
         "last_changed": "Last changed",
         "last_updated": "Last updated",
         "remaining_time": "Remaining time",
-        "install_status": "Install status"
+        "install_status": "Install status",
+        "device_name": "Device name",
+        "area_name": "Area name",
+        "floor_name": "Floor name"
       },
       "multi-textfield": {
         "add_item": "Add {item}"


### PR DESCRIPTION
## Proposed change

Allow to set entity, device and area name in secondary line for tile card.
It will be used for favorites in home dashboard to show the area after the state (add more context)
Similar to https://github.com/home-assistant/frontend/pull/26857

<img width="742" height="182" alt="CleanShot 2026-01-14 at 17 20 12" src="https://github.com/user-attachments/assets/43628b02-e985-4523-a994-20005ac6f0ff" />

I think we will need somehow to merge the **entity name picker** and **state content picker** to a single universal one : **content picker**.

But that we will certainly be for another PR and we will need to have a migration path.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
