### PR TITLE
Add animation duration tokens and button transition update

### DIFF
--- a/src/components/ha-button.ts
+++ b/src/components/ha-button.ts
@@ -58,7 +58,8 @@ export class HaButton extends Button {
           font-size: var(--ha-font-size-m);
           line-height: 1;
 
-          transition: background-color 0.15s ease-in-out;
+          transition: background-color var(--ha-animation-duration-fast)
+            ease-out;
           text-wrap: wrap;
         }
 

--- a/src/resources/theme/core.globals.ts
+++ b/src/resources/theme/core.globals.ts
@@ -64,8 +64,8 @@ export const coreStyles = css`
 
   @media (prefers-reduced-motion: reduce) {
     html {
-      --ha-animation-duration-none: 0ms;
-      --ha-animation-duration-instant: 0ms;
+      --ha-animation-duration-none: 1ms;
+      --ha-animation-duration-instant: 1ms;
       --ha-animation-duration-fast: 1ms;
       --ha-animation-duration-normal: 1ms;
       --ha-animation-duration-slow: 1ms;

--- a/src/resources/theme/core.globals.ts
+++ b/src/resources/theme/core.globals.ts
@@ -55,6 +55,8 @@ export const coreStyles = css`
     --ha-shadow-spread-md: 0;
     --ha-shadow-spread-lg: 0;
 
+    --ha-animation-duration-none: 0ms;
+    --ha-animation-duration-instant: 75ms;
     --ha-animation-duration-fast: 150ms;
     --ha-animation-duration-normal: 250ms;
     --ha-animation-duration-slow: 350ms;
@@ -62,6 +64,8 @@ export const coreStyles = css`
 
   @media (prefers-reduced-motion: reduce) {
     html {
+      --ha-animation-duration-none: 0ms;
+      --ha-animation-duration-instant: 0ms;
       --ha-animation-duration-fast: 0ms;
       --ha-animation-duration-normal: 0ms;
       --ha-animation-duration-slow: 0ms;

--- a/src/resources/theme/core.globals.ts
+++ b/src/resources/theme/core.globals.ts
@@ -55,7 +55,7 @@ export const coreStyles = css`
     --ha-shadow-spread-md: 0;
     --ha-shadow-spread-lg: 0;
 
-    --ha-animation-duration-none: 0ms;
+    --ha-animation-duration-none: 1ms;
     --ha-animation-duration-instant: 75ms;
     --ha-animation-duration-fast: 150ms;
     --ha-animation-duration-normal: 250ms;


### PR DESCRIPTION
## Breaking change
None.

## Proposed change
- New animation duration tokens for future usage in tooltips, and other smaller elements.
- Use a duration token in `ha-button`, and change easing type to `ease-out`.

## Screenshots
Not applicable.

## Type of change
Code quality improvements to existing code.

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
