### PR TITLE
Fix "unamed" -> "unnamed" (potential crash / non registered translation information bug)

### DIFF
--- a/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
@@ -282,7 +282,7 @@ export class HomeAreaViewStrategy extends ReactiveElement {
       if (device) {
         heading =
           computeDeviceName(device) ||
-          hass.localize("ui.panel.lovelace.strategy.home.unamed_device");
+          hass.localize("ui.panel.lovelace.strategy.home.unnamed_device");
       } else {
         heading = hass.localize("ui.panel.lovelace.strategy.home.others");
       }

--- a/src/panels/lovelace/strategies/home/home-other-devices-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-other-devices-view-strategy.ts
@@ -112,7 +112,7 @@ export class HomeOtherDevicesViewStrategy extends ReactiveElement {
       if (device) {
         heading =
           computeDeviceName(device) ||
-          hass.localize("ui.panel.lovelace.strategy.home.unamed_device");
+          hass.localize("ui.panel.lovelace.strategy.home.unnamed_device");
       }
 
       sections.push({

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7889,7 +7889,7 @@
             "areas": "Areas",
             "other_areas": "Other areas",
             "devices": "Devices",
-            "unamed_device": "Unnamed device",
+            "unnamed_device": "Unnamed device",
             "others": "Others",
             "scenes": "Scenes",
             "automations": "Automations",


### PR DESCRIPTION
## Proposed change
Fix "unamed" -> "unnamed" (potential crash / non registered translation information bug)


## Type of change
- [ ] Dependency upgrade
- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
I've searched for "unamed" in the repository in order to change all places, but I may have missed something, so please correct me if there's something missing (because one result I found was not shown which is kind of weird)

This was not tested, just from looking at the code

This may be relevant to change in other translations (not included in this repo or not found by me) as well

I'm not quite sure whether this may break something because of old wrong versions of the word (backward compatibility or things inside other languages or inside the project that I've missed, but I'm pretty confident that this should at least be a little positive because I think that there were many errors through this already (but I'm not quite sure))


## Checklist
- [ ] The code change is tested and works locally. -> Not tested (see above)
- [x ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works. -> Not tested (see above)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
Does not seem relevant to me in this case

