### PR TITLE
Visually preview sun condition

### DIFF
--- a/src/panels/config/automation/condition/types/ha-automation-condition-sun.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-sun.ts
@@ -1,4 +1,5 @@
-import { html, LitElement } from "lit";
+import type { SVGTemplateResult } from "lit";
+import { html, LitElement, svg } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../../common/dom/fire_event";
@@ -8,6 +9,46 @@ import type { ConditionElement } from "../ha-automation-condition-row";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
 import "../../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../../components/ha-form/types";
+
+function getSunPreviewSVG(condition: SunCondition): SVGTemplateResult {
+  let bar1 = { start: 0, width: 0 };
+  let bar2 = { start: 0, width: 0 };
+
+  if (condition.before === "sunrise") {
+    bar1.width = 25;
+    if (condition.after === "sunset") {
+      bar2 = { start: 75, width: 25 };
+    } else if (condition.after === "sunrise") {
+      // This makes no sense
+      bar1.width = 0;
+    }
+  } else if (condition.before === "sunset") {
+    bar2 = { start: 50, width: 25 };
+    if (condition.after === "sunset") {
+      // This makes no sense
+      bar2 = { start: 0, width: 0 };
+    } else if (condition.after === "sunrise") {
+      bar1 = { start: 25, width: 25 };
+    } else {
+      bar1 = { start: 0, width: 50 };
+    }
+  } else if (condition.after === "sunrise") {
+    bar1 = { start: 25, width: 25 };
+    bar2 = { start: 50, width: 50 };
+  } else if (condition.after === "sunset") {
+    bar2 = { start: 75, width: 25 };
+  }
+
+  return svg`
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="30px" fill="none">
+  <rect id="outline" x="0" y="5%" width="100%" height="85%" stroke="#000" fill="none"/>
+  <line id="sun_up_line"   x1="25%" y1="2%" x2="25%" y2="93%" stroke="#000" fill="none"/>
+  <line id="noon_line"     x1="50%" y1="2%" x2="50%" y2="93%" stroke="#000" fill="none"/>
+  <line id="sun_down_line" x1="75%" y1="2%" x2="75%" y2="93%" stroke="#000" fill="none"/>
+  <rect id="bar_1" x="${bar1.start}%" y="10%" width="${bar1.width}%" height="75%" stroke-opacity="0" stroke="#0f0f00" fill="#3f7f00"/>
+  <rect id="bar_2" x="${bar2.start}%" y="10%" width="${bar2.width}%" height="75%" stroke-opacity="0" stroke="#0f0f00" fill="#3f7f00"/>
+</svg>`;
+}
 
 @customElement("ha-automation-condition-sun")
 export class HaSunCondition extends LitElement implements ConditionElement {
@@ -77,7 +118,9 @@ export class HaSunCondition extends LitElement implements ConditionElement {
         .disabled=${this.disabled}
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
-      ></ha-form>
+      >
+      </ha-form>
+      ${getSunPreviewSVG(this.condition)}
     `;
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
This PR adds a preview image for the 'Sun' condition.
Progress:

- [x] Before / after, sunset / sunrise
- [ ] Offsets
- [ ] Styling


Preview:

![brave_C8SDxpdogN](https://github.com/user-attachments/assets/5b917bc9-baa7-42d8-936c-3746f32ef3f0)



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml
condition: sun
before: sunset
after: sunrise

```

## Additional information
This PR is not complete yet!

If there is interest in this feature, I'll add the offset into the mix as well.
As for styling, suggestions are welcome.

Please note that I am not very familiar with web development in the frameworks used for HA.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
