### PR TITLE
Fix sidebar not closing when reduced motion is enabled

### DIFF
--- a/src/components/ha-drawer.ts
+++ b/src/components/ha-drawer.ts
@@ -186,9 +186,11 @@ export class HaDrawer extends DrawerBase {
           padding-inline-start var(--ha-animation-duration-normal) ease;
       }
       @media (prefers-reduced-motion: reduce) {
+        /* Use 1ms instead of "none" so the transitionend event still fires.
+           The MDC drawer foundation relies on it to complete the close cycle. */
         .mdc-drawer,
         .mdc-drawer-app-content {
-          transition: none;
+          transition: 1ms;
         }
       }
     `,


### PR DESCRIPTION
## Proposed change

Fix the sidebar not closing on devices with `prefers-reduced-motion: reduce` enabled.

The MDC drawer foundation relies on `transitionend` CSS events to complete its open/close state machine. When `transition: none` was set for reduced motion, no transition event fired, leaving the drawer stuck in the closing state with the scrim blocking all interaction.

Using `transition: 1ms` instead ensures the event fires (imperceptibly) while still respecting the reduced motion preference.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #29875
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
