### PR TITLE
Reuse <voice-assistant-brand-icon>

### DIFF
--- a/src/dialogs/voice-assistant-setup/cloud/cloud-step-intro.ts
+++ b/src/dialogs/voice-assistant-setup/cloud/cloud-step-intro.ts
@@ -5,8 +5,8 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-button";
 import "../../../components/ha-svg-icon";
 import type { HomeAssistant } from "../../../types";
-import { brandsUrl } from "../../../util/brands-url";
 import { AssistantSetupStyles } from "../styles";
+import "../../../components/voice-assistant-brand-icon";
 
 @customElement("cloud-step-intro")
 export class CloudStepIntro extends LitElement {
@@ -62,26 +62,16 @@ export class CloudStepIntro extends LitElement {
           </div>
           <div class="feature">
             <div class="logos">
-              <img
-                alt="Google Assistant"
-                src=${brandsUrl({
-                  domain: "google_assistant",
-                  type: "icon",
-                  darkOptimized: this.hass.themes?.darkMode,
-                })}
-                crossorigin="anonymous"
-                referrerpolicy="no-referrer"
-              />
-              <img
-                alt="Amazon Alexa"
-                src=${brandsUrl({
-                  domain: "alexa",
-                  type: "icon",
-                  darkOptimized: this.hass.themes?.darkMode,
-                })}
-                crossorigin="anonymous"
-                referrerpolicy="no-referrer"
-              />
+              <voice-assistant-brand-icon
+                .voiceAssistantId=${"cloud.google_assistant"}
+                .hass=${this.hass}
+              >
+              </voice-assistant-brand-icon>
+              <voice-assistant-brand-icon
+                .voiceAssistantId=${"cloud.alexa"}
+                .hass=${this.hass}
+              >
+              </voice-assistant-brand-icon>
             </div>
             <h2>
               ${this.hass.localize(

--- a/src/panels/config/voice-assistants/assist-pref.ts
+++ b/src/panels/config/voice-assistants/assist-pref.ts
@@ -46,9 +46,9 @@ import {
 } from "../../../dialogs/generic/show-dialog-box";
 import { showVoiceCommandDialog } from "../../../dialogs/voice-command-dialog/show-ha-voice-command-dialog";
 import type { HomeAssistant } from "../../../types";
-import { brandsUrl } from "../../../util/brands-url";
 import { documentationUrl } from "../../../util/documentation-url";
 import { showVoiceAssistantPipelineDetailDialog } from "./show-dialog-voice-assistant-pipeline-detail";
+import "../../../components/voice-assistant-brand-icon";
 
 @customElement("assist-pref")
 export class AssistPref extends LitElement {
@@ -103,16 +103,12 @@ export class AssistPref extends LitElement {
     return html`
       <ha-card outlined>
         <h1 class="card-header">
-          <img
-            alt=""
-            src=${brandsUrl({
-              domain: "assist_pipeline",
-              type: "icon",
-              darkOptimized: this.hass.themes?.darkMode,
-            })}
-            crossorigin="anonymous"
-            referrerpolicy="no-referrer"
-          />Assist
+          <voice-assistant-brand-icon
+            .voiceAssistantId=${"conversation"}
+            .hass=${this.hass}
+          >
+          </voice-assistant-brand-icon
+          >Assist
         </h1>
         <div class="header-actions">
           <a

--- a/src/panels/config/voice-assistants/cloud-alexa-pref.ts
+++ b/src/panels/config/voice-assistants/cloud-alexa-pref.ts
@@ -18,7 +18,7 @@ import {
   setExposeNewEntities,
 } from "../../../data/expose";
 import type { HomeAssistant } from "../../../types";
-import { brandsUrl } from "../../../util/brands-url";
+import "../../../components/voice-assistant-brand-icon";
 
 @customElement("cloud-alexa-pref")
 export class CloudAlexaPref extends LitElement {
@@ -64,16 +64,12 @@ export class CloudAlexaPref extends LitElement {
     return html`
       <ha-card outlined>
         <h1 class="card-header">
-          <img
-            alt=""
-            src=${brandsUrl({
-              domain: "alexa",
-              type: "icon",
-              darkOptimized: this.hass.themes?.darkMode,
-            })}
-            crossorigin="anonymous"
-            referrerpolicy="no-referrer"
-          />${this.hass.localize("ui.panel.config.cloud.account.alexa.title")}
+          <voice-assistant-brand-icon
+            .voiceAssistantId=${"cloud.alexa"}
+            .hass=${this.hass}
+          >
+          </voice-assistant-brand-icon
+          >${this.hass.localize("ui.panel.config.cloud.account.alexa.title")}
         </h1>
         <div class="header-actions">
           <a

--- a/src/panels/config/voice-assistants/cloud-discover.ts
+++ b/src/panels/config/voice-assistants/cloud-discover.ts
@@ -6,7 +6,7 @@ import "../../../components/ha-button";
 import "../../../components/ha-card";
 import "../../../components/ha-svg-icon";
 import type { HomeAssistant } from "../../../types";
-import { brandsUrl } from "../../../util/brands-url";
+import "../../../components/voice-assistant-brand-icon";
 
 @customElement("cloud-discover")
 export class CloudDiscover extends LitElement {
@@ -47,26 +47,16 @@ export class CloudDiscover extends LitElement {
             </div>
             <div class="feature">
               <div class="logos">
-                <img
-                  alt="Google Assistant"
-                  src=${brandsUrl({
-                    domain: "google_assistant",
-                    type: "icon",
-                    darkOptimized: this.hass.themes?.darkMode,
-                  })}
-                  crossorigin="anonymous"
-                  referrerpolicy="no-referrer"
-                />
-                <img
-                  alt="Amazon Alexa"
-                  src=${brandsUrl({
-                    domain: "alexa",
-                    type: "icon",
-                    darkOptimized: this.hass.themes?.darkMode,
-                  })}
-                  crossorigin="anonymous"
-                  referrerpolicy="no-referrer"
-                />
+                <voice-assistant-brand-icon
+                  .voiceAssistantId=${"cloud.google_assistant"}
+                  .hass=${this.hass}
+                >
+                </voice-assistant-brand-icon>
+                <voice-assistant-brand-icon
+                  .voiceAssistantId=${"cloud.alexa"}
+                  .hass=${this.hass}
+                >
+                </voice-assistant-brand-icon>
               </div>
               <h2>
                 ${this.hass.localize(

--- a/src/panels/config/voice-assistants/cloud-google-pref.ts
+++ b/src/panels/config/voice-assistants/cloud-google-pref.ts
@@ -20,8 +20,8 @@ import {
   setExposeNewEntities,
 } from "../../../data/expose";
 import type { HomeAssistant } from "../../../types";
-import { brandsUrl } from "../../../util/brands-url";
 import { showSaveSuccessToast } from "../../../util/toast-saved-success";
+import "../../../components/voice-assistant-brand-icon";
 
 @customElement("cloud-google-pref")
 export class CloudGooglePref extends LitElement {
@@ -70,16 +70,12 @@ export class CloudGooglePref extends LitElement {
     return html`
       <ha-card outlined>
         <h1 class="card-header">
-          <img
-            alt=""
-            src=${brandsUrl({
-              domain: "google_assistant",
-              type: "icon",
-              darkOptimized: this.hass.themes?.darkMode,
-            })}
-            crossorigin="anonymous"
-            referrerpolicy="no-referrer"
-          />${this.hass.localize("ui.panel.config.cloud.account.google.title")}
+          <voice-assistant-brand-icon
+            .voiceAssistantId=${"cloud.google_assistant"}
+            .hass=${this.hass}
+          >
+          </voice-assistant-brand-icon
+          >${this.hass.localize("ui.panel.config.cloud.account.google.title")}
         </h1>
         <div class="header-actions">
           <a

--- a/src/panels/config/voice-assistants/entity-voice-settings.ts
+++ b/src/panels/config/voice-assistants/entity-voice-settings.ts
@@ -37,9 +37,9 @@ import { fetchCloudGoogleEntity } from "../../../data/google_assistant";
 import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
-import { brandsUrl } from "../../../util/brands-url";
 import { documentationUrl } from "../../../util/documentation-url";
 import type { EntityRegistrySettings } from "../entities/entity-registry-settings";
+import "../../../components/voice-assistant-brand-icon";
 
 @customElement("entity-voice-settings")
 export class EntityVoiceSettings extends SubscribeMixin(LitElement) {
@@ -213,17 +213,12 @@ export class EntityVoiceSettings extends SubscribeMixin(LitElement) {
 
             return html`
               <ha-settings-row .threeLine=${!supported && manualConfig}>
-                <img
-                  alt=""
-                  src=${brandsUrl({
-                    domain: voiceAssistants[key].domain,
-                    type: "icon",
-                    darkOptimized: this.hass.themes?.darkMode,
-                  })}
-                  crossorigin="anonymous"
-                  referrerpolicy="no-referrer"
+                <voice-assistant-brand-icon
                   slot="prefix"
-                />
+                  .voiceAssistantId=${key}
+                  .hass=${this.hass}
+                >
+                </voice-assistant-brand-icon>
                 <span slot="heading">${voiceAssistants[key].name}</span>
                 ${!supported
                   ? html`<div slot="description" class="unsupported">

--- a/src/panels/config/voice-assistants/expose/expose-assistant-icon.ts
+++ b/src/panels/config/voice-assistants/expose/expose-assistant-icon.ts
@@ -4,9 +4,9 @@ import { customElement, property } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import { voiceAssistants } from "../../../../data/expose";
 import type { HomeAssistant } from "../../../../types";
-import { brandsUrl } from "../../../../util/brands-url";
 import "../../../../components/ha-svg-icon";
 import "../../../../components/ha-tooltip";
+import "../../../../components/voice-assistant-brand-icon";
 
 @customElement("voice-assistants-expose-assistant-icon")
 export class VoiceAssistantExposeAssistantIcon extends LitElement {
@@ -25,21 +25,14 @@ export class VoiceAssistantExposeAssistantIcon extends LitElement {
     if (!this.assistant || !voiceAssistants[this.assistant]) return nothing;
     return html`
       <div class="container" id="container">
-        <img
-          class="logo"
+        <voice-assistant-brand-icon
           style=${styleMap({
             filter: this.manual ? "grayscale(100%)" : undefined,
           })}
-          alt=${voiceAssistants[this.assistant].name}
-          src=${brandsUrl({
-            domain: voiceAssistants[this.assistant].domain,
-            type: "icon",
-            darkOptimized: this.hass.themes?.darkMode,
-          })}
-          crossorigin="anonymous"
-          referrerpolicy="no-referrer"
-          slot="prefix"
-        />
+          .voiceAssistantId=${this.assistant}
+          .hass=${this.hass}
+        >
+        </voice-assistant-brand-icon>
         ${this.unsupported
           ? html`
               <ha-svg-icon


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
PR https://github.com/home-assistant/frontend/pull/28854 introduced a new reusable `<voice-assistant-brand-icon>`, which was only used in 1 new location.
In this PR, that icon component is now used in all locations where a voice assistant icon is displayed.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
