### PR TITLE
Display Z-Wave home ID as hexadecimal

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/functions.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/functions.ts
@@ -1,0 +1,9 @@
+/**
+ * Formats a Z-Wave home ID as an uppercase hexadecimal string with 0x prefix.
+ * Z-Wave home IDs are 32-bit values (4 bytes).
+ *
+ * @param homeId - The home ID as a number
+ * @returns Formatted hex string (e.g., "0xD34DB33F")
+ */
+export const formatHomeIdAsHex = (homeId: number): string =>
+  "0x" + homeId.toString(16).toUpperCase().padStart(8, "0");

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -56,6 +56,7 @@ import { showZWaveJSAddNodeDialog } from "./add-node/show-dialog-zwave_js-add-no
 import { showZWaveJSRebuildNetworkRoutesDialog } from "./show-dialog-zwave_js-rebuild-network-routes";
 import { showZWaveJSRemoveNodeDialog } from "./show-dialog-zwave_js-remove-node";
 import { configTabs } from "./zwave_js-config-router";
+import { formatHomeIdAsHex } from "./functions";
 
 @customElement("zwave_js-config-dashboard")
 class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
@@ -271,7 +272,11 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                           "ui.panel.config.zwave_js.dashboard.home_id"
                         )}:
                       </span>
-                      <span>${this._network.controller.home_id}</span>
+                      <span
+                        >${formatHomeIdAsHex(
+                          this._network.controller.home_id
+                        )}</span
+                      >
                     </div>
                     <div class="row">
                       <span>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Z-Wave typically refers to the networks' home ID as hexadecimal numbers. HA on the other hand uses the decimal representation in many locations, including the network panel. This makes it harder to correlate the displayed home IDs with Z-Wave logs and cache files.

This PR changes the one location that is controlled by the frontend.

<img width="616" height="317" alt="grafik" src="https://github.com/user-attachments/assets/e957965f-e5bc-42ee-ae0d-71294aeb827b" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
