### PR TITLE
Fix heading card badges overflow on narrow screens

### DIFF
--- a/src/panels/lovelace/cards/hui-heading-card.ts
+++ b/src/panels/lovelace/cards/hui-heading-card.ts
@@ -155,6 +155,7 @@ export class HuiHeadingCard extends LitElement implements LovelaceCard {
       align-items: center;
       overflow: visible;
       gap: var(--ha-space-2);
+      max-height: 100%;
     }
     .content:hover ha-icon-next {
       transform: translateX(calc(4px * var(--scale-direction)));
@@ -222,6 +223,9 @@ export class HuiHeadingCard extends LitElement implements LovelaceCard {
       align-items: center;
       justify-content: flex-end;
       gap: 4px 10px;
+      flex-wrap: wrap;
+      max-height: 100%;
+      overflow-y: clip;
     }
   `;
 }


### PR DESCRIPTION
## Proposed change

Fix badges in the heading card overflowing outside the card container on narrow screens. When there are many button badges, they now wrap to the next line and stay constrained within the card boundaries instead of extending beyond and overlapping into adjacent sections.

<img width="776" height="138" alt="image" src="https://github.com/user-attachments/assets/b17cb322-3631-464c-8d1b-8d689c91b40c" />

A side effect is that it pushes the title to be vertically centered but I think that's ok because it is only when there is overflow

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml
```

## Additional information

- This PR fixes or closes issue: fixes #29330
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.