### PR TITLE
Slightly darken borders of top bar and sidebar for semantic separation

### DIFF
--- a/src/components/ha-drawer.ts
+++ b/src/components/ha-drawer.ts
@@ -87,7 +87,11 @@ export class HaDrawer extends DrawerBase {
       .mdc-drawer {
         position: fixed;
         top: 0;
-        border-color: var(--divider-color, rgba(0, 0, 0, 0.12));
+        border-color: color-mix(
+          in srgb,
+          var(--divider-color, rgba(0, 0, 0, 0.12)),
+          var(--primary-text-color) 15%
+        );
         inset-inline-start: 0 !important;
         inset-inline-end: initial !important;
       }

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -732,7 +732,12 @@ class HaSidebar extends SubscribeMixin(ScrollableFadeMixin(LitElement)) {
             --sidebar-menu-button-text-color,
             var(--primary-text-color)
           );
-          border-bottom: 1px solid var(--divider-color);
+          border-bottom: 1px solid
+            color-mix(
+              in srgb,
+              var(--divider-color),
+              var(--primary-text-color) 15%
+            );
           background-color: var(
             --sidebar-menu-button-background-color,
             inherit

--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -247,7 +247,12 @@ class HassTabsSubpage extends LitElement {
           padding-right: var(--safe-area-inset-right);
           background-color: var(--sidebar-background-color);
           font-weight: var(--ha-font-weight-normal);
-          border-bottom: 1px solid var(--divider-color);
+          border-bottom: 1px solid
+            color-mix(
+              in srgb,
+              var(--divider-color),
+              var(--primary-text-color) 15%
+            );
           box-sizing: border-box;
         }
         :host([narrow]) .toolbar {

--- a/src/resources/theme/color/color.globals.ts
+++ b/src/resources/theme/color/color.globals.ts
@@ -299,7 +299,7 @@ export const colorStyles = css`
     --mdc-theme-error: var(--error-color);
     --app-header-text-color: var(--sidebar-text-color);
     --app-header-background-color: var(--sidebar-background-color);
-    --app-header-border-bottom: 1px solid var(--divider-color);
+    --app-header-border-bottom: 1px solid color-mix(in srgb, var(--divider-color), var(--primary-text-color) 15%);
     --app-theme-color: var(--app-header-background-color);
     --mdc-checkbox-unchecked-color: rgba(var(--rgb-primary-text-color), 0.54);
     --mdc-checkbox-disabled-color: var(--disabled-text-color);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

While passing by my kitchen tablet and seeing it in just the corner of my eye, I've just noticed that the color-accent-less light theme in HA 2026.02 kinda sucks when viewed on such a mediocre screen.

Even on a better screen, there is little contrast (and thus structure) between the top bar and the rest of the UI, but on a worse screen, you just get a wall of white.

This is because it's #ffffff against #fafafa, with a border of #e0e0e0 that is used for _all_ borders including cards.
However, cards do exist in a different space than the nav.

This is not an issue with the default dark theme, as there, the contrast is a lot better.
(#1c1c1c against #111111)

I would argue that it would be semantically correct to have the nav separator in a  darker color than the individual card borders, because of that "exists in a different realm" thing.

Here's how that could look like with this PR:
<img width="906" height="706" alt="image" src="https://github.com/user-attachments/assets/e8bb62eb-bfff-4c9f-affe-2a818da9406b" />

And here is how it looks right now:
<img width="907" height="698" alt="image" src="https://github.com/user-attachments/assets/50c07ad4-f492-452d-8d81-b81d8c30c050" />

The 15% were chosen basically at random. 20% was too dark.
There could also be completely different approaches utilizing its own distinct color var, but this approach was easy.


It is possible and likely that I've missed some things that need changing.
There are a bunch of matches for `border-bottom: 1px solid var(--divider-color);`, but just replacing all of those is probably a bad idea.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (arguably, given that it's an UX thing on the tablet, I guess)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
