### PR TITLE
Migrate country picker to generic picker

### DIFF
--- a/src/components/ha-country-picker.ts
+++ b/src/components/ha-country-picker.ts
@@ -1,12 +1,18 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../common/dom/fire_event";
-import { stopPropagation } from "../common/dom/stop_propagation";
 import { caseInsensitiveStringCompare } from "../common/string/compare";
-import "./ha-list-item";
-import "./ha-select";
-import type { HaSelect } from "./ha-select";
+import type { FrontendLocaleData } from "../data/translation";
+import type { HomeAssistant, ValueChangedEvent } from "../types";
+import "./ha-generic-picker";
+import type { HaGenericPicker } from "./ha-generic-picker";
+import type { PickerComboBoxItem } from "./ha-picker-combo-box";
+
+const SEARCH_KEYS = [
+  { name: "primary", weight: 10 },
+  { name: "search_labels.english", weight: 5 },
+];
 
 export const COUNTRIES = [
   "AD",
@@ -260,9 +266,44 @@ export const COUNTRIES = [
   "ZW",
 ];
 
+export const getCountryOptions = (
+  countries: string[],
+  noSort: boolean,
+  locale?: FrontendLocaleData
+): PickerComboBoxItem[] => {
+  const language = locale?.language ?? "en";
+  const countryDisplayNames = new Intl.DisplayNames(language, {
+    type: "region",
+    fallback: "code",
+  });
+  const englishDisplayNames = new Intl.DisplayNames("en", {
+    type: "region",
+    fallback: "code",
+  });
+
+  const options: PickerComboBoxItem[] = countries.map((country) => {
+    const primary = countryDisplayNames.of(country) ?? country;
+    const englishName = englishDisplayNames.of(country) ?? country;
+    return {
+      id: country,
+      primary,
+      search_labels: {
+        english: englishName !== primary ? englishName : null,
+      },
+    };
+  });
+
+  if (!noSort && locale) {
+    options.sort((a, b) =>
+      caseInsensitiveStringCompare(a.primary, b.primary, locale.language)
+    );
+  }
+  return options;
+};
+
 @customElement("ha-country-picker")
 export class HaCountryPicker extends LitElement {
-  @property() public language = "en";
+  @property({ attribute: false }) public hass?: HomeAssistant;
 
   @property() public value?: string;
 
@@ -278,76 +319,75 @@ export class HaCountryPicker extends LitElement {
 
   @property({ attribute: "no-sort", type: Boolean }) public noSort = false;
 
-  private _getOptions = memoizeOne(
-    (language?: string, countries?: string[]) => {
-      let options: { label: string; value: string }[] = [];
-      const countryDisplayNames = new Intl.DisplayNames(language, {
-        type: "region",
-        fallback: "code",
-      });
-      if (countries) {
-        options = countries.map((country) => ({
-          value: country,
-          label: countryDisplayNames
-            ? countryDisplayNames.of(country)!
-            : country,
-        }));
-      } else {
-        options = COUNTRIES.map((country) => ({
-          value: country,
-          label: countryDisplayNames
-            ? countryDisplayNames.of(country)!
-            : country,
-        }));
-      }
+  @state() private _defaultCountries: string[] = COUNTRIES;
 
-      if (!this.noSort) {
-        options.sort((a, b) =>
-          caseInsensitiveStringCompare(a.label, b.label, language)
-        );
-      }
-      return options;
-    }
-  );
+  @query("ha-generic-picker", true) public genericPicker!: HaGenericPicker;
+
+  private _getCountryOptions = memoizeOne(getCountryOptions);
+
+  private _getItems = () =>
+    this._getCountryOptions(
+      this.countries ?? this._defaultCountries,
+      this.noSort,
+      this.hass?.locale
+    );
+
+  private _getCountryName = (country?: string) =>
+    this._getItems().find((c) => c.id === country)?.primary;
+
+  private _valueRenderer = (value: string) =>
+    html`<span slot="headline">${this._getCountryName(value) ?? value}</span>`;
 
   protected render() {
-    const options = this._getOptions(this.language, this.countries);
+    const label =
+      this.label ??
+      (this.hass?.localize("ui.components.country-picker.country") ||
+        "Country");
+
+    const value =
+      this.value ??
+      (this.required && !this.disabled ? this._getItems()[0]?.id : this.value);
 
     return html`
-      <ha-select
-        .label=${this.label}
-        .value=${this.value}
-        .required=${this.required}
-        .helper=${this.helper}
+      <ha-generic-picker
+        .hass=${this.hass}
+        .notFoundLabel=${this._notFoundLabel}
+        .emptyLabel=${this.hass?.localize(
+          "ui.components.country-picker.no_countries"
+        ) || "No countries available"}
+        .label=${label}
+        .value=${value}
+        .valueRenderer=${this._valueRenderer}
         .disabled=${this.disabled}
-        @selected=${this._changed}
-        @closed=${stopPropagation}
-        fixedMenuPosition
-        naturalMenuWidth
-      >
-        ${options.map(
-          (option) => html`
-            <ha-list-item .value=${option.value}>${option.label}</ha-list-item>
-          `
-        )}
-      </ha-select>
+        .helper=${this.helper}
+        .getItems=${this._getItems}
+        .searchKeys=${SEARCH_KEYS}
+        @value-changed=${this._changed}
+        hide-clear-icon
+      ></ha-generic-picker>
     `;
   }
 
   static styles = css`
-    ha-select {
+    ha-generic-picker {
       width: 100%;
+      min-width: 200px;
+      display: block;
     }
   `;
 
-  private _changed(ev): void {
-    const target = ev.target as HaSelect;
-    if (target.value === "" || target.value === this.value) {
-      return;
-    }
-    this.value = target.value;
+  private _changed(ev: ValueChangedEvent<string>): void {
+    ev.stopPropagation();
+    this.value = ev.detail.value;
     fireEvent(this, "value-changed", { value: this.value });
   }
+
+  private _notFoundLabel = (search: string) => {
+    const term = html`<b>'${search}'</b>`;
+    return this.hass
+      ? this.hass.localize("ui.components.country-picker.no_match", { term })
+      : html`No countries found for ${term}`;
+  };
 }
 
 declare global {

--- a/src/components/ha-country-picker.ts
+++ b/src/components/ha-country-picker.ts
@@ -1,12 +1,11 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property, query, state } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../common/dom/fire_event";
 import { caseInsensitiveStringCompare } from "../common/string/compare";
 import type { FrontendLocaleData } from "../data/translation";
 import type { HomeAssistant, ValueChangedEvent } from "../types";
 import "./ha-generic-picker";
-import type { HaGenericPicker } from "./ha-generic-picker";
 import type { PickerComboBoxItem } from "./ha-picker-combo-box";
 
 const SEARCH_KEYS = [
@@ -321,15 +320,11 @@ export class HaCountryPicker extends LitElement {
 
   @property({ attribute: "no-sort", type: Boolean }) public noSort = false;
 
-  @state() private _defaultCountries: string[] = COUNTRIES;
-
-  @query("ha-generic-picker", true) public genericPicker!: HaGenericPicker;
-
   private _getCountryOptions = memoizeOne(getCountryOptions);
 
   private _getItems = () =>
     this._getCountryOptions(
-      this.countries ?? this._defaultCountries,
+      this.countries ?? COUNTRIES,
       this.noSort,
       this.hass?.locale
     );

--- a/src/components/ha-country-picker.ts
+++ b/src/components/ha-country-picker.ts
@@ -361,6 +361,7 @@ export class HaCountryPicker extends LitElement {
         .value=${value}
         .valueRenderer=${this._valueRenderer}
         .disabled=${this.disabled}
+        .required=${this.required}
         .helper=${this.helper}
         .getItems=${this._getItems}
         .searchKeys=${SEARCH_KEYS}

--- a/src/components/ha-country-picker.ts
+++ b/src/components/ha-country-picker.ts
@@ -11,6 +11,7 @@ import type { PickerComboBoxItem } from "./ha-picker-combo-box";
 
 const SEARCH_KEYS = [
   { name: "primary", weight: 10 },
+  { name: "secondary", weight: 8 },
   { name: "search_labels.english", weight: 5 },
 ];
 
@@ -287,6 +288,7 @@ export const getCountryOptions = (
     return {
       id: country,
       primary,
+      secondary: country,
       search_labels: {
         english: englishName !== primary ? englishName : null,
       },

--- a/src/onboarding/onboarding-core-config.ts
+++ b/src/onboarding/onboarding-core-config.ts
@@ -68,7 +68,7 @@ class OnboardingCoreConfig extends LitElement {
 
       <ha-country-picker
         class="flex"
-        .language=${this.hass.locale.language}
+        .hass=${this.hass}
         .label=${this.hass.localize(
           "ui.panel.config.core.section.core.core_config.country"
         ) || "Country"}
@@ -76,8 +76,7 @@ class OnboardingCoreConfig extends LitElement {
         .disabled=${this._working}
         .value=${this._countryValue}
         @value-changed=${this._handleCountryChanged}
-      >
-      </ha-country-picker>
+      ></ha-country-picker>
 
       <div class="footer">
         <ha-button @click=${this._save} .disabled=${this._working}>

--- a/src/panels/config/core/ha-config-section-general.ts
+++ b/src/panels/config/core/ha-config-section-general.ts
@@ -228,7 +228,6 @@ class HaConfigSectionGeneral extends LitElement {
                 name="country"
                 .disabled=${disabled}
                 .value=${this._country}
-                @closed=${stopPropagation}
                 @value-changed=${this._handleValueChanged}
               ></ha-country-picker>
               <ha-language-picker

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -762,7 +762,9 @@
         "none": "None"
       },
       "country-picker": {
-        "country": "Country"
+        "country": "Country",
+        "no_match": "No countries found for {term}",
+        "no_countries": "No countries available"
       },
       "pipeline-picker": {
         "pipeline": "Assistant",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
For consistency with the language picker and the added search ability, migrate the country picker to the generic picker.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
