### PR TITLE
Add repository handling for missing addons in HaConfigAppDashboard

### DIFF
--- a/src/panels/config/apps/ha-config-app-dashboard.ts
+++ b/src/panels/config/apps/ha-config-app-dashboard.ts
@@ -9,6 +9,7 @@ import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../common/dom/fire_event";
+import { navigate } from "../../../common/navigate";
 import { extractSearchParam } from "../../../common/url/search-params";
 import type { HassioAddonDetails } from "../../../data/hassio/addon";
 import { fetchHassioAddonInfo } from "../../../data/hassio/addon";
@@ -44,6 +45,8 @@ class HaConfigAppDashboard extends LitElement {
 
   @state() private _fromStore = false;
 
+  @state() private _loading = true;
+
   private _computeTail = memoizeOne((route: Route) => {
     const pathParts = route.path.split("/").filter(Boolean);
     // Path is like /<slug>/info or /<slug>/config
@@ -59,8 +62,14 @@ class HaConfigAppDashboard extends LitElement {
   protected async firstUpdated(): Promise<void> {
     this._fromStore = extractSearchParam("store") === "true";
     const repositoryUrl = extractSearchParam("repository_url");
+    if (repositoryUrl) {
+      navigate(`/config/app/${this.route.path.split("/")[1]}`, {
+        replace: true,
+      });
+    }
     await this._loadAddon(repositoryUrl);
     this.addEventListener("hass-api-called", (ev) => this._apiCalled(ev));
+    this._loading = false;
   }
 
   protected updated(changedProperties: PropertyValues) {
@@ -69,7 +78,7 @@ class HaConfigAppDashboard extends LitElement {
       const oldSlug = oldRoute?.path.split("/")[1];
       const newSlug = this.route.path.split("/")[1];
 
-      if (oldSlug !== newSlug && newSlug) {
+      if (oldSlug !== newSlug && newSlug && !this._loading) {
         this._loadAddon();
       }
     }

--- a/src/panels/config/apps/ha-config-app-dashboard.ts
+++ b/src/panels/config/apps/ha-config-app-dashboard.ts
@@ -13,6 +13,11 @@ import { extractSearchParam } from "../../../common/url/search-params";
 import type { HassioAddonDetails } from "../../../data/hassio/addon";
 import { fetchHassioAddonInfo } from "../../../data/hassio/addon";
 import { extractApiErrorMessage } from "../../../data/hassio/common";
+import {
+  addStoreRepository,
+  fetchSupervisorStore,
+} from "../../../data/supervisor/store";
+import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-error-screen";
 import "../../../layouts/hass-loading-screen";
 import "../../../layouts/hass-tabs-subpage";
@@ -39,6 +44,8 @@ class HaConfigAppDashboard extends LitElement {
 
   @state() private _fromStore = false;
 
+  private _repositoryUrl?: string | null;
+
   private _computeTail = memoizeOne((route: Route) => {
     const pathParts = route.path.split("/").filter(Boolean);
     // Path is like /<slug>/info or /<slug>/config
@@ -53,6 +60,7 @@ class HaConfigAppDashboard extends LitElement {
 
   protected async firstUpdated(): Promise<void> {
     this._fromStore = extractSearchParam("store") === "true";
+    this._repositoryUrl = extractSearchParam("repository_url");
     await this._loadAddon();
     this.addEventListener("hass-api-called", (ev) => this._apiCalled(ev));
   }
@@ -148,7 +156,51 @@ class HaConfigAppDashboard extends LitElement {
     try {
       this._addon = await fetchHassioAddonInfo(this.hass, slug);
     } catch (err: any) {
-      this._error = `Error loading addon: ${extractApiErrorMessage(err)}`;
+      if (this._repositoryUrl) {
+        await this._handleMissingRepository(slug, this._repositoryUrl);
+        if (this._addon) {
+          return;
+        }
+      }
+      this._error = `Error loading app: ${extractApiErrorMessage(err)}`;
+    }
+  }
+
+  private async _handleMissingRepository(
+    slug: string,
+    repositoryUrl: string
+  ): Promise<void> {
+    try {
+      const storeInfo = await fetchSupervisorStore(this.hass);
+      if (
+        storeInfo.repositories.some((repo) => repo.source === repositoryUrl)
+      ) {
+        // Repository is already installed, addon just doesn't exist
+        return;
+      }
+
+      if (
+        !(await showConfirmationDialog(this, {
+          title: this.hass.localize(
+            "ui.panel.config.apps.my.add_repository_title"
+          ),
+          text: this.hass.localize(
+            "ui.panel.config.apps.my.add_repository_description",
+            { repository: this._repositoryUrl! }
+          ),
+          confirmText: this.hass.localize("ui.common.add"),
+          dismissText: this.hass.localize("ui.common.cancel"),
+        }))
+      ) {
+        this._error = this.hass.localize(
+          "ui.panel.config.apps.my.error_repository_not_found"
+        );
+      }
+
+      await addStoreRepository(this.hass, repositoryUrl);
+      this._addon = await fetchHassioAddonInfo(this.hass, slug);
+    } catch (err: any) {
+      this._error = extractApiErrorMessage(err);
     }
   }
 

--- a/src/panels/config/apps/ha-config-app-dashboard.ts
+++ b/src/panels/config/apps/ha-config-app-dashboard.ts
@@ -44,7 +44,7 @@ class HaConfigAppDashboard extends LitElement {
 
   @state() private _fromStore = false;
 
-  private _repositoryUrl?: string | null;
+  @state() private _repositoryUrl: string | null = null;
 
   private _computeTail = memoizeOne((route: Route) => {
     const pathParts = route.path.split("/").filter(Boolean);
@@ -162,7 +162,7 @@ class HaConfigAppDashboard extends LitElement {
           return;
         }
       }
-      this._error = `Error loading app: ${extractApiErrorMessage(err)}`;
+      this._error ??= `Error loading app: ${extractApiErrorMessage(err)}`;
     }
   }
 
@@ -186,7 +186,7 @@ class HaConfigAppDashboard extends LitElement {
           ),
           text: this.hass.localize(
             "ui.panel.config.apps.my.add_repository_description",
-            { repository: this._repositoryUrl! }
+            { repository: repositoryUrl }
           ),
           confirmText: this.hass.localize("ui.common.add"),
           dismissText: this.hass.localize("ui.common.cancel"),
@@ -195,6 +195,7 @@ class HaConfigAppDashboard extends LitElement {
         this._error = this.hass.localize(
           "ui.panel.config.apps.my.error_repository_not_found"
         );
+        return;
       }
 
       await addStoreRepository(this.hass, repositoryUrl);

--- a/src/panels/config/apps/ha-config-app-dashboard.ts
+++ b/src/panels/config/apps/ha-config-app-dashboard.ts
@@ -44,8 +44,6 @@ class HaConfigAppDashboard extends LitElement {
 
   @state() private _fromStore = false;
 
-  @state() private _repositoryUrl: string | null = null;
-
   private _computeTail = memoizeOne((route: Route) => {
     const pathParts = route.path.split("/").filter(Boolean);
     // Path is like /<slug>/info or /<slug>/config
@@ -60,8 +58,8 @@ class HaConfigAppDashboard extends LitElement {
 
   protected async firstUpdated(): Promise<void> {
     this._fromStore = extractSearchParam("store") === "true";
-    this._repositoryUrl = extractSearchParam("repository_url");
-    await this._loadAddon();
+    const repositoryUrl = extractSearchParam("repository_url");
+    await this._loadAddon(repositoryUrl);
     this.addEventListener("hass-api-called", (ev) => this._apiCalled(ev));
   }
 
@@ -146,7 +144,7 @@ class HaConfigAppDashboard extends LitElement {
     `;
   }
 
-  private async _loadAddon(): Promise<void> {
+  private async _loadAddon(repositoryUrl?: string | null): Promise<void> {
     const slug = this.route.path.split("/")[1];
     if (!slug) {
       this._error = "No addon specified";
@@ -156,13 +154,20 @@ class HaConfigAppDashboard extends LitElement {
     try {
       this._addon = await fetchHassioAddonInfo(this.hass, slug);
     } catch (err: any) {
-      if (this._repositoryUrl) {
-        await this._handleMissingRepository(slug, this._repositoryUrl);
-        if (this._addon) {
+      if (repositoryUrl) {
+        try {
+          await this._handleMissingRepository(slug, repositoryUrl);
+          if (this._addon) {
+            // Clear error if we successfully added the repository and loaded the addon
+            this._error = undefined;
+            return;
+          }
+        } catch (addRepoErr: any) {
+          this._error = extractApiErrorMessage(addRepoErr);
           return;
         }
       }
-      this._error ??= `Error loading app: ${extractApiErrorMessage(err)}`;
+      this._error = `Error loading app: ${extractApiErrorMessage(err)}`;
     }
   }
 
@@ -170,39 +175,33 @@ class HaConfigAppDashboard extends LitElement {
     slug: string,
     repositoryUrl: string
   ): Promise<void> {
-    try {
-      const storeInfo = await fetchSupervisorStore(this.hass);
-      if (
-        storeInfo.repositories.some((repo) => repo.source === repositoryUrl)
-      ) {
-        // Repository is already installed, addon just doesn't exist
-        return;
-      }
-
-      if (
-        !(await showConfirmationDialog(this, {
-          title: this.hass.localize(
-            "ui.panel.config.apps.my.add_repository_title"
-          ),
-          text: this.hass.localize(
-            "ui.panel.config.apps.my.add_repository_description",
-            { repository: repositoryUrl }
-          ),
-          confirmText: this.hass.localize("ui.common.add"),
-          dismissText: this.hass.localize("ui.common.cancel"),
-        }))
-      ) {
-        this._error = this.hass.localize(
-          "ui.panel.config.apps.my.error_repository_not_found"
-        );
-        return;
-      }
-
-      await addStoreRepository(this.hass, repositoryUrl);
-      this._addon = await fetchHassioAddonInfo(this.hass, slug);
-    } catch (err: any) {
-      this._error = extractApiErrorMessage(err);
+    const storeInfo = await fetchSupervisorStore(this.hass);
+    if (storeInfo.repositories.some((repo) => repo.source === repositoryUrl)) {
+      // Repository is already installed, addon just doesn't exist
+      return;
     }
+
+    if (
+      !(await showConfirmationDialog(this, {
+        title: this.hass.localize(
+          "ui.panel.config.apps.my.add_repository_title"
+        ),
+        text: this.hass.localize(
+          "ui.panel.config.apps.my.add_repository_description",
+          { repository: repositoryUrl }
+        ),
+        confirmText: this.hass.localize("ui.common.add"),
+        dismissText: this.hass.localize("ui.common.cancel"),
+      }))
+    ) {
+      this._error = this.hass.localize(
+        "ui.panel.config.apps.my.error_repository_not_found"
+      );
+      return;
+    }
+
+    await addStoreRepository(this.hass, repositoryUrl);
+    this._addon = await fetchHassioAddonInfo(this.hass, slug);
   }
 
   private async _apiCalled(ev): Promise<void> {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2614,6 +2614,11 @@
               "password": "Password"
             }
           },
+          "my": {
+            "add_repository_title": "Add app repository?",
+            "add_repository_description": "This app requires a repository that is currently not known. Do you want to add the repository {repository}?",
+            "error_repository_not_found": "The repository for this app was not found"
+          },
           "panel": {
             "info": "Info",
             "documentation": "Documentation",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


This PR adds back support for supplying a repository URL with my links pointing to apps.
This PR was initially created with Claude and then adjusted by a human.


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

<img width="698" height="261" alt="image" src="https://github.com/user-attachments/assets/8624b9e0-a260-448e-8d09-f2111d454a78" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29455
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches app dashboard navigation and adds a new flow that mutates Supervisor store repositories via API; failures or unexpected prompts could impact UX but scope is limited to this page.
> 
> **Overview**
> `ha-config-app-dashboard` now accepts an optional `repository_url` query param: it cleans the URL via `navigate(..., { replace: true })`, and if the app lookup fails it checks the Supervisor store for that repository and prompts the user to add it before retrying the app load.
> 
> Adds a small loading guard to avoid double-loading on initial route updates, and introduces new English strings for the add-repository confirmation/cancel flow and error message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe2d56e89fbce2efe611efcd2dc302b3b533d3b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->