### PR TITLE
Remove dialog scrim backdrop filter

### DIFF
--- a/src/resources/theme/main.globals.ts
+++ b/src/resources/theme/main.globals.ts
@@ -48,9 +48,6 @@ export const mainStyles = css`
      */
     --safe-width: calc(100vw - var(--safe-area-inset-left) - var(--safe-area-inset-right));
     --safe-height: calc(100vh - var(--safe-area-inset-top) - var(--safe-area-inset-bottom));
-
-    /* dialog backdrop filter */
-    --ha-dialog-scrim-backdrop-filter: brightness(68%);
   }
 `;
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Remove the `ha-dialog-scrim-backdrop-filter` that was introduced in https://github.com/home-assistant/frontend/pull/28458. Adding that had inadvertent side effects on other dialogs which now have an over-darkened background:
https://github.com/user-attachments/assets/8d0f50ba-a3be-441e-85da-b6481b3a96eb

It also breaks themes that use `ha-dialog-surface-backdrop-filter`:
https://github.com/user-attachments/assets/0e6f7cac-245d-4088-81ff-72e79e288c18

A nicer way to fix the period selector on the energy dashboard would be to have a fullscreen scrim (like `mdc-dialog__scrim`) with a background color. Currently the period selector only darkens the energy dashboard, not the sidebar.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Custom theme example:
```yaml
--ha-dialog-surface-backdrop-filter: blur(8px)
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
