### PR TITLE
Improved HTML presentation table support to ha-markdown, compatible w…

### DIFF
--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -134,15 +134,50 @@ export class HaMarkdown extends LitElement {
     }
     table[role="presentation"] {
       --markdown-table-border-collapse: separate;
-      --markdown-table-border-width: attr(border, 0);
+      --markdown-table-border-width: 0;
       --markdown-table-padding-inline: 0;
       --markdown-table-padding-block: 0;
-      th {
-        vertical-align: attr(valign, middle);
-      }
+      th,
       td {
+        vertical-align: middle;
+      }
+    }
+    table[role="presentation"] td[valign="top"],
+    table[role="presentation"] th[valign="top"] {
+      vertical-align: top;
+    }
+    table[role="presentation"] td[valign="middle"],
+    table[role="presentation"] th[valign="middle"] {
+      vertical-align: middle;
+    }
+    table[role="presentation"] td[valign="bottom"],
+    table[role="presentation"] th[valign="bottom"] {
+      vertical-align: bottom;
+    }
+    table[role="presentation"] td[valign="baseline"],
+    table[role="presentation"] th[valign="baseline"] {
+      vertical-align: baseline;
+    }
+    @supports (border-width: attr(border px, 0)) {
+      table[role="presentation"] {
+        --markdown-table-border-width: attr(border px, 0);
+      }
+      table[role="presentation"] th,
+      table[role="presentation"] td {
         vertical-align: attr(valign, middle);
       }
+    }
+    table[role="presentation"][border="0"] {
+      --markdown-table-border-width: 0;
+    }
+    table[role="presentation"][border="1"] {
+      --markdown-table-border-width: 1px;
+    }
+    table[role="presentation"][border="2"] {
+      --markdown-table-border-width: 2px;
+    }
+    table[role="presentation"][border="3"] {
+      --markdown-table-border-width: 3px;
     }
     table {
       border-collapse: var(--markdown-table-border-collapse, collapse);


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Improved HTML presentation table support in ha-markdown with iOS/Safari compatibility

Summary

This PR enhances ha-markdown to properly support HTML presentation tables with valign and border attributes, with full compatibility across all platforms including iOS Safari and the Home Assistant Companion App.

Background

This is a follow-up to PR #29001, which enhanced presentation table support but had compatibility issues with iOS Safari and the Companion App. The current frontend code uses the `attr()` function for assigning css variables, but this is not supported by Safari / Webkit. My original PR only addresses the alignment issue and not the border issue on Safari.
This PR resolves those issues with a cross-browser compatible approach.

Changes

✅ Support for valign attribute for vertical alignment (top, middle, bottom, baseline)
✅ Support for border attribute for cell borders (0, 1, 2, 3px) using explicit attribute selectors
✅ Default styling for presentation tables (no borders, no padding)
✅ CSS variables for customization (--markdown-table-border-width, etc.)
✅ Future-proof @supports rule for attr() function when browsers support it
✅ Full backward compatibility with existing markdown tables

Key Improvements over #29001

Cross-browser compatibility: Uses explicit attribute selectors (border="0", border="1", etc.) instead of relying on the experimental attr() CSS function

iOS/Safari tested: Fully tested and working on iOS Safari and the Home Assistant Companion App (Android and iOS)
Immediate functionality: Works today across all browsers without waiting for attr() support

Testing

✅ Tested on desktop browsers (Chrome, Firefox, Edge)
✅ Tested on iOS Safari
✅ Tested on Home Assistant Companion App (iOS and Android)
✅ Verified backward compatibility with existing markdown tables

Use Case

Enables custom integrations and cards to render HTML presentation tables with proper styling in markdown content, particularly useful for weather alerts, status displays, and other formatted content that requires specific alignment and border control.

Example:  table formatting before this PR. Vertical alignment is "off", in addition with Safari, unwanted borders are shown round the table and cells.:

<img width="659" height="131" alt="image" src="https://github.com/user-attachments/assets/fe70707c-9521-47ff-8f72-b3505b566be9" />

Table formatting in markdown after this PR (also tested on Safari browser, borders are not shown):

<img width="511" height="102" alt="image" src="https://github.com/user-attachments/assets/54f6714f-e188-492f-a594-b40527e263f5" />



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Create a markdown card with the following yaml:
```yaml
type: markdown
content: |-
  <table role="presentation">
    <tr>
      <td rowspan="2" width="70"><img src="https://placehold.co/48x48/FF9D00/000?text=!" width="48" height="48"/></td>
      <td><strong>Severe Weather Alert</strong></td>
    </tr>
    <tr>
      <td>Orange severity - Active from 21:00 to 11:00</td>
    </tr>
  </table>
grid_options:
  columns: full
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #28343
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x ] The code change is tested and works locally.
- [x ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
