### PR TITLE
Append current entity state to history and statistics charts

### DIFF
--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -716,6 +716,18 @@ export class StateHistoryChartLine extends LitElement {
       // Add an entry for final values
       pushData(endTime, prevValues);
 
+      // For sensors, append current state if viewing recent data
+      const now = new Date();
+      // allow 1s of leeway for "now"
+      const isUpToNow = now.getTime() - endTime.getTime() <= 1000;
+      if (domain === "sensor" && isUpToNow && data.length === 1) {
+        const stateObj = this.hass.states[states.entity_id];
+        const currentValue = stateObj ? safeParseFloat(stateObj.state) : null;
+        if (currentValue !== null) {
+          data[0].data!.push([now, currentValue]);
+        }
+      }
+
       // Concat two arrays
       Array.prototype.push.apply(datasets, data);
     });


### PR DESCRIPTION
## Proposed change

When viewing charts that display data "up to now", the chart line would previously end at the last historical or statistical data point. It always annoyed me that the current value was included, especially if there was significant change.

This PR appends the current entity state at the current timestamp when viewing recent data. Mostly for more-info. This matches the existing behavior in `hui-power-sources-graph-card`.

**Changes:**
- `statistics-chart`: Appends current state for non-external statistics when viewing data within 10 minutes of now (accounts for 5-minute aggregation periods)
- `state-history-chart-line`: Appends current state for sensor entities when viewing data within 1 second of now

The current state is only appended during data generation (when history loads/refreshes), so old appended values won't accumulate - they get replaced by actual history when it arrives.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml
```

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io