### PR TITLE
Fixes for picker combo box scrolling and selection

### DIFF
--- a/src/components/ha-picker-combo-box.ts
+++ b/src/components/ha-picker-combo-box.ts
@@ -545,11 +545,19 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
 
   /**
    * Initialize keyboard selection to the currently selected value,
-   * or fall back to the first item.
+   * or fall back to the first item (skipping section titles).
    */
   private _initializeSelectedIndex(): void {
+    if (!this.virtualizerElement?.items?.length) {
+      return;
+    }
     const initialIndex = this._getInitialSelectedIndex();
-    this._selectedItemIndex = initialIndex > 0 ? initialIndex : 0;
+    let index = initialIndex > 0 ? initialIndex : 0;
+    // Skip section titles (strings)
+    if (typeof this.virtualizerElement.items[index] === "string") {
+      index += 1;
+    }
+    this._selectedItemIndex = index;
     this._scrollToSelectedItem();
   }
 

--- a/src/components/ha-picker-combo-box.ts
+++ b/src/components/ha-picker-combo-box.ts
@@ -523,9 +523,7 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
     this._items = this._getItems();
 
     // Reset scroll position when filter changes
-    if (this.virtualizerElement) {
-      this.virtualizerElement.scrollToIndex(0);
-    }
+    this.virtualizerElement?.element(0)?.scrollIntoView();
   }
 
   private _registerKeyboardShortcuts() {
@@ -654,7 +652,9 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
       ?.querySelector(".selected")
       ?.classList.remove("selected");
 
-    this.virtualizerElement?.scrollToIndex(this._selectedItemIndex, "nearest");
+    this.virtualizerElement
+      ?.element(this._selectedItemIndex)
+      ?.scrollIntoView({ block: "nearest" });
 
     requestAnimationFrame(() => {
       this.virtualizerElement

--- a/src/components/ha-picker-combo-box.ts
+++ b/src/components/ha-picker-combo-box.ts
@@ -706,7 +706,7 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
     }
 
     if (this._selectedItemIndex === -1) {
-      return;
+      this._initializeSelectedIndex();
     }
 
     // if filter button is focused

--- a/src/components/ha-picker-combo-box.ts
+++ b/src/components/ha-picker-combo-box.ts
@@ -654,7 +654,7 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
       ?.querySelector(".selected")
       ?.classList.remove("selected");
 
-    this.virtualizerElement?.scrollToIndex(this._selectedItemIndex, "end");
+    this.virtualizerElement?.scrollToIndex(this._selectedItemIndex, "nearest");
 
     requestAnimationFrame(() => {
       this.virtualizerElement

--- a/src/components/ha-picker-combo-box.ts
+++ b/src/components/ha-picker-combo-box.ts
@@ -561,6 +561,10 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
     if (typeof this.virtualizerElement.items[index] === "string") {
       index += 1;
     }
+    // Bounds check: ensure index is valid after skipping section title
+    if (index >= this.virtualizerElement.items.length) {
+      return;
+    }
     this._selectedItemIndex = index;
     this._scrollToSelectedItem();
   }

--- a/src/components/ha-picker-combo-box.ts
+++ b/src/components/ha-picker-combo-box.ts
@@ -539,20 +539,24 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
 
   private _focusList() {
     if (this._selectedItemIndex === -1) {
-      this._selectNextItem();
+      this._initializeSelectedIndex();
     }
   }
 
   /**
    * Initialize keyboard selection to the currently selected value,
-   * or fall back to the first item (skipping section titles).
+   * or fall back to the first item when searching (skipping section titles).
    */
   private _initializeSelectedIndex(): void {
     if (!this.virtualizerElement?.items?.length) {
       return;
     }
     const initialIndex = this._getInitialSelectedIndex();
-    let index = initialIndex > 0 ? initialIndex : 0;
+    // Only initialize to first item if searching, otherwise require a selected value
+    if (initialIndex === 0 && !this._search) {
+      return;
+    }
+    let index = initialIndex;
     // Skip section titles (strings)
     if (typeof this.virtualizerElement.items[index] === "string") {
       index += 1;
@@ -582,7 +586,9 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
     // If no item is selected yet, start from the currently selected value
     if (this._selectedItemIndex === -1) {
       this._initializeSelectedIndex();
-      return;
+      if (this._selectedItemIndex !== -1) {
+        return;
+      }
     }
 
     const nextIndex =
@@ -715,6 +721,9 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
 
     if (this._selectedItemIndex === -1) {
       this._initializeSelectedIndex();
+      if (this._selectedItemIndex === -1) {
+        return;
+      }
     }
 
     // if filter button is focused

--- a/src/components/ha-picker-combo-box.ts
+++ b/src/components/ha-picker-combo-box.ts
@@ -543,6 +543,16 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
     }
   }
 
+  /**
+   * Initialize keyboard selection to the currently selected value,
+   * or fall back to the first item.
+   */
+  private _initializeSelectedIndex(): void {
+    const initialIndex = this._getInitialSelectedIndex();
+    this._selectedItemIndex = initialIndex > 0 ? initialIndex : 0;
+    this._scrollToSelectedItem();
+  }
+
   private _selectNextItem = (ev?: KeyboardEvent) => {
     ev?.stopPropagation();
     ev?.preventDefault();
@@ -558,6 +568,12 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
 
     if (maxItems === -1) {
       this._resetSelectedItem();
+      return;
+    }
+
+    // If no item is selected yet, start from the currently selected value
+    if (this._selectedItemIndex === -1) {
+      this._initializeSelectedIndex();
       return;
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Affects all usages of generic pickers and quick search (and any other uses of this component I'm unaware of)

There are a few opinionated changes here, but I believe they are generally make the experience a lot nicer.

- Replace deprecated `scrollToIndex()` with `element().scrollIntoView()`
- Use `nearest` to stop window scroll bug when using keyboard navigation
- Add function to select the correct index, ignoring section titles and falling back to first item (first item only when searching)

What this allows:

- Selection of the first item after a search
  - This will also be true on quick search ("devices" -> enter -> navigate instead of the additional arrow key down to select the first item)
- Prompts with an initial value will
  - Select the current item instead of starting from the top
  - Close the prompt with the enter key instead of requiring esc or reselection
- Stop underlying window from scrolling with keyboard navigation

https://github.com/user-attachments/assets/73356cd7-0660-45c3-aa15-3cc60fe4c144

https://github.com/user-attachments/assets/793a78c3-fb22-4197-a118-e1dc61572580

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
