### PR TITLE
Add tag-id column in tag table

### DIFF
--- a/src/panels/config/tags/ha-config-tags.ts
+++ b/src/panels/config/tags/ha-config-tags.ts
@@ -88,6 +88,12 @@ export class HaConfigTags extends SubscribeMixin(LitElement) {
         filterable: true,
         flex: 2,
       },
+      id: {
+        title: localize("ui.panel.config.tag.headers.tag_id"),
+        main: true,
+        sortable: true,
+        filterable: true,
+      },
       last_scanned_datetime: {
         title: localize("ui.panel.config.tag.headers.last_scanned"),
         sortable: true,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3444,7 +3444,8 @@
             "icon": "Icon",
             "name": "Name",
             "last_scanned": "Last scanned",
-            "write": "Write"
+            "write": "Write",
+            "tag_id": "Tag ID"
           },
           "detail": {
             "new_tag": "New tag",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Currently there is no chance for a user to find a tag again if you only know its id. The Tag ID is already displayed on the tag detail page, but you can't filter by it. Once you start giving your tags some telling names, this starts to become an issue. This is especially annoying if you find your ids in some automations and have no clue which tag they belong to.
The API already provides the tag id, so what this PR does is only adding this already existing column to the tag table in the config UI. The column is filterable, so the search also considers it.

<img width="1470" height="371" alt="Screenshot 2026-02-03 at 22 51 57" src="https://github.com/user-attachments/assets/d8f87b14-893a-42ec-a4d2-8b60d8ece0e3" />


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Checklist
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

[docs-repository]: https://github.com/home-assistant/home-assistant.io