### PR TITLE
Fix sensor card graph not updating when value is unchanged

### DIFF
--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -214,20 +214,19 @@ export class HuiGraphHeaderFooter
     if (entityHistory?.length) {
       const purgeBeforeTimestamp =
         (Date.now() - this._config.hours_to_show * 60 * 60 * 1000) / 1000;
-      const expiredStates = entityHistory.filter(
-        (entry) => entry.lu < purgeBeforeTimestamp
+      let purgedHistory = entityHistory.filter(
+        (entry) => entry.lu >= purgeBeforeTimestamp
       );
-      if (expiredStates.length) {
-        let purgedHistory = entityHistory.filter(
-          (entry) => entry.lu >= purgeBeforeTimestamp
-        );
+      if (purgedHistory.length !== entityHistory.length) {
         if (
           !purgedHistory.length ||
           purgedHistory[0].lu !== purgeBeforeTimestamp
         ) {
           // Preserve the last expired state as the start boundary
           const lastExpiredState = {
-            ...expiredStates[expiredStates.length - 1],
+            ...entityHistory.findLast(
+              (entry) => entry.lu < purgeBeforeTimestamp
+            )!,
           };
           lastExpiredState.lu = purgeBeforeTimestamp;
           delete lastExpiredState.lc;

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -224,9 +224,7 @@ export class HuiGraphHeaderFooter
         ) {
           // Preserve the last expired state as the start boundary
           const lastExpiredState = {
-            ...entityHistory.findLast(
-              (entry) => entry.lu < purgeBeforeTimestamp
-            )!,
+            ...entityHistory[entityHistory.length - purgedHistory.length - 1],
           };
           lastExpiredState.lu = purgeBeforeTimestamp;
           delete lastExpiredState.lc;

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -6,6 +6,7 @@ import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import "../../../components/ha-spinner";
+import type { HistoryStates } from "../../../data/history";
 import { subscribeHistoryStatesTimeWindow } from "../../../data/history";
 import type { HomeAssistant } from "../../../types";
 import { findEntities } from "../common/find-entities";
@@ -65,6 +66,8 @@ export class HuiGraphHeaderFooter
   @state() private _coordinates?: [number, number][];
 
   private _error?: string;
+
+  private _history?: HistoryStates;
 
   private _interval?: number;
 
@@ -161,24 +164,8 @@ export class HuiGraphHeaderFooter
           // Message came in before we had a chance to unload
           return;
         }
-        const width = this.clientWidth || this.offsetWidth;
-        // sample to 1 point per hour or 1 point per 5 pixels
-        const maxDetails = Math.max(
-          10,
-          this._config.detail! > 1
-            ? Math.max(width / 5, this._config.hours_to_show!)
-            : this._config.hours_to_show!
-        );
-        const useMean = this._config.detail !== 2;
-        const { points } = coordinatesMinimalResponseCompressedState(
-          combinedHistory[this._config.entity],
-          width,
-          width / 5,
-          maxDetails,
-          { minY: this._config.limits?.min, maxY: this._config.limits?.max },
-          useMean
-        );
-        this._coordinates = points;
+        this._history = combinedHistory;
+        this._computeCoordinates();
       },
       this._config.hours_to_show!,
       [this._config.entity]
@@ -190,10 +177,66 @@ export class HuiGraphHeaderFooter
     this._setRedrawTimer();
   }
 
-  private _redrawGraph() {
-    if (this._coordinates) {
-      this._coordinates = [...this._coordinates];
+  private _computeCoordinates() {
+    if (!this._history || !this._config) {
+      return;
     }
+    const entityHistory = this._history[this._config.entity];
+    if (!entityHistory?.length) {
+      return;
+    }
+    const width = this.clientWidth || this.offsetWidth;
+    // sample to 1 point per hour or 1 point per 5 pixels
+    const maxDetails = Math.max(
+      10,
+      this._config.detail! > 1
+        ? Math.max(width / 5, this._config.hours_to_show!)
+        : this._config.hours_to_show!
+    );
+    const useMean = this._config.detail !== 2;
+    const { points } = coordinatesMinimalResponseCompressedState(
+      entityHistory,
+      width,
+      width / 5,
+      maxDetails,
+      { minY: this._config.limits?.min, maxY: this._config.limits?.max },
+      useMean
+    );
+    this._coordinates = points;
+  }
+
+  private _redrawGraph() {
+    if (!this._history || !this._config?.hours_to_show) {
+      return;
+    }
+    const entityId = this._config.entity;
+    const entityHistory = this._history[entityId];
+    if (entityHistory?.length) {
+      const purgeBeforeTimestamp =
+        (Date.now() - this._config.hours_to_show * 60 * 60 * 1000) / 1000;
+      const expiredStates = entityHistory.filter(
+        (entry) => entry.lu < purgeBeforeTimestamp
+      );
+      if (expiredStates.length) {
+        let purgedHistory = entityHistory.filter(
+          (entry) => entry.lu >= purgeBeforeTimestamp
+        );
+        if (
+          !purgedHistory.length ||
+          purgedHistory[0].lu !== purgeBeforeTimestamp
+        ) {
+          // Preserve the last expired state as the start boundary
+          const lastExpiredState = {
+            ...expiredStates[expiredStates.length - 1],
+          };
+          lastExpiredState.lu = purgeBeforeTimestamp;
+          delete lastExpiredState.lc;
+          purgedHistory = [lastExpiredState, ...purgedHistory];
+        }
+        this._history = { ...this._history, [entityId]: purgedHistory };
+      }
+    }
+    this._computeCoordinates();
   }
 
   private _setRedrawTimer() {
@@ -211,6 +254,7 @@ export class HuiGraphHeaderFooter
       this._subscribed.then((unsub) => unsub?.());
       this._subscribed = undefined;
     }
+    this._history = undefined;
   }
 
   protected updated(changedProps: PropertyValues) {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The `_redrawGraph` timer only cloned the coordinates array reference without recomputing from history data, so the time window never shifted forward.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29883
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
