### PR TITLE
Normalize SI unit prefixes in distribution card proportions

### DIFF
--- a/src/common/number/normalize-by-si-prefix.ts
+++ b/src/common/number/normalize-by-si-prefix.ts
@@ -1,0 +1,28 @@
+const SI_PREFIX_MULTIPLIERS: Record<string, number> = {
+  T: 1e12,
+  G: 1e9,
+  M: 1e6,
+  k: 1e3,
+  m: 1e-3,
+  "\u00B5": 1e-6, // µ (micro sign)
+  "\u03BC": 1e-6, // μ (greek small letter mu)
+};
+
+/**
+ * Normalize a numeric value by detecting SI unit prefixes (T, G, M, k, m, µ).
+ * Only applies when the unit is longer than 1 character and starts with a
+ * recognized prefix, avoiding false positives on standalone units like "m" (meters).
+ */
+export const normalizeValueBySIPrefix = (
+  value: number,
+  unit: string | undefined
+): number => {
+  if (!unit || unit.length <= 1) {
+    return value;
+  }
+  const prefix = unit[0];
+  if (prefix in SI_PREFIX_MULTIPLIERS) {
+    return value * SI_PREFIX_MULTIPLIERS[prefix];
+  }
+  return value;
+};

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -14,6 +14,7 @@ import {
 import type { Collection, HassEntity } from "home-assistant-js-websocket";
 import { getCollection } from "home-assistant-js-websocket";
 import memoizeOne from "memoize-one";
+import { normalizeValueBySIPrefix } from "../common/number/normalize-by-si-prefix";
 import {
   calcDate,
   calcDateProperty,
@@ -1431,26 +1432,10 @@ export const getPowerFromState = (stateObj: HassEntity): number | undefined => {
     return undefined;
   }
 
-  // Normalize to watts (W) based on unit of measurement (case-sensitive)
-  // Supported units: GW, kW, MW, mW, TW, W
-  const unit = stateObj.attributes.unit_of_measurement;
-  switch (unit) {
-    case "W":
-      return value;
-    case "kW":
-      return value * 1000;
-    case "mW":
-      return value / 1000;
-    case "MW":
-      return value * 1_000_000;
-    case "GW":
-      return value * 1_000_000_000;
-    case "TW":
-      return value * 1_000_000_000_000;
-    default:
-      // Assume value is in watts (W) if no unit or an unsupported unit is provided
-      return value;
-  }
+  return normalizeValueBySIPrefix(
+    value,
+    stateObj.attributes.unit_of_measurement
+  );
 };
 
 /**

--- a/src/panels/lovelace/cards/hui-distribution-card.ts
+++ b/src/panels/lovelace/cards/hui-distribution-card.ts
@@ -204,6 +204,26 @@ export class HuiDistributionCard
     }
   );
 
+  private _normalizeValue(value: number, unit: string | undefined): number {
+    if (!unit || unit.length <= 1) {
+      return value;
+    }
+    const prefixMultipliers: Record<string, number> = {
+      T: 1e12,
+      G: 1e9,
+      M: 1e6,
+      k: 1e3,
+      m: 1e-3,
+      "\u00B5": 1e-6, // µ (micro sign)
+      "\u03BC": 1e-6, // μ (greek small letter mu)
+    };
+    const prefix = unit[0];
+    if (prefix in prefixMultipliers) {
+      return value * prefixMultipliers[prefix];
+    }
+    return value;
+  }
+
   private _convertToSegments(): {
     segments: Segment[];
     hiddenIndices: number[];
@@ -230,8 +250,12 @@ export class HuiDistributionCard
       const stateObj = this.hass!.states[entity.entity];
       if (!stateObj) return;
 
-      const value = Number(stateObj.state);
-      if (value <= 0 || isNaN(value)) return;
+      const rawValue = Number(stateObj.state);
+      if (rawValue <= 0 || isNaN(rawValue)) return;
+      const value = this._normalizeValue(
+        rawValue,
+        stateObj.attributes.unit_of_measurement
+      );
 
       const color = entity.color
         ? computeCssColor(entity.color)

--- a/src/panels/lovelace/cards/hui-distribution-card.ts
+++ b/src/panels/lovelace/cards/hui-distribution-card.ts
@@ -9,6 +9,7 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import { getGraphColorByIndex } from "../../../common/color/colors";
 import { computeCssColor } from "../../../common/color/compute-color";
 import { computeDomain } from "../../../common/entity/compute_domain";
+import { normalizeValueBySIPrefix } from "../../../common/number/normalize-by-si-prefix";
 import { MobileAwareMixin } from "../../../mixins/mobile-aware-mixin";
 import type { EntityNameItem } from "../../../common/entity/compute_entity_name_display";
 import { computeLovelaceEntityName } from "../common/entity/compute-lovelace-entity-name";
@@ -204,26 +205,6 @@ export class HuiDistributionCard
     }
   );
 
-  private _normalizeValue(value: number, unit: string | undefined): number {
-    if (!unit || unit.length <= 1) {
-      return value;
-    }
-    const prefixMultipliers: Record<string, number> = {
-      T: 1e12,
-      G: 1e9,
-      M: 1e6,
-      k: 1e3,
-      m: 1e-3,
-      "\u00B5": 1e-6, // µ (micro sign)
-      "\u03BC": 1e-6, // μ (greek small letter mu)
-    };
-    const prefix = unit[0];
-    if (prefix in prefixMultipliers) {
-      return value * prefixMultipliers[prefix];
-    }
-    return value;
-  }
-
   private _convertToSegments(): {
     segments: Segment[];
     hiddenIndices: number[];
@@ -252,7 +233,7 @@ export class HuiDistributionCard
 
       const rawValue = Number(stateObj.state);
       if (rawValue <= 0 || isNaN(rawValue)) return;
-      const value = this._normalizeValue(
+      const value = normalizeValueBySIPrefix(
         rawValue,
         stateObj.attributes.unit_of_measurement
       );

--- a/test/common/number/normalize-by-si-prefix.test.ts
+++ b/test/common/number/normalize-by-si-prefix.test.ts
@@ -1,0 +1,54 @@
+import { assert, describe, it } from "vitest";
+
+import { normalizeValueBySIPrefix } from "../../../src/common/number/normalize-by-si-prefix";
+
+describe("normalizeValueBySIPrefix", () => {
+  it("Applies kilo prefix (k)", () => {
+    assert.equal(normalizeValueBySIPrefix(11, "kW"), 11000);
+    assert.equal(normalizeValueBySIPrefix(2.5, "kWh"), 2500);
+  });
+
+  it("Applies mega prefix (M)", () => {
+    assert.equal(normalizeValueBySIPrefix(3, "MW"), 3_000_000);
+  });
+
+  it("Applies giga prefix (G)", () => {
+    assert.equal(normalizeValueBySIPrefix(1, "GW"), 1_000_000_000);
+  });
+
+  it("Applies tera prefix (T)", () => {
+    assert.equal(normalizeValueBySIPrefix(2, "TW"), 2_000_000_000_000);
+  });
+
+  it("Applies milli prefix (m)", () => {
+    assert.equal(normalizeValueBySIPrefix(500, "mW"), 0.5);
+  });
+
+  it("Applies micro prefix (µ micro sign U+00B5)", () => {
+    assert.equal(normalizeValueBySIPrefix(1000, "\u00B5W"), 0.001);
+  });
+
+  it("Applies micro prefix (μ greek mu U+03BC)", () => {
+    assert.equal(normalizeValueBySIPrefix(1000, "\u03BCW"), 0.001);
+  });
+
+  it("Returns value unchanged for single-char units", () => {
+    assert.equal(normalizeValueBySIPrefix(100, "W"), 100);
+    assert.equal(normalizeValueBySIPrefix(5, "m"), 5);
+    assert.equal(normalizeValueBySIPrefix(22, "K"), 22);
+  });
+
+  it("Returns value unchanged for undefined unit", () => {
+    assert.equal(normalizeValueBySIPrefix(42, undefined), 42);
+  });
+
+  it("Returns value unchanged for unrecognized prefixes", () => {
+    assert.equal(normalizeValueBySIPrefix(20, "°C"), 20);
+    assert.equal(normalizeValueBySIPrefix(50, "dB"), 50);
+    assert.equal(normalizeValueBySIPrefix(1013, "hPa"), 1013);
+  });
+
+  it("Returns value unchanged for empty string", () => {
+    assert.equal(normalizeValueBySIPrefix(10, ""), 10);
+  });
+});


### PR DESCRIPTION
## Proposed change

The distribution card compares raw numeric state values without considering SI unit prefixes. When entities report values with different prefixes (e.g., one in `W` and another in `kW`), the bar proportions are completely wrong — 11 kW appears as ~10% of the bar next to 100 W instead of dominating at 11,000 W.

This adds a normalization step that detects common SI prefixes (`T`, `G`, `M`, `k`, `m`, `µ`) and applies the appropriate multiplier before values are used for proportion calculation. The displayed values remain unchanged (still formatted via `formatEntityState`).

Energy dashboard has the same logic

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml
```

## Additional information

- This PR fixes or closes issue: fixes #29509
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.