### PR TITLE
Add link to manage discovered devices in add integration dialog

### DIFF
--- a/src/panels/config/integrations/dialog-add-integration.ts
+++ b/src/panels/config/integrations/dialog-add-integration.ts
@@ -445,6 +445,7 @@ class AddIntegrationDialog extends LitElement {
         .integration=${integration}
         .flowsInProgress=${flowsInProgress}
         .navigateToResult=${this._navigateToResult}
+        .showManageLink=${this._showDiscovered}
         style=${styleMap({
           minWidth: `${this._width}px`,
           minHeight: `581px`,
@@ -452,7 +453,8 @@ class AddIntegrationDialog extends LitElement {
         @close-dialog=${this.closeDialog}
         @supported-by=${this._handleSupportedByEvent}
         @select-brand=${this._handleSelectBrandEvent}
-      ></ha-domain-integrations>`;
+      ></ha-domain-integrations>
+`;
   }
 
   private _handleSelectBrandEvent(ev: CustomEvent) {

--- a/src/panels/config/integrations/dialog-add-integration.ts
+++ b/src/panels/config/integrations/dialog-add-integration.ts
@@ -453,7 +453,7 @@ class AddIntegrationDialog extends LitElement {
         @close-dialog=${this.closeDialog}
         @supported-by=${this._handleSupportedByEvent}
         @select-brand=${this._handleSelectBrandEvent}
-      ></ha-domain-integrations> `;
+      ></ha-domain-integrations>`;
   }
 
   private _handleSelectBrandEvent(ev: CustomEvent) {

--- a/src/panels/config/integrations/dialog-add-integration.ts
+++ b/src/panels/config/integrations/dialog-add-integration.ts
@@ -453,8 +453,7 @@ class AddIntegrationDialog extends LitElement {
         @close-dialog=${this.closeDialog}
         @supported-by=${this._handleSupportedByEvent}
         @select-brand=${this._handleSelectBrandEvent}
-      ></ha-domain-integrations>
-`;
+      ></ha-domain-integrations> `;
   }
 
   private _handleSelectBrandEvent(ev: CustomEvent) {

--- a/src/panels/config/integrations/ha-config-integrations-dashboard.ts
+++ b/src/panels/config/integrations/ha-config-integrations-dashboard.ts
@@ -129,9 +129,7 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
     window.location.hash.substring(1)
   );
 
-  @state() private _searchParams = new URLSearchParams(
-    window.location.search
-  );
+  @state() private _searchParams = new URLSearchParams(window.location.search);
 
   @state() private _filter: string = history.state?.filter || "";
 

--- a/src/panels/config/integrations/ha-config-integrations-dashboard.ts
+++ b/src/panels/config/integrations/ha-config-integrations-dashboard.ts
@@ -125,8 +125,12 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
 
   @state() private _showDisabled = false;
 
-  @state() private _searchParms = new URLSearchParams(
+  @state() private _hashParams = new URLSearchParams(
     window.location.hash.substring(1)
+  );
+
+  @state() private _searchParams = new URLSearchParams(
+    window.location.search
   );
 
   @state() private _filter: string = history.state?.filter || "";
@@ -356,8 +360,8 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
       this._handleRouteChanged();
     }
     if (
-      (this._searchParms.has("config_entry") ||
-        this._searchParms.has("domain")) &&
+      (this._hashParams.has("config_entry") ||
+        this._hashParams.has("domain")) &&
       changed.has("configEntries") &&
       !changed.get("configEntries") &&
       this.configEntries
@@ -449,7 +453,9 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
       <hass-tabs-subpage
         .hass=${this.hass}
         .narrow=${this.narrow}
-        back-path="/config"
+        .backPath=${this._searchParams.has("historyBack")
+          ? undefined
+          : "/config"}
         .route=${this.route}
         .tabs=${configSections.devices}
         has-fab
@@ -799,7 +805,7 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
 
   private async _highlightEntry() {
     await nextRender();
-    const entryId = this._searchParms.get("config_entry");
+    const entryId = this._hashParams.get("config_entry");
     let domain: string | null;
     if (entryId) {
       const configEntry = this.configEntries!.find(
@@ -810,7 +816,7 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
       }
       domain = configEntry.domain;
     } else {
-      domain = this._searchParms.get("domain");
+      domain = this._hashParams.get("domain");
     }
     const card: HaIntegrationCard = this.shadowRoot!.querySelector(
       `[data-domain=${domain}]`

--- a/src/panels/config/integrations/ha-domain-integrations.ts
+++ b/src/panels/config/integrations/ha-domain-integrations.ts
@@ -1,5 +1,5 @@
 import type { RequestSelectedDetail } from "@material/mwc-list/mwc-list-item-base";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { fireEvent } from "../../../common/dom/fire_event";
@@ -41,6 +41,9 @@ class HaDomainIntegrations extends LitElement {
 
   @property({ attribute: false })
   public navigateToResult = false;
+
+  @property({ attribute: false })
+  public showManageLink = false;
 
   protected render() {
     return html`<ha-list>
@@ -87,8 +90,8 @@ class HaDomainIntegrations extends LitElement {
                     "ui.panel.config.integrations.available_integrations"
                   )}
                 </h3>`
-              : ""}`
-        : ""}
+              : nothing}`
+        : nothing}
       ${this.integration?.iot_standards
         ? this.integration.iot_standards
             .filter((standard) =>
@@ -231,6 +234,27 @@ class HaDomainIntegrations extends LitElement {
               >
               </ha-integration-list-item>`}`
         : ""}
+      ${this.showManageLink &&
+      // Only show manage link if not already on the integrations dashboard
+      !location.pathname.startsWith("/config/integrations")
+        ? html`<ha-list-item
+            twoLine
+            @request-selected=${this._manageDiscovered}
+            hasMeta
+          >
+            <span
+              >${this.hass.localize(
+                "ui.panel.config.integrations.manage_discovered"
+              )}</span
+            >
+            <span slot="secondary"
+              >${this.hass.localize(
+                "ui.panel.config.integrations.manage_discovered_description"
+              )}</span
+            >
+            <ha-icon-next slot="meta"></ha-icon-next>
+          </ha-list-item>`
+        : nothing}
     </ha-list> `;
   }
 
@@ -309,6 +333,14 @@ class HaDomainIntegrations extends LitElement {
       }
     );
     fireEvent(this, "close-dialog");
+  }
+
+  private _manageDiscovered(ev: CustomEvent<RequestSelectedDetail>) {
+    if (!shouldHandleRequestSelectedEvent(ev)) {
+      return;
+    }
+    fireEvent(this, "close-dialog");
+    navigate("/config/integrations/dashboard?historyBack=1");
   }
 
   private _standardPicked(ev: CustomEvent<RequestSelectedDetail>) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5984,6 +5984,8 @@
           "integration": "integration",
           "discovered": "Discovered",
           "discovered_devices": "{count, plural,\n one {# discovered device}\n other {# discovered devices}\n}",
+          "manage_discovered": "Manage discovered devices",
+          "manage_discovered_description": "Ignore or configure previously discovered devices",
           "disabled": "Disabled",
           "available_integrations": "Available integrations",
           "new_flow": "Set up another instance of {integration}",


### PR DESCRIPTION
## Proposed change

Add link to manage discovered devices in add integration dialog

<img width="529" height="376" alt="CleanShot 2026-01-26 at 15 03 22" src="https://github.com/user-attachments/assets/38d44add-f588-4473-90dd-a109dfafeddb" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
