### PR TITLE
Аdd action-specific indicator icons to heading-card

### DIFF
--- a/src/panels/lovelace/cards/hui-heading-card.ts
+++ b/src/panels/lovelace/cards/hui-heading-card.ts
@@ -1,3 +1,4 @@
+import { mdiOpenInNew, mdiRoomServiceOutline } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
@@ -5,6 +6,7 @@ import "../../../components/ha-card";
 import "../../../components/ha-icon";
 import "../../../components/ha-icon-next";
 import "../../../components/ha-state-icon";
+import "../../../components/ha-svg-icon";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import "../../../state-display/state-display";
 import type { HomeAssistant } from "../../../types";
@@ -18,6 +20,23 @@ import type {
   LovelaceGridOptions,
 } from "../types";
 import type { HeadingCardConfig } from "./types";
+
+// Mapping of tap actions to their indicator icons
+// Only actions in this map will show an indicator icon in the heading card
+const TAP_ACTION_INDICATOR_ICONS = {
+  navigate: "navigate", // Special value for ha-icon-next
+  url: mdiOpenInNew,
+  "perform-action": mdiRoomServiceOutline,
+} as const;
+
+// Type for actions that support indicators
+type IndicatorSupportedAction = keyof typeof TAP_ACTION_INDICATOR_ICONS;
+
+// Helper to check if an action supports tap action indicators
+const supportsTapActionIndicator = (
+  action?: string
+): action is IndicatorSupportedAction =>
+  action !== undefined && action in TAP_ACTION_INDICATOR_ICONS;
 
 export const migrateHeadingCardConfig = (
   config: HeadingCardConfig
@@ -76,6 +95,17 @@ export class HuiHeadingCard extends LitElement implements LovelaceCard {
     handleAction(this, this.hass!, this._config!, ev.detail.action!);
   }
 
+  private get _tapActionIndicatorIcon(): string | undefined {
+    const action = this._config?.tap_action?.action;
+
+    // Use the centralized mapping - only supported actions have icons
+    if (action && supportsTapActionIndicator(action)) {
+      return TAP_ACTION_INDICATOR_ICONS[action];
+    }
+
+    return undefined;
+  }
+
   protected render() {
     if (!this._config || !this.hass) {
       return nothing;
@@ -103,7 +133,13 @@ export class HuiHeadingCard extends LitElement implements LovelaceCard {
             ${this._config.heading
               ? html`<p>${this._config.heading}</p>`
               : nothing}
-            ${actionable ? html`<ha-icon-next></ha-icon-next>` : nothing}
+            ${this._tapActionIndicatorIcon
+              ? this._tapActionIndicatorIcon === "navigate"
+                ? html`<ha-icon-next></ha-icon-next>`
+                : html`<ha-svg-icon
+                    .path=${this._tapActionIndicatorIcon}
+                  ></ha-svg-icon>`
+              : nothing}
           </div>
           ${badges?.length
             ? html`
@@ -143,7 +179,8 @@ export class HuiHeadingCard extends LitElement implements LovelaceCard {
     [role="button"] {
       cursor: pointer;
     }
-    ha-icon-next {
+    ha-icon-next,
+    .content ha-svg-icon {
       display: inline-block;
       transition: transform 180ms ease-in-out;
     }
@@ -156,7 +193,8 @@ export class HuiHeadingCard extends LitElement implements LovelaceCard {
       overflow: visible;
       gap: var(--ha-space-2);
     }
-    .content:hover ha-icon-next {
+    .content:hover ha-icon-next,
+    .content:hover ha-svg-icon {
       transform: translateX(calc(4px * var(--scale-direction)));
     }
     .container .content {
@@ -188,9 +226,11 @@ export class HuiHeadingCard extends LitElement implements LovelaceCard {
       --mdc-icon-size: 18px;
     }
     .content ha-icon,
-    .content ha-icon-next {
+    .content ha-icon-next,
+    .content ha-svg-icon {
       display: flex;
       flex: none;
+      --mdc-icon-size: 18px;
     }
     .content p {
       margin: 0;


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR enhances the heading card to display action-specific indicator icons based on the configured `tap_action` type, following the same pattern as proposed by PR #29052 .

**Current behavior:**
- Heading card shows a chevron (`ha-icon-next`) for all tap actions, regardless of the action type

**New behavior:**
- **Navigate action**: Shows chevron (no visual change - existing behavior)
- **URL action**: Shows external link icon (`mdiOpenInNew`) to indicate opening an external URL
- **Perform-action**: Shows service icon (`mdiRoomServiceOutline`) to indicate triggering a Home Assistant action (Matches Perform action of automation editor UI)
- **None/no action**: Shows no indicator (existing behavior)

**Benefits:**
- Provides clear visual feedback about what will happen when the heading is tapped
- Improves user experience by making action types immediately recognizable

**Screenshot:**

<img width="801" height="440" alt="image" src="https://github.com/user-attachments/assets/80be5557-6211-4bd1-b664-ced49e1c2a0c" />


**What else:**
For `perfom_action` we could consider to set the action icon to the icon corresponding to the selected action. This is not implemented but if desire, I can do another PR next to this one, or include it in this one

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: Related to the same design pattern as PR #29052 (tile card tap action indicators)
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
