### PR TITLE
Revert "Fix ha-card styling of .card-content when not first element but not following .card-header"

### DIFF
--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -51,10 +51,7 @@ export class HaCard extends LitElement {
       font-weight: var(--ha-font-weight-normal);
     }
 
-    :host
-      ::slotted(
-        .card-content:not(:nth-child(1 of .card-content, .card-header))
-      ),
+    :host ::slotted(.card-content:not(:first-child)),
     slot:not(:first-child)::slotted(.card-content) {
       padding-top: 0;
       margin-top: calc(var(--ha-space-2) * -1);


### PR DESCRIPTION
Reverts home-assistant/frontend#28935.
Not sure why this should have been done in the 1st place.
Please check carefully if it is really needed.