### PR TITLE
Add guard for failed JSON parsing of localStorage entries

### DIFF
--- a/src/util/ha-pref-storage.ts
+++ b/src/util/ha-pref-storage.ts
@@ -42,8 +42,13 @@ export function getState(): Partial<StoredHomeAssistant> {
       try {
         value = JSON.parse(storageItem);
       } catch (_err: any) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `Failed to json parse localStorage key: ${key}. Key value: ${storageItem}`,
+          _err
+        );
+        window.localStorage.removeItem(key);
         if (key === "selectedTheme") {
-          window.localStorage.removeItem(key);
           state[key] = { theme: "" };
         }
         return;

--- a/src/util/ha-pref-storage.ts
+++ b/src/util/ha-pref-storage.ts
@@ -38,7 +38,16 @@ export function getState(): Partial<StoredHomeAssistant> {
   STORED_STATE.forEach((key) => {
     const storageItem = window.localStorage.getItem(key);
     if (storageItem !== null) {
-      let value = JSON.parse(storageItem);
+      let value;
+      try {
+        value = JSON.parse(storageItem);
+      } catch (_err: any) {
+        if (key === "selectedTheme") {
+          window.localStorage.removeItem(key);
+          state[key] = { theme: "" };
+        }
+        return;
+      }
       // selectedTheme went from string to object on 20200718
       if (key === "selectedTheme" && typeof value === "string") {
         value = { theme: value };


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This change makes makes settings resilient to invalid `selectedTheme` data stored in browser `localStorage`, which previously caused startup to hang due to an uncaught JSON parse error (as reported by [JK123456789](https://discordapp.com/channels/330944238910963714/554842238073700352/1469237144148246549) in the Discord).
The malformed data is now safely handled by clearing the bad entry and falling back to the default theme, while continuing to persist valid theme settings locally to avoid flashes on load.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
