### PR TITLE
Fix race condition in state-display-mixin causing untranslated states

### DIFF
--- a/src/state/state-display-mixin.ts
+++ b/src/state/state-display-mixin.ts
@@ -6,6 +6,15 @@ import type { HassBaseEl } from "./hass-base-mixin";
 
 export default <T extends Constructor<HassBaseEl>>(superClass: T) => {
   class StateDisplayMixin extends superClass {
+    private _updateFormatFunctionsIteration = 0;
+
+    protected firstUpdated(changedProps) {
+      super.firstUpdated(changedProps);
+      this.addEventListener("translations-updated", () =>
+        this._updateFormatFunctions()
+      );
+    }
+
     protected hassConnected() {
       super.hassConnected();
       this._updateFormatFunctions();
@@ -34,10 +43,12 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) => {
       }
     }
 
-    private _updateFormatFunctions = async () => {
-      if (!this.hass || !this.hass.config) {
+    private async _updateFormatFunctions() {
+      if (!this.hass?.config) {
         return;
       }
+
+      const iteration = ++this._updateFormatFunctionsIteration;
 
       let sensorNumericDeviceClasses: string[] = [];
 
@@ -49,6 +60,10 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) => {
         } catch (_err: any) {
           // ignore
         }
+      }
+
+      if (this._updateFormatFunctionsIteration !== iteration) {
+        return;
       }
 
       const {
@@ -67,6 +82,11 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) => {
         this.hass.floors,
         sensorNumericDeviceClasses
       );
+
+      if (this._updateFormatFunctionsIteration !== iteration) {
+        return;
+      }
+
       this._updateHass({
         formatEntityState,
         formatEntityAttributeName,
@@ -74,7 +94,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) => {
         formatEntityAttributeValueToParts,
         formatEntityName,
       });
-    };
+    }
   }
   return StateDisplayMixin;
 };


### PR DESCRIPTION
## Proposed change

Fix intermittent issue where entity states show raw values (e.g., "not_home" instead of "Not home", "on" instead of "On") after page refresh.

The `_updateFormatFunctions` method could be called multiple times concurrently from `hassConnected()` and `willUpdate()`. Since the method is async, concurrent calls would race - a slower earlier call could complete after a faster later call and overwrite the hass object with format functions using an outdated `localize` function.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR is related to issue or discussion: fixes #29307, fixes #29291

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.
