### PR TITLE
Add flow rate picker to gas, water, and water device energy dialogs

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -159,6 +159,9 @@ export interface GasSourceTypeEnergyPreference {
   // kWh/volume meter
   stat_energy_from: string;
 
+  // Flow rate (m³/h, L/min, etc.)
+  stat_rate?: string;
+
   // $ meter
   stat_cost: string | null;
 
@@ -173,6 +176,9 @@ export interface WaterSourceTypeEnergyPreference {
 
   // volume meter
   stat_energy_from: string;
+
+  // Flow rate (L/min, gal/min, m³/h, etc.)
+  stat_rate?: string;
 
   // $ meter
   stat_cost: string | null;
@@ -368,6 +374,9 @@ export const getReferencedStatisticIdsPower = (
 
   for (const source of prefs.energy_sources) {
     if (source.type === "gas" || source.type === "water") {
+      if (source.stat_rate) {
+        statIDs.push(source.stat_rate);
+      }
       continue;
     }
 
@@ -389,6 +398,7 @@ export const getReferencedStatisticIdsPower = (
     }
   }
   statIDs.push(...prefs.device_consumption.map((d) => d.stat_rate));
+  statIDs.push(...prefs.device_consumption_water.map((d) => d.stat_rate));
 
   return statIDs.filter(Boolean) as string[];
 };

--- a/src/panels/config/energy/dialogs/dialog-energy-device-settings-water.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-device-settings-water.ts
@@ -20,6 +20,7 @@ import type { HomeAssistant, ValueChangedEvent } from "../../../../types";
 import type { EnergySettingsDeviceWaterDialogParams } from "./show-dialogs-energy";
 
 const volumeUnitClasses = ["volume"];
+const flowRateUnitClasses = ["volume_flow_rate"];
 
 @customElement("dialog-energy-device-settings-water")
 export class DialogEnergyDeviceSettingsWater
@@ -36,9 +37,13 @@ export class DialogEnergyDeviceSettingsWater
 
   @state() private _volume_units?: string[];
 
+  @state() private _flow_rate_units?: string[];
+
   @state() private _error?: string;
 
   private _excludeList?: string[];
+
+  private _excludeListFlowRate?: string[];
 
   private _possibleParents: DeviceConsumptionEnergyPreference[] = [];
 
@@ -51,9 +56,15 @@ export class DialogEnergyDeviceSettingsWater
     this._volume_units = (
       await getSensorDeviceClassConvertibleUnits(this.hass, "water")
     ).units;
+    this._flow_rate_units = (
+      await getSensorDeviceClassConvertibleUnits(this.hass, "volume_flow_rate")
+    ).units;
     this._excludeList = this._params.device_consumptions
       .map((entry) => entry.stat_consumption)
       .filter((id) => id !== this._device?.stat_consumption);
+    this._excludeListFlowRate = this._params.device_consumptions
+      .map((entry) => entry.stat_rate)
+      .filter((id) => id && id !== this._device?.stat_rate) as string[];
 
     this._open = true;
   }
@@ -92,6 +103,7 @@ export class DialogEnergyDeviceSettingsWater
     this._device = undefined;
     this._error = undefined;
     this._excludeList = undefined;
+    this._excludeListFlowRate = undefined;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
@@ -134,12 +146,6 @@ export class DialogEnergyDeviceSettingsWater
         @closed=${this._dialogClosed}
       >
         ${this._error ? html`<p class="error">${this._error}</p>` : ""}
-        <div>
-          ${this.hass.localize(
-            "ui.panel.config.energy.device_consumption_water.dialog.selected_stat_intro",
-            { unit: pickableUnit }
-          )}
-        </div>
 
         <ha-statistic-picker
           .hass=${this.hass}
@@ -151,7 +157,26 @@ export class DialogEnergyDeviceSettingsWater
           )}
           .excludeStatistics=${this._excludeList}
           @value-changed=${this._statisticChanged}
+          .helper=${this.hass.localize(
+            "ui.panel.config.energy.device_consumption_water.dialog.selected_stat_intro",
+            { unit: pickableUnit }
+          )}
           autofocus
+        ></ha-statistic-picker>
+
+        <ha-statistic-picker
+          .hass=${this.hass}
+          .includeUnitClass=${flowRateUnitClasses}
+          .value=${this._device?.stat_rate}
+          .label=${this.hass.localize(
+            "ui.panel.config.energy.device_consumption_water.dialog.device_consumption_water_flow_rate"
+          )}
+          .excludeStatistics=${this._excludeListFlowRate}
+          @value-changed=${this._flowRateStatisticChanged}
+          .helper=${this.hass.localize(
+            "ui.panel.config.energy.device_consumption_water.dialog.selected_stat_intro",
+            { unit: this._flow_rate_units?.join(", ") || "" }
+          )}
         ></ha-statistic-picker>
 
         <ha-textfield
@@ -216,6 +241,20 @@ export class DialogEnergyDeviceSettingsWater
     this._computePossibleParents();
   }
 
+  private _flowRateStatisticChanged(ev: ValueChangedEvent<string>) {
+    if (!this._device) {
+      return;
+    }
+    const newDevice = {
+      ...this._device,
+      stat_rate: ev.detail.value,
+    } as DeviceConsumptionEnergyPreference;
+    if (!newDevice.stat_rate) {
+      delete newDevice.stat_rate;
+    }
+    this._device = newDevice;
+  }
+
   private _nameChanged(ev) {
     const newDevice = {
       ...this._device!,
@@ -252,7 +291,9 @@ export class DialogEnergyDeviceSettingsWater
       haStyleDialog,
       css`
         ha-statistic-picker {
+          display: block;
           width: 100%;
+          margin-bottom: var(--ha-space-4);
         }
         ha-select {
           display: block;

--- a/src/panels/config/energy/dialogs/dialog-energy-gas-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-gas-settings.ts
@@ -30,6 +30,7 @@ import type { EnergySettingsGasDialogParams } from "./show-dialogs-energy";
 
 const gasDeviceClasses = ["gas", "energy"];
 const gasUnitClasses = ["volume", "energy"];
+const flowRateUnitClasses = ["volume_flow_rate"];
 
 @customElement("dialog-energy-gas-settings")
 export class DialogEnergyGasSettings
@@ -52,9 +53,13 @@ export class DialogEnergyGasSettings
 
   @state() private _gas_units?: string[];
 
+  @state() private _flow_rate_units?: string[];
+
   @state() private _error?: string;
 
   private _excludeList?: string[];
+
+  private _excludeListFlowRate?: string[];
 
   public async showDialog(
     params: EnergySettingsGasDialogParams
@@ -81,9 +86,15 @@ export class DialogEnergyGasSettings
     this._gas_units = (
       await getSensorDeviceClassConvertibleUnits(this.hass, "gas")
     ).units;
+    this._flow_rate_units = (
+      await getSensorDeviceClassConvertibleUnits(this.hass, "volume_flow_rate")
+    ).units;
     this._excludeList = this._params.gas_sources
       .map((entry) => entry.stat_energy_from)
       .filter((id) => id !== this._source?.stat_energy_from);
+    this._excludeListFlowRate = this._params.gas_sources
+      .map((entry) => entry.stat_rate)
+      .filter((id) => id && id !== this._source?.stat_rate) as string[];
 
     this._open = true;
   }
@@ -99,6 +110,7 @@ export class DialogEnergyGasSettings
     this._pickedDisplayUnit = undefined;
     this._error = undefined;
     this._excludeList = undefined;
+    this._excludeListFlowRate = undefined;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
@@ -147,12 +159,6 @@ export class DialogEnergyGasSettings
             ${this.hass.localize("ui.panel.config.energy.gas.dialog.paragraph")}
           </p>
           <p>
-            ${this.hass.localize(
-              "ui.panel.config.energy.gas.dialog.entity_para",
-              { unit: pickableUnit }
-            )}
-          </p>
-          <p>
             ${this.hass.localize("ui.panel.config.energy.gas.dialog.note_para")}
           </p>
         </div>
@@ -169,7 +175,26 @@ export class DialogEnergyGasSettings
           )}
           .excludeStatistics=${this._excludeList}
           @value-changed=${this._statisticChanged}
+          .helper=${this.hass.localize(
+            "ui.panel.config.energy.gas.dialog.entity_para",
+            { unit: pickableUnit }
+          )}
           autofocus
+        ></ha-statistic-picker>
+
+        <ha-statistic-picker
+          .hass=${this.hass}
+          .includeUnitClass=${flowRateUnitClasses}
+          .value=${this._source.stat_rate}
+          .label=${this.hass.localize(
+            "ui.panel.config.energy.gas.dialog.gas_flow_rate"
+          )}
+          .excludeStatistics=${this._excludeListFlowRate}
+          @value-changed=${this._flowRateStatisticChanged}
+          .helper=${this.hass.localize(
+            "ui.panel.config.energy.gas.dialog.flow_rate_para",
+            { unit: this._flow_rate_units?.join(", ") || "" }
+          )}
         ></ha-statistic-picker>
 
         <p>
@@ -341,6 +366,13 @@ export class DialogEnergyGasSettings
     };
   }
 
+  private _flowRateStatisticChanged(ev: ValueChangedEvent<string>) {
+    this._source = {
+      ...this._source!,
+      stat_rate: ev.detail.value || undefined,
+    };
+  }
+
   private async _statisticChanged(ev: ValueChangedEvent<string>) {
     if (ev.detail.value) {
       const metadata = await getStatisticMetadata(this.hass, [ev.detail.value]);
@@ -380,6 +412,10 @@ export class DialogEnergyGasSettings
       haStyle,
       haStyleDialog,
       css`
+        ha-statistic-picker {
+          display: block;
+          margin-bottom: var(--ha-space-4);
+        }
         ha-formfield {
           display: block;
         }

--- a/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
@@ -24,6 +24,8 @@ import { haStyle, haStyleDialog } from "../../../../resources/styles";
 import type { HomeAssistant, ValueChangedEvent } from "../../../../types";
 import type { EnergySettingsWaterDialogParams } from "./show-dialogs-energy";
 
+const flowRateUnitClasses = ["volume_flow_rate"];
+
 @customElement("dialog-energy-water-settings")
 export class DialogEnergyWaterSettings
   extends LitElement
@@ -41,9 +43,13 @@ export class DialogEnergyWaterSettings
 
   @state() private _water_units?: string[];
 
+  @state() private _flow_rate_units?: string[];
+
   @state() private _error?: string;
 
   private _excludeList?: string[];
+
+  private _excludeListFlowRate?: string[];
 
   public async showDialog(
     params: EnergySettingsWaterDialogParams
@@ -62,9 +68,15 @@ export class DialogEnergyWaterSettings
     this._water_units = (
       await getSensorDeviceClassConvertibleUnits(this.hass, "water")
     ).units;
+    this._flow_rate_units = (
+      await getSensorDeviceClassConvertibleUnits(this.hass, "volume_flow_rate")
+    ).units;
     this._excludeList = this._params.water_sources
       .map((entry) => entry.stat_energy_from)
       .filter((id) => id !== this._source?.stat_energy_from);
+    this._excludeListFlowRate = this._params.water_sources
+      .map((entry) => entry.stat_rate)
+      .filter((id) => id && id !== this._source?.stat_rate) as string[];
 
     this._open = true;
   }
@@ -79,6 +91,7 @@ export class DialogEnergyWaterSettings
     this._source = undefined;
     this._error = undefined;
     this._excludeList = undefined;
+    this._excludeListFlowRate = undefined;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
@@ -108,19 +121,6 @@ export class DialogEnergyWaterSettings
         @closed=${this._dialogClosed}
       >
         ${this._error ? html`<p class="error">${this._error}</p>` : ""}
-        <div>
-          <p>
-            ${this.hass.localize(
-              "ui.panel.config.energy.water.dialog.paragraph"
-            )}
-          </p>
-          <p>
-            ${this.hass.localize(
-              "ui.panel.config.energy.water.dialog.entity_para",
-              { unit: pickableUnit }
-            )}
-          </p>
-        </div>
 
         <ha-statistic-picker
           .hass=${this.hass}
@@ -133,7 +133,26 @@ export class DialogEnergyWaterSettings
           )}
           .excludeStatistics=${this._excludeList}
           @value-changed=${this._statisticChanged}
+          .helper=${this.hass.localize(
+            "ui.panel.config.energy.water.dialog.entity_para",
+            { unit: pickableUnit }
+          )}
           autofocus
+        ></ha-statistic-picker>
+
+        <ha-statistic-picker
+          .hass=${this.hass}
+          .includeUnitClass=${flowRateUnitClasses}
+          .value=${this._source.stat_rate}
+          .label=${this.hass.localize(
+            "ui.panel.config.energy.water.dialog.water_flow_rate"
+          )}
+          .excludeStatistics=${this._excludeListFlowRate}
+          @value-changed=${this._flowRateStatisticChanged}
+          .helper=${this.hass.localize(
+            "ui.panel.config.energy.water.dialog.flow_rate_para",
+            { unit: this._flow_rate_units?.join(", ") || "" }
+          )}
         ></ha-statistic-picker>
 
         <p>
@@ -287,6 +306,13 @@ export class DialogEnergyWaterSettings
     };
   }
 
+  private _flowRateStatisticChanged(ev: ValueChangedEvent<string>) {
+    this._source = {
+      ...this._source!,
+      stat_rate: ev.detail.value || undefined,
+    };
+  }
+
   private async _statisticChanged(ev: ValueChangedEvent<string>) {
     if (
       ev.detail.value &&
@@ -320,6 +346,10 @@ export class DialogEnergyWaterSettings
       haStyle,
       haStyleDialog,
       css`
+        ha-statistic-picker {
+          display: block;
+          margin-bottom: var(--ha-space-4);
+        }
         ha-formfield {
           display: block;
         }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3924,7 +3924,9 @@
               "cost_entity_helper_volume": "volume",
               "cost_number": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_number%]",
               "cost_number_input": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_number%]",
-              "gas_usage": "Gas usage"
+              "gas_usage": "Gas usage",
+              "gas_flow_rate": "Gas flow rate",
+              "flow_rate_para": "Optionally pick a sensor which measures the gas flow rate in either of {unit}."
             }
           },
           "water": {
@@ -3948,7 +3950,9 @@
               "cost_entity_helper": "Any entity with a unit of `{currency}/(valid water unit)` (e.g. `{currency}/gal` or `{currency}/m³`) may be used and will be automatically converted.",
               "cost_number": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_number%]",
               "cost_number_input": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_number%]",
-              "water_usage": "Water usage"
+              "water_usage": "Water usage",
+              "water_flow_rate": "Water flow rate",
+              "flow_rate_para": "Optionally pick a sensor which measures the water flow rate in either of {unit}."
             }
           },
           "device_consumption": {
@@ -3980,6 +3984,7 @@
               "header": "Add a water device",
               "display_name": "Display name",
               "device_consumption_water": "Device water consumption",
+              "device_consumption_water_flow_rate": "Device water flow rate",
               "selected_stat_intro": "Select the water sensor that measures the device's water usage in either of {unit}.",
               "included_in_device": "Upstream device",
               "included_in_device_helper": "If this device is already counted by another device (such as a water meter measured by the main water supply), selecting the upstream device prevents duplicate water tracking.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3924,7 +3924,7 @@
               "cost_entity_helper_volume": "volume",
               "cost_number": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_number%]",
               "cost_number_input": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_number%]",
-              "gas_usage": "Gas usage",
+              "gas_usage": "Gas consumption",
               "gas_flow_rate": "Gas flow rate",
               "flow_rate_para": "Optionally pick a sensor which measures the gas flow rate in either of {unit}."
             }
@@ -3950,7 +3950,7 @@
               "cost_entity_helper": "Any entity with a unit of `{currency}/(valid water unit)` (e.g. `{currency}/gal` or `{currency}/m³`) may be used and will be automatically converted.",
               "cost_number": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_number%]",
               "cost_number_input": "[%key:ui::panel::config::energy::grid::flow_dialog::from::cost_number%]",
-              "water_usage": "Water usage",
+              "water_usage": "Water consumption",
               "water_flow_rate": "Water flow rate",
               "flow_rate_para": "Optionally pick a sensor which measures the water flow rate in either of {unit}."
             }
@@ -3985,7 +3985,7 @@
               "display_name": "Display name",
               "device_consumption_water": "Device water consumption",
               "device_consumption_water_flow_rate": "Device water flow rate",
-              "selected_stat_intro": "Select the water sensor that measures the device's water usage in either of {unit}.",
+              "selected_stat_intro": "Select the water sensor that measures the device's water consumption in either of {unit}.",
               "included_in_device": "Upstream device",
               "included_in_device_helper": "If this device is already counted by another device (such as a water meter measured by the main water supply), selecting the upstream device prevents duplicate water tracking.",
               "no_upstream_devices": "No eligible upstream devices"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add optional flow rate (`stat_rate`) picker to gas source, water source, and water device configuration dialogs, matching the pattern used for power tracking in grid/solar/battery sources and energy devices.

- Add `stat_rate` to `GasSourceTypeEnergyPreference` and `WaterSourceTypeEnergyPreference` interfaces
- Collect gas/water/water-device `stat_rate` in `getReferencedStatisticIdsPower()` for data fetching
- Flow rate picker filters to `volume_flow_rate` device class sensors
- Move entity help text to picker `.helper` props for cleaner layout

Graphs to display this new data will be added in a follow up PR.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
<img width="1130" height="1066" alt="image" src="https://github.com/user-attachments/assets/bd2de800-813d-4590-96e5-6ff204aa30df" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: home-assistant/core#163274

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr