### PR TITLE
Correct Developer Tools Tab Translation Key

### DIFF
--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -300,7 +300,7 @@ export const configSections: Record<string, PageNavigation[]> = {
   developer_tools: [
     {
       path: "/config/developer-tools",
-      translationKey: "panel.developer_tools",
+      translationKey: "ui.panel.config.dashboard.developer_tools.main",
       iconPath: mdiHammer,
       iconColor: "#7A5AA6",
       core: true,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

In #29631 the wrong key was selected for the dev tools page title. It should be `ui.panel.config.dashboard.developer_tools.main` not `panel.developer_tools`.

I can only apologise, the key I used in the first PR used to be there but has been removed from `en.json`, I must have had a cached copy of the translations file.

I have triple checked this is the correct key:

<img width="710" height="209" alt="image" src="https://github.com/user-attachments/assets/a5eac70d-60d1-4282-8f14-2c55e05dfb3c" />
<img width="518" height="265" alt="image" src="https://github.com/user-attachments/assets/12c306c3-f436-4ea1-aef1-dcb8c9e97e88" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29631
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:
