### PR TITLE
Make explanation of "search command(s)" shortcut consistent

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2191,7 +2191,7 @@
           "on_any_page": "On any page",
           "on_pages_with_tables": "On pages with tables",
           "search": "Quick search",
-          "search_command": "search command",
+          "search_command": "search commands",
           "search_entities": "search entities",
           "search_devices": "search devices",
           "search_in_table": "to search in tables"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Currently the explanation of the "c" keyboard shortcut is inconsistent with the explanations of "e" and "d" shortcuts by using singular:

<img width="890" height="487" alt="image" src="https://github.com/user-attachments/assets/0337bb9d-9b71-4921-9e80-fea8ae7192ff" />

This command changes it to "search commands" to make all three consistent.


Background: In German the current wording results in
- Befehl suchen
- Entitäten _durchsuchen_
- Geräte _durchsuchen_

With this small change the first also results in
- Befehle _durchsuchen_

making this more noticeable than the simple "s" added in English.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests



## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
