### PR TITLE
Fix ZHA dashboard using disabled and ignored config entries

### DIFF
--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -323,9 +323,9 @@ class ZHAConfigDashboard extends LitElement {
     const configEntries = await getConfigEntries(this.hass, {
       domain: "zha",
     });
-    if (configEntries.length) {
-      this._configEntry = configEntries[0];
-    }
+    this._configEntry = configEntries.find(
+      (entry) => entry.disabled_by === null && entry.source !== "ignore"
+    );
   }
 
   private async _fetchConfiguration(): Promise<void> {


### PR DESCRIPTION
## Proposed change

This fixes an issue where the ZHA dashboard also used ignored discoveries for getting the config entry if none was explicitly provided when accessing the ZHA dashboard via the new Protocols links.
This can happen if you ignored a discovery in the past and later set up ZHA with another adapter, clicking on "Devices" or "Entities" only shows an empty list then.

Before the new Protocols links, this was not an issue, as the config entry parameter was always explicitly provided.

Follow-up to:
- https://github.com/home-assistant/frontend/pull/28448
- https://github.com/home-assistant/frontend/pull/28736

Similar to:
- https://github.com/home-assistant/frontend/pull/29254
- https://github.com/home-assistant/frontend/pull/29078 (though no config entry picker for ZHA)

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/161191
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
