### PR TITLE
Fix energy dashboard date/time tooltip date labelling

### DIFF
--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -33,15 +33,15 @@ import { filterXSS } from "../../../../../common/util/xss";
 import type { StatisticPeriod } from "../../../../../data/recorder";
 import { getSuggestedPeriod } from "../../../../../data/energy";
 
-export function getSuggestedMax(period: StatisticPeriod, end: Date): number {
+export function getSuggestedMax(period: StatisticPeriod, end: Date): Date {
   let suggestedMax = new Date(end);
 
   if (period === "5minute") {
-    return suggestedMax.getTime();
+    return suggestedMax;
   }
   suggestedMax.setMinutes(0, 0, 0);
   if (period === "hour") {
-    return suggestedMax.getTime();
+    return suggestedMax;
   }
   // Sometimes around DST we get a time of 0:59 instead of 23:59 as expected.
   // Correct for this when showing days/months so we don't get an extra day.
@@ -50,11 +50,11 @@ export function getSuggestedMax(period: StatisticPeriod, end: Date): number {
   }
   suggestedMax.setHours(0);
   if (period === "day" || period === "week") {
-    return suggestedMax.getTime();
+    return suggestedMax;
   }
   // period === month
   suggestedMax.setDate(1);
-  return suggestedMax.getTime();
+  return suggestedMax;
 }
 
 function createYAxisLabelFormatter(locale: FrontendLocaleData) {

--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -81,7 +81,7 @@ export function getCommonOptions(
   formatTotal?: (total: number) => string,
   detailedDailyData = false
 ): ECOption {
-  const dayDifference = differenceInDays(end, start);
+  const suggestedPeriod = getSuggestedPeriod(start, end, detailedDailyData);
 
   const compare = compareStart !== undefined && compareEnd !== undefined;
   const showCompareYear =
@@ -91,10 +91,7 @@ export function getCommonOptions(
     xAxis: {
       type: "time",
       min: start,
-      max: getSuggestedMax(
-        getSuggestedPeriod(start, end, detailedDailyData),
-        end
-      ),
+      max: getSuggestedMax(suggestedPeriod, end),
     },
     yAxis: {
       type: "value",
@@ -137,7 +134,7 @@ export function getCommonOptions(
                 items,
                 locale,
                 config,
-                dayDifference,
+                suggestedPeriod,
                 compare,
                 showCompareYear,
                 unit,
@@ -151,7 +148,7 @@ export function getCommonOptions(
           [params],
           locale,
           config,
-          dayDifference,
+          suggestedPeriod,
           compare,
           showCompareYear,
           unit,
@@ -167,7 +164,7 @@ function formatTooltip(
   params: CallbackDataParams[],
   locale: FrontendLocaleData,
   config: HassConfig,
-  dayDifference: number,
+  suggestedPeriod: string,
   compare: boolean | null,
   showCompareYear: boolean,
   unit?: string,
@@ -181,9 +178,9 @@ function formatTooltip(
   const date = new Date(params[0].value?.[2] ?? params[0].value?.[0]);
   let period: string;
 
-  if (dayDifference >= 89) {
+  if (suggestedPeriod === "month") {
     period = `${formatDateMonthYear(date, locale, config)}`;
-  } else if (dayDifference > 0) {
+  } else if (suggestedPeriod === "day") {
     period = `${(showCompareYear ? formatDateShort : formatDateVeryShort)(date, locale, config)}`;
   } else {
     period = `${


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The tooltip logic for energy graphs was using hard-coded differenceInDays to select the date format to show in the tooltip. This doesn't match the fetched energy data when the range is long. As a result you get tooltips stating a whole month even though a bar is a single day:

<img width="503" height="319" alt="Image" src="https://github.com/user-attachments/assets/9d8d64fa-ba20-4acc-8539-b70cb9ff0165" />

This PR fixes that by making tooltip date formatting use the `getSuggestedPeriod()` helper used by the other energy charge functions. With this in place the tooltip now looks like:

<img width="506" height="318" alt="image" src="https://github.com/user-attachments/assets/7d5beaf0-8891-4452-a65b-34f0a6112b5c" />

Doesn't break showing of "month" bars:

<img width="504" height="316" alt="image" src="https://github.com/user-attachments/assets/84619979-e2cd-427e-aee4-c89c7616eda4" />


(p.s. ignore the unrealistic data, its a dev environment with fake sensors)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29430
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
