### PR TITLE
Fix history-graph card rendering stale data point on left edge

### DIFF
--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -142,7 +142,7 @@ export const subscribeHistory = (
   );
 };
 
-class HistoryStream {
+export class HistoryStream {
   hass: HomeAssistant;
 
   hoursToShow?: number;
@@ -221,6 +221,7 @@ class HistoryStream {
         // only expire the rest of the history as it ages.
         const lastExpiredState = expiredStates[expiredStates.length - 1];
         lastExpiredState.lu = purgeBeforePythonTime;
+        delete lastExpiredState.lc;
         newHistory[entityId].unshift(lastExpiredState);
       }
     }

--- a/test/data/history.test.ts
+++ b/test/data/history.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, assert, vi } from "vitest";
+import { HistoryStream } from "../../src/data/history";
+import type { HomeAssistant } from "../../src/types";
+
+const mockHass = {} as HomeAssistant;
+
+describe("HistoryStream.processMessage", () => {
+  it("should delete lc from boundary state when pruning expired history", () => {
+    const now = Date.now();
+    const hoursToShow = 1;
+    const stream = new HistoryStream(mockHass, hoursToShow);
+    const purgeBeforePythonTime = (now - 60 * 60 * hoursToShow * 1000) / 1000;
+
+    // Seed combinedHistory with states where lc differs from lu
+    // (simulating a sensor reporting the same value multiple times)
+    const oldLc = purgeBeforePythonTime - 3600; // lc is 1 hour before purge time
+    const oldLu = purgeBeforePythonTime - 10; // lu is 10 seconds before purge time
+    stream.combinedHistory = {
+      "sensor.power": [
+        { s: "500", a: {}, lc: oldLc, lu: oldLu },
+        { s: "500", a: {}, lu: purgeBeforePythonTime + 100 },
+      ],
+    };
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    const result = stream.processMessage({
+      states: {
+        "sensor.power": [{ s: "510", a: {}, lu: purgeBeforePythonTime + 200 }],
+      },
+    });
+
+    vi.useRealTimers();
+
+    const boundaryState = result["sensor.power"][0];
+    // lc should be deleted so chart uses lu instead of stale lc
+    assert.equal(boundaryState.lc, undefined);
+    // lu should be set to approximately purgeBeforePythonTime
+    assert.closeTo(boundaryState.lu, purgeBeforePythonTime, 1);
+    // value should be preserved from the expired state
+    assert.equal(boundaryState.s, "500");
+  });
+
+  it("should handle boundary state without lc correctly", () => {
+    const now = Date.now();
+    const hoursToShow = 1;
+    const stream = new HistoryStream(mockHass, hoursToShow);
+    const purgeBeforePythonTime = (now - 60 * 60 * hoursToShow * 1000) / 1000;
+
+    // State without lc (lc equals lu, so lc is omitted)
+    stream.combinedHistory = {
+      "sensor.power": [
+        { s: "500", a: {}, lu: purgeBeforePythonTime - 10 },
+        { s: "510", a: {}, lu: purgeBeforePythonTime + 100 },
+      ],
+    };
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    const result = stream.processMessage({
+      states: {
+        "sensor.power": [{ s: "520", a: {}, lu: purgeBeforePythonTime + 200 }],
+      },
+    });
+
+    vi.useRealTimers();
+
+    const boundaryState = result["sensor.power"][0];
+    assert.equal(boundaryState.lc, undefined);
+    assert.closeTo(boundaryState.lu, purgeBeforePythonTime, 1);
+    assert.equal(boundaryState.s, "500");
+  });
+
+  it("should not modify states when none are expired", () => {
+    const now = Date.now();
+    const hoursToShow = 1;
+    const stream = new HistoryStream(mockHass, hoursToShow);
+    const purgeBeforePythonTime = (now - 60 * 60 * hoursToShow * 1000) / 1000;
+
+    // All states are within the time window
+    stream.combinedHistory = {
+      "sensor.power": [
+        {
+          s: "500",
+          a: {},
+          lc: purgeBeforePythonTime + 50,
+          lu: purgeBeforePythonTime + 100,
+        },
+      ],
+    };
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    const result = stream.processMessage({
+      states: {
+        "sensor.power": [{ s: "510", a: {}, lu: purgeBeforePythonTime + 200 }],
+      },
+    });
+
+    vi.useRealTimers();
+
+    // First state should retain its original lc since it wasn't expired
+    const firstState = result["sensor.power"][0];
+    assert.equal(firstState.lc, purgeBeforePythonTime + 50);
+    assert.equal(firstState.lu, purgeBeforePythonTime + 100);
+  });
+});


### PR DESCRIPTION
## Proposed change

When `HistoryStream.processMessage()` prunes expired history, it preserves the last expired state as a boundary marker and updates its `lu` (last_updated) timestamp to `purgeBeforePythonTime`. However, it does not update or remove the `lc` (last_changed) field. Downstream chart processing (`processLineChartEntities` and `processTimelineEntity`) preferentially uses `lc` over `lu` for data point timestamps:

```typescript
last_changed: (state.lc ? state.lc : state.lu) * 1000
```

When `lc` is present (because a sensor reported the same value consecutively, meaning `lc` reflects when the value *last actually changed* which could be arbitrarily far in the past), the chart plots the boundary point at the original stale `lc` time — far to the left of the visible window, creating the "weird outlier line."

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml
```

## Additional information

- This PR fixes or closes issue: fixes #28654
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.