### PR TITLE
Use ha-form for wait_for_trigger timeout

### DIFF
--- a/src/panels/config/automation/action/types/ha-automation-action-wait_for_trigger.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-wait_for_trigger.ts
@@ -1,17 +1,20 @@
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
+import memoizeOne from "memoize-one";
 import { ensureArray } from "../../../../../common/array/ensure-array";
-import { createDurationData } from "../../../../../common/datetime/create_duration_data";
-import { fireEvent } from "../../../../../common/dom/fire_event";
-import type { TimeChangedEvent } from "../../../../../components/ha-base-time-input";
-import "../../../../../components/ha-duration-input";
-import "../../../../../components/ha-formfield";
-import "../../../../../components/ha-textfield";
+import { isTemplate } from "../../../../../common/string/has-template";
+import "../../../../../components/ha-form/ha-form";
+import type {
+  HaFormSchema,
+  SchemaUnion,
+} from "../../../../../components/ha-form/types";
 import type { WaitForTriggerAction } from "../../../../../data/script";
-import type { HomeAssistant, ValueChangedEvent } from "../../../../../types";
+import type { HomeAssistant } from "../../../../../types";
 import "../../trigger/ha-automation-trigger";
 import type { ActionElement } from "../ha-automation-action-row";
 import { handleChangeEvent } from "../ha-automation-action-row";
+
+type TimeoutType = "string_template" | "object_template" | "duration";
 
 @customElement("ha-automation-action-wait_for_trigger")
 export class HaWaitForTriggerAction
@@ -34,33 +37,49 @@ export class HaWaitForTriggerAction
     return { wait_for_trigger: [] };
   }
 
+  private _schema = memoizeOne(
+    (timeoutType: TimeoutType) =>
+      [
+        {
+          name: "timeout",
+          required: false,
+          selector:
+            timeoutType === "string_template"
+              ? { template: {} }
+              : timeoutType === "object_template"
+                ? { object: {} }
+                : { duration: { enable_millisecond: true } },
+        },
+        {
+          name: "continue_on_timeout",
+          selector: { boolean: {} },
+        },
+      ] as const satisfies readonly HaFormSchema[]
+  );
+
   protected render() {
-    const timeData = createDurationData(this.action.timeout);
+    const timeout = this.action.timeout;
+    const timeoutType: TimeoutType =
+      typeof timeout === "string" && isTemplate(timeout)
+        ? "string_template"
+        : typeof timeout === "object" &&
+            timeout !== null &&
+            Object.values(timeout).some(
+              (v) => typeof v === "string" && isTemplate(v)
+            )
+          ? "object_template"
+          : "duration";
 
     return html`
       ${this.inSidebar || (!this.inSidebar && !this.indent)
         ? html`
-            <ha-duration-input
-              .label=${this.hass.localize(
-                "ui.panel.config.automation.editor.actions.type.wait_for_trigger.timeout"
-              )}
-              .data=${timeData}
+            <ha-form
+              .hass=${this.hass}
+              .data=${this.action}
+              .schema=${this._schema(timeoutType)}
               .disabled=${this.disabled}
-              enable-millisecond
-              @value-changed=${this._timeoutChanged}
-            ></ha-duration-input>
-            <ha-formfield
-              .disabled=${this.disabled}
-              .label=${this.hass.localize(
-                "ui.panel.config.automation.editor.actions.type.wait_for_trigger.continue_timeout"
-              )}
-            >
-              <ha-switch
-                .checked=${this.action.continue_on_timeout ?? true}
-                .disabled=${this.disabled}
-                @change=${this._continueChanged}
-              ></ha-switch>
-            </ha-formfield>
+              .computeLabel=${this._computeLabelCallback}
+            ></ha-form>
           `
         : nothing}
       ${this.indent || (!this.inSidebar && !this.indent)
@@ -78,29 +97,20 @@ export class HaWaitForTriggerAction
     `;
   }
 
-  private _timeoutChanged(ev: ValueChangedEvent<TimeChangedEvent>): void {
-    ev.stopPropagation();
-    const value = ev.detail.value;
-    fireEvent(this, "value-changed", {
-      value: { ...this.action, timeout: value },
-    });
-  }
-
-  private _continueChanged(ev) {
-    fireEvent(this, "value-changed", {
-      value: { ...this.action, continue_on_timeout: ev.target.checked },
-    });
-  }
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ): string =>
+    this.hass.localize(
+      `ui.panel.config.automation.editor.actions.type.wait_for_trigger.${
+        schema.name === "continue_on_timeout" ? "continue_timeout" : schema.name
+      }`
+    );
 
   private _valueChanged(ev: CustomEvent): void {
     handleChangeEvent(this, ev);
   }
 
   static styles = css`
-    ha-duration-input {
-      display: block;
-      margin-bottom: 24px;
-    }
     ha-automation-trigger.expansion-panel {
       display: block;
       margin-top: 24px;

--- a/src/panels/config/automation/action/types/ha-automation-action-wait_for_trigger.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-wait_for_trigger.ts
@@ -11,10 +11,9 @@ import type {
 import type { WaitForTriggerAction } from "../../../../../data/script";
 import type { HomeAssistant } from "../../../../../types";
 import "../../trigger/ha-automation-trigger";
+import type { TimeoutType } from "../../types";
 import type { ActionElement } from "../ha-automation-action-row";
 import { handleChangeEvent } from "../ha-automation-action-row";
-
-type TimeoutType = "string_template" | "object_template" | "duration";
 
 @customElement("ha-automation-action-wait_for_trigger")
 export class HaWaitForTriggerAction

--- a/src/panels/config/automation/action/types/ha-automation-action-wait_template.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-wait_template.ts
@@ -10,8 +10,7 @@ import type {
   HaFormSchema,
   SchemaUnion,
 } from "../../../../../components/ha-form/types";
-
-type TimeoutType = "string_template" | "object_template" | "duration";
+import type { TimeoutType } from "../../types";
 
 @customElement("ha-automation-action-wait_template")
 export class HaWaitAction extends LitElement implements ActionElement {

--- a/src/panels/config/automation/types.ts
+++ b/src/panels/config/automation/types.ts
@@ -1,0 +1,1 @@
+export type TimeoutType = "string_template" | "object_template" | "duration";


### PR DESCRIPTION
## Proposed change

The `wait_for_trigger` action already used a duration picker for the timeout field, but it had no support for template-based timeouts — those could only be set via YAML. With this change, when the timeout is set via a template, the UI now clearly shows a template editor instead of the duration picker, so users can see at a glance whether their timeout is a fixed duration or dynamically computed, and can edit both without leaving the visual editor.

This brings `wait_for_trigger` in line with `wait_template`, which received the same improvement in [e7a8d15](https://github.com/home-assistant/frontend/commit/e7a8d15a139580986b60143de8627d83f6e1c39d) (related: #29862). Both wait actions now behave consistently when it comes to timeout input.

Internally this replaces the manually-wired `ha-duration-input` + `ha-formfield`/`ha-switch` with a unified `ha-form` backed by a memoized schema. A `TimeoutType` discriminant (`"string_template" | "object_template" | "duration"`) drives which selector is rendered, so existing automations using template or object-style timeouts continue to be handled correctly in the visual editor.

The `ha-automation-trigger` part (trigger list with sidebar/indent conditional rendering) is unchanged.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #29862

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
