### PR TITLE
Fix stale data point in history-graph cards with sub-hour windows

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -877,10 +877,20 @@ export class HaChartBase extends LitElement {
           };
         }
         if (s.sampling === "minmax") {
-          const minX =
-            xAxis?.min && typeof xAxis.min === "number" ? xAxis.min : undefined;
-          const maxX =
-            xAxis?.max && typeof xAxis.max === "number" ? xAxis.max : undefined;
+          const minX = xAxis?.min
+            ? xAxis.min instanceof Date
+              ? xAxis.min.getTime()
+              : typeof xAxis.min === "number"
+                ? xAxis.min
+                : undefined
+            : undefined;
+          const maxX = xAxis?.max
+            ? xAxis.max instanceof Date
+              ? xAxis.max.getTime()
+              : typeof xAxis.max === "number"
+                ? xAxis.max
+                : undefined
+            : undefined;
           return {
             ...s,
             sampling: undefined,

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -185,6 +185,10 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
   }
 
   private async _fetchStatistics(sensorNumericDeviceClasses: string[]) {
+    if (this._hoursToShow < 1) {
+      // Statistics are hourly aggregates, not useful for sub-hour windows
+      return;
+    }
     const now = new Date();
     const start = new Date();
     start.setHours(start.getHours() - this._hoursToShow - 1);


### PR DESCRIPTION
## Proposed change

Fix stale outlier data points appearing on the left edge of `history-graph` cards when using sub-hour `hours_to_show` values (e.g., `0.1` or `0.05`).

**Root cause:** The card fetches hourly statistics aggregates and merges them with real-time state history. For sub-hour windows, these hourly stats fall within the chart's time range but represent stale aggregate data from up to an hour ago, causing a misleading outlier point on the left side of the graph.

**Fix:**
1. Skip fetching statistics entirely when `hours_to_show < 1`, since hourly aggregates are not meaningful for sub-hour chart windows.
2. Fix `Date` object handling in `ha-chart-base` downsampling bounds — `xAxis.min`/`xAxis.max` can be `Date` objects but were only checked for `number`, causing the downsampler to operate without proper bounds.

## Screenshots

N/A

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #28654
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
