### PR TITLE
Virtualize notification drawer

### DIFF
--- a/src/dialogs/notifications/notification-drawer.ts
+++ b/src/dialogs/notifications/notification-drawer.ts
@@ -185,12 +185,12 @@ export class HuiNotificationDrawer extends LitElement {
       flex: 1 1 auto;
       min-height: 0;
       overflow: auto;
+      padding-top: var(--ha-space-4);
     }
 
     .notifications {
       display: flex;
       flex-direction: column;
-      padding-top: 16px;
       padding-left: var(--safe-area-inset-left, 0px);
       padding-inline-start: var(--safe-area-inset-left, 0px);
       padding-bottom: var(--safe-area-inset-bottom, 0px);
@@ -210,19 +210,19 @@ export class HuiNotificationDrawer extends LitElement {
     }
 
     .notification {
-      padding: 0 16px 16px;
+      padding: 0 var(--ha-space-4) var(--ha-space-4);
       width: 100%;
     }
 
     .notification-actions {
       border-top: 1px solid var(--divider-color);
-      padding: 16px;
+      padding: var(--ha-space-4);
       text-align: center;
       flex: 0 0 auto;
     }
 
     .empty {
-      padding: 16px;
+      padding: var(--ha-space-4);
       text-align: center;
     }
   `;

--- a/src/dialogs/notifications/notification-drawer.ts
+++ b/src/dialogs/notifications/notification-drawer.ts
@@ -1,4 +1,5 @@
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
+import type { PropertyValues } from "lit";
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
@@ -11,6 +12,7 @@ import "./notification-item";
 import "../../components/ha-header-bar";
 import "../../components/ha-button";
 import "../../components/ha-drawer";
+import { loadVirtualizer } from "../../resources/virtualizer";
 import type { HaDrawer } from "../../components/ha-drawer";
 import { computeRTLDirection } from "../../common/util/compute_rtl";
 
@@ -66,6 +68,14 @@ export class HuiNotificationDrawer extends LitElement {
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   };
 
+  public willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+
+    if (!this.hasUpdated) {
+      loadVirtualizer();
+    }
+  }
+
   protected render() {
     if (!this._open) {
       return nothing;
@@ -111,24 +121,21 @@ export class HuiNotificationDrawer extends LitElement {
         </ha-header-bar>
         <div class="notifications">
           ${notifications.length
-            ? html`${notifications.map(
-                (notification) =>
-                  html`<div class="notification">
-                    <notification-item
-                      .hass=${this.hass}
-                      .notification=${notification}
-                    ></notification-item>
-                  </div>`
-              )}
-              ${this._notifications.length > 1
-                ? html`<div class="notification-actions">
-                    <ha-button appearance="filled" @click=${this._dismissAll}>
-                      ${this.hass.localize(
-                        "ui.notification_drawer.dismiss_all"
-                      )}
-                    </ha-button>
-                  </div>`
-                : ""}`
+            ? html`<div class="list-container">
+                  <lit-virtualizer
+                    .items=${notifications}
+                    .renderItem=${this._renderItem}
+                  ></lit-virtualizer>
+                </div>
+                ${this._notifications.length > 1
+                  ? html`<div class="notification-actions">
+                      <ha-button appearance="filled" @click=${this._dismissAll}>
+                        ${this.hass.localize(
+                          "ui.notification_drawer.dismiss_all"
+                        )}
+                      </ha-button>
+                    </div>`
+                  : ""}`
             : html` <div class="empty">
                 ${this.hass.localize("ui.notification_drawer.empty")}
                 <div></div>
@@ -137,6 +144,15 @@ export class HuiNotificationDrawer extends LitElement {
       </ha-drawer>
     `;
   }
+
+  private _renderItem = (notification: PersistentNotification) => html`
+    <div class="notification">
+      <notification-item
+        .hass=${this.hass}
+        .notification=${notification}
+      ></notification-item>
+    </div>
+  `;
 
   private _dialogClosed(ev: Event) {
     ev.stopPropagation();
@@ -165,8 +181,15 @@ export class HuiNotificationDrawer extends LitElement {
       }
     }
 
+    .list-container {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow: auto;
+    }
+
     .notifications {
-      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
       padding-top: 16px;
       padding-left: var(--safe-area-inset-left, 0px);
       padding-inline-start: var(--safe-area-inset-left, 0px);
@@ -188,11 +211,14 @@ export class HuiNotificationDrawer extends LitElement {
 
     .notification {
       padding: 0 16px 16px;
+      width: 100%;
     }
 
     .notification-actions {
-      padding: 0 16px 16px;
+      border-top: 1px solid var(--divider-color);
+      padding: 16px;
       text-align: center;
+      flex: 0 0 auto;
     }
 
     .empty {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
I woke up this morning to 4000+ persistent notifications and growing, it seems something had gone haywire, but the experience was pretty grim. 

Trying to open the drawer basically hung the web browser, so it took a long time before I could even figure out what was happening.

If I open the drawer and let it sit for about a minute, it would finally render the top 10 notifications so I could at least see them. 
To dismiss the rest, I would have had to scroll all the way down through thousands of notifications. 
The scrollbar was non-responsive due to the load, scrolling otherwise was extremely laggy, it was very difficult to reach the dismiss button, especially as more notifications kept coming in.

This adds a virtualizer so the notifications are much snappier and now show instantly when opening the drawer, instead of trying to render all thousands of them at once. 

This also pins the dismiss all button to the bottom of the drawer, instead of requiring to scroll through the bottom of the list to make the dismiss button visible.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://github.com/orgs/home-assistant/discussions/2033
https://community.home-assistant.io/t/dismiss-notifications/571757
https://community.home-assistant.io/t/wth-making-multiple-persistent-notifications-easier-to-dismiss/804979
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
