### PR TITLE
Add projector_screen cover device class icons

### DIFF
--- a/src/common/entity/cover_icon.ts
+++ b/src/common/entity/cover_icon.ts
@@ -9,6 +9,8 @@ import type { HassEntity } from "home-assistant-js-websocket";
 
 export const computeOpenIcon = (stateObj: HassEntity): string => {
   switch (stateObj.attributes.device_class) {
+    case "projector_screen":
+      return mdiArrowDown; // "Open" means deploy (go down)
     case "awning":
     case "door":
     case "gate":
@@ -21,6 +23,8 @@ export const computeOpenIcon = (stateObj: HassEntity): string => {
 
 export const computeCloseIcon = (stateObj: HassEntity): string => {
   switch (stateObj.attributes.device_class) {
+    case "projector_screen":
+      return mdiArrowUp; // "Close" means retract (go up)
     case "awning":
     case "door":
     case "gate":

--- a/src/data/cover.ts
+++ b/src/data/cover.ts
@@ -103,6 +103,7 @@ export function canStopTilt(stateObj: CoverEntity): boolean {
 interface CoverEntityAttributes extends HassEntityAttributeBase {
   current_position?: number;
   current_tilt_position?: number;
+  device_class?: string;
 }
 
 export interface CoverEntity extends HassEntityBase {

--- a/src/fake_data/entity_component_icons.ts
+++ b/src/fake_data/entity_component_icons.ts
@@ -348,6 +348,14 @@ export const ENTITY_COMPONENT_ICONS: Record<string, ComponentIcons> = {
         opening: "mdi:arrow-up-box",
       },
     },
+    projector_screen: {
+      default: "mdi:projector-screen",
+      state: {
+        closed: "mdi:projector-screen-off",
+        closing: "mdi:arrow-up-box",
+        opening: "mdi:arrow-down-box",
+      },
+    },
     window: {
       default: "mdi:window-open",
       state: {

--- a/test/common/entity/cover_icon.test.ts
+++ b/test/common/entity/cover_icon.test.ts
@@ -26,6 +26,13 @@ describe("computeOpenIcon", () => {
     expect(computeOpenIcon(stateObj)).toBe(mdiArrowExpandHorizontal);
   });
 
+  it("returns mdiArrowDown for projector_screen (inverted - open means deploy/down)", () => {
+    const stateObj = {
+      attributes: { device_class: "projector_screen" },
+    } as HassEntity;
+    expect(computeOpenIcon(stateObj)).toBe(mdiArrowDown);
+  });
+
   it("returns mdiArrowUp for other device classes", () => {
     const stateObj = { attributes: { device_class: "window" } } as HassEntity;
     expect(computeOpenIcon(stateObj)).toBe(mdiArrowUp);
@@ -45,6 +52,13 @@ describe("computeCloseIcon", () => {
 
     stateObj.attributes.device_class = "curtain";
     expect(computeCloseIcon(stateObj)).toBe(mdiArrowCollapseHorizontal);
+  });
+
+  it("returns mdiArrowUp for projector_screen (inverted - close means retract/up)", () => {
+    const stateObj = {
+      attributes: { device_class: "projector_screen" },
+    } as HassEntity;
+    expect(computeCloseIcon(stateObj)).toBe(mdiArrowUp);
   });
 
   it("returns mdiArrowDown for other device classes", () => {


### PR DESCRIPTION
## Proposed change

Adds frontend support for the `projector_screen` cover device class. Swaps directional icons so the open button shows a down arrow (deploy) and the close button shows an up arrow (retract), matching the physical behavior of projector screens.

Depends on core PR: https://github.com/home-assistant/core/pull/163618

## Type of change

- [x] New feature

## Additional information

- Core PR: https://github.com/home-assistant/core/pull/163618
- Architecture discussion: https://github.com/home-assistant/architecture/discussions/983
- Community thread: https://community.home-assistant.io/t/open-close-direction-for-projector-screens/464292

## Changes

- `cover_icon.ts`: Add `projector_screen` case to `computeOpenIcon` (↓) and `computeCloseIcon` (↑)
- `cover.ts`: Add `device_class` to `CoverEntityAttributes` interface
- `entity_component_icons.ts`: Add projector_screen icon set with inverted directional arrows
- Tests added for both open and close icon computation

## Checklist

- [x] The code change is tested and works locally
- [x] There is no commented-out code in this PR
- [x] Tests have been added to verify that the new code works