### PR TITLE
Add color settings for entity in distribution card

### DIFF
--- a/src/panels/lovelace/cards/hui-distribution-card.ts
+++ b/src/panels/lovelace/cards/hui-distribution-card.ts
@@ -7,6 +7,7 @@ import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { getGraphColorByIndex } from "../../../common/color/colors";
+import { computeCssColor } from "../../../common/color/compute-color";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { MobileAwareMixin } from "../../../mixins/mobile-aware-mixin";
 import type { EntityNameItem } from "../../../common/entity/compute_entity_name_display";
@@ -33,6 +34,7 @@ const LEGEND_OVERFLOW_LIMIT_MOBILE = 6;
 interface ProcessedEntity {
   entity: string;
   name?: string | EntityNameItem | EntityNameItem[];
+  color?: string;
 }
 
 interface LegendItem {
@@ -147,6 +149,7 @@ export class HuiDistributionCard
     this._configEntities = entities.map((entity) => ({
       entity: entity.entity,
       name: entity.name,
+      color: entity.color,
     }));
   }
 
@@ -230,7 +233,9 @@ export class HuiDistributionCard
       const value = Number(stateObj.state);
       if (value <= 0 || isNaN(value)) return;
 
-      const color = getGraphColorByIndex(entity.originalIndex, computedStyles);
+      const color = entity.color
+        ? computeCssColor(entity.color)
+        : getGraphColorByIndex(entity.originalIndex, computedStyles);
       const name = computeLovelaceEntityName(this.hass!, stateObj, entity.name);
       const formattedValue = this.hass!.formatEntityState(stateObj);
 
@@ -279,7 +284,9 @@ export class HuiDistributionCard
         name: name,
         value: value,
         formattedValue: formattedValue,
-        color: getGraphColorByIndex(index, computedStyles),
+        color: entity.color
+          ? computeCssColor(entity.color)
+          : getGraphColorByIndex(index, computedStyles),
         isHidden: isHidden,
         isDisabled: isZeroOrNegative,
       };

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -664,7 +664,9 @@ export interface HomeSummaryCard extends LovelaceCardConfig {
   double_tap_action?: ActionConfig;
 }
 
-export interface DistributionEntityConfig extends EntityConfig {}
+export interface DistributionEntityConfig extends EntityConfig {
+  color?: string;
+}
 
 export interface DistributionCardConfig extends LovelaceCardConfig {
   type: "distribution";

--- a/src/panels/lovelace/editor/config-elements/hui-distribution-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-distribution-card-editor.ts
@@ -24,14 +24,19 @@ import type { LovelaceCardEditor } from "../../types";
 import "../hui-sub-element-editor";
 import { processEditorEntities } from "../process-editor-entities";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
-import { entitiesConfigStruct } from "../structs/entities-struct";
 import type { EditDetailElementEvent, SubElementEditorConfig } from "../types";
+
+const distributionEntityConfigStruct = object({
+  entity: string(),
+  name: optional(string()),
+  color: optional(string()),
+});
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
   object({
     title: optional(string()),
-    entities: array(union([string(), entitiesConfigStruct])),
+    entities: array(union([string(), distributionEntityConfigStruct])),
   })
 );
 
@@ -43,6 +48,10 @@ const SUB_SCHEMA = [
     context: {
       entity: "entity",
     },
+  },
+  {
+    name: "color",
+    selector: { ui_color: {} },
   },
 ] as const;
 

--- a/src/panels/lovelace/editor/config-elements/hui-distribution-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-distribution-card-editor.ts
@@ -18,16 +18,17 @@ import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { HaEntityPickerEntityFilterFunc } from "../../../../data/entity/entity";
 import type { HomeAssistant } from "../../../../types";
 import type { DistributionCardConfig } from "../../cards/types";
-import type { EntityConfig } from "../../entity-rows/types";
 import "../../components/hui-entity-editor";
+import type { EntityConfig } from "../../entity-rows/types";
 import type { LovelaceCardEditor } from "../../types";
 import "../hui-sub-element-editor";
 import { processEditorEntities } from "../process-editor-entities";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
+import { entityNameStruct } from "../structs/entity-name-struct";
 import type { EditDetailElementEvent, SubElementEditorConfig } from "../types";
 
 const distributionEntityConfigStruct = object({
-  entity: string(),
+  entity: entityNameStruct,
   name: optional(string()),
   color: optional(string()),
 });

--- a/src/panels/lovelace/editor/config-elements/hui-distribution-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-distribution-card-editor.ts
@@ -28,8 +28,8 @@ import { entityNameStruct } from "../structs/entity-name-struct";
 import type { EditDetailElementEvent, SubElementEditorConfig } from "../types";
 
 const distributionEntityConfigStruct = object({
-  entity: entityNameStruct,
-  name: optional(string()),
+  entity: string(),
+  name: optional(entityNameStruct),
   color: optional(string()),
 });
 


### PR DESCRIPTION
## Proposed change

Allow to choose color for each entity in distribution card 

<img width="487" height="88" alt="CleanShot 2026-02-05 at 16 18 02" src="https://github.com/user-attachments/assets/a0c5cb71-499f-45c5-9bbf-ddc921da599c" />

```yaml
type: distribution
entities:
  - entity: sensor.floor_heating_thermostat_power
    color: light-blue
    name: Sensor
  - entity: sensor.aqara_wall_outlet_h2_uk_power_2
    color: indigo
    name: Wall outlet
  - entity: sensor.power_consumption
    color: purple
    name: Untracked
```

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
