### PR TITLE
Fix integer states displaying with decimal places when step attribute is absent

### DIFF
--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -122,11 +122,11 @@ export const getNumberFormatOptions = (
       minimumFractionDigits: precision,
     };
   }
-  if (
-    Number.isInteger(Number(entityState?.attributes?.step)) &&
-    Number.isInteger(Number(entityState?.state))
-  ) {
-    return { maximumFractionDigits: 0 };
+  if (Number.isInteger(Number(entityState?.state))) {
+    const step = entityState?.attributes?.step;
+    if (step === undefined || Number.isInteger(Number(step))) {
+      return { maximumFractionDigits: 0 };
+    }
   }
   return undefined;
 };

--- a/test/common/string/format_number.test.ts
+++ b/test/common/string/format_number.test.ts
@@ -169,10 +169,10 @@ describe("formatNumber", () => {
     );
   });
 
-  it("Does not set any Intl.NumberFormatOptions when there is no step attribute", () => {
-    assert.strictEqual(
+  it("Sets maximumFractionDigits to 0 when state is integer and there is no step attribute", () => {
+    assert.deepStrictEqual(
       getNumberFormatOptions({ state: "3.0" } as unknown as HassEntity),
-      undefined
+      { maximumFractionDigits: 0 }
     );
   });
 });


### PR DESCRIPTION
## Proposed change

Fixes numeric entities without a `step` attribute (e.g. battery sensors) showing decimal places even when the state value is an integer.

The previous logic in `getNumberFormatOptions` required both `step` and `state` to be integers before setting `maximumFractionDigits: 0`. This meant entities without a `step` attribute — like battery sensors — would fall through to `getDefaultFormatOptions`, which preserves trailing decimal zeros from the state string (e.g. `"88.0"` → `"88.0"` instead of `"88"`).

Now, when the `step` attribute is absent and the state is an integer, the value is correctly formatted without decimal places. When `step` is present, the existing behavior is preserved (non-integer step still allows decimals).

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- Closes #29634
- Updated existing test to match new behavior
- All existing format_number tests pass