### PR TITLE
Make the repeat icon in automation editor able to be themed. Change look when in dark mode

### DIFF
--- a/src/components/ha-automation-row.ts
+++ b/src/components/ha-automation-row.ts
@@ -155,7 +155,7 @@ export class HaAutomationRow extends LitElement {
     }
     :host([building-block]) ::slotted([slot="leading-icon"]) {
       --mdc-icon-size: var(--ha-space-5);
-      color: var(--ha-color-on-surface);
+      color: var(--ha-color-on-surface-default);
       transform: rotate(-45deg);
     }
     :host([collapsed]) .expand-button {

--- a/src/components/ha-automation-row.ts
+++ b/src/components/ha-automation-row.ts
@@ -155,7 +155,7 @@ export class HaAutomationRow extends LitElement {
     }
     :host([building-block]) ::slotted([slot="leading-icon"]) {
       --mdc-icon-size: var(--ha-space-5);
-      color: var(--white-color);
+      color: var(--ha-color-on-surface);
       transform: rotate(-45deg);
     }
     :host([collapsed]) .expand-button {

--- a/src/components/ha-automation-row.ts
+++ b/src/components/ha-automation-row.ts
@@ -155,7 +155,7 @@ export class HaAutomationRow extends LitElement {
     }
     :host([building-block]) ::slotted([slot="leading-icon"]) {
       --mdc-icon-size: var(--ha-space-5);
-      color: var(--ha-color-on-surface-default);
+      color: var(--ha-color-surface-default);
       transform: rotate(-45deg);
     }
     :host([collapsed]) .expand-button {


### PR DESCRIPTION
The repeat icon is forced to white
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Change from --white to --ha-color-surface-default
For the light theme, this keeps the "recycle" icon light colored.  
For dark theme thought, it change it to dark - which IMO looks fine:

<img width="231" height="106" alt="image" src="https://github.com/user-attachments/assets/16e9dfa5-eec0-4785-b4b8-c8fa04abb9cf" />

....
Light theme, for completeness:
<img width="229" height="127" alt="image" src="https://github.com/user-attachments/assets/259407b7-2188-4e42-b6b5-475bf2ec1b6b" />



<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
