### PR TITLE
Automation editor: Add continue on error UI for actions

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -629,6 +629,7 @@ export interface ActionSidebarConfig extends BaseSidebarConfig {
   save: (value: Action) => void;
   rename: () => void;
   disable: () => void;
+  continueOnError: () => void;
   duplicate: () => void;
   cut: () => void;
   copy: () => void;

--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -6,6 +6,8 @@ import {
   mdiArrowDown,
   mdiArrowRightThin,
   mdiArrowUp,
+  mdiCheckboxBlankOutline,
+  mdiCheckboxOutline,
   mdiContentCopy,
   mdiContentCut,
   mdiDelete,
@@ -15,7 +17,6 @@ import {
   mdiPlaylistEdit,
   mdiPlusCircleMultipleOutline,
   mdiRenameBox,
-  mdiStopCircle,
   mdiStopCircleOutline,
 } from "@mdi/js";
 import deepClone from "deep-clone-simple";
@@ -430,12 +431,12 @@ export default class HaAutomationActionRow extends LitElement {
                 <ha-svg-icon
                   slot="icon"
                   .path=${(this.action as NonConditionAction).continue_on_error
-                    ? mdiStopCircle
-                    : mdiAlertCircleCheck}
+                    ? mdiCheckboxOutline
+                    : mdiCheckboxBlankOutline}
                 ></ha-svg-icon>
                 ${this._renderOverflowLabel(
                   this.hass.localize(
-                    `ui.panel.config.automation.editor.actions.${(this.action as NonConditionAction).continue_on_error === true ? "stop" : "continue"}_on_error`
+                    `ui.panel.config.automation.editor.actions.continue_on_error`
                   )
                 )}
               </ha-dropdown-item>

--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -4,6 +4,7 @@ import {
   mdiAlertCircleCheck,
   mdiAppleKeyboardCommand,
   mdiArrowDown,
+  mdiArrowRightThin,
   mdiArrowUp,
   mdiContentCopy,
   mdiContentCut,
@@ -14,13 +15,14 @@ import {
   mdiPlaylistEdit,
   mdiPlusCircleMultipleOutline,
   mdiRenameBox,
+  mdiStopCircle,
   mdiStopCircleOutline,
 } from "@mdi/js";
 import deepClone from "deep-clone-simple";
 import type { HassServiceTarget } from "home-assistant-js-websocket";
 import { dump } from "js-yaml";
 import type { PropertyValues, TemplateResult } from "lit";
-import { LitElement, html, nothing } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { ensureArray } from "../../../../common/array/ensure-array";
@@ -35,6 +37,7 @@ import "../../../../components/ha-automation-row";
 import type { HaAutomationRow } from "../../../../components/ha-automation-row";
 import "../../../../components/ha-card";
 import "../../../../components/ha-dropdown";
+import type { HaDropdownSelectEvent } from "../../../../components/ha-dropdown";
 import "../../../../components/ha-dropdown-item";
 import "../../../../components/ha-expansion-panel";
 import "../../../../components/ha-icon-button";
@@ -91,7 +94,6 @@ import "./types/ha-automation-action-set_conversation_response";
 import "./types/ha-automation-action-stop";
 import "./types/ha-automation-action-wait_for_trigger";
 import "./types/ha-automation-action-wait_template";
-import type { HaDropdownSelectEvent } from "../../../../components/ha-dropdown";
 
 export const getAutomationActionType = memoizeOne(
   (action: Action | undefined) => {
@@ -263,23 +265,25 @@ export default class HaAutomationActionRow extends LitElement {
           describeAction(this.hass, this._entityReg, this.action)
         )}
         ${target ? this._renderTargets(target) : nothing}
+        ${type !== "condition" &&
+        (this.action as NonConditionAction).continue_on_error === true
+          ? html`<ha-svg-icon
+                class="arrow-right"
+                .path=${mdiArrowRightThin}
+              ></ha-svg-icon
+              ><ha-svg-icon
+                id="svg-icon"
+                .path=${mdiAlertCircleCheck}
+              ></ha-svg-icon>
+              <ha-tooltip for="svg-icon">
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.actions.continue_on_error"
+                )}
+              </ha-tooltip>`
+          : nothing}
       </h3>
 
       <slot name="icons" slot="icons"></slot>
-
-      ${type !== "condition" &&
-      (this.action as NonConditionAction).continue_on_error === true
-        ? html`<ha-svg-icon
-              id="svg-icon"
-              slot="icons"
-              .path=${mdiAlertCircleCheck}
-            ></ha-svg-icon>
-            <ha-tooltip for="svg-icon">
-              ${this.hass.localize(
-                "ui.panel.config.automation.editor.actions.continue_on_error"
-              )}
-            </ha-tooltip>`
-        : nothing}
 
       <ha-dropdown
         slot="icons"
@@ -417,6 +421,27 @@ export default class HaAutomationActionRow extends LitElement {
             )
           )}
         </ha-dropdown-item>
+
+        ${type !== "condition"
+          ? html`<ha-dropdown-item
+                value="continue_on_error"
+                .disabled=${this.disabled}
+              >
+                <ha-svg-icon
+                  slot="icon"
+                  .path=${(this.action as NonConditionAction).continue_on_error
+                    ? mdiStopCircle
+                    : mdiAlertCircleCheck}
+                ></ha-svg-icon>
+                ${this._renderOverflowLabel(
+                  this.hass.localize(
+                    `ui.panel.config.automation.editor.actions.${(this.action as NonConditionAction).continue_on_error === true ? "stop" : "continue"}_on_error`
+                  )
+                )}
+              </ha-dropdown-item>
+              <wa-divider></wa-divider>`
+          : nothing}
+
         <ha-dropdown-item
           value="delete"
           variant="danger"
@@ -584,6 +609,25 @@ export default class HaAutomationActionRow extends LitElement {
       this.openSidebar(value); // refresh sidebar
     }
 
+    if (this._yamlMode && !this.optionsInSidebar) {
+      this._actionEditor?.yamlEditor?.setValue(value);
+    }
+  };
+
+  private _continueOnError = () => {
+    const value = { ...this.action };
+
+    if ((value as NonConditionAction).continue_on_error) {
+      delete (value as NonConditionAction).continue_on_error;
+    } else {
+      (value as NonConditionAction).continue_on_error = true;
+    }
+
+    fireEvent(this, "value-changed", { value });
+
+    if (this._selected && this.optionsInSidebar) {
+      this.openSidebar(value); // refresh sidebar
+    }
     if (this._yamlMode && !this.optionsInSidebar) {
       this._actionEditor?.yamlEditor?.setValue(value);
     }
@@ -790,6 +834,7 @@ export default class HaAutomationActionRow extends LitElement {
         this.openSidebar();
       },
       disable: this._onDisable,
+      continueOnError: this._continueOnError,
       delete: this._onDelete,
       copy: this._copyAction,
       cut: this._cutAction,
@@ -898,13 +943,30 @@ export default class HaAutomationActionRow extends LitElement {
       case "disable":
         this._onDisable();
         break;
+      case "continue_on_error":
+        this._continueOnError();
+        break;
       case "delete":
         this._onDelete();
         break;
     }
   }
 
-  static styles = [rowStyles, overflowStyles];
+  static styles = [
+    rowStyles,
+    overflowStyles,
+    css`
+      ha-svg-icon.arrow-right {
+        --icon-primary-color: var(--ha-color-fill-neutral-normal-resting);
+      }
+      ha-svg-icon#svg-icon {
+        --icon-primary-color: var(--ha-color-fill-neutral-loud-active);
+      }
+      ha-svg-icon#svg-icon:hover {
+        --icon-primary-color: var(--ha-color-fill-neutral-loud-hover);
+      }
+    `,
+  ];
 }
 
 declare global {

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
@@ -1,7 +1,8 @@
 import "@home-assistant/webawesome/dist/components/divider/divider";
 import {
-  mdiAlertCircleCheck,
   mdiAppleKeyboardCommand,
+  mdiCheckboxBlankOutline,
+  mdiCheckboxOutline,
   mdiContentCopy,
   mdiContentCut,
   mdiDelete,
@@ -10,7 +11,6 @@ import {
   mdiPlaylistEdit,
   mdiPlusCircleMultipleOutline,
   mdiRenameBox,
-  mdiStopCircle,
   mdiStopCircleOutline,
 } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
@@ -269,12 +269,12 @@ export default class HaAutomationSidebarAction extends LitElement {
                 slot="icon"
                 .path=${(this.config.config.action as NonConditionAction)
                   .continue_on_error
-                  ? mdiStopCircle
-                  : mdiAlertCircleCheck}
+                  ? mdiCheckboxOutline
+                  : mdiCheckboxBlankOutline}
               ></ha-svg-icon>
               <div class="overflow-label">
                 ${this.hass.localize(
-                  `ui.panel.config.automation.editor.actions.${(this.config.config.action as NonConditionAction).continue_on_error === true ? "stop" : "continue"}_on_error`
+                  `ui.panel.config.automation.editor.actions.continue_on_error`
                 )}
                 <span class="shortcut-placeholder ${isMac ? "mac" : ""}"></span>
               </div>

--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-action.ts
@@ -1,5 +1,6 @@
 import "@home-assistant/webawesome/dist/components/divider/divider";
 import {
+  mdiAlertCircleCheck,
   mdiAppleKeyboardCommand,
   mdiContentCopy,
   mdiContentCut,
@@ -9,19 +10,26 @@ import {
   mdiPlaylistEdit,
   mdiPlusCircleMultipleOutline,
   mdiRenameBox,
+  mdiStopCircle,
   mdiStopCircleOutline,
 } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { keyed } from "lit/directives/keyed";
+import { STRINGS_SEPARATOR_DOT } from "../../../../common/const";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { handleStructError } from "../../../../common/structs/handle-errors";
 import type { LocalizeKeys } from "../../../../common/translations/localize";
+import type { HaDropdownSelectEvent } from "../../../../components/ha-dropdown";
 import "../../../../components/ha-dropdown-item";
 import { ACTION_BUILDING_BLOCKS } from "../../../../data/action";
 import type { ActionSidebarConfig } from "../../../../data/automation";
 import { domainToName } from "../../../../data/integration";
-import type { RepeatAction, ServiceAction } from "../../../../data/script";
+import type {
+  NonConditionAction,
+  RepeatAction,
+  ServiceAction,
+} from "../../../../data/script";
 import type { HomeAssistant } from "../../../../types";
 import { isMac } from "../../../../util/is_mac";
 import type HaAutomationConditionEditor from "../action/ha-automation-action-editor";
@@ -29,7 +37,6 @@ import { getAutomationActionType } from "../action/ha-automation-action-row";
 import { getRepeatType } from "../action/types/ha-automation-action-repeat";
 import { overflowStyles, sidebarEditorStyles } from "../styles";
 import "./ha-automation-sidebar-card";
-import type { HaDropdownSelectEvent } from "../../../../components/ha-dropdown";
 
 @customElement("ha-automation-sidebar-action")
 export default class HaAutomationSidebarAction extends LitElement {
@@ -125,7 +132,12 @@ export default class HaAutomationSidebarAction extends LitElement {
           ? html` (${this.hass.localize(
               "ui.panel.config.automation.editor.actions.disabled"
             )})`
-          : ""}</span
+          : ""}${type !== "condition" &&
+        (this.config.config.action as NonConditionAction).continue_on_error
+          ? `${STRINGS_SEPARATOR_DOT}${this.hass.localize(
+              "ui.panel.config.automation.editor.actions.continue_on_error"
+            )}`
+          : nothing}</span
       >
 
       <ha-dropdown-item slot="menu-items" value="run">
@@ -247,6 +259,28 @@ export default class HaAutomationSidebarAction extends LitElement {
           <span class="shortcut-placeholder ${isMac ? "mac" : ""}"></span>
         </div>
       </ha-dropdown-item>
+      ${type !== "condition"
+        ? html`<ha-dropdown-item
+              slot="menu-items"
+              value="continue_on_error"
+              .disabled=${this.disabled}
+            >
+              <ha-svg-icon
+                slot="icon"
+                .path=${(this.config.config.action as NonConditionAction)
+                  .continue_on_error
+                  ? mdiStopCircle
+                  : mdiAlertCircleCheck}
+              ></ha-svg-icon>
+              <div class="overflow-label">
+                ${this.hass.localize(
+                  `ui.panel.config.automation.editor.actions.${(this.config.config.action as NonConditionAction).continue_on_error === true ? "stop" : "continue"}_on_error`
+                )}
+                <span class="shortcut-placeholder ${isMac ? "mac" : ""}"></span>
+              </div>
+            </ha-dropdown-item>
+            <wa-divider></wa-divider>`
+        : nothing}
       <ha-dropdown-item
         slot="menu-items"
         value="delete"
@@ -362,6 +396,9 @@ export default class HaAutomationSidebarAction extends LitElement {
         break;
       case "disable":
         this.config.disable();
+        break;
+      case "continue_on_error":
+        this.config.continueOnError();
         break;
       case "delete":
         this.config.delete();

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5255,6 +5255,7 @@
               "unsupported_action": "No visual editor support for this action",
               "type_select": "Action type",
               "continue_on_error": "Continue on error",
+              "stop_on_error": "Stop on error",
               "action": "Action",
               "copied_to_clipboard": "Action copied to clipboard",
               "cut_to_clipboard": "Action cut to clipboard",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5255,7 +5255,6 @@
               "unsupported_action": "No visual editor support for this action",
               "type_select": "Action type",
               "continue_on_error": "Continue on error",
-              "stop_on_error": "Stop on error",
               "action": "Action",
               "copied_to_clipboard": "Action copied to clipboard",
               "cut_to_clipboard": "Action cut to clipboard",


### PR DESCRIPTION
## Proposed change
- Automation editor: Add continue on error UI for actions
- fixes #29574


<details>
<summary>Screenshots</summary>
<img width="695" height="505" alt="grafik" src="https://github.com/user-attachments/assets/3450fa91-56ec-4034-9086-c6a744121276" />
<img width="690" height="503" alt="grafik" src="https://github.com/user-attachments/assets/ce5c1a39-7f4f-456b-81b5-edb43eca0a6c" />
<img width="694" height="297" alt="grafik" src="https://github.com/user-attachments/assets/93df0be2-66dc-4153-8cca-b283308cba4b" />



</details>

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
