### PR TITLE
Replace "Power sensor type" with "Type of power measurement"

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3844,7 +3844,7 @@
               "energy_out_of_battery": "Energy discharged from the battery",
               "power": "Battery power",
               "power_helper": "Pick a sensor which measures the electricity flowing into and out of the battery in either of {unit}. Positive values indicate discharging the battery, negative values indicate charging the battery.",
-              "sensor_type": "Power sensor type",
+              "sensor_type": "Type of power measurement",
               "type_none": "No power sensor",
               "type_standard": "Standard",
               "type_inverted": "Inverted",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

For battery systems there can now be four different types of power measurement:
- No power sensor
- Standard
- Inverted
- Two sensors

So the headline for this selector needs to cover zero, single, or dual sensors.

Thus the current "Power sensor type" which only fits the two single sensor options is replaced with "Type of power measurement" which works fine with none and dual, too.

_The [documentation page](https://rc.home-assistant.io/docs/energy/battery/) does not cover this setting so no update is needed there._

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
