### PR TITLE
Fix Z-Wave security strategy selection not reflecting in UI

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/add-node/zwave-js-add-node-select-security-strategy.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/add-node/zwave-js-add-node-select-security-strategy.ts
@@ -79,6 +79,7 @@ export class ZWaveJsAddNodeSelectMethod extends LitElement {
     const selectedStrategy = Number(
       event.detail.value.strategy
     ) as InclusionStrategy;
+    this._inclusionStrategy = selectedStrategy;
     fireEvent(this, "z-wave-strategy-selected", {
       strategy: selectedStrategy,
     });


### PR DESCRIPTION
## Proposed change

The radio buttons in the Z-Wave security strategy selection dialog (shown when including a new device with custom security options) did not visually reflect the user's choice. Clicking an option would briefly highlight it and then deselect.

The root cause is that the `_selectStrategy` event handler in `zwave-js-add-node-select-security-strategy` fired the selection event to the parent dialog but never updated its own `_inclusionStrategy` state. Since the `ha-form` data binding reads from `this._inclusionStrategy`, the form data always remained `undefined` and no option appeared selected.

The fix sets `this._inclusionStrategy` before firing the event, so the component re-renders with the correct selection.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

N/A - UI-only change in the Z-Wave JS add node dialog.

## Additional information

- This PR fixes or closes issue: fixes #29443
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [ ] The code change is tested and works locally. - **test still pending**
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.