### PR TITLE
Support Energy Collections in Statistic Card Visual Editor

### DIFF
--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -195,7 +195,7 @@ export const fetchStatistic = (
   statistic_id: string,
   period: {
     fixed_period?: { start: string | Date; end: string | Date };
-    calendar?: { period: string; offset: number };
+    calendar?: { period: string; offset?: number };
     rolling_window?: { duration: HaDurationData; offset: HaDurationData };
   },
   units?: StatisticsUnitConfiguration

--- a/src/panels/lovelace/cards/hui-statistic-card.ts
+++ b/src/panels/lovelace/cards/hui-statistic-card.ts
@@ -166,7 +166,7 @@ export class HuiStatisticCard extends LitElement implements LovelaceCard {
         energy_date_selection: true,
         ...config,
         period: STATISTIC_CARD_DEFAULT_PERIOD,
-      } as StatisticCardConfig;
+      };
     }
 
     this._config = config;

--- a/src/panels/lovelace/cards/hui-statistic-card.ts
+++ b/src/panels/lovelace/cards/hui-statistic-card.ts
@@ -9,7 +9,10 @@ import { formatNumber } from "../../../common/number/format_number";
 import "../../../components/ha-alert";
 import "../../../components/ha-card";
 import "../../../components/ha-state-icon";
-import { getEnergyDataCollection } from "../../../data/energy";
+import {
+  getEnergyDataCollection,
+  validateEnergyCollectionKey,
+} from "../../../data/energy";
 import type { StatisticsMetaData } from "../../../data/recorder";
 import {
   fetchStatistic,
@@ -152,6 +155,9 @@ export class HuiStatisticCard extends LitElement implements LovelaceCard {
       !isValidEntityId(config.entity)
     ) {
       throw new Error("Invalid entity");
+    }
+    if (config.collection_key) {
+      validateEnergyCollectionKey(config.collection_key);
     }
     // Migrate legacy period option to new key
     if (config.period === PERIOD_ENERGY) {

--- a/src/panels/lovelace/cards/hui-statistic-card.ts
+++ b/src/panels/lovelace/cards/hui-statistic-card.ts
@@ -36,6 +36,7 @@ import type {
 import type { HuiErrorCard } from "./hui-error-card";
 import type { EntityCardConfig, StatisticCardConfig } from "./types";
 
+/* @deprecated */
 export const PERIOD_ENERGY = "energy_date_selection";
 export const STATISTIC_CARD_DEFAULT_PERIOD = {
   calendar: { period: "month" },

--- a/src/panels/lovelace/cards/hui-statistic-card.ts
+++ b/src/panels/lovelace/cards/hui-statistic-card.ts
@@ -34,6 +34,9 @@ import type { HuiErrorCard } from "./hui-error-card";
 import type { EntityCardConfig, StatisticCardConfig } from "./types";
 
 export const PERIOD_ENERGY = "energy_date_selection";
+export const STATISTIC_CARD_DEFAULT_PERIOD = {
+  calendar: { period: "month" },
+};
 
 @customElement("hui-statistic-card")
 export class HuiStatisticCard extends LitElement implements LovelaceCard {
@@ -60,7 +63,7 @@ export class HuiStatisticCard extends LitElement implements LovelaceCard {
 
     return {
       entity: foundEntities[0] || "",
-      period: { calendar: { period: "month" } },
+      period: STATISTIC_CARD_DEFAULT_PERIOD,
     };
   }
 
@@ -92,7 +95,7 @@ export class HuiStatisticCard extends LitElement implements LovelaceCard {
 
   public connectedCallback() {
     super.connectedCallback();
-    if (this._config?.period === PERIOD_ENERGY) {
+    if (this._useEnergyDateSelect()) {
       this._subscribeEnergy();
     } else {
       this._setFetchStatisticTimer();
@@ -149,6 +152,14 @@ export class HuiStatisticCard extends LitElement implements LovelaceCard {
       !isValidEntityId(config.entity)
     ) {
       throw new Error("Invalid entity");
+    }
+    // Migrate legacy period option to new key
+    if (config.period === PERIOD_ENERGY) {
+      config = {
+        energy_date_selection: true,
+        ...config,
+        period: STATISTIC_CARD_DEFAULT_PERIOD,
+      } as StatisticCardConfig;
     }
 
     this._config = config;
@@ -250,17 +261,18 @@ export class HuiStatisticCard extends LitElement implements LovelaceCard {
       | undefined;
 
     if (this.hass) {
-      if (this._config.period === PERIOD_ENERGY && !this._energySub) {
+      const useDateSelect = this._useEnergyDateSelect();
+      if (useDateSelect && !this._energySub) {
         this._subscribeEnergy();
         return;
       }
-      if (this._config.period !== PERIOD_ENERGY && this._energySub) {
+      if (!useDateSelect && this._energySub) {
         this._unsubscribeEnergy();
         this._setFetchStatisticTimer();
         return;
       }
       if (
-        this._config.period === PERIOD_ENERGY &&
+        useDateSelect &&
         this._energySub &&
         changedProps.has("_config") &&
         oldConfig?.collection_key !== this._config.collection_key
@@ -306,11 +318,19 @@ export class HuiStatisticCard extends LitElement implements LovelaceCard {
     }
   }
 
+  private _useEnergyDateSelect() {
+    if (!this._config) return false;
+    // Use date selection if enabled through config key
+    if (this._config.energy_date_selection) return true;
+    // Otherwise check if period key is set to the legacy energy mode value
+    return this._config.period === PERIOD_ENERGY;
+  }
+
   private _setFetchStatisticTimer() {
     this._fetchStatistic();
     // statistics are created every hour
     clearInterval(this._interval);
-    if (this._config?.period !== PERIOD_ENERGY) {
+    if (!this._useEnergyDateSelect()) {
       this._interval = window.setInterval(
         () => this._fetchStatistic(),
         5 * 1000 * 60

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -166,11 +166,14 @@ export interface ButtonCardConfig extends LovelaceCardConfig {
 }
 
 export interface EnergyCardBaseConfig extends LovelaceCardConfig {
-  title?: string;
   collection_key?: string;
 }
 
-export interface EnergyCardSankeyConfig extends EnergyCardBaseConfig {
+export interface EnergyCardConfig extends EnergyCardBaseConfig {
+  title?: string;
+}
+
+export interface EnergyCardSankeyConfig extends EnergyCardConfig {
   layout?: "auto" | "vertical" | "horizontal";
   group_by_floor?: boolean;
   group_by_area?: boolean;
@@ -182,61 +185,61 @@ export interface EnergyDateSelectorCardConfig extends EnergyCardBaseConfig {
   disable_compare?: boolean;
 }
 
-export interface EnergyDistributionCardConfig extends EnergyCardBaseConfig {
+export interface EnergyDistributionCardConfig extends EnergyCardConfig {
   type: "energy-distribution";
   link_dashboard?: boolean;
 }
-export interface EnergyUsageGraphCardConfig extends EnergyCardBaseConfig {
+export interface EnergyUsageGraphCardConfig extends EnergyCardConfig {
   type: "energy-usage-graph";
 }
 
-export interface EnergySolarGraphCardConfig extends EnergyCardBaseConfig {
+export interface EnergySolarGraphCardConfig extends EnergyCardConfig {
   type: "energy-solar-graph";
 }
 
-export interface EnergyGasGraphCardConfig extends EnergyCardBaseConfig {
+export interface EnergyGasGraphCardConfig extends EnergyCardConfig {
   type: "energy-gas-graph";
 }
 
-export interface EnergyWaterGraphCardConfig extends EnergyCardBaseConfig {
+export interface EnergyWaterGraphCardConfig extends EnergyCardConfig {
   type: "energy-water-graph";
 }
 
-export interface EnergyDevicesGraphCardConfig extends EnergyCardBaseConfig {
+export interface EnergyDevicesGraphCardConfig extends EnergyCardConfig {
   type: "energy-devices-graph";
   max_devices?: number;
   hide_compound_stats?: boolean;
   modes?: ("bar" | "pie")[];
 }
 
-export interface EnergyDevicesDetailGraphCardConfig extends EnergyCardBaseConfig {
+export interface EnergyDevicesDetailGraphCardConfig extends EnergyCardConfig {
   type: "energy-devices-detail-graph";
   max_devices?: number;
 }
 
-export interface EnergySourcesTableCardConfig extends EnergyCardBaseConfig {
+export interface EnergySourcesTableCardConfig extends EnergyCardConfig {
   type: "energy-sources-table";
   types?: (keyof EnergySourceByType)[];
   show_only_totals?: boolean;
 }
 
-export interface EnergySolarGaugeCardConfig extends EnergyCardBaseConfig {
+export interface EnergySolarGaugeCardConfig extends EnergyCardConfig {
   type: "energy-solar-consumed-gauge";
 }
 
-export interface EnergySelfSufficiencyGaugeCardConfig extends EnergyCardBaseConfig {
+export interface EnergySelfSufficiencyGaugeCardConfig extends EnergyCardConfig {
   type: "energy-self-sufficiency-gauge";
 }
 
-export interface EnergyGridNeutralityGaugeCardConfig extends EnergyCardBaseConfig {
+export interface EnergyGridNeutralityGaugeCardConfig extends EnergyCardConfig {
   type: "energy-grid-neutrality-gauge";
 }
 
-export interface EnergyCarbonGaugeCardConfig extends EnergyCardBaseConfig {
+export interface EnergyCarbonGaugeCardConfig extends EnergyCardConfig {
   type: "energy-carbon-consumed-gauge";
 }
 
-export interface PowerSourcesGraphCardConfig extends EnergyCardBaseConfig {
+export interface PowerSourcesGraphCardConfig extends EnergyCardConfig {
   type: "power-sources-graph";
   show_legend?: boolean;
 }
@@ -471,7 +474,7 @@ export interface StatisticsGraphCardConfig extends EnergyCardBaseConfig {
   expand_legend?: boolean;
 }
 
-export interface StatisticCardConfig extends Omit<EnergyCardBaseConfig, "title"> {
+export interface StatisticCardConfig extends EnergyCardBaseConfig {
   name?: string | EntityNameItem | EntityNameItem[];
   entities: (EntityConfig | string)[];
   period:

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -480,7 +480,7 @@ export interface StatisticCardConfig extends EnergyCardBaseConfig {
   period:
     | {
         fixed_period?: { start: string; end: string };
-        calendar?: { period: string; offset: number };
+        calendar?: { period: string; offset?: number };
         rolling_window?: { duration: HaDurationData; offset: HaDurationData };
       }
     | "energy_date_selection"; // Maintained for legacy compatibility, use new key instead.

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -471,7 +471,7 @@ export interface StatisticsGraphCardConfig extends EnergyCardBaseConfig {
   expand_legend?: boolean;
 }
 
-export interface StatisticCardConfig extends EnergyCardBaseConfig {
+export interface StatisticCardConfig extends Omit<EnergyCardBaseConfig, "title"> {
   name?: string | EntityNameItem | EntityNameItem[];
   entities: (EntityConfig | string)[];
   period:
@@ -480,7 +480,7 @@ export interface StatisticCardConfig extends EnergyCardBaseConfig {
         calendar?: { period: string; offset: number };
         rolling_window?: { duration: HaDurationData; offset: HaDurationData };
       }
-    | "energy_date_selection"; // Maintained for legacy compatability, use new key instead.
+    | "energy_date_selection"; // Maintained for legacy compatibility, use new key instead.
   energy_date_selection?: boolean;
   stat_type: keyof Statistic;
   theme?: string;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -471,7 +471,7 @@ export interface StatisticsGraphCardConfig extends EnergyCardBaseConfig {
   expand_legend?: boolean;
 }
 
-export interface StatisticCardConfig extends LovelaceCardConfig {
+export interface StatisticCardConfig extends EnergyCardBaseConfig {
   name?: string | EntityNameItem | EntityNameItem[];
   entities: (EntityConfig | string)[];
   period:
@@ -480,7 +480,8 @@ export interface StatisticCardConfig extends LovelaceCardConfig {
         calendar?: { period: string; offset: number };
         rolling_window?: { duration: HaDurationData; offset: HaDurationData };
       }
-    | "energy_date_selection";
+    | "energy_date_selection"; // Maintained for legacy compatability, use new key instead.
+  energy_date_selection?: boolean;
   stat_type: keyof Statistic;
   theme?: string;
 }

--- a/src/panels/lovelace/editor/config-elements/hui-energy-devices-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-energy-devices-card-editor.ts
@@ -19,7 +19,7 @@ import "../../../../components/ha-form/ha-form";
 import type { HaFormSchema } from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
 import type {
-  EnergyCardBaseConfig,
+  EnergyCardConfig,
   EnergyDevicesDetailGraphCardConfig,
   EnergyDevicesGraphCardConfig,
 } from "../../cards/types";
@@ -44,7 +44,7 @@ const cardConfigStruct = assign(
 const chartModeOpts = ["bar", "pie"] as const;
 
 type EnergyDevicesCardConfig =
-  | EnergyCardBaseConfig
+  | EnergyCardConfig
   | EnergyDevicesGraphCardConfig
   | EnergyDevicesDetailGraphCardConfig;
 @customElement("hui-energy-devices-card-editor")

--- a/src/panels/lovelace/editor/config-elements/hui-energy-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-energy-graph-card-editor.ts
@@ -17,6 +17,7 @@ import type { HaFormSchema } from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
 import type {
   EnergyCardBaseConfig,
+  EnergyCardConfig,
   EnergyDistributionCardConfig,
   PowerSourcesGraphCardConfig,
 } from "../../cards/types";
@@ -46,10 +47,6 @@ const cardConfigStruct = assign(
   })
 );
 
-type EnergyGraphCardConfig =
-  | EnergyCardBaseConfig
-  | EnergyDistributionCardConfig
-  | PowerSourcesGraphCardConfig;
 @customElement("hui-energy-graph-card-editor")
 export class HuiEnergyGraphCardEditor
   extends LitElement
@@ -57,16 +54,28 @@ export class HuiEnergyGraphCardEditor
 {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
-  @state() private _config?: EnergyGraphCardConfig;
+  @state() private _config?:
+    | EnergyCardBaseConfig
+    | EnergyCardConfig
+    | EnergyDistributionCardConfig
+    | PowerSourcesGraphCardConfig;
 
-  public setConfig(config: EnergyGraphCardConfig): void {
+  public setConfig(
+    config:
+      | EnergyCardBaseConfig
+      | EnergyCardConfig
+      | EnergyDistributionCardConfig
+      | PowerSourcesGraphCardConfig
+  ): void {
     assert(config, cardConfigStruct);
     this._config = config;
   }
 
   private _schema = memoizeOne((type: string) => {
     const schema: HaFormSchema[] = [
-      { name: "title", selector: { text: {} } },
+      ...(type !== "energy-compare"
+        ? [{ name: "title", selector: { text: {} } }]
+        : []),
       ...(type === "power-sources-graph"
         ? [
             {

--- a/src/panels/lovelace/editor/config-elements/hui-statistic-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistic-card-editor.ts
@@ -90,7 +90,7 @@ export class HuiStatisticCardEditor
         energy_date_selection: true,
         ...config,
         period: STATISTIC_CARD_DEFAULT_PERIOD,
-      } as StatisticCardConfig;
+      };
     }
     this._config = config;
     this._fetchMetadata();

--- a/src/panels/lovelace/editor/config-elements/hui-statistic-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistic-card-editor.ts
@@ -1,12 +1,20 @@
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
-import { any, assert, assign, object, optional, string } from "superstruct";
+import {
+  any,
+  assert,
+  assign,
+  boolean,
+  object,
+  optional,
+  string,
+} from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
 import { deepEqual } from "../../../../common/util/deep-equal";
 import "../../../../components/ha-form/ha-form";
-import type { SchemaUnion } from "../../../../components/ha-form/types";
+import type { HaFormSchema } from "../../../../components/ha-form/types";
 import type {
   StatisticsMetaData,
   StatisticType,
@@ -22,6 +30,10 @@ import { headerFooterConfigStructs } from "../../header-footer/structs";
 import type { LovelaceCardEditor } from "../../types";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import { entityNameStruct } from "../structs/entity-name-struct";
+import {
+  PERIOD_ENERGY,
+  STATISTIC_CARD_DEFAULT_PERIOD,
+} from "../../cards/hui-statistic-card";
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -34,6 +46,7 @@ const cardConfigStruct = assign(
     period: optional(any()),
     theme: optional(string()),
     footer: optional(headerFooterConfigStructs),
+    energy_date_selection: optional(boolean()),
     collection_key: optional(string()),
   })
 );
@@ -71,6 +84,14 @@ export class HuiStatisticCardEditor
 
   public setConfig(config: StatisticCardConfig): void {
     assert(config, cardConfigStruct);
+    // Migrate legacy period option to new key
+    if (config.period === PERIOD_ENERGY) {
+      config = {
+        energy_date_selection: true,
+        ...config,
+        period: STATISTIC_CARD_DEFAULT_PERIOD,
+      } as StatisticCardConfig;
+    }
     this._config = config;
     this._fetchMetadata();
   }
@@ -104,6 +125,7 @@ export class HuiStatisticCardEditor
     (
       selectedPeriodKey: string | undefined,
       localize: LocalizeFunc,
+      enableDateSelect: boolean,
       metadata?: StatisticsMetaData
     ) =>
       [
@@ -126,24 +148,48 @@ export class HuiStatisticCardEditor
             },
           },
         },
+        ...(!enableDateSelect
+          ? [
+              {
+                name: "period",
+                required: true,
+                selector:
+                  selectedPeriodKey && selectedPeriodKey in periods
+                    ? {
+                        select: {
+                          multiple: false,
+                          options: Object.keys(periods).map((periodKey) => ({
+                            value: periodKey,
+                            label:
+                              localize(
+                                `ui.panel.lovelace.editor.card.statistic.periods.${periodKey}`
+                              ) || periodKey,
+                          })),
+                        },
+                      }
+                    : { object: {} },
+              },
+            ]
+          : []),
         {
-          name: "period",
-          required: true,
-          selector:
-            selectedPeriodKey && selectedPeriodKey in periods
-              ? {
-                  select: {
-                    multiple: false,
-                    options: Object.keys(periods).map((periodKey) => ({
-                      value: periodKey,
-                      label:
-                        localize(
-                          `ui.panel.lovelace.editor.card.statistic.periods.${periodKey}`
-                        ) || periodKey,
-                    })),
+          name: "",
+          type: "grid",
+          schema: [
+            ...(enableDateSelect
+              ? ([
+                  {
+                    type: "string",
+                    name: "collection_key",
+                    required: false,
                   },
-                }
-              : { object: {} },
+                ] as HaFormSchema[])
+              : []),
+            {
+              name: "energy_date_selection",
+              required: false,
+              selector: { boolean: {} },
+            },
+          ],
         },
         {
           name: "name",
@@ -180,6 +226,7 @@ export class HuiStatisticCardEditor
     const schema = this._schema(
       typeof data.period === "string" ? data.period : undefined,
       this.hass.localize,
+      !!this._config!.energy_date_selection,
       this._metadata
     );
 
@@ -188,6 +235,7 @@ export class HuiStatisticCardEditor
         .hass=${this.hass}
         .data=${data}
         .schema=${schema}
+        .computeHelper=${this._computeHelperCallback}
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
       ></ha-form>
@@ -244,26 +292,34 @@ export class HuiStatisticCardEditor
     fireEvent(this, "config-changed", { config });
   }
 
-  private _computeLabelCallback = (
-    schema: SchemaUnion<ReturnType<typeof this._schema>>
-  ) => {
-    if (schema.name === "period") {
-      return this.hass!.localize(
-        "ui.panel.lovelace.editor.card.statistic.period"
-      );
+  private _computeHelperCallback = (schema) => {
+    switch (schema.name) {
+      case "collection_key":
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.generic.collection_key_description`
+        );
+      default:
+        return undefined;
     }
+  };
 
-    if (schema.name === "theme") {
-      return `${this.hass!.localize(
-        "ui.panel.lovelace.editor.card.generic.theme"
-      )} (${this.hass!.localize(
-        "ui.panel.lovelace.editor.card.config.optional"
-      )})`;
+  private _computeLabelCallback = (schema) => {
+    switch (schema.name) {
+      case "period":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.card.statistic.period"
+        );
+      case "theme":
+        return `${this.hass!.localize(
+          "ui.panel.lovelace.editor.card.generic.theme"
+        )} (${this.hass!.localize(
+          "ui.panel.lovelace.editor.card.config.optional"
+        )})`;
+      default:
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.generic.${schema.name}`
+        );
     }
-
-    return this.hass!.localize(
-      `ui.panel.lovelace.editor.card.generic.${schema.name}`
-    );
   };
 }
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR adds more structured support for using the `statistics-card` with energy collections in the visual editor. Previously this was only possible using manual YAML editing.

The changes the use of the "period" field being set to the string "energy_date_selection" in favour of adding a toggle select for consistency. I've added logic to detect the old period string and convert to the new config scheme, so backwards compatibility is maintained. If this PR goes ahead, I'd suggest we look at deprecating the original usage (I don't know what that process involves).

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Default state of the editor:

<img width="513" height="788" alt="image" src="https://github.com/user-attachments/assets/efa9d62b-3614-4fdb-9ff4-743ab8b4966e" />

When energy date picker support is enabled, the optional collection key field becomes visible, and the period field is hidden:

<img width="505" height="505" alt="image" src="https://github.com/user-attachments/assets/1d3c95b9-5107-428f-9cb9-831b642818b8" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
