### PR TITLE
Add force-arm checkbox and status message to alarm control panel

### DIFF
--- a/src/data/alarm_control_panel.ts
+++ b/src/data/alarm_control_panel.ts
@@ -12,6 +12,7 @@ import type {
 } from "home-assistant-js-websocket";
 import { supportsFeature } from "../common/entity/supports-feature";
 import { showEnterCodeDialog } from "../dialogs/enter-code/show-enter-code-dialog";
+import type { EnterCodeDialogParams } from "../dialogs/enter-code/show-enter-code-dialog";
 import type { HomeAssistant } from "../types";
 import { getExtendedEntityRegistryEntry } from "./entity/entity_registry";
 
@@ -31,6 +32,8 @@ interface AlarmControlPanelEntityAttributes extends HassEntityAttributeBase {
   code_format?: "text" | "number";
   changed_by?: string | null;
   code_arm_required?: boolean;
+  force_arm_available?: boolean;
+  status_message?: string | null;
 }
 
 export interface AlarmControlPanelEntity extends HassEntityBase {
@@ -47,11 +50,13 @@ export const callAlarmAction = (
     | "arm_vacation"
     | "arm_custom_bypass"
     | "disarm",
-  code?: string
+  code?: string,
+  forceArm?: boolean
 ) => {
   hass!.callService("alarm_control_panel", `alarm_${action}`, {
     entity_id: entity,
     code,
+    ...(forceArm ? { force_arm: true } : {}),
   });
 };
 
@@ -110,11 +115,13 @@ export const setProtectedAlarmControlPanelMode = async (
   element: HTMLElement,
   hass: HomeAssistant,
   stateObj: AlarmControlPanelEntity,
-  mode: AlarmMode
+  mode: AlarmMode,
+  forceArm?: boolean
 ) => {
   const { service } = ALARM_MODES[mode];
 
   let code: string | undefined;
+  let actualForceArm = forceArm;
 
   if (
     (mode !== "disarmed" &&
@@ -130,8 +137,9 @@ export const setProtectedAlarmControlPanelMode = async (
 
     if (!defaultCode) {
       const disarm = mode === "disarmed";
+      const showForceArm = !disarm && !!stateObj.attributes.force_arm_available;
 
-      const response = await showEnterCodeDialog(element, {
+      const dialogParams: EnterCodeDialogParams = {
         codeFormat: stateObj.attributes.code_format,
         title: hass.localize(
           `ui.card.alarm_control_panel.${disarm ? "disarm" : "arm"}`
@@ -139,16 +147,23 @@ export const setProtectedAlarmControlPanelMode = async (
         submitText: hass.localize(
           `ui.card.alarm_control_panel.${disarm ? "disarm" : "arm"}`
         ),
-      });
+        showForceArm,
+      };
+
+      const response = await showEnterCodeDialog(element, dialogParams);
       if (response == null) {
         throw new Error("Code dialog closed");
       }
       code = response;
+      if (showForceArm) {
+        actualForceArm = dialogParams.forceArm;
+      }
     }
   }
 
   await hass.callService("alarm_control_panel", service, {
     entity_id: stateObj.entity_id,
     code,
+    ...(actualForceArm ? { force_arm: true } : {}),
   });
 };

--- a/src/dialogs/enter-code/dialog-enter-code.ts
+++ b/src/dialogs/enter-code/dialog-enter-code.ts
@@ -4,8 +4,10 @@ import { customElement, property, query, state } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
 import { fireEvent } from "../../common/dom/fire_event";
 import "../../components/ha-button";
+import "../../components/ha-checkbox";
 import "../../components/ha-control-button";
 import "../../components/ha-dialog-footer";
+import "../../components/ha-formfield";
 import "../../components/ha-textfield";
 import "../../components/ha-dialog";
 import type { HaTextField } from "../../components/ha-textfield";
@@ -45,12 +47,15 @@ export class DialogEnterCode
 
   @state() private _narrow = false;
 
+  @state() private _forceArm = false;
+
   private _closeAction?: "submit" | "cancel";
 
   public async showDialog(dialogParams: EnterCodeDialogParams): Promise<void> {
     this._dialogParams = dialogParams;
     this._open = true;
     this._showClearButton = false;
+    this._forceArm = false;
     this._closeAction = undefined;
     this._narrow = matchMedia(
       "all and (max-width: 450px), all and (max-height: 500px)"
@@ -74,6 +79,9 @@ export class DialogEnterCode
   }
 
   private _submit(): void {
+    if (this._dialogParams?.showForceArm) {
+      this._dialogParams.forceArm = this._forceArm;
+    }
     this._dialogParams?.submit?.(this._input?.value ?? "");
     this._closeAction = "submit";
     this.closeDialog();
@@ -100,6 +108,26 @@ export class DialogEnterCode
     const field = e.currentTarget as HaTextField;
     const val = field.value;
     this._showClearButton = !!val;
+  }
+
+  private _forceArmChanged(ev: Event): void {
+    this._forceArm = (ev.target as any).checked;
+  }
+
+  private _renderForceArm() {
+    if (!this._dialogParams?.showForceArm) {
+      return nothing;
+    }
+    return html`
+      <ha-formfield
+        .label=${this.hass!.localize("ui.card.alarm_control_panel.force_arm")}
+      >
+        <ha-checkbox
+          .checked=${this._forceArm}
+          @change=${this._forceArmChanged}
+        ></ha-checkbox>
+      </ha-formfield>
+    `;
   }
 
   protected render() {
@@ -130,6 +158,7 @@ export class DialogEnterCode
             pattern=${ifDefined(this._dialogParams.codePattern)}
             inputmode="text"
           ></ha-textfield>
+          ${this._renderForceArm()}
           <ha-dialog-footer slot="footer">
             <ha-button
               slot="secondaryAction"
@@ -165,6 +194,7 @@ export class DialogEnterCode
             inputmode="numeric"
             ?autofocus=${!this._narrow}
           ></ha-textfield>
+          ${this._renderForceArm()}
           <div class="keypad">
             ${BUTTONS.map((value) =>
               value === ""
@@ -215,6 +245,10 @@ export class DialogEnterCode
     ha-textfield {
       width: 100%;
       margin: auto;
+    }
+    ha-formfield {
+      display: block;
+      margin-top: 8px;
     }
     .container {
       display: flex;

--- a/src/dialogs/enter-code/show-enter-code-dialog.ts
+++ b/src/dialogs/enter-code/show-enter-code-dialog.ts
@@ -6,6 +6,8 @@ export interface EnterCodeDialogParams {
   submitText?: string;
   cancelText?: string;
   title?: string;
+  showForceArm?: boolean;
+  forceArm?: boolean;
   submit?: (code?: string) => void;
   cancel?: () => void;
 }

--- a/src/dialogs/more-info/controls/more-info-alarm_control_panel.ts
+++ b/src/dialogs/more-info/controls/more-info-alarm_control_panel.ts
@@ -1,12 +1,16 @@
-import type { CSSResultGroup } from "lit";
+import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import { stateColorCss } from "../../../common/entity/state_color";
+import "../../../components/ha-alert";
+import "../../../components/ha-checkbox";
 import "../../../components/ha-control-button";
+import "../../../components/ha-formfield";
 import "../../../components/ha-state-icon";
 import type { AlarmControlPanelEntity } from "../../../data/alarm_control_panel";
 import { setProtectedAlarmControlPanelMode } from "../../../data/alarm_control_panel";
+import { getExtendedEntityRegistryEntry } from "../../../data/entity/entity_registry";
 import "../../../state-control/alarm_control_panel/ha-state-control-alarm_control_panel-modes";
 import type { HomeAssistant } from "../../../types";
 import "../components/ha-more-info-state-header";
@@ -17,6 +21,41 @@ class MoreInfoAlarmControlPanel extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public stateObj?: AlarmControlPanelEntity;
+
+  @state() private _forceArm = false;
+
+  @state() private _codeRequired?: boolean;
+
+  private async _updateCodeRequired() {
+    if (!this.stateObj || !this.hass) {
+      this._codeRequired = undefined;
+      return;
+    }
+    if (
+      !this.stateObj.attributes.code_arm_required ||
+      !this.stateObj.attributes.code_format
+    ) {
+      this._codeRequired = false;
+      return;
+    }
+    const entry = await getExtendedEntityRegistryEntry(
+      this.hass,
+      this.stateObj.entity_id
+    ).catch(() => undefined);
+    const defaultCode = entry?.options?.alarm_control_panel?.default_code;
+    this._codeRequired = !defaultCode;
+  }
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    if (changedProps.has("stateObj")) {
+      this._forceArm = false;
+      this._updateCodeRequired();
+    }
+  }
+
+  private _forceArmChanged(ev: Event): void {
+    this._forceArm = (ev.target as any).checked;
+  }
 
   private async _disarm() {
     setProtectedAlarmControlPanelMode(
@@ -41,6 +80,28 @@ class MoreInfoAlarmControlPanel extends LitElement {
         .hass=${this.hass}
         .stateObj=${this.stateObj}
       ></ha-more-info-state-header>
+      ${this.stateObj.attributes.status_message
+        ? html`
+            <ha-alert alert-type="warning">
+              ${this.stateObj.attributes.status_message}
+            </ha-alert>
+          `
+        : nothing}
+      ${this.stateObj.attributes.force_arm_available &&
+      this._codeRequired === false
+        ? html`
+            <ha-formfield
+              .label=${this.hass.localize(
+                "ui.card.alarm_control_panel.force_arm"
+              )}
+            >
+              <ha-checkbox
+                .checked=${this._forceArm}
+                @change=${this._forceArmChanged}
+              ></ha-checkbox>
+            </ha-formfield>
+          `
+        : nothing}
       <div class="controls" style=${styleMap(style)}>
         ${["triggered", "arming", "pending"].includes(this.stateObj.state)
           ? html`
@@ -55,6 +116,7 @@ class MoreInfoAlarmControlPanel extends LitElement {
               <ha-state-control-alarm_control_panel-modes
                 .stateObj=${this.stateObj}
                 .hass=${this.hass}
+                .forceArm=${this._forceArm}
               >
               </ha-state-control-alarm_control_panel-modes>
             `}
@@ -117,6 +179,15 @@ class MoreInfoAlarmControlPanel extends LitElement {
           background-color: var(--icon-color);
           transition: background-color 180ms ease-in-out;
           opacity: 0.2;
+        }
+        ha-alert {
+          display: block;
+          margin: 0 16px;
+        }
+        ha-formfield {
+          display: block;
+          text-align: center;
+          margin: 8px 0;
         }
         ha-control-button.disarm {
           height: 60px;

--- a/src/state-control/alarm_control_panel/ha-state-control-alarm_control_panel-modes.ts
+++ b/src/state-control/alarm_control_panel/ha-state-control-alarm_control_panel-modes.ts
@@ -25,6 +25,8 @@ export class HaStateControlAlarmControlPanelModes extends LitElement {
 
   @property({ attribute: false }) public stateObj!: AlarmControlPanelEntity;
 
+  @property({ type: Boolean, attribute: "force-arm" }) public forceArm = false;
+
   @state() _currentMode?: AlarmMode;
 
   private _modes = memoizeOne((stateObj: AlarmControlPanelEntity) => {
@@ -51,7 +53,8 @@ export class HaStateControlAlarmControlPanelModes extends LitElement {
       this,
       this.hass!,
       this.stateObj!,
-      mode
+      mode,
+      this.forceArm
     );
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -98,6 +98,7 @@
         "arm_night": "Arm night",
         "arm_vacation": "Arm vacation",
         "arm_custom_bypass": "Custom bypass",
+        "force_arm": "Force arm (bypass open sensors)",
         "modes_label": "Modes",
         "modes": {
           "armed_away": "Away",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

I'm a maintainer for the [Securitas Direct (alarm) new API](https://github.com/guerrerotook/securitas-direct-new-api/) HACS integration. In the Securitas official app, if you try to arm the alarm and it fails because (eg) a window is open, it will tell you that it failed, why it failed, and will optionally allow you to force arm the alarm anyway.

With our integration, we're using the built in alarm card in HA, but we don't have any way in the card to inform the user that they have failed to arm the alarm. The card just goes from arming back to disarmed, no other info is provided. Also, there is no place for the user to choose to force-arm the alarm.

I'm sure this functionality is not limited to Securitas so it would seem to make sense to support this in the default HA alarm card.

This is still a work in progress. I've got a PR ready to go against core and I need the development_pr build from here so that I can work on the frontend changes. 


## Screenshots

I need the development_pr build in order to produce the screenshots

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

I will fill in the below once I've opened the other PRs

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

I will do all of the following once the PR is ready to go

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


## Summary
- Display `status_message` attribute as a warning alert on the alarm more-info dialog
- Show a force-arm checkbox when `force_arm_available` is true, allowing users to bypass open sensors
- Checkbox appears on the more-info page when no code entry is required, or on the code entry dialog when it is (never both)
- Pass `force_arm: true` through to arm service calls when checked

## Companion PR
Depends on core PR: https://github.com/clintongormley/homeassistant-core/pull/1 (adds `force_arm_available`, `status_message`, and `force_arm` service parameter to the alarm_control_panel base class)

## Test plan
- [ ] Open alarm entity more-info when `force_arm_available` is false — no checkbox, no status message
- [ ] Trigger arming exception (arm with door open) — status message appears as warning, force-arm checkbox appears
- [ ] Check force-arm and arm — service call includes `force_arm: true`
- [ ] Successful force-arm clears checkbox and status message
- [ ] Verify checkbox placement: on more-info when no PIN required, on code dialog when PIN required

🤖 Generated with [Claude Code](https://claude.com/claude-code)