### PR TITLE
Fix updates, discovered devices and repairs cards flickering

### DIFF
--- a/src/panels/lovelace/cards/hui-discovered-devices-card.ts
+++ b/src/panels/lovelace/cards/hui-discovered-devices-card.ts
@@ -131,9 +131,10 @@ export class HuiDiscoveredDevicesCard
     }
 
     // Update visibility based on admin status and discovered devices count
-    const shouldBeHidden =
+    const shouldBeHidden = Boolean(
       !this.hass.user?.is_admin ||
-      (this._config.hide_empty && this._discoveredFlows.length === 0);
+      (this._config.hide_empty && this._discoveredFlows.length === 0)
+    );
 
     if (shouldBeHidden !== this.hidden) {
       this.style.display = shouldBeHidden ? "none" : "";

--- a/src/panels/lovelace/cards/hui-repairs-card.ts
+++ b/src/panels/lovelace/cards/hui-repairs-card.ts
@@ -97,9 +97,10 @@ export class HuiRepairsCard
     }
 
     // Update visibility based on admin status and repairs count
-    const shouldBeHidden =
+    const shouldBeHidden = Boolean(
       !this.hass.user?.is_admin ||
-      (this._config.hide_empty && this._repairsIssues.length === 0);
+      (this._config.hide_empty && this._repairsIssues.length === 0)
+    );
 
     if (shouldBeHidden !== this.hidden) {
       this.style.display = shouldBeHidden ? "none" : "";

--- a/src/panels/lovelace/cards/hui-updates-card.ts
+++ b/src/panels/lovelace/cards/hui-updates-card.ts
@@ -91,9 +91,10 @@ export class HuiUpdatesCard extends LitElement implements LovelaceCard {
     const updateEntities = this._getUpdateEntities();
 
     // Update visibility based on admin status and updates count
-    const shouldBeHidden =
+    const shouldBeHidden = Boolean(
       !this.hass.user?.is_admin ||
-      (this._config.hide_empty && updateEntities.length === 0);
+      (this._config.hide_empty && updateEntities.length === 0)
+    );
 
     if (shouldBeHidden !== this.hidden) {
       this.style.display = shouldBeHidden ? "none" : "";
@@ -103,7 +104,7 @@ export class HuiUpdatesCard extends LitElement implements LovelaceCard {
   }
 
   protected render(): TemplateResult | typeof nothing {
-    if (!this._config || !this.hass || this.hidden) {
+    if (!this._config || !this.hass) {
       return nothing;
     }
 


### PR DESCRIPTION
## Proposed change

Fix updates, repairs, and discovered devices cards flickering on every Home Assistant state update.

The `shouldBeHidden` visibility check could evaluate to `undefined` instead of `false` when `hide_empty` was not set in the config. Since `undefined !== false` is always `true`, the visibility toggle ran on every update cycle, causing an infinite flicker loop.

Wrap the expression in `Boolean()` to ensure `shouldBeHidden` is always a proper boolean. Also remove the redundant `this.hidden` check from the updates card `render()` method — the card should always render its content and rely on `display: none` for hiding.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
