### PR TITLE
hui-graph-header-footer: add own action handler

### DIFF
--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -123,9 +123,7 @@ export class HuiGraphHeaderFooter
     }
 
     return html`
-      <div class="graph-container" @click=${this._handleClick}>
-        <hui-graph-base .coordinates=${this._coordinates}></hui-graph-base>
-      </div>
+      <hui-graph-base .coordinates=${this._coordinates}></hui-graph-base>
     `;
   }
 
@@ -137,6 +135,7 @@ export class HuiGraphHeaderFooter
 
   public connectedCallback() {
     super.connectedCallback();
+    this.addEventListener("click", this._handleClick);
     if (this.hasUpdated && this._config) {
       this._subscribeHistory();
     }
@@ -233,6 +232,7 @@ export class HuiGraphHeaderFooter
   static styles = css`
     :host {
       display: block;
+      cursor: pointer;
     }
     ha-spinner {
       position: absolute;
@@ -243,9 +243,6 @@ export class HuiGraphHeaderFooter
       justify-content: center;
       position: relative;
       padding-bottom: 20%;
-    }
-    .graph-container {
-      cursor: pointer;
     }
     .info {
       position: absolute;

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -3,6 +3,7 @@ import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
+import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import "../../../components/ha-spinner";
 import { subscribeHistoryStatesTimeWindow } from "../../../data/history";
@@ -122,8 +123,16 @@ export class HuiGraphHeaderFooter
     }
 
     return html`
-      <hui-graph-base .coordinates=${this._coordinates}></hui-graph-base>
+      <div class="graph-container" @click=${this._handleClick}>
+        <hui-graph-base .coordinates=${this._coordinates}></hui-graph-base>
+      </div>
     `;
+  }
+
+  private _handleClick(): void {
+    fireEvent(this, "hass-more-info", {
+      entityId: this._config?.entity ?? null,
+    });
   }
 
   public connectedCallback() {
@@ -234,6 +243,9 @@ export class HuiGraphHeaderFooter
       justify-content: center;
       position: relative;
       padding-bottom: 20%;
+    }
+    .graph-container {
+      cursor: pointer;
     }
     .info {
       position: absolute;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


The `hui-graph-header-footer` does not have own action handler.
Because of that – here is how a tap is processed for a graph footer:
1. When a footer is added into Entities card – more-info is not shown for a “graph entity” - UNEXPECTED.
2. When a footer is added into Entity card:
a. Before 2026.2 – more-info was shown for the “main entity” of the Entity card - UNEXPECTED.
b. Since 2026.2 – more-info is not shown - UNEXPECTED.
3. For the Sensor card  - which is internally Entity card where “main entity” & “graph entity” are same:
a. Before 2026.2 – more-info was shown for the “main/graph entity” of the Entity card - OK.
b. Since 2026.2 – more-info is not shown - WRONG.

In 2026.2 a processing was changed in https://github.com/home-assistant/frontend/pull/28949.

After this current PR - `hui-graph-header-footer` has own action handler:
1. When a footer is added into Entities card – more-info is shown for a “graph entity” - OK.
2. When a footer is added into Entity card - more-info is shown for a “graph entity” - OK.
3. For the Sensor card  - more-info is shown for the “main/graph entity” - OK.



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/29463
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
