### PR TITLE
Hide actions in attributes view

### DIFF
--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -96,7 +96,6 @@ interface ChildView {
   viewTitle?: string;
   viewImport?: () => Promise<unknown>;
   viewParams?: any;
-  keepHeader?: boolean;
 }
 
 declare global {
@@ -350,7 +349,6 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
     this._childView = {
       viewTag: "ha-more-info-attributes",
       viewParams: { entityId: this._entityId },
-      keepHeader: true,
     };
   }
 
@@ -408,8 +406,7 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
 
     const isDefaultView = this._currView === DEFAULT_VIEW && !this._childView;
     const isSpecificInitialView =
-      this._initialView !== DEFAULT_VIEW &&
-      (!this._childView || this._childView.keepHeader);
+      this._initialView !== DEFAULT_VIEW && !this._childView;
     const showCloseIcon =
       (isDefaultView &&
         this._parentEntityIds.length === 0 &&
@@ -448,12 +445,7 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
     const breadcrumb = [areaName, deviceName, entityName].filter(
       (v): v is string => Boolean(v)
     );
-    const title =
-      (this._childView && !this._childView.keepHeader
-        ? this._childView.viewTitle
-        : undefined) ||
-      breadcrumb.pop() ||
-      entityId;
+    const title = this._childView?.viewTitle || breadcrumb.pop() || entityId;
 
     const isRTL = computeRTL(this.hass);
 

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -406,9 +406,7 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
     const deviceType =
       (deviceId && this.hass.devices[deviceId].entry_type) || "device";
 
-    const isDefaultView =
-      this._currView === DEFAULT_VIEW &&
-      (!this._childView || this._childView.keepHeader);
+    const isDefaultView = this._currView === DEFAULT_VIEW && !this._childView;
     const isSpecificInitialView =
       this._initialView !== DEFAULT_VIEW &&
       (!this._childView || this._childView.keepHeader);


### PR DESCRIPTION
## Proposed change

This PR simplifies the `isDefaultView` condition in the more-info dialog to properly hide actions when child views (like attributes view) are displayed. With 2026.2 and the changes in how we display attributes, the previous logic was misaligned with the rest of the sub-views we have.

The issue was that actions were still showing in the attributes view when they should be hidden, which is inconsistent with other child views in the more-info dialog.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

N/A - UI bugfix only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: 
- Link to documentation pull request: N/A

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io