### PR TITLE
Add search filter to Radio Browser media source

### DIFF
--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -18,6 +18,7 @@ import { until } from "lit/directives/until";
 import { fireEvent } from "../../common/dom/fire_event";
 import { debounce } from "../../common/util/debounce";
 import { isUnavailableState } from "../../data/entity";
+import "../search-input-outlined";
 import type {
   MediaPlayerItem,
   MediaPickedEvent,
@@ -101,6 +102,8 @@ export class HaMediaPlayerBrowse extends LitElement {
 
   @state() private _currentItem?: MediaPlayerItem;
 
+  @state() private _searchQuery = "";
+
   @query(".header") private _header?: HTMLDivElement;
 
   @query(".content") private _content?: HTMLDivElement;
@@ -173,6 +176,7 @@ export class HaMediaPlayerBrowse extends LitElement {
     // We're navigating. Reset the shizzle.
     this._content?.scrollTo(0, 0);
     this.scrolled = false;
+    this._searchQuery = "";
     const oldCurrentItem = this._currentItem;
     const oldParentItem = this._parentItem;
     this._currentItem = undefined;
@@ -334,7 +338,17 @@ export class HaMediaPlayerBrowse extends LitElement {
     const subtitle = this.hass.localize(
       `ui.components.media-browser.class.${currentItem.media_class}`
     );
-    const children = currentItem.children || [];
+    const allChildren = currentItem.children || [];
+    const isRadioBrowser = currentItem.media_content_id?.startsWith(
+      "media-source://radio_browser"
+    );
+    const showRadioSearch = isRadioBrowser && allChildren.length > 0;
+    const children =
+      showRadioSearch && this._searchQuery
+        ? allChildren.filter((child) =>
+            child.title.toLowerCase().includes(this._searchQuery.toLowerCase())
+          )
+        : allChildren;
     const mediaClass = MediaClassBrowserSettings[currentItem.media_class];
     const childrenMediaClass = currentItem.children_media_class
       ? MediaClassBrowserSettings[currentItem.children_media_class]
@@ -427,6 +441,22 @@ export class HaMediaPlayerBrowse extends LitElement {
                     `
                   : ""
               }
+          ${
+            showRadioSearch
+              ? html`
+                  <div class="radio-search">
+                    <search-input-outlined
+                      .hass=${this.hass}
+                      .filter=${this._searchQuery}
+                      .placeholder=${this.hass.localize(
+                        "ui.components.media-browser.radio_browser.search_placeholder"
+                      )}
+                      @value-changed=${this._handleSearchQuery}
+                    ></search-input-outlined>
+                  </div>
+                `
+              : nothing
+          }
           <div
             class="content"
             @scroll=${this._scroll}
@@ -771,6 +801,10 @@ export class HaMediaPlayerBrowse extends LitElement {
     this._resizeObserver.observe(this);
   }
 
+  private _handleSearchQuery(ev: CustomEvent) {
+    this._searchQuery = ev.detail.value;
+  }
+
   private _closeDialogAction(): void {
     fireEvent(this, "close-dialog");
   }
@@ -884,6 +918,19 @@ export class HaMediaPlayerBrowse extends LitElement {
 
         .no-items {
           padding-left: 32px;
+        }
+
+        .radio-search {
+          padding: 8px 16px;
+          background-color: var(--card-background-color);
+          position: sticky;
+          top: 0;
+          z-index: 2;
+          border-bottom: 1px solid var(--divider-color);
+        }
+
+        .radio-search search-input-outlined {
+          width: 100%;
         }
 
         .highlight-add-button {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -994,7 +994,10 @@
         "media_player_unavailable": "The selected media player is unavailable.",
         "auto": "Auto",
         "grid": "Grid",
-        "list": "List"
+        "list": "List",
+        "radio_browser": {
+          "search_placeholder": "Search radio stations"
+        }
       },
       "todo": {
         "item": {


### PR DESCRIPTION
## Summary

Add a real-time search/filter input field to the media browser when browsing **Radio Browser** content. The search field appears exclusively when the active media source is `radio_browser` (i.e. `media_content_id` starts with `media-source://radio_browser`), so it does not affect any other media source.

## Changes

- **`ha-media-player-browse.ts`**:
  - Imports `search-input-outlined` component.
  - Adds `_searchQuery` state (auto-reset on navigation).
  - Detects Radio Browser source via `media_content_id` prefix.
  - Renders a sticky search field above the content list on all Radio Browser levels.
  - Filters the loaded children client-side by title (case-insensitive) – no extra API calls.
  - Adds `_handleSearchQuery()` event handler.

- **`src/translations/en.json`**: Adds translation key
  `ui.compon  `ui.compon  `ui.compon  `ui.search_placeholde  `ui.compon  `ui.compon  `ui.compon  `ui.searit  `ui.compon  `ui.compon  `ui.compon  `ui.search_placehoea  `ui.compon  `uiurr  `ui.compon  `ui.compon  `ui.compon  `ui.search_placeholde  `ui.compon  `ui.compon  `ui.compon  `ui.searit  `ui.compon  `ui.compon  `ui.compon  `ui.search_placehoea  `ui.compon  `uiurr  `ui.compon  `ui.compon  `ui.compon  `ui.search_placeholde  `ui.compon  `ui.compon  `ui.compon  `ui.sden  `ui.co th  `ui.compon  `ui.compon  `ui.co`homeassistant/core`) to enable global cross-category search.