### PR TITLE
Remove default title for new dashboards

### DIFF
--- a/src/panels/lovelace/views/default-view.ts
+++ b/src/panels/lovelace/views/default-view.ts
@@ -8,6 +8,5 @@ export const generateDefaultView = (
 ) =>
   ({
     type: "sections",
-    title: localize("ui.panel.lovelace.editor.default_view_title"),
     sections: [generateDefaultSection(localize, includeHeading)],
   }) as LovelaceViewConfig;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8143,7 +8143,6 @@
         },
         "editor": {
           "header": "Edit UI",
-          "default_view_title": "Home",
           "yaml_unsupported": "The edit UI is not available when in YAML mode.",
           "undo_redo_failed_to_apply_changes": "Unable to apply changes: {error}",
           "menu": {


### PR DESCRIPTION
## Proposed change

Remove default title for new dashboards so it is using the name of the dashboard instead.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
