### PR TITLE
Fix chart axis colors in edit mode

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -375,6 +375,10 @@ export class HaChartBase extends LitElement {
       }
 
       const style = getComputedStyle(this);
+      const rootStyle = getComputedStyle(document.documentElement);
+      const getVar = (name: string) =>
+        style.getPropertyValue(name).trim() ||
+        rootStyle.getPropertyValue(name).trim();
       echarts.registerTheme("custom", this._createTheme(style));
 
       this.chart = echarts.init(container, "custom");
@@ -421,7 +425,7 @@ export class HaChartBase extends LitElement {
                       ...axis.axisPointer,
                       status: "show",
                       handle: {
-                        color: style.getPropertyValue("--primary-color"),
+                        color: getVar("--primary-color"),
                         margin: 0,
                         size: 20,
                         ...axis.axisPointer?.handle,
@@ -634,21 +638,24 @@ export class HaChartBase extends LitElement {
   }
 
   private _createTheme(style: CSSStyleDeclaration) {
+    const rootStyle = getComputedStyle(document.documentElement);
+    const getVar = (name: string) =>
+      style.getPropertyValue(name).trim() ||
+      rootStyle.getPropertyValue(name).trim();
     const textBorderColor =
-      style.getPropertyValue("--ha-card-background") ||
-      style.getPropertyValue("--card-background-color");
+      getVar("--ha-card-background") || getVar("--card-background-color");
     const textBorderWidth = 2;
     return {
       color: getAllGraphColors(style),
       backgroundColor: "transparent",
       textStyle: {
-        color: style.getPropertyValue("--primary-text-color"),
+        color: getVar("--primary-text-color"),
         fontFamily: "Roboto, Noto, sans-serif",
       },
       title: {
-        textStyle: { color: style.getPropertyValue("--primary-text-color") },
+        textStyle: { color: getVar("--primary-text-color") },
         subtextStyle: {
-          color: style.getPropertyValue("--secondary-text-color"),
+          color: getVar("--secondary-text-color"),
         },
       },
       line: {
@@ -684,18 +691,18 @@ export class HaChartBase extends LitElement {
         axisTick: { show: false },
         axisLabel: {
           show: true,
-          color: style.getPropertyValue("--primary-text-color"),
+          color: getVar("--primary-text-color"),
         },
         splitLine: {
           show: false,
-          lineStyle: { color: style.getPropertyValue("--divider-color") },
+          lineStyle: { color: getVar("--divider-color") },
         },
         splitArea: {
           show: false,
           areaStyle: {
             color: [
-              style.getPropertyValue("--divider-color") + "3F",
-              style.getPropertyValue("--divider-color") + "7F",
+              getVar("--divider-color") + "3F",
+              getVar("--divider-color") + "7F",
             ],
           },
         },
@@ -703,26 +710,26 @@ export class HaChartBase extends LitElement {
       valueAxis: {
         axisLine: {
           show: true,
-          lineStyle: { color: style.getPropertyValue("--divider-color") },
+          lineStyle: { color: getVar("--divider-color") },
         },
         axisTick: {
           show: true,
-          lineStyle: { color: style.getPropertyValue("--divider-color") },
+          lineStyle: { color: getVar("--divider-color") },
         },
         axisLabel: {
           show: true,
-          color: style.getPropertyValue("--primary-text-color"),
+          color: getVar("--primary-text-color"),
         },
         splitLine: {
           show: true,
-          lineStyle: { color: style.getPropertyValue("--divider-color") },
+          lineStyle: { color: getVar("--divider-color") },
         },
         splitArea: {
           show: false,
           areaStyle: {
             color: [
-              style.getPropertyValue("--divider-color") + "3F",
-              style.getPropertyValue("--divider-color") + "7F",
+              getVar("--divider-color") + "3F",
+              getVar("--divider-color") + "7F",
             ],
           },
         },
@@ -730,26 +737,26 @@ export class HaChartBase extends LitElement {
       logAxis: {
         axisLine: {
           show: true,
-          lineStyle: { color: style.getPropertyValue("--divider-color") },
+          lineStyle: { color: getVar("--divider-color") },
         },
         axisTick: {
           show: true,
-          lineStyle: { color: style.getPropertyValue("--divider-color") },
+          lineStyle: { color: getVar("--divider-color") },
         },
         axisLabel: {
           show: true,
-          color: style.getPropertyValue("--primary-text-color"),
+          color: getVar("--primary-text-color"),
         },
         splitLine: {
           show: true,
-          lineStyle: { color: style.getPropertyValue("--divider-color") },
+          lineStyle: { color: getVar("--divider-color") },
         },
         splitArea: {
           show: false,
           areaStyle: {
             color: [
-              style.getPropertyValue("--divider-color") + "3F",
-              style.getPropertyValue("--divider-color") + "7F",
+              getVar("--divider-color") + "3F",
+              getVar("--divider-color") + "7F",
             ],
           },
         },
@@ -757,53 +764,53 @@ export class HaChartBase extends LitElement {
       timeAxis: {
         axisLine: {
           show: true,
-          lineStyle: { color: style.getPropertyValue("--divider-color") },
+          lineStyle: { color: getVar("--divider-color") },
         },
         axisTick: {
           show: true,
-          lineStyle: { color: style.getPropertyValue("--divider-color") },
+          lineStyle: { color: getVar("--divider-color") },
         },
         axisLabel: {
           show: true,
-          color: style.getPropertyValue("--primary-text-color"),
+          color: getVar("--primary-text-color"),
         },
         splitLine: {
           show: true,
-          lineStyle: { color: style.getPropertyValue("--divider-color") },
+          lineStyle: { color: getVar("--divider-color") },
         },
         splitArea: {
           show: false,
           areaStyle: {
             color: [
-              style.getPropertyValue("--divider-color") + "3F",
-              style.getPropertyValue("--divider-color") + "7F",
+              getVar("--divider-color") + "3F",
+              getVar("--divider-color") + "7F",
             ],
           },
         },
       },
       legend: {
-        textStyle: { color: style.getPropertyValue("--primary-text-color") },
-        inactiveColor: style.getPropertyValue("--disabled-text-color"),
-        pageIconColor: style.getPropertyValue("--primary-text-color"),
-        pageIconInactiveColor: style.getPropertyValue("--disabled-text-color"),
+        textStyle: { color: getVar("--primary-text-color") },
+        inactiveColor: getVar("--disabled-text-color"),
+        pageIconColor: getVar("--primary-text-color"),
+        pageIconInactiveColor: getVar("--disabled-text-color"),
         pageTextStyle: {
-          color: style.getPropertyValue("--secondary-text-color"),
+          color: getVar("--secondary-text-color"),
         },
       },
       tooltip: {
-        backgroundColor: style.getPropertyValue("--card-background-color"),
-        borderColor: style.getPropertyValue("--divider-color"),
+        backgroundColor: getVar("--card-background-color"),
+        borderColor: getVar("--divider-color"),
         textStyle: {
-          color: style.getPropertyValue("--primary-text-color"),
+          color: getVar("--primary-text-color"),
           fontSize: 12,
         },
         axisPointer: {
-          lineStyle: { color: style.getPropertyValue("--info-color") },
-          crossStyle: { color: style.getPropertyValue("--info-color") },
+          lineStyle: { color: getVar("--info-color") },
+          crossStyle: { color: getVar("--info-color") },
         },
         extraCssText:
           "direction:" +
-          style.getPropertyValue("--direction") +
+          getVar("--direction") +
           ";margin-inline-start:3px;margin-inline-end:8px;",
       },
       timeline: {},


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
In Lovelace edit mode, chart axis labels and ticks switch to low-contrast colours in dark theme because the chart theme resolves its text and axis colours from the card host, which no longer has the correct theme variables under edit-mode wrappers.

<img width="499" height="829" alt="image" src="https://github.com/user-attachments/assets/bb51b7e0-a153-45b4-b89b-b742600cd5d0" />

My changes update the chart theme to resolve styles from the root theme variables with a host fallabck, this way chart labels remain readable in edit mode without changing normal mode styling.

<img width="392" height="504" alt="image" src="https://github.com/user-attachments/assets/fb9c3618-b0e8-4340-972d-3400b0ed3bd6" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
