### PR TITLE
Fixed dark mode hidden text in debug assistant

### DIFF
--- a/src/panels/config/voice-assistants/debug/assist-render-pipeline-run.ts
+++ b/src/panels/config/voice-assistants/debug/assist-render-pipeline-run.ts
@@ -670,6 +670,7 @@ export class AssistPipelineDebug extends LitElement {
       background-color: var(--light-primary-color);
       color: var(--text-light-primary-color, var(--primary-text-color));
       direction: var(--direction);
+      --primary-text-color: var(--text-light-primary-color, var(--primary-text-color));
     }
 
     .message.user,

--- a/src/panels/config/voice-assistants/debug/assist-render-pipeline-run.ts
+++ b/src/panels/config/voice-assistants/debug/assist-render-pipeline-run.ts
@@ -1,23 +1,23 @@
 import type { TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
-import "../../../../components/ha-card";
+import { formatNumber } from "../../../../common/number/format_number";
+import type { LocalizeKeys } from "../../../../common/translations/localize";
 import "../../../../components/ha-alert";
 import "../../../../components/ha-button";
-import "../../../../components/ha-spinner";
+import "../../../../components/ha-card";
 import "../../../../components/ha-expansion-panel";
-import type { PipelineRun } from "../../../../data/assist_pipeline";
-import type { HomeAssistant } from "../../../../types";
-import { formatNumber } from "../../../../common/number/format_number";
+import "../../../../components/ha-spinner";
 import "../../../../components/ha-yaml-editor";
-import { showAlertDialog } from "../../../../dialogs/generic/show-dialog-box";
-import type { LocalizeKeys } from "../../../../common/translations/localize";
+import type { PipelineRun } from "../../../../data/assist_pipeline";
 import type {
-  ChatLogAssistantContent,
   ChatLog,
+  ChatLogAssistantContent,
   ChatLogContent,
   ChatLogUserContent,
 } from "../../../../data/chat_log";
+import { showAlertDialog } from "../../../../dialogs/generic/show-dialog-box";
+import type { HomeAssistant } from "../../../../types";
 
 const RUN_DATA = ["pipeline", "language"];
 const WAKE_WORD_DATA = ["engine"];
@@ -670,7 +670,10 @@ export class AssistPipelineDebug extends LitElement {
       background-color: var(--light-primary-color);
       color: var(--text-light-primary-color, var(--primary-text-color));
       direction: var(--direction);
-      --primary-text-color: var(--text-light-primary-color, var(--primary-text-color));
+      --primary-text-color: var(
+        --text-light-primary-color,
+        var(--primary-text-color)
+      );
     }
 
     .message.user,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This change is (my first PR to home assistant) and fixes a very small visual UI bug in the debug assistant when in dark mode. Some text is illegible (text in an expandable) so I've fixed that.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Doesn't apply.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I've captured some screenshots of the page before and after the fix:

### Before

The issue is the text at the bottom of the image that should read "Result for assist__HassTurnOff" but the text is in white:

<img width="1270" height="802" alt="SCR-20260115-shxh" src="https://github.com/user-attachments/assets/efa55e0b-ff19-4db1-be94-dddc0ffe1c20" />

### After

<img width="1294" height="750" alt="SCR-20260115-sign" src="https://github.com/user-attachments/assets/8f5929a1-e225-45ff-bc00-42d3e196d40a" />

I've also tested the light mode before and after were unchanged.

<details>
<summary><strong>Light mode screenshot included but there's no visual change</strong></summary>
<img width="1338" height="798" alt="SCR-20260115-shzx" src="https://github.com/user-attachments/assets/150a43f9-5825-435e-b0fb-3829d4d941c3" />
</details>

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

I couldn't see any visual regression tests so assumed that it was manual. I have also tested across browsers and the result is the same.

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
