### PR TITLE
Make storage charts consistent with lifetime chart

### DIFF
--- a/src/panels/config/storage/storage-breakdown-chart.ts
+++ b/src/panels/config/storage/storage-breakdown-chart.ts
@@ -55,17 +55,16 @@ export class StorageBreakdownChart extends LitElement {
           <span class="heading">${heading}</span>
           <span class="description">${description}</span>
         </div>
-        ${hasChildren
-          ? html`<ha-icon-button
-              .path=${this._chartType === "sunburst"
-                ? mdiViewArray
-                : mdiChartDonutVariant}
-              .label=${this.hass.localize(
-                "ui.panel.config.storage.change_chart_type"
-              )}
-              @click=${this._handleChartTypeChange}
-            ></ha-icon-button>`
-          : nothing}
+        <ha-icon-button
+          .path=${this._chartType === "sunburst"
+            ? mdiViewArray
+            : mdiChartDonutVariant}
+          .label=${this.hass.localize(
+            "ui.panel.config.storage.change_chart_type"
+          )}
+          .disabled=${!hasChildren}
+          @click=${this._handleChartTypeChange}
+        ></ha-icon-button>
       </div>
 
       <div class="chart-container ${this._chartType}">
@@ -213,26 +212,24 @@ export class StorageBreakdownChart extends LitElement {
   static styles = css`
     .header {
       display: flex;
-      align-items: flex-start;
-      justify-content: space-between;
-      margin-bottom: var(--ha-space-2);
+      align-items: flex-end;
+      gap: var(--ha-space-2);
     }
 
     .heading-text {
       display: flex;
-      flex-direction: column;
-      gap: var(--ha-space-1);
+      flex: 1;
     }
 
     .heading {
-      font-weight: 500;
-      font-size: var(--ha-font-size-m);
       color: var(--primary-text-color);
+      line-height: var(--ha-line-height-expanded);
+      margin-right: 8px;
     }
 
     .description {
-      font-size: var(--ha-font-size-s);
       color: var(--secondary-text-color);
+      line-height: var(--ha-line-height-expanded);
     }
 
     ha-icon-button {

--- a/src/panels/config/storage/storage-breakdown-chart.ts
+++ b/src/panels/config/storage/storage-breakdown-chart.ts
@@ -224,7 +224,7 @@ export class StorageBreakdownChart extends LitElement {
     .heading {
       color: var(--primary-text-color);
       line-height: var(--ha-line-height-expanded);
-      margin-right: 8px;
+      margin-right: var(--ha-space-2);
     }
 
     .description {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
The storage charts are using different font styles, compared to the default font style like the lifetime chart. This PR is making it consistent.

https://github.com/user-attachments/assets/cd421be2-70aa-4ead-9a6a-4ae198125626




Build with Claude.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
