### PR TITLE
Add support for vacuum segment mapping to areas

### DIFF
--- a/src/components/ha-vacuum-segment-area-mapper.ts
+++ b/src/components/ha-vacuum-segment-area-mapper.ts
@@ -8,6 +8,7 @@ import { getVacuumSegments } from "../data/vacuum";
 import type { HomeAssistant } from "../types";
 import "./ha-alert";
 import "./ha-area-picker";
+import { haStyle } from "../resources/styles";
 
 type AreaSegmentMapping = Record<string, string[]>; // area ID -> segment IDs
 
@@ -26,11 +27,7 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
   @state() private _error?: string;
 
   public get lastSeenSegments() {
-    return this._segments?.map((seg: Segment) => ({
-      id: seg.id,
-      name: seg.name,
-      ...(seg.group && { group: seg.group }),
-    }));
+    return this._segments;
   }
 
   protected willUpdate(changedProps: PropertyValues): void {
@@ -77,16 +74,14 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
     const groupedSegments = this._groupSegments(this._segments);
 
     return html`
-      <div class="segments">
-        ${Object.entries(groupedSegments).map(
-          ([groupName, segments]) => html`
-            ${groupName !== "undefined"
-              ? html`<div class="group-header">${groupName}</div>`
-              : nothing}
+      ${Object.entries(groupedSegments).map(
+        ([groupName, segments]) => html`
+          ${groupName !== "undefined" ? html`<h2>${groupName}</h2>` : nothing}
+          <ha-md-list>
             ${segments.map((segment) => this._renderSegment(segment))}
-          `
-        )}
-      </div>
+          </ha-md-list>
+        `
+      )}
     `;
   }
 
@@ -108,12 +103,10 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
     const mappedAreas = this._getSegmentAreas(segment.id);
 
     return html`
-      <div class="segment-row">
-        <div class="segment-info">
-          <div class="segment-name">${segment.name}</div>
-          <div class="segment-id">${segment.id}</div>
-        </div>
+      <ha-md-list-item>
+        <span slot="headline">${segment.name}</span>
         <ha-area-picker
+          slot="end"
           .hass=${this.hass}
           .value=${mappedAreas}
           .label=${"Area"}
@@ -121,7 +114,7 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
           @value-changed=${this._handleAreaChanged}
           data-segment-id=${segment.id}
         ></ha-area-picker>
-      </div>
+      </ha-md-list-item>
     `;
   }
 
@@ -175,80 +168,29 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
     fireEvent(this, "value-changed", { value: newMapping });
   }
 
-  static styles: CSSResultGroup = css`
-    :host {
-      display: block;
-    }
-
-    .loading {
-      padding: var(--ha-space-4);
-      text-align: center;
-      color: var(--secondary-text-color);
-    }
-
-    .segments {
-      display: flex;
-      flex-direction: column;
-      gap: var(--ha-space-2);
-    }
-
-    .group-header {
-      font-weight: 500;
-      color: var(--primary-text-color);
-      padding: var(--ha-space-3) var(--ha-space-2);
-      margin-top: var(--ha-space-2);
-      background-color: var(--secondary-background-color);
-      border-radius: var(--ha-card-border-radius, 12px);
-    }
-
-    .segment-row {
-      display: flex;
-      align-items: center;
-      gap: var(--ha-space-4);
-      padding: var(--ha-space-2);
-      border-radius: var(--ha-card-border-radius, 12px);
-      background-color: var(--card-background-color);
-      border: 1px solid var(--divider-color);
-    }
-
-    .segment-info {
-      flex: 1;
-      min-width: 0;
-    }
-
-    .segment-name {
-      font-weight: 500;
-      color: var(--primary-text-color);
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .segment-id {
-      font-size: 0.875rem;
-      color: var(--secondary-text-color);
-      font-family: var(--ha-font-family-code);
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    ha-area-picker {
-      flex: 1;
-      min-width: 200px;
-    }
-
-    @media (max-width: 600px) {
-      .segment-row {
-        flex-direction: column;
-        align-items: stretch;
+  static styles: CSSResultGroup = [
+    haStyle,
+    css`
+      :host {
+        display: block;
       }
 
       ha-area-picker {
-        min-width: 0;
+        flex: 1;
       }
-    }
-  `;
+
+      h2 {
+        margin: 0;
+        margin-inline-start: var(--ha-space-4);
+      }
+
+      .loading {
+        padding: var(--ha-space-4);
+        text-align: center;
+        color: var(--secondary-text-color);
+      }
+    `,
+  ];
 }
 
 declare global {

--- a/src/components/ha-vacuum-segment-area-mapper.ts
+++ b/src/components/ha-vacuum-segment-area-mapper.ts
@@ -1,14 +1,15 @@
-import "@material/mwc-list/mwc-list-item";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
 import type { Segment } from "../data/vacuum";
 import { getVacuumSegments } from "../data/vacuum";
+import { haStyle } from "../resources/styles";
 import type { HomeAssistant } from "../types";
 import "./ha-alert";
 import "./ha-area-picker";
-import { haStyle } from "../resources/styles";
+import "./ha-md-list";
+import "./ha-md-list-item";
 
 type AreaSegmentMapping = Record<string, string[]>; // area ID -> segment IDs
 
@@ -66,7 +67,11 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
 
     if (!this._segments || this._segments.length === 0) {
       return html`
-        <ha-alert alert-type="info"> No segments available </ha-alert>
+        <ha-alert alert-type="info">
+          ${this.hass.localize(
+            "ui.dialogs.vacuum_segment_mapping.no_segments"
+          )}
+        </ha-alert>
       `;
     }
 
@@ -109,8 +114,9 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
           slot="end"
           .hass=${this.hass}
           .value=${mappedAreas}
-          .label=${"Area"}
-          allow-custom-entity
+          .label=${this.hass.localize(
+            "ui.dialogs.vacuum_segment_mapping.area_label"
+          )}
           @value-changed=${this._handleAreaChanged}
           data-segment-id=${segment.id}
         ></ha-area-picker>

--- a/src/components/ha-vacuum-segment-area-mapper.ts
+++ b/src/components/ha-vacuum-segment-area-mapper.ts
@@ -1,0 +1,258 @@
+import "@material/mwc-list/mwc-list-item";
+import type { CSSResultGroup, PropertyValues } from "lit";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../common/dom/fire_event";
+import type { Segment } from "../data/vacuum";
+import { getVacuumSegments } from "../data/vacuum";
+import type { HomeAssistant } from "../types";
+import "./ha-alert";
+import "./ha-area-picker";
+
+type AreaSegmentMapping = Record<string, string[]>; // area ID -> segment IDs
+
+@customElement("ha-vacuum-segment-area-mapper")
+export class HaVacuumSegmentAreaMapper extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: "entity-id" }) public entityId!: string;
+
+  @property({ attribute: false }) public value?: AreaSegmentMapping;
+
+  @state() private _segments?: Segment[];
+
+  @state() private _loading = false;
+
+  @state() private _error?: string;
+
+  public get lastSeenSegments() {
+    return this._segments?.map((seg: Segment) => ({
+      id: seg.id,
+      name: seg.name,
+      ...(seg.group && { group: seg.group }),
+    }));
+  }
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+
+    if (changedProps.has("entityId") && this.entityId) {
+      this._loadSegments();
+    }
+  }
+
+  private async _loadSegments() {
+    this._loading = true;
+    this._error = undefined;
+
+    try {
+      const result = await getVacuumSegments(this.hass, this.entityId);
+      this._segments = result.segments;
+    } catch (err: any) {
+      this._error = err.message || "Failed to load segments";
+      this._segments = undefined;
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  protected render() {
+    if (this._loading) {
+      return html`
+        <div class="loading">${this.hass.localize("ui.common.loading")}...</div>
+      `;
+    }
+
+    if (this._error) {
+      return html` <ha-alert alert-type="error">${this._error}</ha-alert> `;
+    }
+
+    if (!this._segments || this._segments.length === 0) {
+      return html`
+        <ha-alert alert-type="info"> No segments available </ha-alert>
+      `;
+    }
+
+    // Group segments by group (if available)
+    const groupedSegments = this._groupSegments(this._segments);
+
+    return html`
+      <div class="segments">
+        ${Object.entries(groupedSegments).map(
+          ([groupName, segments]) => html`
+            ${groupName !== "undefined"
+              ? html`<div class="group-header">${groupName}</div>`
+              : nothing}
+            ${segments.map((segment) => this._renderSegment(segment))}
+          `
+        )}
+      </div>
+    `;
+  }
+
+  private _groupSegments(segments: Segment[]): Record<string, Segment[]> {
+    const grouped: Record<string, Segment[]> = {};
+
+    for (const segment of segments) {
+      const group = segment.group || "undefined";
+      if (!grouped[group]) {
+        grouped[group] = [];
+      }
+      grouped[group].push(segment);
+    }
+
+    return grouped;
+  }
+
+  private _renderSegment(segment: Segment) {
+    const mappedAreas = this._getSegmentAreas(segment.id);
+
+    return html`
+      <div class="segment-row">
+        <div class="segment-info">
+          <div class="segment-name">${segment.name}</div>
+          <div class="segment-id">${segment.id}</div>
+        </div>
+        <ha-area-picker
+          .hass=${this.hass}
+          .value=${mappedAreas}
+          .label=${"Area"}
+          allow-custom-entity
+          @value-changed=${this._handleAreaChanged}
+          data-segment-id=${segment.id}
+        ></ha-area-picker>
+      </div>
+    `;
+  }
+
+  private _handleAreaChanged = (ev: CustomEvent) => {
+    const target = ev.currentTarget as HTMLElement;
+    const segmentId = target.dataset.segmentId;
+    if (segmentId) {
+      this._areaChanged(segmentId, ev);
+    }
+  };
+
+  private _getSegmentAreas(segmentId: string): string | undefined {
+    if (!this.value) {
+      return undefined;
+    }
+
+    // Find which area(s) contain this segment
+    for (const [areaId, segmentIds] of Object.entries(this.value)) {
+      if (segmentIds.includes(segmentId)) {
+        return areaId;
+      }
+    }
+
+    return undefined;
+  }
+
+  private _areaChanged(segmentId: string, ev: CustomEvent) {
+    ev.stopPropagation();
+    const newAreaId = ev.detail.value as string | undefined;
+
+    // Create a copy of the current mapping
+    const newMapping: AreaSegmentMapping = { ...this.value };
+
+    // Remove segment from all areas
+    for (const areaId of Object.keys(newMapping)) {
+      newMapping[areaId] = newMapping[areaId].filter((id) => id !== segmentId);
+      // Remove empty area entries
+      if (newMapping[areaId].length === 0) {
+        delete newMapping[areaId];
+      }
+    }
+
+    // Add segment to new area if specified
+    if (newAreaId) {
+      if (!newMapping[newAreaId]) {
+        newMapping[newAreaId] = [];
+      }
+      newMapping[newAreaId].push(segmentId);
+    }
+
+    fireEvent(this, "value-changed", { value: newMapping });
+  }
+
+  static styles: CSSResultGroup = css`
+    :host {
+      display: block;
+    }
+
+    .loading {
+      padding: var(--ha-space-4);
+      text-align: center;
+      color: var(--secondary-text-color);
+    }
+
+    .segments {
+      display: flex;
+      flex-direction: column;
+      gap: var(--ha-space-2);
+    }
+
+    .group-header {
+      font-weight: 500;
+      color: var(--primary-text-color);
+      padding: var(--ha-space-3) var(--ha-space-2);
+      margin-top: var(--ha-space-2);
+      background-color: var(--secondary-background-color);
+      border-radius: var(--ha-card-border-radius, 12px);
+    }
+
+    .segment-row {
+      display: flex;
+      align-items: center;
+      gap: var(--ha-space-4);
+      padding: var(--ha-space-2);
+      border-radius: var(--ha-card-border-radius, 12px);
+      background-color: var(--card-background-color);
+      border: 1px solid var(--divider-color);
+    }
+
+    .segment-info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .segment-name {
+      font-weight: 500;
+      color: var(--primary-text-color);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .segment-id {
+      font-size: 0.875rem;
+      color: var(--secondary-text-color);
+      font-family: var(--ha-font-family-code);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    ha-area-picker {
+      flex: 1;
+      min-width: 200px;
+    }
+
+    @media (max-width: 600px) {
+      .segment-row {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      ha-area-picker {
+        min-width: 0;
+      }
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-vacuum-segment-area-mapper": HaVacuumSegmentAreaMapper;
+  }
+}

--- a/src/components/ha-vacuum-segment-area-mapper.ts
+++ b/src/components/ha-vacuum-segment-area-mapper.ts
@@ -68,9 +68,7 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
     if (!this._segments || this._segments.length === 0) {
       return html`
         <ha-alert alert-type="info">
-          ${this.hass.localize(
-            "ui.dialogs.vacuum_segment_mapping.no_segments"
-          )}
+          ${this.hass.localize("ui.dialogs.vacuum_segment_mapping.no_segments")}
         </ha-alert>
       `;
     }
@@ -81,7 +79,7 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
     return html`
       ${Object.entries(groupedSegments).map(
         ([groupName, segments]) => html`
-          ${groupName !== "undefined" ? html`<h2>${groupName}</h2>` : nothing}
+          ${groupName ? html`<h2>${groupName}</h2>` : nothing}
           <ha-md-list>
             ${segments.map((segment) => this._renderSegment(segment))}
           </ha-md-list>
@@ -94,7 +92,7 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
     const grouped: Record<string, Segment[]> = {};
 
     for (const segment of segments) {
-      const group = segment.group || "undefined";
+      const group = segment.group || "";
       if (!grouped[group]) {
         grouped[group] = [];
       }

--- a/src/data/entity/entity_registry.ts
+++ b/src/data/entity/entity_registry.ts
@@ -9,6 +9,7 @@ import { debounce } from "../../common/util/debounce";
 import type { HomeAssistant } from "../../types";
 import type { LightColor } from "../light";
 import type { RegistryEntry } from "../registry";
+import type { Segment } from "../vacuum";
 
 type EntityCategory = "config" | "diagnostic";
 
@@ -120,6 +121,11 @@ export interface SwitchAsXEntityOptions {
   invert: boolean;
 }
 
+export interface VacuumEntityOptions {
+  area_mapping?: Record<string, string[]>;
+  last_seen_segments?: Segment[];
+}
+
 export interface EntityRegistryOptions {
   number?: NumberEntityOptions;
   sensor?: SensorEntityOptions;
@@ -128,6 +134,7 @@ export interface EntityRegistryOptions {
   lock?: LockEntityOptions;
   weather?: WeatherEntityOptions;
   light?: LightEntityOptions;
+  vacuum?: VacuumEntityOptions;
   switch_as_x?: SwitchAsXEntityOptions;
   conversation?: Record<string, unknown>;
   "cloud.alexa"?: Record<string, unknown>;
@@ -150,7 +157,8 @@ export interface EntityRegistryEntryUpdateParams {
     | AlarmControlPanelEntityOptions
     | CalendarEntityOptions
     | WeatherEntityOptions
-    | LightEntityOptions;
+    | LightEntityOptions
+    | VacuumEntityOptions;
   aliases?: string[];
   labels?: string[];
   categories?: Record<string, string | null>;

--- a/src/data/vacuum.ts
+++ b/src/data/vacuum.ts
@@ -2,6 +2,7 @@ import type {
   HassEntityAttributeBase,
   HassEntityBase,
 } from "home-assistant-js-websocket";
+import type { HomeAssistant } from "../types";
 import { UNAVAILABLE } from "./entity/entity";
 
 export type VacuumEntityState =
@@ -29,6 +30,7 @@ export const enum VacuumEntityFeature {
   MAP = 2048,
   STATE = 4096,
   START = 8192,
+  CLEAN_AREA = 16384,
 }
 
 interface VacuumEntityAttributes extends HassEntityAttributeBase {
@@ -62,3 +64,18 @@ export function canReturnHome(stateObj: VacuumEntity): boolean {
   }
   return stateObj.state !== "returning";
 }
+
+export interface Segment {
+  id: string;
+  name: string;
+  group?: string;
+}
+
+export const getVacuumSegments = (
+  hass: HomeAssistant,
+  entity_id: string
+): Promise<{ segments: Segment[] }> =>
+  hass.callWS({
+    type: "vacuum/get_segments",
+    entity_id,
+  });

--- a/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-segment-mapping.ts
+++ b/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-segment-mapping.ts
@@ -133,6 +133,7 @@ export class HaMoreInfoViewVacuumSegmentMapping extends LitElement {
 
     ha-vacuum-segment-area-mapper {
       flex: 1;
+      padding-inline-start: var(--ha-space-2);
     }
 
     .footer {

--- a/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-segment-mapping.ts
+++ b/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-segment-mapping.ts
@@ -133,7 +133,6 @@ export class HaMoreInfoViewVacuumSegmentMapping extends LitElement {
 
     ha-vacuum-segment-area-mapper {
       flex: 1;
-      padding: var(--ha-space-4);
     }
 
     .footer {

--- a/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-segment-mapping.ts
+++ b/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-segment-mapping.ts
@@ -2,6 +2,7 @@ import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../../components/ha-button";
+import "../../../../components/ha-spinner";
 import "../../../../components/ha-vacuum-segment-area-mapper";
 import type { HaVacuumSegmentAreaMapper } from "../../../../components/ha-vacuum-segment-area-mapper";
 import type {

--- a/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-segment-mapping.ts
+++ b/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-segment-mapping.ts
@@ -1,0 +1,152 @@
+import type { CSSResultGroup } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import "../../../../components/ha-button";
+import "../../../../components/ha-vacuum-segment-area-mapper";
+import type { HaVacuumSegmentAreaMapper } from "../../../../components/ha-vacuum-segment-area-mapper";
+import type {
+  ExtEntityRegistryEntry,
+  VacuumEntityOptions,
+} from "../../../../data/entity/entity_registry";
+import {
+  getExtendedEntityRegistryEntry,
+  updateEntityRegistryEntry,
+} from "../../../../data/entity/entity_registry";
+import type { HomeAssistant } from "../../../../types";
+
+@customElement("ha-more-info-view-vacuum-segment-mapping")
+export class HaMoreInfoViewVacuumSegmentMapping extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public params!: { entityId: string };
+
+  @state() private _areaMapping?: Record<string, string[]>;
+
+  @state() private _submitting = false;
+
+  @state() private _dirty = false;
+
+  @state() private _error?: string;
+
+  private _entry?: ExtEntityRegistryEntry;
+
+  protected firstUpdated() {
+    this._loadCurrentMapping();
+  }
+
+  private async _loadCurrentMapping() {
+    if (!this.params.entityId) return;
+
+    this._entry = await getExtendedEntityRegistryEntry(
+      this.hass,
+      this.params.entityId
+    );
+
+    if (this._entry?.options?.vacuum) {
+      this._areaMapping = this._entry.options.vacuum.area_mapping || {};
+    } else {
+      this._areaMapping = {};
+    }
+  }
+
+  private _valueChanged(ev: CustomEvent) {
+    this._areaMapping = ev.detail.value;
+    this._dirty = true;
+  }
+
+  private async _save() {
+    if (!this.params.entityId || !this._areaMapping) return;
+    this._error = undefined;
+    this._submitting = true;
+
+    // Get current segments from the mapper component
+    const mapper = this.shadowRoot!.querySelector(
+      "ha-vacuum-segment-area-mapper"
+    ) as HaVacuumSegmentAreaMapper;
+
+    const options: VacuumEntityOptions = {
+      ...(this._entry?.options?.vacuum ?? {}),
+      area_mapping: this._areaMapping,
+      last_seen_segments: mapper.lastSeenSegments,
+    };
+
+    try {
+      await updateEntityRegistryEntry(this.hass, this.params.entityId, {
+        options_domain: "vacuum",
+        options: options,
+      });
+      this._dirty = false;
+    } catch (err: any) {
+      this._error = err.message;
+    } finally {
+      this._submitting = false;
+    }
+  }
+
+  protected render() {
+    if (!this._areaMapping) {
+      return html`<ha-spinner active></ha-spinner>`;
+    }
+
+    return html`
+      <div class="content">
+        ${this._error
+          ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
+          : nothing}
+
+        <ha-vacuum-segment-area-mapper
+          .hass=${this.hass}
+          .entityId=${this.params.entityId}
+          .value=${this._areaMapping}
+          @value-changed=${this._valueChanged}
+        ></ha-vacuum-segment-area-mapper>
+
+        <div class="footer">
+          <ha-button
+            @click=${this._save}
+            .disabled=${!this._dirty || this._submitting}
+          >
+            ${this.hass.localize("ui.common.save")}
+          </ha-button>
+        </div>
+      </div>
+    `;
+  }
+
+  static styles: CSSResultGroup = css`
+    :host {
+      display: block;
+      height: 100%;
+    }
+
+    .content {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    ha-spinner {
+      margin: var(--ha-space-8);
+      display: flex;
+      justify-self: center;
+    }
+
+    ha-vacuum-segment-area-mapper {
+      flex: 1;
+      padding: var(--ha-space-4);
+    }
+
+    .footer {
+      display: flex;
+      justify-content: flex-end;
+      padding: var(--ha-space-4);
+      border-top: 1px solid var(--divider-color);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-more-info-view-vacuum-segment-mapping": HaMoreInfoViewVacuumSegmentMapping;
+  }
+}

--- a/src/dialogs/more-info/components/vacuum/show-view-vacuum-segment-mapping.ts
+++ b/src/dialogs/more-info/components/vacuum/show-view-vacuum-segment-mapping.ts
@@ -1,0 +1,16 @@
+import { fireEvent } from "../../../../common/dom/fire_event";
+
+export const loadVacuumSegmentMappingView = () =>
+  import("./ha-more-info-view-vacuum-segment-mapping");
+
+export const showVacuumSegmentMappingView = (
+  element: HTMLElement,
+  entityId: string
+): void => {
+  fireEvent(element, "show-child-view", {
+    viewTag: "ha-more-info-view-vacuum-segment-mapping",
+    viewImport: loadVacuumSegmentMappingView,
+    viewTitle: "Map vacuum segments to areas",
+    viewParams: { entityId },
+  });
+};

--- a/src/dialogs/more-info/components/vacuum/show-view-vacuum-segment-mapping.ts
+++ b/src/dialogs/more-info/components/vacuum/show-view-vacuum-segment-mapping.ts
@@ -1,16 +1,18 @@
 import { fireEvent } from "../../../../common/dom/fire_event";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
 
 export const loadVacuumSegmentMappingView = () =>
   import("./ha-more-info-view-vacuum-segment-mapping");
 
 export const showVacuumSegmentMappingView = (
   element: HTMLElement,
+  localize: LocalizeFunc,
   entityId: string
 ): void => {
   fireEvent(element, "show-child-view", {
     viewTag: "ha-more-info-view-vacuum-segment-mapping",
     viewImport: loadVacuumSegmentMappingView,
-    viewTitle: "Map vacuum segments to areas",
+    viewTitle: localize("ui.dialogs.vacuum_segment_mapping.title"),
     viewParams: { entityId },
   });
 };

--- a/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
+++ b/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
@@ -29,10 +29,7 @@ import {
 import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
 import { haStyleDialog } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
-
-export interface VacuumSegmentMappingDialogParams {
-  entityId: string;
-}
+import type { VacuumSegmentMappingDialogParams } from "./show-dialog-vacuum-segment-mapping";
 
 @customElement("dialog-vacuum-segment-mapping")
 export class DialogVacuumSegmentMapping
@@ -161,7 +158,9 @@ export class DialogVacuumSegmentMapping
         .hass=${this.hass}
         .open=${this._open}
         @closed=${this._dialogClosed}
-        header-title="Map vacuum segments to areas"
+        .headerTitle=${this.hass.localize(
+          "ui.dialogs.vacuum_segment_mapping.title"
+        )}
         .headerSubtitle=${breadcrumb.join(
           computeRTL(this.hass) ? " ◂ " : " ▸ "
         )}

--- a/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
+++ b/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
@@ -17,7 +17,7 @@ import "../../../../components/ha-button";
 import "../../../../components/ha-dialog-footer";
 import "../../../../components/ha-vacuum-segment-area-mapper";
 import type { HaVacuumSegmentAreaMapper } from "../../../../components/ha-vacuum-segment-area-mapper";
-import "../../../../components/ha-wa-dialog";
+import "../../../../components/ha-dialog";
 import type {
   ExtEntityRegistryEntry,
   VacuumEntityOptions,
@@ -155,7 +155,7 @@ export class DialogVacuumSegmentMapping
     );
 
     return html`
-      <ha-wa-dialog
+      <ha-dialog
         .hass=${this.hass}
         .open=${this._open}
         @closed=${this._dialogClosed}
@@ -189,7 +189,7 @@ export class DialogVacuumSegmentMapping
             ${this.hass.localize("ui.common.save")}
           </ha-button>
         </ha-dialog-footer>
-      </ha-wa-dialog>
+      </ha-dialog>
     `;
   }
 

--- a/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
+++ b/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
@@ -96,6 +96,7 @@ export class DialogVacuumSegmentMapping
       ) as HaVacuumSegmentAreaMapper;
 
       const options: VacuumEntityOptions = {
+        ...(this._entry?.options?.vacuum ?? {}),
         area_mapping: this._areaMapping,
         last_seen_segments: mapper.lastSeenSegments,
       };

--- a/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
+++ b/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
@@ -1,0 +1,203 @@
+import type { CSSResultGroup } from "lit";
+import { html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import { computeAreaName } from "../../../../common/entity/compute_area_name";
+import { computeDeviceName } from "../../../../common/entity/compute_device_name";
+import {
+  computeEntityEntryName,
+  computeEntityName,
+} from "../../../../common/entity/compute_entity_name";
+import {
+  getEntityContext,
+  getEntityEntryContext,
+} from "../../../../common/entity/context/get_entity_context";
+import { computeRTL } from "../../../../common/util/compute_rtl";
+import "../../../../components/ha-button";
+import "../../../../components/ha-dialog-footer";
+import "../../../../components/ha-vacuum-segment-area-mapper";
+import type { HaVacuumSegmentAreaMapper } from "../../../../components/ha-vacuum-segment-area-mapper";
+import "../../../../components/ha-wa-dialog";
+import type {
+  ExtEntityRegistryEntry,
+  VacuumEntityOptions,
+} from "../../../../data/entity/entity_registry";
+import {
+  getExtendedEntityRegistryEntry,
+  updateEntityRegistryEntry,
+} from "../../../../data/entity/entity_registry";
+import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
+import { haStyleDialog } from "../../../../resources/styles";
+import type { HomeAssistant } from "../../../../types";
+
+export interface VacuumSegmentMappingDialogParams {
+  entityId: string;
+}
+
+@customElement("dialog-vacuum-segment-mapping")
+export class DialogVacuumSegmentMapping
+  extends LitElement
+  implements HassDialog<VacuumSegmentMappingDialogParams>
+{
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _params?: VacuumSegmentMappingDialogParams;
+
+  @state() private _open = false;
+
+  @state() private _areaMapping?: Record<string, string[]>;
+
+  @state() private _submitting = false;
+
+  private _entry?: ExtEntityRegistryEntry;
+
+  public async showDialog(
+    params: VacuumSegmentMappingDialogParams
+  ): Promise<void> {
+    this._params = params;
+    this._open = true;
+    await this._loadCurrentMapping();
+  }
+
+  public closeDialog(): boolean {
+    this._open = false;
+    this._params = undefined;
+    this._areaMapping = undefined;
+    return true;
+  }
+
+  private async _loadCurrentMapping() {
+    if (!this._params) return;
+
+    const entityId = this._params.entityId;
+    this._entry = await getExtendedEntityRegistryEntry(this.hass, entityId);
+
+    if (this._entry?.options?.vacuum) {
+      this._areaMapping = this._entry.options.vacuum.area_mapping || {};
+    } else {
+      this._areaMapping = {};
+    }
+  }
+
+  private _dialogClosed(): void {
+    this._params = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  private _valueChanged(ev: CustomEvent) {
+    this._areaMapping = ev.detail.value;
+  }
+
+  private async _save() {
+    if (!this._params || !this._areaMapping) return;
+
+    this._submitting = true;
+
+    try {
+      const mapper = this.renderRoot.querySelector(
+        "ha-vacuum-segment-area-mapper"
+      ) as HaVacuumSegmentAreaMapper;
+
+      const options: VacuumEntityOptions = {
+        area_mapping: this._areaMapping,
+        last_seen_segments: mapper.lastSeenSegments,
+      };
+
+      await updateEntityRegistryEntry(this.hass, this._params.entityId, {
+        options_domain: "vacuum",
+        options: options,
+      });
+
+      this.closeDialog();
+    } catch (_err: any) {
+      // Error will be shown by the system
+    } finally {
+      this._submitting = false;
+    }
+  }
+
+  protected render() {
+    if (!this._params) {
+      return nothing;
+    }
+
+    const stateObj = this.hass.states[this._params.entityId];
+
+    const context = stateObj
+      ? getEntityContext(
+          stateObj,
+          this.hass.entities,
+          this.hass.devices,
+          this.hass.areas,
+          this.hass.floors
+        )
+      : this._entry
+        ? getEntityEntryContext(
+            this._entry,
+            this.hass.entities,
+            this.hass.devices,
+            this.hass.areas,
+            this.hass.floors
+          )
+        : undefined;
+
+    const entityName = stateObj
+      ? computeEntityName(stateObj, this.hass.entities, this.hass.devices)
+      : this._entry
+        ? computeEntityEntryName(this._entry, this.hass.devices)
+        : this._params.entityId;
+
+    const deviceName = context?.device
+      ? computeDeviceName(context.device)
+      : undefined;
+    const areaName = context?.area ? computeAreaName(context.area) : undefined;
+
+    const breadcrumb = [areaName, deviceName, entityName].filter(
+      (v): v is string => Boolean(v)
+    );
+
+    return html`
+      <ha-wa-dialog
+        .hass=${this.hass}
+        .open=${this._open}
+        @closed=${this._dialogClosed}
+        header-title="Map vacuum segments to areas"
+        .headerSubtitle=${breadcrumb.join(
+          computeRTL(this.hass) ? " ◂ " : " ▸ "
+        )}
+      >
+        <ha-vacuum-segment-area-mapper
+          .hass=${this.hass}
+          entity-id=${this._params.entityId}
+          .value=${this._areaMapping}
+          @value-changed=${this._valueChanged}
+        ></ha-vacuum-segment-area-mapper>
+
+        <ha-dialog-footer slot="footer">
+          <ha-button
+            slot="secondaryAction"
+            appearance="plain"
+            @click=${this.closeDialog}
+          >
+            ${this.hass.localize("ui.common.cancel")}
+          </ha-button>
+          <ha-button
+            slot="primaryAction"
+            @click=${this._save}
+            .disabled=${this._submitting}
+          >
+            ${this.hass.localize("ui.common.save")}
+          </ha-button>
+        </ha-dialog-footer>
+      </ha-wa-dialog>
+    `;
+  }
+
+  static styles: CSSResultGroup = [haStyleDialog];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-vacuum-segment-mapping": DialogVacuumSegmentMapping;
+  }
+}

--- a/src/panels/config/entities/dialogs/show-dialog-vacuum-segment-mapping.ts
+++ b/src/panels/config/entities/dialogs/show-dialog-vacuum-segment-mapping.ts
@@ -1,0 +1,19 @@
+import { fireEvent } from "../../../../common/dom/fire_event";
+
+export interface VacuumSegmentMappingDialogParams {
+  entityId: string;
+}
+
+export const loadVacuumSegmentMappingDialog = () =>
+  import("./dialog-vacuum-segment-mapping");
+
+export const showVacuumSegmentMappingDialog = (
+  element: HTMLElement,
+  params: VacuumSegmentMappingDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-vacuum-segment-mapping",
+    dialogImport: loadVacuumSegmentMappingDialog,
+    dialogParams: params,
+  });
+};

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -919,7 +919,7 @@ export class EntityRegistrySettingsEditor extends LitElement {
               <ha-icon-next slot="meta"></ha-icon-next>
             </ha-list-item>
           `
-        : ""}
+        : nothing}
       ${this._disabledBy &&
       this._disabledBy !== "user" &&
       this._disabledBy !== "integration"

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -82,6 +82,7 @@ import {
   getSensorDeviceClassConvertibleUnits,
   getSensorNumericDeviceClasses,
 } from "../../../data/sensor";
+import { VacuumEntityFeature } from "../../../data/vacuum";
 import type { WeatherUnits } from "../../../data/weather";
 import { getWeatherConvertibleUnits } from "../../../data/weather";
 import { showOptionsFlowDialog } from "../../../dialogs/config-flow/show-dialog-options-flow";
@@ -89,6 +90,7 @@ import {
   showAlertDialog,
   showConfirmationDialog,
 } from "../../../dialogs/generic/show-dialog-box";
+import { showVacuumSegmentMappingView } from "../../../dialogs/more-info/components/vacuum/show-view-vacuum-segment-mapping";
 import { showVoiceAssistantsView } from "../../../dialogs/more-info/components/voice/show-view-voice-assistants";
 import { showMoreInfoDialog } from "../../../dialogs/more-info/show-ha-more-info-dialog";
 import { haStyle } from "../../../resources/styles";
@@ -893,6 +895,25 @@ export class EntityRegistrySettingsEditor extends LitElement {
         <ha-icon-next slot="meta"></ha-icon-next>
       </ha-list-item>
 
+      ${domain === "vacuum" &&
+      stateObj &&
+      supportsFeature(stateObj, VacuumEntityFeature.CLEAN_AREA)
+        ? html`
+            <ha-list-item
+              class="menu-item"
+              twoline
+              hasMeta
+              .disabled=${this.disabled}
+              @click=${this._handleVacuumSegmentMappingClicked}
+            >
+              <span>Map vacuum segments to areas</span>
+              <span slot="secondary">
+                Configure which areas each vacuum segment should clean
+              </span>
+              <ha-icon-next slot="meta"></ha-icon-next>
+            </ha-list-item>
+          `
+        : ""}
       ${this._disabledBy &&
       this._disabledBy !== "user" &&
       this._disabledBy !== "integration"
@@ -1482,6 +1503,10 @@ export class EntityRegistrySettingsEditor extends LitElement {
       this,
       this.hass.localize("ui.dialogs.entity_registry.editor.voice_assistants")
     );
+  }
+
+  private _handleVacuumSegmentMappingClicked() {
+    showVacuumSegmentMappingView(this, this.entry.entity_id);
   }
 
   private async _showOptionsFlow() {

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -906,9 +906,15 @@ export class EntityRegistrySettingsEditor extends LitElement {
               .disabled=${this.disabled}
               @click=${this._handleVacuumSegmentMappingClicked}
             >
-              <span>Map vacuum segments to areas</span>
+              <span
+                >${this.hass.localize(
+                  "ui.dialogs.vacuum_segment_mapping.title"
+                )}</span
+              >
               <span slot="secondary">
-                Configure which areas each vacuum segment should clean
+                ${this.hass.localize(
+                  "ui.dialogs.vacuum_segment_mapping.description"
+                )}
               </span>
               <ha-icon-next slot="meta"></ha-icon-next>
             </ha-list-item>
@@ -1506,7 +1512,11 @@ export class EntityRegistrySettingsEditor extends LitElement {
   }
 
   private _handleVacuumSegmentMappingClicked() {
-    showVacuumSegmentMappingView(this, this.entry.entity_id);
+    showVacuumSegmentMappingView(
+      this,
+      this.hass.localize,
+      this.entry.entity_id
+    );
   }
 
   private async _showOptionsFlow() {

--- a/src/panels/config/repairs/ha-config-repairs.ts
+++ b/src/panels/config/repairs/ha-config-repairs.ts
@@ -6,6 +6,11 @@ import { STRINGS_SEPARATOR_DOT } from "../../../common/const";
 import "../../../components/ha-md-list";
 import "../../../components/ha-md-list-item";
 import { domainToName } from "../../../data/integration";
+import type { StatisticsValidationResult } from "../../../data/recorder";
+import {
+  STATISTIC_TYPES,
+  updateStatisticsIssues,
+} from "../../../data/recorder";
 import {
   fetchRepairsIssueData,
   type RepairsIssue,
@@ -16,11 +21,7 @@ import { brandsUrl } from "../../../util/brands-url";
 import { fixStatisticsIssue } from "../developer-tools/statistics/fix-statistics";
 import { showRepairsFlowDialog } from "./show-dialog-repair-flow";
 import { showRepairsIssueDialog } from "./show-repair-issue-dialog";
-import type { StatisticsValidationResult } from "../../../data/recorder";
-import {
-  STATISTIC_TYPES,
-  updateStatisticsIssues,
-} from "../../../data/recorder";
+import { showVacuumSegmentMappingDialog } from "../entities/dialogs/show-dialog-vacuum-segment-mapping";
 
 @customElement("ha-config-repairs")
 class HaConfigRepairs extends LitElement {
@@ -138,6 +139,23 @@ class HaConfigRepairs extends LitElement {
       if ("flow_id" in data.issue_data) {
         showConfigFlowDialog(this, {
           continueFlowId: data.issue_data.flow_id as string,
+        });
+      }
+    } else if (
+      issue.domain === "vacuum" &&
+      issue.translation_key === "segments_changed"
+    ) {
+      const data = await fetchRepairsIssueData(
+        this.hass.connection,
+        issue.domain,
+        issue.issue_id
+      );
+      if (
+        "entity_id" in data.issue_data &&
+        typeof data.issue_data.entity_id === "string"
+      ) {
+        showVacuumSegmentMappingDialog(this, {
+          entityId: data.issue_data.entity_id,
         });
       }
     } else if (

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1376,7 +1376,10 @@
     },
     "dialogs": {
       "vacuum_segment_mapping": {
-        "title": "Map vacuum segments to areas"
+        "title": "Map vacuum segments to areas",
+        "no_segments": "No segments available",
+        "area_label": "Area",
+        "description": "Configure which areas each vacuum segment should clean"
       },
       "safe_mode": {
         "title": "Safe mode",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1375,6 +1375,9 @@
       }
     },
     "dialogs": {
+      "vacuum_segment_mapping": {
+        "title": "Map vacuum segments to areas"
+      },
       "safe_mode": {
         "title": "Safe mode",
         "text": "Home Assistant is running in safe mode, custom integrations and frontend modules are not available. Restart Home Assistant to exit safe mode."


### PR DESCRIPTION



## Proposed change

Adds support for mapping vacuum segments to HA areas. This way a vacuum can be told to clean an area.
For https://github.com/home-assistant/core/pull/149315


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
