### PR TITLE
Fix hardcoded collection keys in energy dashboard

### DIFF
--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -40,6 +40,7 @@ import "../lovelace/views/hui-view";
 import "../lovelace/views/hui-view-container";
 
 export const DEFAULT_ENERGY_COLLECTION_KEY = "energy_dashboard";
+export const DEFAULT_POWER_COLLECTION_KEY = "energy_dashboard_now";
 
 const EMPTY_PREFERENCES: EnergyPreferences = {
   energy_sources: [],
@@ -87,7 +88,7 @@ const POWER_VIEW = {
   path: "now",
   strategy: {
     type: "power",
-    collection_key: "energy_dashboard_now",
+    collection_key: DEFAULT_POWER_COLLECTION_KEY,
   },
 } as LovelaceViewConfig;
 
@@ -350,7 +351,7 @@ class PanelEnergy extends LitElement {
 
   private _dumpCSV = async () => {
     const energyData = getEnergyDataCollection(this.hass, {
-      key: "energy_dashboard",
+      key: DEFAULT_ENERGY_COLLECTION_KEY,
     });
 
     if (!energyData.prefs || !energyData.state.stats) {

--- a/src/panels/energy/strategies/energy-overview-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-overview-view-strategy.ts
@@ -119,7 +119,7 @@ export class EnergyOverviewViewStrategy extends ReactiveElement {
               "ui.panel.energy.cards.energy_usage_graph_title"
             ),
             type: "energy-usage-graph",
-            collection_key: "energy_dashboard",
+            collection_key: collectionKey,
           },
         ],
       });

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -55,7 +55,7 @@ export class EnergyViewStrategy extends ReactiveElement {
 
     view.cards!.push({
       type: "energy-compare",
-      collection_key: "energy_dashboard",
+      collection_key: collectionKey,
     });
 
     // Only include if we have a grid or battery.
@@ -63,7 +63,7 @@ export class EnergyViewStrategy extends ReactiveElement {
       view.cards!.push({
         title: hass.localize("ui.panel.energy.cards.energy_usage_graph_title"),
         type: "energy-usage-graph",
-        collection_key: "energy_dashboard",
+        collection_key: collectionKey,
       });
     }
 
@@ -72,7 +72,7 @@ export class EnergyViewStrategy extends ReactiveElement {
       view.cards!.push({
         title: hass.localize("ui.panel.energy.cards.energy_solar_graph_title"),
         type: "energy-solar-graph",
-        collection_key: "energy_dashboard",
+        collection_key: collectionKey,
       });
     }
 
@@ -82,7 +82,7 @@ export class EnergyViewStrategy extends ReactiveElement {
         title: hass.localize("ui.panel.energy.cards.energy_distribution_title"),
         type: "energy-distribution",
         view_layout: { position: "sidebar" },
-        collection_key: "energy_dashboard",
+        collection_key: collectionKey,
       });
     }
 
@@ -92,7 +92,7 @@ export class EnergyViewStrategy extends ReactiveElement {
           "ui.panel.energy.cards.energy_sources_table_title"
         ),
         type: "energy-sources-table",
-        collection_key: "energy_dashboard",
+        collection_key: collectionKey,
         types: ["grid", "solar", "battery"],
       });
     }
@@ -102,7 +102,7 @@ export class EnergyViewStrategy extends ReactiveElement {
       view.cards!.push({
         type: "energy-grid-neutrality-gauge",
         view_layout: { position: "sidebar" },
-        collection_key: "energy_dashboard",
+        collection_key: collectionKey,
       });
     }
 
@@ -112,14 +112,14 @@ export class EnergyViewStrategy extends ReactiveElement {
         view.cards!.push({
           type: "energy-solar-consumed-gauge",
           view_layout: { position: "sidebar" },
-          collection_key: "energy_dashboard",
+          collection_key: collectionKey,
         });
       }
       if (hasGrid) {
         view.cards!.push({
           type: "energy-self-sufficiency-gauge",
           view_layout: { position: "sidebar" },
-          collection_key: "energy_dashboard",
+          collection_key: collectionKey,
         });
       }
     }
@@ -129,7 +129,7 @@ export class EnergyViewStrategy extends ReactiveElement {
       view.cards!.push({
         type: "energy-carbon-consumed-gauge",
         view_layout: { position: "sidebar" },
-        collection_key: "energy_dashboard",
+        collection_key: collectionKey,
       });
     }
 
@@ -140,19 +140,19 @@ export class EnergyViewStrategy extends ReactiveElement {
           "ui.panel.energy.cards.energy_devices_detail_graph_title"
         ),
         type: "energy-devices-detail-graph",
-        collection_key: "energy_dashboard",
+        collection_key: collectionKey,
       });
       view.cards!.push({
         title: hass.localize(
           "ui.panel.energy.cards.energy_devices_graph_title"
         ),
         type: "energy-devices-graph",
-        collection_key: "energy_dashboard",
+        collection_key: collectionKey,
       });
       view.cards!.push({
         title: hass.localize("ui.panel.energy.cards.energy_sankey_title"),
         type: "energy-sankey",
-        collection_key: "energy_dashboard",
+        collection_key: collectionKey,
         group_by_floor: showFloorsNAreas,
         group_by_area: showFloorsNAreas,
       });


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

One of the elements in the energy overview strategy uses a hardcoded collection key, whilst the rest use the `collectionKey` variable. 

All of the elements in the energy view strategy are using hardcoded values desipte the `collectionKey` property also existing there. This means the individual cards would not use the correct collection key if ever overridden from the default. 

This shouldn't change the behaviour as the `collectionKey` is currently just the default key which is the same as the hardcoded value.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
