### PR TITLE
Add tap action indicators to tile cards

### DIFF
--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -1,3 +1,10 @@
+import {
+  mdiCommentProcessingOutline,
+  mdiInformationOutline,
+  mdiOpenInNew,
+  mdiRoomServiceOutline,
+  mdiToggleSwitchOutline,
+} from "@mdi/js";
 import type { HassEntity } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
@@ -12,6 +19,7 @@ import { computeDomain } from "../../../common/entity/compute_domain";
 import { stateActive } from "../../../common/entity/state_active";
 import { stateColorCss } from "../../../common/entity/state_color";
 import "../../../components/ha-card";
+import "../../../components/ha-icon-next";
 import "../../../components/ha-ripple";
 import "../../../components/ha-state-icon";
 import "../../../components/ha-svg-icon";
@@ -47,6 +55,27 @@ export const getEntityDefaultTileIconAction = (entityId: string) => {
   return supportsIconAction ? "toggle" : "none";
 };
 
+// Mapping of tap actions to their indicator icons
+// Only actions in this map will show an indicator icon in the tile card
+const TAP_ACTION_INDICATOR_ICONS = {
+  navigate: "navigate", // Special value for ha-icon-next
+  url: mdiOpenInNew,
+  "more-info": mdiInformationOutline,
+  assist: mdiCommentProcessingOutline,
+  toggle: mdiToggleSwitchOutline,
+  "call-service": mdiRoomServiceOutline, // Legacy service call
+  "perform-action": mdiRoomServiceOutline, // Modern action (same as call-service)
+} as const;
+
+// Type for actions that support indicators
+type IndicatorSupportedAction = keyof typeof TAP_ACTION_INDICATOR_ICONS;
+
+// Helper to check if an action supports tap action indicators
+export const supportsTapActionIndicator = (
+  action?: string
+): action is IndicatorSupportedAction =>
+  action !== undefined && action in TAP_ACTION_INDICATOR_ICONS;
+
 @customElement("hui-tile-card")
 export class HuiTileCard extends LitElement implements LovelaceCard {
   public static async getConfigElement(): Promise<LovelaceCardEditor> {
@@ -81,10 +110,15 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
 
   @state() private _featureContext: LovelaceCardFeatureContext = {};
 
+  private _hasTapActionConfigured = false;
+
   public setConfig(config: TileCardConfig): void {
     if (!config.entity) {
       throw new Error("Specify an entity");
     }
+
+    // Track if tap_action was explicitly configured by user
+    this._hasTapActionConfigured = config.tap_action !== undefined;
 
     this._config = {
       tap_action: {
@@ -221,6 +255,31 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     );
   }
 
+  private get _showTapActionIndicator(): boolean {
+    // Explicit config overrides everything
+    if (this._config?.show_tap_action_indicator !== undefined) {
+      return this._config.show_tap_action_indicator;
+    }
+
+    // Show indicator by default only if tap_action was explicitly configured by user
+    return this._hasTapActionConfigured;
+  }
+
+  private get _tapActionIndicatorIcon(): string | undefined {
+    if (!this._showTapActionIndicator) {
+      return undefined;
+    }
+
+    const action = this._config?.tap_action?.action;
+
+    // Use the centralized mapping - only supported actions have icons
+    if (action && supportsTapActionIndicator(action)) {
+      return TAP_ACTION_INDICATOR_ICONS[action];
+    }
+
+    return undefined;
+  }
+
   private _featurePosition = memoizeOne((config: TileCardConfig) => {
     if (config.vertical) {
       return "bottom";
@@ -335,6 +394,17 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
                 ? html`<span slot="secondary">${stateDisplay}</span>`
                 : nothing}
             </ha-tile-info>
+            ${this._tapActionIndicatorIcon
+              ? html`
+                  <div class="action-indicator">
+                    ${this._tapActionIndicatorIcon === "navigate"
+                      ? html`<ha-icon-next></ha-icon-next>`
+                      : html`<ha-svg-icon
+                          .path=${this._tapActionIndicatorIcon}
+                        ></ha-svg-icon>`}
+                  </div>
+                `
+              : nothing}
           </div>
           ${features.length > 0
             ? html`
@@ -444,6 +514,25 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       min-width: 0;
       transition: background-color 180ms ease-in-out;
       box-sizing: border-box;
+    }
+    .action-indicator {
+      display: flex;
+      align-items: center;
+      margin-inline-start: auto;
+      color: var(--secondary-text-color);
+      opacity: 0.6;
+      pointer-events: none;
+    }
+    .content.vertical .action-indicator {
+      position: absolute;
+      top: var(--ha-space-2);
+      right: var(--ha-space-2);
+      inset-inline-end: var(--ha-space-2);
+      inset-inline-start: initial;
+    }
+    ha-icon-next,
+    .action-indicator ha-svg-icon {
+      --mdc-icon-size: 20px;
     }
     hui-card-features {
       --feature-color: var(--tile-color);

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -628,6 +628,7 @@ export interface TileCardConfig extends LovelaceCardConfig {
   icon_tap_action?: ActionConfig;
   icon_hold_action?: ActionConfig;
   icon_double_tap_action?: ActionConfig;
+  show_tap_action_indicator?: boolean;
   features?: LovelaceCardFeatureConfig[];
   features_position?: LovelaceCardFeaturePosition;
 }

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -30,7 +30,10 @@ import type {
   LovelaceCardFeatureConfig,
   LovelaceCardFeatureContext,
 } from "../../card-features/types";
-import { getEntityDefaultTileIconAction } from "../../cards/hui-tile-card";
+import {
+  getEntityDefaultTileIconAction,
+  supportsTapActionIndicator,
+} from "../../cards/hui-tile-card";
 import type { TileCardConfig } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
 import { actionConfigStruct } from "../structs/action-struct";
@@ -57,6 +60,7 @@ const cardConfigStruct = assign(
     icon_tap_action: optional(actionConfigStruct),
     icon_hold_action: optional(actionConfigStruct),
     icon_double_tap_action: optional(actionConfigStruct),
+    show_tap_action_indicator: optional(boolean()),
     features: optional(array(any())),
     features_position: optional(enums(["bottom", "inline"])),
   })
@@ -88,7 +92,8 @@ export class HuiTileCardEditor
     (
       localize: LocalizeFunc,
       entityId: string | undefined,
-      hideState: boolean
+      hideState: boolean,
+      tapAction: string | undefined
     ) =>
       [
         { name: "entity", selector: { entity: {} } },
@@ -190,6 +195,16 @@ export class HuiTileCardEditor
                 },
               },
             },
+            ...(tapAction && supportsTapActionIndicator(tapAction)
+              ? ([
+                  {
+                    name: "show_tap_action_indicator",
+                    selector: {
+                      boolean: {},
+                    },
+                  },
+                ] as const satisfies readonly HaFormSchema[])
+              : []),
             {
               name: "icon_tap_action",
               selector: {
@@ -266,11 +281,13 @@ export class HuiTileCardEditor
     }
 
     const entityId = this._config!.entity;
+    const tapAction = this._config!.tap_action?.action;
 
     const schema = this._schema(
       this.hass.localize,
       entityId,
-      this._config.hide_state ?? false
+      this._config.hide_state ?? false,
+      tapAction
     );
 
     const vertical = this._config.vertical ?? false;
@@ -285,6 +302,11 @@ export class HuiTileCardEditor
     // Default features position to bottom and force it to bottom in vertical mode
     if (!data.features_position || vertical) {
       data.features_position = "bottom";
+    }
+
+    // Set show_tap_action_indicator default: true if tap_action explicitly configured
+    if (data.show_tap_action_indicator === undefined && data.tap_action) {
+      data.show_tap_action_indicator = true;
     }
 
     const featureContext = this._featureContext(entityId);
@@ -359,6 +381,16 @@ export class HuiTileCardEditor
       delete config.content_layout;
     }
 
+    // Remove show_tap_action_indicator in two cases:
+    // 1. When tap_action is removed (no longer relevant)
+    // 2. When it's true and tap_action exists (matches default, to keep config clean)
+    if (
+      config.tap_action === undefined ||
+      config.show_tap_action_indicator !== false
+    ) {
+      delete config.show_tap_action_indicator;
+    }
+
     config = orderProperties(config, fieldOrder);
 
     fireEvent(this, "config-changed", { config });
@@ -420,6 +452,7 @@ export class HuiTileCardEditor
       case "icon_hold_action":
       case "icon_double_tap_action":
       case "show_entity_picture":
+      case "show_tap_action_indicator":
       case "hide_state":
       case "state_content":
       case "content_layout":
@@ -441,6 +474,7 @@ export class HuiTileCardEditor
   ) => {
     switch (schema.name) {
       case "color":
+      case "show_tap_action_indicator":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.tile.${schema.name}_helper`
         );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8407,6 +8407,8 @@
               "icon_tap_action": "Icon tap behavior",
               "icon_hold_action": "Icon hold behavior",
               "icon_double_tap_action": "Icon double tap behavior",
+              "show_tap_action_indicator": "Show tap action indicator",
+              "show_tap_action_indicator_helper": "Display an icon indicating the tap action (e.g., chevron for navigation)",
               "show_entity_picture": "Show entity picture",
               "hide_state": "Hide state",
               "state_content": "State content",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Tile cards now display visual indicators showing the configured `tap_action` behavior, improving discovering and user experience.

**Problem:** Tile cards support various tap actions (navigate, toggle, assist, etc.) but provide no visual about what happens when tapped. Users are blind when tap action is configured (except bg color change on hover) and must tap to discover the behavior.

**Solution:** Display contextual icons based on the configured `tap_action`

**The visibility of the indicator icon is configurable via the card editor.**

**Screenshots:**

<img width="702" height="400" alt="Capture d’écran du 2026-01-18 07-16-22" src="https://github.com/user-attachments/assets/195da903-ff9e-4884-99f7-8f0a55f89f0e" />
<img width="702" height="400" alt="Capture d’écran du 2026-01-18 07-16-39" src="https://github.com/user-attachments/assets/c73e14a4-561c-4054-ac76-0030908f5110" />

**Default unchanged**

<img width="1032" height="783" alt="Capture d’écran du 2026-01-18 07-18-10" src="https://github.com/user-attachments/assets/ffdca268-3fca-40ab-912f-07a8ac473027" />

**`tap_action` selected**

<img width="1036" height="885" alt="Capture d’écran du 2026-01-18 07-18-45" src="https://github.com/user-attachments/assets/aa47ee68-cb3d-4e11-bd48-8b2b006d3145" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
# No tap_action configured - uses default more-info with NO indicator
type: tile
entity: sensor.temperature
# No indicator shown (backward compatible - existing dashboards unchanged)

# Explicitly configured more-info - CAN show indicator
type: tile
entity: sensor.temperature
tap_action:
  action: more-info
# Indicator shown by default (user explicitly configured this action)

# Indicator shown for navigation
type: tile
entity: light.living_room
tap_action:
  action: navigate
  navigation_path: /lovelace/living-room

# Opt-out if unwanted
type: tile
entity: sensor.temperature
tap_action:
  action: more-info
show_tap_action_indicator: false

# All action types supported
type: tile
entity: script.movie_mode
tap_action:
  action: perform-action
  perform_action: script.turn_on
  target:
    entity_id: script.movie_mode
# Shows room-service icon (matches automation editor)
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/2255
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43137

| Action                          | Icon               | Rationale                                      |
| ------------------------------- | ------------------ | ---------------------------------------------- |
| `navigate`                      | Chevron (>)        | Indicates navigation to another view           |
| `url`                           | Open-in-new        | Shows external link behavior                   |
| `more-info`                     | Info icon          | Entity details modal                           |
| `assist`                        | Comment processing | Voice assistant (matches HA convention)        |
| `toggle`                        | Toggle switch      | Clear state change metaphor                    |
| `call-service`/`perform-action` | Room service       | Matches Perform action of automation editor UI |

**Default Behavior:** Indicators are **enabled by default** when `tap_action` is explicitly configured, maximizing feature discoverability for all users. Users can opt-out per card with `show_tap_action_indicator: false`.

**Important distinction:** Cards with **no `tap_action` configured** (using implicit more-info default) show **no indicator**. This design choice:
- **Avoids visual noise** - Most tile cards use the default more-info behavior and don't need an indicator
- **Preserves existing dashboards** - A lot of existing cards remain visually unchanged
- **Signals intent** - Indicator appears only when users **explicitly configure** an action, communicating "this card has custom behavior"
- **Progressive disclosure** - Advanced users who customize tap actions get helpful visual cues; casual users see clean, uncluttered cards

Even if a user explicitly sets `tap_action: { action: "more-info" }`, the indicator appears, distinguishing "I chose this" from "this is the default."

**Only `tap_action`?** The indicator reflects the _primary expected behavior_ when interacting with the card. `tap_action` is the default interaction widely used I guess. `hold_action` and `double_tap_action` are advanced, secondary actions that would create visual clutter and confusing UX if all shown simultaneously.

**Implementation details:**

- Centralized icon mapping in `TAP_ACTION_INDICATOR_ICONS` constant for maintainability
- `supportsTapActionIndicator()` helper ensures type-safety and use in car and editor
- Editor toggle appears only for supported actions (automatically hidden for `none`)
- Icons chosen to match existing HA patterns 
- Backward compatible - existing configs work unchanged


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
