### PR TITLE
Prevent quick search to close from hot keys

### DIFF
--- a/src/common/keyboard/shortcuts.ts
+++ b/src/common/keyboard/shortcuts.ts
@@ -16,6 +16,7 @@ export interface ShortcutConfig {
    * Default is false to avoid interrupting copy/paste.
    */
   allowWhenTextSelected?: boolean;
+  allowInInput?: boolean;
 }
 
 /**
@@ -29,7 +30,10 @@ function registerShortcuts(
 
   Object.entries(shortcuts).forEach(([key, config]) => {
     wrappedShortcuts[key] = (event: KeyboardEvent) => {
-      if (!canOverrideAlphanumericInput(event.composedPath())) {
+      if (
+        !config.allowInInput &&
+        !canOverrideAlphanumericInput(event.composedPath())
+      ) {
         return;
       }
       if (!config.allowWhenTextSelected && window.getSelection()?.toString()) {

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -161,7 +161,7 @@ export class QuickBar extends LitElement {
   // #region render
 
   protected render() {
-    if (!this._open) {
+    if (!this._open && !this._opened) {
       return nothing;
     }
 

--- a/src/dialogs/quick-bar/show-dialog-quick-bar.ts
+++ b/src/dialogs/quick-bar/show-dialog-quick-bar.ts
@@ -1,4 +1,5 @@
 import { fireEvent } from "../../common/dom/fire_event";
+import { closeDialog } from "../make-dialog-manager";
 
 export type QuickBarSection =
   | "entity"
@@ -25,4 +26,8 @@ export const showQuickBar = (
     dialogParams,
     addHistory: false,
   });
+};
+
+export const closeQuickBar = (): void => {
+  closeDialog("ha-quick-bar");
 };


### PR DESCRIPTION
## Proposed change
- quick search
  - when open prevent `e`, `c`, `d` to close it
  - allow `cmd+K` to close it again.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
