### PR TITLE
Filter hidden entities in common controls section

### DIFF
--- a/src/panels/lovelace/strategies/usage_prediction/common-controls-section-strategy.ts
+++ b/src/panels/lovelace/strategies/usage_prediction/common-controls-section-strategy.ts
@@ -58,9 +58,17 @@ export class CommonControlsSectionStrategy extends ReactiveElement {
     }
 
     const predictedCommonControl = await getCommonControlUsagePrediction(hass);
-    let predictedEntities = predictedCommonControl.entities.filter(
-      (entity) => entity in hass.states
-    );
+    let predictedEntities = predictedCommonControl.entities.filter((entity) => {
+      if (!(entity in hass.states)) {
+        return false;
+      }
+      const entityEntry = hass.entities[entity];
+      // Filter out hidden entities (respects user/integration/device hidden_by)
+      if (entityEntry?.hidden) {
+        return false;
+      }
+      return true;
+    });
 
     if (config.exclude_entities?.length) {
       predictedEntities = predictedEntities.filter(


### PR DESCRIPTION
## Breaking change

None

## Proposed change

Currently, the "favourite" section includes common controls, but it displays all predicted entities as long as they exist in `hass.states`, ignoring the entity registry's `hidden` property. This means entities that users have explicitly hidden (or that integrations have marked as internal/diagnostic) still appear.

This change filters them out if they are hidden to respects user preferences for entity visibility.

Please note that user added favourites will still continue to be shown even if marked as hidden, I think this is desired.

**Implementation details:**
- Adds filtering check using `hass.entities[entity]?.hidden`
- Matches the pattern used in `src/common/entity/entity_filter.ts` (lines 89-91)
- Aligns with behavior in `home-area-view-strategy.ts`, `area-view-strategy.ts`, and `areas-strategy-helper.ts`

## Screenshots

None - this is a filtering logic change with no direct visual changes beyond entities being appropriately filtered from the section.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr