### PR TITLE
Add back energy distribution card to electricity tab

### DIFF
--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -8,6 +8,10 @@ import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
 import { DEFAULT_ENERGY_COLLECTION_KEY } from "../ha-panel-energy";
 import { shouldShowFloorsAndAreas } from "./show-floors-and-areas";
+import {
+  LARGE_SCREEN_CONDITION,
+  SMALL_SCREEN_CONDITION,
+} from "../../lovelace/strategies/helpers/screen-conditions";
 
 @customElement("energy-view-strategy")
 export class EnergyViewStrategy extends ReactiveElement {
@@ -20,8 +24,11 @@ export class EnergyViewStrategy extends ReactiveElement {
 
     const view: LovelaceViewConfig = {
       type: "sections",
-      max_columns: 3,
       sections: [],
+      sidebar: {
+        sections: [{ cards: [] }],
+        visibility: [LARGE_SCREEN_CONDITION],
+      },
       footer: {
         card: {
           type: "energy-date-selection",
@@ -62,6 +69,22 @@ export class EnergyViewStrategy extends ReactiveElement {
 
     const mainCards: LovelaceCardConfig[] = [];
     const gaugeCards: LovelaceCardConfig[] = [];
+    const sidebarSection = view.sidebar!.sections![0];
+
+    if (hasGrid || hasBattery || hasSolar) {
+      const distributionCard = {
+        title: hass.localize("ui.panel.energy.cards.energy_distribution_title"),
+        type: "energy-distribution",
+        collection_key: collectionKey,
+      };
+      sidebarSection.cards!.push(distributionCard);
+      view.sections!.push({
+        type: "grid",
+        column_span: 1,
+        cards: [distributionCard],
+        visibility: [SMALL_SCREEN_CONDITION],
+      });
+    }
 
     // Only include if we have a grid source & return.
     if (hasReturn) {
@@ -100,9 +123,15 @@ export class EnergyViewStrategy extends ReactiveElement {
     }
 
     if (gaugeCards.length) {
+      sidebarSection.cards!.push({
+        type: "grid",
+        columns: gaugeCards.length === 1 ? 1 : 2,
+        cards: gaugeCards,
+      });
       view.sections!.push({
         type: "grid",
-        column_span: 3,
+        column_span: 1,
+        visibility: [SMALL_SCREEN_CONDITION],
         cards:
           gaugeCards.length === 1
             ? [gaugeCards[0]]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The distribution card was removed in #29867 but users without water, gas or power don't get the summary tab so they need it back.
Now that the footer width is set in `px` it was easier to fit it in using the sidebar layout.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
<img width="2400" height="1534" alt="image" src="https://github.com/user-attachments/assets/8ef9cda6-02c8-429e-8698-bfec8b6c5a98" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
