### PR TITLE
Migrate category dialogs to ha-wa-dialog

### DIFF
--- a/src/panels/config/category/dialog-assign-category.ts
+++ b/src/panels/config/category/dialog-assign-category.ts
@@ -4,10 +4,8 @@ import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-alert";
 import "../../../components/ha-button";
-import { createCloseHeading } from "../../../components/ha-dialog";
-import "../../../components/ha-icon-picker";
-import "../../../components/ha-settings-row";
-import "../../../components/ha-textfield";
+import "../../../components/ha-wa-dialog";
+import "../../../components/ha-dialog-footer";
 import { updateEntityRegistryEntry } from "../../../data/entity/entity_registry";
 import { haStyleDialog } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
@@ -28,66 +26,72 @@ class DialogAssignCategory extends LitElement {
 
   @state() private _submitting?: boolean;
 
+  @state() private _open = false;
+
   public showDialog(params: AssignCategoryDialogParams): void {
     this._params = params;
     this._scope = params.scope;
     this._category = params.entityReg.categories[params.scope];
     this._error = undefined;
+    this._open = true;
   }
 
   public closeDialog(): void {
+    this._open = false;
+  }
+
+  private _dialogClosed(): void {
     this._error = "";
     this._params = undefined;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
   protected render() {
-    if (!this._params) {
+    if (!this._open) {
       return nothing;
     }
-    const entry = this._params.entityReg.categories[this._params.scope];
+    const entry = this._params!.entityReg.categories[this._params!.scope];
     return html`
-      <ha-dialog
-        open
-        @closed=${this.closeDialog}
-        .heading=${createCloseHeading(
-          this.hass,
-          entry
-            ? this.hass.localize("ui.panel.config.category.assign.edit")
-            : this.hass.localize("ui.panel.config.category.assign.assign")
-        )}
+      <ha-wa-dialog
+        .hass=${this.hass}
+        .open=${this._open}
+        header-title=${entry
+          ? this.hass.localize("ui.panel.config.category.assign.edit")
+          : this.hass.localize("ui.panel.config.category.assign.assign")}
+        @closed=${this._dialogClosed}
       >
-        <div>
-          ${this._error
-            ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
-            : ""}
-          <div class="form">
-            <ha-category-picker
-              .hass=${this.hass}
-              .scope=${this._scope}
-              .label=${this.hass.localize(
-                "ui.components.category-picker.category"
-              )}
-              .value=${this._category}
-              @value-changed=${this._categoryChanged}
-            ></ha-category-picker>
-          </div>
+        ${this._error
+          ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
+          : ""}
+        <div class="form">
+          <ha-category-picker
+            .hass=${this.hass}
+            .scope=${this._scope}
+            .label=${this.hass.localize(
+              "ui.components.category-picker.category"
+            )}
+            .value=${this._category}
+            @value-changed=${this._categoryChanged}
+            autofocus
+          ></ha-category-picker>
         </div>
-        <ha-button
-          appearance="plain"
-          slot="primaryAction"
-          @click=${this.closeDialog}
-        >
-          ${this.hass.localize("ui.common.cancel")}
-        </ha-button>
-        <ha-button
-          slot="primaryAction"
-          @click=${this._updateEntry}
-          .disabled=${!!this._submitting}
-        >
-          ${this.hass.localize("ui.common.save")}
-        </ha-button>
-      </ha-dialog>
+        <ha-dialog-footer slot="footer">
+          <ha-button
+            slot="secondaryAction"
+            appearance="plain"
+            @click=${this.closeDialog}
+          >
+            ${this.hass.localize("ui.common.cancel")}
+          </ha-button>
+          <ha-button
+            slot="primaryAction"
+            @click=${this._updateEntry}
+            .disabled=${!!this._submitting}
+          >
+            ${this.hass.localize("ui.common.save")}
+          </ha-button>
+        </ha-dialog-footer>
+      </ha-wa-dialog>
     `;
   }
 

--- a/src/panels/config/category/dialog-assign-category.ts
+++ b/src/panels/config/category/dialog-assign-category.ts
@@ -47,10 +47,10 @@ class DialogAssignCategory extends LitElement {
   }
 
   protected render() {
-    if (!this._open) {
+    if (!this._params) {
       return nothing;
     }
-    const entry = this._params!.entityReg.categories[this._params!.scope];
+    const entry = this._params.entityReg.categories[this._params.scope];
     return html`
       <ha-wa-dialog
         .hass=${this.hass}

--- a/src/panels/config/category/dialog-category-registry-detail.ts
+++ b/src/panels/config/category/dialog-category-registry-detail.ts
@@ -59,10 +59,10 @@ class DialogCategoryDetail extends LitElement {
   }
 
   protected render() {
-    if (!this._open) {
+    if (!this._params) {
       return nothing;
     }
-    const entry = this._params!.entry;
+    const entry = this._params.entry;
     const nameInvalid = !this._isNameValid();
     return html`
       <ha-wa-dialog

--- a/src/panels/config/category/dialog-category-registry-detail.ts
+++ b/src/panels/config/category/dialog-category-registry-detail.ts
@@ -3,9 +3,9 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-alert";
-import { createCloseHeading } from "../../../components/ha-dialog";
+import "../../../components/ha-wa-dialog";
+import "../../../components/ha-dialog-footer";
 import "../../../components/ha-icon-picker";
-import "../../../components/ha-settings-row";
 import "../../../components/ha-button";
 import "../../../components/ha-textfield";
 import type {
@@ -30,11 +30,14 @@ class DialogCategoryDetail extends LitElement {
 
   @state() private _submitting?: boolean;
 
+  @state() private _open = false;
+
   public async showDialog(
     params: CategoryRegistryDetailDialogParams
   ): Promise<void> {
     this._params = params;
     this._error = undefined;
+    this._open = true;
     if (this._params.entry) {
       this._name = this._params.entry.name || "";
       this._icon = this._params.entry.icon || null;
@@ -46,73 +49,71 @@ class DialogCategoryDetail extends LitElement {
   }
 
   public closeDialog(): void {
+    this._open = false;
+  }
+
+  private _dialogClosed(): void {
     this._error = "";
     this._params = undefined;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
   protected render() {
-    if (!this._params) {
+    if (!this._open) {
       return nothing;
     }
-    const entry = this._params.entry;
+    const entry = this._params!.entry;
     const nameInvalid = !this._isNameValid();
     return html`
-      <ha-dialog
-        open
-        @closed=${this.closeDialog}
-        .heading=${createCloseHeading(
-          this.hass,
-          entry
-            ? this.hass.localize("ui.panel.config.category.editor.edit")
-            : this.hass.localize("ui.panel.config.category.editor.create")
-        )}
+      <ha-wa-dialog
+        .hass=${this.hass}
+        .open=${this._open}
+        header-title=${entry
+          ? this.hass.localize("ui.panel.config.category.editor.edit")
+          : this.hass.localize("ui.panel.config.category.editor.create")}
+        @closed=${this._dialogClosed}
       >
-        <div>
-          ${this._error
-            ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
-            : ""}
-          <div class="form">
-            <ha-textfield
-              .value=${this._name}
-              @input=${this._nameChanged}
-              .label=${this.hass.localize(
-                "ui.panel.config.category.editor.name"
-              )}
-              .validationMessage=${this.hass.localize(
-                "ui.panel.config.category.editor.required_error_msg"
-              )}
-              required
-              dialogInitialFocus
-            ></ha-textfield>
+        ${this._error
+          ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
+          : ""}
+        <div class="form">
+          <ha-textfield
+            .value=${this._name}
+            @input=${this._nameChanged}
+            .label=${this.hass.localize("ui.panel.config.category.editor.name")}
+            .validationMessage=${this.hass.localize(
+              "ui.panel.config.category.editor.required_error_msg"
+            )}
+            required
+            autofocus
+          ></ha-textfield>
 
-            <ha-icon-picker
-              .hass=${this.hass}
-              .value=${this._icon}
-              @value-changed=${this._iconChanged}
-              .label=${this.hass.localize(
-                "ui.panel.config.category.editor.icon"
-              )}
-            ></ha-icon-picker>
-          </div>
+          <ha-icon-picker
+            .hass=${this.hass}
+            .value=${this._icon}
+            @value-changed=${this._iconChanged}
+            .label=${this.hass.localize("ui.panel.config.category.editor.icon")}
+          ></ha-icon-picker>
         </div>
-        <ha-button
-          appearance="plain"
-          slot="secondaryAction"
-          @click=${this.closeDialog}
-        >
-          ${this.hass.localize("ui.common.cancel")}
-        </ha-button>
-        <ha-button
-          slot="primaryAction"
-          @click=${this._updateEntry}
-          .disabled=${nameInvalid || !!this._submitting}
-        >
-          ${entry
-            ? this.hass.localize("ui.common.save")
-            : this.hass.localize("ui.common.add")}
-        </ha-button>
-      </ha-dialog>
+        <ha-dialog-footer slot="footer">
+          <ha-button
+            slot="secondaryAction"
+            appearance="plain"
+            @click=${this.closeDialog}
+          >
+            ${this.hass.localize("ui.common.cancel")}
+          </ha-button>
+          <ha-button
+            slot="primaryAction"
+            @click=${this._updateEntry}
+            .disabled=${nameInvalid || !!this._submitting}
+          >
+            ${entry
+              ? this.hass.localize("ui.common.save")
+              : this.hass.localize("ui.common.add")}
+          </ha-button>
+        </ha-dialog-footer>
+      </ha-wa-dialog>
     `;
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Unblocks #29002 
Resolves #29008 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: resolves #29008
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
