### PR TITLE
Use max width for dashboard footer

### DIFF
--- a/src/data/lovelace/config/view.ts
+++ b/src/data/lovelace/config/view.ts
@@ -37,7 +37,7 @@ export interface LovelaceViewHeaderConfig {
   badges_wrap?: "wrap" | "scroll";
 }
 
-export const DEFAULT_FOOTER_MAX_WIDTH = 600;
+export const DEFAULT_FOOTER_MAX_WIDTH_PX = 600;
 
 export interface LovelaceViewFooterConfig {
   card?: LovelaceCardConfig;

--- a/src/data/lovelace/config/view.ts
+++ b/src/data/lovelace/config/view.ts
@@ -37,6 +37,8 @@ export interface LovelaceViewHeaderConfig {
   badges_wrap?: "wrap" | "scroll";
 }
 
+export const DEFAULT_FOOTER_MAX_WIDTH = 600;
+
 export interface LovelaceViewFooterConfig {
   card?: LovelaceCardConfig;
   max_width?: number;

--- a/src/data/lovelace/config/view.ts
+++ b/src/data/lovelace/config/view.ts
@@ -39,7 +39,7 @@ export interface LovelaceViewHeaderConfig {
 
 export interface LovelaceViewFooterConfig {
   card?: LovelaceCardConfig;
-  column_span?: number;
+  max_width?: number;
 }
 
 export interface LovelaceViewSidebarConfig {

--- a/src/panels/energy/strategies/energy-overview-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-overview-view-strategy.ts
@@ -22,7 +22,6 @@ export class EnergyOverviewViewStrategy extends ReactiveElement {
       dense_section_placement: true,
       max_columns: 3,
       footer: {
-        column_span: 1.1,
         card: {
           type: "energy-date-selection",
           collection_key: collectionKey,

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -23,7 +23,6 @@ export class EnergyViewStrategy extends ReactiveElement {
       max_columns: 3,
       sections: [],
       footer: {
-        column_span: 1.1,
         card: {
           type: "energy-date-selection",
           collection_key: collectionKey,

--- a/src/panels/energy/strategies/gas-view-strategy.ts
+++ b/src/panels/energy/strategies/gas-view-strategy.ts
@@ -21,7 +21,6 @@ export class GasViewStrategy extends ReactiveElement {
       max_columns: 3,
       sections: [{ type: "grid", cards: [], column_span: 3 }],
       footer: {
-        column_span: 1.1,
         card: {
           type: "energy-date-selection",
           collection_key: collectionKey,

--- a/src/panels/energy/strategies/water-view-strategy.ts
+++ b/src/panels/energy/strategies/water-view-strategy.ts
@@ -22,7 +22,6 @@ export class WaterViewStrategy extends ReactiveElement {
       max_columns: 3,
       sections: [{ type: "grid", cards: [], column_span: 3 }],
       footer: {
-        column_span: 1.1,
         card: {
           type: "energy-date-selection",
           collection_key: collectionKey,

--- a/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
@@ -105,7 +105,7 @@ export class HuiDialogEditViewFooter extends LitElement {
         .hass=${this.hass}
         .open=${this._open}
         header-title=${title}
-        .width=${"medium"}
+        width="medium"
         @closed=${this._dialogClosed}
         class=${this._yamlMode ? "yaml-mode" : ""}
       >

--- a/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
@@ -105,7 +105,7 @@ export class HuiDialogEditViewFooter extends LitElement {
         .hass=${this.hass}
         .open=${this._open}
         header-title=${title}
-        .width=${this._yamlMode ? "full" : "large"}
+        .width=${"medium"}
         @closed=${this._dialogClosed}
         class=${this._yamlMode ? "yaml-mode" : ""}
       >

--- a/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-dialog-edit-view-footer.ts
@@ -91,7 +91,6 @@ export class HuiDialogEditViewFooter extends LitElement {
         <hui-view-footer-settings-editor
           .hass=${this.hass}
           .config=${this._config}
-          .maxColumns=${this._params.maxColumns}
           @config-changed=${this._configChanged}
         ></hui-view-footer-settings-editor>
       `;

--- a/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
@@ -1,6 +1,5 @@
 import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
-import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-form/ha-form";
 import type {
@@ -10,42 +9,36 @@ import type {
 import type { LovelaceViewFooterConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
 
+const SCHEMA = [
+  {
+    name: "max_width",
+    selector: {
+      number: {
+        min: 100,
+        max: 1600,
+        step: 10,
+        unit_of_measurement: "px",
+      },
+    },
+  },
+] as const satisfies HaFormSchema[];
+
 @customElement("hui-view-footer-settings-editor")
 export class HuiViewFooterSettingsEditor extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public config?: LovelaceViewFooterConfig;
 
-  @property({ attribute: false }) public maxColumns = 4;
-
-  private _schema = memoizeOne(
-    (maxColumns: number) =>
-      [
-        {
-          name: "column_span",
-          selector: {
-            number: {
-              min: 1,
-              max: maxColumns,
-              slider_ticks: true,
-            },
-          },
-        },
-      ] as const satisfies HaFormSchema[]
-  );
-
   protected render() {
     const data = {
-      column_span: this.config?.column_span || 1,
+      max_width: this.config?.max_width || 600,
     };
-
-    const schema = this._schema(this.maxColumns);
 
     return html`
       <ha-form
         .hass=${this.hass}
         .data=${data}
-        .schema=${schema}
+        .schema=${SCHEMA}
         .computeLabel=${this._computeLabel}
         .computeHelper=${this._computeHelper}
         @value-changed=${this._valueChanged}
@@ -65,16 +58,12 @@ export class HuiViewFooterSettingsEditor extends LitElement {
     fireEvent(this, "config-changed", { config });
   }
 
-  private _computeLabel = (
-    schema: SchemaUnion<ReturnType<typeof this._schema>>
-  ) =>
+  private _computeLabel = (schema: SchemaUnion<typeof SCHEMA>) =>
     this.hass.localize(
       `ui.panel.lovelace.editor.edit_view_footer.settings.${schema.name}`
     );
 
-  private _computeHelper = (
-    schema: SchemaUnion<ReturnType<typeof this._schema>>
-  ) =>
+  private _computeHelper = (schema: SchemaUnion<typeof SCHEMA>) =>
     this.hass.localize(
       `ui.panel.lovelace.editor.edit_view_footer.settings.${schema.name}_helper`
     ) || "";

--- a/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
@@ -6,7 +6,10 @@ import type {
   HaFormSchema,
   SchemaUnion,
 } from "../../../../components/ha-form/types";
-import type { LovelaceViewFooterConfig } from "../../../../data/lovelace/config/view";
+import {
+  DEFAULT_FOOTER_MAX_WIDTH,
+  type LovelaceViewFooterConfig,
+} from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
 
 const SCHEMA = [
@@ -31,7 +34,7 @@ export class HuiViewFooterSettingsEditor extends LitElement {
 
   protected render() {
     const data = {
-      max_width: this.config?.max_width || 600,
+      max_width: this.config?.max_width || DEFAULT_FOOTER_MAX_WIDTH,
     };
 
     return html`

--- a/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
@@ -40,7 +40,6 @@ export class HuiViewFooterSettingsEditor extends LitElement {
         .data=${data}
         .schema=${SCHEMA}
         .computeLabel=${this._computeLabel}
-        .computeHelper=${this._computeHelper}
         @value-changed=${this._valueChanged}
       ></ha-form>
     `;
@@ -62,11 +61,6 @@ export class HuiViewFooterSettingsEditor extends LitElement {
     this.hass.localize(
       `ui.panel.lovelace.editor.edit_view_footer.settings.${schema.name}`
     );
-
-  private _computeHelper = (schema: SchemaUnion<typeof SCHEMA>) =>
-    this.hass.localize(
-      `ui.panel.lovelace.editor.edit_view_footer.settings.${schema.name}_helper`
-    ) || "";
 }
 
 declare global {

--- a/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
+++ b/src/panels/lovelace/editor/view-footer/hui-view-footer-settings-editor.ts
@@ -7,7 +7,7 @@ import type {
   SchemaUnion,
 } from "../../../../components/ha-form/types";
 import {
-  DEFAULT_FOOTER_MAX_WIDTH,
+  DEFAULT_FOOTER_MAX_WIDTH_PX,
   type LovelaceViewFooterConfig,
 } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
@@ -34,7 +34,7 @@ export class HuiViewFooterSettingsEditor extends LitElement {
 
   protected render() {
     const data = {
-      max_width: this.config?.max_width || DEFAULT_FOOTER_MAX_WIDTH,
+      max_width: this.config?.max_width || DEFAULT_FOOTER_MAX_WIDTH_PX,
     };
 
     return html`

--- a/src/panels/lovelace/editor/view-footer/show-edit-view-footer-dialog.ts
+++ b/src/panels/lovelace/editor/view-footer/show-edit-view-footer-dialog.ts
@@ -4,7 +4,6 @@ import type { LovelaceViewFooterConfig } from "../../../../data/lovelace/config/
 export interface EditViewFooterDialogParams {
   saveConfig: (config: LovelaceViewFooterConfig) => void;
   config: LovelaceViewFooterConfig;
-  maxColumns: number;
 }
 
 export const showEditViewFooterDialog = (

--- a/src/panels/lovelace/views/hui-view-footer.ts
+++ b/src/panels/lovelace/views/hui-view-footer.ts
@@ -8,7 +8,7 @@ import "../../../components/ha-ripple";
 import "../../../components/ha-svg-icon";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
 import {
-  DEFAULT_FOOTER_MAX_WIDTH,
+  DEFAULT_FOOTER_MAX_WIDTH_PX,
   type LovelaceViewConfig,
   type LovelaceViewFooterConfig,
 } from "../../../data/lovelace/config/view";
@@ -179,7 +179,7 @@ export class HuiViewFooter extends LitElement {
       <div
         class=${classMap({ wrapper: true, "edit-mode": editMode })}
         style=${styleMap({
-          "--footer-max-width": `${this.config?.max_width || DEFAULT_FOOTER_MAX_WIDTH}px`,
+          "--footer-max-width": `${this.config?.max_width || DEFAULT_FOOTER_MAX_WIDTH_PX}px`,
         })}
       >
         ${editMode

--- a/src/panels/lovelace/views/hui-view-footer.ts
+++ b/src/panels/lovelace/views/hui-view-footer.ts
@@ -7,9 +7,10 @@ import { styleMap } from "lit/directives/style-map";
 import "../../../components/ha-ripple";
 import "../../../components/ha-svg-icon";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
-import type {
-  LovelaceViewConfig,
-  LovelaceViewFooterConfig,
+import {
+  DEFAULT_FOOTER_MAX_WIDTH,
+  type LovelaceViewConfig,
+  type LovelaceViewFooterConfig,
 } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
 import type { HuiCard } from "../cards/hui-card";
@@ -178,9 +179,7 @@ export class HuiViewFooter extends LitElement {
       <div
         class=${classMap({ wrapper: true, "edit-mode": editMode })}
         style=${styleMap({
-          "--footer-max-width": this.config?.max_width
-            ? `${this.config.max_width}px`
-            : undefined,
+          "--footer-max-width": `${this.config?.max_width || DEFAULT_FOOTER_MAX_WIDTH}px`,
         })}
       >
         ${editMode

--- a/src/panels/lovelace/views/hui-view-footer.ts
+++ b/src/panels/lovelace/views/hui-view-footer.ts
@@ -19,7 +19,6 @@ import { showEditCardDialog } from "../editor/card-editor/show-edit-card-dialog"
 import { replaceView } from "../editor/config-util";
 import { showEditViewFooterDialog } from "../editor/view-footer/show-edit-view-footer-dialog";
 import type { Lovelace } from "../types";
-import { DEFAULT_MAX_COLUMNS } from "./hui-sections-view";
 
 @customElement("hui-view-footer")
 export class HuiViewFooter extends LitElement {
@@ -97,13 +96,8 @@ export class HuiViewFooter extends LitElement {
   }
 
   private _configure() {
-    const viewConfig = this.lovelace.config.views[
-      this.viewIndex
-    ] as LovelaceViewConfig;
-
     showEditViewFooterDialog(this, {
       config: this.config || {},
-      maxColumns: viewConfig.max_columns || DEFAULT_MAX_COLUMNS,
       saveConfig: (newConfig: LovelaceViewFooterConfig) => {
         this._saveFooterConfig(newConfig);
       },
@@ -180,13 +174,13 @@ export class HuiViewFooter extends LitElement {
 
     if (!card && !editMode) return nothing;
 
-    const columnSpan = this.config?.column_span || 1;
-
     return html`
       <div
         class=${classMap({ wrapper: true, "edit-mode": editMode })}
         style=${styleMap({
-          "--footer-column-span": String(columnSpan),
+          "--footer-max-width": this.config?.max_width
+            ? `${this.config.max_width}px`
+            : undefined,
         })}
       >
         ${editMode
@@ -228,23 +222,18 @@ export class HuiViewFooter extends LitElement {
 
     :host([sticky]) {
       position: sticky;
-      bottom: 0;
+      bottom: var(--row-gap);
       z-index: 4;
     }
 
     .wrapper {
-      padding: var(--ha-space-4) 0;
-      padding-bottom: max(
-        var(--ha-space-4),
-        var(--safe-area-inset-bottom, 0px)
+      padding: var(--ha-space-2) 0;
+      padding-bottom: calc(
+        max(var(--ha-space-2), var(--safe-area-inset-bottom, 0px))
       );
       box-sizing: content-box;
       margin: 0 auto;
-      max-width: calc(
-        var(--footer-column-span, 1) / var(--column-count, 1) * 100% +
-          (var(--footer-column-span, 1) - var(--column-count, 1)) /
-          var(--column-count, 1) * var(--column-gap, 32px)
-      );
+      max-width: var(--footer-max-width, 600px);
     }
 
     .wrapper:not(.edit-mode) {
@@ -315,7 +304,7 @@ export class HuiViewFooter extends LitElement {
       border-bottom-left-radius: 0px;
       border-bottom-right-radius: 0px;
       background: var(--secondary-background-color);
-      --mdc-icon-button-size: 36px;
+      --ha-icon-button-size: 36px;
       --mdc-icon-size: 20px;
       color: var(--primary-text-color);
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8494,8 +8494,7 @@
             "edit_yaml": "[%key:ui::panel::lovelace::editor::edit_view::edit_yaml%]",
             "saving_failed": "[%key:ui::panel::lovelace::editor::edit_view::saving_failed%]",
             "settings": {
-              "column_span": "Width",
-              "column_span_helper": "[%key:ui::panel::lovelace::editor::edit_section::settings::column_span_helper%]"
+              "max_width": "Max width"
             }
           },
           "edit_badges": {


### PR DESCRIPTION
## Breaking change

The `column_span` property in the view footer config has been replaced with `max_width`. Existing `column_span` values will no longer have any effect.

## Proposed change

Replace `column_span` with `max_width` for the view footer configuration. Instead of spanning a number of grid columns, the footer now uses a pixel-based max-width (default 600px) for simpler and more predictable sizing.

Changes:
- Replace `column_span` with `max_width` in `LovelaceViewFooterConfig`
- Update footer editor to use a number input instead of a column span slider
- Fix icon button size variable to use `--ha-icon-button-size` (consistent with header and section)
- Append `px` unit when setting the CSS custom property
- Fixed the sticky position using `bottom: var(--row-gap)`.

## Screenshots

<img width="610" height="263" alt="CleanShot 2026-03-03 at 10 00 16" src="https://github.com/user-attachments/assets/0fe1b551-8835-4407-9534-21daa35ce7ef" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
