### PR TITLE
Add arrow and fix footer for vacuum segment mapper

### DIFF
--- a/src/components/ha-vacuum-segment-area-mapper.ts
+++ b/src/components/ha-vacuum-segment-area-mapper.ts
@@ -1,6 +1,7 @@
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { mdiArrowRightThin } from "@mdi/js";
 import { fireEvent } from "../common/dom/fire_event";
 import type { Segment } from "../data/vacuum";
 import { getVacuumSegments } from "../data/vacuum";
@@ -8,8 +9,7 @@ import { haStyle } from "../resources/styles";
 import type { HomeAssistant } from "../types";
 import "./ha-alert";
 import "./ha-area-picker";
-import "./ha-md-list";
-import "./ha-md-list-item";
+import "./ha-svg-icon";
 
 type AreaSegmentMapping = Record<string, string[]>; // area ID -> segment IDs
 
@@ -80,9 +80,7 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
       ${Object.entries(groupedSegments).map(
         ([groupName, segments]) => html`
           ${groupName ? html`<h2>${groupName}</h2>` : nothing}
-          <ha-md-list>
-            ${segments.map((segment) => this._renderSegment(segment))}
-          </ha-md-list>
+          ${segments.map((segment) => this._renderSegment(segment))}
         `
       )}
     `;
@@ -106,10 +104,10 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
     const mappedAreas = this._getSegmentAreas(segment.id);
 
     return html`
-      <ha-md-list-item>
-        <span slot="headline">${segment.name}</span>
+      <div class="segment-row">
+        <span class="segment-name">${segment.name}</span>
+        <ha-svg-icon class="arrow" .path=${mdiArrowRightThin}></ha-svg-icon>
         <ha-area-picker
-          slot="end"
           .hass=${this.hass}
           .value=${mappedAreas}
           .label=${this.hass.localize(
@@ -118,7 +116,7 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
           @value-changed=${this._handleAreaChanged}
           data-segment-id=${segment.id}
         ></ha-area-picker>
-      </ha-md-list-item>
+      </div>
     `;
   }
 
@@ -179,8 +177,36 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
         display: block;
       }
 
-      ha-area-picker {
+      .segment-row {
+        display: flex;
+        align-items: center;
+        gap: var(--ha-space-4);
+        padding: var(--ha-space-2) var(--ha-space-4);
+      }
+
+      .segment-name {
         flex: 1;
+        font: var(--ha-font-body-l);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .arrow {
+        flex-shrink: 0;
+        color: var(--secondary-text-color);
+      }
+
+      @media (max-width: 600px) {
+        .arrow {
+          display: none;
+        }
+      }
+
+      ha-area-picker {
+        flex: 2;
+        min-width: 0;
+        max-width: 300px;
       }
 
       h2 {

--- a/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-segment-mapping.ts
+++ b/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-segment-mapping.ts
@@ -117,13 +117,11 @@ export class HaMoreInfoViewVacuumSegmentMapping extends LitElement {
   static styles: CSSResultGroup = css`
     :host {
       display: block;
-      height: 100%;
     }
 
     .content {
       display: flex;
       flex-direction: column;
-      height: 100%;
     }
 
     ha-spinner {
@@ -142,6 +140,13 @@ export class HaMoreInfoViewVacuumSegmentMapping extends LitElement {
       justify-content: flex-end;
       padding: var(--ha-space-4);
       border-top: 1px solid var(--divider-color);
+      background: var(
+        --ha-dialog-surface-background,
+        var(--mdc-theme-surface, #fff)
+      );
+      position: sticky;
+      bottom: 0;
+      z-index: 10;
     }
   `;
 }


### PR DESCRIPTION
## Proposed change

Improve the vacuum segment mapping UI :
- Fix misaligned rows with a consistent flex layout
- Add arrow icon between segment name and area picker to clarify the mapping (hidden on mobile to preserve space)
- Make save footer sticky (for mobile)

## Screenshots

<img width="592" height="545" alt="CleanShot 2026-03-04 at 14 38 44" src="https://github.com/user-attachments/assets/0ce4a382-aa03-45c1-b453-afa3262d91cb" />

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
