### PR TITLE
Coversation -> Conversation

### DIFF
--- a/src/components/ha-conversation-agent-picker.ts
+++ b/src/components/ha-conversation-agent-picker.ts
@@ -77,7 +77,7 @@ export class HaConversationAgentPicker extends LitElement {
       <ha-select
         .label=${this.label ||
         this.hass!.localize(
-          "ui.components.coversation-agent-picker.conversation_agent"
+          "ui.components.conversation-agent-picker.conversation_agent"
         )}
         .value=${value}
         .required=${this.required}
@@ -90,7 +90,7 @@ export class HaConversationAgentPicker extends LitElement {
         ${!this.required
           ? html`<ha-list-item .value=${NONE}>
               ${this.hass!.localize(
-                "ui.components.coversation-agent-picker.none"
+                "ui.components.conversation-agent-picker.none"
               )}
             </ha-list-item>`
           : nothing}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -757,7 +757,7 @@
       "config-entry-picker": {
         "config_entry": "Integration"
       },
-      "coversation-agent-picker": {
+      "conversation-agent-picker": {
         "conversation_agent": "Conversation agent",
         "none": "None"
       },


### PR DESCRIPTION
Proposed change
Fix "coversation" -> "conversation" (potential crash / non registered translation information bug)

Type of change
 Dependency upgrade
[ x] Bugfix (non-breaking change which fixes an issue)
 New feature (thank you!)
 Breaking change (fix/feature causing existing functionality to break)
 Code quality improvements to existing code or addition of tests
Additional information
I've searched for "unamed" in the repository in order to change all places, but I may have missed something, so please correct me if there's something missing (because one result I found was not shown which is kind of weird)

This was not tested, just from looking at the code

This may be relevant to change in other translations (not included in this repo or not found by me) as well

I'm not quite sure whether this may break something because of old wrong versions of the word (backward compatibility or things inside other languages or inside the project that I've missed, but I'm pretty confident that this should at least be a little positive because I think that there were many errors through this already (but I'm not quite sure))

Checklist
 The code change is tested and works locally. -> Not tested (see above)
[x ] There is no commented out code in this PR.
 Tests have been added to verify that the new code works. -> Not tested (see above)
If user exposed functionality or configuration variables are added/changed:

 Documentation added/updated for [www.home-assistant.io][docs-repository]
Does not seem relevant to me in this case