### PR TITLE
Add empty state to Home panel strategies

### DIFF
--- a/src/panels/home/ha-panel-home.ts
+++ b/src/panels/home/ha-panel-home.ts
@@ -15,12 +15,13 @@ import {
 import type { LovelaceDashboardStrategyConfig } from "../../data/lovelace/config/types";
 import type { HomeAssistant, PanelInfo, Route } from "../../types";
 import { showToast } from "../../util/toast";
+import { showAreaRegistryDetailDialog } from "../config/areas/show-dialog-area-registry-detail";
+import { showDeviceRegistryDetailDialog } from "../config/devices/device-registry-detail/show-dialog-device-registry-detail";
+import { showAddIntegrationDialog } from "../config/integrations/show-add-integration-dialog";
 import "../lovelace/hui-root";
 import type { ExtraActionItem } from "../lovelace/hui-root";
 import { expandLovelaceConfigStrategies } from "../lovelace/strategies/get-strategy";
 import type { Lovelace } from "../lovelace/types";
-import { showAreaRegistryDetailDialog } from "../config/areas/show-dialog-area-registry-detail";
-import { showDeviceRegistryDetailDialog } from "../config/devices/device-registry-detail/show-dialog-device-registry-detail";
 import { showEditHomeDialog } from "./dialogs/show-dialog-edit-home";
 
 @customElement("ha-panel-home")
@@ -172,12 +173,25 @@ class PanelHome extends LitElement {
   private _handleLLCustomEvent = (ev: Event) => {
     const detail = (ev as CustomEvent).detail;
     if (detail.home_panel) {
-      const { type, device_id } = detail.home_panel;
-      if (type === "assign_area") {
-        this._showAssignAreaDialog(device_id);
+      const { type } = detail.home_panel;
+      switch (type) {
+        case "assign_area": {
+          const { device_id } = detail.home_panel;
+          this._showAssignAreaDialog(device_id);
+          break;
+        }
+        case "add_integration": {
+          this._showAddIntegrationDialog();
+          break;
+        }
       }
     }
   };
+
+  private async _showAddIntegrationDialog() {
+    await this.hass.loadFragmentTranslation("config");
+    showAddIntegrationDialog(this, { navigateToResult: false });
+  }
 
   private _showAssignAreaDialog(deviceId: string) {
     const device = this.hass.devices[deviceId];

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -57,13 +57,21 @@ export interface ConditionalCardConfig extends LovelaceCardConfig {
   conditions: (Condition | LegacyCondition)[];
 }
 
+export interface EmptyStateButtonConfig {
+  text: string;
+  icon?: string;
+  appearance?: "accent" | "filled" | "outlined" | "plain";
+  variant?: "brand" | "neutral" | "success" | "warning" | "danger";
+  tap_action: ActionConfig;
+}
+
 export interface EmptyStateCardConfig extends LovelaceCardConfig {
   content_only?: boolean;
   icon?: string;
+  icon_color?: string;
   title?: string;
   content?: string;
-  action_button_text?: string;
-  tap_action?: ActionConfig;
+  buttons?: EmptyStateButtonConfig[];
 }
 
 export interface EntityCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
@@ -378,10 +378,11 @@ export class HomeAreaViewStrategy extends ReactiveElement {
               ? {
                   buttons: [
                     {
+                      icon: "mdi:plus",
                       text: hass.localize(
                         "ui.panel.lovelace.strategy.home-area.no_devices_add_device"
                       ),
-                      appearance: "filled",
+                      appearance: "plain",
                       variant: "brand",
                       tap_action: {
                         action: "fire-dom-event",
@@ -391,6 +392,7 @@ export class HomeAreaViewStrategy extends ReactiveElement {
                       },
                     },
                     {
+                      icon: "mdi:home-plus",
                       text: hass.localize(
                         "ui.panel.lovelace.strategy.home-area.no_devices_assign_device"
                       ),

--- a/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
@@ -27,6 +27,7 @@ import {
 export interface HomeAreaViewStrategyConfig {
   type: "home-area";
   area?: string;
+  home_panel?: boolean;
 }
 
 @customElement("home-area-view-strategy")
@@ -373,7 +374,7 @@ export class HomeAreaViewStrategy extends ReactiveElement {
             content: hass.localize(
               "ui.panel.lovelace.strategy.home-area.no_devices_content"
             ),
-            ...(hass.user?.is_admin
+            ...(config.home_panel && hass.user?.is_admin
               ? {
                   buttons: [
                     {

--- a/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
@@ -365,6 +365,7 @@ export class HomeAreaViewStrategy extends ReactiveElement {
           {
             type: "empty-state",
             icon: "mdi:sofa-outline",
+            icon_color: "primary",
             content_only: true,
             title: hass.localize(
               "ui.panel.lovelace.strategy.areas.empty_state_title"
@@ -372,6 +373,36 @@ export class HomeAreaViewStrategy extends ReactiveElement {
             content: hass.localize(
               "ui.panel.lovelace.strategy.areas.empty_state_content"
             ),
+            ...(hass.user?.is_admin
+              ? {
+                  buttons: [
+                    {
+                      text: hass.localize(
+                        "ui.panel.lovelace.strategy.areas.empty_state_add_device"
+                      ),
+                      appearance: "filled",
+                      variant: "brand",
+                      tap_action: {
+                        action: "fire-dom-event",
+                        home_panel: {
+                          type: "add_integration",
+                        },
+                      },
+                    },
+                    {
+                      text: hass.localize(
+                        "ui.panel.lovelace.strategy.areas.empty_state_assign_device"
+                      ),
+                      appearance: "plain",
+                      variant: "brand",
+                      tap_action: {
+                        action: "navigate",
+                        navigation_path: "/home/other-devices",
+                      },
+                    },
+                  ],
+                }
+              : {}),
           } as EmptyStateCardConfig,
         ],
       };

--- a/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
@@ -368,17 +368,17 @@ export class HomeAreaViewStrategy extends ReactiveElement {
             icon_color: "primary",
             content_only: true,
             title: hass.localize(
-              "ui.panel.lovelace.strategy.areas.empty_state_title"
+              "ui.panel.lovelace.strategy.home-area.no_devices_title"
             ),
             content: hass.localize(
-              "ui.panel.lovelace.strategy.areas.empty_state_content"
+              "ui.panel.lovelace.strategy.home-area.no_devices_content"
             ),
             ...(hass.user?.is_admin
               ? {
                   buttons: [
                     {
                       text: hass.localize(
-                        "ui.panel.lovelace.strategy.areas.empty_state_add_device"
+                        "ui.panel.lovelace.strategy.home-area.no_devices_add_device"
                       ),
                       appearance: "filled",
                       variant: "brand",
@@ -391,7 +391,7 @@ export class HomeAreaViewStrategy extends ReactiveElement {
                     },
                     {
                       text: hass.localize(
-                        "ui.panel.lovelace.strategy.areas.empty_state_assign_device"
+                        "ui.panel.lovelace.strategy.home-area.no_devices_assign_device"
                       ),
                       appearance: "plain",
                       variant: "brand",

--- a/src/panels/lovelace/strategies/home/home-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-dashboard-strategy.ts
@@ -59,6 +59,7 @@ export class HomeDashboardStrategy extends ReactiveElement {
         strategy: {
           type: "home-area",
           area: area.area_id,
+          home_panel: config.home_panel,
         } satisfies HomeAreaViewStrategyConfig,
       };
     });
@@ -92,6 +93,7 @@ export class HomeDashboardStrategy extends ReactiveElement {
           strategy: {
             type: "home-overview",
             favorite_entities: config.favorite_entities,
+            home_panel: config.home_panel,
           } satisfies HomeOverviewViewStrategyConfig,
         },
         ...areaViews,

--- a/src/panels/lovelace/strategies/home/home-other-devices-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-other-devices-view-strategy.ts
@@ -142,7 +142,7 @@ export class HomeOtherDevicesViewStrategy extends ReactiveElement {
                       type: "button",
                       icon: "mdi:home-plus",
                       text: hass.localize(
-                        "ui.panel.lovelace.strategy.other_devices.assign_area"
+                        "ui.panel.lovelace.strategy.home-other-devices.assign_area"
                       ),
                       tap_action: {
                         action: "fire-dom-event",
@@ -178,7 +178,7 @@ export class HomeOtherDevicesViewStrategy extends ReactiveElement {
           {
             type: "heading",
             heading: hass.localize(
-              "ui.panel.lovelace.strategy.other_devices.helpers"
+              "ui.panel.lovelace.strategy.home-other-devices.helpers"
             ),
           } satisfies HeadingCardConfig,
           ...helpersEntities.map((e) => ({
@@ -197,7 +197,7 @@ export class HomeOtherDevicesViewStrategy extends ReactiveElement {
           {
             type: "heading",
             heading: hass.localize(
-              "ui.panel.lovelace.strategy.other_devices.entities"
+              "ui.panel.lovelace.strategy.home-other-devices.entities"
             ),
           } satisfies HeadingCardConfig,
           ...otherEntities.map((e) => ({
@@ -216,12 +216,13 @@ export class HomeOtherDevicesViewStrategy extends ReactiveElement {
           {
             type: "empty-state",
             icon: "mdi:check-all",
+            icon_color: "primary",
             content_only: true,
             title: hass.localize(
-              "ui.panel.lovelace.strategy.other_devices.empty_state_title"
+              "ui.panel.lovelace.strategy.home-other-devices.all_organized_title"
             ),
             content: hass.localize(
-              "ui.panel.lovelace.strategy.other_devices.empty_state_content"
+              "ui.panel.lovelace.strategy.home-other-devices.all_organized_content"
             ),
           } as EmptyStateCardConfig,
         ],

--- a/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
@@ -363,6 +363,7 @@ export class HomeOverviewViewStrategy extends ReactiveElement {
               ? {
                   buttons: [
                     {
+                      icon: "mdi:plus",
                       text: hass.localize(
                         "ui.panel.lovelace.strategy.home.welcome_add_device"
                       ),
@@ -373,6 +374,18 @@ export class HomeOverviewViewStrategy extends ReactiveElement {
                         home_panel: {
                           type: "add_integration",
                         },
+                      },
+                    },
+                    {
+                      icon: "mdi:home-edit",
+                      text: hass.localize(
+                        "ui.panel.lovelace.strategy.home.welcome_edit_areas"
+                      ),
+                      appearance: "plain",
+                      variant: "brand",
+                      tap_action: {
+                        action: "navigate",
+                        navigation_path: "/config/areas/dashboard",
                       },
                     },
                   ],

--- a/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
@@ -20,6 +20,7 @@ import type { HomeAssistant } from "../../../../types";
 import type {
   AreaCardConfig,
   DiscoveredDevicesCardConfig,
+  EmptyStateCardConfig,
   HomeSummaryCard,
   MarkdownCardConfig,
   TileCardConfig,
@@ -340,6 +341,46 @@ export class HomeOverviewViewStrategy extends ReactiveElement {
             cards: [summaryHeadingCard, ...sidebarSummaryCards],
           }
         : undefined;
+
+    // No sections, show empty state
+    if (floorsSections.length === 0) {
+      return {
+        type: "panel",
+        cards: [
+          {
+            type: "empty-state",
+            icon: "mdi:home-assistant",
+            icon_color: "primary",
+            content_only: true,
+            title: hass.localize(
+              "ui.panel.lovelace.strategy.home.welcome_title"
+            ),
+            content: hass.localize(
+              "ui.panel.lovelace.strategy.home.welcome_content"
+            ),
+            ...(hass.user?.is_admin
+              ? {
+                  buttons: [
+                    {
+                      text: hass.localize(
+                        "ui.panel.lovelace.strategy.home.welcome_add_device"
+                      ),
+                      appearance: "filled",
+                      variant: "brand",
+                      tap_action: {
+                        action: "fire-dom-event",
+                        home_panel: {
+                          type: "add_integration",
+                        },
+                      },
+                    },
+                  ],
+                }
+              : {}),
+          } as EmptyStateCardConfig,
+        ],
+      };
+    }
 
     const sections = (
       [favoritesSection, mobileSummarySection, ...floorsSections] satisfies (

--- a/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
@@ -33,6 +33,7 @@ import { OTHER_DEVICES_FILTERS } from "./helpers/other-devices-filters";
 export interface HomeOverviewViewStrategyConfig {
   type: "home-overview";
   favorite_entities?: string[];
+  home_panel?: boolean;
 }
 
 const computeAreaCard = (
@@ -358,7 +359,7 @@ export class HomeOverviewViewStrategy extends ReactiveElement {
             content: hass.localize(
               "ui.panel.lovelace.strategy.home.welcome_content"
             ),
-            ...(hass.user?.is_admin
+            ...(config.home_panel && hass.user?.is_admin
               ? {
                   buttons: [
                     {

--- a/src/panels/lovelace/strategies/original-states/original-states-view-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states/original-states-view-strategy.ts
@@ -71,6 +71,7 @@ export class OriginalStatesViewStrategy extends ReactiveElement {
           {
             type: "empty-state",
             icon: "mdi:home-assistant",
+            icon_color: "primary",
             content_only: true,
             title: hass.localize(
               "ui.panel.lovelace.strategy.original-states.empty_state_title"
@@ -80,13 +81,19 @@ export class OriginalStatesViewStrategy extends ReactiveElement {
             ),
             ...(hass.user?.is_admin
               ? {
-                  action_button_text: hass.localize(
-                    "ui.panel.lovelace.strategy.original-states.empty_state_action"
-                  ),
-                  tap_action: {
-                    action: "navigate",
-                    navigation_path: "/config/integrations/dashboard",
-                  },
+                  buttons: [
+                    {
+                      text: hass.localize(
+                        "ui.panel.lovelace.strategy.original-states.empty_state_action"
+                      ),
+                      appearance: "filled",
+                      variant: "brand",
+                      tap_action: {
+                        action: "navigate",
+                        navigation_path: "/config/integrations/dashboard",
+                      },
+                    },
+                  ],
                 }
               : {}),
           } as EmptyStateCardConfig,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7523,8 +7523,10 @@
             "empty_state_action": "Go to the integrations page"
           },
           "areas": {
-            "empty_state_title": "No devices",
-            "empty_state_content": "There are no devices assigned to this area yet. Assign devices to this area to see them here.",
+            "empty_state_title": "This is a blank canvas",
+            "empty_state_content": "Add your smart lights, switches, or sensors to this area to get started.",
+            "empty_state_add_device": "Add new device",
+            "empty_state_assign_device": "Assign existing device",
             "sensors": "Sensors",
             "sensors_description": "To display temperature and humidity sensors in the overview and in the area view, add a sensor to that area and {edit_the_area} to configure related sensors.",
             "edit_the_area": "edit the area",
@@ -8282,14 +8284,14 @@
             },
             "empty_state": {
               "name": "Empty state",
-              "description": "The Empty state card displays a centered message with an optional icon and action button.",
+              "description": "The Empty state card displays a centered message with an optional icon and action buttons.",
               "style": "Style",
               "style_options": {
                 "card": "Card",
                 "content-only": "Content only"
               },
               "content": "Content",
-              "action_text": "Action button text"
+              "buttons": "Buttons"
             },
             "button": {
               "name": "Button",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7559,7 +7559,8 @@
             "favorites": "Favorites",
             "welcome_title": "No devices here yet",
             "welcome_content": "Add lights, switches, sensors, or other smart home devices to get started.",
-            "welcome_add_device": "Add new device"
+            "welcome_add_device": "Add new device",
+            "welcome_edit_areas": "Edit areas"
           },
           "common_controls": {
             "not_loaded": "Usage Prediction integration is not loaded.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7523,10 +7523,6 @@
             "empty_state_action": "Go to the integrations page"
           },
           "areas": {
-            "empty_state_title": "This is a blank canvas",
-            "empty_state_content": "Add your smart lights, switches, or sensors to this area to get started.",
-            "empty_state_add_device": "Add new device",
-            "empty_state_assign_device": "Assign existing device",
             "sensors": "Sensors",
             "sensors_description": "To display temperature and humidity sensors in the overview and in the area view, add a sensor to that area and {edit_the_area} to configure related sensors.",
             "edit_the_area": "edit the area",
@@ -7560,7 +7556,10 @@
             "automations": "Automations",
             "for_you": "For you",
             "home": "Home",
-            "favorites": "Favorites"
+            "favorites": "Favorites",
+            "welcome_title": "No devices here yet",
+            "welcome_content": "Add lights, switches, sensors, or other smart home devices to get started.",
+            "welcome_add_device": "Add new device"
           },
           "common_controls": {
             "not_loaded": "Usage Prediction integration is not loaded.",
@@ -7582,12 +7581,18 @@
             "media_players": "Media players",
             "other_media_players": "Other media players"
           },
-          "other_devices": {
+          "home-other-devices": {
             "helpers": "Helpers",
             "entities": "Entities",
             "assign_area": "Assign area",
-            "empty_state_title": "All devices are organized",
-            "empty_state_content": "There are no unassigned devices left. All devices are organized into areas."
+            "all_organized_title": "All devices are organized",
+            "all_organized_content": "There are no unassigned devices left. All devices are organized into areas."
+          },
+          "home-area": {
+            "no_devices_title": "This is a blank canvas",
+            "no_devices_content": "Add your smart lights, switches, or sensors to this area to get started.",
+            "no_devices_add_device": "Add new device",
+            "no_devices_assign_device": "Assign existing device"
           }
         },
         "cards": {


### PR DESCRIPTION
## Proposed change

Add empty state cards to the Home panel strategies when there is no content to display:

- **Home Overview**: Shows a welcome message with "Add new device" button when there are no areas or devices
- **Home Area View**: Shows a message with "Add new device" and "Assign existing device" buttons when an area has no devices
- **Home Other Devices**: Shows a success message when all devices have been organized into areas

Also includes:
- Support for multiple buttons in the empty-state card
- Button customization options (icon, appearance, variant)
- Icon color support for the empty-state card
- Translation key reorganization for home strategies (renamed to `home-area` and `home-other-devices`)
- Context-specific translation keys (`welcome_*`, `no_devices_*`, `all_organized_*`)

### Screenshots : 

**Home Overview**

<img width="695" height="652" alt="CleanShot 2026-01-21 at 18 13 17" src="https://github.com/user-attachments/assets/64956b43-196c-474c-85e6-91f6acc6ad0e" />

**Home Area View**

<img width="695" height="652" alt="CleanShot 2026-01-21 at 18 12 53" src="https://github.com/user-attachments/assets/11af2900-1673-4d5c-beb4-e9ab35e774b8" />

**Home Other Devices**

<img width="698" height="663" alt="CleanShot 2026-01-21 at 18 05 52" src="https://github.com/user-attachments/assets/76488e8f-2c89-4e87-bf06-7e6db2ece64a" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/29004
- This PR is related to issue or discussion: 
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
