### PR TITLE
Allow trace graph to scroll independently of the step-details tab

### DIFF
--- a/src/components/trace/hat-script-graph.ts
+++ b/src/components/trace/hat-script-graph.ts
@@ -642,6 +642,20 @@ export class HatScriptGraph extends LitElement {
   protected updated(changedProps: PropertyValues<this>) {
     super.updated(changedProps);
 
+    if (!changedProps.has("trace") && !changedProps.has("selected")) {
+      return;
+    }
+
+    // Scroll to active node when selection changes
+    if (changedProps.has("selected")) {
+      const activeNode = this.renderRoot.querySelector(
+        "hat-graph-node[active], hat-graph-branch[active]"
+      ) as HTMLElement;
+      if (activeNode) {
+        activeNode.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      }
+    }
+
     if (!changedProps.has("trace")) {
       return;
     }

--- a/src/components/trace/hat-script-graph.ts
+++ b/src/components/trace/hat-script-graph.ts
@@ -8,8 +8,6 @@ import {
   mdiCallSplit,
   mdiCheckboxBlankOutline,
   mdiCheckboxMarkedOutline,
-  mdiChevronDown,
-  mdiChevronUp,
   mdiClose,
   mdiCodeBraces,
   mdiCodeBrackets,
@@ -45,7 +43,6 @@ import type {
   TraceExtended,
 } from "../../data/trace";
 import type { HomeAssistant } from "../../types";
-import "../ha-icon-button";
 import "../ha-service-icon";
 import "./hat-graph-branch";
 import { BRANCH_HEIGHT, NODE_SIZE, SPACING } from "./hat-graph-const";
@@ -588,7 +585,6 @@ export class HatScriptGraph extends LitElement {
       "conditions" in this.trace.config ? "conditions" : "condition";
     const actionKey = "actions" in this.trace.config ? "actions" : "action";
 
-    const paths = Object.keys(this.trackedNodes);
     const triggerNodes =
       triggerKey in this.trace.config
         ? flattenTriggers(ensureArray(this.trace.config[triggerKey])).map(
@@ -619,19 +615,6 @@ export class HatScriptGraph extends LitElement {
                   this._renderActionNode(action, `sequence/${i}`, i === 0)
               )}`
             : ""}
-        </div>
-        <div class="actions">
-          <ha-icon-button
-            .disabled=${paths.length === 0 || paths[0] === this.selected}
-            @click=${this._previousTrackedNode}
-            .path=${mdiChevronUp}
-          ></ha-icon-button>
-          <ha-icon-button
-            .disabled=${paths.length === 0 ||
-            paths[paths.length - 1] === this.selected}
-            @click=${this._nextTrackedNode}
-            .path=${mdiChevronDown}
-          ></ha-icon-button>
         </div>
       `;
     } catch (err: any) {
@@ -689,7 +672,7 @@ export class HatScriptGraph extends LitElement {
     }
   }
 
-  private _previousTrackedNode() {
+  public previousTrackedNode() {
     const nodes = Object.keys(this.trackedNodes);
     const prevIndex = nodes.indexOf(this.selected!) - 1;
     if (prevIndex >= 0) {
@@ -701,7 +684,7 @@ export class HatScriptGraph extends LitElement {
     }
   }
 
-  private _nextTrackedNode() {
+  public nextTrackedNode() {
     const nodes = Object.keys(this.trackedNodes);
     const nextIndex = nodes.indexOf(this.selected!) + 1;
     if (nextIndex < nodes.length) {
@@ -738,10 +721,6 @@ export class HatScriptGraph extends LitElement {
         display: flex;
         flex-direction: column;
         align-items: center;
-      }
-      .actions {
-        display: flex;
-        flex-direction: column;
       }
       .parent {
         margin-left: 8px;

--- a/src/components/trace/hat-script-graph.ts
+++ b/src/components/trace/hat-script-graph.ts
@@ -8,6 +8,8 @@ import {
   mdiCallSplit,
   mdiCheckboxBlankOutline,
   mdiCheckboxMarkedOutline,
+  mdiChevronDown,
+  mdiChevronUp,
   mdiClose,
   mdiCodeBraces,
   mdiCodeBrackets,
@@ -43,6 +45,7 @@ import type {
   TraceExtended,
 } from "../../data/trace";
 import type { HomeAssistant } from "../../types";
+import "../ha-icon-button";
 import "../ha-service-icon";
 import "./hat-graph-branch";
 import { BRANCH_HEIGHT, NODE_SIZE, SPACING } from "./hat-graph-const";
@@ -585,6 +588,7 @@ export class HatScriptGraph extends LitElement {
       "conditions" in this.trace.config ? "conditions" : "condition";
     const actionKey = "actions" in this.trace.config ? "actions" : "action";
 
+    const paths = Object.keys(this.trackedNodes);
     const triggerNodes =
       triggerKey in this.trace.config
         ? flattenTriggers(ensureArray(this.trace.config[triggerKey])).map(
@@ -593,28 +597,43 @@ export class HatScriptGraph extends LitElement {
         : undefined;
     try {
       return html`
-        <div class="parent graph-container">
-          ${triggerNodes
-            ? html`<hat-graph-branch start .short=${triggerNodes.length < 2}>
-                ${triggerNodes}
-              </hat-graph-branch>`
-            : ""}
-          ${conditionKey in this.trace.config
-            ? html`${ensureArray(this.trace.config[conditionKey])?.map(
-                (condition, i) => this._renderCondition(condition, i)
-              )}`
-            : ""}
-          ${actionKey in this.trace.config
-            ? html`${ensureArray(this.trace.config[actionKey]).map(
-                (action, i) => this._renderActionNode(action, `action/${i}`)
-              )}`
-            : ""}
-          ${"sequence" in this.trace.config
-            ? html`${ensureArray<Action>(this.trace.config.sequence).map(
-                (action, i) =>
-                  this._renderActionNode(action, `sequence/${i}`, i === 0)
-              )}`
-            : ""}
+        <div class="graph-scroll ha-scrollbar">
+          <div class="parent graph-container">
+            ${triggerNodes
+              ? html`<hat-graph-branch start .short=${triggerNodes.length < 2}>
+                  ${triggerNodes}
+                </hat-graph-branch>`
+              : ""}
+            ${conditionKey in this.trace.config
+              ? html`${ensureArray(this.trace.config[conditionKey])?.map(
+                  (condition, i) => this._renderCondition(condition, i)
+                )}`
+              : ""}
+            ${actionKey in this.trace.config
+              ? html`${ensureArray(this.trace.config[actionKey]).map(
+                  (action, i) => this._renderActionNode(action, `action/${i}`)
+                )}`
+              : ""}
+            ${"sequence" in this.trace.config
+              ? html`${ensureArray<Action>(this.trace.config.sequence).map(
+                  (action, i) =>
+                    this._renderActionNode(action, `sequence/${i}`, i === 0)
+                )}`
+              : ""}
+          </div>
+        </div>
+        <div class="actions">
+          <ha-icon-button
+            .disabled=${paths.length === 0 || paths[0] === this.selected}
+            @click=${this._previousTrackedNode}
+            .path=${mdiChevronUp}
+          ></ha-icon-button>
+          <ha-icon-button
+            .disabled=${paths.length === 0 ||
+            paths[paths.length - 1] === this.selected}
+            @click=${this._nextTrackedNode}
+            .path=${mdiChevronDown}
+          ></ha-icon-button>
         </div>
       `;
     } catch (err: any) {
@@ -686,7 +705,7 @@ export class HatScriptGraph extends LitElement {
     }
   }
 
-  public previousTrackedNode() {
+  private _previousTrackedNode() {
     const nodes = Object.keys(this.trackedNodes);
     const prevIndex = nodes.indexOf(this.selected!) - 1;
     if (prevIndex >= 0) {
@@ -698,7 +717,7 @@ export class HatScriptGraph extends LitElement {
     }
   }
 
-  public nextTrackedNode() {
+  private _nextTrackedNode() {
     const nodes = Object.keys(this.trackedNodes);
     const nextIndex = nodes.indexOf(this.selected!) + 1;
     if (nextIndex < nodes.length) {
@@ -714,6 +733,8 @@ export class HatScriptGraph extends LitElement {
     return css`
       :host {
         display: flex;
+        flex-direction: row;
+        overflow: hidden;
         --stroke-clr: var(--stroke-color, var(--secondary-text-color));
         --active-clr: var(--active-color, var(--primary-color));
         --track-clr: var(--track-color, var(--accent-color));
@@ -731,10 +752,19 @@ export class HatScriptGraph extends LitElement {
         --hat-graph-node-size: ${NODE_SIZE}px;
         --hat-graph-branch-height: ${BRANCH_HEIGHT}px;
       }
+      .graph-scroll {
+        flex: 1;
+        overflow: auto;
+        min-width: 0;
+      }
       .graph-container {
         display: flex;
         flex-direction: column;
         align-items: center;
+      }
+      .actions {
+        display: flex;
+        flex-direction: column;
       }
       .parent {
         margin-left: 8px;

--- a/src/layouts/hass-subpage.ts
+++ b/src/layouts/hass-subpage.ts
@@ -23,6 +23,8 @@ class HassSubpage extends LitElement {
 
   @property({ type: Boolean, reflect: true }) public narrow = false;
 
+  @property({ type: Boolean }) public scrollable = true;
+
   // @ts-ignore
   @restoreScroll(".content") private _savedScrollPos?: number;
 
@@ -57,7 +59,14 @@ class HassSubpage extends LitElement {
           <slot name="toolbar-icon"></slot>
         </div>
       </div>
-      <div class="content ha-scrollbar" @scroll=${this._saveScrollPos}>
+      <div
+        class=${classMap({
+          content: true,
+          "ha-scrollbar": this.scrollable,
+          "not-scrollable": !this.scrollable,
+        })}
+        @scroll=${this._saveScrollPos}
+      >
         <slot></slot>
       </div>
       <div id="fab">
@@ -163,6 +172,12 @@ class HassSubpage extends LitElement {
           overflow: auto;
           -webkit-overflow-scrolling: touch;
         }
+        .not-scrollable {
+          overflow: hidden;
+          display: flex;
+          flex-direction: column;
+        }
+
         :host([narrow]) .content {
           width: calc(
             100% - var(--safe-area-inset-left, 0px) - var(

--- a/src/layouts/hass-subpage.ts
+++ b/src/layouts/hass-subpage.ts
@@ -172,7 +172,7 @@ class HassSubpage extends LitElement {
           overflow: auto;
           -webkit-overflow-scrolling: touch;
         }
-        .not-scrollable {
+        .content.not-scrollable {
           overflow: hidden;
           display: flex;
           flex-direction: column;

--- a/src/panels/config/automation/ha-automation-trace.ts
+++ b/src/panels/config/automation/ha-automation-trace.ts
@@ -1,7 +1,5 @@
 import "@home-assistant/webawesome/dist/components/divider/divider";
 import {
-  mdiChevronDown,
-  mdiChevronUp,
   mdiDotsVertical,
   mdiDownload,
   mdiInformationOutline,
@@ -231,24 +229,6 @@ export class HaAutomationTrace extends LitElement {
                         .selected=${this._selected?.path}
                         @graph-node-selected=${this._pickNode}
                       ></hat-script-graph>
-                      <div class="graph-nav-overlay">
-                        <ha-icon-button
-                          .disabled=${!trackedNodes ||
-                          Object.keys(trackedNodes).length === 0 ||
-                          Object.keys(trackedNodes)[0] === this._selected?.path}
-                          @click=${this._selectPrevNode}
-                          .path=${mdiChevronUp}
-                        ></ha-icon-button>
-                        <ha-icon-button
-                          .disabled=${!trackedNodes ||
-                          Object.keys(trackedNodes).length === 0 ||
-                          Object.keys(trackedNodes)[
-                            Object.keys(trackedNodes).length - 1
-                          ] === this._selected?.path}
-                          @click=${this._selectNextNode}
-                          .path=${mdiChevronDown}
-                        ></ha-icon-button>
-                      </div>
                     </div>
 
                     <div class="info">
@@ -513,14 +493,6 @@ export class HaAutomationTrace extends LitElement {
     this._logbookEntries = traceInfo.logbookEntries;
   }
 
-  private _selectPrevNode() {
-    this._graph?.previousTrackedNode();
-  }
-
-  private _selectNextNode() {
-    this._graph?.nextTrackedNode();
-  }
-
   private _showTab(ev: Event) {
     this._view = (ev.target as any).view;
   }
@@ -615,28 +587,22 @@ export class HaAutomationTrace extends LitElement {
           max-width: 50%;
           box-sizing: border-box;
           display: flex;
-          flex-direction: row;
+          flex-direction: column;
           overflow: hidden;
         }
         hat-script-graph {
           flex: 1;
-          overflow: auto;
           min-width: 0;
+          min-height: 0;
         }
         :host([narrow]) .graph {
           max-width: 100%;
           overflow: visible;
           height: auto;
-          flex-direction: column;
         }
         :host([narrow]) hat-script-graph {
           overflow: visible;
           flex: none;
-        }
-        .graph-nav-overlay {
-          display: flex;
-          flex-direction: column;
-          flex-shrink: 0;
         }
         .info {
           flex: 1;

--- a/src/panels/config/automation/ha-automation-trace.ts
+++ b/src/panels/config/automation/ha-automation-trace.ts
@@ -1,5 +1,7 @@
 import "@home-assistant/webawesome/dist/components/divider/divider";
 import {
+  mdiChevronDown,
+  mdiChevronUp,
   mdiDotsVertical,
   mdiDownload,
   mdiInformationOutline,
@@ -101,7 +103,12 @@ export class HaAutomationTrace extends LitElement {
 
     return html`
       ${devButtons}
-      <hass-subpage .hass=${this.hass} .narrow=${this.narrow} .header=${title}>
+      <hass-subpage
+        .hass=${this.hass}
+        .narrow=${this.narrow}
+        .header=${title}
+        .scrollable=${this.narrow}
+      >
         ${!this.narrow && stateObj?.attributes.id
           ? html`
               <ha-button
@@ -224,6 +231,24 @@ export class HaAutomationTrace extends LitElement {
                         .selected=${this._selected?.path}
                         @graph-node-selected=${this._pickNode}
                       ></hat-script-graph>
+                      <div class="graph-nav-overlay">
+                        <ha-icon-button
+                          .disabled=${!trackedNodes ||
+                          Object.keys(trackedNodes).length === 0 ||
+                          Object.keys(trackedNodes)[0] === this._selected?.path}
+                          @click=${this._selectPrevNode}
+                          .path=${mdiChevronUp}
+                        ></ha-icon-button>
+                        <ha-icon-button
+                          .disabled=${!trackedNodes ||
+                          Object.keys(trackedNodes).length === 0 ||
+                          Object.keys(trackedNodes)[
+                            Object.keys(trackedNodes).length - 1
+                          ] === this._selected?.path}
+                          @click=${this._selectNextNode}
+                          .path=${mdiChevronDown}
+                        ></ha-icon-button>
+                      </div>
                     </div>
 
                     <div class="info">
@@ -488,6 +513,14 @@ export class HaAutomationTrace extends LitElement {
     this._logbookEntries = traceInfo.logbookEntries;
   }
 
+  private _selectPrevNode() {
+    this._graph?.previousTrackedNode();
+  }
+
+  private _selectNextNode() {
+    this._graph?.nextTrackedNode();
+  }
+
   private _showTab(ev: Event) {
     this._view = (ev.target as any).view;
   }
@@ -558,15 +591,19 @@ export class HaAutomationTrace extends LitElement {
         }
 
         .main {
-          min-height: calc(100% - var(--header-height));
+          flex: 1;
+          min-height: 0;
           display: flex;
+          overflow: hidden;
           background-color: var(--card-background-color);
           direction: ltr;
         }
 
         :host([narrow]) .main {
+          flex: none;
           height: auto;
           flex-direction: column;
+          overflow: visible;
         }
 
         .container {
@@ -575,18 +612,39 @@ export class HaAutomationTrace extends LitElement {
 
         .graph {
           border-right: 1px solid var(--divider-color);
-          overflow-x: auto;
           max-width: 50%;
-          padding-bottom: 16px;
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          overflow: hidden;
+        }
+        hat-script-graph {
+          flex: 1;
+          overflow: auto;
+          min-width: 0;
         }
         :host([narrow]) .graph {
           max-width: 100%;
-          justify-content: center;
+          overflow: visible;
+          height: auto;
+          flex-direction: column;
+        }
+        :host([narrow]) hat-script-graph {
+          overflow: visible;
+          flex: none;
+        }
+        .graph-nav-overlay {
           display: flex;
+          flex-direction: column;
+          flex-shrink: 0;
         }
         .info {
           flex: 1;
+          overflow-y: auto;
           background-color: var(--card-background-color);
+        }
+        :host([narrow]) .info {
+          overflow: visible;
         }
         .trace-link {
           text-decoration: none;

--- a/src/panels/config/script/ha-script-trace.ts
+++ b/src/panels/config/script/ha-script-trace.ts
@@ -1,7 +1,5 @@
 import "@home-assistant/webawesome/dist/components/divider/divider";
 import {
-  mdiChevronDown,
-  mdiChevronUp,
   mdiDotsVertical,
   mdiDownload,
   mdiInformationOutline,
@@ -225,24 +223,6 @@ export class HaScriptTrace extends LitElement {
                         .selected=${this._selected?.path}
                         @graph-node-selected=${this._pickNode}
                       ></hat-script-graph>
-                      <div class="graph-nav-overlay">
-                        <ha-icon-button
-                          .disabled=${!trackedNodes ||
-                          Object.keys(trackedNodes).length === 0 ||
-                          Object.keys(trackedNodes)[0] === this._selected?.path}
-                          @click=${this._selectPrevNode}
-                          .path=${mdiChevronUp}
-                        ></ha-icon-button>
-                        <ha-icon-button
-                          .disabled=${!trackedNodes ||
-                          Object.keys(trackedNodes).length === 0 ||
-                          Object.keys(trackedNodes)[
-                            Object.keys(trackedNodes).length - 1
-                          ] === this._selected?.path}
-                          @click=${this._selectNextNode}
-                          .path=${mdiChevronDown}
-                        ></ha-icon-button>
-                      </div>
                     </div>
 
                     <div class="info">
@@ -415,14 +395,6 @@ export class HaScriptTrace extends LitElement {
 
   private _pickNode(ev) {
     this._selected = ev.detail;
-  }
-
-  private _selectPrevNode() {
-    this._graph?.previousTrackedNode();
-  }
-
-  private _selectNextNode() {
-    this._graph?.nextTrackedNode();
   }
 
   private _refreshTraces() {
@@ -621,28 +593,22 @@ export class HaScriptTrace extends LitElement {
           max-width: 50%;
           box-sizing: border-box;
           display: flex;
-          flex-direction: row;
+          flex-direction: column;
           overflow: hidden;
         }
         hat-script-graph {
           flex: 1;
-          overflow: auto;
           min-width: 0;
+          min-height: 0;
         }
         :host([narrow]) .graph {
           max-width: 100%;
           overflow: visible;
           height: auto;
-          flex-direction: column;
         }
         :host([narrow]) hat-script-graph {
           overflow: visible;
           flex: none;
-        }
-        .graph-nav-overlay {
-          display: flex;
-          flex-direction: column;
-          flex-shrink: 0;
         }
         .info {
           flex: 1;

--- a/src/panels/config/script/ha-script-trace.ts
+++ b/src/panels/config/script/ha-script-trace.ts
@@ -1,5 +1,7 @@
 import "@home-assistant/webawesome/dist/components/divider/divider";
 import {
+  mdiChevronDown,
+  mdiChevronUp,
   mdiDotsVertical,
   mdiDownload,
   mdiInformationOutline,
@@ -103,7 +105,12 @@ export class HaScriptTrace extends LitElement {
 
     return html`
       ${devButtons}
-      <hass-subpage .hass=${this.hass} .narrow=${this.narrow} .header=${title}>
+      <hass-subpage
+        .hass=${this.hass}
+        .narrow=${this.narrow}
+        .header=${title}
+        .scrollable=${this.narrow}
+      >
         ${!this.narrow && this.scriptId
           ? html`
               <ha-button
@@ -218,6 +225,24 @@ export class HaScriptTrace extends LitElement {
                         .selected=${this._selected?.path}
                         @graph-node-selected=${this._pickNode}
                       ></hat-script-graph>
+                      <div class="graph-nav-overlay">
+                        <ha-icon-button
+                          .disabled=${!trackedNodes ||
+                          Object.keys(trackedNodes).length === 0 ||
+                          Object.keys(trackedNodes)[0] === this._selected?.path}
+                          @click=${this._selectPrevNode}
+                          .path=${mdiChevronUp}
+                        ></ha-icon-button>
+                        <ha-icon-button
+                          .disabled=${!trackedNodes ||
+                          Object.keys(trackedNodes).length === 0 ||
+                          Object.keys(trackedNodes)[
+                            Object.keys(trackedNodes).length - 1
+                          ] === this._selected?.path}
+                          @click=${this._selectNextNode}
+                          .path=${mdiChevronDown}
+                        ></ha-icon-button>
+                      </div>
                     </div>
 
                     <div class="info">
@@ -390,6 +415,14 @@ export class HaScriptTrace extends LitElement {
 
   private _pickNode(ev) {
     this._selected = ev.detail;
+  }
+
+  private _selectPrevNode() {
+    this._graph?.previousTrackedNode();
+  }
+
+  private _selectNextNode() {
+    this._graph?.nextTrackedNode();
   }
 
   private _refreshTraces() {
@@ -565,14 +598,18 @@ export class HaScriptTrace extends LitElement {
         }
 
         .main {
-          min-height: calc(100% - var(--header-height));
+          flex: 1;
+          min-height: 0;
           display: flex;
+          overflow: hidden;
           background-color: var(--card-background-color);
         }
 
         :host([narrow]) .main {
+          flex: none;
           height: auto;
           flex-direction: column;
+          overflow: visible;
         }
 
         .container {
@@ -581,15 +618,39 @@ export class HaScriptTrace extends LitElement {
 
         .graph {
           border-right: 1px solid var(--divider-color);
-          overflow-x: auto;
           max-width: 50%;
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          overflow: hidden;
+        }
+        hat-script-graph {
+          flex: 1;
+          overflow: auto;
+          min-width: 0;
         }
         :host([narrow]) .graph {
           max-width: 100%;
+          overflow: visible;
+          height: auto;
+          flex-direction: column;
+        }
+        :host([narrow]) hat-script-graph {
+          overflow: visible;
+          flex: none;
+        }
+        .graph-nav-overlay {
+          display: flex;
+          flex-direction: column;
+          flex-shrink: 0;
         }
         .info {
           flex: 1;
+          overflow-y: auto;
           background-color: var(--card-background-color);
+        }
+        :host([narrow]) .info {
+          overflow: visible;
         }
         .trace-link {
           text-decoration: none;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When navigating a trace for an automation, especially big, complex automations, the graph on the left and the panel on the right are basically unusable together. Navigating on the graph requires you to scroll the whole panel away from what you are looking at, and then scrolling back to see the yaml/variables etc.

If we separate the scrolling on the graph (left) and the data panel (right), then we can more easily debug large automations.

If we take it one step further, we can make the up/down buttons on the graph float, and make them scroll to the selected node when pressed.

**Mobile Note**  - I tested this briefly on Chromium with mobile dimensions, and while it isn't improved on a mobile device, it doesn't seem worse or even any different than it currently is. I think making this interface useful on mobile is a bigger ask - visiting between the graph and the details by scrolling up and down on a phone is pretty poor.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Before:

https://github.com/user-attachments/assets/bb4a731a-d1a8-459b-b944-dcfed9abff45

After:

https://github.com/user-attachments/assets/015c589f-910b-41d9-9ad4-f61cf02af0ad


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

**I have to be entirely honest here** - this change was written entirely using Claude code. I am not a frontend engineer, and am not comfortable owning this code. Grokking existing patterns in the frontend code would be a large task for me to get correct. 

I am not thrilled with it changing the access patterns of the up/down to public, and moving that to an entirely new file, it seems perhaps there could be a cleaner way to achieve the same thing that someone intimate with this code may be able to achieve quickly. I believe that change happened in it's attempt to get the buttons floating on the right of the graph, rather than fixed at the top of the graph.

I am not comfortable saying I entirely understand the code, mostly because CSS is my weakness.

That said, I think this PR, or really, the end state (who cares about the code that AI has written), is quite an improvement on the user experience of the Automation trace tab.

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
