### PR TITLE
Add search filter to Radio Browser media source

### DIFF
--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -61,6 +61,10 @@ import "./ha-browse-media-manual";
 import type { ManualMediaPickedEvent } from "./ha-browse-media-manual";
 import "./ha-browse-media-tts";
 import type { TtsMediaPickedEvent } from "./ha-browse-media-tts";
+import {
+  filterRadioBrowserChildren,
+  RADIO_BROWSER_MEDIA_SOURCE_PREFIX,
+} from "./radio-browser-util";
 
 declare global {
   interface HASSDomEvents {
@@ -412,13 +416,11 @@ export class HaMediaPlayerBrowse extends LitElement {
     }
 
     const isRadioBrowser = currentItem.media_content_id?.startsWith(
-      "media-source://radio_browser"
+      RADIO_BROWSER_MEDIA_SOURCE_PREFIX
     );
     const showRadioSearch = isRadioBrowser && children.length > 0;
     if (showRadioSearch && this._searchQuery) {
-      children = children.filter((child) =>
-        child.title.toLowerCase().includes(this._searchQuery.toLowerCase())
-      );
+      children = filterRadioBrowserChildren(children, this._searchQuery);
     }
 
     const mediaClass = MediaClassBrowserSettings[currentItem.media_class];

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -18,6 +18,7 @@ import { fireEvent } from "../../common/dom/fire_event";
 import { slugify } from "../../common/string/slugify";
 import { debounce } from "../../common/util/debounce";
 import { isUnavailableState } from "../../data/entity/entity";
+import "../search-input-outlined";
 import type {
   MediaPickedEvent,
   MediaPlayerBrowseAction,
@@ -129,6 +130,8 @@ export class HaMediaPlayerBrowse extends LitElement {
 
   @state() private _currentItem?: MediaPlayerItem;
 
+  @state() private _searchQuery = "";
+
   @query(".header") private _header?: HTMLDivElement;
 
   @query(".content") private _content?: HTMLDivElement;
@@ -201,6 +204,7 @@ export class HaMediaPlayerBrowse extends LitElement {
     // We're navigating. Reset the shizzle.
     this._content?.scrollTo(0, 0);
     this.scrolled = false;
+    this._searchQuery = "";
     const oldCurrentItem = this._currentItem;
     const oldParentItem = this._parentItem;
     this._currentItem = undefined;
@@ -407,6 +411,16 @@ export class HaMediaPlayerBrowse extends LitElement {
       });
     }
 
+    const isRadioBrowser = currentItem.media_content_id?.startsWith(
+      "media-source://radio_browser"
+    );
+    const showRadioSearch = isRadioBrowser && children.length > 0;
+    if (showRadioSearch && this._searchQuery) {
+      children = children.filter((child) =>
+        child.title.toLowerCase().includes(this._searchQuery.toLowerCase())
+      );
+    }
+
     const mediaClass = MediaClassBrowserSettings[currentItem.media_class];
     const childrenMediaClass = currentItem.children_media_class
       ? MediaClassBrowserSettings[currentItem.children_media_class]
@@ -504,6 +518,22 @@ export class HaMediaPlayerBrowse extends LitElement {
                     `
                   : ""
               }
+          ${
+            showRadioSearch
+              ? html`
+                  <div class="radio-search">
+                    <search-input-outlined
+                      .hass=${this.hass}
+                      .filter=${this._searchQuery}
+                      .placeholder=${this.hass.localize(
+                        "ui.components.media-browser.radio_browser.search_placeholder"
+                      )}
+                      @value-changed=${this._handleSearchQuery}
+                    ></search-input-outlined>
+                  </div>
+                `
+              : nothing
+          }
           <div
             class="content"
             @scroll=${this._scroll}
@@ -888,6 +918,10 @@ export class HaMediaPlayerBrowse extends LitElement {
     this._resizeObserver.observe(this);
   }
 
+  private _handleSearchQuery(ev: CustomEvent) {
+    this._searchQuery = ev.detail.value;
+  }
+
   private _closeDialogAction(): void {
     fireEvent(this, "close-dialog");
   }
@@ -1002,6 +1036,19 @@ export class HaMediaPlayerBrowse extends LitElement {
 
         .no-items {
           padding-left: 32px;
+        }
+
+        .radio-search {
+          padding: 8px 16px;
+          background-color: var(--card-background-color);
+          position: sticky;
+          top: 0;
+          z-index: 2;
+          border-bottom: 1px solid var(--divider-color);
+        }
+
+        .radio-search search-input-outlined {
+          width: 100%;
         }
 
         .highlight-add-button {

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -1045,7 +1045,6 @@ export class HaMediaPlayerBrowse extends LitElement {
           background-color: var(--card-background-color);
           position: sticky;
           top: 0;
-          z-index: 2;
           border-bottom: 1px solid var(--divider-color);
         }
 

--- a/src/components/media-player/radio-browser-util.ts
+++ b/src/components/media-player/radio-browser-util.ts
@@ -1,0 +1,18 @@
+import type { MediaPlayerItem } from "../../data/media-player";
+
+export const RADIO_BROWSER_MEDIA_SOURCE_PREFIX = "media-source://radio_browser";
+
+/**
+ * Filters a list of media items by title for the Radio Browser search input.
+ * The comparison is case-insensitive.
+ */
+export function filterRadioBrowserChildren(
+  children: MediaPlayerItem[],
+  query: string
+): MediaPlayerItem[] {
+  if (!query) return children;
+  const lowerQuery = query.toLowerCase();
+  return children.filter((child) =>
+    child.title.toLowerCase().includes(lowerQuery)
+  );
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1170,7 +1170,10 @@
         "media_player_unavailable": "The selected media player is unavailable.",
         "auto": "Auto",
         "grid": "Grid",
-        "list": "List"
+        "list": "List",
+        "radio_browser": {
+          "search_placeholder": "Search radio stations"
+        }
       },
       "todo": {
         "item": {

--- a/test/components/media-player/ha-media-player-browse.test.ts
+++ b/test/components/media-player/ha-media-player-browse.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { MediaPlayerItem } from "../../../src/data/media-player";
+import { filterRadioBrowserChildren } from "../../../src/components/media-player/radio-browser-util";
+
+const makeItem = (title: string): MediaPlayerItem =>
+  ({
+    title,
+    media_content_id: `media-source://radio_browser/${title}`,
+    media_content_type: "audio/mpeg",
+    media_class: "music",
+    children_media_class: null,
+    can_play: true,
+    can_expand: false,
+    can_search: false,
+    thumbnail: null,
+  }) as unknown as MediaPlayerItem;
+
+const ITEMS = [
+  makeItem("Rock FM"),
+  makeItem("Jazz Vibes"),
+  makeItem("Classic Rock Radio"),
+  makeItem("Top 40"),
+];
+
+describe("filterRadioBrowserChildren", () => {
+  it("returns all items when query is empty", () => {
+    expect(filterRadioBrowserChildren(ITEMS, "")).toEqual(ITEMS);
+  });
+
+  it("filters items by title (case-insensitive)", () => {
+    const result = filterRadioBrowserChildren(ITEMS, "rock");
+    expect(result).toHaveLength(2);
+    expect(result[0].title).toBe("Rock FM");
+    expect(result[1].title).toBe("Classic Rock Radio");
+  });
+
+  it("is case-insensitive for uppercase query", () => {
+    const result = filterRadioBrowserChildren(ITEMS, "JAZZ");
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("Jazz Vibes");
+  });
+
+  it("returns an empty array when no items match", () => {
+    expect(filterRadioBrowserChildren(ITEMS, "zzznomatch")).toHaveLength(0);
+  });
+
+  it("returns all items when query matches all titles", () => {
+    const result = filterRadioBrowserChildren(ITEMS, "radio");
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("Classic Rock Radio");
+  });
+
+  it("handles an empty items array gracefully", () => {
+    expect(filterRadioBrowserChildren([], "rock")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Add a real-time search/filter input field to the media browser when browsing **Radio Browser** content. The search field appears exclusively when the active media source is `radio_browser` (i.e. `media_content_id` starts with `media-source://radio_browser`), so it does not affect any other media source.

## Changes

- **`ha-media-player-browse.ts`**:
  - Imports `search-input-outlined` component.
  - Adds `_searchQuery` state (auto-reset on navigation).
  - Detects Radio Browser source via `media_content_id` prefix.
  - Renders a sticky search field above the content list on all Radio Browser levels.
  - Filters the loaded children client-side by title (case-insensitive) – no extra API calls.
  - Adds `_handleSearchQuery()` event handler.

- **`src/translatio- **`src/translatio- **`src/translatio- **`sron- **`src/translatio- **`src/trase- **`src/trade- **`src/translatio- **`src/translatio- **`src/it works

The filter works client-side on the items already loaded from the Radio Browser. Changes to homeassistant/core would be needed to enable global cross-category search. If someone helps me on homeassistant/core changes please contact me, so that we can implement a global cross-category search on the Radio Browser.

## Screenshots
### no filtering:
<img width="1209" height="561" alt="Bildschirmfoto 2026-03-07 um 11 25 15" src="https://github.com/user-attachments/assets/7a2614d3-2d69-4c36-8360-3f53b68d830e" />

### filtering on the top page:
<img width="1209" height="561" alt="Bildschirmfoto 2026-03-07 um 11 25 36" src="https://github.com/user-attachments/assets/9cdc51a2-d92b-45a6-8396-565936902393" />

### filtering on the sub page:
<img width="1209" height="561" alt="Bildschirmfoto 2026-03-07 um 11 27 05" src="https://github.com/user-attachments/assets/374c79b8-52b2-496b-9d16-9978c7acd902" />
