### PR TITLE
Fix Horizontal Scrolling on System Logs Page

### DIFF
--- a/src/components/ha-ansi-to-html.ts
+++ b/src/components/ha-ansi-to-html.ts
@@ -29,20 +29,12 @@ export class HaAnsiToHtml extends LitElement {
   @property({ type: Boolean, attribute: "wrap-disabled" }) public wrapDisabled =
     false;
 
-  @property({ type: Boolean, attribute: "overflow-disabled" })
-  public overflowDisabled = false;
-
   @query("pre") private _pre?: HTMLPreElement;
 
   @litState() private _filter = "";
 
   protected render(): TemplateResult {
-    return html`<pre
-      class=${classMap({
-        wrap: !this.wrapDisabled,
-        overflow: !this.overflowDisabled,
-      })}
-    ></pre>`;
+    return html`<pre class=${classMap({ wrap: !this.wrapDisabled })}></pre>`;
   }
 
   protected firstUpdated(_changedProperties: PropertyValues): void {
@@ -57,9 +49,6 @@ export class HaAnsiToHtml extends LitElement {
   static styles = css`
     pre {
       margin: 0;
-    }
-    pre.overflow {
-      overflow-x: auto;
     }
     pre.wrap {
       white-space: pre-wrap;

--- a/src/components/ha-ansi-to-html.ts
+++ b/src/components/ha-ansi-to-html.ts
@@ -29,12 +29,20 @@ export class HaAnsiToHtml extends LitElement {
   @property({ type: Boolean, attribute: "wrap-disabled" }) public wrapDisabled =
     false;
 
+  @property({ type: Boolean, attribute: "overflow-disabled" })
+  public overflowDisabled = false;
+
   @query("pre") private _pre?: HTMLPreElement;
 
   @litState() private _filter = "";
 
   protected render(): TemplateResult {
-    return html`<pre class=${classMap({ wrap: !this.wrapDisabled })}></pre>`;
+    return html`<pre
+      class=${classMap({
+        wrap: !this.wrapDisabled,
+        overflow: !this.overflowDisabled,
+      })}
+    ></pre>`;
   }
 
   protected firstUpdated(_changedProperties: PropertyValues): void {
@@ -48,8 +56,10 @@ export class HaAnsiToHtml extends LitElement {
 
   static styles = css`
     pre {
-      overflow-x: auto;
       margin: 0;
+    }
+    pre.overflow {
+      overflow-x: auto;
     }
     pre.wrap {
       white-space: pre-wrap;

--- a/src/panels/config/logs/error-log-card.ts
+++ b/src/panels/config/logs/error-log-card.ts
@@ -276,6 +276,7 @@ class ErrorLogCard extends LitElement {
                 </div>`
               : nothing}
             <ha-ansi-to-html
+              overflow-disabled
               ?wrap-disabled=${!this._wrapLines}
             ></ha-ansi-to-html>
             <div id="scroll-bottom-marker"></div>
@@ -766,6 +767,7 @@ class ErrorLogCard extends LitElement {
       padding-top: 16px;
       padding-bottom: 16px;
       overflow-y: scroll;
+      overflow-x: auto;
       min-height: var(--error-log-card-height, calc(100vh - 244px));
       max-height: var(--error-log-card-height, calc(100vh - 244px));
       border-top: 1px solid var(--divider-color);

--- a/src/panels/config/logs/error-log-card.ts
+++ b/src/panels/config/logs/error-log-card.ts
@@ -769,8 +769,7 @@ class ErrorLogCard extends LitElement {
       text-align: start;
       padding-top: 16px;
       padding-bottom: 16px;
-      overflow-y: scroll;
-      overflow-x: auto;
+      overflow: auto;
       min-height: var(--error-log-card-height, calc(100vh - 244px));
       max-height: var(--error-log-card-height, calc(100vh - 244px));
       border-top: 1px solid var(--divider-color);

--- a/src/panels/config/logs/error-log-card.ts
+++ b/src/panels/config/logs/error-log-card.ts
@@ -276,7 +276,6 @@ class ErrorLogCard extends LitElement {
                 </div>`
               : nothing}
             <ha-ansi-to-html
-              overflow-disabled
               ?wrap-disabled=${!this._wrapLines}
             ></ha-ansi-to-html>
             <div id="scroll-bottom-marker"></div>

--- a/src/panels/config/logs/error-log-card.ts
+++ b/src/panels/config/logs/error-log-card.ts
@@ -759,6 +759,10 @@ class ErrorLogCard extends LitElement {
       float: right;
     }
 
+    .card-content {
+      margin-top: -8px;
+    }
+
     .error-log {
       position: relative;
       font-family: var(--ha-font-family-code);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When viewing the raw logs on the home assistant Logs page (/config/logs), with line wrapping disabled, the horizontal scroll bar appears inside the vertically scrolling region. This means the bar disappears as you scroll vertically.

The issue stems from the horizontal scroll bar being inside the log display element, but the vertical scroll bar being in the div above.

To fix this, an option to disable horizontal scrolling in the log element is added and horizontal scrolling enabled in the layer above.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29372

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
