### PR TITLE
voice-assistants-expose-assistant-icon: fix tooltip

### DIFF
--- a/src/panels/config/voice-assistants/expose/assistants-table-column.ts
+++ b/src/panels/config/voice-assistants/expose/assistants-table-column.ts
@@ -32,6 +32,7 @@ export function getAssistantsTableColumn<T>(
               supportedEntities[vaId].includes(entry.entity_id);
             const manual = entry.manAssistants?.includes(vaId);
             return getAssistantsTableColumnIcon(
+              entry.entity_id,
               entry.assistants.includes(vaId),
               vaId,
               hass,
@@ -45,6 +46,7 @@ export function getAssistantsTableColumn<T>(
 }
 
 export const getAssistantsTableColumnIcon = (
+  id: string,
   show: boolean,
   vaId: string,
   hass: HomeAssistant,
@@ -57,6 +59,7 @@ export const getAssistantsTableColumnIcon = (
   );
   return show
     ? html`<voice-assistants-expose-assistant-icon
+        .id=${id}
         .assistant=${vaId}
         .hass=${hass}
         .manual=${manual ?? false}

--- a/src/panels/config/voice-assistants/expose/expose-assistant-icon.ts
+++ b/src/panels/config/voice-assistants/expose/expose-assistant-icon.ts
@@ -2,6 +2,7 @@ import { mdiAlertCircle } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
+import { slugify } from "../../../../common/string/slugify";
 import { voiceAssistants } from "../../../../data/expose";
 import type { HomeAssistant } from "../../../../types";
 import "../../../../components/ha-svg-icon";
@@ -23,8 +24,9 @@ export class VoiceAssistantExposeAssistantIcon extends LitElement {
 
   render() {
     if (!this.assistant || !voiceAssistants[this.assistant]) return nothing;
+    const id = slugify(this.id) + "-" + this.assistant;
     return html`
-      <div class="container" id="container">
+      <div class="container" id=${id}>
         <voice-assistant-brand-icon
           style=${styleMap({
             filter: this.manual ? "grayscale(100%)" : undefined,
@@ -43,7 +45,7 @@ export class VoiceAssistantExposeAssistantIcon extends LitElement {
           : nothing}
       </div>
       <ha-tooltip
-        for="container"
+        for=${id}
         placement="left"
         .disabled=${!this.unsupported && !this.manual}
       >


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

For `voice-assistants-expose-assistant-icon`, a tooltip can be shown under some conditions.
But currently the tooltip cannot be shown since it has a wrongly set `for` which cannot be unique in a data table.
After this PR the "for" is = "entity_id + name of assistant" & thus is unique and supposed to be working.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
