### PR TITLE
Fix sensor card graph time axis not progressing when value is unchanged

### DIFF
--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -193,13 +193,19 @@ export class HuiGraphHeaderFooter
         ? Math.max(width / 5, this._config.hours_to_show!)
         : this._config.hours_to_show!
     );
+    const now = Date.now();
     const useMean = this._config.detail !== 2;
     const { points } = coordinatesMinimalResponseCompressedState(
       entityHistory,
       width,
       width / 5,
       maxDetails,
-      { minY: this._config.limits?.min, maxY: this._config.limits?.max },
+      {
+        minX: now - this._config.hours_to_show! * HOUR,
+        maxX: now,
+        minY: this._config.limits?.min,
+        maxY: this._config.limits?.max,
+      },
       useMean
     );
     this._coordinates = points;


### PR DESCRIPTION
## Proposed change

The graph header/footer in the sensor card doesn't visually update when the sensor value remains constant for extended periods (e.g., a solar panel sensor at `0 W` overnight).

The root cause is that `_computeCoordinates()` passes no `minX`/`maxX` bounds to the coordinate calculation. This means `calcPoints` defaults the x-axis range to the first and last data point timestamps. When the backend stops sending updates (because `significant_changes_only = true` and the value hasn't changed), the data points don't change, so every periodic redraw produces the same visual output — the graph appears frozen.

This fix passes explicit time window bounds (`now - hours_to_show` to `now`) so the graph's x-axis always represents the actual time window. As time passes, data points shift left and the flat trailing line correctly extends to "now".

Note: PR #29889 fixed history data staleness but did not address the x-axis time bounds, which is the remaining issue reported in #29883.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #29883
- This PR is related to issue or discussion: #29939

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
