### PR TITLE
Improve default favorite color temps and colors

### DIFF
--- a/src/data/light.ts
+++ b/src/data/light.ts
@@ -111,12 +111,13 @@ export type LightColor =
       rgbww_color: [number, number, number, number, number];
     };
 
-const COLOR_TEMP_COUNT = 4;
+const COLOR_TEMP_COUNT = 5;
 const DEFAULT_COLORED_COLORS = [
-  { rgb_color: [127, 172, 255] }, // blue #7FACFF
-  { rgb_color: [215, 150, 255] }, // purple #D796FF
-  { rgb_color: [255, 158, 243] }, // pink #FF9EF3
-  { rgb_color: [255, 110, 84] }, // red #FF6E54
+  { rgb_color: [255, 85, 85] }, // Red    #FF5555
+  { rgb_color: [40, 240, 60] }, // Green  #28F03C
+  { rgb_color: [60, 140, 255] }, // Blue   #3C8CFF
+  { rgb_color: [255, 215, 60] }, // Yellow #FFD73C
+  { rgb_color: [210, 90, 255] }, // Purple #D25AFF
 ] as LightColor[];
 
 export const computeDefaultFavoriteColors = (
@@ -131,26 +132,54 @@ export const computeDefaultFavoriteColors = (
 
   const supportsColor = lightSupportsColor(stateObj);
 
-  if (supportsColorTemp) {
-    const min = stateObj.attributes.min_color_temp_kelvin!;
-    const max = stateObj.attributes.max_color_temp_kelvin!;
-    const step = (max - min) / (COLOR_TEMP_COUNT - 1);
+  if (supportsColorTemp || supportsColor) {
+    const min = supportsColorTemp
+      ? stateObj.attributes.min_color_temp_kelvin!
+      : 2000;
+    const max = supportsColorTemp
+      ? stateObj.attributes.max_color_temp_kelvin!
+      : 6500;
 
-    for (let i = 0; i < COLOR_TEMP_COUNT; i++) {
-      colors.push({
-        color_temp_kelvin: Math.round(min + step * i),
-      });
-    }
-  } else if (supportsColor) {
-    const min = 2000;
-    const max = 6500;
-    const step = (max - min) / (COLOR_TEMP_COUNT - 1);
+    const steps = new Set<number>([min, max]);
+    [
+      2700, // Warm White
+      4000, // Neutral White
+      5500, // Daylight
+    ].forEach((preset) => {
+      if (
+        preset >= min + 250 &&
+        preset <= max - 250 &&
+        steps.size < COLOR_TEMP_COUNT
+      ) {
+        steps.add(preset);
+      }
+    });
 
-    for (let i = 0; i < COLOR_TEMP_COUNT; i++) {
-      colors.push({
-        rgb_color: temperature2rgb(Math.round(min + step * i)),
-      });
+    const kelvinSteps = Array.from(steps).sort((a, b) => a - b);
+    while (kelvinSteps.length < COLOR_TEMP_COUNT) {
+      let maxGap = 0;
+      let insertIndex = 1;
+
+      for (let i = 0; i < kelvinSteps.length - 1; i++) {
+        const gap = kelvinSteps[i + 1] - kelvinSteps[i];
+
+        if (gap > maxGap) {
+          maxGap = gap;
+          insertIndex = i + 1;
+        }
+      }
+
+      const midpoint = Math.round(kelvinSteps[insertIndex - 1] + maxGap / 2);
+      kelvinSteps.splice(insertIndex, 0, midpoint);
     }
+
+    kelvinSteps.forEach((kelvin) => {
+      if (supportsColorTemp) {
+        colors.push({ color_temp_kelvin: kelvin });
+      } else {
+        colors.push({ rgb_color: temperature2rgb(kelvin) });
+      }
+    });
   }
 
   if (supportsColor) {
@@ -159,5 +188,3 @@ export const computeDefaultFavoriteColors = (
 
   return colors;
 };
-
-export const formatTempColor = (value: number) => `${value} K`;

--- a/src/dialogs/more-info/components/lights/ha-more-info-light-favorite-colors.ts
+++ b/src/dialogs/more-info/components/lights/ha-more-info-light-favorite-colors.ts
@@ -192,7 +192,7 @@ export class HaMoreInfoLightFavoriteColors extends LitElement {
                       `ui.dialogs.more_info_control.light.favorite_color.${
                         this.editMode ? "edit" : "set"
                       }`,
-                      { number: index }
+                      { number: index + 1 }
                     )}
                     .disabled=${this.stateObj!.state === UNAVAILABLE}
                     .color=${color}
@@ -212,11 +212,11 @@ export class HaMoreInfoLightFavoriteColors extends LitElement {
                           .index=${index}
                           aria-label=${this.hass.localize(
                             `ui.dialogs.more_info_control.light.favorite_color.delete`,
-                            { number: index }
+                            { number: index + 1 }
                           )}
                           .title=${this.hass.localize(
                             `ui.dialogs.more_info_control.light.favorite_color.delete`,
-                            { number: index }
+                            { number: index + 1 }
                           )}
                         >
                           <ha-svg-icon .path=${mdiMinus}></ha-svg-icon>
@@ -256,7 +256,7 @@ export class HaMoreInfoLightFavoriteColors extends LitElement {
       justify-content: center;
       margin: calc(var(--ha-space-2) * -1);
       flex-wrap: wrap;
-      max-width: 250px;
+      max-width: 300px;
       user-select: none;
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Today, I found myself wondering why I didn't really use the favorite colors feature.
I've asked around and heard the same from other people, so I thought that it would be worth looking into.

The answer I arrived at eventually was "Because it doesn't offer what I actually want".

<br/>

When plotted, I've noticed that the colors provided do only cover a very limited subset of the color wheel:
<img width="400" height="402" alt="image" src="https://github.com/user-attachments/assets/5f170f9a-94bb-44e1-803e-34aa41c86f14" />


The Kelvin generation in the prior config (for a light with 2000-6500k capability) ended up with
<img width="1000" height="200" alt="image" src="https://github.com/user-attachments/assets/9a8e77a4-27ea-4a57-ac74-88e66658444f" />
with the standard 2700k nowhere to be found.

<br/>

So what would I actually want?

For colors, a more even distribution, so that the defaults allow me to test all the capabilities of my lights.
<img width="400" height="405" alt="image" src="https://github.com/user-attachments/assets/280f02a4-f5a3-4a69-9202-d1dd583bf43b" />
These are the ones I've settled on, but I don't have any strong feelings about them. Any other set with an equal coverage would be fine.

For color temperature, I wanted the minimum the light can do, the maximum the light can do and common presets (2700, 4000,5500). So the code now does that if the light has that spectrum, and if not, it synthesizes some middle steps to fill up the total preset count.
That ends up looking like this for a light that can do 2000-6500k
<img width="1000" height="200" alt="image" src="https://github.com/user-attachments/assets/12c18296-9714-47ad-95a8-38581b8072de" />


To achieve this, I've raised the number of favorites to 5 each and also raised the width to fit the 5:

<img width="469" height="861" alt="image" src="https://github.com/user-attachments/assets/949d0387-3c6b-4c78-bdc0-293c6c556633" />

(Color temps and color order in this screenshot are not what the code in the PR generates, but from an earlier state)

I'd say it's fine. It's a bit more bottom-heavy now, but I'd argue it's worth it.


<br/><br/>

Additionally, I've noticed and fixed this
<img width="163" height="89" alt="image" src="https://github.com/user-attachments/assets/4e6ceba8-8c0a-4ce2-9cbe-51144c843164" />
which was technically correct, but likely confusing to less technical users.

And, finally, nothing seems to have used `formatTempColor` anymore?
So now it's gone.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
