### PR TITLE
Fix Matter dashboard using disabled and ignored config entries

### DIFF
--- a/src/panels/config/integrations/integration-panels/matter/matter-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/matter/matter-config-dashboard.ts
@@ -333,9 +333,9 @@ export class MatterConfigDashboard extends LitElement {
     const configEntries = await getConfigEntries(this.hass, {
       domain: "matter",
     });
-    if (configEntries.length) {
-      this._configEntry = configEntries[0];
-    }
+    this._configEntry = configEntries.find(
+      (entry) => entry.disabled_by === null && entry.source !== "ignore"
+    );
   }
 
   static get styles(): CSSResultGroup {


### PR DESCRIPTION
## Proposed change

This fixes an issue where the Matter dashboard also used ignored discoveries for getting the config entry if none was explicitly provided, e.g. when accessing the Matter dashboard via the new Protocols links.

Similar to (though we do not yet use a config entry picker for the Matter dashboard):
- https://github.com/home-assistant/frontend/pull/29078

Follow-up to:
- https://github.com/home-assistant/frontend/pull/28825

Fixes: https://github.com/home-assistant/core/issues/161860

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
