### PR TITLE
Fix history timeline showing same color for all zones

### DIFF
--- a/src/components/chart/timeline-color.ts
+++ b/src/components/chart/timeline-color.ts
@@ -41,7 +41,7 @@ function computeTimelineStateColor(
   // otherwise return undefined to get unique colors from the generic color handler.
   if (
     (domain === "person" || domain === "device_tracker") &&
-    !(FIXED_DOMAIN_STATES[domain] as readonly string[]).includes(state)
+    !((FIXED_DOMAIN_STATES[domain] || []) as readonly string[]).includes(state)
   ) {
     return computeCssValue(
       `--state-${domain}-${slugify(state, "_")}-color`,

--- a/src/components/chart/timeline-color.ts
+++ b/src/components/chart/timeline-color.ts
@@ -6,6 +6,7 @@ import { computeDomain } from "../../common/entity/compute_domain";
 import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { FIXED_DOMAIN_STATES } from "../../common/entity/get_states";
 import { stateColorProperties } from "../../common/entity/state_color";
+import { slugify } from "../../common/string/slugify";
 import { UNAVAILABLE, UNKNOWN } from "../../data/entity/entity";
 import { computeCssValue } from "../../resources/css-variables";
 
@@ -32,6 +33,22 @@ function computeTimelineStateColor(
     return computeCssValue("--history-unknown-color", computedStyles);
   }
 
+  const domain = computeDomain(stateObj.entity_id);
+
+  // Zone states for person/device_tracker don't have specific CSS color variables,
+  // so they all fall back to the same --state-person-active-color.
+  // Only use a custom CSS variable if explicitly defined (e.g. --state-person-kitchen-color),
+  // otherwise return undefined to get unique colors from the generic color handler.
+  if (
+    (domain === "person" || domain === "device_tracker") &&
+    !(FIXED_DOMAIN_STATES[domain] as readonly string[]).includes(state)
+  ) {
+    return computeCssValue(
+      `--state-${domain}-${slugify(state, "_")}-color`,
+      computedStyles
+    );
+  }
+
   const properties = stateColorProperties(stateObj, state);
 
   if (!properties) {
@@ -41,8 +58,6 @@ function computeTimelineStateColor(
   const rgb = computeCssValue(properties, computedStyles);
 
   if (!rgb) return undefined;
-
-  const domain = computeDomain(stateObj.entity_id);
   const shade = DOMAIN_STATE_SHADES[domain]?.[state] as number | number;
   if (!shade) {
     return rgb;


### PR DESCRIPTION
## Proposed change

Fix for person and device_tracker entities where all zone states (e.g. "Kitchen", "Office", "Living Room") displayed with the same color in the history timeline, making the graph impossible to read.

This doesn't make the colors deterministic based on the zone name but they are consistent on the graph and activity log.

State based CSS var is kept for backwards compatibility.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #14705
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr