### PR TITLE
Correct value update for 'ha-selector-select' elements displaying as radio buttons.

### DIFF
--- a/src/components/ha-selector/ha-selector-select.ts
+++ b/src/components/ha-selector/ha-selector-select.ts
@@ -120,7 +120,7 @@ export class HaSelectSelector extends LitElement {
                     .checked=${item.value === this.value}
                     .value=${item.value}
                     .disabled=${item.disabled || this.disabled}
-                    @change=${this._valueChanged}
+                    @change=${this._radioChanged}
                   ></ha-radio>
                 </ha-formfield>
               `
@@ -282,22 +282,24 @@ export class HaSelectSelector extends LitElement {
     );
   }
 
+  private _radioChanged(ev) {
+    ev.stopPropagation();
+    this._valueChanged(ev);
+  }
+
   private _selectChanged(ev) {
+    ev.stopPropagation();
     // Additional handling for reset of select elements
     if (ev.detail?.value === undefined && this.value !== undefined) {
-      ev.stopPropagation();
       fireEvent(this, "value-changed", {
         value: undefined,
       });
       return;
     }
-
     this._valueChanged(ev);
   }
 
   private _valueChanged(ev) {
-    ev.stopPropagation();
-
     const value = ev.detail?.value || ev.target.value;
     if (this.disabled || value === undefined || value === (this.value ?? "")) {
       return;

--- a/src/components/ha-selector/ha-selector-select.ts
+++ b/src/components/ha-selector/ha-selector-select.ts
@@ -93,7 +93,7 @@ export class HaSelectSelector extends LitElement {
         <ha-select-box
           .options=${options}
           .value=${this.value as string | undefined}
-          @value-changed=${this._valueChanged}
+          @value-changed=${this._selectChanged}
           .maxColumns=${this.selector.select?.box_max_columns}
           .hass=${this.hass}
         ></ha-select-box>
@@ -236,7 +236,7 @@ export class HaSelectSelector extends LitElement {
         .disabled=${this.disabled}
         .required=${this.required}
         clearable
-        @selected=${this._valueChanged}
+        @selected=${this._selectChanged}
         .options=${options}
       >
       </ha-select>
@@ -282,15 +282,21 @@ export class HaSelectSelector extends LitElement {
     );
   }
 
-  private _valueChanged(ev) {
-    ev.stopPropagation();
-
+  private _selectChanged(ev) {
+    // Additional handling for reset of select elements
     if (ev.detail?.value === undefined && this.value !== undefined) {
+      ev.stopPropagation();
       fireEvent(this, "value-changed", {
         value: undefined,
       });
       return;
     }
+
+    this._valueChanged(ev);
+  }
+
+  private _valueChanged(ev) {
+    ev.stopPropagation();
 
     const value = ev.detail?.value || ev.target.value;
     if (this.disabled || value === undefined || value === (this.value ?? "")) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

PR #29392 introduced a change to `ha-selector-select` which appears to have caused an unintentional issue with selectors displaying as radio buttons.

The previous logic in the `_valueChanged` callback for resetting of select elements in `ha-selector-select` required a value in the event data to exist when deciding whether to reset. However the new logic instead resets if a different value doesn't exist. Unfortunately this means that the radio button variant using the same callback breaks because that doesn't provide any event data.

To resolve this, the reset logic has been separated out into a separate function `_selectChanged` which becomes the callback for select elements. This new function performs the reset check, and if reset not required forwards on to the `_valueChanged` callback. This should hopefully avoid similar problems in the future by ensuring different element types have independent handling.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29608
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
