### PR TITLE
Fix vertical-align in markdown tables with presentation role

### DIFF
--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -7,7 +7,7 @@ import {
   type CSSResultGroup,
 } from "lit";
 import { customElement, property, query } from "lit/decorators";
-import "./ha-markdown-element.ts";
+import "./ha-markdown-element";
 
 @customElement("ha-markdown")
 export class HaMarkdown extends LitElement {

--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -7,7 +7,7 @@ import {
   type CSSResultGroup,
 } from "lit";
 import { customElement, property, query } from "lit/decorators";
-import "./ha-markdown-element";
+import "./ha-markdown-element.ts";
 
 @customElement("ha-markdown")
 export class HaMarkdown extends LitElement {
@@ -138,10 +138,10 @@ export class HaMarkdown extends LitElement {
       --markdown-table-padding-inline: 0;
       --markdown-table-padding-block: 0;
       th {
-        vertical-align: attr(align, center);
+        vertical-align: attr(valign, middle);
       }
       td {
-        vertical-align: attr(align, left);
+        vertical-align: attr(valign, middle);
       }
     }
     table {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Fix vertical-align in markdown card  presentation tables to use valign attribute

The role="presentation" table styling in markdown cards incorrectly reads the align HTML attribute for the CSS vertical-align property. The align attribute contains horizontal alignment values (left, center, right), which are invalid for vertical-align. This causes table cells to ignore the intended vertical alignment.

This PR fixes the issue by using the valign HTML attribute instead, which contains the correct vertical alignment values (top, middle, bottom, baseline) that are valid for the CSS vertical-align property.

Technical Details:

Changed:` vertical-align: attr(align, left)`, :` vertical-align: attr(align, center)`
To: vertical-align: `attr(valign, middle)`
Now properly respects `<td valign="top">`, `<td valign="middle">`, etc.
Falls back to middle when `valign `is not specified
Use cases: Alert cards, notification layouts, dashboard widgets - anywhere icons need to align properly with adjacent text in layout tables.

Before: Icon and text vertical alignment broken (valign attribute ignored)

<img width="489" height="129" alt="image" src="https://github.com/user-attachments/assets/07d3cf05-b310-46d0-bf6a-0b672607fcd3" />



After: Proper vertical alignment with valign attribute respected

<img width="471" height="103" alt="image" src="https://github.com/user-attachments/assets/b11d1b6b-a23e-486a-abee-5b7be1149fac" />




## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
Add the following to a markdown card:
```
### Table example role="presentation"

<table role="presentation">
  <tr>
    <td rowspan="2" width="70"><img src="https://placehold.co/48x48/FF9D00/000?text=!" width="48" height="48"/></td>
    <td><strong>Severe Weather Alert</strong></td>
  </tr>
  <tr>
    <td>Orange severity - Active from 21:00 to 11:00</td>
  </tr>
</table>
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #28343 (role="presentation" now works)
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x ] The code change is tested and works locally.
- [x ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
