### PR TITLE
Fix sidebar menu accessibility for screen readers

### DIFF
--- a/src/components/ha-md-list-item.ts
+++ b/src/components/ha-md-list-item.ts
@@ -1,6 +1,6 @@
 import { ListItemEl } from "@material/web/list/internal/listitem/list-item";
 import { styles } from "@material/web/list/internal/listitem/list-item-styles";
-import { css, html, nothing, type TemplateResult } from "lit";
+import { css, html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { customElement } from "lit/decorators";
 import "./ha-ripple";
 
@@ -26,6 +26,26 @@ export const haMdListStyles = [
 @customElement("ha-md-list-item")
 export class HaMdListItem extends ListItemEl {
   static override styles = haMdListStyles;
+
+  protected override updated(changedProps: PropertyValues): void {
+    super.updated(changedProps);
+
+    // Fix accessibility: Remove list semantics for interactive elements
+    // so that native link/button roles are properly announced by screen readers
+    if (changedProps.has("type") || changedProps.has("href")) {
+      const itemElement = this.renderRoot.querySelector("#item");
+      if (itemElement) {
+        if (this.type === "link" || this.type === "button") {
+          // Use "none" role to remove list semantics and let the native
+          // <a> or <button> element provide proper accessibility
+          itemElement.setAttribute("role", "none");
+        } else {
+          // Keep listitem role for non-interactive text items
+          itemElement.setAttribute("role", "listitem");
+        }
+      }
+    }
+  }
 
   protected renderRipple(): TemplateResult | typeof nothing {
     if (this.type === "text") {

--- a/src/components/ha-md-list.ts
+++ b/src/components/ha-md-list.ts
@@ -1,5 +1,6 @@
 import { List } from "@material/web/list/internal/list";
 import { styles } from "@material/web/list/internal/list-styles";
+import type { PropertyValues } from "lit";
 import { css } from "lit";
 import { customElement } from "lit/decorators";
 
@@ -13,6 +14,16 @@ export class HaMdList extends List {
       }
     `,
   ];
+
+  protected override willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+
+    // Override the default "list" role if a custom role attribute is provided
+    const roleAttr = this.getAttribute("role");
+    if (roleAttr) {
+      (this as any).internals.role = roleAttr;
+    }
+  }
 }
 
 declare global {

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -261,7 +261,7 @@ class HaSidebar extends SubscribeMixin(LitElement) {
       ${this._renderHeader()}
       ${this._renderAllPanels(selectedPanel)}
       ${this._renderDivider()}
-      <ha-md-list>
+      <ha-md-list role="navigation" aria-label="User navigation">
         ${this._renderNotifications()}
         ${this._renderUserItem(selectedPanel)}
       </ha-md-list>
@@ -404,6 +404,8 @@ class HaSidebar extends SubscribeMixin(LitElement) {
 
     return html`
       <ha-md-list
+        role="navigation"
+        aria-label="Main navigation"
         class="ha-scrollbar"
         @focusin=${this._listboxFocusIn}
         @focusout=${this._listboxFocusOut}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
-->


## Proposed change
  Fix sidebar menu accessibility for screen readers by properly announcing navigation items as links instead of list items.

  Currently, the main navigation menu items in the sidebar are announced by screen readers as "list item" or as plain text, (e.g., "Settings, list item") because Material Web components use role="listitem" on all list items regardless of whether they are links, buttons, or text. This makes navigation less intuitive for screen reader users.

  This PR overrides the role attributes to use proper semantic HTML roles, so menu items are now announced as links (e.g., "Link,Settings"), providing a better accessibility experience.

  Changes:
  - Override role="listitem" to role="none" for interactive elements in ha-md-list-item, allowing native <a> and <button> semantic roles to be announced
  - Add support for custom role attributes in ha-md-list component
  - Apply role="navigation" and descriptive aria-label attributes to sidebar menu lists

  Visual impact: None - this is purely an accessibility improvement with zero visual changes.



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (no n-breaking change which fixes an issue)

## Example configuration

  N/A - This is a frontend accessibility fix that requires no configuration.


```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x ] The code change is tested and works locally.
- [x ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
