### PR TITLE
Add footer card support to sections view

### DIFF
--- a/src/data/lovelace/config/view.ts
+++ b/src/data/lovelace/config/view.ts
@@ -37,6 +37,11 @@ export interface LovelaceViewHeaderConfig {
   badges_wrap?: "wrap" | "scroll";
 }
 
+export interface LovelaceViewFooterConfig {
+  card?: LovelaceCardConfig;
+  column_span?: number;
+}
+
 export interface LovelaceViewSidebarConfig {
   sections?: LovelaceSectionConfig[];
   content_label?: string;
@@ -68,6 +73,7 @@ export interface LovelaceViewConfig extends LovelaceBaseViewConfig {
   cards?: LovelaceCardConfig[];
   sections?: LovelaceSectionRawConfig[];
   header?: LovelaceViewHeaderConfig;
+  footer?: LovelaceViewFooterConfig;
   // Only used for section view, it should move to a section view config type when the views will have dedicated editor.
   sidebar?: LovelaceViewSidebarConfig;
 }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
@@ -127,26 +127,30 @@ export class HuiCreateDialogCard
           ></ha-icon-button>
           <span slot="title">${title}</span>
 
-          <ha-tab-group @wa-tab-show=${this._handleTabChanged}>
-            <ha-tab-group-tab
-              slot="nav"
-              .active=${this._currTab === "card"}
-              panel="card"
-              ?autofocus=${this._narrow}
-            >
-              ${this.hass!.localize(
-                "ui.panel.lovelace.editor.cardpicker.by_card"
-              )}
-            </ha-tab-group-tab>
-            <ha-tab-group-tab
-              slot="nav"
-              .active=${this._currTab === "entity"}
-              panel="entity"
-              >${this.hass!.localize(
-                "ui.panel.lovelace.editor.cardpicker.by_entity"
-              )}</ha-tab-group-tab
-            >
-          </ha-tab-group>
+          ${!this._params.saveCard
+            ? html`
+                <ha-tab-group @wa-tab-show=${this._handleTabChanged}>
+                  <ha-tab-group-tab
+                    slot="nav"
+                    .active=${this._currTab === "card"}
+                    panel="card"
+                    ?autofocus=${this._narrow}
+                  >
+                    ${this.hass!.localize(
+                      "ui.panel.lovelace.editor.cardpicker.by_card"
+                    )}
+                  </ha-tab-group-tab>
+                  <ha-tab-group-tab
+                    slot="nav"
+                    .active=${this._currTab === "entity"}
+                    panel="entity"
+                    >${this.hass!.localize(
+                      "ui.panel.lovelace.editor.cardpicker.by_entity"
+                    )}</ha-tab-group-tab
+                  >
+                </ha-tab-group>
+              `
+            : nothing}
         </ha-dialog-header>
         ${cache(
           this._currTab === "card"
@@ -253,6 +257,17 @@ export class HuiCreateDialogCard
       } else if ("entity" in config) {
         config.entity = this._params!.entities[0];
       }
+    }
+
+    if (this._params!.saveCard) {
+      showEditCardDialog(this, {
+        lovelaceConfig: this._params!.lovelaceConfig,
+        saveCardConfig: this._params!.saveCard,
+        cardConfig: config,
+        isNew: true,
+      });
+      this.closeDialog();
+      return;
     }
 
     const lovelaceConfig = this._params!.lovelaceConfig;

--- a/src/panels/lovelace/editor/card-editor/show-create-card-dialog.ts
+++ b/src/panels/lovelace/editor/card-editor/show-create-card-dialog.ts
@@ -1,4 +1,5 @@
 import { fireEvent } from "../../../../common/dom/fire_event";
+import type { LovelaceCardConfig } from "../../../../data/lovelace/config/card";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
 import type { LovelaceContainerPath } from "../lovelace-path";
 
@@ -8,6 +9,7 @@ export interface CreateCardDialogParams {
   path: LovelaceContainerPath;
   suggestedCards?: string[];
   entities?: string[]; // We can pass entity id's that will be added to the config when a card is picked
+  saveCard?: (cardConfig: LovelaceCardConfig) => void; // Optional: pick a single card and return it via callback, hides entity tab
 }
 
 export const importCreateCardDialog = () => import("./hui-dialog-create-card");

--- a/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
@@ -1,4 +1,4 @@
-import { mdiClose, mdiDotsVertical, mdiPlaylistEdit } from "@mdi/js";
+import { mdiDotsVertical, mdiPlaylistEdit } from "@mdi/js";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
@@ -6,8 +6,8 @@ import { classMap } from "lit/directives/class-map";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { deepEqual } from "../../../../common/util/deep-equal";
 import "../../../../components/ha-button";
+import "../../../../components/ha-dialog-footer";
 import "../../../../components/ha-dialog";
-import "../../../../components/ha-dialog-header";
 import "../../../../components/ha-dropdown";
 import "../../../../components/ha-dropdown-item";
 import "../../../../components/ha-spinner";
@@ -40,6 +40,8 @@ export class HuiDialogEditViewFooter extends LitElement {
 
   @query("ha-yaml-editor") private _editor?: HaYamlEditor;
 
+  @state() private _open = false;
+
   protected updated(changedProperties: PropertyValues) {
     if (this._yamlMode && changedProperties.has("_yamlMode")) {
       const config = {
@@ -54,9 +56,14 @@ export class HuiDialogEditViewFooter extends LitElement {
 
     this._dirty = false;
     this._config = this._params.config;
+    this._open = true;
   }
 
   public closeDialog(): void {
+    this._open = false;
+  }
+
+  private _dialogClosed(): void {
     this._params = undefined;
     this._config = undefined;
     this._yamlMode = false;
@@ -76,7 +83,7 @@ export class HuiDialogEditViewFooter extends LitElement {
       content = html`
         <ha-yaml-editor
           .hass=${this.hass}
-          dialogInitialFocus
+          autofocus
           @value-changed=${this._viewYamlChanged}
         ></ha-yaml-editor>
       `;
@@ -97,50 +104,43 @@ export class HuiDialogEditViewFooter extends LitElement {
 
     return html`
       <ha-dialog
-        open
-        scrimClickAction
-        escapeKeyAction
-        @closed=${this.closeDialog}
-        .heading=${title}
+        .hass=${this.hass}
+        .open=${this._open}
+        header-title=${title}
+        width="large"
+        @closed=${this._dialogClosed}
         class=${classMap({
           "yaml-mode": this._yamlMode,
         })}
       >
-        <ha-dialog-header show-border slot="heading">
+        <ha-dropdown
+          slot="headerActionItems"
+          placement="bottom-end"
+          @wa-select=${this._handleAction}
+        >
           <ha-icon-button
-            slot="navigationIcon"
-            dialogAction="cancel"
-            .label=${this.hass!.localize("ui.common.close")}
-            .path=${mdiClose}
+            slot="trigger"
+            .label=${this.hass!.localize("ui.common.menu")}
+            .path=${mdiDotsVertical}
           ></ha-icon-button>
-          <h2 slot="title">${title}</h2>
-          <ha-dropdown
-            slot="actionItems"
-            placement="bottom-end"
-            @wa-select=${this._handleAction}
-          >
-            <ha-icon-button
-              slot="trigger"
-              .label=${this.hass!.localize("ui.common.menu")}
-              .path=${mdiDotsVertical}
-            ></ha-icon-button>
-            <ha-dropdown-item value="toggle-mode">
-              ${this.hass!.localize(
-                `ui.panel.lovelace.editor.edit_view_footer.edit_${!this._yamlMode ? "yaml" : "ui"}`
-              )}
-              <ha-svg-icon slot="icon" .path=${mdiPlaylistEdit}></ha-svg-icon>
-            </ha-dropdown-item>
-          </ha-dropdown>
-        </ha-dialog-header>
+          <ha-dropdown-item value="toggle-mode">
+            ${this.hass!.localize(
+              `ui.panel.lovelace.editor.edit_view_footer.edit_${!this._yamlMode ? "yaml" : "ui"}`
+            )}
+            <ha-svg-icon slot="icon" .path=${mdiPlaylistEdit}></ha-svg-icon>
+          </ha-dropdown-item>
+        </ha-dropdown>
         ${content}
-        <ha-button
-          slot="primaryAction"
-          .disabled=${!this._config || this._saving || !this._dirty}
-          @click=${this._save}
-          .loading=${this._saving}
-        >
-          ${this.hass!.localize("ui.common.save")}</ha-button
-        >
+        <ha-dialog-footer slot="footer">
+          <ha-button
+            slot="primaryAction"
+            .disabled=${!this._config || this._saving || !this._dirty}
+            @click=${this._save}
+            .loading=${this._saving}
+          >
+            ${this.hass!.localize("ui.common.save")}</ha-button
+          >
+        </ha-dialog-footer>
       </ha-dialog>
     `;
   }
@@ -201,17 +201,6 @@ export class HuiDialogEditViewFooter extends LitElement {
       css`
         ha-dialog.yaml-mode {
           --dialog-content-padding: 0;
-        }
-        h2 {
-          margin: 0;
-          font-size: inherit;
-          font-weight: inherit;
-        }
-
-        @media all and (min-width: 600px) {
-          ha-dialog {
-            --mdc-dialog-min-width: 600px;
-          }
         }
       `,
     ];

--- a/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
@@ -1,14 +1,14 @@
 import { mdiDotsVertical, mdiPlaylistEdit } from "@mdi/js";
-import type { CSSResultGroup, PropertyValues } from "lit";
+import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
-import { classMap } from "lit/directives/class-map";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { deepEqual } from "../../../../common/util/deep-equal";
 import "../../../../components/ha-button";
-import "../../../../components/ha-dialog-footer";
 import "../../../../components/ha-dialog";
+import "../../../../components/ha-dialog-footer";
 import "../../../../components/ha-dropdown";
+import type { HaDropdownSelectEvent } from "../../../../components/ha-dropdown";
 import "../../../../components/ha-dropdown-item";
 import "../../../../components/ha-spinner";
 import "../../../../components/ha-yaml-editor";
@@ -22,7 +22,6 @@ import {
 import type { HomeAssistant } from "../../../../types";
 import "./hui-view-footer-settings-editor";
 import type { EditViewFooterDialogParams } from "./show-edit-view-footer-dialog";
-import type { HaDropdownSelectEvent } from "../../../../components/ha-dropdown";
 
 @customElement("hui-dialog-edit-view-footer")
 export class HuiDialogEditViewFooter extends LitElement {

--- a/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
@@ -1,0 +1,225 @@
+import { mdiClose, mdiDotsVertical, mdiPlaylistEdit } from "@mdi/js";
+import type { CSSResultGroup, PropertyValues } from "lit";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property, query, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import { deepEqual } from "../../../../common/util/deep-equal";
+import "../../../../components/ha-button";
+import "../../../../components/ha-dialog";
+import "../../../../components/ha-dialog-header";
+import "../../../../components/ha-dropdown";
+import "../../../../components/ha-dropdown-item";
+import "../../../../components/ha-spinner";
+import "../../../../components/ha-yaml-editor";
+import type { HaYamlEditor } from "../../../../components/ha-yaml-editor";
+import type { LovelaceViewFooterConfig } from "../../../../data/lovelace/config/view";
+import { showAlertDialog } from "../../../../dialogs/generic/show-dialog-box";
+import {
+  haStyleDialog,
+  haStyleDialogFixedTop,
+} from "../../../../resources/styles";
+import type { HomeAssistant } from "../../../../types";
+import "./hui-view-footer-settings-editor";
+import type { EditViewFooterDialogParams } from "./show-edit-view-footer-dialog";
+import type { HaDropdownSelectEvent } from "../../../../components/ha-dropdown";
+
+@customElement("hui-dialog-edit-view-footer")
+export class HuiDialogEditViewFooter extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @state() private _params?: EditViewFooterDialogParams;
+
+  @state() private _config?: LovelaceViewFooterConfig;
+
+  @state() private _saving = false;
+
+  @state() private _dirty = false;
+
+  @state() private _yamlMode = false;
+
+  @query("ha-yaml-editor") private _editor?: HaYamlEditor;
+
+  protected updated(changedProperties: PropertyValues) {
+    if (this._yamlMode && changedProperties.has("_yamlMode")) {
+      const config = {
+        ...this._config,
+      };
+      this._editor?.setValue(config);
+    }
+  }
+
+  public showDialog(params: EditViewFooterDialogParams): void {
+    this._params = params;
+
+    this._dirty = false;
+    this._config = this._params.config;
+  }
+
+  public closeDialog(): void {
+    this._params = undefined;
+    this._config = undefined;
+    this._yamlMode = false;
+    this._dirty = false;
+    this._saving = false;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render() {
+    if (!this._params || !this.hass) {
+      return nothing;
+    }
+
+    let content;
+
+    if (this._yamlMode) {
+      content = html`
+        <ha-yaml-editor
+          .hass=${this.hass}
+          dialogInitialFocus
+          @value-changed=${this._viewYamlChanged}
+        ></ha-yaml-editor>
+      `;
+    } else {
+      content = html`
+        <hui-view-footer-settings-editor
+          .hass=${this.hass}
+          .config=${this._config}
+          .maxColumns=${this._params.maxColumns}
+          @config-changed=${this._configChanged}
+        ></hui-view-footer-settings-editor>
+      `;
+    }
+
+    const title = this.hass.localize(
+      "ui.panel.lovelace.editor.edit_view_footer.header"
+    );
+
+    return html`
+      <ha-dialog
+        open
+        scrimClickAction
+        escapeKeyAction
+        @closed=${this.closeDialog}
+        .heading=${title}
+        class=${classMap({
+          "yaml-mode": this._yamlMode,
+        })}
+      >
+        <ha-dialog-header show-border slot="heading">
+          <ha-icon-button
+            slot="navigationIcon"
+            dialogAction="cancel"
+            .label=${this.hass!.localize("ui.common.close")}
+            .path=${mdiClose}
+          ></ha-icon-button>
+          <h2 slot="title">${title}</h2>
+          <ha-dropdown
+            slot="actionItems"
+            placement="bottom-end"
+            @wa-select=${this._handleAction}
+          >
+            <ha-icon-button
+              slot="trigger"
+              .label=${this.hass!.localize("ui.common.menu")}
+              .path=${mdiDotsVertical}
+            ></ha-icon-button>
+            <ha-dropdown-item value="toggle-mode">
+              ${this.hass!.localize(
+                `ui.panel.lovelace.editor.edit_view_footer.edit_${!this._yamlMode ? "yaml" : "ui"}`
+              )}
+              <ha-svg-icon slot="icon" .path=${mdiPlaylistEdit}></ha-svg-icon>
+            </ha-dropdown-item>
+          </ha-dropdown>
+        </ha-dialog-header>
+        ${content}
+        <ha-button
+          slot="primaryAction"
+          .disabled=${!this._config || this._saving || !this._dirty}
+          @click=${this._save}
+          .loading=${this._saving}
+        >
+          ${this.hass!.localize("ui.common.save")}</ha-button
+        >
+      </ha-dialog>
+    `;
+  }
+
+  private async _handleAction(ev: HaDropdownSelectEvent) {
+    const action = ev.detail.item.value;
+
+    if (action === "toggle-mode") {
+      this._yamlMode = !this._yamlMode;
+    }
+  }
+
+  private _configChanged(ev: CustomEvent): void {
+    if (
+      ev.detail &&
+      ev.detail.config &&
+      !deepEqual(this._config, ev.detail.config)
+    ) {
+      this._config = ev.detail.config;
+      this._dirty = true;
+    }
+  }
+
+  private _viewYamlChanged(ev: CustomEvent) {
+    ev.stopPropagation();
+    if (!ev.detail.isValid) {
+      return;
+    }
+    this._config = ev.detail.value;
+    this._dirty = true;
+  }
+
+  private async _save(): Promise<void> {
+    if (!this._params || !this._config) {
+      return;
+    }
+
+    this._saving = true;
+
+    try {
+      await this._params.saveConfig(this._config);
+      this.closeDialog();
+    } catch (err: any) {
+      showAlertDialog(this, {
+        text: `${this.hass!.localize(
+          "ui.panel.lovelace.editor.edit_view_footer.saving_failed"
+        )}: ${err.message}`,
+      });
+    } finally {
+      this._saving = false;
+    }
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyleDialog,
+      haStyleDialogFixedTop,
+      css`
+        ha-dialog.yaml-mode {
+          --dialog-content-padding: 0;
+        }
+        h2 {
+          margin: 0;
+          font-size: inherit;
+          font-weight: inherit;
+        }
+
+        @media all and (min-width: 600px) {
+          ha-dialog {
+            --mdc-dialog-min-width: 600px;
+          }
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-dialog-edit-view-footer": HuiDialogEditViewFooter;
+  }
+}

--- a/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
@@ -26,7 +26,7 @@ import type { HaDropdownSelectEvent } from "../../../../components/ha-dropdown";
 
 @customElement("hui-dialog-edit-view-footer")
 export class HuiDialogEditViewFooter extends LitElement {
-  @property({ attribute: false }) public hass?: HomeAssistant;
+  @property({ attribute: false }) public hass!: HomeAssistant;
 
   @state() private _params?: EditViewFooterDialogParams;
 
@@ -77,7 +77,7 @@ export class HuiDialogEditViewFooter extends LitElement {
       return nothing;
     }
 
-    let content;
+    let content: TemplateResult;
 
     if (this._yamlMode) {
       content = html`
@@ -107,11 +107,9 @@ export class HuiDialogEditViewFooter extends LitElement {
         .hass=${this.hass}
         .open=${this._open}
         header-title=${title}
-        width="large"
+        .width=${this._yamlMode ? "full" : "large"}
         @closed=${this._dialogClosed}
-        class=${classMap({
-          "yaml-mode": this._yamlMode,
-        })}
+        class=${this._yamlMode ? "yaml-mode" : ""}
       >
         <ha-dropdown
           slot="headerActionItems"
@@ -134,7 +132,7 @@ export class HuiDialogEditViewFooter extends LitElement {
         <ha-dialog-footer slot="footer">
           <ha-button
             slot="primaryAction"
-            .disabled=${!this._config || this._saving || !this._dirty}
+            .disabled=${!this._config || !this._dirty}
             @click=${this._save}
             .loading=${this._saving}
           >

--- a/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
@@ -35,10 +35,6 @@ export class HuiViewFooterSettingsEditor extends LitElement {
   );
 
   protected render() {
-    if (!this.hass) {
-      return nothing;
-    }
-
     const data = {
       column_span: this.config?.column_span || 1,
     };

--- a/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
@@ -1,0 +1,91 @@
+import { html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-form/ha-form";
+import type {
+  HaFormSchema,
+  SchemaUnion,
+} from "../../../../components/ha-form/types";
+import type { LovelaceViewFooterConfig } from "../../../../data/lovelace/config/view";
+import type { HomeAssistant } from "../../../../types";
+
+@customElement("hui-view-footer-settings-editor")
+export class HuiViewFooterSettingsEditor extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public config?: LovelaceViewFooterConfig;
+
+  @property({ attribute: false }) public maxColumns = 4;
+
+  private _schema = memoizeOne(
+    (maxColumns: number) =>
+      [
+        {
+          name: "column_span",
+          selector: {
+            number: {
+              min: 1,
+              max: maxColumns,
+              slider_ticks: true,
+            },
+          },
+        },
+      ] as const satisfies HaFormSchema[]
+  );
+
+  protected render() {
+    if (!this.hass) {
+      return nothing;
+    }
+
+    const data = {
+      column_span: this.config?.column_span || 1,
+    };
+
+    const schema = this._schema(this.maxColumns);
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${schema}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const newData = ev.detail.value;
+
+    const config: LovelaceViewFooterConfig = {
+      ...this.config,
+      ...newData,
+    };
+
+    fireEvent(this, "config-changed", { config });
+  }
+
+  private _computeLabel = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) =>
+    this.hass.localize(
+      `ui.panel.lovelace.editor.edit_view_footer.settings.${schema.name}`
+    );
+
+  private _computeHelper = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) =>
+    this.hass.localize(
+      `ui.panel.lovelace.editor.edit_view_footer.settings.${schema.name}_helper`
+    ) || "";
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-view-footer-settings-editor": HuiViewFooterSettingsEditor;
+  }
+}

--- a/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, nothing } from "lit";
+import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../common/dom/fire_event";

--- a/src/panels/lovelace/editor/view-footer/show-edit-view-footer-dialog.ts
+++ b/src/panels/lovelace/editor/view-footer/show-edit-view-footer-dialog.ts
@@ -1,0 +1,19 @@
+import { fireEvent } from "../../../../common/dom/fire_event";
+import type { LovelaceViewFooterConfig } from "../../../../data/lovelace/config/view";
+
+export interface EditViewFooterDialogParams {
+  saveConfig: (config: LovelaceViewFooterConfig) => void;
+  config: LovelaceViewFooterConfig;
+  maxColumns: number;
+}
+
+export const showEditViewFooterDialog = (
+  element: HTMLElement,
+  dialogParams: EditViewFooterDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "hui-dialog-edit-view-footer",
+    dialogImport: () => import("./hui-dialog-edit-view-footer"),
+    dialogParams: dialogParams,
+  });
+};

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -30,6 +30,7 @@ import {
 import type { HuiSection } from "../sections/hui-section";
 import type { Lovelace } from "../types";
 import { generateDefaultSection } from "./default-section";
+import "./hui-view-footer";
 import "./hui-view-header";
 import "./hui-view-sidebar";
 
@@ -305,6 +306,12 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
               `
             : nothing}
         </div>
+        <hui-view-footer
+          .hass=${this.hass}
+          .lovelace=${this.lovelace}
+          .viewIndex=${this.index}
+          .config=${this._config?.footer}
+        ></hui-view-footer>
         <div class="imported-cards-section">
           ${editMode && this._config?.cards?.length
             ? html`
@@ -647,6 +654,10 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
     hui-view-header {
       display: block;
       padding-top: var(--row-gap);
+    }
+
+    hui-view-footer {
+      display: block;
     }
 
     .imported-cards {

--- a/src/panels/lovelace/views/hui-view-footer.ts
+++ b/src/panels/lovelace/views/hui-view-footer.ts
@@ -1,0 +1,306 @@
+import { mdiPencil, mdiPlus } from "@mdi/js";
+import type { PropertyValues } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
+import { styleMap } from "lit/directives/style-map";
+import "../../../components/ha-ripple";
+import "../../../components/ha-svg-icon";
+import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
+import type {
+  LovelaceViewConfig,
+  LovelaceViewFooterConfig,
+} from "../../../data/lovelace/config/view";
+import type { HomeAssistant } from "../../../types";
+import type { HuiCard } from "../cards/hui-card";
+import { showCreateCardDialog } from "../editor/card-editor/show-create-card-dialog";
+import { showEditCardDialog } from "../editor/card-editor/show-edit-card-dialog";
+import { replaceView } from "../editor/config-util";
+import { showEditViewFooterDialog } from "../editor/view-footer/show-edit-view-footer-dialog";
+import type { Lovelace } from "../types";
+import { DEFAULT_MAX_COLUMNS } from "./hui-sections-view";
+
+@customElement("hui-view-footer")
+export class HuiViewFooter extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public lovelace!: Lovelace;
+
+  @property({ attribute: false }) public card?: HuiCard;
+
+  @property({ attribute: false }) public config?: LovelaceViewFooterConfig;
+
+  @property({ attribute: false }) public viewIndex!: number;
+
+  willUpdate(changedProperties: PropertyValues<typeof this>): void {
+    if (changedProperties.has("config")) {
+      if (this.config?.card) {
+        this.card = this._createCardElement(this.config.card);
+      } else {
+        this.card = undefined;
+      }
+      this._checkHidden();
+      return;
+    }
+
+    if (this.card) {
+      if (changedProperties.has("hass")) {
+        this.card.hass = this.hass;
+      }
+      if (changedProperties.has("lovelace")) {
+        this.card.preview = this.lovelace.editMode;
+      }
+    }
+
+    if (changedProperties.has("lovelace") || changedProperties.has("card")) {
+      this._checkHidden();
+    }
+  }
+
+  private _checkHidden() {
+    const hidden = !this.card && !this.lovelace?.editMode;
+    this.toggleAttribute("hidden", hidden);
+  }
+
+  private _createCardElement(cardConfig: LovelaceCardConfig) {
+    const element = document.createElement("hui-card");
+    element.hass = this.hass;
+    element.preview = this.lovelace.editMode;
+    element.config = cardConfig;
+    element.load();
+    return element;
+  }
+
+  private _addCard() {
+    showCreateCardDialog(this, {
+      lovelaceConfig: this.lovelace.config,
+      saveConfig: this.lovelace.saveConfig,
+      path: [this.viewIndex],
+      saveCard: (newCardConfig: LovelaceCardConfig) => {
+        this._saveFooterConfig({ ...this.config, card: newCardConfig });
+      },
+    });
+  }
+
+  private _deleteCard(ev) {
+    ev.stopPropagation();
+    const newConfig = { ...this.config };
+    delete newConfig.card;
+    this._saveFooterConfig(newConfig);
+  }
+
+  private _configure() {
+    const viewConfig = this.lovelace.config.views[
+      this.viewIndex
+    ] as LovelaceViewConfig;
+
+    showEditViewFooterDialog(this, {
+      config: this.config || {},
+      maxColumns: viewConfig.max_columns || DEFAULT_MAX_COLUMNS,
+      saveConfig: (newConfig: LovelaceViewFooterConfig) => {
+        this._saveFooterConfig(newConfig);
+      },
+    });
+  }
+
+  private _editCard(ev) {
+    ev.stopPropagation();
+    const cardConfig = this.config?.card;
+    if (!cardConfig) return;
+
+    showEditCardDialog(this, {
+      cardConfig,
+      lovelaceConfig: this.lovelace.config,
+      saveCardConfig: (newCardConfig: LovelaceCardConfig) => {
+        this._saveFooterConfig({ ...this.config, card: newCardConfig });
+      },
+    });
+  }
+
+  private _saveFooterConfig(footerConfig: LovelaceViewFooterConfig) {
+    const viewConfig = this.lovelace.config.views[
+      this.viewIndex
+    ] as LovelaceViewConfig;
+
+    const config = { ...viewConfig, footer: footerConfig };
+
+    const updatedConfig = replaceView(
+      this.hass,
+      this.lovelace.config,
+      this.viewIndex,
+      config
+    );
+    this.lovelace.saveConfig(updatedConfig);
+  }
+
+  render() {
+    if (!this.lovelace) return nothing;
+
+    const editMode = Boolean(this.lovelace?.editMode);
+    const card = this.card;
+
+    if (!card && !editMode) return nothing;
+
+    const columnSpan = this.config?.column_span || 1;
+
+    return html`
+      <div
+        class=${classMap({ wrapper: true, "edit-mode": editMode })}
+        style=${styleMap({
+          "--footer-column-span": String(columnSpan),
+        })}
+      >
+        ${editMode
+          ? html`
+              <div class="actions-container">
+                <div class="actions">
+                  <ha-icon-button
+                    .label=${this.hass.localize("ui.common.edit")}
+                    @click=${this._configure}
+                    .path=${mdiPencil}
+                  ></ha-icon-button>
+                </div>
+              </div>
+            `
+          : nothing}
+        <div class=${classMap({ container: true, "edit-mode": editMode })}>
+          ${editMode
+            ? card
+              ? html`
+                  <hui-card-edit-mode
+                    @ll-edit-card=${this._editCard}
+                    @ll-delete-card=${this._deleteCard}
+                    .hass=${this.hass}
+                    .lovelace=${this.lovelace!}
+                    .path=${[0]}
+                    no-duplicate
+                    no-move
+                  >
+                    ${card}
+                  </hui-card-edit-mode>
+                `
+              : html`
+                  <button class="add" @click=${this._addCard}>
+                    <ha-ripple></ha-ripple>
+                    <ha-svg-icon .path=${mdiPlus}></ha-svg-icon>
+                    ${this.hass.localize(
+                      "ui.panel.lovelace.editor.edit_card.add"
+                    )}
+                  </button>
+                `
+            : card}
+        </div>
+      </div>
+    `;
+  }
+
+  static styles = css`
+    :host([hidden]) {
+      display: none !important;
+    }
+
+    :host {
+      position: sticky;
+      bottom: 0;
+      z-index: 4;
+    }
+
+    .wrapper {
+      padding: var(--ha-space-4) 0;
+      padding-bottom: max(
+        var(--ha-space-4),
+        var(--safe-area-inset-bottom, 0px)
+      );
+      box-sizing: content-box;
+      margin: 0 auto;
+      max-width: calc(
+        var(--footer-column-span, 1) * var(--column-max-width, 500px) +
+          (var(--footer-column-span, 1) - 1) * var(--column-gap, 32px)
+      );
+    }
+
+    .wrapper:not(.edit-mode) {
+      --ha-card-box-shadow:
+        0px 3px 5px -1px rgba(0, 0, 0, 0.2),
+        0px 6px 10px 0px rgba(0, 0, 0, 0.14),
+        0px 1px 18px 0px rgba(0, 0, 0, 0.12);
+      --ha-card-border-color: var(--divider-color);
+    }
+
+    .container {
+      position: relative;
+    }
+
+    .container.edit-mode {
+      padding: 8px;
+      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      border: 2px dashed var(--divider-color);
+      border-start-end-radius: 0;
+    }
+
+    .actions-container {
+      position: relative;
+      height: 34px;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+    }
+
+    .actions {
+      z-index: 1;
+      position: absolute;
+      height: 36px;
+      bottom: -2px;
+      right: 0;
+      inset-inline-end: 0;
+      inset-inline-start: initial;
+      opacity: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: opacity 0.2s ease-in-out;
+      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      border-bottom-left-radius: 0px;
+      border-bottom-right-radius: 0px;
+      background: var(--secondary-background-color);
+      --mdc-icon-button-size: 36px;
+      --mdc-icon-size: 20px;
+      color: var(--primary-text-color);
+    }
+
+    .add {
+      position: relative;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: center;
+      outline: none;
+      gap: var(--ha-space-2);
+      height: 36px;
+      padding: 6px 20px 6px 20px;
+      box-sizing: border-box;
+      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      background-color: transparent;
+      border-width: 2px;
+      border-style: dashed;
+      border-color: var(--primary-color);
+      --mdc-icon-size: 18px;
+      cursor: pointer;
+      font-size: var(--ha-font-size-m);
+      color: var(--primary-text-color);
+      --ha-ripple-color: var(--primary-color);
+      --ha-ripple-hover-opacity: 0.04;
+      --ha-ripple-pressed-opacity: 0.12;
+    }
+
+    .add:focus {
+      border-style: solid;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-view-footer": HuiViewFooter;
+  }
+}

--- a/src/panels/lovelace/views/hui-view-footer.ts
+++ b/src/panels/lovelace/views/hui-view-footer.ts
@@ -61,6 +61,7 @@ export class HuiViewFooter extends LitElement {
   private _checkHidden() {
     const hidden = !this.card && !this.lovelace?.editMode;
     this.toggleAttribute("hidden", hidden);
+    this.toggleAttribute("sticky", Boolean(this.card));
   }
 
   private _createCardElement(cardConfig: LovelaceCardConfig) {
@@ -225,7 +226,7 @@ export class HuiViewFooter extends LitElement {
       display: none !important;
     }
 
-    :host {
+    :host([sticky]) {
       position: sticky;
       bottom: 0;
       z-index: 4;

--- a/src/panels/lovelace/views/hui-view-footer.ts
+++ b/src/panels/lovelace/views/hui-view-footer.ts
@@ -13,6 +13,7 @@ import type {
 } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
 import type { HuiCard } from "../cards/hui-card";
+import { computeCardGridSize } from "../common/compute-card-grid-size";
 import { showCreateCardDialog } from "../editor/card-editor/show-create-card-dialog";
 import { showEditCardDialog } from "../editor/card-editor/show-edit-card-dialog";
 import { replaceView } from "../editor/config-util";
@@ -66,7 +67,12 @@ export class HuiViewFooter extends LitElement {
     const element = document.createElement("hui-card");
     element.hass = this.hass;
     element.preview = this.lovelace.editMode;
+    element.layout = "grid";
     element.config = cardConfig;
+    element.addEventListener("card-updated", (ev: Event) => {
+      ev.stopPropagation();
+      this.requestUpdate();
+    });
     element.load();
     return element;
   }
@@ -133,6 +139,38 @@ export class HuiViewFooter extends LitElement {
     this.lovelace.saveConfig(updatedConfig);
   }
 
+  private _renderCard(card: HuiCard, editMode: boolean) {
+    const gridOptions = card.getGridOptions();
+    const { rows } = computeCardGridSize(gridOptions);
+
+    return html`
+      <div
+        class="card ${classMap({
+          "fit-rows": typeof rows === "number",
+        })}"
+        style=${styleMap({
+          "--row-size": typeof rows === "number" ? String(rows) : undefined,
+        })}
+      >
+        ${editMode
+          ? html`
+              <hui-card-edit-mode
+                @ll-edit-card=${this._editCard}
+                @ll-delete-card=${this._deleteCard}
+                .hass=${this.hass}
+                .lovelace=${this.lovelace!}
+                .path=${[0]}
+                no-duplicate
+                no-move
+              >
+                ${card}
+              </hui-card-edit-mode>
+            `
+          : card}
+      </div>
+    `;
+  }
+
   render() {
     if (!this.lovelace) return nothing;
 
@@ -164,22 +202,10 @@ export class HuiViewFooter extends LitElement {
             `
           : nothing}
         <div class=${classMap({ container: true, "edit-mode": editMode })}>
-          ${editMode
-            ? card
+          ${card
+            ? this._renderCard(card, editMode)
+            : editMode
               ? html`
-                  <hui-card-edit-mode
-                    @ll-edit-card=${this._editCard}
-                    @ll-delete-card=${this._deleteCard}
-                    .hass=${this.hass}
-                    .lovelace=${this.lovelace!}
-                    .path=${[0]}
-                    no-duplicate
-                    no-move
-                  >
-                    ${card}
-                  </hui-card-edit-mode>
-                `
-              : html`
                   <button class="add" @click=${this._addCard}>
                     <ha-ripple></ha-ripple>
                     <ha-svg-icon .path=${mdiPlus}></ha-svg-icon>
@@ -188,7 +214,7 @@ export class HuiViewFooter extends LitElement {
                     )}
                   </button>
                 `
-            : card}
+              : nothing}
         </div>
       </div>
     `;
@@ -228,7 +254,15 @@ export class HuiViewFooter extends LitElement {
     }
 
     .container {
+      --row-height: var(--ha-section-grid-row-height, 56px);
+      --row-gap: var(--ha-section-grid-row-gap, 8px);
+      --column-gap: var(--ha-section-grid-column-gap, 8px);
       position: relative;
+      display: grid;
+      grid-template-columns: repeat(12, minmax(0, 1fr));
+      grid-auto-rows: auto;
+      row-gap: var(--row-gap);
+      column-gap: var(--column-gap);
     }
 
     .container.edit-mode {
@@ -236,6 +270,20 @@ export class HuiViewFooter extends LitElement {
       border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
       border: 2px dashed var(--divider-color);
       border-start-end-radius: 0;
+    }
+
+    .card {
+      position: relative;
+      grid-column: 1 / -1;
+      grid-row: span var(--row-size, 1);
+    }
+
+    .card.fit-rows {
+      height: calc(
+        (var(--row-size, 1) * (var(--row-height) + var(--row-gap))) - var(
+            --row-gap
+          )
+      );
     }
 
     .actions-container {
@@ -269,6 +317,8 @@ export class HuiViewFooter extends LitElement {
     }
 
     .add {
+      grid-column: 1 / -1;
+      margin: 0 auto;
       position: relative;
       display: flex;
       flex-direction: row;

--- a/src/panels/lovelace/views/hui-view-footer.ts
+++ b/src/panels/lovelace/views/hui-view-footer.ts
@@ -276,6 +276,7 @@ export class HuiViewFooter extends LitElement {
       position: relative;
       grid-column: 1 / -1;
       grid-row: span var(--row-size, 1);
+      max-height: 25dvh;
     }
 
     .card.fit-rows {

--- a/src/panels/lovelace/views/hui-view-footer.ts
+++ b/src/panels/lovelace/views/hui-view-footer.ts
@@ -210,7 +210,7 @@ export class HuiViewFooter extends LitElement {
                     <ha-ripple></ha-ripple>
                     <ha-svg-icon .path=${mdiPlus}></ha-svg-icon>
                     ${this.hass.localize(
-                      "ui.panel.lovelace.editor.edit_card.add"
+                      "ui.panel.lovelace.editor.edit_view_footer.add"
                     )}
                   </button>
                 `

--- a/src/panels/lovelace/views/hui-view-footer.ts
+++ b/src/panels/lovelace/views/hui-view-footer.ts
@@ -266,7 +266,7 @@ export class HuiViewFooter extends LitElement {
     }
 
     .container.edit-mode {
-      padding: 8px;
+      padding: var(--ha-space-2);
       border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
       border: 2px dashed var(--divider-color);
       border-start-end-radius: 0;
@@ -276,6 +276,7 @@ export class HuiViewFooter extends LitElement {
       position: relative;
       grid-column: 1 / -1;
       grid-row: span var(--row-size, 1);
+      max-height: 25vh;
       max-height: 25dvh;
     }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8346,6 +8346,16 @@
               }
             }
           },
+          "edit_view_footer": {
+            "header": "Footer settings",
+            "edit_ui": "[%key:ui::panel::lovelace::editor::edit_view::edit_ui%]",
+            "edit_yaml": "[%key:ui::panel::lovelace::editor::edit_view::edit_yaml%]",
+            "saving_failed": "[%key:ui::panel::lovelace::editor::edit_view::saving_failed%]",
+            "settings": {
+              "column_span": "Width",
+              "column_span_helper": "[%key:ui::panel::lovelace::editor::edit_section::settings::column_span_helper%]"
+            }
+          },
           "edit_badges": {
             "view_no_badges": "Badges are not be supported by the current view type."
           },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8348,6 +8348,7 @@
           },
           "edit_view_footer": {
             "header": "Footer settings",
+            "add": "Add footer",
             "edit_ui": "[%key:ui::panel::lovelace::editor::edit_view::edit_ui%]",
             "edit_yaml": "[%key:ui::panel::lovelace::editor::edit_view::edit_yaml%]",
             "saving_failed": "[%key:ui::panel::lovelace::editor::edit_view::saving_failed%]",


### PR DESCRIPTION
## Proposed change

Add a sticky footer to the sections view that supports a single card, similar to the existing view header. The footer sticks to the bottom of the viewport and includes:

- A `hui-view-footer` component that renders a single card in a sticky footer
- Full edit mode support with add/edit/delete card actions
- A settings dialog with a width slider (`column_span`) to control how many columns the footer spans
- A `saveCard` callback on `CreateCardDialogParams` for single-card picking mode (hides the entity tab since that flow generates multiple cards)
- No resizing of the card because the whole footer is resizable. Can use fractional width like `column_span: 0.5` for smaller sizes

Talked with @piitaya about adding a footer like this. It is needed mainly so users can replicate the energy dashboard and so we can eventually migrate it to a normal dashboard strategy (like Overview, Lights, etc.) instead of a custom panel.

<img width="894" height="916" alt="image" src="https://github.com/user-attachments/assets/f8bdfbbf-2994-4424-a2ae-6637b4fe4aae" />

<img width="894" height="314" alt="image" src="https://github.com/user-attachments/assets/b43d1c93-d74b-4563-947f-d4316caf758e" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr