### PR TITLE
Add label for toggle button in area strategy

### DIFF
--- a/src/components/ha-control-button.ts
+++ b/src/components/ha-control-button.ts
@@ -33,6 +33,7 @@ export class HaControlButton extends LitElement {
       --control-button-background-color: var(--disabled-color);
       --control-button-background-opacity: 0.2;
       --control-button-border-radius: var(--ha-border-radius-md);
+      --control-button-font-weight: var(--ha-font-weight-medium);
       --control-button-padding: 8px;
       --mdc-icon-size: 20px;
       --ha-ripple-color: var(--secondary-text-color);
@@ -59,7 +60,7 @@ export class HaControlButton extends LitElement {
       box-sizing: border-box;
       line-height: inherit;
       font-family: var(--ha-font-family-body);
-      font-weight: var(--ha-font-weight-medium);
+      font-weight: var(--control-button-font-weight);
       outline: none;
       overflow: hidden;
       background: none;

--- a/src/components/ha-heading-badge.ts
+++ b/src/components/ha-heading-badge.ts
@@ -38,7 +38,7 @@ export class HaBadge extends LitElement {
       font-weight: var(--ha-heading-badge-font-weight, 400);
       line-height: var(--ha-heading-badge-line-height, 20px);
       letter-spacing: 0.1px;
-      --mdc-icon-size: 14px;
+      --mdc-icon-size: 16px;
     }
     ::slotted([slot="icon"]) {
       --ha-icon-display: block;

--- a/src/panels/light/strategies/light-view-strategy.ts
+++ b/src/panels/light/strategies/light-view-strategy.ts
@@ -17,6 +17,7 @@ import {
   SMALL_SCREEN_CONDITION,
 } from "../../lovelace/strategies/helpers/screen-conditions";
 import type { ToggleGroupCardConfig } from "../../lovelace/cards/types";
+import type { ButtonHeadingBadgeConfig } from "../../lovelace/heading-badges/types";
 
 export interface LightViewStrategyConfig {
   type: "light";
@@ -75,6 +76,7 @@ const processAreasForLight = (
           {
             type: "button",
             icon: "mdi:power",
+            text: hass.localize("ui.panel.lovelace.strategy.light.off"),
             tap_action: {
               action: "perform-action",
               perform_action: "light.turn_on",
@@ -89,11 +91,12 @@ const processAreasForLight = (
                 conditions: [anyOnCondition],
               },
             ],
-          },
+          } satisfies ButtonHeadingBadgeConfig,
           {
             type: "button",
             icon: "mdi:power",
             color: "amber",
+            text: hass.localize("ui.panel.lovelace.strategy.light.on"),
             tap_action: {
               action: "perform-action",
               perform_action: "light.turn_off",
@@ -102,7 +105,7 @@ const processAreasForLight = (
               },
             },
             visibility: [SMALL_SCREEN_CONDITION, anyOnCondition],
-          },
+          } satisfies ButtonHeadingBadgeConfig,
         ] satisfies LovelaceCardConfig[],
       });
 

--- a/src/panels/light/strategies/light-view-strategy.ts
+++ b/src/panels/light/strategies/light-view-strategy.ts
@@ -95,7 +95,7 @@ const processAreasForLight = (
           {
             type: "button",
             icon: "mdi:power",
-            color: "amber",
+            color: "orange",
             text: hass.localize("ui.panel.lovelace.strategy.light.on"),
             tap_action: {
               action: "perform-action",

--- a/src/panels/lovelace/heading-badges/hui-button-heading-badge.ts
+++ b/src/panels/lovelace/heading-badges/hui-button-heading-badge.ts
@@ -108,7 +108,7 @@ export class HuiButtonHeadingBadge
         var(--ha-border-radius-pill)
       );
       --control-button-padding: 0;
-      --mdc-icon-size: var(--ha-heading-badge-icon-size, 14px);
+      --mdc-icon-size: var(--ha-heading-badge-icon-size, 16px);
       width: auto;
       height: var(--ha-heading-badge-size, 26px);
       min-width: var(--ha-heading-badge-size, 26px);
@@ -121,6 +121,8 @@ export class HuiButtonHeadingBadge
       --control-button-icon-color: var(--color);
       --control-button-background-color: var(--color);
       --control-button-focus-color: var(--color);
+      --control-button-background-opacity: 0.2;
+      --control-button-font-weight: var(--ha-font-weight-bold);
       --ha-ripple-color: var(--color);
     }
     .content {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8089,7 +8089,9 @@
           },
           "light": {
             "lights": "Lights",
-            "other_lights": "Other lights"
+            "other_lights": "Other lights",
+            "on": "On",
+            "off": "Off"
           },
           "security": {
             "devices": "Devices",


### PR DESCRIPTION
## Proposed change

Add label for toggle button in area heading of light view strategy.

- Add "On" and "Off" text labels to the light toggle heading badges so users can see the current state
- Increase icon size from 14px to 16px in heading badges and button heading badges for better readability
- Add bold font weight to increase text readability
- Change color from amber to orange for better contrast
-  
## Screenshots

<img width="386" height="682" alt="CleanShot 2026-03-03 at 11 56 07" src="https://github.com/user-attachments/assets/e9e2b9db-b908-446b-9586-181740000a49" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
