### PR TITLE
Don't show back button when opening the add integration sub page directly

### DIFF
--- a/src/panels/config/integrations/dialog-add-integration.ts
+++ b/src/panels/config/integrations/dialog-add-integration.ts
@@ -1,3 +1,4 @@
+import { mdiClose } from "@mdi/js";
 import type { IFuseOptions } from "fuse.js";
 import Fuse from "fuse.js";
 import type { HassConfig } from "home-assistant-js-websocket";
@@ -91,6 +92,8 @@ class AddIntegrationDialog extends LitElement {
 
   @state() private _showDiscovered = false;
 
+  @state() private _openedDirectly = false;
+
   @state() private _navigateToResult = false;
 
   @state() private _open = false;
@@ -132,6 +135,7 @@ class AddIntegrationDialog extends LitElement {
       params?.brand === "_discovered"
         ? undefined
         : params?.domain || params?.brand;
+    this._openedDirectly = !!(params?.brand || params?.domain);
     this._initialFilter = params?.initialFilter;
     this._navigateToResult = params?.navigateToResult ?? false;
     this._narrow = matchMedia(
@@ -147,6 +151,7 @@ class AddIntegrationDialog extends LitElement {
     this._prevPickedBrand = undefined;
     this._flowsInProgress = undefined;
     this._showDiscovered = false;
+    this._openedDirectly = false;
     this._navigateToResult = false;
     this._filter = undefined;
     this._width = undefined;
@@ -436,7 +441,16 @@ class AddIntegrationDialog extends LitElement {
     }
 
     return html`<div slot="heading">
-        <ha-icon-button-prev @click=${this._prevClicked}></ha-icon-button-prev>
+        ${this._openedDirectly
+          ? html`<ha-icon-button
+              class="header-close-button"
+              .label=${this.hass.localize("ui.common.close")}
+              .path=${mdiClose}
+              dialogAction="close"
+            ></ha-icon-button>`
+          : html`<ha-icon-button-prev
+              @click=${this._prevClicked}
+            ></ha-icon-button-prev>`}
         <h2 class="mdc-dialog__title">${heading}</h2>
       </div>
       <ha-domain-integrations
@@ -839,7 +853,8 @@ class AddIntegrationDialog extends LitElement {
       ha-integration-list-item {
         width: 100%;
       }
-      ha-icon-button-prev {
+      ha-icon-button-prev,
+      .header-close-button {
         color: var(--secondary-text-color);
         position: absolute;
         left: 16px;


### PR DESCRIPTION
## Proposed change

Don't show back button when opening the add integration sub page directly

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
