### PR TITLE
Add default state/numeric_state options to automation triggers and conditions

### DIFF
--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -21,6 +21,7 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import { mainWindow } from "../../../common/dom/get_main_window";
 import { computeAreaName } from "../../../common/entity/compute_area_name";
 import { computeDomain } from "../../../common/entity/compute_domain";
+import { isNumericState } from "../../../common/number/format_number";
 import { computeEntityNameList } from "../../../common/entity/compute_entity_name_display";
 import { computeFloorName } from "../../../common/entity/compute_floor_name";
 import { stringCompare } from "../../../common/string/compare";
@@ -1832,9 +1833,7 @@ class DialogAddAutomationElement
       const stateObj = this.hass.states[entityId];
       if (
         NUMERIC_DOMAINS.includes(domain) ||
-        (stateObj &&
-          ("unit_of_measurement" in stateObj.attributes ||
-            "state_class" in stateObj.attributes))
+        (stateObj && isNumericState(stateObj))
       ) {
         items.push(
           this._convertToItem("numeric_state", {}, type, this.hass.localize)

--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -1818,6 +1818,33 @@ class DialogAddAutomationElement
     this._getItemsByTarget();
   };
 
+  private _getDefaultStateItems(
+    type: "trigger" | "condition"
+  ): AddAutomationElementListItem[] {
+    const items: AddAutomationElementListItem[] = [
+      this._convertToItem("state", {}, type, this.hass.localize),
+    ];
+
+    const entityId = this._selectedTarget?.entity_id;
+    if (entityId) {
+      const NUMERIC_DOMAINS = ["counter", "input_number", "number", "sensor"];
+      const domain = computeDomain(entityId);
+      const stateObj = this.hass.states[entityId];
+      if (
+        NUMERIC_DOMAINS.includes(domain) ||
+        (stateObj &&
+          ("unit_of_measurement" in stateObj.attributes ||
+            "state_class" in stateObj.attributes))
+      ) {
+        items.push(
+          this._convertToItem("numeric_state", {}, type, this.hass.localize)
+        );
+      }
+    }
+
+    return items;
+  }
+
   private async _getItemsByTarget() {
     if (!this._selectedTarget) {
       return;
@@ -1830,10 +1857,19 @@ class DialogAddAutomationElement
           this._selectedTarget
         );
 
-        this._targetItems = this._getDomainGroupedTriggerListItems(
+        const grouped = this._getDomainGroupedTriggerListItems(
           this.hass.localize,
           items
         );
+        if (this._selectedTarget.entity_id) {
+          grouped.push({
+            title: this.hass.localize(
+              `ui.panel.config.automation.editor.triggers.groups.entity.label` as LocalizeKeys
+            ),
+            items: this._getDefaultStateItems("trigger"),
+          });
+        }
+        this._targetItems = grouped;
         return;
       }
       if (this._params!.type === "condition") {
@@ -1842,10 +1878,19 @@ class DialogAddAutomationElement
           this._selectedTarget
         );
 
-        this._targetItems = this._getDomainGroupedConditionListItems(
+        const grouped = this._getDomainGroupedConditionListItems(
           this.hass.localize,
           items
         );
+        if (this._selectedTarget.entity_id) {
+          grouped.push({
+            title: this.hass.localize(
+              `ui.panel.config.automation.editor.conditions.groups.entity.label` as LocalizeKeys
+            ),
+            items: this._getDefaultStateItems("condition"),
+          });
+        }
+        this._targetItems = grouped;
         return;
       }
 

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -318,6 +318,7 @@ export default class HaAutomationCondition extends SubscribeMixin(LitElement) {
       };
       conditions = this.conditions.concat({
         ...elClass.defaultConfig,
+        ...(target?.entity_id ? { entity_id: target.entity_id } : {}),
       });
     }
     this._focusLastConditionOnChange = true;

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -234,6 +234,7 @@ export default class HaAutomationTrigger extends SubscribeMixin(LitElement) {
       };
       triggers = this.triggers.concat({
         ...elClass.defaultConfig,
+        ...(target?.entity_id ? { entity_id: target.entity_id } : {}),
       });
     }
     this._focusLastTriggerOnChange = true;


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The add automation element dialog now always includes "state" (and "numeric_state" for numeric entities) as default options for entity targets, ensuring there is always at least one trigger or condition available.

For entity targets, "state" is always included if not already provided by the backend, and "numeric_state" is added when the entity is numeric (based on domain, unit of measurement, or state class). For floor, area, and device targets, no defaults are added since they don't represent a single entity.

## Screenshots

<img width="1038" height="811" alt="CleanShot 2026-03-09 at 12 29 16" src="https://github.com/user-attachments/assets/b2caf2e4-b7f3-4e40-abd9-132553f877f7" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/29711
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr