### PR TITLE
Add wind power as energy source in dashboard

### DIFF
--- a/demo/src/stubs/energy.ts
+++ b/demo/src/stubs/energy.ts
@@ -103,7 +103,11 @@ export const mockEnergy = (hass: MockHomeAssistant) => {
   );
   hass.mockWS(
     "energy/info",
-    (): EnergyInfo => ({ cost_sensors: {}, solar_forecast_domains: [] })
+    (): EnergyInfo => ({
+      cost_sensors: {},
+      solar_forecast_domains: [],
+      wind_forecast_domains: [],
+    })
   );
   hass.mockWS(
     "energy/fossil_energy_consumption",

--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -63,6 +63,13 @@ export const emptySolarEnergyPreference =
     config_entry_solar_forecast: null,
   });
 
+export const emptyWindEnergyPreference =
+  (): WindSourceTypeEnergyPreference => ({
+    type: "wind",
+    stat_energy_from: "",
+    config_entry_wind_forecast: null,
+  });
+
 export const emptyBatteryEnergyPreference =
   (): BatterySourceTypeEnergyPreference => ({
     type: "battery",
@@ -91,6 +98,11 @@ interface EnergySolarForecast {
   wh_hours: Record<string, number>;
 }
 export type EnergySolarForecasts = Record<string, EnergySolarForecast>;
+
+interface EnergyWindForecast {
+  wh_hours: Record<string, number>;
+}
+export type EnergyWindForecasts = Record<string, EnergyWindForecast>;
 
 export interface DeviceConsumptionEnergyPreference {
   // This is an ever increasing value
@@ -146,6 +158,14 @@ export interface SolarSourceTypeEnergyPreference {
   config_entry_solar_forecast: string[] | null;
 }
 
+export interface WindSourceTypeEnergyPreference {
+  type: "wind";
+
+  stat_energy_from: string;
+  stat_rate?: string;
+  config_entry_wind_forecast: string[] | null;
+}
+
 export interface BatterySourceTypeEnergyPreference {
   type: "battery";
   stat_energy_from: string;
@@ -191,6 +211,7 @@ export interface WaterSourceTypeEnergyPreference {
 
 export type EnergySource =
   | SolarSourceTypeEnergyPreference
+  | WindSourceTypeEnergyPreference
   | GridSourceTypeEnergyPreference
   | BatterySourceTypeEnergyPreference
   | GasSourceTypeEnergyPreference
@@ -205,6 +226,7 @@ export interface EnergyPreferences {
 export interface EnergyInfo {
   cost_sensors: Record<string, string>;
   solar_forecast_domains: string[];
+  wind_forecast_domains: string[];
 }
 
 export interface EnergyValidationIssue {
@@ -270,6 +292,7 @@ export const getFossilEnergyConsumption = async (
 export interface EnergySourceByType {
   grid?: GridSourceTypeEnergyPreference[];
   solar?: SolarSourceTypeEnergyPreference[];
+  wind?: WindSourceTypeEnergyPreference[];
   battery?: BatterySourceTypeEnergyPreference[];
   gas?: GasSourceTypeEnergyPreference[];
   water?: WaterSourceTypeEnergyPreference[];
@@ -309,6 +332,11 @@ export const getReferencedStatisticIds = (
     }
 
     if (source.type === "solar") {
+      statIDs.push(source.stat_energy_from);
+      continue;
+    }
+
+    if (source.type === "wind") {
       statIDs.push(source.stat_energy_from);
       continue;
     }
@@ -381,6 +409,11 @@ export const getReferencedStatisticIdsPower = (
     }
 
     if (source.type === "solar") {
+      statIDs.push(source.stat_rate);
+      continue;
+    }
+
+    if (source.type === "wind") {
       statIDs.push(source.stat_rate);
       continue;
     }
@@ -862,6 +895,11 @@ export const getEnergySolarForecasts = (hass: HomeAssistant) =>
     type: "energy/solar_forecast",
   });
 
+export const getEnergyWindForecasts = (hass: HomeAssistant) =>
+  hass.callWS<EnergyWindForecasts>({
+    type: "energy/wind_forecast",
+  });
+
 const energyGasUnitClass = ["volume", "energy"] as const;
 export type EnergyGasUnitClass = (typeof energyGasUnitClass)[number];
 
@@ -957,12 +995,14 @@ export interface EnergySumData {
   to_battery?: Record<number, number>;
   from_battery?: Record<number, number>;
   solar?: Record<number, number>;
+  wind?: Record<number, number>;
   total: {
     to_grid?: number;
     from_grid?: number;
     to_battery?: number;
     from_battery?: number;
     solar?: number;
+    wind?: number;
   };
   timestamps: number[];
 }
@@ -1008,6 +1048,7 @@ const getSummedDataPartial = (
     to_grid?: string[];
     from_grid?: string[];
     solar?: string[];
+    wind?: string[];
     to_battery?: string[];
     from_battery?: string[];
   } = {};
@@ -1018,6 +1059,15 @@ const getSummedDataPartial = (
         statIds.solar.push(source.stat_energy_from);
       } else {
         statIds.solar = [source.stat_energy_from];
+      }
+      continue;
+    }
+
+    if (source.type === "wind") {
+      if (statIds.wind) {
+        statIds.wind.push(source.stat_energy_from);
+      } else {
+        statIds.wind = [source.stat_energy_from];
       }
       continue;
     }
@@ -1140,7 +1190,11 @@ const computeConsumptionDataPartial = (
     } = computeConsumptionSingle({
       from_grid: data.from_grid && (data.from_grid[t] ?? 0),
       to_grid: data.to_grid && (data.to_grid[t] ?? 0),
-      solar: data.solar && (data.solar[t] ?? 0),
+      solar:
+        data.solar || data.wind
+          ? (data.solar ? (data.solar[t] ?? 0) : 0) +
+            (data.wind ? (data.wind[t] ?? 0) : 0)
+          : undefined,
       to_battery: data.to_battery && (data.to_battery[t] ?? 0),
       from_battery: data.from_battery && (data.from_battery[t] ?? 0),
     });
@@ -1320,7 +1374,7 @@ export const calculateSolarConsumedGauge = (
   hasBattery: boolean,
   data: EnergySumData
 ): number | undefined => {
-  if (!data.total.solar) {
+  if (!data.total.solar && !data.total.wind) {
     return undefined;
   }
   const { consumption, compareConsumption: _ } = computeConsumptionData(
@@ -1328,7 +1382,7 @@ export const calculateSolarConsumedGauge = (
     undefined
   );
   if (!hasBattery) {
-    const solarProduction = data.total.solar;
+    const solarProduction = (data.total.solar ?? 0) + (data.total.wind ?? 0);
     return (consumption.total.used_solar / solarProduction) * 100;
   }
 
@@ -1691,6 +1745,16 @@ export const downloadEnergyData = (
     });
 
   printCategory("solar_production", solar_productions, electricUnit);
+
+  const wind_productions: string[] = [];
+  energy_sources
+    .filter((s) => s.type === "wind")
+    .forEach((source) => {
+      source = source as WindSourceTypeEnergyPreference;
+      wind_productions.push(source.stat_energy_from);
+    });
+
+  printCategory("wind_production", wind_productions, electricUnit);
 
   const gas_consumptions: string[] = [];
   const gas_consumptions_cost: string[] = [];

--- a/src/panels/config/energy/components/ha-energy-wind-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-wind-settings.ts
@@ -1,0 +1,228 @@
+import { mdiDelete, mdiPencil, mdiPlus, mdiWindPower } from "@mdi/js";
+import type { CSSResultGroup, TemplateResult } from "lit";
+import { html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-card";
+import "../../../../components/ha-button";
+import "../../../../components/ha-icon-button";
+import type {
+  EnergyInfo,
+  EnergyPreferences,
+  EnergyPreferencesValidation,
+  EnergyValidationIssue,
+  WindSourceTypeEnergyPreference,
+} from "../../../../data/energy";
+import { saveEnergyPreferences } from "../../../../data/energy";
+import type { StatisticsMetaData } from "../../../../data/recorder";
+import { getStatisticLabel } from "../../../../data/recorder";
+import {
+  showConfirmationDialog,
+  showAlertDialog,
+} from "../../../../dialogs/generic/show-dialog-box";
+import { haStyle } from "../../../../resources/styles";
+import type { HomeAssistant } from "../../../../types";
+import { documentationUrl } from "../../../../util/documentation-url";
+import { showEnergySettingsWindDialog } from "../dialogs/show-dialogs-energy";
+import "./ha-energy-validation-result";
+import { energyCardStyles } from "./styles";
+
+@customElement("ha-energy-wind-settings")
+export class EnergyWindSettings extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false })
+  public preferences!: EnergyPreferences;
+
+  @property({ attribute: false })
+  public statsMetadata?: Record<string, StatisticsMetaData>;
+
+  @property({ attribute: false })
+  public validationResult?: EnergyPreferencesValidation;
+
+  @property({ attribute: false })
+  public info?: EnergyInfo;
+
+  protected render(): TemplateResult {
+    const windSources: WindSourceTypeEnergyPreference[] = [];
+    const windValidation: EnergyValidationIssue[][] = [];
+
+    this.preferences.energy_sources.forEach((source, idx) => {
+      if (source.type !== "wind") {
+        return;
+      }
+      windSources.push(source);
+
+      if (this.validationResult) {
+        windValidation.push(this.validationResult.energy_sources[idx]);
+      }
+    });
+
+    return html`
+      <ha-card>
+        <h1 class="card-header">
+          <ha-svg-icon .path=${mdiWindPower}></ha-svg-icon>
+          ${this.hass.localize("ui.panel.config.energy.wind.title")}
+        </h1>
+
+        <div class="card-content">
+          <p>
+            ${this.hass.localize("ui.panel.config.energy.wind.sub")}
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href=${documentationUrl(this.hass, "/docs/energy/wind-turbines/")}
+              >${this.hass.localize(
+                "ui.panel.config.energy.wind.learn_more"
+              )}</a
+            >
+          </p>
+          ${windValidation.map(
+            (result) => html`
+              <ha-energy-validation-result
+                .hass=${this.hass}
+                .issues=${result}
+              ></ha-energy-validation-result>
+            `
+          )}
+          ${windSources.length > 0
+            ? html`
+                <div class="items-container">
+                  ${windSources.map((source) => {
+                    const entityState =
+                      this.hass.states[source.stat_energy_from];
+                    return html`
+                      <div class="row" .source=${source}>
+                        ${entityState?.attributes.icon
+                          ? html`<ha-icon
+                              .icon=${entityState.attributes.icon}
+                            ></ha-icon>`
+                          : html`<ha-svg-icon
+                              .path=${mdiWindPower}
+                            ></ha-svg-icon>`}
+                        <span class="content"
+                          >${getStatisticLabel(
+                            this.hass,
+                            source.stat_energy_from,
+                            this.statsMetadata?.[source.stat_energy_from]
+                          )}</span
+                        >
+                        ${this.info
+                          ? html`
+                              <ha-icon-button
+                                .label=${this.hass.localize(
+                                  "ui.panel.config.energy.wind.edit_wind_production"
+                                )}
+                                @click=${this._editSource}
+                                .path=${mdiPencil}
+                              ></ha-icon-button>
+                            `
+                          : ""}
+                        <ha-icon-button
+                          .label=${this.hass.localize(
+                            "ui.panel.config.energy.wind.delete_wind_production"
+                          )}
+                          @click=${this._deleteSource}
+                          .path=${mdiDelete}
+                        ></ha-icon-button>
+                      </div>
+                    `;
+                  })}
+                </div>
+              `
+            : ""}
+          ${this.info
+            ? html`
+                <div class="row">
+                  <ha-button
+                    @click=${this._addSource}
+                    appearance="filled"
+                    size="small"
+                  >
+                    <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
+                    ${this.hass.localize(
+                      "ui.panel.config.energy.wind.add_wind_production"
+                    )}
+                  </ha-button>
+                </div>
+              `
+            : ""}
+        </div>
+      </ha-card>
+    `;
+  }
+
+  private _addSource() {
+    showEnergySettingsWindDialog(this, {
+      info: this.info!,
+      wind_sources: this.preferences.energy_sources.filter(
+        (src) => src.type === "wind"
+      ) as WindSourceTypeEnergyPreference[],
+      saveCallback: async (source) => {
+        await this._savePreferences({
+          ...this.preferences,
+          energy_sources: this.preferences.energy_sources.concat(source),
+        });
+      },
+    });
+  }
+
+  private _editSource(ev) {
+    const origSource: WindSourceTypeEnergyPreference =
+      ev.currentTarget.closest(".row").source;
+    showEnergySettingsWindDialog(this, {
+      info: this.info!,
+      source: { ...origSource },
+      wind_sources: this.preferences.energy_sources.filter(
+        (src) => src.type === "wind"
+      ) as WindSourceTypeEnergyPreference[],
+      saveCallback: async (newSource) => {
+        await this._savePreferences({
+          ...this.preferences,
+          energy_sources: this.preferences.energy_sources.map((src) =>
+            src === origSource ? newSource : src
+          ),
+        });
+      },
+    });
+  }
+
+  private async _deleteSource(ev) {
+    const sourceToDelete: WindSourceTypeEnergyPreference =
+      ev.currentTarget.closest(".row").source;
+
+    if (
+      !(await showConfirmationDialog(this, {
+        title: this.hass.localize("ui.panel.config.energy.delete_source"),
+      }))
+    ) {
+      return;
+    }
+
+    try {
+      await this._savePreferences({
+        ...this.preferences,
+        energy_sources: this.preferences.energy_sources.filter(
+          (source) => source !== sourceToDelete
+        ),
+      });
+    } catch (err: any) {
+      showAlertDialog(this, { title: `Failed to save config: ${err.message}` });
+    }
+  }
+
+  private async _savePreferences(preferences: EnergyPreferences) {
+    const result = await saveEnergyPreferences(this.hass, preferences);
+    fireEvent(this, "value-changed", { value: result });
+  }
+
+  static get styles(): CSSResultGroup {
+    return [haStyle, energyCardStyles];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-energy-wind-settings": EnergyWindSettings;
+  }
+}

--- a/src/panels/config/energy/dialogs/dialog-energy-wind-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-wind-settings.ts
@@ -1,0 +1,359 @@
+import { mdiPlus } from "@mdi/js";
+import type { CSSResultGroup } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/entity/ha-statistic-picker";
+import "../../../../components/ha-checkbox";
+import type { HaCheckbox } from "../../../../components/ha-checkbox";
+import "../../../../components/ha-formfield";
+import "../../../../components/ha-button";
+import "../../../../components/ha-dialog-footer";
+import "../../../../components/ha-radio";
+import "../../../../components/ha-svg-icon";
+import "../../../../components/ha-dialog";
+import type { HaRadio } from "../../../../components/ha-radio";
+import type { ConfigEntry } from "../../../../data/config_entries";
+import { getConfigEntries } from "../../../../data/config_entries";
+import type { WindSourceTypeEnergyPreference } from "../../../../data/energy";
+import {
+  emptyWindEnergyPreference,
+  energyStatisticHelpUrl,
+} from "../../../../data/energy";
+import { getSensorDeviceClassConvertibleUnits } from "../../../../data/sensor";
+import { showConfigFlowDialog } from "../../../../dialogs/config-flow/show-dialog-config-flow";
+import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
+import { haStyle, haStyleDialog } from "../../../../resources/styles";
+import type { HomeAssistant, ValueChangedEvent } from "../../../../types";
+import { brandsUrl } from "../../../../util/brands-url";
+import type { EnergySettingsWindDialogParams } from "./show-dialogs-energy";
+
+const energyUnitClasses = ["energy"];
+const powerUnitClasses = ["power"];
+
+@customElement("dialog-energy-wind-settings")
+export class DialogEnergyWindSettings
+  extends LitElement
+  implements HassDialog<EnergySettingsWindDialogParams>
+{
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _params?: EnergySettingsWindDialogParams;
+
+  @state() private _open = false;
+
+  @state() private _source?: WindSourceTypeEnergyPreference;
+
+  @state() private _configEntries?: ConfigEntry[];
+
+  @state() private _forecast?: boolean;
+
+  @state() private _energy_units?: string[];
+
+  @state() private _power_units?: string[];
+
+  @state() private _error?: string;
+
+  private _excludeList?: string[];
+
+  private _excludeListPower?: string[];
+
+  public async showDialog(
+    params: EnergySettingsWindDialogParams
+  ): Promise<void> {
+    this._params = params;
+    this._fetchWindForecastConfigEntries();
+    this._source = params.source
+      ? { ...params.source }
+      : emptyWindEnergyPreference();
+    this._forecast = this._source.config_entry_wind_forecast !== null;
+    this._energy_units = (
+      await getSensorDeviceClassConvertibleUnits(this.hass, "energy")
+    ).units;
+    this._power_units = (
+      await getSensorDeviceClassConvertibleUnits(this.hass, "power")
+    ).units;
+    this._excludeList = this._params.wind_sources
+      .map((entry) => entry.stat_energy_from)
+      .filter((id) => id !== this._source?.stat_energy_from);
+    this._excludeListPower = this._params.wind_sources
+      .map((entry) => entry.stat_rate)
+      .filter((id) => id && id !== this._source?.stat_rate) as string[];
+
+    this._open = true;
+  }
+
+  public closeDialog() {
+    this._open = false;
+    return true;
+  }
+
+  private _dialogClosed() {
+    this._params = undefined;
+    this._source = undefined;
+    this._error = undefined;
+    this._excludeList = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render() {
+    if (!this._params || !this._source) {
+      return nothing;
+    }
+
+    return html`
+      <ha-dialog
+        .hass=${this.hass}
+        .open=${this._open}
+        header-title=${this.hass.localize(
+          "ui.panel.config.energy.wind.dialog.header"
+        )}
+        prevent-scrim-close
+        @closed=${this._dialogClosed}
+      >
+        ${this._error ? html`<p class="error">${this._error}</p>` : ""}
+
+        <ha-statistic-picker
+          .hass=${this.hass}
+          .helpMissingEntityUrl=${energyStatisticHelpUrl}
+          .includeUnitClass=${energyUnitClasses}
+          .value=${this._source.stat_energy_from}
+          .label=${this.hass.localize(
+            "ui.panel.config.energy.wind.dialog.wind_production_energy"
+          )}
+          .excludeStatistics=${this._excludeList}
+          @value-changed=${this._statisticChanged}
+          .helper=${this.hass.localize(
+            "ui.panel.config.energy.wind.dialog.entity_para",
+            { unit: this._energy_units?.join(", ") || "" }
+          )}
+          autofocus
+        ></ha-statistic-picker>
+
+        <ha-statistic-picker
+          .hass=${this.hass}
+          .includeUnitClass=${powerUnitClasses}
+          .value=${this._source.stat_rate}
+          .label=${this.hass.localize(
+            "ui.panel.config.energy.wind.dialog.wind_production_power"
+          )}
+          .excludeStatistics=${this._excludeListPower}
+          @value-changed=${this._powerStatisticChanged}
+          .helper=${this.hass.localize(
+            "ui.panel.config.energy.wind.dialog.entity_para",
+            { unit: this._power_units?.join(", ") || "" }
+          )}
+        ></ha-statistic-picker>
+
+        <h3>
+          ${this.hass.localize(
+            "ui.panel.config.energy.wind.dialog.wind_production_forecast"
+          )}
+        </h3>
+        <p>
+          ${this.hass.localize(
+            "ui.panel.config.energy.wind.dialog.wind_production_forecast_description"
+          )}
+        </p>
+
+        <ha-formfield
+          label=${this.hass.localize(
+            "ui.panel.config.energy.wind.dialog.dont_forecast_production"
+          )}
+        >
+          <ha-radio
+            value="false"
+            name="forecast"
+            .checked=${!this._forecast}
+            @change=${this._handleForecastChanged}
+          ></ha-radio>
+        </ha-formfield>
+        <ha-formfield
+          label=${this.hass.localize(
+            "ui.panel.config.energy.wind.dialog.forecast_production"
+          )}
+        >
+          <ha-radio
+            value="true"
+            name="forecast"
+            .checked=${this._forecast}
+            @change=${this._handleForecastChanged}
+          ></ha-radio>
+        </ha-formfield>
+        ${this._forecast
+          ? html`<div class="forecast-options">
+              ${this._configEntries?.map(
+                (entry) =>
+                  html`<ha-formfield
+                    .label=${html`<div
+                      style="display: flex; align-items: center;"
+                    >
+                      <img
+                        alt=""
+                        crossorigin="anonymous"
+                        referrerpolicy="no-referrer"
+                        style="height: 24px; margin-right: 16px; margin-inline-end: 16px; margin-inline-start: initial;"
+                        src=${brandsUrl({
+                          domain: entry.domain,
+                          type: "icon",
+                          darkOptimized: this.hass.themes?.darkMode,
+                        })}
+                      />${entry.title}
+                    </div>`}
+                  >
+                    <ha-checkbox
+                      .entry=${entry}
+                      @change=${this._forecastCheckChanged}
+                      .checked=${!!this._source?.config_entry_wind_forecast?.includes(
+                        entry.entry_id
+                      )}
+                    >
+                    </ha-checkbox>
+                  </ha-formfield>`
+              )}
+              <ha-button
+                appearance="filled"
+                size="small"
+                @click=${this._addForecast}
+              >
+                <ha-svg-icon .path=${mdiPlus} slot="start"></ha-svg-icon>
+                ${this.hass.localize(
+                  "ui.panel.config.energy.wind.dialog.add_forecast"
+                )}
+              </ha-button>
+            </div>`
+          : ""}
+
+        <ha-dialog-footer slot="footer">
+          <ha-button
+            appearance="plain"
+            @click=${this.closeDialog}
+            slot="secondaryAction"
+          >
+            ${this.hass.localize("ui.common.cancel")}
+          </ha-button>
+          <ha-button
+            @click=${this._save}
+            .disabled=${!this._source.stat_energy_from}
+            slot="primaryAction"
+          >
+            ${this.hass.localize("ui.common.save")}
+          </ha-button>
+        </ha-dialog-footer>
+      </ha-dialog>
+    `;
+  }
+
+  private async _fetchWindForecastConfigEntries() {
+    const domains = this._params!.info.wind_forecast_domains;
+    this._configEntries =
+      domains.length === 0
+        ? []
+        : domains.length === 1
+          ? await getConfigEntries(this.hass, {
+              type: ["service"],
+              domain: domains[0],
+            })
+          : (await getConfigEntries(this.hass, { type: ["service"] })).filter(
+              (entry) => domains.includes(entry.domain)
+            );
+  }
+
+  private _handleForecastChanged(ev: CustomEvent) {
+    const input = ev.currentTarget as HaRadio;
+    this._forecast = input.value === "true";
+  }
+
+  private _forecastCheckChanged(ev) {
+    const input = ev.currentTarget as HaCheckbox;
+    const entry = (input as any).entry as ConfigEntry;
+    const checked = input.checked;
+    if (checked) {
+      if (this._source!.config_entry_wind_forecast === null) {
+        this._source!.config_entry_wind_forecast = [];
+      }
+      this._source!.config_entry_wind_forecast.push(entry.entry_id);
+    } else {
+      this._source!.config_entry_wind_forecast!.splice(
+        this._source!.config_entry_wind_forecast!.indexOf(entry.entry_id),
+        1
+      );
+    }
+  }
+
+  private _addForecast() {
+    showConfigFlowDialog(this, {
+      startFlowHandler: "forecast_wind",
+      dialogClosedCallback: (params) => {
+        if (params.entryId) {
+          if (this._source!.config_entry_wind_forecast === null) {
+            this._source!.config_entry_wind_forecast = [];
+          }
+          this._source!.config_entry_wind_forecast.push(params.entryId);
+          this._fetchWindForecastConfigEntries();
+        }
+      },
+    });
+  }
+
+  private _statisticChanged(ev: ValueChangedEvent<string>) {
+    this._source = { ...this._source!, stat_energy_from: ev.detail.value };
+  }
+
+  private _powerStatisticChanged(ev: ValueChangedEvent<string>) {
+    this._source = { ...this._source!, stat_rate: ev.detail.value };
+  }
+
+  private async _save() {
+    try {
+      if (!this._forecast) {
+        this._source!.config_entry_wind_forecast = null;
+      }
+      await this._params!.saveCallback(this._source!);
+      this.closeDialog();
+    } catch (err: any) {
+      this._error = err.message;
+    }
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      haStyleDialog,
+      css`
+        ha-statistic-picker {
+          display: block;
+          margin-bottom: var(--ha-space-4);
+        }
+        img {
+          height: 24px;
+          margin-right: 16px;
+          margin-inline-end: 16px;
+          margin-inline-start: initial;
+        }
+        ha-formfield {
+          display: block;
+        }
+        ha-statistic-picker {
+          width: 100%;
+        }
+        .forecast-options {
+          padding-left: 32px;
+          padding-inline-start: 32px;
+          padding-inline-end: initial;
+        }
+        .forecast-options ha-button {
+          padding-left: 8px;
+          padding-inline-start: 8px;
+          padding-inline-end: initial;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-energy-wind-settings": DialogEnergyWindSettings;
+  }
+}

--- a/src/panels/config/energy/dialogs/show-dialogs-energy.ts
+++ b/src/panels/config/energy/dialogs/show-dialogs-energy.ts
@@ -8,6 +8,7 @@ import type {
   GridSourceTypeEnergyPreference,
   SolarSourceTypeEnergyPreference,
   WaterSourceTypeEnergyPreference,
+  WindSourceTypeEnergyPreference,
 } from "../../../../data/energy";
 import type { StatisticsMetaData } from "../../../../data/recorder";
 
@@ -22,6 +23,13 @@ export interface EnergySettingsSolarDialogParams {
   source?: SolarSourceTypeEnergyPreference;
   solar_sources: SolarSourceTypeEnergyPreference[];
   saveCallback: (source: SolarSourceTypeEnergyPreference) => Promise<void>;
+}
+
+export interface EnergySettingsWindDialogParams {
+  info: EnergyInfo;
+  source?: WindSourceTypeEnergyPreference;
+  wind_sources: WindSourceTypeEnergyPreference[];
+  saveCallback: (source: WindSourceTypeEnergyPreference) => Promise<void>;
 }
 
 export interface EnergySettingsBatteryDialogParams {
@@ -88,6 +96,17 @@ export const showEnergySettingsSolarDialog = (
   fireEvent(element, "show-dialog", {
     dialogTag: "dialog-energy-solar-settings",
     dialogImport: () => import("./dialog-energy-solar-settings"),
+    dialogParams: dialogParams,
+  });
+};
+
+export const showEnergySettingsWindDialog = (
+  element: HTMLElement,
+  dialogParams: EnergySettingsWindDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-energy-wind-settings",
+    dialogImport: () => import("./dialog-energy-wind-settings"),
     dialogParams: dialogParams,
   });
 };

--- a/src/panels/config/energy/ha-config-energy.ts
+++ b/src/panels/config/energy/ha-config-energy.ts
@@ -27,6 +27,7 @@ import "./components/ha-energy-device-settings";
 import "./components/ha-energy-device-settings-water";
 import "./components/ha-energy-grid-settings";
 import "./components/ha-energy-solar-settings";
+import "./components/ha-energy-wind-settings";
 import "./components/ha-energy-battery-settings";
 import "./components/ha-energy-gas-settings";
 import "./components/ha-energy-water-settings";
@@ -162,6 +163,14 @@ class HaConfigEnergy extends LitElement {
             .info=${this._info}
             @value-changed=${this._prefsChanged}
           ></ha-energy-solar-settings>
+          <ha-energy-wind-settings
+            .hass=${this.hass}
+            .preferences=${this._preferences!}
+            .statsMetadata=${this._statsMetadata}
+            .validationResult=${this._validationResult}
+            .info=${this._info}
+            @value-changed=${this._prefsChanged}
+          ></ha-energy-wind-settings>
           <ha-energy-battery-settings
             .hass=${this.hass}
             .preferences=${this._preferences!}
@@ -302,6 +311,7 @@ class HaConfigEnergy extends LitElement {
 
         ha-energy-grid-settings,
         ha-energy-solar-settings,
+        ha-energy-wind-settings,
         ha-energy-battery-settings,
         ha-energy-gas-settings,
         ha-energy-water-settings,

--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -260,11 +260,12 @@ class PanelEnergy extends LitElement {
     }
 
     const hasEnergy = this._prefs.energy_sources.some((source) =>
-      ["grid", "solar", "battery"].includes(source.type)
+      ["grid", "solar", "wind", "battery"].includes(source.type)
     );
 
     const hasPowerSource = this._prefs.energy_sources.some((source) => {
       if (source.type === "solar" && source.stat_rate) return true;
+      if (source.type === "wind" && source.stat_rate) return true;
       if (source.type === "battery" && source.stat_rate) return true;
       if (source.type === "grid") {
         return !!source.stat_rate || !!source.power_config;

--- a/src/panels/energy/strategies/energy-overview-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-overview-view-strategy.ts
@@ -52,6 +52,9 @@ export class EnergyOverviewViewStrategy extends ReactiveElement {
     const hasSolar = prefs.energy_sources.some(
       (source) => source.type === "solar"
     );
+    const hasWind = prefs.energy_sources.some(
+      (source) => source.type === "wind"
+    );
     const hasWaterSources = prefs.energy_sources.some(
       (source) => source.type === "water"
     );
@@ -65,7 +68,7 @@ export class EnergyOverviewViewStrategy extends ReactiveElement {
       return false;
     });
 
-    if (hasGrid || hasBattery || hasSolar) {
+    if (hasGrid || hasBattery || hasSolar || hasWind) {
       view.sections!.push({
         type: "grid",
         cards: [

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -47,6 +47,9 @@ export class EnergyViewStrategy extends ReactiveElement {
     const hasSolar = prefs.energy_sources.some(
       (source) => source.type === "solar"
     );
+    const hasWind = prefs.energy_sources.some(
+      (source) => source.type === "wind"
+    );
     const hasBattery = prefs.energy_sources.some(
       (source) => source.type === "battery"
     );
@@ -73,6 +76,15 @@ export class EnergyViewStrategy extends ReactiveElement {
       });
     }
 
+    // Only include if we have a wind source.
+    if (hasWind) {
+      view.cards!.push({
+        title: hass.localize("ui.panel.energy.cards.energy_wind_graph_title"),
+        type: "energy-wind-graph",
+        collection_key: collectionKey,
+      });
+    }
+
     // Only include if we have a grid or battery.
     if (hasGrid || hasBattery) {
       view.cards!.push({
@@ -90,7 +102,7 @@ export class EnergyViewStrategy extends ReactiveElement {
         ),
         type: "energy-sources-table",
         collection_key: collectionKey,
-        types: ["grid", "solar", "battery"],
+        types: ["grid", "solar", "wind", "battery"],
       });
     }
 
@@ -103,8 +115,8 @@ export class EnergyViewStrategy extends ReactiveElement {
       });
     }
 
-    // Only include if we have a solar source.
-    if (hasSolar) {
+    // Only include if we have a solar or wind source.
+    if (hasSolar || hasWind) {
       if (hasReturn) {
         view.cards!.push({
           type: "energy-solar-consumed-gauge",

--- a/src/panels/energy/strategies/power-view-strategy.ts
+++ b/src/panels/energy/strategies/power-view-strategy.ts
@@ -30,6 +30,7 @@ export class PowerViewStrategy extends ReactiveElement {
 
     const hasPowerSources = prefs?.energy_sources.some((source) => {
       if (source.type === "solar" && source.stat_rate) return true;
+      if (source.type === "wind" && source.stat_rate) return true;
       if (source.type === "battery" && source.stat_rate) return true;
       if (source.type === "grid") {
         return !!source.stat_rate || !!source.power_config;

--- a/src/panels/lovelace/cards/energy/hui-energy-carbon-consumed-gauge-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-carbon-consumed-gauge-card.ts
@@ -105,7 +105,8 @@ class HuiEnergyCarbonGaugeCard
           )
         : 0;
 
-      const totalSolarProduction = summedData.total.solar ?? 0;
+      const totalSolarProduction =
+        (summedData.total.solar ?? 0) + (summedData.total.wind ?? 0);
 
       const totalGridReturned = summedData.total.to_grid ?? 0;
 

--- a/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
@@ -115,6 +115,7 @@ class HuiEnergyDistrubutionCard
       !!types.grid?.[0] &&
       (!!types.grid[0].stat_energy_from || !!types.grid[0].stat_energy_to);
     const hasSolarProduction = types.solar !== undefined;
+    const hasWindProduction = types.wind !== undefined;
     const hasBattery = types.battery !== undefined;
     const hasGas = types.gas !== undefined;
     const hasWater = types.water !== undefined;
@@ -148,8 +149,10 @@ class HuiEnergyDistrubutionCard
 
     let totalSolarProduction: number | null = null;
 
-    if (hasSolarProduction) {
-      totalSolarProduction = summedData.total.solar ?? 0;
+    if (hasSolarProduction || hasWindProduction) {
+      totalSolarProduction =
+        (hasSolarProduction ? (summedData.total.solar ?? 0) : 0) +
+        (hasWindProduction ? (summedData.total.wind ?? 0) : 0);
     }
 
     let totalBatteryIn: number | null = null;

--- a/src/panels/lovelace/cards/energy/hui-energy-solar-consumed-gauge-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-solar-consumed-gauge-card.ts
@@ -75,7 +75,7 @@ class HuiEnergySolarGaugeCard
     }
 
     const { summedData, compareSummedData: _ } = getSummedData(this._data);
-    if (!("solar" in summedData.total)) {
+    if (!("solar" in summedData.total) && !("wind" in summedData.total)) {
       return nothing;
     }
 

--- a/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
@@ -32,6 +32,7 @@ const colorPropertyMap = {
   battery_in: "--energy-battery-in-color",
   battery_out: "--energy-battery-out-color",
   solar: "--energy-solar-color",
+  wind: "--energy-wind-color",
   gas: "--energy-gas-color",
   water: "--energy-water-color",
 };
@@ -247,11 +248,13 @@ export class HuiEnergySourcesTableCard
       gas: 0,
       water: 0,
       solar: 0,
+      wind: 0,
     };
     const totalsCompare = {
       gas: 0,
       water: 0,
       solar: 0,
+      wind: 0,
     };
     const totalCosts = {
       gas: 0,
@@ -303,6 +306,7 @@ export class HuiEnergySourcesTableCard
 
     const units = {
       solar: "kWh",
+      wind: "kWh",
       gas: this._data.gasUnit,
       water: this._data.waterUnit,
     };
@@ -357,7 +361,7 @@ export class HuiEnergySourcesTableCard
 
     const showOnlyTotals = this._config.show_only_totals;
 
-    const _renderSimpleCategory = (type: "solar" | "gas" | "water") =>
+    const _renderSimpleCategory = (type: "solar" | "wind" | "gas" | "water") =>
       html` ${types[type]?.map((source, idx) => {
         const cost_stat =
           type in hasCosts &&
@@ -496,7 +500,7 @@ export class HuiEnergySourcesTableCard
               </tr>
             </thead>
             <tbody class="mdc-data-table__content">
-              ${_renderSimpleCategory("solar")}
+              ${_renderSimpleCategory("solar")} ${_renderSimpleCategory("wind")}
               ${types.battery?.map((source, idx) => {
                 const {
                   hasData: hasFromData,

--- a/src/panels/lovelace/cards/energy/hui-energy-wind-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-wind-graph-card.ts
@@ -1,0 +1,468 @@
+import { endOfToday, isToday, startOfToday } from "date-fns";
+import type { HassConfig, UnsubscribeFunc } from "home-assistant-js-websocket";
+import type { PropertyValues } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
+import memoizeOne from "memoize-one";
+import type { BarSeriesOption, LineSeriesOption } from "echarts/charts";
+import { getEnergyColor } from "./common/color";
+import { formatNumber } from "../../../../common/number/format_number";
+import "../../../../components/chart/ha-chart-base";
+import "../../../../components/ha-card";
+import type {
+  EnergyData,
+  EnergyWindForecasts,
+  WindSourceTypeEnergyPreference,
+} from "../../../../data/energy";
+import {
+  getEnergyDataCollection,
+  getEnergyWindForecasts,
+  getSuggestedPeriod,
+} from "../../../../data/energy";
+import type { Statistics, StatisticsMetaData } from "../../../../data/recorder";
+import { getStatisticLabel } from "../../../../data/recorder";
+import type { FrontendLocaleData } from "../../../../data/translation";
+import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
+import type { HomeAssistant } from "../../../../types";
+import type { LovelaceCard } from "../../types";
+import type { EnergyWindGraphCardConfig } from "../types";
+import { hasConfigChanged } from "../../common/has-changed";
+import {
+  fillDataGapsAndRoundCaps,
+  getCommonOptions,
+  getCompareTransform,
+} from "./common/energy-chart-options";
+import type { ECOption } from "../../../../resources/echarts/echarts";
+import "./common/hui-energy-graph-chip";
+import "../../../../components/ha-tooltip";
+
+@customElement("hui-energy-wind-graph-card")
+export class HuiEnergyWindGraphCard
+  extends SubscribeMixin(LitElement)
+  implements LovelaceCard
+{
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _config?: EnergyWindGraphCardConfig;
+
+  @state() private _chartData: ECOption["series"][] = [];
+
+  @state() private _start = startOfToday();
+
+  @state() private _end = endOfToday();
+
+  @state() private _compareStart?: Date;
+
+  @state() private _compareEnd?: Date;
+
+  @state() private _total?: number;
+
+  protected hassSubscribeRequiredHostProps = ["_config"];
+
+  public hassSubscribe(): UnsubscribeFunc[] {
+    return [
+      getEnergyDataCollection(this.hass, {
+        key: this._config?.collection_key,
+      }).subscribe((data) => this._getStatistics(data)),
+    ];
+  }
+
+  public getCardSize(): Promise<number> | number {
+    return 3;
+  }
+
+  public setConfig(config: EnergyWindGraphCardConfig): void {
+    this._config = config;
+  }
+
+  protected shouldUpdate(changedProps: PropertyValues): boolean {
+    return (
+      hasConfigChanged(this, changedProps) ||
+      changedProps.size > 1 ||
+      !changedProps.has("hass")
+    );
+  }
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    return html`
+      <ha-card>
+        ${this._config.title
+          ? html` <div class="card-header">
+              <span>${this._config.title}</span>
+              ${this._total
+                ? html`<hui-energy-graph-chip
+                    .tooltip=${this._formatTotal(this._total)}
+                  >
+                    ${formatNumber(this._total, this.hass.locale)} kWh
+                  </hui-energy-graph-chip>`
+                : nothing}
+            </div>`
+          : nothing}
+        <div
+          class="content ${classMap({
+            "has-header": !!this._config.title,
+          })}"
+        >
+          <ha-chart-base
+            .hass=${this.hass}
+            .data=${this._chartData}
+            .options=${this._createOptions(
+              this._start,
+              this._end,
+              this.hass.locale,
+              this.hass.config,
+              this._compareStart,
+              this._compareEnd
+            )}
+            chart-type="bar"
+          ></ha-chart-base>
+          ${!this._chartData.length
+            ? html`<div class="no-data">
+                ${isToday(this._start)
+                  ? this.hass.localize("ui.panel.lovelace.cards.energy.no_data")
+                  : this.hass.localize(
+                      "ui.panel.lovelace.cards.energy.no_data_period"
+                    )}
+              </div>`
+            : ""}
+        </div>
+      </ha-card>
+    `;
+  }
+
+  private _formatTotal = (total: number) =>
+    this.hass.localize(
+      "ui.panel.lovelace.cards.energy.energy_wind_graph.total_produced",
+      { num: formatNumber(total, this.hass.locale) }
+    );
+
+  private _createOptions = memoizeOne(
+    (
+      start: Date,
+      end: Date,
+      locale: FrontendLocaleData,
+      config: HassConfig,
+      compareStart?: Date,
+      compareEnd?: Date
+    ): ECOption =>
+      getCommonOptions(
+        start,
+        end,
+        locale,
+        config,
+        "kWh",
+        compareStart,
+        compareEnd,
+        this._formatTotal
+      )
+  );
+
+  private async _getStatistics(energyData: EnergyData): Promise<void> {
+    this._start = energyData.start;
+    this._end = energyData.end || endOfToday();
+
+    this._compareStart = energyData.startCompare;
+    this._compareEnd = energyData.endCompare;
+
+    const windSources: WindSourceTypeEnergyPreference[] =
+      energyData.prefs.energy_sources.filter(
+        (source) => source.type === "wind"
+      ) as WindSourceTypeEnergyPreference[];
+
+    let forecasts: EnergyWindForecasts | undefined;
+    if (
+      windSources.some((source) => source.config_entry_wind_forecast?.length)
+    ) {
+      try {
+        forecasts = await getEnergyWindForecasts(this.hass);
+      } catch (_e) {
+        // ignore
+      }
+    }
+
+    const datasets: ECOption["series"] = [];
+
+    const computedStyles = getComputedStyle(this);
+
+    if (energyData.statsCompare) {
+      datasets.push(
+        ...this._processDataSet(
+          energyData.statsCompare,
+          energyData.statsMetadata,
+          windSources,
+          computedStyles,
+          true
+        )
+      );
+    } else {
+      // add empty dataset so compare bars are first
+      // `stack: wind` so it doesn't take up space yet
+      const firstId = windSources[0]?.stat_energy_from ?? "placeholder";
+      datasets.push({
+        id: "compare-" + firstId,
+        type: "bar",
+        stack: "wind",
+        data: [],
+      });
+    }
+
+    datasets.push(
+      ...this._processDataSet(
+        energyData.stats,
+        energyData.statsMetadata,
+        windSources,
+        computedStyles
+      )
+    );
+
+    fillDataGapsAndRoundCaps(datasets as BarSeriesOption[]);
+
+    if (forecasts) {
+      datasets.push(
+        ...this._processForecast(
+          energyData.statsMetadata,
+          forecasts,
+          windSources,
+          computedStyles.getPropertyValue("--primary-text-color"),
+          energyData.start,
+          energyData.end
+        )
+      );
+    }
+
+    this._chartData = datasets;
+    this._total = this._processTotal(energyData.stats, windSources);
+  }
+
+  private _processTotal(
+    statistics: Statistics,
+    windSources: WindSourceTypeEnergyPreference[]
+  ) {
+    return windSources.reduce(
+      (sum, source) =>
+        sum +
+        (source.stat_energy_from in statistics
+          ? statistics[source.stat_energy_from].reduce(
+              (acc, curr) => acc + (curr.change || 0),
+              0
+            )
+          : 0),
+      0
+    );
+  }
+
+  private _processDataSet(
+    statistics: Statistics,
+    statisticsMetaData: Record<string, StatisticsMetaData>,
+    windSources: WindSourceTypeEnergyPreference[],
+    computedStyles: CSSStyleDeclaration,
+    compare = false
+  ) {
+    const data: BarSeriesOption[] = [];
+    const compareTransform = getCompareTransform(
+      this._start,
+      this._compareStart!
+    );
+
+    windSources.forEach((source, idx) => {
+      let prevStart: number | null = null;
+
+      const windProductionData: BarSeriesOption["data"] = [];
+
+      // Process wind production data.
+      if (source.stat_energy_from in statistics) {
+        const stats = statistics[source.stat_energy_from];
+
+        for (const point of stats) {
+          if (
+            point.change === null ||
+            point.change === undefined ||
+            point.change === 0
+          ) {
+            continue;
+          }
+          if (prevStart === point.start) {
+            continue;
+          }
+          const dataPoint: (Date | string | number)[] = [
+            point.start,
+            point.change,
+          ];
+          if (compare) {
+            dataPoint[2] = dataPoint[0];
+            dataPoint[0] = compareTransform(new Date(point.start));
+          }
+          windProductionData.push(dataPoint);
+          prevStart = point.start;
+        }
+      }
+
+      data.push({
+        type: "bar",
+        cursor: "default",
+        id: compare
+          ? "compare-" + source.stat_energy_from
+          : source.stat_energy_from,
+        name: this.hass.localize(
+          "ui.panel.lovelace.cards.energy.energy_wind_graph.production",
+          {
+            name: getStatisticLabel(
+              this.hass,
+              source.stat_energy_from,
+              statisticsMetaData[source.stat_energy_from]
+            ),
+          }
+        ),
+        barMaxWidth: 50,
+        itemStyle: {
+          borderColor: getEnergyColor(
+            computedStyles,
+            this.hass.themes.darkMode,
+            false,
+            compare,
+            "--energy-wind-color",
+            idx
+          ),
+        },
+        color: getEnergyColor(
+          computedStyles,
+          this.hass.themes.darkMode,
+          true,
+          compare,
+          "--energy-wind-color",
+          idx
+        ),
+        data: windProductionData,
+        stack: compare ? "compare" : "wind",
+      });
+    });
+
+    return data;
+  }
+
+  private _processForecast(
+    statisticsMetaData: Record<string, StatisticsMetaData>,
+    forecasts: EnergyWindForecasts,
+    windSources: WindSourceTypeEnergyPreference[],
+    borderColor: string,
+    start: Date,
+    end?: Date
+  ) {
+    const data: LineSeriesOption[] = [];
+
+    const period = getSuggestedPeriod(start, end);
+
+    // Process wind forecast data.
+    windSources.forEach((source) => {
+      if (source.config_entry_wind_forecast) {
+        const forecastsData: Record<string, number> | undefined = {};
+        source.config_entry_wind_forecast.forEach((configEntryId) => {
+          if (!forecasts![configEntryId]) {
+            return;
+          }
+          Object.entries(forecasts![configEntryId].wh_hours).forEach(
+            ([date, value]) => {
+              const dateObj = new Date(date);
+              if (dateObj < start || (end && dateObj > end)) {
+                return;
+              }
+              if (period === "month") {
+                dateObj.setDate(1);
+              }
+              if (period === "month" || period === "day") {
+                dateObj.setHours(0, 0, 0, 0);
+              } else {
+                dateObj.setMinutes(0, 0, 0);
+              }
+              const time = dateObj.getTime();
+              if (time in forecastsData) {
+                forecastsData[time] += value;
+              } else {
+                forecastsData[time] = value;
+              }
+            }
+          );
+        });
+
+        if (forecastsData) {
+          const windForecastData: LineSeriesOption["data"] = [];
+          for (const [time, value] of Object.entries(forecastsData)) {
+            windForecastData.push([Number(time), value / 1000]);
+          }
+
+          if (windForecastData.length) {
+            data.push({
+              id: "forecast-" + source.stat_energy_from,
+              type: "line",
+              stack: "forecast",
+              name: this.hass.localize(
+                "ui.panel.lovelace.cards.energy.energy_wind_graph.forecast",
+                {
+                  name: getStatisticLabel(
+                    this.hass,
+                    source.stat_energy_from,
+                    statisticsMetaData[source.stat_energy_from]
+                  ),
+                }
+              ),
+              step: false,
+              color: borderColor,
+              lineStyle: {
+                type: [7, 5],
+                width: 1.5,
+              },
+              symbol: "none",
+              data: windForecastData,
+            });
+          }
+        }
+      }
+    });
+
+    return data;
+  }
+
+  static styles = css`
+    ha-card {
+      height: 100%;
+    }
+    .card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding-bottom: 0;
+    }
+    .content {
+      padding: 16px;
+    }
+    .has-header {
+      padding-top: 0;
+    }
+    .no-data {
+      position: absolute;
+      height: 100%;
+      top: 0;
+      left: 0;
+      right: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 20%;
+      margin-left: 32px;
+      margin-inline-start: 32px;
+      margin-inline-end: initial;
+      box-sizing: border-box;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-energy-wind-graph-card": HuiEnergyWindGraphCard;
+  }
+}

--- a/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
@@ -156,6 +156,13 @@ export class HuiPowerSourcesGraphCard
           "ui.panel.lovelace.cards.energy.power_graph.solar"
         ),
       },
+      wind: {
+        stats: [] as string[],
+        color: "--energy-wind-color",
+        name: this.hass.localize(
+          "ui.panel.lovelace.cards.energy.power_graph.wind"
+        ),
+      },
       grid: {
         stats: [] as string[],
         color: "--energy-grid-consumption-color",
@@ -178,6 +185,13 @@ export class HuiPowerSourcesGraphCard
       if (source.type === "solar") {
         if (source.stat_rate) {
           statIds.solar.stats.push(source.stat_rate);
+        }
+        continue;
+      }
+
+      if (source.type === "wind") {
+        if (source.stat_rate) {
+          statIds.wind.stats.push(source.stat_rate);
         }
         continue;
       }
@@ -250,7 +264,7 @@ export class HuiPowerSourcesGraphCard
           data: positive,
           z: 3 - keyIndex, // draw in reverse order so 0 value lines are overwritten
         });
-        if (key !== "solar") {
+        if (key !== "solar" && key !== "wind") {
           datasets.push({
             ...commonSeriesOptions,
             id: `${key}-negative`,
@@ -275,7 +289,8 @@ export class HuiPowerSourcesGraphCard
         }
         this._legendData!.push({
           id: key,
-          secondaryIds: key !== "solar" ? [`${key}-negative`] : [],
+          secondaryIds:
+            key !== "solar" && key !== "wind" ? [`${key}-negative`] : [],
           name: statIds[key].name,
           itemStyle: {
             color: `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, 0.75)`,

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -184,6 +184,11 @@ export interface EnergySolarGraphCardConfig extends EnergyCardBaseConfig {
   title?: string;
 }
 
+export interface EnergyWindGraphCardConfig extends EnergyCardBaseConfig {
+  type: "energy-wind-graph";
+  title?: string;
+}
+
 export interface EnergyGasGraphCardConfig extends EnergyCardBaseConfig {
   type: "energy-gas-graph";
   title?: string;

--- a/src/panels/lovelace/create-element/create-card-element.ts
+++ b/src/panels/lovelace/create-element/create-card-element.ts
@@ -61,6 +61,8 @@ const LAZY_LOAD_TYPES = {
     import("../cards/energy/hui-energy-self-sufficiency-gauge-card"),
   "energy-solar-graph": () =>
     import("../cards/energy/hui-energy-solar-graph-card"),
+  "energy-wind-graph": () =>
+    import("../cards/energy/hui-energy-wind-graph-card"),
   "energy-sources-table": () =>
     import("../cards/energy/hui-energy-sources-table-card"),
   "energy-usage-graph": () =>

--- a/src/panels/lovelace/editor/get-dashboard-documentation-url.ts
+++ b/src/panels/lovelace/editor/get-dashboard-documentation-url.ts
@@ -11,6 +11,7 @@ const NON_STANDARD_URLS = {
   "energy-date-selection": "energy/#energy-date-picker",
   "energy-usage-graph": "energy/#energy-usage-graph",
   "energy-solar-graph": "energy/#solar-production-graph",
+  "energy-wind-graph": "energy/#wind-production-graph",
   "energy-gas-graph": "energy/#gas-consumption-graph",
   "energy-water-graph": "energy/#water-consumption-graph",
   "energy-distribution": "energy/#energy-distribution",

--- a/src/resources/theme/color/color.globals.ts
+++ b/src/resources/theme/color/color.globals.ts
@@ -60,6 +60,7 @@ export const colorStyles = css`
     --energy-grid-consumption-color: #488fc2;
     --energy-grid-return-color: #8353d1;
     --energy-solar-color: #ff9800;
+    --energy-wind-color: #78909c;
     --energy-non-fossil-color: #0f9d58;
     --energy-battery-out-color: #4db6ac;
     --energy-battery-in-color: #f06292;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3890,6 +3890,27 @@
               "add_forecast": "Add forecast"
             }
           },
+          "wind": {
+            "title": "Wind turbines",
+            "sub": "Let Home Assistant monitor your wind turbines and optimize energy usage with Home Assistant.",
+            "learn_more": "More information on how to get started.",
+            "add_wind_production": "Add wind production",
+            "edit_wind_production": "Edit wind production",
+            "delete_wind_production": "Delete wind production",
+            "dialog": {
+              "header": "Configure wind turbines",
+              "entity_para": "Pick a sensor which measures wind production in either of {unit}.",
+              "wind_production_energy": "Wind production energy",
+              "wind_production_power": "Wind production power",
+              "wind_production_forecast": "Wind production forecast",
+              "wind_production_forecast_description": "Adding wind production forecast information will allow you to quickly see your expected production for today.",
+              "wind_forecast_description": "Would you like to include a forecast for this wind production source? This will help you plan energy usage.",
+              "dont_forecast_production": "Don't forecast production",
+              "forecast_production": "Forecast production",
+              "add_forecast": "Add forecast",
+              "create_forecast": "Create a wind production forecast"
+            }
+          },
           "battery": {
             "title": "Home battery storage",
             "sub": "If you have a battery system, you can configure it to monitor how much energy was stored and used from your battery.",
@@ -8182,6 +8203,7 @@
               "grid_total": "Grid total",
               "gas_total": "Gas total",
               "solar_total": "Solar total",
+              "wind_total": "Wind total",
               "water_total": "Water total",
               "source": "Source",
               "energy": "Usage",
@@ -8192,6 +8214,11 @@
               "total_costs": "Total costs"
             },
             "energy_solar_graph": {
+              "production": "Production {name}",
+              "forecast": "Forecast {name}",
+              "total_produced": "Total produced {num} kWh"
+            },
+            "energy_wind_graph": {
               "production": "Production {name}",
               "forecast": "Forecast {name}",
               "total_produced": "Total produced {num} kWh"
@@ -8252,6 +8279,7 @@
             "power_graph": {
               "grid": "Grid",
               "solar": "Solar",
+              "wind": "Wind production",
               "battery": "Battery",
               "usage": "Consumption"
             },
@@ -10358,6 +10386,7 @@
         "cards": {
           "energy_usage_graph_title": "Electricity usage",
           "energy_solar_graph_title": "Solar production",
+          "energy_wind_graph_title": "Wind production",
           "energy_gas_graph_title": "Gas consumption",
           "energy_water_graph_title": "Water consumption",
           "energy_distribution_title": "Energy distribution",


### PR DESCRIPTION
## Summary
- Adds full frontend support for wind energy production: settings UI, configuration dialog, and forecast setup
- New `energy-wind-graph` card with dedicated `--energy-wind-color` (#78909c) for wind production visualization
- Updates distribution card, sources table, carbon/solar-consumed/self-sufficiency gauges, and power graph to include wind production alongside solar
- Strategy updates to auto-generate wind cards when wind sources are configured

## Test plan
- [x] TypeScript type check passes (0 new errors)
- [x] ESLint, Prettier, and lit-analyzer pass (verified by pre-commit hooks)
- [x] Rspack demo build compiles successfully
- [ ] Configure a wind energy source via Settings → Energy → Electricity tab
- [ ] Verify wind production graph card appears on energy dashboard
- [ ] Verify distribution card includes wind in production total
- [ ] Verify energy sources table shows wind row with correct color
- [ ] Verify consumed/sufficiency gauges account for wind production

## Related PRs
- Backend companion: https://github.com/home-assistant/core/pull/163967

🤖 Generated with [Claude Code](https://claude.com/claude-code)