### PR TITLE
Add tabs to energy config page

### DIFF
--- a/src/panels/config/energy/ha-config-energy.ts
+++ b/src/panels/config/energy/ha-config-energy.ts
@@ -1,5 +1,5 @@
 import "../../../layouts/hass-error-screen";
-import { mdiDownload } from "@mdi/js";
+import { mdiDownload, mdiFire, mdiLightningBolt, mdiWater } from "@mdi/js";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
@@ -31,7 +31,7 @@ import "./components/ha-energy-battery-settings";
 import "./components/ha-energy-gas-settings";
 import "./components/ha-energy-water-settings";
 import { fileDownload } from "../../../util/file_download";
-import { configSections } from "../ha-panel-config";
+import type { PageNavigation } from "../../../layouts/hass-tabs-subpage";
 
 const INITIAL_CONFIG: EnergyPreferences = {
   energy_sources: [],
@@ -39,7 +39,26 @@ const INITIAL_CONFIG: EnergyPreferences = {
   device_consumption_water: [],
 };
 
-const TABS = ["electricity", "gas", "water"];
+const TABS: PageNavigation[] = [
+  {
+    path: "/config/energy/electricity",
+    translationKey: "ui.panel.config.energy.tabs.electricity",
+    iconPath: mdiLightningBolt,
+    iconColor: "#F1C447",
+  },
+  {
+    path: "/config/energy/gas",
+    translationKey: "ui.panel.config.energy.tabs.gas",
+    iconPath: mdiFire,
+    iconColor: "#F1C447",
+  },
+  {
+    path: "/config/energy/water",
+    translationKey: "ui.panel.config.energy.tabs.water",
+    iconPath: mdiWater,
+    iconColor: "#F1C447",
+  },
+];
 
 @customElement("ha-config-energy")
 class HaConfigEnergy extends LitElement {
@@ -71,7 +90,7 @@ class HaConfigEnergy extends LitElement {
 
   protected firstUpdated() {
     const tab = this.route.path.substring(1);
-    if (!tab || !TABS.includes(tab)) {
+    if (!tab || !TABS.some((t) => t.path.endsWith(`/${tab}`))) {
       navigate(`${this.route.prefix}/electricity`, { replace: true });
     }
     this._fetchConfig();
@@ -101,7 +120,7 @@ class HaConfigEnergy extends LitElement {
           ? undefined
           : "/config/lovelace/dashboards"}
         .route=${this.route}
-        .tabs=${configSections.energy}
+        .tabs=${TABS}
       >
         <ha-icon-button
           slot="toolbar-icon"

--- a/src/panels/config/energy/ha-config-energy.ts
+++ b/src/panels/config/energy/ha-config-energy.ts
@@ -3,6 +3,8 @@ import { mdiDownload } from "@mdi/js";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { cache } from "lit/directives/cache";
+import { navigate } from "../../../common/navigate";
 import type {
   EnergyPreferencesValidation,
   EnergyInfo,
@@ -17,7 +19,7 @@ import {
 import type { StatisticsMetaData } from "../../../data/recorder";
 import { getStatisticMetadata } from "../../../data/recorder";
 import "../../../layouts/hass-loading-screen";
-import "../../../layouts/hass-subpage";
+import "../../../layouts/hass-tabs-subpage";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant, Route } from "../../../types";
 import "../../../components/ha-alert";
@@ -29,12 +31,15 @@ import "./components/ha-energy-battery-settings";
 import "./components/ha-energy-gas-settings";
 import "./components/ha-energy-water-settings";
 import { fileDownload } from "../../../util/file_download";
+import { configSections } from "../ha-panel-config";
 
 const INITIAL_CONFIG: EnergyPreferences = {
   energy_sources: [],
   device_consumption: [],
   device_consumption_water: [],
 };
+
+const TABS = ["electricity", "gas", "water"];
 
 @customElement("ha-config-energy")
 class HaConfigEnergy extends LitElement {
@@ -60,7 +65,15 @@ class HaConfigEnergy extends LitElement {
 
   @state() private _statsMetadata?: Record<string, StatisticsMetaData>;
 
+  private get _currTab(): string {
+    return this.route.path.substring(1) || "electricity";
+  }
+
   protected firstUpdated() {
+    const tab = this.route.path.substring(1);
+    if (!tab || !TABS.includes(tab)) {
+      navigate(`${this.route.prefix}/electricity`, { replace: true });
+    }
     this._fetchConfig();
   }
 
@@ -81,13 +94,14 @@ class HaConfigEnergy extends LitElement {
     }
 
     return html`
-      <hass-subpage
+      <hass-tabs-subpage
         .hass=${this.hass}
         .narrow=${this.narrow}
         .backPath=${this._searchParms.has("historyBack")
           ? undefined
           : "/config/lovelace/dashboards"}
-        .header=${this.hass.localize("ui.panel.config.energy.caption")}
+        .route=${this.route}
+        .tabs=${configSections.energy}
       >
         <ha-icon-button
           slot="toolbar-icon"
@@ -100,7 +114,15 @@ class HaConfigEnergy extends LitElement {
         <ha-alert>
           ${this.hass.localize("ui.panel.config.energy.new_device_info")}
         </ha-alert>
-        <div class="content">
+        <div class="content">${cache(this._renderTabContent())}</div>
+      </hass-tabs-subpage>
+    `;
+  }
+
+  private _renderTabContent(): TemplateResult {
+    switch (this._currTab) {
+      case "electricity":
+        return html`
           <ha-energy-grid-settings
             .hass=${this.hass}
             .preferences=${this._preferences!}
@@ -123,20 +145,6 @@ class HaConfigEnergy extends LitElement {
             .validationResult=${this._validationResult}
             @value-changed=${this._prefsChanged}
           ></ha-energy-battery-settings>
-          <ha-energy-gas-settings
-            .hass=${this.hass}
-            .preferences=${this._preferences!}
-            .statsMetadata=${this._statsMetadata}
-            .validationResult=${this._validationResult}
-            @value-changed=${this._prefsChanged}
-          ></ha-energy-gas-settings>
-          <ha-energy-water-settings
-            .hass=${this.hass}
-            .preferences=${this._preferences!}
-            .statsMetadata=${this._statsMetadata}
-            .validationResult=${this._validationResult}
-            @value-changed=${this._prefsChanged}
-          ></ha-energy-water-settings>
           <ha-energy-device-settings
             .hass=${this.hass}
             .preferences=${this._preferences!}
@@ -144,6 +152,26 @@ class HaConfigEnergy extends LitElement {
             .validationResult=${this._validationResult}
             @value-changed=${this._prefsChanged}
           ></ha-energy-device-settings>
+        `;
+      case "gas":
+        return html`
+          <ha-energy-gas-settings
+            .hass=${this.hass}
+            .preferences=${this._preferences!}
+            .statsMetadata=${this._statsMetadata}
+            .validationResult=${this._validationResult}
+            @value-changed=${this._prefsChanged}
+          ></ha-energy-gas-settings>
+        `;
+      case "water":
+        return html`
+          <ha-energy-water-settings
+            .hass=${this.hass}
+            .preferences=${this._preferences!}
+            .statsMetadata=${this._statsMetadata}
+            .validationResult=${this._validationResult}
+            @value-changed=${this._prefsChanged}
+          ></ha-energy-water-settings>
           <ha-energy-device-settings-water
             .hass=${this.hass}
             .preferences=${this._preferences!}
@@ -151,9 +179,10 @@ class HaConfigEnergy extends LitElement {
             .validationResult=${this._validationResult}
             @value-changed=${this._prefsChanged}
           ></ha-energy-device-settings-water>
-        </div>
-      </hass-subpage>
-    `;
+        `;
+      default:
+        return html``;
+    }
   }
 
   private async _fetchConfig() {

--- a/src/panels/config/energy/ha-config-energy.ts
+++ b/src/panels/config/energy/ha-config-energy.ts
@@ -1,7 +1,7 @@
 import "../../../layouts/hass-error-screen";
 import { mdiDownload } from "@mdi/js";
 import type { CSSResultGroup, TemplateResult } from "lit";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { cache } from "lit/directives/cache";
 import { navigate } from "../../../common/navigate";
@@ -119,7 +119,7 @@ class HaConfigEnergy extends LitElement {
     `;
   }
 
-  private _renderTabContent(): TemplateResult {
+  private _renderTabContent(): TemplateResult | typeof nothing {
     switch (this._currTab) {
       case "electricity":
         return html`
@@ -181,7 +181,7 @@ class HaConfigEnergy extends LitElement {
           ></ha-energy-device-settings-water>
         `;
       default:
-        return html``;
+        return nothing;
     }
   }
 

--- a/src/panels/config/energy/ha-config-energy.ts
+++ b/src/panels/config/energy/ha-config-energy.ts
@@ -1,6 +1,6 @@
 import "../../../layouts/hass-error-screen";
 import { mdiDownload, mdiFire, mdiLightningBolt, mdiWater } from "@mdi/js";
-import type { CSSResultGroup, TemplateResult } from "lit";
+import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { cache } from "lit/directives/cache";
@@ -88,11 +88,16 @@ class HaConfigEnergy extends LitElement {
     return this.route.path.substring(1) || "electricity";
   }
 
-  protected firstUpdated() {
-    const tab = this.route.path.substring(1);
-    if (!tab || !TABS.some((t) => t.path.endsWith(`/${tab}`))) {
-      navigate(`${this.route.prefix}/electricity`, { replace: true });
+  protected willUpdate(changedProperties: PropertyValues) {
+    if (changedProperties.has("route")) {
+      const tab = this.route.path.substring(1);
+      if (!tab || !TABS.some((t) => t.path.endsWith(`/${tab}`))) {
+        navigate(`${this.route.prefix}/electricity`, { replace: true });
+      }
     }
+  }
+
+  protected firstUpdated() {
     this._fetchConfig();
   }
 

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -8,7 +8,6 @@ import {
   mdiCog,
   mdiDatabase,
   mdiDevices,
-  mdiFire,
   mdiFlask,
   mdiHammer,
   mdiInformationOutline,
@@ -32,7 +31,6 @@ import {
   mdiTools,
   mdiUpdate,
   mdiViewDashboard,
-  mdiWater,
   mdiZigbee,
   mdiZWave,
 } from "@mdi/js";
@@ -307,26 +305,13 @@ export const configSections: Record<string, PageNavigation[]> = {
       core: true,
     },
   ],
+  // Not used as a tab, but this way it will stay in the quick bar
   energy: [
     {
       component: "energy",
-      path: "/config/energy/electricity",
-      translationKey: "ui.panel.config.energy.tabs.electricity",
+      path: "/config/energy",
+      translationKey: "ui.panel.config.energy.caption",
       iconPath: mdiLightningBolt,
-      iconColor: "#F1C447",
-    },
-    {
-      component: "energy",
-      path: "/config/energy/gas",
-      translationKey: "ui.panel.config.energy.tabs.gas",
-      iconPath: mdiFire,
-      iconColor: "#F1C447",
-    },
-    {
-      component: "energy",
-      path: "/config/energy/water",
-      translationKey: "ui.panel.config.energy.tabs.water",
-      iconPath: mdiWater,
       iconColor: "#F1C447",
     },
   ],

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -8,6 +8,7 @@ import {
   mdiCog,
   mdiDatabase,
   mdiDevices,
+  mdiFire,
   mdiFlask,
   mdiHammer,
   mdiInformationOutline,
@@ -31,6 +32,7 @@ import {
   mdiTools,
   mdiUpdate,
   mdiViewDashboard,
+  mdiWater,
   mdiZigbee,
   mdiZWave,
 } from "@mdi/js";
@@ -305,13 +307,26 @@ export const configSections: Record<string, PageNavigation[]> = {
       core: true,
     },
   ],
-  // Not used as a tab, but this way it will stay in the quick bar
   energy: [
     {
       component: "energy",
-      path: "/config/energy",
-      translationKey: "ui.panel.config.energy.caption",
+      path: "/config/energy/electricity",
+      translationKey: "ui.panel.config.energy.tabs.electricity",
       iconPath: mdiLightningBolt,
+      iconColor: "#F1C447",
+    },
+    {
+      component: "energy",
+      path: "/config/energy/gas",
+      translationKey: "ui.panel.config.energy.tabs.gas",
+      iconPath: mdiFire,
+      iconColor: "#F1C447",
+    },
+    {
+      component: "energy",
+      path: "/config/energy/water",
+      translationKey: "ui.panel.config.energy.tabs.water",
+      iconPath: mdiWater,
       iconColor: "#F1C447",
     },
   ],

--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -321,7 +321,16 @@ class PanelEnergy extends LitElement {
 
   private _navigateConfig(ev?: Event) {
     ev?.stopPropagation();
-    navigate("/config/energy?historyBack=1");
+    const viewPath = this.route?.path?.split("/")[1] || "";
+    const tabMap: Record<string, string> = {
+      overview: "electricity",
+      electricity: "electricity",
+      gas: "gas",
+      water: "water",
+      now: "electricity",
+    };
+    const tab = tabMap[viewPath] || "electricity";
+    navigate(`/config/energy/${tab}?historyBack=1`);
   }
 
   private _reloadConfig() {

--- a/src/panels/my/ha-panel-my.ts
+++ b/src/panels/my/ha-panel-my.ts
@@ -139,7 +139,7 @@ export const getMyRedirects = (): Redirects => ({
   },
   config_energy: {
     component: "energy",
-    redirect: "/config/energy/dashboard",
+    redirect: "/config/energy",
   },
   config_ssdp: {
     component: "ssdp",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3784,6 +3784,7 @@
           }
         },
         "energy": {
+          "caption": "Energy",
           "description": "Monitor your energy production and consumption",
           "new_device_info": "After setting up a new device, it can take up to 2 hours for new data to arrive in your energy dashboard.",
           "tabs": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3784,7 +3784,6 @@
           }
         },
         "energy": {
-          "caption": "Energy",
           "description": "Monitor your energy production and consumption",
           "new_device_info": "After setting up a new device, it can take up to 2 hours for new data to arrive in your energy dashboard.",
           "tabs": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3787,6 +3787,11 @@
           "caption": "Energy",
           "description": "Monitor your energy production and consumption",
           "new_device_info": "After setting up a new device, it can take up to 2 hours for new data to arrive in your energy dashboard.",
+          "tabs": {
+            "electricity": "Electricity",
+            "gas": "Gas",
+            "water": "Water"
+          },
           "delete_source": "Are you sure you want to remove this source?",
           "delete_integration": "Are you sure you want to remove this integration? It will remove the entities it provides",
           "grid": {


### PR DESCRIPTION
## Proposed change

Split the energy config page (`/config/energy`) into three tabs — Electricity, Gas, and Water — using `hass-tabs-subpage`, matching the standard config page tab pattern used by Automations and Devices.

The edit button on the energy panel now navigates to the correct config tab based on the user's current energy panel view (e.g., gas panel tab → gas config tab).

Updated the `my` link to work open the default tab (Electricity). We can add specific links to the other tabs later.

The tabs are different than the Energy dashboard tabs but these are the ones we use for config pages so they fit better here.

## Screenshots
<img width="2084" height="544" alt="image" src="https://github.com/user-attachments/assets/0b8877c7-3c26-4355-9c40-402e634935ae" />


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr