### PR TITLE
Fix crash when using invalid visibility condition type

### DIFF
--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -105,6 +105,11 @@ function checkStateCondition(
       : UNKNOWN;
   let value = condition.state ?? condition.state_not;
 
+  // Guard against invalid/incomplete condition configuration
+  if (value === undefined) {
+    return false;
+  }
+
   // Handle entity_id, UI should be updated for conditional card (filters does not have UI for now)
   if (Array.isArray(value)) {
     const entityValues = value

--- a/test/panels/lovelace/common/validate-condition.test.ts
+++ b/test/panels/lovelace/common/validate-condition.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkConditionsMet,
+  validateConditionalConfig,
+} from "../../../../src/panels/lovelace/common/validate-condition";
+import type { HomeAssistant } from "../../../../src/types";
+
+const createMockHass = (states: Record<string, { state: string }> = {}) =>
+  ({
+    states,
+    user: { id: "user1" },
+  }) as unknown as HomeAssistant;
+
+describe("validateConditionalConfig", () => {
+  describe("state condition validation", () => {
+    it("should return true for valid state condition", () => {
+      const conditions = [
+        { condition: "state", entity: "sensor.test", state: "on" },
+      ] as any;
+      expect(validateConditionalConfig(conditions)).toBe(true);
+    });
+
+    it("should return false for state condition without state or state_not", () => {
+      const conditions = [{ condition: "state", entity: "sensor.test" }] as any;
+      expect(validateConditionalConfig(conditions)).toBe(false);
+    });
+  });
+
+  describe("numeric_state condition validation", () => {
+    it("should return true for valid numeric_state condition", () => {
+      const conditions = [
+        { condition: "numeric_state", entity: "sensor.test", above: 0 },
+      ] as any;
+      expect(validateConditionalConfig(conditions)).toBe(true);
+    });
+  });
+});
+
+describe("checkConditionsMet", () => {
+  describe("state condition evaluation", () => {
+    it("should return true when state matches", () => {
+      const hass = createMockHass({
+        "sensor.test": { state: "on" },
+      });
+      const conditions = [
+        { condition: "state", entity: "sensor.test", state: "on" },
+      ] as any;
+      expect(checkConditionsMet(conditions, hass)).toBe(true);
+    });
+
+    it("should return false when state does not match", () => {
+      const hass = createMockHass({
+        "sensor.test": { state: "off" },
+      });
+      const conditions = [
+        { condition: "state", entity: "sensor.test", state: "on" },
+      ] as any;
+      expect(checkConditionsMet(conditions, hass)).toBe(false);
+    });
+
+    it("should return false for condition without state or state_not", () => {
+      const hass = createMockHass({
+        "sensor.test": { state: "on" },
+      });
+      const conditions = [{ condition: "state", entity: "sensor.test" }] as any;
+      expect(checkConditionsMet(conditions, hass)).toBe(false);
+    });
+
+    it("should not crash with invalid condition type", () => {
+      const hass = createMockHass({
+        "sensor.test": { state: "5" },
+      });
+      const conditions = [
+        { condition: "numeric", entity: "sensor.test", above: 0 },
+      ] as any;
+      // Should not throw - this was the bug
+      expect(() => checkConditionsMet(conditions, hass)).not.toThrow();
+      expect(checkConditionsMet(conditions, hass)).toBe(false);
+    });
+  });
+
+  describe("numeric_state condition evaluation", () => {
+    it("should return true when value is above threshold", () => {
+      const hass = createMockHass({
+        "sensor.test": { state: "5" },
+      });
+      const conditions = [
+        { condition: "numeric_state", entity: "sensor.test", above: 0 },
+      ] as any;
+      expect(checkConditionsMet(conditions, hass)).toBe(true);
+    });
+  });
+
+  describe("legacy conditions", () => {
+    it("should handle legacy state condition", () => {
+      const hass = createMockHass({
+        "sensor.test": { state: "on" },
+      });
+      const conditions = [{ entity: "sensor.test", state: "on" }] as any;
+      expect(checkConditionsMet(conditions, hass)).toBe(true);
+    });
+
+    it("should return false for legacy condition without state", () => {
+      const hass = createMockHass({
+        "sensor.test": { state: "on" },
+      });
+      const conditions = [{ entity: "sensor.test" }] as any;
+      expect(checkConditionsMet(conditions, hass)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Potentially fix frontend crash when visibility conditions have missing `state`/`state_not` fields (e.g., typo `condition: numeric` instead of `numeric_state`).
And add some tests.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29146
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
