### PR TITLE
Migrate currency picker to generic

### DIFF
--- a/src/components/ha-currency-picker.ts
+++ b/src/components/ha-currency-picker.ts
@@ -1,12 +1,11 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property, query } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../common/dom/fire_event";
 import { caseInsensitiveStringCompare } from "../common/string/compare";
 import type { FrontendLocaleData } from "../data/translation";
 import type { HomeAssistant, ValueChangedEvent } from "../types";
 import "./ha-generic-picker";
-import type { HaGenericPicker } from "./ha-generic-picker";
 import type { PickerComboBoxItem } from "./ha-picker-combo-box";
 
 const SEARCH_KEYS = [
@@ -212,8 +211,6 @@ export class HaCurrencyPicker extends LitElement {
 
   @property({ type: Boolean, reflect: true }) public disabled = false;
 
-  @query("ha-generic-picker", true) public genericPicker!: HaGenericPicker;
-
   private _getCurrencyOptions = memoizeOne(getCurrencyOptions);
 
   private _getItems = () => this._getCurrencyOptions(this.hass?.locale);
@@ -241,6 +238,7 @@ export class HaCurrencyPicker extends LitElement {
         .value=${this.value}
         .valueRenderer=${this._valueRenderer}
         .disabled=${this.disabled}
+        .required=${this.required}
         .getItems=${this._getItems}
         .searchKeys=${SEARCH_KEYS}
         @value-changed=${this._changed}

--- a/src/components/ha-currency-picker.ts
+++ b/src/components/ha-currency-picker.ts
@@ -1,12 +1,18 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, query } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../common/dom/fire_event";
-import { stopPropagation } from "../common/dom/stop_propagation";
 import { caseInsensitiveStringCompare } from "../common/string/compare";
-import "./ha-list-item";
-import "./ha-select";
-import type { HaSelect } from "./ha-select";
+import type { FrontendLocaleData } from "../data/translation";
+import type { HomeAssistant, ValueChangedEvent } from "../types";
+import "./ha-generic-picker";
+import type { HaGenericPicker } from "./ha-generic-picker";
+import type { PickerComboBoxItem } from "./ha-picker-combo-box";
+
+const SEARCH_KEYS = [
+  { name: "primary", weight: 10 },
+  { name: "secondary", weight: 8 },
+];
 
 const CURRENCIES = [
   "AED",
@@ -172,9 +178,31 @@ const curSymbol = (currency: string, locale?: string) =>
   new Intl.NumberFormat(locale, { style: "currency", currency })
     .formatToParts(1)
     .find((x) => x.type === "currency")?.value;
+
+export const getCurrencyOptions = (
+  locale?: FrontendLocaleData
+): PickerComboBoxItem[] => {
+  const language = locale?.language ?? "en";
+  const currencyDisplayNames = new Intl.DisplayNames(language, {
+    type: "currency",
+    fallback: "code",
+  });
+
+  const options: PickerComboBoxItem[] = CURRENCIES.map((currency) => ({
+    id: currency,
+    primary: `${currencyDisplayNames.of(currency)} (${curSymbol(currency, language)})`,
+    secondary: currency,
+  }));
+
+  options.sort((a, b) =>
+    caseInsensitiveStringCompare(a.primary, b.primary, language)
+  );
+  return options;
+};
+
 @customElement("ha-currency-picker")
 export class HaCurrencyPicker extends LitElement {
-  @property() public language = "en";
+  @property({ attribute: false }) public hass?: HomeAssistant;
 
   @property() public value?: string;
 
@@ -184,60 +212,63 @@ export class HaCurrencyPicker extends LitElement {
 
   @property({ type: Boolean, reflect: true }) public disabled = false;
 
-  private _getOptions = memoizeOne((language?: string) => {
-    const currencyDisplayNames = new Intl.DisplayNames(language, {
-      type: "currency",
-      fallback: "code",
-    });
-    const options = CURRENCIES.map((currency) => ({
-      value: currency,
-      label: `${
-        currencyDisplayNames ? currencyDisplayNames.of(currency)! : currency
-      } (${curSymbol(currency, language)})`,
-    }));
-    options.sort((a, b) =>
-      caseInsensitiveStringCompare(a.label, b.label, language)
-    );
-    return options;
-  });
+  @query("ha-generic-picker", true) public genericPicker!: HaGenericPicker;
+
+  private _getCurrencyOptions = memoizeOne(getCurrencyOptions);
+
+  private _getItems = () => this._getCurrencyOptions(this.hass?.locale);
+
+  private _getCurrencyName = (currency?: string) =>
+    this._getItems().find((c) => c.id === currency)?.primary;
+
+  private _valueRenderer = (value: string) =>
+    html`<span slot="headline">${this._getCurrencyName(value) ?? value}</span>`;
 
   protected render() {
-    const options = this._getOptions(this.language);
+    const label =
+      this.label ??
+      (this.hass?.localize("ui.components.currency-picker.currency") ||
+        "Currency");
 
     return html`
-      <ha-select
-        .label=${this.label}
+      <ha-generic-picker
+        .hass=${this.hass}
+        .notFoundLabel=${this._notFoundLabel}
+        .emptyLabel=${this.hass?.localize(
+          "ui.components.currency-picker.no_currencies"
+        ) || "No currencies available"}
+        .label=${label}
         .value=${this.value}
-        .required=${this.required}
+        .valueRenderer=${this._valueRenderer}
         .disabled=${this.disabled}
-        @selected=${this._changed}
-        @closed=${stopPropagation}
-        fixedMenuPosition
-        naturalMenuWidth
-      >
-        ${options.map(
-          (option) => html`
-            <ha-list-item .value=${option.value}>${option.label}</ha-list-item>
-          `
-        )}
-      </ha-select>
+        .getItems=${this._getItems}
+        .searchKeys=${SEARCH_KEYS}
+        @value-changed=${this._changed}
+        hide-clear-icon
+      ></ha-generic-picker>
     `;
   }
 
   static styles = css`
-    ha-select {
+    ha-generic-picker {
       width: 100%;
+      min-width: 200px;
+      display: block;
     }
   `;
 
-  private _changed(ev): void {
-    const target = ev.target as HaSelect;
-    if (target.value === "" || target.value === this.value) {
-      return;
-    }
-    this.value = target.value;
+  private _changed(ev: ValueChangedEvent<string>): void {
+    ev.stopPropagation();
+    this.value = ev.detail.value;
     fireEvent(this, "value-changed", { value: this.value });
   }
+
+  private _notFoundLabel = (search: string) => {
+    const term = html`<b>'${search}'</b>`;
+    return this.hass
+      ? this.hass.localize("ui.components.currency-picker.no_match", { term })
+      : html`No currencies found for ${term}`;
+  };
 }
 
 declare global {

--- a/src/panels/config/core/ha-config-section-general.ts
+++ b/src/panels/config/core/ha-config-section-general.ts
@@ -200,7 +200,7 @@ class HaConfigSectionGeneral extends LitElement {
               </div>
               <div>
                 <ha-currency-picker
-                  .language=${this.hass.locale.language}
+                  .hass=${this.hass}
                   .label=${this.hass.localize(
                     "ui.panel.config.core.section.core.core_config.currency"
                   )}
@@ -208,8 +208,7 @@ class HaConfigSectionGeneral extends LitElement {
                   .disabled=${disabled}
                   .value=${this._currency}
                   @value-changed=${this._handleValueChanged}
-                >
-                </ha-currency-picker>
+                ></ha-currency-picker>
                 <a
                   href="https://en.wikipedia.org/wiki/ISO_4217#Active_codes"
                   target="_blank"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -764,6 +764,11 @@
       "country-picker": {
         "country": "Country"
       },
+      "currency-picker": {
+        "currency": "Currency",
+        "no_match": "No currencies found for {term}",
+        "no_currencies": "No currencies available"
+      },
       "timezone-picker": {
         "time_zone": "Time zone",
         "no_match": "No time zones found for {term}",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
For consistency with the rest of general settings and searchability, migrates to generic picker.

Related PR: #29192


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
