### PR TITLE
Fix dupl. id error in water-sankey

### DIFF
--- a/src/panels/lovelace/cards/water/hui-water-sankey-card.ts
+++ b/src/panels/lovelace/cards/water/hui-water-sankey-card.ts
@@ -157,7 +157,7 @@ class HuiWaterSankeyCard
       }
 
       nodes.push({
-        id: source.stat_energy_from,
+        id: `source-${source.stat_energy_from}`,
         label: getStatisticLabel(
           this.hass,
           source.stat_energy_from,
@@ -169,7 +169,7 @@ class HuiWaterSankeyCard
       });
 
       links.push({
-        source: source.stat_energy_from,
+        source: `source-${source.stat_energy_from}`,
         target: "home",
         value,
       });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Fix water-sankey crash when user adds the same stat to water & water-devices, as we have two nodes with duplicate ids.

Arguably they shouldn't be doing this, though maybe there's some possibly convoluted usecase where this could make sense...

Anyway it shouldn't cause a crash & blank card. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #28387 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
