### PR TITLE
Adjust brands assets to proxy brand images through local API

### DIFF
--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -15,6 +15,7 @@ import { iconColorCSS } from "../../common/style/icon_color_css";
 import { cameraUrlWithWidthHeight } from "../../data/camera";
 import { CLIMATE_HVAC_ACTION_TO_MODE } from "../../data/climate";
 import type { HomeAssistant } from "../../types";
+import { addBrandsAuth } from "../../util/brands-url";
 import "../ha-state-icon";
 
 @customElement("state-badge")
@@ -137,6 +138,7 @@ export class StateBadge extends LitElement {
           let imageUrl =
             stateObj.attributes.entity_picture_local ||
             stateObj.attributes.entity_picture;
+          imageUrl = addBrandsAuth(imageUrl);
           if (this.hass) {
             imageUrl = this.hass.hassUrl(imageUrl);
           }

--- a/src/components/ha-selector/ha-selector-media.ts
+++ b/src/components/ha-selector/ha-selector-media.ts
@@ -13,7 +13,11 @@ import {
 } from "../../data/media-player";
 import type { MediaSelector, MediaSelectorValue } from "../../data/selector";
 import type { HomeAssistant } from "../../types";
-import { brandsUrl, extractDomainFromBrandUrl } from "../../util/brands-url";
+import {
+  brandsUrl,
+  extractDomainFromBrandUrl,
+  isBrandUrl,
+} from "../../util/brands-url";
 import "../ha-alert";
 import "../ha-form/ha-form";
 import type { SchemaUnion } from "../ha-form/types";
@@ -72,22 +76,19 @@ export class HaMediaSelector extends LitElement {
       if (thumbnail === oldThumbnail) {
         return;
       }
-      if (thumbnail && thumbnail.startsWith("/")) {
-        this._thumbnailUrl = undefined;
-        // Thumbnails served by local API require authentication
-        getSignedPath(this.hass, thumbnail).then((signedPath) => {
-          this._thumbnailUrl = signedPath.path;
-        });
-      } else if (
-        thumbnail &&
-        thumbnail.startsWith("https://brands.home-assistant.io")
-      ) {
+      if (thumbnail && isBrandUrl(thumbnail)) {
         // The backend is not aware of the theme used by the users,
         // so we rewrite the URL to show a proper icon
         this._thumbnailUrl = brandsUrl({
           domain: extractDomainFromBrandUrl(thumbnail),
           type: "icon",
           darkOptimized: this.hass.themes?.darkMode,
+        });
+      } else if (thumbnail && thumbnail.startsWith("/")) {
+        this._thumbnailUrl = undefined;
+        // Thumbnails served by local API require authentication
+        getSignedPath(this.hass, thumbnail).then((signedPath) => {
+          this._thumbnailUrl = signedPath.path;
         });
       } else {
         this._thumbnailUrl = thumbnail;

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -765,6 +765,16 @@ export class HaMediaPlayerBrowse extends LitElement {
       return "";
     }
 
+    if (isBrandUrl(thumbnailUrl)) {
+      // The backend is not aware of the theme used by the users,
+      // so we rewrite the URL to show a proper icon
+      return brandsUrl({
+        domain: extractDomainFromBrandUrl(thumbnailUrl),
+        type: "icon",
+        darkOptimized: this.hass.themes?.darkMode,
+      });
+    }
+
     if (thumbnailUrl.startsWith("/")) {
       // Thumbnails served by local API require authentication
       return new Promise((resolve, reject) => {
@@ -784,16 +794,6 @@ export class HaMediaPlayerBrowse extends LitElement {
             reader.onerror = (e) => reject(e);
             reader.readAsDataURL(blob);
           });
-      });
-    }
-
-    if (isBrandUrl(thumbnailUrl)) {
-      // The backend is not aware of the theme used by the users,
-      // so we rewrite the URL to show a proper icon
-      thumbnailUrl = brandsUrl({
-        domain: extractDomainFromBrandUrl(thumbnailUrl),
-        type: "icon",
-        darkOptimized: this.hass.themes?.darkMode,
       });
     }
 

--- a/src/entrypoints/service-worker.ts
+++ b/src/entrypoints/service-worker.ts
@@ -32,21 +32,28 @@ const initRouting = () => {
     new CacheFirst({ matchOptions: { ignoreSearch: true } })
   );
 
-  // Cache any brand images used for 30 days
-  // Use revalidation so cache is always available during an extended outage
+  // Cache any brand images used for 1 day
+  // Brands are proxied via the local API with backend caching.
+  // Strip the rotating access token from cache keys so token rotation
+  // doesn't bust the cache, while preserving other params like fallback.
   registerRoute(
     ({ url, request }) =>
-      url.origin === "https://brands.home-assistant.io" &&
+      url.pathname.startsWith("/api/brands/") &&
       request.destination === "image",
     new StaleWhileRevalidate({
       cacheName: "brands",
-      // CORS must be forced to work for CSS images
-      fetchOptions: { mode: "cors", credentials: "omit" },
       plugins: [
+        {
+          cacheKeyWillBeUsed: async ({ request }) => {
+            const url = new URL(request.url);
+            url.searchParams.delete("token");
+            return url.href;
+          },
+        },
         // Add 404 so we quickly respond to domains with missing images
         new CacheableResponsePlugin({ statuses: [0, 200, 404] }),
         new ExpirationPlugin({
-          maxAgeSeconds: 60 * 60 * 24 * 30,
+          maxAgeSeconds: 60 * 60 * 24,
           purgeOnQuotaError: true,
         }),
       ],

--- a/src/entrypoints/service-worker.ts
+++ b/src/entrypoints/service-worker.ts
@@ -35,7 +35,7 @@ const initRouting = () => {
   // Cache any brand images used for 1 day
   // Brands are proxied via the local API with backend caching.
   // Strip the rotating access token from cache keys so token rotation
-  // doesn't bust the cache, while preserving other params like fallback.
+  // doesn't bust the cache, while preserving other params like "placeholder".
   registerRoute(
     ({ url, request }) =>
       url.pathname.startsWith("/api/brands/") &&

--- a/src/panels/config/integrations/dialog-add-integration.ts
+++ b/src/panels/config/integrations/dialog-add-integration.ts
@@ -578,7 +578,6 @@ class AddIntegrationDialog extends LitElement {
     }
     return html`
       <ha-integration-list-item
-        brand
         .hass=${this.hass}
         .integration=${integration}
         tabindex="0"

--- a/src/panels/config/integrations/ha-integration-list-item.ts
+++ b/src/panels/config/integrations/ha-integration-list-item.ts
@@ -30,8 +30,6 @@ export class HaIntegrationListItem extends ListItemBase {
   // eslint-disable-next-line lit/attribute-names
   @property({ type: Boolean }) hasMeta = true;
 
-  @property({ type: Boolean }) brand = false;
-
   // @ts-expect-error
   protected override renderSingleLine() {
     if (!this.integration) {
@@ -68,7 +66,6 @@ export class HaIntegrationListItem extends ListItemBase {
               domain: this.integration.domain,
               type: "icon",
               darkOptimized: this.hass.themes?.darkMode,
-              brand: this.brand,
             })}
             crossorigin="anonymous"
             referrerpolicy="no-referrer"

--- a/src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts
@@ -224,7 +224,6 @@ export class ThreadConfigPanel extends SubscribeMixin(LitElement) {
                   slot="graphic"
                   .src=${brandsUrl({
                     domain: router.brand,
-                    brand: true,
                     type: "icon",
                     darkOptimized: this.hass.themes?.darkMode,
                   })}

--- a/src/panels/lovelace/badges/hui-entity-badge.ts
+++ b/src/panels/lovelace/badges/hui-entity-badge.ts
@@ -18,6 +18,7 @@ import "../../../components/ha-svg-icon";
 import { cameraUrlWithWidthHeight } from "../../../data/camera";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import type { HomeAssistant } from "../../../types";
+import { addBrandsAuth } from "../../../util/brands-url";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { computeLovelaceEntityName } from "../common/entity/compute-lovelace-entity-name";
 import { findEntities } from "../common/find-entities";
@@ -143,7 +144,7 @@ export class HuiEntityBadge extends LitElement implements LovelaceBadge {
 
     if (!entityPicture) return undefined;
 
-    let imageUrl = this.hass!.hassUrl(entityPicture);
+    let imageUrl = this.hass!.hassUrl(addBrandsAuth(entityPicture));
     if (computeStateDomain(stateObj) === "camera") {
       imageUrl = cameraUrlWithWidthHeight(imageUrl, 32, 32);
     }

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -21,6 +21,7 @@ import { cameraUrlWithWidthHeight } from "../../../data/camera";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import "../../../state-display/state-display";
 import type { HomeAssistant } from "../../../types";
+import { addBrandsAuth } from "../../../util/brands-url";
 import "../card-features/hui-card-features";
 import type { LovelaceCardFeatureContext } from "../card-features/types";
 import { computeLovelaceEntityName } from "../common/entity/compute-lovelace-entity-name";
@@ -158,7 +159,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
 
     if (!entityPicture) return undefined;
 
-    let imageUrl = this.hass!.hassUrl(entityPicture);
+    let imageUrl = this.hass!.hassUrl(addBrandsAuth(entityPicture));
     if (computeDomain(entity.entity_id) === "camera") {
       imageUrl = cameraUrlWithWidthHeight(imageUrl, 80, 80);
     }

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -30,7 +30,10 @@ import { subscribeEntityRegistryDisplay } from "../data/ws-entity_registry_displ
 import { subscribeFloorRegistry } from "../data/ws-floor_registry";
 import { subscribePanels } from "../data/ws-panels";
 import { translationMetadata } from "../resources/translations-metadata";
-import { fetchBrandsAccessToken } from "../util/brands-url";
+import {
+  clearBrandsTokenRefresh,
+  fetchAndScheduleBrandsAccessToken,
+} from "../util/brands-url";
 import type { Constructor, HomeAssistant, ServiceCallResponse } from "../types";
 import { getLocalLanguage } from "../util/common-translation";
 import { fetchWithAuth } from "../util/fetch-with-auth";
@@ -321,6 +324,9 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       });
       clearInterval(this.__backendPingInterval);
 
+      // Fetch the brands access token on initial connect and schedule refresh
+      fetchAndScheduleBrandsAccessToken(this.hass!);
+
       this.__backendPingInterval = setInterval(() => {
         if (this.hass?.connected) {
           // If the backend is busy, or the connection is latent,
@@ -345,10 +351,8 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       this._updateHass({ connected: true });
       broadcastConnectionStatus("connected");
 
-      // Refresh the brands access token on reconnect
-      fetchBrandsAccessToken(this.hass!).catch(() => {
-        // Ignore failures; older backends may not support this command
-      });
+      // Refresh the brands access token on reconnect and restart refresh schedule
+      fetchAndScheduleBrandsAccessToken(this.hass!);
 
       // on reconnect always fetch config as we might miss an update while we were disconnected
       // @ts-ignore
@@ -367,5 +371,6 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       this._updateHass({ connected: false });
       broadcastConnectionStatus("disconnected");
       clearInterval(this.__backendPingInterval);
+      clearBrandsTokenRefresh();
     }
   };

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -321,9 +321,6 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       });
       clearInterval(this.__backendPingInterval);
 
-      // Fetch the brands access token for authenticated brand image requests
-      fetchBrandsAccessToken(this.hass!);
-
       this.__backendPingInterval = setInterval(() => {
         if (this.hass?.connected) {
           // If the backend is busy, or the connection is latent,
@@ -349,7 +346,9 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       broadcastConnectionStatus("connected");
 
       // Refresh the brands access token on reconnect
-      fetchBrandsAccessToken(this.hass!);
+      fetchBrandsAccessToken(this.hass!).catch(() => {
+        // Ignore failures; older backends may not support this command
+      });
 
       // on reconnect always fetch config as we might miss an update while we were disconnected
       // @ts-ignore

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -30,6 +30,7 @@ import { subscribeEntityRegistryDisplay } from "../data/ws-entity_registry_displ
 import { subscribeFloorRegistry } from "../data/ws-floor_registry";
 import { subscribePanels } from "../data/ws-panels";
 import { translationMetadata } from "../resources/translations-metadata";
+import { fetchBrandsAccessToken } from "../util/brands-url";
 import type { Constructor, HomeAssistant, ServiceCallResponse } from "../types";
 import { getLocalLanguage } from "../util/common-translation";
 import { fetchWithAuth } from "../util/fetch-with-auth";
@@ -319,6 +320,10 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         this._updateHass({ systemData: {} });
       });
       clearInterval(this.__backendPingInterval);
+
+      // Fetch the brands access token for authenticated brand image requests
+      fetchBrandsAccessToken(this.hass!);
+
       this.__backendPingInterval = setInterval(() => {
         if (this.hass?.connected) {
           // If the backend is busy, or the connection is latent,
@@ -342,6 +347,9 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
 
       this._updateHass({ connected: true });
       broadcastConnectionStatus("connected");
+
+      // Refresh the brands access token on reconnect
+      fetchBrandsAccessToken(this.hass!);
 
       // on reconnect always fetch config as we might miss an update while we were disconnected
       // @ts-ignore

--- a/src/util/brands-url.ts
+++ b/src/util/brands-url.ts
@@ -1,8 +1,9 @@
+import type { HomeAssistant } from "../types";
+
 export interface BrandsOptions {
   domain: string;
   type: "icon" | "logo" | "icon@2x" | "logo@2x";
   darkOptimized?: boolean;
-  brand?: boolean;
 }
 
 export interface HardwareBrandsOptions {
@@ -12,17 +13,54 @@ export interface HardwareBrandsOptions {
   darkOptimized?: boolean;
 }
 
-export const brandsUrl = (options: BrandsOptions): string =>
-  `https://brands.home-assistant.io/${options.brand ? "brands/" : ""}_/${options.domain}/${
-    options.darkOptimized ? "dark_" : ""
-  }${options.type}.png`;
+let _brandsAccessToken: string | undefined;
 
-export const hardwareBrandsUrl = (options: HardwareBrandsOptions): string =>
-  `https://brands.home-assistant.io/hardware/${options.category}/${
+export const fetchBrandsAccessToken = async (
+  hass: HomeAssistant
+): Promise<void> => {
+  const result = await hass.callWS<{ token: string }>({
+    type: "brands/access_token",
+  });
+  _brandsAccessToken = result.token;
+};
+
+export const brandsUrl = (options: BrandsOptions): string => {
+  const base = `/api/brands/integration/${options.domain}/${
+    options.darkOptimized ? "dark_" : ""
+  }${options.type}.png?fallback=placeholder`;
+  if (_brandsAccessToken) {
+    return `${base}&token=${_brandsAccessToken}`;
+  }
+  return base;
+};
+
+export const hardwareBrandsUrl = (options: HardwareBrandsOptions): string => {
+  const base = `/api/brands/hardware/${options.category}/${
     options.darkOptimized ? "dark_" : ""
   }${options.manufacturer}${options.model ? `_${options.model}` : ""}.png`;
+  if (_brandsAccessToken) {
+    return `${base}?token=${_brandsAccessToken}`;
+  }
+  return base;
+};
 
-export const extractDomainFromBrandUrl = (url: string) => url.split("/")[4];
+export const addBrandsAuth = (url: string): string => {
+  if (!_brandsAccessToken || !url.startsWith("/api/brands/")) {
+    return url;
+  }
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}token=${_brandsAccessToken}`;
+};
+
+export const extractDomainFromBrandUrl = (url: string): string => {
+  // Handle both new local API paths (/api/brands/integration/{domain}/...)
+  // and legacy CDN URLs (https://brands.home-assistant.io/_/{domain}/...)
+  if (url.startsWith("/api/brands/")) {
+    return url.split("/")[4];
+  }
+  return url.split("/")[4];
+};
 
 export const isBrandUrl = (thumbnail: string | ""): boolean =>
+  thumbnail.startsWith("/api/brands/") ||
   thumbnail.startsWith("https://brands.home-assistant.io/");

--- a/src/util/brands-url.ts
+++ b/src/util/brands-url.ts
@@ -27,9 +27,9 @@ export const fetchBrandsAccessToken = async (
 export const brandsUrl = (options: BrandsOptions): string => {
   const base = `/api/brands/integration/${options.domain}/${
     options.darkOptimized ? "dark_" : ""
-  }${options.type}.png?fallback=placeholder`;
+  }${options.type}.png`;
   if (_brandsAccessToken) {
-    return `${base}&token=${_brandsAccessToken}`;
+    return `${base}?token=${_brandsAccessToken}`;
   }
   return base;
 };

--- a/src/util/brands-url.ts
+++ b/src/util/brands-url.ts
@@ -14,6 +14,21 @@ export interface HardwareBrandsOptions {
 }
 
 let _brandsAccessToken: string | undefined;
+let _brandsRefreshInterval: ReturnType<typeof setInterval> | undefined;
+
+// Token refreshes every 30 minutes and is valid for 1 hour.
+// Re-fetch every 30 minutes to always have a valid token.
+const TOKEN_REFRESH_MS = 30 * 60 * 1000;
+
+export const fetchAndScheduleBrandsAccessToken = (
+  hass: HomeAssistant
+): Promise<void> =>
+  fetchBrandsAccessToken(hass).then(
+    () => scheduleBrandsTokenRefresh(hass),
+    () => {
+      // Ignore failures; older backends may not support this command
+    }
+  );
 
 export const fetchBrandsAccessToken = async (
   hass: HomeAssistant
@@ -22,6 +37,22 @@ export const fetchBrandsAccessToken = async (
     type: "brands/access_token",
   });
   _brandsAccessToken = result.token;
+};
+
+export const scheduleBrandsTokenRefresh = (hass: HomeAssistant): void => {
+  clearBrandsTokenRefresh();
+  _brandsRefreshInterval = setInterval(() => {
+    fetchBrandsAccessToken(hass).catch(() => {
+      // Ignore failures; older backends may not support this command
+    });
+  }, TOKEN_REFRESH_MS);
+};
+
+export const clearBrandsTokenRefresh = (): void => {
+  if (_brandsRefreshInterval) {
+    clearInterval(_brandsRefreshInterval);
+    _brandsRefreshInterval = undefined;
+  }
 };
 
 export const brandsUrl = (options: BrandsOptions): string => {

--- a/src/util/brands-url.ts
+++ b/src/util/brands-url.ts
@@ -48,17 +48,26 @@ export const addBrandsAuth = (url: string): string => {
   if (!_brandsAccessToken || !url.startsWith("/api/brands/")) {
     return url;
   }
-  const separator = url.includes("?") ? "&" : "?";
-  return `${url}${separator}token=${_brandsAccessToken}`;
+  const fullUrl = new URL(url, location.origin);
+  fullUrl.searchParams.set("token", _brandsAccessToken);
+  return `${fullUrl.pathname}${fullUrl.search}`;
 };
 
 export const extractDomainFromBrandUrl = (url: string): string => {
   // Handle both new local API paths (/api/brands/integration/{domain}/...)
   // and legacy CDN URLs (https://brands.home-assistant.io/_/{domain}/...)
   if (url.startsWith("/api/brands/")) {
+    // /api/brands/integration/{domain}/... -> ["" ,"api", "brands", "integration", "{domain}", ...]
     return url.split("/")[4];
   }
-  return url.split("/")[4];
+  // https://brands.home-assistant.io/_/{domain}/... -> ["", "_", "{domain}", ...]
+  const parsed = new URL(url);
+  const segments = parsed.pathname.split("/").filter((s) => s.length > 0);
+  const underscoreIdx = segments.indexOf("_");
+  if (underscoreIdx !== -1 && underscoreIdx + 1 < segments.length) {
+    return segments[underscoreIdx + 1];
+  }
+  return segments[1] ?? "";
 };
 
 export const isBrandUrl = (thumbnail: string | ""): boolean =>

--- a/test/util/generate-brands-url.test.ts
+++ b/test/util/generate-brands-url.test.ts
@@ -1,5 +1,10 @@
 import { assert, describe, it } from "vitest";
-import { addBrandsAuth, brandsUrl } from "../../src/util/brands-url";
+import type { HomeAssistant } from "../../src/types";
+import {
+  addBrandsAuth,
+  brandsUrl,
+  fetchBrandsAccessToken,
+} from "../../src/util/brands-url";
 
 describe("Generate brands Url", () => {
   it("Generate logo brands url for cloud component", () => {
@@ -35,6 +40,30 @@ describe("addBrandsAuth", () => {
     assert.strictEqual(
       addBrandsAuth("/api/brands/integration/demo/icon.png"),
       "/api/brands/integration/demo/icon.png"
+    );
+  });
+
+  it("Appends token to brands URL when token is available", async () => {
+    const mockHass = {
+      callWS: async () => ({ token: "test-token-123" }),
+    } as unknown as HomeAssistant;
+    await fetchBrandsAccessToken(mockHass);
+
+    assert.strictEqual(
+      addBrandsAuth("/api/brands/integration/demo/icon.png"),
+      "/api/brands/integration/demo/icon.png?token=test-token-123"
+    );
+  });
+
+  it("Replaces existing token param instead of duplicating", async () => {
+    const mockHass = {
+      callWS: async () => ({ token: "new-token" }),
+    } as unknown as HomeAssistant;
+    await fetchBrandsAccessToken(mockHass);
+
+    assert.strictEqual(
+      addBrandsAuth("/api/brands/integration/demo/icon.png?token=old-token"),
+      "/api/brands/integration/demo/icon.png?token=new-token"
     );
   });
 });

--- a/test/util/generate-brands-url.test.ts
+++ b/test/util/generate-brands-url.test.ts
@@ -1,27 +1,42 @@
 import { assert, describe, it } from "vitest";
-import { brandsUrl } from "../../src/util/brands-url";
+import { addBrandsAuth, brandsUrl } from "../../src/util/brands-url";
 
 describe("Generate brands Url", () => {
   it("Generate logo brands url for cloud component", () => {
     assert.strictEqual(
-      // @ts-ignore
       brandsUrl({ domain: "cloud", type: "logo" }),
-      "https://brands.home-assistant.io/_/cloud/logo.png"
+      "/api/brands/integration/cloud/logo.png?fallback=placeholder"
     );
   });
   it("Generate icon brands url for cloud component", () => {
     assert.strictEqual(
-      // @ts-ignore
       brandsUrl({ domain: "cloud", type: "icon" }),
-      "https://brands.home-assistant.io/_/cloud/icon.png"
+      "/api/brands/integration/cloud/icon.png?fallback=placeholder"
     );
   });
 
   it("Generate dark theme optimized logo brands url for cloud component", () => {
     assert.strictEqual(
-      // @ts-ignore
       brandsUrl({ domain: "cloud", type: "logo", darkOptimized: true }),
-      "https://brands.home-assistant.io/_/cloud/dark_logo.png"
+      "/api/brands/integration/cloud/dark_logo.png?fallback=placeholder"
+    );
+  });
+});
+
+describe("addBrandsAuth", () => {
+  it("Returns non-brands URLs unchanged", () => {
+    assert.strictEqual(
+      addBrandsAuth("/api/camera_proxy/camera.foo?token=abc"),
+      "/api/camera_proxy/camera.foo?token=abc"
+    );
+  });
+
+  it("Returns brands URL unchanged when no token is available", () => {
+    assert.strictEqual(
+      addBrandsAuth(
+        "/api/brands/integration/demo/icon.png?fallback=placeholder"
+      ),
+      "/api/brands/integration/demo/icon.png?fallback=placeholder"
     );
   });
 });

--- a/test/util/generate-brands-url.test.ts
+++ b/test/util/generate-brands-url.test.ts
@@ -1,9 +1,11 @@
-import { assert, describe, it } from "vitest";
+import { assert, describe, it, vi, afterEach } from "vitest";
 import type { HomeAssistant } from "../../src/types";
 import {
   addBrandsAuth,
   brandsUrl,
+  clearBrandsTokenRefresh,
   fetchBrandsAccessToken,
+  scheduleBrandsTokenRefresh,
 } from "../../src/util/brands-url";
 
 describe("Generate brands Url", () => {
@@ -65,5 +67,78 @@ describe("addBrandsAuth", () => {
       addBrandsAuth("/api/brands/integration/demo/icon.png?token=old-token"),
       "/api/brands/integration/demo/icon.png?token=new-token"
     );
+  });
+});
+
+describe("scheduleBrandsTokenRefresh", () => {
+  afterEach(() => {
+    clearBrandsTokenRefresh();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("Refreshes the token after 30 minutes", async () => {
+    vi.useFakeTimers();
+    let callCount = 0;
+    const mockHass = {
+      callWS: async () => {
+        callCount++;
+        return { token: `token-${callCount}` };
+      },
+    } as unknown as HomeAssistant;
+
+    await fetchBrandsAccessToken(mockHass);
+    assert.strictEqual(callCount, 1);
+    assert.strictEqual(
+      brandsUrl({ domain: "test", type: "icon" }),
+      "/api/brands/integration/test/icon.png?token=token-1"
+    );
+
+    scheduleBrandsTokenRefresh(mockHass);
+
+    // Advance 30 minutes
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    assert.strictEqual(callCount, 2);
+    assert.strictEqual(
+      brandsUrl({ domain: "test", type: "icon" }),
+      "/api/brands/integration/test/icon.png?token=token-2"
+    );
+  });
+
+  it("Does not refresh before 30 minutes", async () => {
+    vi.useFakeTimers();
+    let callCount = 0;
+    const mockHass = {
+      callWS: async () => {
+        callCount++;
+        return { token: `token-${callCount}` };
+      },
+    } as unknown as HomeAssistant;
+
+    await fetchBrandsAccessToken(mockHass);
+    scheduleBrandsTokenRefresh(mockHass);
+
+    // Advance 29 minutes — should not have refreshed
+    await vi.advanceTimersByTimeAsync(29 * 60 * 1000);
+    assert.strictEqual(callCount, 1);
+  });
+
+  it("clearBrandsTokenRefresh stops the interval", async () => {
+    vi.useFakeTimers();
+    let callCount = 0;
+    const mockHass = {
+      callWS: async () => {
+        callCount++;
+        return { token: `token-${callCount}` };
+      },
+    } as unknown as HomeAssistant;
+
+    await fetchBrandsAccessToken(mockHass);
+    scheduleBrandsTokenRefresh(mockHass);
+    clearBrandsTokenRefresh();
+
+    // Advance 30 minutes — should not have refreshed because we cleared
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    assert.strictEqual(callCount, 1);
   });
 });

--- a/test/util/generate-brands-url.test.ts
+++ b/test/util/generate-brands-url.test.ts
@@ -5,20 +5,20 @@ describe("Generate brands Url", () => {
   it("Generate logo brands url for cloud component", () => {
     assert.strictEqual(
       brandsUrl({ domain: "cloud", type: "logo" }),
-      "/api/brands/integration/cloud/logo.png?fallback=placeholder"
+      "/api/brands/integration/cloud/logo.png"
     );
   });
   it("Generate icon brands url for cloud component", () => {
     assert.strictEqual(
       brandsUrl({ domain: "cloud", type: "icon" }),
-      "/api/brands/integration/cloud/icon.png?fallback=placeholder"
+      "/api/brands/integration/cloud/icon.png"
     );
   });
 
   it("Generate dark theme optimized logo brands url for cloud component", () => {
     assert.strictEqual(
       brandsUrl({ domain: "cloud", type: "logo", darkOptimized: true }),
-      "/api/brands/integration/cloud/dark_logo.png?fallback=placeholder"
+      "/api/brands/integration/cloud/dark_logo.png"
     );
   });
 });
@@ -33,10 +33,8 @@ describe("addBrandsAuth", () => {
 
   it("Returns brands URL unchanged when no token is available", () => {
     assert.strictEqual(
-      addBrandsAuth(
-        "/api/brands/integration/demo/icon.png?fallback=placeholder"
-      ),
-      "/api/brands/integration/demo/icon.png?fallback=placeholder"
+      addBrandsAuth("/api/brands/integration/demo/icon.png"),
+      "/api/brands/integration/demo/icon.png"
     );
   });
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Updates the frontend to fetch brand images from the new local `/api/brands/` endpoints instead of directly from the CDN. This works together with the new `brands` system integration in Home Assistant Core.

### Brand URL generation (`brands-url.ts`)
- `brandsUrl()` now returns `/api/brands/integration/{domain}/{image}?fallback=placeholder` instead of CDN URLs
- `hardwareBrandsUrl()` now returns `/api/brands/hardware/{category}/{image}` instead of CDN URLs
- Removed `brand` option from `BrandsOptions` (no longer needed since brand/integration are merged on the CDN)
- Added `fetchBrandsAccessToken()` to obtain an access token via the `brands/access_token` WebSocket command
- Added `addBrandsAuth()` utility to inject the access token into `/api/brands/` URLs used in entity pictures

### Authentication
- `connection-mixin.ts` calls `fetchBrandsAccessToken()` on initial connect and reconnect
- `addBrandsAuth()` is used in `state-badge.ts`, `hui-tile-card.ts`, and `hui-entity-badge.ts` to authenticate entity picture URLs that point to `/api/brands/`

### Media browser thumbnail handling
- `ha-media-player-browse.ts` and `ha-selector-media.ts`: Moved the `isBrandUrl()` check *before* the `startsWith("/")` check, since brand URLs are now local paths that would otherwise be treated as signed-path requests

### Service worker caching (`service-worker.ts`)
- Updated route matcher from CDN origin to `/api/brands/` path prefix
- Added `cacheKeyWillBeUsed` plugin to strip the rotating `token` param from cache keys
- Reduced cache TTL from 30 days to 1 day (backend handles long-term caching)
- Removed CORS fetch options (no longer cross-origin)

### Cleanup
- Removed `brand` property from `ha-integration-list-item.ts`
- Removed `brand` attribute from `dialog-add-integration.ts`
- Removed `brand: true` from `thread-config-panel.ts`

### Tests
- Updated `generate-brands-url.test.ts` expected URLs from CDN to local API paths
- Added `addBrandsAuth` tests

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43726
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2975
- Link to backend pull request: https://github.com/home-assistant/core/pull/163960

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
