### PR TITLE
Add tap_action and image_tap_action to Area card

### DIFF
--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -134,6 +134,9 @@ export interface AreaCardConfig extends LovelaceCardConfig {
   features?: LovelaceCardFeatureConfig[];
   features_position?: LovelaceCardFeaturePosition;
   exclude_entities?: string[];
+  vertical?: boolean;
+  tap_action?: ActionConfig;
+  image_tap_action?: ActionConfig;
 }
 
 export interface ButtonCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-area-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-area-card-editor.ts
@@ -39,6 +39,7 @@ import {
 } from "../../cards/hui-area-card";
 import type { AreaCardConfig, AreaCardDisplayType } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
+import { actionConfigStruct } from "../structs/action-struct";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import type { EditDetailElementEvent, EditSubElementEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
@@ -61,6 +62,8 @@ const cardConfigStruct = assign(
     features_position: optional(enums(["bottom", "inline"])),
     aspect_ratio: optional(string()),
     exclude_entities: optional(array(string())),
+    tap_action: optional(actionConfigStruct),
+    image_tap_action: optional(actionConfigStruct),
   })
 );
 
@@ -187,10 +190,26 @@ export class HuiAreaCardEditor
           iconPath: mdiGestureTap,
           schema: [
             {
-              name: "navigation_path",
-              required: false,
-              selector: { navigation: {} },
+              name: "tap_action",
+              selector: {
+                ui_action: {
+                  default_action: "none",
+                },
+              },
             },
+            ...(displayType !== "compact"
+              ? ([
+                  {
+                    name: "image_tap_action",
+                    selector: {
+                      ui_action: {
+                        default_action:
+                          displayType === "camera" ? "more-info" : "none",
+                      },
+                    },
+                  },
+                ] as const satisfies readonly HaFormSchema[])
+              : []),
           ],
         },
       ] as const satisfies readonly HaFormSchema[]
@@ -390,7 +409,10 @@ export class HuiAreaCardEditor
 
     const vertical = this._config.vertical && displayType === "compact";
 
-    const featuresSchema = this._featuresSchema(this.hass.localize, vertical);
+    const featuresSchema = this._featuresSchema(
+      this.hass.localize,
+      Boolean(vertical)
+    );
 
     const data = {
       camera_view: "auto",
@@ -400,6 +422,14 @@ export class HuiAreaCardEditor
       content_layout: vertical ? "vertical" : "horizontal",
       ...this._config,
     };
+
+    // Backwards compatibility: convert navigation_path to tap_action for display
+    if (data.navigation_path && !data.tap_action) {
+      data.tap_action = {
+        action: "navigate",
+        navigation_path: data.navigation_path,
+      };
+    }
 
     // Default features position to bottom and force it to bottom in vertical mode
     if (!data.features_position || vertical) {
@@ -459,8 +489,18 @@ export class HuiAreaCardEditor
       ...newConfig,
     };
 
+    // Clean up navigation_path if tap_action is set
+    if (config.tap_action && config.navigation_path) {
+      delete config.navigation_path;
+    }
+
     if (config.display_type !== "camera") {
       delete config.camera_view;
+    }
+
+    // Clean up image_tap_action if compact display type (no image area)
+    if (config.display_type === "compact" && config.image_tap_action) {
+      delete config.image_tap_action;
     }
 
     // Convert content_layout to vertical
@@ -545,12 +585,13 @@ export class HuiAreaCardEditor
       case "camera_view":
       case "content":
       case "interactions":
+      case "tap_action":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.generic.${schema.name}`
         );
-      case "navigation_path":
+      case "image_tap_action":
         return this.hass!.localize(
-          "ui.panel.lovelace.editor.action-editor.navigation_path"
+          `ui.panel.lovelace.editor.card.area.${schema.name}`
         );
       case "features_position":
         return this.hass!.localize(

--- a/src/panels/lovelace/editor/config-elements/hui-area-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-area-card-editor.ts
@@ -194,6 +194,7 @@ export class HuiAreaCardEditor
               selector: {
                 ui_action: {
                   default_action: "none",
+                  actions: ["navigate", "url", "perform-action", "none"],
                 },
               },
             },
@@ -205,6 +206,16 @@ export class HuiAreaCardEditor
                       ui_action: {
                         default_action:
                           displayType === "camera" ? "more-info" : "none",
+                        actions:
+                          displayType === "camera"
+                            ? [
+                                "more-info",
+                                "navigate",
+                                "url",
+                                "perform-action",
+                                "none",
+                              ]
+                            : ["navigate", "url", "perform-action", "none"],
                       },
                     },
                   },
@@ -499,7 +510,13 @@ export class HuiAreaCardEditor
     }
 
     // Clean up image_tap_action if compact display type (no image area)
-    if (config.display_type === "compact" && config.image_tap_action) {
+    // or if it's more-info but not in camera mode (no entity to show)
+    if (
+      config.image_tap_action &&
+      (config.display_type === "compact" ||
+        (config.display_type !== "camera" &&
+          config.image_tap_action.action === "more-info"))
+    ) {
       delete config.image_tap_action;
     }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8214,7 +8214,8 @@
                 "icon": "Area icon",
                 "picture": "Area picture",
                 "camera": "Camera feed"
-              }
+              },
+              "image_tap_action": "Image tap behavior"
             },
             "calendar": {
               "name": "Calendar",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Replace the legacy `navigation_path` option with the standard `tap_action` system used by other cards (like tile card), and adds `image_tap_action` for image/camera interactions.

Changes
- Add tap_action and image_tap_action to area card config
- tap_action defaults to none
- image_tap_action defaults to more-info for camera display type, none otherwise
- When image_tap_action is not configured, image clicks use the card's tap_action
- Backwards compatible: existing navigation_path configs continue to work
- Editor saves in new format and removes navigation_path when tap_action is set

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43195

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
