### PR TITLE
Restore more info attributes accordion, show attributes view when not present

### DIFF
--- a/src/components/ha-attributes.ts
+++ b/src/components/ha-attributes.ts
@@ -107,31 +107,38 @@ class HaAttributes extends LitElement {
       haStyle,
       css`
         .attribute-container {
-          margin-bottom: 8px;
           direction: ltr;
+          padding: var(--ha-space-2) var(--ha-space-4);
         }
+
         .data-entry {
           display: flex;
           flex-direction: row;
           justify-content: space-between;
+          padding: var(--ha-space-2) 0;
+          border-bottom: 1px solid var(--divider-color);
         }
+
+        .data-entry:last-of-type {
+          border-bottom: none;
+        }
+
         .data-entry .value {
           max-width: 60%;
           overflow-wrap: break-word;
           text-align: right;
         }
+
         .key {
           flex-grow: 1;
+          color: var(--secondary-text-color);
         }
+
         .attribution {
           color: var(--secondary-text-color);
           text-align: center;
-          margin-top: 16px;
-        }
-        hr {
-          border-color: var(--divider-color);
-          border-bottom: none;
-          margin: 16px 0;
+          margin-top: var(--ha-space-4);
+          font-size: var(--ha-font-size-s);
         }
       `,
     ];

--- a/src/data/entity/entity_attributes.ts
+++ b/src/data/entity/entity_attributes.ts
@@ -190,7 +190,7 @@ export const NON_NUMERIC_ATTRIBUTES = [
   "xy_color",
 ];
 
-const MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS: Record<string, string[]> = {
+export const MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS = {
   default: [],
   cover: ["current_position", "current_tilt_position"],
   input_boolean: [],
@@ -228,7 +228,7 @@ const MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS: Record<string, string[]> = {
     "battery_icon",
   ],
   valve: ["current_position", "current_tilt_position"],
-};
+} as const satisfies Record<string, readonly string[]>;
 
 export const computeShownAttributes = (stateObj: HassEntity) => {
   const domain = computeStateDomain(stateObj);

--- a/src/data/entity/entity_attributes.ts
+++ b/src/data/entity/entity_attributes.ts
@@ -190,6 +190,46 @@ export const NON_NUMERIC_ATTRIBUTES = [
   "xy_color",
 ];
 
+const MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS: Record<string, string[]> = {
+  default: [],
+  cover: ["current_position", "current_tilt_position"],
+  input_boolean: [],
+  light: [
+    "brightness",
+    "color_temp",
+    "color_temp_kelvin",
+    "white_value",
+    "effect_list",
+    "effect",
+    "hs_color",
+    "rgb_color",
+    "rgbw_color",
+    "rgbww_color",
+    "xy_color",
+    "min_mireds",
+    "max_mireds",
+    "min_color_temp_kelvin",
+    "max_color_temp_kelvin",
+    "entity_id",
+    "supported_color_modes",
+    "color_mode",
+  ],
+  lock: ["code_format"],
+  person: ["id", "user_id", "editable", "device_trackers"],
+  remote: ["activity_list", "current_activity"],
+  siren: [],
+  switch: [],
+  timer: ["remaining", "restore"],
+  vacuum: [
+    "fan_speed",
+    "fan_speed_list",
+    "status",
+    "battery_level",
+    "battery_icon",
+  ],
+  valve: ["current_position", "current_tilt_position"],
+};
+
 export const computeShownAttributes = (stateObj: HassEntity) => {
   const domain = computeStateDomain(stateObj);
   const filtersArray = STATE_ATTRIBUTES.concat(
@@ -199,5 +239,35 @@ export const computeShownAttributes = (stateObj: HassEntity) => {
   );
   return Object.keys(stateObj.attributes).filter(
     (key) => filtersArray.indexOf(key) === -1
+  );
+};
+
+export const computeMainViewShownAttributes = (
+  stateObj: HassEntity,
+  moreInfoType: string
+) => {
+  const mainViewExtraFilters =
+    MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS[moreInfoType];
+
+  if (!mainViewExtraFilters) {
+    return [];
+  }
+
+  return computeShownAttributes(stateObj).filter(
+    (attribute) => mainViewExtraFilters.indexOf(attribute) === -1
+  );
+};
+
+export const computeAdditionalMoreInfoAttributes = (
+  stateObj: HassEntity,
+  moreInfoType: string
+) => {
+  const shownAttributes = computeShownAttributes(stateObj);
+  const mainViewAttributes = new Set(
+    computeMainViewShownAttributes(stateObj, moreInfoType)
+  );
+
+  return shownAttributes.filter(
+    (attribute) => !mainViewAttributes.has(attribute)
   );
 };

--- a/src/dialogs/more-info/controls/more-info-cover.ts
+++ b/src/dialogs/more-info/controls/more-info-cover.ts
@@ -7,6 +7,7 @@ import "../../../components/ha-attributes";
 import "../../../components/ha-icon-button-group";
 import "../../../components/ha-icon-button-toggle";
 import type { CoverEntity } from "../../../data/cover";
+import { MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS } from "../../../data/entity/entity_attributes";
 import {
   CoverEntityFeature,
   computeCoverPositionStateDisplay,
@@ -20,6 +21,9 @@ import "../components/ha-more-info-state-header";
 import { moreInfoControlStyle } from "../components/more-info-control-style";
 
 type Mode = "position" | "button";
+
+const EXTRA_FILTERS =
+  MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS.cover.join(",");
 
 @customElement("more-info-cover")
 class MoreInfoCover extends LitElement {
@@ -179,7 +183,7 @@ class MoreInfoCover extends LitElement {
       <ha-attributes
         .hass=${this.hass}
         .stateObj=${this.stateObj}
-        extra-filters="current_position,current_tilt_position"
+        .extraFilters=${EXTRA_FILTERS}
       ></ha-attributes>
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-cover.ts
+++ b/src/dialogs/more-info/controls/more-info-cover.ts
@@ -3,6 +3,7 @@ import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { supportsFeature } from "../../../common/entity/supports-feature";
+import "../../../components/ha-attributes";
 import "../../../components/ha-icon-button-group";
 import "../../../components/ha-icon-button-toggle";
 import type { CoverEntity } from "../../../data/cover";
@@ -175,6 +176,11 @@ class MoreInfoCover extends LitElement {
           }
         </div>
       </div>
+      <ha-attributes
+        .hass=${this.hass}
+        .stateObj=${this.stateObj}
+        extra-filters="current_position,current_tilt_position"
+      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-default.ts
+++ b/src/dialogs/more-info/controls/more-info-default.ts
@@ -1,6 +1,7 @@
 import type { HassEntity } from "home-assistant-js-websocket";
-import { LitElement, nothing } from "lit";
+import { html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
+import "../../../components/ha-attributes";
 import type { HomeAssistant } from "../../../types";
 
 @customElement("more-info-default")
@@ -14,7 +15,10 @@ class MoreInfoDefault extends LitElement {
       return nothing;
     }
 
-    return nothing;
+    return html`<ha-attributes
+      .hass=${this.hass}
+      .stateObj=${this.stateObj}
+    ></ha-attributes>`;
   }
 }
 

--- a/src/dialogs/more-info/controls/more-info-input_boolean.ts
+++ b/src/dialogs/more-info/controls/more-info-input_boolean.ts
@@ -3,6 +3,7 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup } from "lit";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
+import "../../../components/ha-attributes";
 import "../../../state-control/ha-state-control-toggle";
 import type { HomeAssistant } from "../../../types";
 import "../components/ha-more-info-state-header";
@@ -32,6 +33,10 @@ class MoreInfoInputBoolean extends LitElement {
           .iconPathOff=${mdiPowerOff}
         ></ha-state-control-toggle>
       </div>
+      <ha-attributes
+        .hass=${this.hass}
+        .stateObj=${this.stateObj}
+      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -17,6 +17,7 @@ import "../../../components/ha-icon-button-group";
 import "../../../components/ha-icon-button-toggle";
 import "../../../components/ha-list-item";
 import { UNAVAILABLE } from "../../../data/entity/entity";
+import { MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS } from "../../../data/entity/entity_attributes";
 import type { ExtEntityRegistryEntry } from "../../../data/entity/entity_registry";
 import { forwardHaptic } from "../../../data/haptics";
 import type { LightEntity } from "../../../data/light";
@@ -41,6 +42,9 @@ import { moreInfoControlStyle } from "../components/more-info-control-style";
 import type { HaDropdownSelectEvent } from "../../../components/ha-dropdown";
 
 type MainControl = "brightness" | "color_temp" | "color";
+
+const EXTRA_FILTERS =
+  MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS.light.join(",");
 
 @customElement("more-info-light")
 class MoreInfoLight extends LitElement {
@@ -290,7 +294,7 @@ class MoreInfoLight extends LitElement {
         <ha-attributes
           .hass=${this.hass}
           .stateObj=${this.stateObj}
-          extra-filters="brightness,color_temp,color_temp_kelvin,white_value,effect_list,effect,hs_color,rgb_color,rgbw_color,rgbww_color,xy_color,min_mireds,max_mireds,min_color_temp_kelvin,max_color_temp_kelvin,entity_id,supported_color_modes,color_mode"
+          .extraFilters=${EXTRA_FILTERS}
         ></ha-attributes>
       </div>
     `;

--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -11,6 +11,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import "../../../components/ha-attribute-icon";
+import "../../../components/ha-attributes";
 import "../../../components/ha-control-select-menu";
 import "../../../components/ha-icon-button-group";
 import "../../../components/ha-icon-button-toggle";
@@ -286,6 +287,11 @@ class MoreInfoLight extends LitElement {
               `
             : nothing}
         </ha-more-info-control-select-container>
+        <ha-attributes
+          .hass=${this.hass}
+          .stateObj=${this.stateObj}
+          extra-filters="brightness,color_temp,color_temp_kelvin,white_value,effect_list,effect,hs_color,rgb_color,rgbw_color,rgbww_color,xy_color,min_mireds,max_mireds,min_color_temp_kelvin,max_color_temp_kelvin,entity_id,supported_color_modes,color_mode"
+        ></ha-attributes>
       </div>
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-lock.ts
+++ b/src/dialogs/more-info/controls/more-info-lock.ts
@@ -10,6 +10,7 @@ import "../../../components/ha-control-button";
 import "../../../components/ha-control-button-group";
 import "../../../components/ha-outlined-icon-button";
 import "../../../components/ha-state-icon";
+import { MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS } from "../../../data/entity/entity_attributes";
 import type { LockEntity } from "../../../data/lock";
 import {
   LockEntityFeature,
@@ -26,6 +27,9 @@ const CONFIRM_TIMEOUT_SECOND = 5;
 const DONE_TIMEOUT_SECOND = 2;
 
 type ButtonState = "normal" | "confirm" | "done";
+
+const EXTRA_FILTERS =
+  MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS.lock.join(",");
 
 @customElement("more-info-lock")
 class MoreInfoLock extends LitElement {
@@ -154,7 +158,7 @@ class MoreInfoLock extends LitElement {
         <ha-attributes
           .hass=${this.hass}
           .stateObj=${this.stateObj}
-          extra-filters="code_format"
+          .extraFilters=${EXTRA_FILTERS}
         ></ha-attributes>
       </div>
     `;

--- a/src/dialogs/more-info/controls/more-info-lock.ts
+++ b/src/dialogs/more-info/controls/more-info-lock.ts
@@ -5,6 +5,7 @@ import { customElement, property, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import { stateColorCss } from "../../../common/entity/state_color";
 import { supportsFeature } from "../../../common/entity/supports-feature";
+import "../../../components/ha-attributes";
 import "../../../components/ha-control-button";
 import "../../../components/ha-control-button-group";
 import "../../../components/ha-outlined-icon-button";
@@ -150,6 +151,11 @@ class MoreInfoLock extends LitElement {
               </ha-control-button-group>
             `
           : nothing}
+        <ha-attributes
+          .hass=${this.hass}
+          .stateObj=${this.stateObj}
+          extra-filters="code_format"
+        ></ha-attributes>
       </div>
     `;
   }
@@ -184,6 +190,9 @@ class MoreInfoLock extends LitElement {
           width: 100%;
           max-width: 400px;
           margin: 0 auto;
+        }
+        ha-control-button-group + ha-attributes:not([empty]) {
+          margin-top: var(--ha-space-4);
         }
         @keyframes pulse {
           0% {

--- a/src/dialogs/more-info/controls/more-info-person.ts
+++ b/src/dialogs/more-info/controls/more-info-person.ts
@@ -3,6 +3,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../common/dom/fire_event";
+import "../../../components/ha-attributes";
 import "../../../components/ha-button";
 import "../../../components/map/ha-map";
 import { showZoneEditor } from "../../../data/zone";
@@ -49,6 +50,11 @@ class MoreInfoPerson extends LitElement {
             </div>
           `
         : ""}
+      <ha-attributes
+        .hass=${this.hass}
+        .stateObj=${this.stateObj}
+        extra-filters="id,user_id,editable,device_trackers"
+      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-person.ts
+++ b/src/dialogs/more-info/controls/more-info-person.ts
@@ -6,8 +6,12 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-attributes";
 import "../../../components/ha-button";
 import "../../../components/map/ha-map";
+import { MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS } from "../../../data/entity/entity_attributes";
 import { showZoneEditor } from "../../../data/zone";
 import type { HomeAssistant } from "../../../types";
+
+const EXTRA_FILTERS =
+  MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS.person.join(",");
 
 @customElement("more-info-person")
 class MoreInfoPerson extends LitElement {
@@ -53,7 +57,7 @@ class MoreInfoPerson extends LitElement {
       <ha-attributes
         .hass=${this.hass}
         .stateObj=${this.stateObj}
-        extra-filters="id,user_id,editable,device_trackers"
+        .extraFilters=${EXTRA_FILTERS}
       ></ha-attributes>
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-remote.ts
+++ b/src/dialogs/more-info/controls/more-info-remote.ts
@@ -1,11 +1,14 @@
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { supportsFeature } from "../../../common/entity/supports-feature";
+import "../../../components/ha-attributes";
 import type { HaSelectSelectEvent } from "../../../components/ha-select";
 import "../../../components/ha-select";
 import type { RemoteEntity } from "../../../data/remote";
 import { REMOTE_SUPPORT_ACTIVITY } from "../../../data/remote";
 import type { HomeAssistant } from "../../../types";
+
+const filterExtraAttributes = "activity_list,current_activity";
 
 @customElement("more-info-remote")
 class MoreInfoRemote extends LitElement {
@@ -41,6 +44,12 @@ class MoreInfoRemote extends LitElement {
             </ha-select>
           `
         : nothing}
+
+      <ha-attributes
+        .hass=${this.hass}
+        .stateObj=${this.stateObj}
+        .extraFilters=${filterExtraAttributes}
+      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-remote.ts
+++ b/src/dialogs/more-info/controls/more-info-remote.ts
@@ -4,11 +4,13 @@ import { supportsFeature } from "../../../common/entity/supports-feature";
 import "../../../components/ha-attributes";
 import type { HaSelectSelectEvent } from "../../../components/ha-select";
 import "../../../components/ha-select";
+import { MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS } from "../../../data/entity/entity_attributes";
 import type { RemoteEntity } from "../../../data/remote";
 import { REMOTE_SUPPORT_ACTIVITY } from "../../../data/remote";
 import type { HomeAssistant } from "../../../types";
 
-const filterExtraAttributes = "activity_list,current_activity";
+const EXTRA_FILTERS =
+  MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS.remote.join(",");
 
 @customElement("more-info-remote")
 class MoreInfoRemote extends LitElement {
@@ -48,7 +50,7 @@ class MoreInfoRemote extends LitElement {
       <ha-attributes
         .hass=${this.hass}
         .stateObj=${this.stateObj}
-        .extraFilters=${filterExtraAttributes}
+        .extraFilters=${EXTRA_FILTERS}
       ></ha-attributes>
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-siren.ts
+++ b/src/dialogs/more-info/controls/more-info-siren.ts
@@ -3,6 +3,7 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup } from "lit";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
+import "../../../components/ha-attributes";
 import "../../../state-control/ha-state-control-toggle";
 import "../../../components/ha-button";
 import type { HomeAssistant } from "../../../types";
@@ -59,6 +60,10 @@ class MoreInfoSiren extends LitElement {
             </ha-button>`
           : nothing}
       </div>
+      <ha-attributes
+        .hass=${this.hass}
+        .stateObj=${this.stateObj}
+      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-switch.ts
+++ b/src/dialogs/more-info/controls/more-info-switch.ts
@@ -3,6 +3,7 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup } from "lit";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
+import "../../../components/ha-attributes";
 import "../../../state-control/ha-state-control-toggle";
 import type { HomeAssistant } from "../../../types";
 import "../components/ha-more-info-state-header";
@@ -32,6 +33,10 @@ class MoreInfoSwitch extends LitElement {
           .iconPathOff=${mdiPowerOff}
         ></ha-state-control-toggle>
       </div>
+      <ha-attributes
+        .hass=${this.hass}
+        .stateObj=${this.stateObj}
+      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-timer.ts
+++ b/src/dialogs/more-info/controls/more-info-timer.ts
@@ -2,8 +2,12 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import "../../../components/ha-attributes";
 import "../../../components/ha-button";
+import { MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS } from "../../../data/entity/entity_attributes";
 import type { TimerEntity } from "../../../data/timer";
 import type { HomeAssistant } from "../../../types";
+
+const EXTRA_FILTERS =
+  MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS.timer.join(",");
 
 @customElement("more-info-timer")
 class MoreInfoTimer extends LitElement {
@@ -66,7 +70,7 @@ class MoreInfoTimer extends LitElement {
       <ha-attributes
         .hass=${this.hass}
         .stateObj=${this.stateObj}
-        extra-filters="remaining,restore"
+        .extraFilters=${EXTRA_FILTERS}
       ></ha-attributes>
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-timer.ts
+++ b/src/dialogs/more-info/controls/more-info-timer.ts
@@ -1,5 +1,6 @@
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
+import "../../../components/ha-attributes";
 import "../../../components/ha-button";
 import type { TimerEntity } from "../../../data/timer";
 import type { HomeAssistant } from "../../../types";
@@ -62,6 +63,11 @@ class MoreInfoTimer extends LitElement {
             `
           : ""}
       </div>
+      <ha-attributes
+        .hass=${this.hass}
+        .stateObj=${this.stateObj}
+        extra-filters="remaining,restore"
+      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-vacuum.ts
+++ b/src/dialogs/more-info/controls/more-info-vacuum.ts
@@ -20,6 +20,7 @@ import "../../../components/ha-icon";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-select";
 import { UNAVAILABLE } from "../../../data/entity/entity";
+import { MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS } from "../../../data/entity/entity_attributes";
 import type { EntityRegistryDisplayEntry } from "../../../data/entity/entity_registry";
 import {
   findBatteryChargingEntity,
@@ -96,6 +97,9 @@ const VACUUM_COMMANDS: VacuumCommand[] = [
   },
 ];
 
+const EXTRA_FILTERS =
+  MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS.vacuum.join(",");
+
 @customElement("more-info-vacuum")
 class MoreInfoVacuum extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -108,9 +112,6 @@ class MoreInfoVacuum extends LitElement {
     }
 
     const stateObj = this.stateObj;
-
-    const filterExtraAttributes =
-      "fan_speed,fan_speed_list,status,battery_level,battery_icon";
 
     return html`
       ${stateObj.state !== UNAVAILABLE
@@ -207,7 +208,7 @@ class MoreInfoVacuum extends LitElement {
       <ha-attributes
         .hass=${this.hass}
         .stateObj=${this.stateObj}
-        .extraFilters=${filterExtraAttributes}
+        .extraFilters=${EXTRA_FILTERS}
       ></ha-attributes>
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-vacuum.ts
+++ b/src/dialogs/more-info/controls/more-info-vacuum.ts
@@ -14,6 +14,7 @@ import memoizeOne from "memoize-one";
 import { computeStateDomain } from "../../../common/entity/compute_state_domain";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import "../../../components/entity/ha-battery-icon";
+import "../../../components/ha-attributes";
 import type { HaSelectSelectEvent } from "../../../components/ha-select";
 import "../../../components/ha-icon";
 import "../../../components/ha-icon-button";
@@ -108,6 +109,9 @@ class MoreInfoVacuum extends LitElement {
 
     const stateObj = this.stateObj;
 
+    const filterExtraAttributes =
+      "fan_speed,fan_speed_list,status,battery_level,battery_icon";
+
     return html`
       ${stateObj.state !== UNAVAILABLE
         ? html` <div class="flex-horizontal">
@@ -199,6 +203,12 @@ class MoreInfoVacuum extends LitElement {
             </div>
           `
         : ""}
+
+      <ha-attributes
+        .hass=${this.hass}
+        .stateObj=${this.stateObj}
+        .extraFilters=${filterExtraAttributes}
+      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/controls/more-info-valve.ts
+++ b/src/dialogs/more-info/controls/more-info-valve.ts
@@ -6,6 +6,7 @@ import { supportsFeature } from "../../../common/entity/supports-feature";
 import "../../../components/ha-attributes";
 import "../../../components/ha-icon-button-group";
 import "../../../components/ha-icon-button-toggle";
+import { MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS } from "../../../data/entity/entity_attributes";
 import type { ValveEntity } from "../../../data/valve";
 import {
   ValveEntityFeature,
@@ -19,6 +20,9 @@ import "../components/ha-more-info-state-header";
 import { moreInfoControlStyle } from "../components/more-info-control-style";
 
 type Mode = "position" | "button";
+
+const EXTRA_FILTERS =
+  MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS.valve.join(",");
 
 @customElement("more-info-valve")
 class MoreInfoValve extends LitElement {
@@ -158,7 +162,7 @@ class MoreInfoValve extends LitElement {
       <ha-attributes
         .hass=${this.hass}
         .stateObj=${this.stateObj}
-        extra-filters="current_position,current_tilt_position"
+        .extraFilters=${EXTRA_FILTERS}
       ></ha-attributes>
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-valve.ts
+++ b/src/dialogs/more-info/controls/more-info-valve.ts
@@ -3,6 +3,7 @@ import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { supportsFeature } from "../../../common/entity/supports-feature";
+import "../../../components/ha-attributes";
 import "../../../components/ha-icon-button-group";
 import "../../../components/ha-icon-button-toggle";
 import type { ValveEntity } from "../../../data/valve";
@@ -154,6 +155,11 @@ class MoreInfoValve extends LitElement {
           }
         </div>
       </div>
+      <ha-attributes
+        .hass=${this.hass}
+        .stateObj=${this.stateObj}
+        extra-filters="current_position,current_tilt_position"
+      ></ha-attributes>
     `;
   }
 

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -44,7 +44,7 @@ import "../../components/ha-dropdown-item";
 import "../../components/ha-icon-button";
 import "../../components/ha-icon-button-prev";
 import "../../components/ha-related-items";
-import { computeShownAttributes } from "../../data/entity/entity_attributes";
+import { computeAdditionalMoreInfoAttributes } from "../../data/entity/entity_attributes";
 import type {
   EntityRegistryEntry,
   ExtEntityRegistryEntry,
@@ -75,6 +75,7 @@ import "./ha-more-info-history-and-logbook";
 import "./ha-more-info-info";
 import "./ha-more-info-settings";
 import "./more-info-content";
+import { stateMoreInfoType } from "./state_more_info_control";
 
 export interface MoreInfoDialogParams {
   entityId: string | null;
@@ -366,7 +367,10 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
     if (!stateObj) {
       return false;
     }
-    return computeShownAttributes(stateObj).length > 0;
+    return (
+      computeAdditionalMoreInfoAttributes(stateObj, stateMoreInfoType(stateObj))
+        .length > 0
+    );
   }
 
   private _goToAddEntityTo(ev) {

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -617,7 +617,7 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
                               ></ha-svg-icon>
                               ${hasMainViewAttributes
                                 ? this.hass.localize(
-                                    "ui.dialogs.more_info_control.all_attributes"
+                                    "ui.dialogs.more_info_control.extra_attributes"
                                   )
                                 : this.hass.localize(
                                     "ui.dialogs.more_info_control.attributes"

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -44,10 +44,7 @@ import "../../components/ha-dropdown-item";
 import "../../components/ha-icon-button";
 import "../../components/ha-icon-button-prev";
 import "../../components/ha-related-items";
-import {
-  computeAdditionalMoreInfoAttributes,
-  computeMainViewShownAttributes,
-} from "../../data/entity/entity_attributes";
+import { computeAdditionalMoreInfoAttributes } from "../../data/entity/entity_attributes";
 import type {
   EntityRegistryEntry,
   ExtEntityRegistryEntry,
@@ -362,27 +359,17 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
     };
   }
 
-  private _computeAttributesMenuData(stateObj: HassEntity | undefined): {
-    hasAdditionalAttributes: boolean;
-    hasMainViewAttributes: boolean;
-  } {
+  private _computeAttributesMenuData(
+    stateObj: HassEntity | undefined
+  ): boolean {
     if (!stateObj) {
-      return { hasAdditionalAttributes: false, hasMainViewAttributes: false };
+      return false;
     }
 
     const moreInfoType = stateMoreInfoType(stateObj);
-    const hasAdditionalAttributes =
-      computeAdditionalMoreInfoAttributes(stateObj, moreInfoType).length > 0;
-
-    if (!hasAdditionalAttributes) {
-      return { hasAdditionalAttributes: false, hasMainViewAttributes: false };
-    }
-
-    return {
-      hasAdditionalAttributes: true,
-      hasMainViewAttributes:
-        computeMainViewShownAttributes(stateObj, moreInfoType).length > 0,
-    };
+    return (
+      computeAdditionalMoreInfoAttributes(stateObj, moreInfoType).length > 0
+    );
   }
 
   private _goToAddEntityTo(ev) {
@@ -410,8 +397,7 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
     const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
     const domain = computeDomain(entityId);
-    const { hasAdditionalAttributes, hasMainViewAttributes } =
-      this._computeAttributesMenuData(stateObj);
+    const hasAdditionalAttributes = this._computeAttributesMenuData(stateObj);
 
     const isAdmin = this.hass.user!.is_admin;
 
@@ -615,13 +601,9 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
                                 slot="icon"
                                 .path=${mdiFormatListBulletedSquare}
                               ></ha-svg-icon>
-                              ${hasMainViewAttributes
-                                ? this.hass.localize(
-                                    "ui.dialogs.more_info_control.extra_attributes"
-                                  )
-                                : this.hass.localize(
-                                    "ui.dialogs.more_info_control.attributes"
-                                  )}
+                              ${this.hass.localize(
+                                "ui.dialogs.more_info_control.attributes"
+                              )}
                             </ha-dropdown-item>
                           `
                         : nothing}

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -44,7 +44,10 @@ import "../../components/ha-dropdown-item";
 import "../../components/ha-icon-button";
 import "../../components/ha-icon-button-prev";
 import "../../components/ha-related-items";
-import { computeAdditionalMoreInfoAttributes } from "../../data/entity/entity_attributes";
+import {
+  computeAdditionalMoreInfoAttributes,
+  computeMainViewShownAttributes,
+} from "../../data/entity/entity_attributes";
 import type {
   EntityRegistryEntry,
   ExtEntityRegistryEntry,
@@ -359,18 +362,27 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
     };
   }
 
-  private _hasDisplayableAttributes(): boolean {
-    if (!this._entityId) {
-      return false;
-    }
-    const stateObj = this.hass.states[this._entityId];
+  private _computeAttributesMenuData(stateObj: HassEntity | undefined): {
+    hasAdditionalAttributes: boolean;
+    hasMainViewAttributes: boolean;
+  } {
     if (!stateObj) {
-      return false;
+      return { hasAdditionalAttributes: false, hasMainViewAttributes: false };
     }
-    return (
-      computeAdditionalMoreInfoAttributes(stateObj, stateMoreInfoType(stateObj))
-        .length > 0
-    );
+
+    const moreInfoType = stateMoreInfoType(stateObj);
+    const hasAdditionalAttributes =
+      computeAdditionalMoreInfoAttributes(stateObj, moreInfoType).length > 0;
+
+    if (!hasAdditionalAttributes) {
+      return { hasAdditionalAttributes: false, hasMainViewAttributes: false };
+    }
+
+    return {
+      hasAdditionalAttributes: true,
+      hasMainViewAttributes:
+        computeMainViewShownAttributes(stateObj, moreInfoType).length > 0,
+    };
   }
 
   private _goToAddEntityTo(ev) {
@@ -398,6 +410,7 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
     const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
     const domain = computeDomain(entityId);
+    const attributesMenuData = this._computeAttributesMenuData(stateObj);
 
     const isAdmin = this.hass.user!.is_admin;
 
@@ -594,16 +607,20 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
                           "ui.dialogs.more_info_control.related"
                         )}
                       </ha-dropdown-item>
-                      ${this._hasDisplayableAttributes()
+                      ${attributesMenuData.hasAdditionalAttributes
                         ? html`
                             <ha-dropdown-item value="attributes">
                               <ha-svg-icon
                                 slot="icon"
                                 .path=${mdiFormatListBulletedSquare}
                               ></ha-svg-icon>
-                              ${this.hass.localize(
-                                "ui.dialogs.more_info_control.attributes"
-                              )}
+                              ${attributesMenuData.hasMainViewAttributes
+                                ? this.hass.localize(
+                                    "ui.dialogs.more_info_control.all_attributes"
+                                  )
+                                : this.hass.localize(
+                                    "ui.dialogs.more_info_control.attributes"
+                                  )}
                             </ha-dropdown-item>
                           `
                         : nothing}

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -410,7 +410,8 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
     const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
     const domain = computeDomain(entityId);
-    const attributesMenuData = this._computeAttributesMenuData(stateObj);
+    const { hasAdditionalAttributes, hasMainViewAttributes } =
+      this._computeAttributesMenuData(stateObj);
 
     const isAdmin = this.hass.user!.is_admin;
 
@@ -607,14 +608,14 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
                           "ui.dialogs.more_info_control.related"
                         )}
                       </ha-dropdown-item>
-                      ${attributesMenuData.hasAdditionalAttributes
+                      ${hasAdditionalAttributes
                         ? html`
                             <ha-dropdown-item value="attributes">
                               <ha-svg-icon
                                 slot="icon"
                                 .path=${mdiFormatListBulletedSquare}
                               ></ha-svg-icon>
-                              ${attributesMenuData.hasMainViewAttributes
+                              ${hasMainViewAttributes
                                 ? this.hass.localize(
                                     "ui.dialogs.more_info_control.all_attributes"
                                   )

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -44,7 +44,10 @@ import "../../components/ha-dropdown-item";
 import "../../components/ha-icon-button";
 import "../../components/ha-icon-button-prev";
 import "../../components/ha-related-items";
-import { computeAdditionalMoreInfoAttributes } from "../../data/entity/entity_attributes";
+import {
+  MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS,
+  computeShownAttributes,
+} from "../../data/entity/entity_attributes";
 import type {
   EntityRegistryEntry,
   ExtEntityRegistryEntry,
@@ -366,10 +369,29 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
       return false;
     }
 
+    const shownAttributes = computeShownAttributes(stateObj);
+    if (shownAttributes.length === 0) {
+      return false;
+    }
+
     const moreInfoType = stateMoreInfoType(stateObj);
-    return (
-      computeAdditionalMoreInfoAttributes(stateObj, moreInfoType).length > 0
+    const hasMainViewAttributesSection = Object.prototype.hasOwnProperty.call(
+      MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS,
+      moreInfoType
     );
+
+    if (!hasMainViewAttributesSection) {
+      return true;
+    }
+
+    const mainViewExtraFilters =
+      MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS[moreInfoType] || [];
+
+    const hasVisibleMainViewAttributes = shownAttributes.some(
+      (attribute) => mainViewExtraFilters.indexOf(attribute) === -1
+    );
+
+    return !hasVisibleMainViewAttributes;
   }
 
   private _goToAddEntityTo(ev) {
@@ -397,7 +419,7 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
     const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
     const domain = computeDomain(entityId);
-    const hasAdditionalAttributes = this._computeAttributesMenuData(stateObj);
+    const showAttributesMenuItem = this._computeAttributesMenuData(stateObj);
 
     const isAdmin = this.hass.user!.is_admin;
 
@@ -594,7 +616,7 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
                           "ui.dialogs.more_info_control.related"
                         )}
                       </ha-dropdown-item>
-                      ${hasAdditionalAttributes
+                      ${showAttributesMenuItem
                         ? html`
                             <ha-dropdown-item value="attributes">
                               <ha-svg-icon

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1522,7 +1522,6 @@
         "related": "Related",
         "add_entity_to": "Add to",
         "attributes": "Attributes",
-        "extra_attributes": "Extra attributes",
         "history": "History",
         "aggregate": "5-minute aggregated",
         "logbook": "Activity",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1522,7 +1522,7 @@
         "related": "Related",
         "add_entity_to": "Add to",
         "attributes": "Attributes",
-        "all_attributes": "All attributes",
+        "extra_attributes": "Extra attributes",
         "history": "History",
         "aggregate": "5-minute aggregated",
         "logbook": "Activity",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1522,6 +1522,7 @@
         "related": "Related",
         "add_entity_to": "Add to",
         "attributes": "Attributes",
+        "all_attributes": "All attributes",
         "history": "History",
         "aggregate": "5-minute aggregated",
         "logbook": "Activity",

--- a/test/data/entity_attributes.test.ts
+++ b/test/data/entity_attributes.test.ts
@@ -1,7 +1,10 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import { describe, expect, it } from "vitest";
 
-import { computeShownAttributes } from "../../src/data/entity/entity_attributes";
+import {
+  computeAdditionalMoreInfoAttributes,
+  computeShownAttributes,
+} from "../../src/data/entity/entity_attributes";
 
 describe("computeShownAttributes", () => {
   it("filters globally hidden attributes", () => {
@@ -47,6 +50,58 @@ describe("computeShownAttributes", () => {
     expect(computeShownAttributes(stateObj)).toEqual([
       "options",
       "current_option",
+    ]);
+  });
+});
+
+describe("computeAdditionalMoreInfoAttributes", () => {
+  it("returns no additional attributes when main view already shows all", () => {
+    const stateObj = {
+      entity_id: "sensor.temperature",
+      attributes: {
+        friendly_name: "Office temperature",
+        unit_of_measurement: "°C",
+        temperature: 21,
+        custom_value: "shown",
+      },
+    } as unknown as HassEntity;
+
+    expect(computeAdditionalMoreInfoAttributes(stateObj, "default")).toEqual(
+      []
+    );
+  });
+
+  it("returns attributes hidden in the main view", () => {
+    const stateObj = {
+      entity_id: "light.office",
+      attributes: {
+        friendly_name: "Office light",
+        brightness: 120,
+        color_mode: "rgb",
+        custom_value: "shown",
+      },
+    } as unknown as HassEntity;
+
+    expect(computeAdditionalMoreInfoAttributes(stateObj, "light")).toEqual([
+      "brightness",
+      "color_mode",
+    ]);
+  });
+
+  it("returns all shown attributes when main view has no attributes section", () => {
+    const stateObj = {
+      entity_id: "climate.office",
+      attributes: {
+        temperature: 21,
+        hvac_mode: "heat",
+        custom_value: "shown",
+      },
+    } as unknown as HassEntity;
+
+    expect(computeAdditionalMoreInfoAttributes(stateObj, "climate")).toEqual([
+      "temperature",
+      "hvac_mode",
+      "custom_value",
     ]);
   });
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
- Restore original accordion menu to show attributes (how it was before)
- Align styles of accordion with view (CSS changes)
- Show attributes overflow option when there are attributes to show and the accordion is not present 

Context for change: https://github.com/home-assistant/frontend/pull/29186#issuecomment-3919566144

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes attribute filtering and menu visibility across many more-info dialogs, so regressions could hide/show the wrong attributes or the Attributes menu for certain entity types.
> 
> **Overview**
> Restores an inline **attributes accordion** (`ha-attributes`) on multiple more-info control panels (e.g., `light`, `cover`, `lock`, `person`, `vacuum`, `timer`, plus `default`/`switch`/`siren`/`input_boolean`) and aligns its styling to match the dedicated attributes view.
> 
> Introduces `MORE_INFO_MAIN_VIEW_EXTRA_ATTRIBUTE_FILTERS` and new helpers (`computeMainViewShownAttributes`, `computeAdditionalMoreInfoAttributes`) to split attributes between the main view and the separate Attributes view; `ha-more-info-dialog` now shows the Attributes menu item only when *additional* attributes exist beyond what the main accordion displays, with accompanying unit tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca75ba8334873769fef50113bc3702c2dfaf7e75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->