### PR TITLE
Revert "Fix for integration 'Add entry' unnecessary dialogs (#26285)"

### DIFF
--- a/src/panels/config/integrations/dialog-add-integration.ts
+++ b/src/panels/config/integrations/dialog-add-integration.ts
@@ -95,12 +95,15 @@ class AddIntegrationDialog extends LitElement {
 
   public async showDialog(params?: AddIntegrationDialogParams): Promise<void> {
     const loadPromise = this._load();
+    this._open = true;
+    this._pickedBrand = params?.brand;
+    this._initialFilter = params?.initialFilter;
+    this._narrow = matchMedia(
+      "all and (max-width: 450px), all and (max-height: 500px)"
+    ).matches;
     if (params?.domain) {
-      // Just open the config flow dialog, do not show this dialog
-      await this._createFlow(params.domain);
-      return;
+      this._createFlow(params.domain);
     }
-
     if (params?.brand) {
       await loadPromise;
       const brand = this._integrations?.[params.brand];
@@ -108,13 +111,6 @@ class AddIntegrationDialog extends LitElement {
         this._fetchFlowsInProgress(Object.keys(brand.integrations));
       }
     }
-    // Only open the dialog if no domain is provided
-    this._open = true;
-    this._pickedBrand = params?.brand;
-    this._initialFilter = params?.initialFilter;
-    this._narrow = matchMedia(
-      "all and (max-width: 450px), all and (max-height: 500px)"
-    ).matches;
   }
 
   public closeDialog() {


### PR DESCRIPTION
This reverts commit aca4a1f86dd48be14eb4263d47c8609521429a23.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This change around last year seems to have had significant breaking effect on config flow dialogs. Specifically, if you click the Add Entry button while there is a pending discovery, the flow just fails to work.

This is the dialog that is supposed to appear when you click the circled button: 

<img width="1087" height="682" alt="image" src="https://github.com/user-attachments/assets/d1438af4-b4a8-432e-9649-8eba01042697" />

Since this original commit landed, clicking the button does nothing because it just returns if there is a pending flow. Some users report it hangs their browser but I haven't experienced that personally. 

Don't like having to revert this but it seems like it was just a minor cosmetic fix, and it's a quite signicant functionality regression.  When I revert this change this flow is functional again. 



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/27073
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
