### PR TITLE
Move entity attributes to three-dots menu subview

### DIFF
--- a/src/dialogs/more-info/controls/more-info-conversation.ts
+++ b/src/dialogs/more-info/controls/more-info-conversation.ts
@@ -2,7 +2,6 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import "../../../components/ha-attributes";
 import type { HomeAssistant } from "../../../types";
 import "../../../components/ha-assist-chat";
 import "../../../components/ha-spinner";

--- a/src/dialogs/more-info/controls/more-info-cover.ts
+++ b/src/dialogs/more-info/controls/more-info-cover.ts
@@ -3,7 +3,6 @@ import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { supportsFeature } from "../../../common/entity/supports-feature";
-import "../../../components/ha-attributes";
 import "../../../components/ha-icon-button-group";
 import "../../../components/ha-icon-button-toggle";
 import type { CoverEntity } from "../../../data/cover";
@@ -176,11 +175,6 @@ class MoreInfoCover extends LitElement {
           }
         </div>
       </div>
-      <ha-attributes
-        .hass=${this.hass}
-        .stateObj=${this.stateObj}
-        extra-filters="current_position,current_tilt_position"
-      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-default.ts
+++ b/src/dialogs/more-info/controls/more-info-default.ts
@@ -1,7 +1,6 @@
 import type { HassEntity } from "home-assistant-js-websocket";
-import { html, LitElement, nothing } from "lit";
+import { LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
-import "../../../components/ha-attributes";
 import type { HomeAssistant } from "../../../types";
 
 @customElement("more-info-default")
@@ -15,10 +14,7 @@ class MoreInfoDefault extends LitElement {
       return nothing;
     }
 
-    return html`<ha-attributes
-      .hass=${this.hass}
-      .stateObj=${this.stateObj}
-    ></ha-attributes>`;
+    return nothing;
   }
 }
 

--- a/src/dialogs/more-info/controls/more-info-input_boolean.ts
+++ b/src/dialogs/more-info/controls/more-info-input_boolean.ts
@@ -3,7 +3,6 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup } from "lit";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
-import "../../../components/ha-attributes";
 import "../../../state-control/ha-state-control-toggle";
 import type { HomeAssistant } from "../../../types";
 import "../components/ha-more-info-state-header";
@@ -33,10 +32,6 @@ class MoreInfoInputBoolean extends LitElement {
           .iconPathOff=${mdiPowerOff}
         ></ha-state-control-toggle>
       </div>
-      <ha-attributes
-        .hass=${this.hass}
-        .stateObj=${this.stateObj}
-      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -12,7 +12,6 @@ import { customElement, property, state } from "lit/decorators";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import "../../../components/ha-attribute-icon";
-import "../../../components/ha-attributes";
 import "../../../components/ha-control-select-menu";
 import "../../../components/ha-icon-button-group";
 import "../../../components/ha-icon-button-toggle";
@@ -299,11 +298,6 @@ class MoreInfoLight extends LitElement {
               `
             : nothing}
         </ha-more-info-control-select-container>
-        <ha-attributes
-          .hass=${this.hass}
-          .stateObj=${this.stateObj}
-          extra-filters="brightness,color_temp,color_temp_kelvin,white_value,effect_list,effect,hs_color,rgb_color,rgbw_color,rgbww_color,xy_color,min_mireds,max_mireds,min_color_temp_kelvin,max_color_temp_kelvin,entity_id,supported_color_modes,color_mode"
-        ></ha-attributes>
       </div>
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-lock.ts
+++ b/src/dialogs/more-info/controls/more-info-lock.ts
@@ -5,7 +5,6 @@ import { customElement, property, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import { stateColorCss } from "../../../common/entity/state_color";
 import { supportsFeature } from "../../../common/entity/supports-feature";
-import "../../../components/ha-attributes";
 import "../../../components/ha-control-button";
 import "../../../components/ha-control-button-group";
 import "../../../components/ha-outlined-icon-button";
@@ -151,11 +150,6 @@ class MoreInfoLock extends LitElement {
               </ha-control-button-group>
             `
           : nothing}
-        <ha-attributes
-          .hass=${this.hass}
-          .stateObj=${this.stateObj}
-          extra-filters="code_format"
-        ></ha-attributes>
       </div>
     `;
   }
@@ -190,9 +184,6 @@ class MoreInfoLock extends LitElement {
           width: 100%;
           max-width: 400px;
           margin: 0 auto;
-        }
-        ha-control-button-group + ha-attributes:not([empty]) {
-          margin-top: var(--ha-space-4);
         }
         @keyframes pulse {
           0% {

--- a/src/dialogs/more-info/controls/more-info-person.ts
+++ b/src/dialogs/more-info/controls/more-info-person.ts
@@ -3,7 +3,6 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../common/dom/fire_event";
-import "../../../components/ha-attributes";
 import "../../../components/ha-button";
 import "../../../components/map/ha-map";
 import { showZoneEditor } from "../../../data/zone";
@@ -50,11 +49,6 @@ class MoreInfoPerson extends LitElement {
             </div>
           `
         : ""}
-      <ha-attributes
-        .hass=${this.hass}
-        .stateObj=${this.stateObj}
-        extra-filters="id,user_id,editable,device_trackers"
-      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-remote.ts
+++ b/src/dialogs/more-info/controls/more-info-remote.ts
@@ -2,14 +2,11 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { supportsFeature } from "../../../common/entity/supports-feature";
-import "../../../components/ha-attributes";
 import type { RemoteEntity } from "../../../data/remote";
 import { REMOTE_SUPPORT_ACTIVITY } from "../../../data/remote";
 import type { HomeAssistant } from "../../../types";
 import "../../../components/ha-select";
 import "../../../components/ha-list-item";
-
-const filterExtraAttributes = "activity_list,current_activity";
 
 @customElement("more-info-remote")
 class MoreInfoRemote extends LitElement {
@@ -51,12 +48,6 @@ class MoreInfoRemote extends LitElement {
             </ha-select>
           `
         : nothing}
-
-      <ha-attributes
-        .hass=${this.hass}
-        .stateObj=${this.stateObj}
-        .extraFilters=${filterExtraAttributes}
-      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-siren.ts
+++ b/src/dialogs/more-info/controls/more-info-siren.ts
@@ -3,7 +3,6 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup } from "lit";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
-import "../../../components/ha-attributes";
 import "../../../state-control/ha-state-control-toggle";
 import "../../../components/ha-button";
 import type { HomeAssistant } from "../../../types";
@@ -60,10 +59,6 @@ class MoreInfoSiren extends LitElement {
             </ha-button>`
           : nothing}
       </div>
-      <ha-attributes
-        .hass=${this.hass}
-        .stateObj=${this.stateObj}
-      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-switch.ts
+++ b/src/dialogs/more-info/controls/more-info-switch.ts
@@ -3,7 +3,6 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup } from "lit";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
-import "../../../components/ha-attributes";
 import "../../../state-control/ha-state-control-toggle";
 import type { HomeAssistant } from "../../../types";
 import "../components/ha-more-info-state-header";
@@ -33,10 +32,6 @@ class MoreInfoSwitch extends LitElement {
           .iconPathOff=${mdiPowerOff}
         ></ha-state-control-toggle>
       </div>
-      <ha-attributes
-        .hass=${this.hass}
-        .stateObj=${this.stateObj}
-      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-timer.ts
+++ b/src/dialogs/more-info/controls/more-info-timer.ts
@@ -1,6 +1,5 @@
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
-import "../../../components/ha-attributes";
 import "../../../components/ha-button";
 import type { TimerEntity } from "../../../data/timer";
 import type { HomeAssistant } from "../../../types";
@@ -63,11 +62,6 @@ class MoreInfoTimer extends LitElement {
             `
           : ""}
       </div>
-      <ha-attributes
-        .hass=${this.hass}
-        .stateObj=${this.stateObj}
-        extra-filters="remaining,restore"
-      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-vacuum.ts
+++ b/src/dialogs/more-info/controls/more-info-vacuum.ts
@@ -15,7 +15,6 @@ import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { computeStateDomain } from "../../../common/entity/compute_state_domain";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import "../../../components/entity/ha-battery-icon";
-import "../../../components/ha-attributes";
 import "../../../components/ha-icon";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-list-item";
@@ -109,9 +108,6 @@ class MoreInfoVacuum extends LitElement {
     }
 
     const stateObj = this.stateObj;
-
-    const filterExtraAttributes =
-      "fan_speed,fan_speed_list,status,battery_level,battery_icon";
 
     return html`
       ${stateObj.state !== UNAVAILABLE
@@ -208,12 +204,6 @@ class MoreInfoVacuum extends LitElement {
             </div>
           `
         : ""}
-
-      <ha-attributes
-        .hass=${this.hass}
-        .stateObj=${this.stateObj}
-        .extraFilters=${filterExtraAttributes}
-      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-valve.ts
+++ b/src/dialogs/more-info/controls/more-info-valve.ts
@@ -3,7 +3,6 @@ import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { supportsFeature } from "../../../common/entity/supports-feature";
-import "../../../components/ha-attributes";
 import "../../../components/ha-icon-button-group";
 import "../../../components/ha-icon-button-toggle";
 import type { ValveEntity } from "../../../data/valve";
@@ -155,11 +154,6 @@ class MoreInfoValve extends LitElement {
           }
         </div>
       </div>
-      <ha-attributes
-        .hass=${this.hass}
-        .stateObj=${this.stateObj}
-        extra-filters="current_position,current_tilt_position"
-      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/ha-more-info-attributes.ts
+++ b/src/dialogs/more-info/ha-more-info-attributes.ts
@@ -55,18 +55,6 @@ class HaMoreInfoAttributes extends LitElement {
 
     const attributes = this._computeDisplayAttributes(this._stateObj);
 
-    if (attributes.length === 0) {
-      return html`
-        <div class="content">
-          <p class="no-attributes">
-            ${this.hass.localize(
-              "ui.dialogs.more_info_control.attributes.no_attributes"
-            )}
-          </p>
-        </div>
-      `;
-    }
-
     return html`
       <div class="content">
         <ha-card>
@@ -115,12 +103,6 @@ class HaMoreInfoAttributes extends LitElement {
     .content {
       padding: var(--ha-space-6);
       padding-bottom: max(var(--safe-area-inset-bottom), var(--ha-space-6));
-    }
-
-    .no-attributes {
-      color: var(--secondary-text-color);
-      text-align: center;
-      margin: var(--ha-space-4) 0;
     }
 
     ha-card {

--- a/src/dialogs/more-info/ha-more-info-attributes.ts
+++ b/src/dialogs/more-info/ha-more-info-attributes.ts
@@ -1,0 +1,170 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import type { CSSResultGroup, PropertyValues } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { computeAttributeNameDisplay } from "../../common/entity/compute_attribute_display";
+import { computeStateDomain } from "../../common/entity/compute_state_domain";
+import "../../components/ha-attribute-value";
+import "../../components/ha-card";
+import {
+  STATE_ATTRIBUTES,
+  STATE_ATTRIBUTES_DOMAIN_CLASS,
+} from "../../data/entity/entity_attributes";
+import type { ExtEntityRegistryEntry } from "../../data/entity/entity_registry";
+import type { HomeAssistant } from "../../types";
+
+interface AttributesViewParams {
+  entityId: string;
+}
+
+@customElement("ha-more-info-attributes")
+class HaMoreInfoAttributes extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public entry?: ExtEntityRegistryEntry | null;
+
+  @property({ attribute: false }) public params?: AttributesViewParams;
+
+  @state() private _stateObj?: HassEntity;
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+    if (changedProps.has("params") || changedProps.has("hass")) {
+      if (this.params?.entityId && this.hass) {
+        this._stateObj = this.hass.states[this.params.entityId];
+      }
+    }
+  }
+
+  private _computeDisplayAttributes(stateObj: HassEntity): string[] {
+    const domain = computeStateDomain(stateObj);
+    const filtersArray = STATE_ATTRIBUTES.concat(
+      (STATE_ATTRIBUTES_DOMAIN_CLASS[domain]?.[
+        stateObj.attributes?.device_class
+      ] || []) as string[]
+    );
+    return Object.keys(stateObj.attributes).filter(
+      (key) => filtersArray.indexOf(key) === -1
+    );
+  }
+
+  protected render() {
+    if (!this.params || !this._stateObj) {
+      return nothing;
+    }
+
+    const attributes = this._computeDisplayAttributes(this._stateObj);
+
+    if (attributes.length === 0) {
+      return html`
+        <div class="content">
+          <p class="no-attributes">
+            ${this.hass.localize(
+              "ui.dialogs.more_info_control.attributes.no_attributes"
+            )}
+          </p>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="content">
+        <ha-card>
+          <div class="card-content">
+            ${attributes.map(
+              (attribute) => html`
+                <div class="data-entry">
+                  <div class="key">
+                    ${computeAttributeNameDisplay(
+                      this.hass.localize,
+                      this._stateObj!,
+                      this.hass.entities,
+                      attribute
+                    )}
+                  </div>
+                  <div class="value">
+                    <ha-attribute-value
+                      .hass=${this.hass}
+                      .attribute=${attribute}
+                      .stateObj=${this._stateObj}
+                    ></ha-attribute-value>
+                  </div>
+                </div>
+              `
+            )}
+          </div>
+        </ha-card>
+        ${this._stateObj.attributes.attribution
+          ? html`
+              <div class="attribution">
+                ${this._stateObj.attributes.attribution}
+              </div>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  static styles: CSSResultGroup = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+    }
+
+    .content {
+      padding: var(--ha-space-6);
+      padding-bottom: max(var(--safe-area-inset-bottom), var(--ha-space-6));
+    }
+
+    .no-attributes {
+      color: var(--secondary-text-color);
+      text-align: center;
+      margin: var(--ha-space-4) 0;
+    }
+
+    ha-card {
+      direction: ltr;
+    }
+
+    .card-content {
+      padding: var(--ha-space-4);
+    }
+
+    .data-entry {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      padding: var(--ha-space-2) 0;
+      border-bottom: 1px solid var(--divider-color);
+    }
+
+    .data-entry:last-child {
+      border-bottom: none;
+    }
+
+    .data-entry .value {
+      max-width: 60%;
+      overflow-wrap: break-word;
+      text-align: right;
+    }
+
+    .key {
+      flex-grow: 1;
+      color: var(--secondary-text-color);
+    }
+
+    .attribution {
+      color: var(--secondary-text-color);
+      text-align: center;
+      margin-top: var(--ha-space-4);
+      font-size: var(--ha-font-size-s);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-more-info-attributes": HaMoreInfoAttributes;
+  }
+}

--- a/src/dialogs/more-info/ha-more-info-attributes.ts
+++ b/src/dialogs/more-info/ha-more-info-attributes.ts
@@ -128,7 +128,7 @@ class HaMoreInfoAttributes extends LitElement {
     }
 
     .card-content {
-      padding: var(--ha-space-4);
+      padding: var(--ha-space-2) var(--ha-space-4);
     }
 
     .data-entry {
@@ -139,7 +139,7 @@ class HaMoreInfoAttributes extends LitElement {
       border-bottom: 1px solid var(--divider-color);
     }
 
-    .data-entry:last-child {
+    .data-entry:last-of-type {
       border-bottom: none;
     }
 

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -4,6 +4,7 @@ import {
   mdiCogOutline,
   mdiDevices,
   mdiDotsVertical,
+  mdiFormatListBulletedSquare,
   mdiInformationOutline,
   mdiPencil,
   mdiPencilOff,
@@ -24,6 +25,7 @@ import { stopPropagation } from "../../common/dom/stop_propagation";
 import { computeAreaName } from "../../common/entity/compute_area_name";
 import { computeDeviceName } from "../../common/entity/compute_device_name";
 import { computeDomain } from "../../common/entity/compute_domain";
+import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import {
   computeEntityEntryName,
   computeEntityName,
@@ -43,6 +45,10 @@ import type { HaDropdownItem } from "../../components/ha-dropdown-item";
 import "../../components/ha-icon-button";
 import "../../components/ha-icon-button-prev";
 import "../../components/ha-related-items";
+import {
+  STATE_ATTRIBUTES,
+  STATE_ATTRIBUTES_DOMAIN_CLASS,
+} from "../../data/entity/entity_attributes";
 import type {
   EntityRegistryEntry,
   ExtEntityRegistryEntry,
@@ -89,6 +95,7 @@ interface ChildView {
   viewTitle?: string;
   viewImport?: () => Promise<unknown>;
   viewParams?: any;
+  keepHeader?: boolean;
 }
 
 declare global {
@@ -331,7 +338,39 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
       case "info":
         this._resetInitialView();
         break;
+      case "attributes":
+        this._showAttributes();
+        break;
     }
+  }
+
+  private _showAttributes(): void {
+    import("./ha-more-info-attributes");
+    this._childView = {
+      viewTag: "ha-more-info-attributes",
+      viewParams: { entityId: this._entityId },
+      keepHeader: true,
+    };
+  }
+
+  private _hasDisplayableAttributes(): boolean {
+    if (!this._entityId) {
+      return false;
+    }
+    const stateObj = this.hass.states[this._entityId];
+    if (!stateObj) {
+      return false;
+    }
+    const domain = computeStateDomain(stateObj);
+    const filtersArray = STATE_ATTRIBUTES.concat(
+      (STATE_ATTRIBUTES_DOMAIN_CLASS[domain]?.[
+        stateObj.attributes?.device_class
+      ] || []) as string[]
+    );
+    const displayAttributes = Object.keys(stateObj.attributes).filter(
+      (key) => filtersArray.indexOf(key) === -1
+    );
+    return displayAttributes.length > 0;
   }
 
   private _goToAddEntityTo(ev) {
@@ -366,12 +405,17 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
     const deviceType =
       (deviceId && this.hass.devices[deviceId].entry_type) || "device";
 
-    const isDefaultView = this._currView === DEFAULT_VIEW && !this._childView;
+    const isDefaultView =
+      this._currView === DEFAULT_VIEW &&
+      (!this._childView || this._childView.keepHeader);
     const isSpecificInitialView =
-      this._initialView !== DEFAULT_VIEW && !this._childView;
+      this._initialView !== DEFAULT_VIEW &&
+      (!this._childView || this._childView.keepHeader);
     const showCloseIcon =
-      (isDefaultView && this._parentEntityIds.length === 0) ||
-      isSpecificInitialView;
+      (isDefaultView &&
+        this._parentEntityIds.length === 0 &&
+        !this._childView) ||
+      (isSpecificInitialView && !this._childView);
 
     const context = stateObj
       ? getEntityContext(
@@ -405,7 +449,12 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
     const breadcrumb = [areaName, deviceName, entityName].filter(
       (v): v is string => Boolean(v)
     );
-    const title = this._childView?.viewTitle || breadcrumb.pop() || entityId;
+    const title =
+      (this._childView && !this._childView.keepHeader
+        ? this._childView.viewTitle
+        : undefined) ||
+      breadcrumb.pop() ||
+      entityId;
 
     const isRTL = computeRTL(this.hass);
 
@@ -554,6 +603,19 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
                             "ui.dialogs.more_info_control.related"
                           )}
                         </ha-dropdown-item>
+                        ${this._hasDisplayableAttributes()
+                          ? html`
+                              <ha-dropdown-item value="attributes">
+                                <ha-svg-icon
+                                  slot="icon"
+                                  .path=${mdiFormatListBulletedSquare}
+                                ></ha-svg-icon>
+                                ${this.hass.localize(
+                                  "ui.dialogs.more_info_control.attributes.title"
+                                )}
+                              </ha-dropdown-item>
+                            `
+                          : nothing}
                         ${this._shouldShowAddEntityTo()
                           ? html`
                               <ha-dropdown-item value="add_to">

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -611,7 +611,7 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
                                   .path=${mdiFormatListBulletedSquare}
                                 ></ha-svg-icon>
                                 ${this.hass.localize(
-                                  "ui.dialogs.more_info_control.attributes.title"
+                                  "ui.dialogs.more_info_control.attributes"
                                 )}
                               </ha-dropdown-item>
                             `

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1473,10 +1473,7 @@
         "info": "Information",
         "related": "Related",
         "add_entity_to": "Add to",
-        "attributes": {
-          "title": "Attributes",
-          "no_attributes": "No attributes available"
-        },
+        "attributes": "Attributes",
         "history": "History",
         "aggregate": "5-minute aggregated",
         "logbook": "Activity",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1473,6 +1473,10 @@
         "info": "Information",
         "related": "Related",
         "add_entity_to": "Add to",
+        "attributes": {
+          "title": "Attributes",
+          "no_attributes": "No attributes available"
+        },
         "history": "History",
         "aggregate": "5-minute aggregated",
         "logbook": "Activity",


### PR DESCRIPTION
<img width="1834" height="710" alt="CleanShot 2026-01-26 at 12 52 01" src="https://github.com/user-attachments/assets/10f3dce1-49f1-483d-beb8-7633940082b4" />

## Summary

- Move entity attributes from inline display to a dedicated subview in the more-info dialog
- Add "Attributes" menu item to the three-dots menu
- Only show the menu item when the entity has displayable attributes
- Attributes are displayed in a card format in the subview

Reason: We should aim to display the most relevant data in a pleasing way for users with a dedicated UI in the more-info. The rest of a device/entities attributes should be considered as non-essencial for most viewing cases, but still accessible with two-clicks.

## Test plan

- [ ] Open a more-info dialog for an entity with attributes (e.g., a light)
- [ ] Verify "Attributes" appears in the three-dots menu
- [ ] Click "Attributes" and verify the attributes subview opens with a card containing the key-value pairs
- [ ] Open a more-info dialog for an entity without displayable attributes
- [ ] Verify "Attributes" does NOT appear in the three-dots menu
- [ ] Test with various entity types (light, lock, cover, vacuum, etc.)

## Screenshots

_TODO: Add screenshots_

🤖 Generated with [Claude Code](https://claude.com/claude-code)