### PR TITLE
Revert "Add vacuum mapping not configured issue"

### DIFF
--- a/src/panels/config/repairs/ha-config-repairs.ts
+++ b/src/panels/config/repairs/ha-config-repairs.ts
@@ -143,8 +143,7 @@ class HaConfigRepairs extends LitElement {
       }
     } else if (
       issue.domain === "vacuum" &&
-      (issue.translation_key === "segments_changed" ||
-        issue.translation_key === "segments_mapping_not_configured")
+      issue.translation_key === "segments_changed"
     ) {
       const data = await fetchRepairsIssueData(
         this.hass.connection,


### PR DESCRIPTION
Reverts home-assistant/frontend#29800 as the core functionality is reverted in https://github.com/home-assistant/core/pull/164259