### PR TITLE
Add discovered devices to add integration dialog

### DIFF
--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -1085,6 +1085,7 @@ export class HaConfigDeviceDashboard extends SubscribeMixin(LitElement) {
     }
     showAddIntegrationDialog(this, {
       domain: this._searchParms.get("domain") || undefined,
+      navigateToResult: true,
     });
   }
 

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -1570,6 +1570,7 @@ ${rejected
     }
     showAddIntegrationDialog(this, {
       domain: this._searchParms.get("domain") || undefined,
+      navigateToResult: true,
     });
   }
 

--- a/src/panels/config/integrations/dialog-add-integration.ts
+++ b/src/panels/config/integrations/dialog-add-integration.ts
@@ -91,6 +91,8 @@ class AddIntegrationDialog extends LitElement {
 
   @state() private _showDiscovered = false;
 
+  @state() private _navigateToResult = false;
+
   @state() private _open = false;
 
   @state() private _narrow = false;
@@ -101,30 +103,26 @@ class AddIntegrationDialog extends LitElement {
 
   public async showDialog(params?: AddIntegrationDialogParams): Promise<void> {
     const loadPromise = this._load();
+
     if (params?.domain) {
       // Just open the config flow dialog, do not show this dialog
+      await loadPromise;
       await this._createFlow(params.domain);
       return;
     }
 
-    if (params?.brand) {
+    if (params?.brand === "_discovered") {
+      // Wait for load to complete before showing discovered flows
       await loadPromise;
-      const brand = this._integrations?.[params.brand];
-      if (brand && "integrations" in brand && brand.integrations) {
-        this._fetchFlowsInProgress(Object.keys(brand.integrations));
-      }
-    }
-
-    if (params?.showDiscovered) {
-      await loadPromise;
-      // Show all discovered flows directly
       this._showDiscovered = true;
     }
 
     // Only open the dialog if no domain is provided
     this._open = true;
-    this._pickedBrand = params?.brand;
+    this._pickedBrand =
+      params?.brand === "_discovered" ? undefined : params?.brand;
     this._initialFilter = params?.initialFilter;
+    this._navigateToResult = params?.navigateToResult ?? false;
     this._narrow = matchMedia(
       "all and (max-width: 450px), all and (max-height: 500px)"
     ).matches;
@@ -138,6 +136,7 @@ class AddIntegrationDialog extends LitElement {
     this._prevPickedBrand = undefined;
     this._flowsInProgress = undefined;
     this._showDiscovered = false;
+    this._navigateToResult = false;
     this._filter = undefined;
     this._width = undefined;
     this._height = undefined;
@@ -369,62 +368,80 @@ class AddIntegrationDialog extends LitElement {
     >
       ${(this._pickedBrand && (!this._integrations || pickedIntegration)) ||
       this._showDiscovered
-        ? html`<div slot="heading">
-              <ha-icon-button-prev
-                @click=${this._prevClicked}
-              ></ha-icon-button-prev>
-              <h2 class="mdc-dialog__title">
-                ${this._showDiscovered
-                  ? this.hass.localize(
-                      "ui.panel.config.integrations.confirm_add_discovered"
-                    )
-                  : this._calculateBrandHeading(pickedIntegration)}
-              </h2>
-            </div>
-            ${this._renderIntegration(pickedIntegration)}`
+        ? this._renderBrandView(pickedIntegration)
         : this._renderAll(integrations)}
     </ha-dialog>`;
   }
 
-  private _calculateBrandHeading(integration: Brand | Integration | undefined) {
+  private _getFlowsForCurrentView(
+    integration: Brand | Integration | undefined
+  ): DataEntryFlowProgress[] {
+    if (this._showDiscovered) {
+      // Show all discovered flows
+      return this._flowsInProgress || [];
+    }
+    if (!this._pickedBrand || !integration) {
+      return [];
+    }
+    // Get domains for this brand
+    let domains: string[] = [];
+    if ("integrations" in integration && integration.integrations) {
+      domains = Object.keys(integration.integrations);
+      if (this._pickedBrand === "apple") {
+        // we show discovered homekit devices in their own brand section, dont show them in apple
+        domains = domains.filter((domain) => domain !== "homekit_controller");
+      }
+    } else {
+      domains = [this._pickedBrand];
+    }
+    return this._getFlowsInProgressForDomains(domains);
+  }
+
+  private _renderBrandView(
+    integration: Brand | Integration | undefined
+  ): TemplateResult {
+    const flowsInProgress = this._getFlowsForCurrentView(integration);
+
+    let heading: string;
     if (
       integration?.iot_standards &&
       !("integrations" in integration) &&
-      !this._flowsInProgress?.length
+      !flowsInProgress.length
     ) {
-      return this.hass.localize(
+      heading = this.hass.localize(
         "ui.panel.config.integrations.what_device_type"
       );
-    }
-    if (
+    } else if (
       integration &&
       !integration?.iot_standards &&
       !("integrations" in integration) &&
-      this._flowsInProgress?.length
+      flowsInProgress.length
     ) {
-      return this.hass.localize(
+      heading = this.hass.localize(
         "ui.panel.config.integrations.confirm_add_discovered"
       );
+    } else {
+      heading = this.hass.localize("ui.panel.config.integrations.what_to_add");
     }
-    return this.hass.localize("ui.panel.config.integrations.what_to_add");
-  }
 
-  private _renderIntegration(
-    integration: Brand | Integration | undefined
-  ): TemplateResult {
-    return html`<ha-domain-integrations
-      .hass=${this.hass}
-      .domain=${this._pickedBrand}
-      .integration=${integration}
-      .flowsInProgress=${this._flowsInProgress}
-      style=${styleMap({
-        minWidth: `${this._width}px`,
-        minHeight: `581px`,
-      })}
-      @close-dialog=${this.closeDialog}
-      @supported-by=${this._handleSupportedByEvent}
-      @select-brand=${this._handleSelectBrandEvent}
-    ></ha-domain-integrations>`;
+    return html`<div slot="heading">
+        <ha-icon-button-prev @click=${this._prevClicked}></ha-icon-button-prev>
+        <h2 class="mdc-dialog__title">${heading}</h2>
+      </div>
+      <ha-domain-integrations
+        .hass=${this.hass}
+        .domain=${this._pickedBrand}
+        .integration=${integration}
+        .flowsInProgress=${flowsInProgress}
+        .navigateToResult=${this._navigateToResult}
+        style=${styleMap({
+          minWidth: `${this._width}px`,
+          minHeight: `581px`,
+        })}
+        @close-dialog=${this.closeDialog}
+        @supported-by=${this._handleSupportedByEvent}
+        @select-brand=${this._handleSelectBrandEvent}
+      ></ha-domain-integrations>`;
   }
 
   private _handleSelectBrandEvent(ev: CustomEvent) {
@@ -633,12 +650,6 @@ class AddIntegrationDialog extends LitElement {
     }
 
     if (integration.integrations) {
-      let domains = integration.domains || [];
-      if (integration.domain === "apple") {
-        // we show discovered homekit devices in their own brand section, dont show them in apple
-        domains = domains.filter((domain) => domain !== "homekit_controller");
-      }
-      this._fetchFlowsInProgress(domains);
       this._pickedBrand = integration.domain;
       return;
     }
@@ -714,9 +725,9 @@ class AddIntegrationDialog extends LitElement {
   }
 
   private async _createFlow(domain: string) {
-    const flowsInProgress = await this._fetchFlowsInProgress([domain]);
+    const flowsInProgress = this._getFlowsInProgressForDomains([domain]);
 
-    if (flowsInProgress?.length) {
+    if (flowsInProgress.length) {
       this._pickedBrand = domain;
       return;
     }
@@ -729,14 +740,15 @@ class AddIntegrationDialog extends LitElement {
       startFlowHandler: domain,
       showAdvanced: this.hass.userData?.showAdvanced,
       manifest,
-      navigateToResult: true,
+      navigateToResult: this._navigateToResult,
     });
   }
 
-  private async _fetchFlowsInProgress(domains: string[]) {
-    const flowsInProgress = (
-      await fetchConfigFlowInProgress(this.hass.connection)
-    ).filter(
+  private _getFlowsInProgressForDomains(domains: string[]) {
+    if (!this._flowsInProgress) {
+      return [];
+    }
+    return this._flowsInProgress.filter(
       (flow) =>
         // filter config flows that are not for the integration we are looking for
         domains.includes(flow.handler) ||
@@ -744,11 +756,6 @@ class AddIntegrationDialog extends LitElement {
         ("alternative_domain" in flow.context &&
           domains.includes(flow.context.alternative_domain))
     );
-
-    if (flowsInProgress.length) {
-      this._flowsInProgress = flowsInProgress;
-    }
-    return flowsInProgress;
   }
 
   private _maybeSubmit(ev: KeyboardEvent) {
@@ -766,14 +773,9 @@ class AddIntegrationDialog extends LitElement {
   private _prevClicked() {
     if (this._showDiscovered) {
       this._showDiscovered = false;
-      // Don't reset _flowsInProgress here - we need to keep the discovered flows
-      // for the count displayed in the main list
       return;
     }
     this._pickedBrand = this._prevPickedBrand;
-    if (!this._prevPickedBrand) {
-      this._flowsInProgress = undefined;
-    }
     this._prevPickedBrand = undefined;
   }
 

--- a/src/panels/config/integrations/dialog-add-integration.ts
+++ b/src/panels/config/integrations/dialog-add-integration.ts
@@ -22,7 +22,10 @@ import "../../../components/ha-list";
 import "../../../components/ha-spinner";
 import "../../../components/search-input";
 import { getConfigEntries } from "../../../data/config_entries";
-import { fetchConfigFlowInProgress } from "../../../data/config_flow";
+import {
+  DISCOVERY_SOURCES,
+  fetchConfigFlowInProgress,
+} from "../../../data/config_flow";
 import type { DataEntryFlowProgress } from "../../../data/data_entry_flow";
 import {
   domainToName,
@@ -65,6 +68,7 @@ export interface IntegrationListItem {
   overwrites_built_in?: boolean;
   is_add?: boolean;
   single_config_entry?: boolean;
+  is_discovered?: boolean;
 }
 
 @customElement("dialog-add-integration")
@@ -84,6 +88,8 @@ class AddIntegrationDialog extends LitElement {
   @state() private _prevPickedBrand?: string;
 
   @state() private _flowsInProgress?: DataEntryFlowProgress[];
+
+  @state() private _showDiscovered = false;
 
   @state() private _open = false;
 
@@ -108,6 +114,13 @@ class AddIntegrationDialog extends LitElement {
         this._fetchFlowsInProgress(Object.keys(brand.integrations));
       }
     }
+
+    if (params?.showDiscovered) {
+      await loadPromise;
+      // Show all discovered flows directly
+      this._showDiscovered = true;
+    }
+
     // Only open the dialog if no domain is provided
     this._open = true;
     this._pickedBrand = params?.brand;
@@ -124,6 +137,7 @@ class AddIntegrationDialog extends LitElement {
     this._pickedBrand = undefined;
     this._prevPickedBrand = undefined;
     this._flowsInProgress = undefined;
+    this._showDiscovered = false;
     this._filter = undefined;
     this._width = undefined;
     this._height = undefined;
@@ -165,8 +179,26 @@ class AddIntegrationDialog extends LitElement {
       h: Integrations,
       components: HassConfig["components"],
       localize: LocalizeFunc,
+      discoveredFlowsCount: number,
       filter?: string
     ): IntegrationListItem[] => {
+      // Create a single discovered devices row if there are any discovered flows
+      const discoveredRows: IntegrationListItem[] =
+        discoveredFlowsCount > 0
+          ? [
+              {
+                name: localize(
+                  "ui.panel.config.integrations.discovered_devices",
+                  { count: discoveredFlowsCount }
+                ),
+                domain: "_discovered",
+                config_flow: true,
+                is_built_in: true,
+                is_discovered: true,
+              },
+            ]
+          : [];
+
       const addDeviceRows: IntegrationListItem[] = PROTOCOL_INTEGRATIONS.filter(
         (domain) => components.includes(domain)
       )
@@ -289,6 +321,7 @@ class AddIntegrationDialog extends LitElement {
         ];
       }
       return [
+        ...discoveredRows,
         ...addDeviceRows,
         ...integrations.sort((a, b) =>
           caseInsensitiveStringCompare(
@@ -307,6 +340,7 @@ class AddIntegrationDialog extends LitElement {
       this._helpers!,
       this.hass.config.components,
       this.hass.localize,
+      this._flowsInProgress?.length ?? 0,
       this._filter
     );
   }
@@ -333,13 +367,18 @@ class AddIntegrationDialog extends LitElement {
         this.hass.localize("ui.panel.config.integrations.new")
       )}
     >
-      ${this._pickedBrand && (!this._integrations || pickedIntegration)
+      ${(this._pickedBrand && (!this._integrations || pickedIntegration)) ||
+      this._showDiscovered
         ? html`<div slot="heading">
               <ha-icon-button-prev
                 @click=${this._prevClicked}
               ></ha-icon-button-prev>
               <h2 class="mdc-dialog__title">
-                ${this._calculateBrandHeading(pickedIntegration)}
+                ${this._showDiscovered
+                  ? this.hass.localize(
+                      "ui.panel.config.integrations.confirm_add_discovered"
+                    )
+                  : this._calculateBrandHeading(pickedIntegration)}
               </h2>
             </div>
             ${this._renderIntegration(pickedIntegration)}`
@@ -496,7 +535,24 @@ class AddIntegrationDialog extends LitElement {
   };
 
   private async _load() {
-    const descriptions = await getIntegrationDescriptions(this.hass);
+    const [descriptions, flowsInProgress] = await Promise.all([
+      getIntegrationDescriptions(this.hass),
+      fetchConfigFlowInProgress(this.hass.connection),
+    ]);
+
+    // Filter discovered flows
+    this._flowsInProgress = flowsInProgress.filter((flow) =>
+      DISCOVERY_SOURCES.includes(flow.context.source)
+    );
+
+    // Load translations for discovered flow handlers
+    if (this._flowsInProgress.length) {
+      const discoveredHandlers = [
+        ...new Set(this._flowsInProgress.map((flow) => flow.handler)),
+      ];
+      await this.hass.loadBackendTranslation("title", discoveredHandlers, true);
+    }
+
     for (const integration in descriptions.custom.integration) {
       if (
         !Object.prototype.hasOwnProperty.call(
@@ -555,6 +611,12 @@ class AddIntegrationDialog extends LitElement {
   private async _handleIntegrationPicked(integration: IntegrationListItem) {
     if (integration.supported_by) {
       this._supportedBy(integration);
+      return;
+    }
+
+    if (integration.is_discovered) {
+      // Show all discovered flows
+      this._showDiscovered = true;
       return;
     }
 
@@ -702,6 +764,12 @@ class AddIntegrationDialog extends LitElement {
   }
 
   private _prevClicked() {
+    if (this._showDiscovered) {
+      this._showDiscovered = false;
+      // Don't reset _flowsInProgress here - we need to keep the discovered flows
+      // for the count displayed in the main list
+      return;
+    }
     this._pickedBrand = this._prevPickedBrand;
     if (!this._prevPickedBrand) {
       this._flowsInProgress = undefined;

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -870,6 +870,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
     }
     showAddIntegrationDialog(this, {
       domain: this.domain,
+      navigateToResult: true,
     });
   }
 

--- a/src/panels/config/integrations/ha-config-integrations-dashboard.ts
+++ b/src/panels/config/integrations/ha-config-integrations-dashboard.ts
@@ -772,6 +772,7 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
   private _createFlow() {
     showAddIntegrationDialog(this, {
       initialFilter: this._filter,
+      navigateToResult: true,
     });
   }
 
@@ -833,6 +834,7 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
     if (brand) {
       showAddIntegrationDialog(this, {
         brand,
+        navigateToResult: true,
       });
       return;
     }
@@ -886,6 +888,7 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
       ) {
         showAddIntegrationDialog(this, {
           domain,
+          navigateToResult: true,
         });
       }
       return;

--- a/src/panels/config/integrations/ha-domain-integrations.ts
+++ b/src/panels/config/integrations/ha-domain-integrations.ts
@@ -39,6 +39,9 @@ class HaDomainIntegrations extends LitElement {
   @property({ attribute: false })
   public flowsInProgress?: DataEntryFlowProgress[];
 
+  @property({ attribute: false })
+  public navigateToResult = false;
+
   protected render() {
     return html`<ha-list>
       ${this.flowsInProgress?.length
@@ -283,7 +286,7 @@ class HaDomainIntegrations extends LitElement {
       {
         startFlowHandler: domain,
         showAdvanced: this.hass.userData?.showAdvanced,
-        navigateToResult: true,
+        navigateToResult: this.navigateToResult,
         manifest: await fetchIntegrationManifest(this.hass, domain),
       }
     );
@@ -300,7 +303,7 @@ class HaDomainIntegrations extends LitElement {
       root instanceof ShadowRoot ? (root.host as HTMLElement) : this,
       {
         continueFlowId: flow.flow_id,
-        navigateToResult: true,
+        navigateToResult: this.navigateToResult,
         showAdvanced: this.hass.userData?.showAdvanced,
         manifest: await fetchIntegrationManifest(this.hass, flow.handler),
       }

--- a/src/panels/config/integrations/ha-domain-integrations.ts
+++ b/src/panels/config/integrations/ha-domain-integrations.ts
@@ -49,6 +49,7 @@ class HaDomainIntegrations extends LitElement {
               (flow) =>
                 html`<ha-list-item
                   graphic="medium"
+                  twoLine
                   .flow=${flow}
                   @request-selected=${this._flowInProgressPicked}
                   hasMeta
@@ -67,6 +68,9 @@ class HaDomainIntegrations extends LitElement {
                   />
                   <span
                     >${localizeConfigFlowTitle(this.hass.localize, flow)}</span
+                  >
+                  <span slot="secondary"
+                    >${domainToName(this.hass.localize, flow.handler)}</span
                   >
                   <ha-icon-next slot="meta"></ha-icon-next>
                 </ha-list-item>`

--- a/src/panels/config/integrations/ha-integration-list-item.ts
+++ b/src/panels/config/integrations/ha-integration-list-item.ts
@@ -1,7 +1,12 @@
 import type { GraphicType } from "@material/mwc-list/mwc-list-item-base";
 import { ListItemBase } from "@material/mwc-list/mwc-list-item-base";
 import { styles } from "@material/mwc-list/mwc-list-item.css";
-import { mdiFileCodeOutline, mdiPackageVariant, mdiWeb } from "@mdi/js";
+import {
+  mdiDevices,
+  mdiFileCodeOutline,
+  mdiPackageVariant,
+  mdiWeb,
+} from "@mdi/js";
 import type { CSSResultGroup } from "lit";
 import { css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
@@ -51,18 +56,23 @@ export class HaIntegrationListItem extends ListItemBase {
         graphicClasses
       )}"
     >
-      <img
-        alt=""
-        loading="lazy"
-        src=${brandsUrl({
-          domain: this.integration.domain,
-          type: "icon",
-          darkOptimized: this.hass.themes?.darkMode,
-          brand: this.brand,
-        })}
-        crossorigin="anonymous"
-        referrerpolicy="no-referrer"
-      />
+      ${this.integration.is_discovered
+        ? html`<ha-svg-icon
+            class="discovered-icon"
+            .path=${mdiDevices}
+          ></ha-svg-icon>`
+        : html`<img
+            alt=""
+            loading="lazy"
+            src=${brandsUrl({
+              domain: this.integration.domain,
+              type: "icon",
+              darkOptimized: this.hass.themes?.darkMode,
+              brand: this.brand,
+            })}
+            crossorigin="anonymous"
+            referrerpolicy="no-referrer"
+          />`}
     </span>`;
   }
 
@@ -144,6 +154,10 @@ export class HaIntegrationListItem extends ListItemBase {
         img {
           width: 40px;
           height: 40px;
+        }
+        .discovered-icon {
+          --mdc-icon-size: 40px;
+          color: var(--primary-color);
         }
         .mdc-deprecated-list-item__meta {
           width: auto;

--- a/src/panels/config/integrations/show-add-integration-dialog.ts
+++ b/src/panels/config/integrations/show-add-integration-dialog.ts
@@ -5,7 +5,7 @@ export interface AddIntegrationDialogParams {
   brand?: string;
   domain?: string;
   initialFilter?: string;
-  showDiscovered?: boolean;
+  navigateToResult?: boolean;
 }
 
 export interface YamlIntegrationDialogParams {

--- a/src/panels/config/integrations/show-add-integration-dialog.ts
+++ b/src/panels/config/integrations/show-add-integration-dialog.ts
@@ -5,6 +5,7 @@ export interface AddIntegrationDialogParams {
   brand?: string;
   domain?: string;
   initialFilter?: string;
+  showDiscovered?: boolean;
 }
 
 export interface YamlIntegrationDialogParams {

--- a/src/panels/lovelace/cards/hui-discovered-devices-card.ts
+++ b/src/panels/lovelace/cards/hui-discovered-devices-card.ts
@@ -16,6 +16,7 @@ import {
 import type { DataEntryFlowProgress } from "../../../data/data_entry_flow";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
+import { showAddIntegrationDialog } from "../../config/integrations/show-add-integration-dialog";
 import type { HomeAssistant } from "../../../types";
 import { handleAction } from "../common/handle-action";
 import { hasAction } from "../common/has-action";
@@ -78,13 +79,7 @@ export class HuiDiscoveredDevicesCard
   }
 
   public setConfig(config: DiscoveredDevicesCardConfig): void {
-    this._config = {
-      tap_action: {
-        action: "navigate",
-        navigation_path: "/config/integrations/dashboard",
-      },
-      ...config,
-    };
+    this._config = config;
   }
 
   public getCardSize(): number {
@@ -108,12 +103,18 @@ export class HuiDiscoveredDevicesCard
     };
   }
 
-  private _handleAction(ev: ActionHandlerEvent) {
+  private async _handleAction(ev: ActionHandlerEvent) {
+    if (ev.detail.action === "tap" && !hasAction(this._config?.tap_action)) {
+      await this.hass!.loadFragmentTranslation("config");
+      showAddIntegrationDialog(this, { brand: "_discovered" });
+      return;
+    }
     handleAction(this, this.hass!, this._config!, ev.detail.action!);
   }
 
   private get _hasCardAction() {
     return (
+      !this._config?.tap_action ||
       hasAction(this._config?.tap_action) ||
       hasAction(this._config?.hold_action) ||
       hasAction(this._config?.double_tap_action)

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -892,7 +892,7 @@ class HUIRoot extends LitElement {
 
   private _addDevice = async () => {
     await this.hass.loadFragmentTranslation("config");
-    showAddIntegrationDialog(this);
+    showAddIntegrationDialog(this, { navigateToResult: true });
   };
 
   private _handleCreateAutomation(): void {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5971,6 +5971,7 @@
           "description": "Manage integrations with services or devices",
           "integration": "integration",
           "discovered": "Discovered",
+          "discovered_devices": "{count, plural,\n one {# discovered device}\n other {# discovered devices}\n}",
           "disabled": "Disabled",
           "available_integrations": "Available integrations",
           "new_flow": "Set up another instance of {integration}",


### PR DESCRIPTION
## Proposed change

Display discovered devices as a grouped row at the top of the add-integration dialog's search results.

- Add a "Discovered" entry in integration search results showing the count of discovered flows
- When clicking the discovered row, show a list of all discovered config flows
- Add `navigateToResult` parameter to control post-config-flow navigation:
  - From dashboard: stay on dashboard after completing flow
  - From settings: navigate to integration page after completing flow
- Optimize flow loading by filtering from a single source instead of re-fetching for each brand

<img width="522" height="667" alt="CleanShot 2026-01-20 at 14 21 02" src="https://github.com/user-attachments/assets/3293b3e5-fcb2-425e-abac-68ec038e95b5" />

<img width="1084" height="792" alt="CleanShot 2026-01-20 at 14 22 34" src="https://github.com/user-attachments/assets/37474dbb-bdda-414e-9b67-4f6aff151309" />


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

N/A

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/29003
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
