### PR TITLE
Fix Z-Wave dashboard picker showing disabled config entries

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-entry-picker.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-entry-picker.ts
@@ -82,9 +82,9 @@ class ZWaveJSConfigEntryPicker extends LitElement {
     const entries = await getConfigEntries(this.hass, {
       domain: "zwave_js",
     });
-    this._configEntries = entries.sort((a, b) =>
-      caseInsensitiveStringCompare(a.title, b.title)
-    );
+    this._configEntries = entries
+      .filter((entry) => entry.disabled_by === null)
+      .sort((a, b) => caseInsensitiveStringCompare(a.title, b.title));
     if (this._configEntries.length === 1) {
       navigate(
         `/config/zwave_js/dashboard?config_entry=${this._configEntries[0].entry_id}`,

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-entry-picker.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-entry-picker.ts
@@ -83,7 +83,9 @@ class ZWaveJSConfigEntryPicker extends LitElement {
       domain: "zwave_js",
     });
     this._configEntries = entries
-      .filter((entry) => entry.disabled_by === null)
+      .filter(
+        (entry) => entry.disabled_by === null && entry.source !== "ignore"
+      )
       .sort((a, b) => caseInsensitiveStringCompare(a.title, b.title));
     if (this._configEntries.length === 1) {
       navigate(


### PR DESCRIPTION
## Proposed change

The changes the behavior of the recently introduced Z-Wave dashboard config entry picker to hide both disabled config entries and ignored config entries (I.e. ignored discoveries).


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Follow-up to PR: https://github.com/home-assistant/frontend/pull/28741
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/160965
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
