### PR TITLE
Fix CSS minification issue for ha-card

### DIFF
--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -51,6 +51,7 @@ export class HaCard extends LitElement {
       font-weight: var(--ha-font-weight-normal);
     }
 
+    /* clean-css ignore:start */
     :host
       ::slotted(
         .card-content:not(:nth-child(1 of .card-content, .card-header))
@@ -59,6 +60,7 @@ export class HaCard extends LitElement {
       padding-top: 0;
       margin-top: calc(var(--ha-space-2) * -1);
     }
+    /* clean-css ignore:end */
 
     :host ::slotted(.card-content) {
       padding: var(--ha-space-4);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

PR #28935 introduced updated ha-card CSS including selector below.

```
host
      ::slotted(
        .card-content:not(:nth-child(1 of .card-content, .card-header))
      ),
```

clean-css minifier used by html-minifier-terser used by babel-plugin-template-html-minifier is incorrectly removing the spaces between `1`, `of` and `.card-content`. In 2026.2.0b0/1/2 non dev build, if you use the example entities card below, having both title and content, you will notice the top padding/margin of entities #states with `.card-content` class has inocrrect top padding and margin - padidng not set to 0 and no negative margin. All other styles are valid as the Browser is only ignoring the rule with the invalid selector. This can be difficult to view due to Lit using adoptedStyleSheet, but if you highlight the ha-card shadowRoot you can view what the Browser has parsed by running `$0.adoptedStyleSheets[0]` in console.

Note: you will not see this issue in a dev build as CSS is not minified and Lit does not use adopted style sheet. So in dev build everything looks fine, which is why this issue has been difficult to debug.

The fix proposes is to have clean-css ignore the minification for this rule. There may be another selector to try which will minify fine, however as 2026.2 is about to be released, this is the recommended fix at this time so as to not introduce any further issues.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

Issue in 2026.2 beta and should be included in final 2026.2 release!

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: entities
title: Test
entities:
  - sun.sun
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29261
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
