### PR TITLE
Move automation help icons from sections to dialogs

### DIFF
--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -116,8 +116,8 @@ import {
 import type { HassDialog } from "../../../dialogs/make-dialog-manager";
 import { KeyboardShortcutMixin } from "../../../mixins/keyboard-shortcut-mixin";
 import type { HomeAssistant, ValueChangedEvent } from "../../../types";
-import { isMac } from "../../../util/is_mac";
 import { documentationUrl } from "../../../util/documentation-url";
+import { isMac } from "../../../util/is_mac";
 import { showToast } from "../../../util/toast";
 import "./add-automation-element/ha-automation-add-from-target";
 import "./add-automation-element/ha-automation-add-items";
@@ -747,20 +747,29 @@ class DialogAddAutomationElement
   }
 
   private _renderHeader() {
+    const docUrl = this._getDocumentationUrl(this._params!.type);
+
     return html`
       <ha-dialog-header subtitle-position="above">
         <span slot="title">${this._getDialogTitle()}</span>
 
         ${this._renderDialogSubtitle()}
         ${!this._narrow || (!this._selectedGroup && !this._selectedTarget)
-          ? html`<ha-icon-button
-              slot="actionItems"
-              .path=${mdiHelpCircle}
-              .label=${this.hass.localize(
-                `ui.panel.config.automation.editor.${this._params!.type}s.learn_more`
-              )}
-              @click=${this._openDocumentation}
-            ></ha-icon-button>`
+          ? html`
+              <a
+                slot="actionItems"
+                href=${docUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <ha-icon-button
+                  .path=${mdiHelpCircle}
+                  .label=${this.hass.localize(
+                    `ui.panel.config.automation.editor.${this._params!.type}s.learn_more`
+                  )}
+                ></ha-icon-button>
+              </a>
+            `
           : nothing}
         ${this._narrow && (this._selectedGroup || this._selectedTarget)
           ? html`<ha-icon-button-prev
@@ -1732,15 +1741,17 @@ class DialogAddAutomationElement
     mainWindow.history.back();
   }
 
-  private _openDocumentation = () => {
-    const docUrl =
-      this._params!.type === "trigger"
-        ? "/docs/automation/trigger/"
-        : this._params!.type === "condition"
-          ? "/docs/automation/condition/"
-          : "/docs/automation/action/";
-    window.open(documentationUrl(this.hass, docUrl), "_blank", "noreferrer");
-  };
+  private _getDocumentationUrl = memoizeOne(
+    (type: "trigger" | "condition" | "action") =>
+      documentationUrl(
+        this.hass,
+        type === "trigger"
+          ? "/docs/automation/trigger/"
+          : type === "condition"
+            ? "/docs/automation/condition/"
+            : "/docs/automation/action/"
+      )
+  );
 
   private _groupSelected(ev) {
     const group = ev.currentTarget;
@@ -2089,7 +2100,7 @@ class DialogAddAutomationElement
           --ha-dialog-max-height: var(--ha-dialog-min-height);
         }
 
-        ha-wa-dialog ha-icon-button[slot="actionItems"] {
+        ha-wa-dialog a[slot="actionItems"] {
           color: var(--secondary-text-color);
         }
 

--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -4,6 +4,7 @@ import {
   mdiAppleKeyboardCommand,
   mdiClose,
   mdiContentPaste,
+  mdiHelpCircle,
   mdiPlus,
 } from "@mdi/js";
 import type {
@@ -116,6 +117,7 @@ import type { HassDialog } from "../../../dialogs/make-dialog-manager";
 import { KeyboardShortcutMixin } from "../../../mixins/keyboard-shortcut-mixin";
 import type { HomeAssistant, ValueChangedEvent } from "../../../types";
 import { isMac } from "../../../util/is_mac";
+import { documentationUrl } from "../../../util/documentation-url";
 import { showToast } from "../../../util/toast";
 import "./add-automation-element/ha-automation-add-from-target";
 import "./add-automation-element/ha-automation-add-items";
@@ -750,6 +752,16 @@ class DialogAddAutomationElement
         <span slot="title">${this._getDialogTitle()}</span>
 
         ${this._renderDialogSubtitle()}
+        ${!this._narrow || (!this._selectedGroup && !this._selectedTarget)
+          ? html`<ha-icon-button
+              slot="actionItems"
+              .path=${mdiHelpCircle}
+              .label=${this.hass.localize(
+                `ui.panel.config.automation.editor.${this._params!.type}s.learn_more`
+              )}
+              @click=${this._openDocumentation}
+            ></ha-icon-button>`
+          : nothing}
         ${this._narrow && (this._selectedGroup || this._selectedTarget)
           ? html`<ha-icon-button-prev
               slot="navigationIcon"
@@ -1720,6 +1732,16 @@ class DialogAddAutomationElement
     mainWindow.history.back();
   }
 
+  private _openDocumentation = () => {
+    const docUrl =
+      this._params!.type === "trigger"
+        ? "/docs/automation/trigger/"
+        : this._params!.type === "condition"
+          ? "/docs/automation/condition/"
+          : "/docs/automation/action/";
+    window.open(documentationUrl(this.hass, docUrl), "_blank", "noreferrer");
+  };
+
   private _groupSelected(ev) {
     const group = ev.currentTarget;
     if (this._selectedGroup === group.value) {
@@ -2065,6 +2087,10 @@ class DialogAddAutomationElement
             )
           );
           --ha-dialog-max-height: var(--ha-dialog-min-height);
+        }
+
+        ha-wa-dialog ha-icon-button[slot="actionItems"] {
+          color: var(--secondary-text-color);
         }
 
         search-input {

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -1,5 +1,5 @@
 import { ContextProvider } from "@lit/context";
-import { mdiContentSave, mdiHelpCircle } from "@mdi/js";
+import { mdiContentSave } from "@mdi/js";
 import type { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
 import { load } from "js-yaml";
 import type { CSSResultGroup, PropertyValues } from "lit";
@@ -55,7 +55,6 @@ import { configEntriesContext } from "../../../data/context";
 import { getActionType, type Action } from "../../../data/script";
 import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import type { HomeAssistant, ValueChangedEvent } from "../../../types";
-import { documentationUrl } from "../../../util/documentation-url";
 import { showToast } from "../../../util/toast";
 import "./action/ha-automation-action";
 import type HaAutomationAction from "./action/ha-automation-action";
@@ -168,18 +167,6 @@ export class HaManualAutomationEditor extends SubscribeMixin(LitElement) {
             "ui.panel.config.automation.editor.triggers.header"
           )}
         </h2>
-        <a
-          href=${documentationUrl(this.hass, "/docs/automation/trigger/")}
-          target="_blank"
-          rel="noreferrer"
-        >
-          <ha-icon-button
-            .path=${mdiHelpCircle}
-            .label=${this.hass.localize(
-              "ui.panel.config.automation.editor.triggers.learn_more"
-            )}
-          ></ha-icon-button>
-        </a>
       </div>
       ${!ensureArray(this.config.triggers)?.length
         ? html`<p>
@@ -214,18 +201,6 @@ export class HaManualAutomationEditor extends SubscribeMixin(LitElement) {
             >(${this.hass.localize("ui.common.optional")})</span
           >
         </h2>
-        <a
-          href=${documentationUrl(this.hass, "/docs/automation/condition/")}
-          target="_blank"
-          rel="noreferrer"
-        >
-          <ha-icon-button
-            .path=${mdiHelpCircle}
-            .label=${this.hass.localize(
-              "ui.panel.config.automation.editor.conditions.learn_more"
-            )}
-          ></ha-icon-button>
-        </a>
       </div>
       ${!ensureArray(this.config.conditions)?.length
         ? html`<p>
@@ -258,20 +233,6 @@ export class HaManualAutomationEditor extends SubscribeMixin(LitElement) {
             "ui.panel.config.automation.editor.actions.header"
           )}
         </h2>
-        <div>
-          <a
-            href=${documentationUrl(this.hass, "/docs/automation/action/")}
-            target="_blank"
-            rel="noreferrer"
-          >
-            <ha-icon-button
-              .path=${mdiHelpCircle}
-              .label=${this.hass.localize(
-                "ui.panel.config.automation.editor.actions.learn_more"
-              )}
-            ></ha-icon-button>
-          </a>
-        </div>
       </div>
       ${!ensureArray(this.config.actions)?.length
         ? html`<p>


### PR DESCRIPTION
## Proposed change

Move the documentation help icons from the "When", "If", and "Then do" sections in the automation editor to the dialogs that open when adding triggers, conditions, or actions.

This provides better contextual help by showing the documentation link when users are actively selecting automation elements, rather than cluttering the main editor view.

<img width="1847" height="1226" alt="CleanShot 2026-02-12 at 09 04 30" src="https://github.com/user-attachments/assets/534ce898-cc92-4b7a-a7d5-6573beb1b605" />


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- **Changes:**
  - Remove help icons from trigger, condition, and action section headers in `manual-automation-editor.ts`
  - Add help icon to dialog header in `add-automation-element-dialog.ts`
  - Icon opens appropriate documentation based on dialog type (trigger/condition/action)
  - Styled with secondary text color to match other dialog action items

- **Screenshots:**
  - Before: Help icons visible in main editor sections
  - After: Help icon appears in the dialog when adding elements

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works (if applicable).

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with entities (areas, devices, helpers, etc.):

- [x] Manual tests have been performed to verify the change works as intended