### PR TITLE
Added Entity Attributes to flexible naming

### DIFF
--- a/src/common/entity/compute_entity_name_display.ts
+++ b/src/common/entity/compute_entity_name_display.ts
@@ -21,6 +21,10 @@ export type EntityNameItem =
   | {
       type: "text";
       text: string;
+    }
+  | {
+      type: "attribute";
+      attribute: string;
     };
 
 export interface EntityNameOptions {
@@ -100,6 +104,8 @@ export const computeEntityNameList = (
         return floor ? computeFloorName(floor) : undefined;
       case "text":
         return item.text;
+      case "attribute":
+        return stateObj.attributes[item.attribute];
       default:
         return "";
     }

--- a/src/panels/lovelace/editor/structs/entity-name-struct.ts
+++ b/src/panels/lovelace/editor/structs/entity-name-struct.ts
@@ -6,6 +6,10 @@ const entityNameItemStruct = union([
     text: string(),
   }),
   object({
+    type: literal("attribute"),
+    attribute: string(),
+  }),
+  object({
     type: union([
       literal("entity"),
       literal("device"),

--- a/test/common/entity/compute_entity_name_display.test.ts
+++ b/test/common/entity/compute_entity_name_display.test.ts
@@ -320,6 +320,66 @@ describe("computeEntityNameDisplay", () => {
 
     expect(result).toBe("Kitchen - Light");
   });
+
+  it("returns an attribute", () => {
+    const stateObj = mockStateObj({
+      entity_id: "light.kitchen",
+      attributes: { color_mode: "HSL" },
+    });
+    const hass = {
+      entities: {
+        "light.kitchen": mockEntity({
+          entity_id: "light.kitchen",
+          name: "Kitchen Light",
+        }),
+      },
+      devices: {},
+      areas: {},
+      floors: {},
+    } as unknown as HomeAssistant;
+
+    const result = computeEntityNameDisplay(
+      stateObj,
+      [{ type: "attribute", attribute: "color_mode" }],
+      hass.entities,
+      hass.devices,
+      hass.areas,
+      hass.floors
+    );
+    expect(result).toBe("HSL");
+  });
+
+  it("mixes attributes with entity types", () => {
+    const stateObj = mockStateObj({
+      entity_id: "light.kitchen",
+      attributes: { color_mode: "HSL" },
+    });
+    const hass = {
+      entities: {
+        "light.kitchen": mockEntity({
+          entity_id: "light.kitchen",
+          name: "Kitchen Light",
+        }),
+      },
+      devices: {},
+      areas: {},
+      floors: {},
+    } as unknown as HomeAssistant;
+
+    const result = computeEntityNameDisplay(
+      stateObj,
+      [
+        { type: "entity" },
+        { type: "text", text: "-" },
+        { type: "attribute", attribute: "color_mode" },
+      ],
+      hass.entities,
+      hass.devices,
+      hass.areas,
+      hass.floors
+    );
+    expect(result).toBe("Kitchen Light - HSL");
+  });
 });
 
 describe("computeEntityNameList", () => {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The change adds the ability to use state attributes in flexible naming. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

The key changes are that a `name:` element in an entity can now use `type: attribute` and `attribute: ${target_attribute}` in the configuration to add an attribute to the naming scheme. 

```yaml
  - type: entities
    entities:
      - entity: sensor.1_times_sq_42_st
        name:
          - type: attribute
            attribute: headsign
      - entity: sensor.2_times_sq_42_st
        name:
          - type: attribute
            attribute: headsign
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/bcpearce/homeassistant-gtfs-realtime/issues/83
  - The issue was raised on a custom integration I maintain.  It's actually somewhat difficult to expose attributes in the frontend with existing card features, and adding attributes to the flexible naming feature seemed like a reasonable way to add this functionality.  
- Link to documentation pull request: TBD

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

https://github.com/home-assistant/home-assistant.io/pull/43345

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
