### PR TITLE
Open edit area dialog when clicking edit button in area view

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -144,6 +144,8 @@ class HUIRoot extends LitElement {
 
   @property({ attribute: false }) public extraActionItems?: ExtraActionItem[];
 
+  @property({ type: Boolean, attribute: "no-edit" }) public noEdit = false;
+
   @state() private _curView?: number | "hass-unused-entities";
 
   private _configChangedByUndo = false;
@@ -345,7 +347,8 @@ class HUIRoot extends LitElement {
           !this._editMode &&
           this.hass!.user?.is_admin &&
           !this.hass!.config.recovery_mode &&
-          !this.hass.kioskMode,
+          !this.hass.kioskMode &&
+          !this.noEdit,
         overflow: true,
         overflow_can_promote: true,
       },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7791,7 +7791,9 @@
           "create_area_action": "View area",
           "add_person_success": "Person added",
           "add_person_action": "View persons",
-          "add_person": "Add person"
+          "add_person": "Add person",
+          "edit_overview": "Edit overview",
+          "edit_area": "Edit area"
         },
         "reload_resources": {
           "refresh_header": "Do you want to refresh?",


### PR DESCRIPTION
## Proposed change

Add context-aware edit button behavior for the home panel:

- **Overview**: Shows "Edit overview" button that opens the home settings dialog (favorite entities)
- **Area views**: Shows "Edit area" button that opens the area edit dialog
- **Other views** (other-devices, media-players): No edit button (nothing to configure)

When an area is deleted while viewing it, the user is automatically redirected to the home overview.

Also adds a `noEdit` property to `hui-root` to allow parent components to hide the default edit button.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/29131
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.
