### PR TITLE
Fix data-table content bottom margin

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -118,8 +118,6 @@ export class HaDataTable extends LitElement {
 
   @property({ type: Boolean }) public clickable = false;
 
-  @property({ attribute: "has-fab", type: Boolean }) public hasFab = false;
-
   /**
    * Add an extra row at the bottom of the data table
    * @type {TemplateResult}
@@ -519,7 +517,6 @@ export class HaDataTable extends LitElement {
                     this._filteredData,
                     localize,
                     this.appendRow,
-                    this.hasFab,
                     this.groupColumn,
                     this.groupOrder,
                     this._collapsedGroups,
@@ -716,14 +713,13 @@ export class HaDataTable extends LitElement {
       data: DataTableRowData[],
       localize: LocalizeFunc,
       appendRow,
-      hasFab: boolean,
       groupColumn: string | undefined,
       groupOrder: string[] | undefined,
       collapsedGroups: string[],
       sortColumn: string | undefined,
       sortDirection: SortingDirection
     ) => {
-      if (appendRow || hasFab || groupColumn) {
+      if (appendRow || groupColumn) {
         let items = [...data];
 
         if (groupColumn) {
@@ -813,13 +809,11 @@ export class HaDataTable extends LitElement {
           items.push({ append: true, selectable: false, content: appendRow });
         }
 
-        if (hasFab) {
-          items.push({ empty: true });
-        }
+        items.push({ empty: true });
 
         return items;
       }
-      return data;
+      return [...data, { empty: true }];
     }
   );
 
@@ -871,7 +865,6 @@ export class HaDataTable extends LitElement {
       this._filteredData,
       this.localizeFunc || this.hass.localize,
       this.appendRow,
-      this.hasFab,
       this.groupColumn,
       this.groupOrder,
       this._collapsedGroups,
@@ -1089,11 +1082,8 @@ export class HaDataTable extends LitElement {
         }
 
         .mdc-data-table__row.empty-row {
-          height: max(
-            var(
-              --data-table-empty-row-height,
-              var(--data-table-row-height, 52px)
-            ),
+          height: var(
+            --data-table-empty-row-height,
             var(--safe-area-inset-bottom, 0px)
           );
         }

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -16,6 +16,8 @@ import type { TemplateResult } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import { styleMap } from "lit/directives/style-map";
+import memoizeOne from "memoize-one";
 import { fireEvent } from "../common/dom/fire_event";
 import type { LocalizeFunc } from "../common/translations/localize";
 import "../components/chips/ha-assist-chip";
@@ -186,6 +188,8 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
 
   @query("search-input-outlined") private _searchInput!: HTMLElement;
 
+  @query("hass-tabs-subpage") private _tabsSubpage!: HTMLElement;
+
   protected supportedShortcuts(): SupportedShortcuts {
     return {
       f: () => this._searchInput.focus(),
@@ -195,6 +199,25 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
   private _showPaneController = new ResizeController(this, {
     callback: (entries) => entries[0]?.contentRect.width > 750,
   });
+
+  private _calcEmptyRowHeight = memoizeOne(
+    (narrow: boolean, hasFab: boolean, showTabs: boolean): string => {
+      const bottomTabs = narrow && showTabs;
+      // tabs in narrow view (bottom) already add padding for the safe area inset
+      // otherwise, add padding so last content row isn't cropped by rounded display
+      // corners or overlayed by home indicator on iOS
+      let height = bottomTabs ? "0px" : "var(--safe-area-inset-bottom, 0px)";
+
+      if (hasFab) {
+        // fab bottom margin in narrow tab view is bigger than otherwise
+        // double the margin to for equal top and bottom margin to fab
+        const fabHeight = 48;
+        const fabMargin = (bottomTabs ? 28 : 16) * 2;
+        height = `calc(${height} + ${fabHeight + fabMargin}px)`;
+      }
+      return height;
+    }
+  );
 
   public clearSelection() {
     this._dataTable.clearSelection();
@@ -491,7 +514,6 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
                 .noDataText=${this.noDataText}
                 .filter=${this.filter}
                 .selectable=${this._selectMode}
-                .hasFab=${this.hasFab}
                 .id=${this.id}
                 .clickable=${this.clickable}
                 .appendRow=${this.appendRow}
@@ -502,6 +524,13 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
                 .initialCollapsedGroups=${this.initialCollapsedGroups}
                 .columnOrder=${this.columnOrder}
                 .hiddenColumns=${this.hiddenColumns}
+                style=${styleMap({
+                  "--data-table-empty-row-height": this._calcEmptyRowHeight(
+                    this.narrow,
+                    this.hasFab,
+                    this._tabsSubpage?.hasAttribute("show-tabs")
+                  ),
+                })}
               >
                 ${!this.narrow
                   ? html`

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -210,7 +210,14 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
   }
 
   protected willUpdate(changedProperties: PropertyValues) {
-    if (changedProperties.has("tabs")) {
+    if (
+      changedProperties.has("tabs") ||
+      (changedProperties.has("hass") &&
+        (this.hass?.config.components !==
+          changedProperties.get("hass")?.config.components ||
+          this.hass?.userData?.showAdvanced !==
+            changedProperties.get("hass")?.userData?.showAdvanced))
+    ) {
       this.showTabs =
         this.tabs.filter((page) => canShowPage(this.hass, page)).length > 1;
     }

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -528,7 +528,7 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
                   "--data-table-empty-row-height": this._calcEmptyRowHeight(
                     this.narrow,
                     this.hasFab,
-                    this._tabsSubpage.showTabs
+                    this._tabsSubpage?.showTabs ?? false
                   ),
                 })}
               >

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -18,6 +18,7 @@ import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
+import { canShowPage } from "../common/config/can_show_page";
 import { fireEvent } from "../common/dom/fire_event";
 import type { LocalizeFunc } from "../common/translations/localize";
 import "../components/chips/ha-assist-chip";
@@ -41,7 +42,7 @@ import "../components/search-input-outlined";
 import { KeyboardShortcutMixin } from "../mixins/keyboard-shortcut-mixin";
 import type { HomeAssistant, Route } from "../types";
 import "./hass-tabs-subpage";
-import type { HassTabsSubpage, PageNavigation } from "./hass-tabs-subpage";
+import type { PageNavigation } from "./hass-tabs-subpage";
 
 @customElement("hass-tabs-subpage-data-table")
 export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
@@ -188,8 +189,6 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
 
   @query("search-input-outlined") private _searchInput!: HTMLElement;
 
-  @query("hass-tabs-subpage") private _tabsSubpage!: HassTabsSubpage;
-
   protected supportedShortcuts(): SupportedShortcuts {
     return {
       f: () => this._searchInput.focus(),
@@ -199,6 +198,11 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
   private _showPaneController = new ResizeController(this, {
     callback: (entries) => entries[0]?.contentRect.width > 750,
   });
+
+  private _showTabs = memoizeOne(
+    (tabs: PageNavigation[]): boolean =>
+      tabs.filter((page) => canShowPage(this.hass, page)).length > 1
+  );
 
   private _calcEmptyRowHeight = memoizeOne(
     (narrow: boolean, hasFab: boolean, showTabs: boolean): string => {
@@ -528,7 +532,7 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
                   "--data-table-empty-row-height": this._calcEmptyRowHeight(
                     this.narrow,
                     this.hasFab,
-                    this._tabsSubpage?.showTabs ?? false
+                    this._showTabs(this.tabs)
                   ),
                 })}
               >

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -528,7 +528,7 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
                   "--data-table-empty-row-height": this._calcEmptyRowHeight(
                     this.narrow,
                     this.hasFab,
-                    this._tabsSubpage?.hasAttribute("show-tabs")
+                    this._tabsSubpage.hasAttribute("show-tabs")
                   ),
                 })}
               >

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -12,12 +12,10 @@ import {
   mdiUnfoldLessHorizontal,
   mdiUnfoldMoreHorizontal,
 } from "@mdi/js";
-import type { TemplateResult } from "lit";
+import type { TemplateResult, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
-import { styleMap } from "lit/directives/style-map";
-import memoizeOne from "memoize-one";
 import { canShowPage } from "../common/config/can_show_page";
 import { fireEvent } from "../common/dom/fire_event";
 import type { LocalizeFunc } from "../common/translations/localize";
@@ -86,7 +84,15 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
    * Do we need to add padding for a fab.
    * @type {Boolean}
    */
-  @property({ attribute: "has-fab", type: Boolean }) public hasFab = false;
+  @property({ attribute: "has-fab", type: Boolean, reflect: true })
+  public hasFab = false;
+
+  /**
+   * Show tabs on top or at bottom (narrow) of the page.
+   * @type {Boolean}
+   */
+  @property({ attribute: "show-tabs", type: Boolean, reflect: true })
+  public showTabs = false;
 
   /**
    * Add an extra row at the bottom of the data table
@@ -199,35 +205,16 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
     callback: (entries) => entries[0]?.contentRect.width > 750,
   });
 
-  private _showTabs = memoizeOne(
-    (tabs: PageNavigation[]): boolean =>
-      tabs.filter((page) => canShowPage(this.hass, page)).length > 1
-  );
-
-  private _calcEmptyRowHeight = memoizeOne(
-    (narrow: boolean, hasFab: boolean, showTabs: boolean): string => {
-      const bottomTabs = narrow && showTabs;
-      // tabs in narrow view (bottom) already add padding for the safe area inset
-      // otherwise, add padding so last content row isn't cropped by rounded display
-      // corners or overlayed by home indicator on iOS
-      let height = bottomTabs ? "0px" : "var(--safe-area-inset-bottom, 0px)";
-
-      if (hasFab) {
-        // fab bottom margin in narrow tab view is bigger than otherwise
-        // double the margin to for equal top and bottom margin to fab
-        const fabHeight = 48;
-        const fabMargin = (bottomTabs ? 28 : 16) * 2;
-        height = `calc(${height} + ${fabHeight + fabMargin}px)`;
-      }
-      return height;
-    }
-  );
-
   public clearSelection() {
     this._dataTable.clearSelection();
   }
 
-  protected willUpdate() {
+  protected willUpdate(changedProperties: PropertyValues) {
+    if (changedProperties.has("tabs")) {
+      this.showTabs =
+        this.tabs.filter((page) => canShowPage(this.hass, page)).length > 1;
+    }
+
     if (this.hasUpdated) {
       return;
     }
@@ -528,13 +515,6 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
                 .initialCollapsedGroups=${this.initialCollapsedGroups}
                 .columnOrder=${this.columnOrder}
                 .hiddenColumns=${this.hiddenColumns}
-                style=${styleMap({
-                  "--data-table-empty-row-height": this._calcEmptyRowHeight(
-                    this.narrow,
-                    this.hasFab,
-                    this._showTabs(this.tabs)
-                  ),
-                })}
               >
                 ${!this.narrow
                   ? html`
@@ -746,6 +726,7 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
       width: 100%;
       height: 100%;
       --data-table-border-width: 0;
+      --data-table-empty-row-height: var(--safe-area-inset-bottom, 0px);
     }
     :host(:not([narrow])) ha-data-table,
     .pane {
@@ -757,6 +738,23 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
           ) - var(--safe-area-inset-bottom, 0px)
       );
       display: block;
+    }
+    /* Last content row shall keep the same padding above fab as fab to 
+       bottom (16px) + the safe-area inset. */
+    :host([has-fab]) ha-data-table {
+      --data-table-empty-row-height: calc(
+        48px + 16px * 2 + var(--safe-area-inset-bottom, 0px)
+      );
+    }
+    /* In narrow view with tabs shown at the bottom, the tab bar already
+       accounts for safe-area-inset-bottom. No extra empty-row height is needed. */
+    :host([narrow][show-tabs]:not([has-fab])) ha-data-table {
+      --data-table-empty-row-height: 0px;
+    }
+    /* Reserve space for fab + doubled narrow-mode bottom padding (28px * 2)
+       when using narrow layout with bottom tabs. */
+    :host([narrow][show-tabs][has-fab]) ha-data-table {
+      --data-table-empty-row-height: calc(48px + 28px * 2);
     }
 
     .pane-content {

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -746,8 +746,8 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
       );
       display: block;
     }
-    /* Last content row shall keep the same padding above fab as fab to 
-       bottom (16px) + the safe-area inset. */
+    /* Last content row should keep the same padding above the fab as the fab
+       has to the bottom (16px standard fab bottom padding) + the safe-area inset. */
     :host([has-fab]) ha-data-table {
       --data-table-empty-row-height: calc(
         48px + 16px * 2 + var(--safe-area-inset-bottom, 0px)

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -41,7 +41,7 @@ import "../components/search-input-outlined";
 import { KeyboardShortcutMixin } from "../mixins/keyboard-shortcut-mixin";
 import type { HomeAssistant, Route } from "../types";
 import "./hass-tabs-subpage";
-import type { PageNavigation } from "./hass-tabs-subpage";
+import type { HassTabsSubpage, PageNavigation } from "./hass-tabs-subpage";
 
 @customElement("hass-tabs-subpage-data-table")
 export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
@@ -188,7 +188,7 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
 
   @query("search-input-outlined") private _searchInput!: HTMLElement;
 
-  @query("hass-tabs-subpage") private _tabsSubpage!: HTMLElement;
+  @query("hass-tabs-subpage") private _tabsSubpage!: HassTabsSubpage;
 
   protected supportedShortcuts(): SupportedShortcuts {
     return {
@@ -528,7 +528,7 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
                   "--data-table-empty-row-height": this._calcEmptyRowHeight(
                     this.narrow,
                     this.hasFab,
-                    this._tabsSubpage.hasAttribute("show-tabs")
+                    this._tabsSubpage.showTabs
                   ),
                 })}
               >

--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -75,8 +75,6 @@ export class HassTabsSubpage extends LitElement {
 
   @state() private _activeTab?: PageNavigation;
 
-  @state() private _tabs: (TemplateResult | string)[] = [""];
-
   // @ts-ignore
   @restoreScroll(".content") private _savedScrollPos?: number;
 
@@ -93,6 +91,7 @@ export class HassTabsSubpage extends LitElement {
       const shownTabs = tabs.filter((page) => canShowPage(this.hass, page));
 
       if (shownTabs.length < 2) {
+        this.showTabs = false;
         if (shownTabs.length === 1) {
           const page = shownTabs[0];
           return [
@@ -102,6 +101,7 @@ export class HassTabsSubpage extends LitElement {
         return [""];
       }
 
+      this.showTabs = true;
       return shownTabs.map(
         (page) => html`
           <a href=${page.path} @click=${this._tabClicked}>
@@ -132,29 +132,19 @@ export class HassTabsSubpage extends LitElement {
         this._isActiveTabPath(tab.path, currentPath)
       );
     }
-
-    if (
-      changedProperties.has("hass") ||
-      changedProperties.has("narrow") ||
-      changedProperties.has("route") ||
-      changedProperties.has("tabs")
-    ) {
-      this._tabs = this._getTabs(
-        this.tabs,
-        this._activeTab,
-        this.hass.config.components,
-        this.hass.language,
-        this.hass.userData,
-        this.narrow,
-        this.localizeFunc || this.hass.localize
-      );
-      this.showTabs = this._tabs.length > 1;
-    }
-
     super.willUpdate(changedProperties);
   }
 
   protected render(): TemplateResult {
+    const tabs = this._getTabs(
+      this.tabs,
+      this._activeTab,
+      this.hass.config.components,
+      this.hass.language,
+      this.hass.userData,
+      this.narrow,
+      this.localizeFunc || this.hass.localize
+    );
     return html`
       <div class="toolbar ${classMap({ narrow: this.narrow })}">
         <slot name="toolbar">
@@ -181,13 +171,11 @@ export class HassTabsSubpage extends LitElement {
                   `}
             ${this.narrow || !this.showTabs
               ? html`<div class="main-title">
-                  <slot name="header"
-                    >${!this.showTabs ? this._tabs[0] : ""}</slot
-                  >
+                  <slot name="header">${!this.showTabs ? tabs[0] : ""}</slot>
                 </div>`
               : ""}
             ${this.showTabs && !this.narrow
-              ? html`<div id="tabbar">${this._tabs}</div>`
+              ? html`<div id="tabbar">${tabs}</div>`
               : ""}
             <div id="toolbar-icon">
               <slot name="toolbar-icon"></slot>
@@ -195,7 +183,7 @@ export class HassTabsSubpage extends LitElement {
           </div>
         </slot>
         ${this.showTabs && this.narrow
-          ? html`<div id="tabbar" class="bottom-bar">${this._tabs}</div>`
+          ? html`<div id="tabbar" class="bottom-bar">${tabs}</div>`
           : ""}
       </div>
       <div class="container">

--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -37,7 +37,7 @@ export interface PageNavigation {
 }
 
 @customElement("hass-tabs-subpage")
-class HassTabsSubpage extends LitElement {
+export class HassTabsSubpage extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public localizeFunc?: LocalizeFunc;

--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -65,7 +65,17 @@ class HassTabsSubpage extends LitElement {
    */
   @property({ type: Boolean, attribute: "has-fab" }) public hasFab = false;
 
+  /**
+   * Whether tabs are shown (2 or more tabs visible).
+   * When both, show-tabs and narrow are true, tabs are shown as bottom bar.
+   * @type {Boolean}
+   */
+  @property({ type: Boolean, attribute: "show-tabs", reflect: true })
+  public showTabs = false;
+
   @state() private _activeTab?: PageNavigation;
+
+  @state() private _tabs: TemplateResult[] | string[] = [""];
 
   // @ts-ignore
   @restoreScroll(".content") private _savedScrollPos?: number;
@@ -122,20 +132,29 @@ class HassTabsSubpage extends LitElement {
         this._isActiveTabPath(tab.path, currentPath)
       );
     }
+
+    if (
+      changedProperties.has("hass") ||
+      changedProperties.has("narrow") ||
+      changedProperties.has("route") ||
+      changedProperties.has("tabs")
+    ) {
+      this._tabs = this._getTabs(
+        this.tabs,
+        this._activeTab,
+        this.hass.config.components,
+        this.hass.language,
+        this.hass.userData,
+        this.narrow,
+        this.localizeFunc || this.hass.localize
+      );
+      this.showTabs = (this._tabs as any).length > 1;
+    }
+
     super.willUpdate(changedProperties);
   }
 
   protected render(): TemplateResult {
-    const tabs = this._getTabs(
-      this.tabs,
-      this._activeTab,
-      this.hass.config.components,
-      this.hass.language,
-      this.hass.userData,
-      this.narrow,
-      this.localizeFunc || this.hass.localize
-    );
-    const showTabs = tabs.length > 1;
     return html`
       <div class="toolbar ${classMap({ narrow: this.narrow })}">
         <slot name="toolbar">
@@ -160,26 +179,26 @@ class HassTabsSubpage extends LitElement {
                       @click=${this._backTapped}
                     ></ha-icon-button-arrow-prev>
                   `}
-            ${this.narrow || !showTabs
+            ${this.narrow || !this.showTabs
               ? html`<div class="main-title">
-                  <slot name="header">${!showTabs ? tabs[0] : ""}</slot>
+                  <slot name="header"
+                    >${!this.showTabs ? this._tabs[0] : ""}</slot
+                  >
                 </div>`
               : ""}
-            ${showTabs && !this.narrow
-              ? html`<div id="tabbar">${tabs}</div>`
+            ${this.showTabs && !this.narrow
+              ? html`<div id="tabbar">${this._tabs}</div>`
               : ""}
             <div id="toolbar-icon">
               <slot name="toolbar-icon"></slot>
             </div>
           </div>
         </slot>
-        ${showTabs && this.narrow
-          ? html`<div id="tabbar" class="bottom-bar">${tabs}</div>`
+        ${this.showTabs && this.narrow
+          ? html`<div id="tabbar" class="bottom-bar">${this._tabs}</div>`
           : ""}
       </div>
-      <div
-        class=${classMap({ container: true, tabs: showTabs && this.narrow })}
-      >
+      <div class="container">
         ${this.pane
           ? html`<div class="pane">
               <div class="shadow-container"></div>
@@ -188,15 +207,12 @@ class HassTabsSubpage extends LitElement {
               </div>
             </div>`
           : nothing}
-        <div
-          class="content ha-scrollbar ${classMap({ tabs: showTabs })}"
-          @scroll=${this._saveScrollPos}
-        >
+        <div class="content ha-scrollbar" @scroll=${this._saveScrollPos}>
           <slot></slot>
           ${this.hasFab ? html`<div class="fab-bottom-space"></div>` : nothing}
         </div>
       </div>
-      <div id="fab" class=${classMap({ tabs: showTabs })}>
+      <div id="fab">
         <slot name="fab"></slot>
       </div>
     `;
@@ -373,7 +389,7 @@ class HassTabsSubpage extends LitElement {
           margin-left: var(--safe-area-inset-left);
           margin-inline-start: var(--safe-area-inset-left);
         }
-        :host([narrow]) .content.tabs {
+        :host([narrow][show-tabs]) .content {
           /* Bottom bar reuses header height */
           margin-bottom: calc(
             var(--header-height, 0px) + var(--safe-area-inset-bottom, 0px)
@@ -384,7 +400,7 @@ class HassTabsSubpage extends LitElement {
           height: calc(64px + var(--safe-area-inset-bottom, 0px));
         }
 
-        :host([narrow]) .content.tabs .fab-bottom-space {
+        :host([narrow][show-tabs]) .content .fab-bottom-space {
           height: calc(80px + var(--safe-area-inset-bottom, 0px));
         }
 
@@ -400,7 +416,7 @@ class HassTabsSubpage extends LitElement {
           justify-content: flex-end;
           gap: var(--ha-space-2);
         }
-        :host([narrow]) #fab.tabs {
+        :host([narrow][show-tabs]) #fab {
           bottom: calc(84px + var(--safe-area-inset-bottom, 0px));
         }
         #fab[is-wide] {

--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -75,7 +75,7 @@ class HassTabsSubpage extends LitElement {
 
   @state() private _activeTab?: PageNavigation;
 
-  @state() private _tabs: TemplateResult[] | string[] = [""];
+  @state() private _tabs: (TemplateResult | string)[] = [""];
 
   // @ts-ignore
   @restoreScroll(".content") private _savedScrollPos?: number;
@@ -148,7 +148,7 @@ class HassTabsSubpage extends LitElement {
         this.narrow,
         this.localizeFunc || this.hass.localize
       );
-      this.showTabs = (this._tabs as any).length > 1;
+      this.showTabs = this._tabs.length > 1;
     }
 
     super.willUpdate(changedProperties);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- `ha-data-table` doesn't provide `has-fab` attribute anymore

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
- Fixes fab overlaying the last data table row.
- Renders same margin from fab to last table row (non-empty) as fab to bottom (tab row or end of view exclusive `--safe-area-inset-bottom`).
- Always render an empty row at bottom of `ha-data-table`. This may have a height of 0px when not needed.
- Use `--data-table-empty-row-height` CSS variable in `ha-data-table` to override empty row height. This is passed from `hass-tabs-subpage-data-table` for correct margin - dependent of showing fab and bottom tab row in its `hass-tabs-subpage` element.
- Add `show-tabs` attribute to `hass-tabs-subpage` element and use it instead of `tabs` class for defining bottom tabs row.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
These are all `hass-tabs-subpage-data-table` layouts with different properties at bottom scroll position.
Narrow screenshots are done on an iphone using the companion app, so rounded display corners and `--safe-area-inset-bottom` for home indicator apply there.
Non-tabs screenshots are taken from the knx config panel using the same data-table code - since I don't know where else in HA a data-table without tabs is used 😬

- narrow, fab, tabs

| before | after |
|--------|--------|
| <img width="603" height="1311" alt="IMG_4090" src="https://github.com/user-attachments/assets/415bc1f0-dd63-455f-ba11-da12d795a9c1" /> | <img width="603" height="1311" alt="IMG_4086" src="https://github.com/user-attachments/assets/1c5d6aaf-13c5-4fd0-9eb4-70423046d742" /> | 

- narrow, no fab, tabs (no change)

| before | after |
|--------|--------|
| <img width="603" height="1311" alt="IMG_4091" src="https://github.com/user-attachments/assets/30cba2dd-dc78-41f1-954f-e00b80898c16" /> | <img width="603" height="1311" alt="IMG_4087" src="https://github.com/user-attachments/assets/025c56b3-d1a4-4141-9be9-745dcd00055b" /> | 

- narrow, fab, no tabs

| before | after |
|--------|--------|
| <img width="603" height="1311" alt="IMG_4092" src="https://github.com/user-attachments/assets/1b085232-1992-4e0b-8be1-25c34420e4af" /> | <img width="603" height="1311" alt="IMG_4088" src="https://github.com/user-attachments/assets/c7ab2685-0280-4456-a4e2-2a23c4d35806" /> | 

- narrow, no fab, no tabs

| before | after |
|--------|--------|
| <img width="603" height="1311" alt="IMG_4093" src="https://github.com/user-attachments/assets/c3ec7904-7d79-4f5a-992c-5796374bca5d" /> | <img width="603" height="1311" alt="IMG_4089" src="https://github.com/user-attachments/assets/d237fccb-dcd8-4e7b-a11c-989773bed53c" /> | 

- no narrow, fab, tabs

| before | after |
|--------|--------|
| <img width="1038" height="550" alt="Bildschirmfoto 2026-02-25 um 07 46 55" src="https://github.com/user-attachments/assets/95b0a547-2c8f-460d-b01b-eece1e6a9e6d" /> | <img width="1038" height="550" alt="Bildschirmfoto 2026-02-25 um 07 44 35" src="https://github.com/user-attachments/assets/84016426-fca9-45a8-98d7-40e235bcbfff" /> | 

- no narrow, no fab, tabs

| before | after |
|--------|--------|
| <img width="1038" height="550" alt="Bildschirmfoto 2026-02-25 um 07 47 03" src="https://github.com/user-attachments/assets/65ded42f-89d2-40a5-92d0-4ed4b08030de" /> | <img width="1038" height="550" alt="Bildschirmfoto 2026-02-25 um 07 44 48" src="https://github.com/user-attachments/assets/e8fcd4e4-a8a4-4083-9d20-0c7740299b19" /> | 

- no narrow, fab, no tabs

| before | after |
|--------|--------|
| <img width="1038" height="550" alt="Bildschirmfoto 2026-02-25 um 07 47 13" src="https://github.com/user-attachments/assets/e1cb60e9-f401-41a3-bf63-cdfd8b2eb352" /> | <img width="1038" height="550" alt="Bildschirmfoto 2026-02-25 um 07 44 59" src="https://github.com/user-attachments/assets/4ae1dd5f-7dde-4215-ae68-82b7592c18f3" /> | 

- no narrow, no fab, no tabs

| before | after |
|--------|--------|
| <img width="1038" height="550" alt="Bildschirmfoto 2026-02-25 um 07 47 33" src="https://github.com/user-attachments/assets/da54693c-4574-44e1-b98c-ea23d1160f7c" /> | <img width="1038" height="550" alt="Bildschirmfoto 2026-02-25 um 07 46 00" src="https://github.com/user-attachments/assets/525424bc-0478-4171-a8b1-dc3ce42f17dc" /> | 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/pull/29688#discussion_r2829379248
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/29688
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
