### PR TITLE
Use unique SVG mask IDs in graph base to fix rendering on Samsung WebView

### DIFF
--- a/src/panels/lovelace/components/hui-graph-base.ts
+++ b/src/panels/lovelace/components/hui-graph-base.ts
@@ -13,6 +13,8 @@ export class HuiGraphBase extends LitElement {
 
   @state() private _path?: string;
 
+  private _uniqueId = `graph-${Math.random().toString(36).substring(2, 9)}`;
+
   protected render(): TemplateResult {
     const width = this.clientWidth || 500;
     const height = this.clientHeight || width / 5;
@@ -21,15 +23,15 @@ export class HuiGraphBase extends LitElement {
       ${this._path
         ? svg`<svg width="100%" height="100%" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">
           <g>
-            <mask id="fill">
+            <mask id="${this._uniqueId}-fill">
               <path
                 class='fill'
                 fill='white'
                 d="${this._path} L ${width}, ${yAxisOrigin} L 0, ${yAxisOrigin} z"
               />
             </mask>
-            <rect height="100%" width="100%" id="fill-rect" fill="var(--accent-color)" mask="url(#fill)"></rect>
-            <mask id="line">
+            <rect height="100%" width="100%" id="${this._uniqueId}-fill-rect" fill="var(--accent-color)" mask="url(#${this._uniqueId}-fill)"></rect>
+            <mask id="${this._uniqueId}-line">
               <path
                 vector-effect="non-scaling-stroke"
                 class='line'
@@ -41,7 +43,7 @@ export class HuiGraphBase extends LitElement {
                 d=${this._path}
               ></path>
             </mask>
-            <rect height="100%" width="100%" id="rect" fill="var(--accent-color)" mask="url(#line)"></rect>
+            <rect height="100%" width="100%" id="${this._uniqueId}-rect" fill="var(--accent-color)" mask="url(#${this._uniqueId}-line)"></rect>
           </g>
         </svg>`
         : svg`<svg width="100%" height="100%" viewBox="0 0 ${width} ${height}"></svg>`}

--- a/src/panels/lovelace/components/hui-graph-base.ts
+++ b/src/panels/lovelace/components/hui-graph-base.ts
@@ -30,7 +30,7 @@ export class HuiGraphBase extends LitElement {
                 d="${this._path} L ${width}, ${yAxisOrigin} L 0, ${yAxisOrigin} z"
               />
             </mask>
-            <rect height="100%" width="100%" id="${this._uniqueId}-fill-rect" fill="var(--accent-color)" mask="url(#${this._uniqueId}-fill)"></rect>
+            <rect height="100%" width="100%" fill="var(--accent-color)" mask="url(#${this._uniqueId}-fill)"></rect>
             <mask id="${this._uniqueId}-line">
               <path
                 vector-effect="non-scaling-stroke"
@@ -43,7 +43,7 @@ export class HuiGraphBase extends LitElement {
                 d=${this._path}
               ></path>
             </mask>
-            <rect height="100%" width="100%" id="${this._uniqueId}-rect" fill="var(--accent-color)" mask="url(#${this._uniqueId}-line)"></rect>
+            <rect height="100%" width="100%" fill="var(--accent-color)" mask="url(#${this._uniqueId}-line)"></rect>
           </g>
         </svg>`
         : svg`<svg width="100%" height="100%" viewBox="0 0 ${width} ${height}"></svg>`}


### PR DESCRIPTION

## Proposed change

The `hui-graph-base` component used hardcoded SVG mask IDs (`fill`, `line`) shared across all instances on a dashboard. On Samsung WebView (S25, Fold7, etc.), SVG `url(#id)` fragment references leak across Shadow DOM boundaries, causing one sensor card's graph to display another card's data.

This generates a unique ID prefix per component instance to prevent SVG mask ID collisions. This follows the existing pattern used in `hui-history-graph-card.ts`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml
type: sensor
entity: sensor.temperature
graph: line
```

## Additional information

- This PR fixes or closes issue: fixes #26065
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.