### PR TITLE
Fix code editor autocomplete using wa popup

### DIFF
--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -1,4 +1,5 @@
-import "@home-assistant/webawesome/dist/components/popover/popover";
+import "@home-assistant/webawesome/dist/components/popup/popup";
+import type WaPopup from "@home-assistant/webawesome/dist/components/popup/popup";
 import type {
   Completion,
   CompletionContext,
@@ -111,6 +112,18 @@ export class HaCodeEditor extends ReactiveElement {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   private _loadedCodeMirror?: typeof import("../resources/codemirror");
 
+  private _completionInfoPopover?: WaPopup;
+
+  private _completionInfoContainer?: HTMLDivElement;
+
+  private _completionInfoDestroy?: () => void;
+
+  private _completionInfoRequest = 0;
+
+  private _completionInfoKey?: string;
+
+  private _completionInfoFrame?: number;
+
   private _editorToolbar?: HaIconButtonToolbar;
 
   private _iconList?: Completion[];
@@ -156,6 +169,14 @@ export class HaCodeEditor extends ReactiveElement {
 
   public disconnectedCallback() {
     fireEvent(this, "dialog-set-fullscreen", false);
+    this._clearCompletionInfo();
+    if (this._completionInfoFrame !== undefined) {
+      cancelAnimationFrame(this._completionInfoFrame);
+      this._completionInfoFrame = undefined;
+    }
+    this._completionInfoPopover?.remove();
+    this._completionInfoPopover = undefined;
+    this._completionInfoContainer = undefined;
     super.disconnectedCallback();
     this.removeEventListener("keydown", stopPropagation);
     this.removeEventListener("keydown", this._handleKeyDown);
@@ -599,6 +620,157 @@ export class HaCodeEditor extends ReactiveElement {
     return completionInfo;
   };
 
+  private _getCompletionInfo = (
+    completion: Completion
+  ): CompletionInfo | Promise<CompletionInfo> | null => {
+    if (this.hass && completion.label in this.hass.states) {
+      return this._renderInfo(completion);
+    }
+
+    if (completion.label.startsWith("mdi:")) {
+      return renderIcon(completion);
+    }
+
+    return null;
+  };
+
+  private _ensureCompletionInfoPopover(): WaPopup {
+    if (!this._completionInfoPopover) {
+      this._completionInfoPopover = document.createElement(
+        "wa-popup"
+      ) as WaPopup;
+      this._completionInfoPopover.classList.add("completion-info-popover");
+      this._completionInfoPopover.placement = "right-start";
+      this._completionInfoPopover.distance = 4;
+      this._completionInfoPopover.flip = true;
+      this._completionInfoPopover.flipFallbackPlacements =
+        "left-start bottom-start top-start";
+      this._completionInfoPopover.shift = true;
+      this._completionInfoPopover.shiftPadding = 8;
+      this._completionInfoPopover.autoSize = "both";
+      this._completionInfoPopover.autoSizePadding = 8;
+
+      this._completionInfoContainer = document.createElement("div");
+      this._completionInfoPopover.appendChild(this._completionInfoContainer);
+      this.renderRoot.appendChild(this._completionInfoPopover);
+    }
+
+    return this._completionInfoPopover;
+  }
+
+  private _clearCompletionInfo() {
+    this._completionInfoRequest += 1;
+    this._completionInfoKey = undefined;
+    this._completionInfoDestroy?.();
+    this._completionInfoDestroy = undefined;
+    this._completionInfoContainer?.replaceChildren();
+
+    if (this._completionInfoPopover?.active) {
+      this._completionInfoPopover.active = false;
+    }
+  }
+
+  private _renderCompletionInfoContent(info: CompletionInfo) {
+    this._completionInfoDestroy?.();
+    this._completionInfoDestroy = undefined;
+
+    if (!this._completionInfoContainer) {
+      return;
+    }
+
+    if (info === null) {
+      this._completionInfoContainer.replaceChildren();
+      return;
+    }
+
+    if ("nodeType" in info) {
+      this._completionInfoContainer.replaceChildren(info);
+      return;
+    }
+
+    this._completionInfoContainer.replaceChildren(info.dom);
+    this._completionInfoDestroy = info.destroy;
+  }
+
+  private _syncCompletionInfoPopover = () => {
+    if (this._completionInfoFrame !== undefined) {
+      cancelAnimationFrame(this._completionInfoFrame);
+    }
+
+    this._completionInfoFrame = requestAnimationFrame(() => {
+      this._completionInfoFrame = undefined;
+      this._syncCompletionInfoPopoverNow();
+    });
+  };
+
+  private _syncCompletionInfoPopoverNow = () => {
+    if (!this.codemirror || !this._loadedCodeMirror) {
+      return;
+    }
+
+    if (window.matchMedia("(max-width: 600px)").matches) {
+      this._clearCompletionInfo();
+      return;
+    }
+
+    const completion = this._loadedCodeMirror.selectedCompletion(
+      this.codemirror.state
+    );
+    const selectedOption = this.codemirror.dom.querySelector(
+      ".cm-tooltip-autocomplete li[aria-selected]"
+    ) as HTMLElement | null;
+
+    if (!completion || !selectedOption) {
+      this._clearCompletionInfo();
+      return;
+    }
+
+    const infoResult = this._getCompletionInfo(completion);
+
+    if (!infoResult) {
+      this._clearCompletionInfo();
+      return;
+    }
+
+    const requestId = ++this._completionInfoRequest;
+    const infoKey = completion.label;
+    const popover = this._ensureCompletionInfoPopover();
+    popover.anchor = selectedOption;
+
+    const showPopover = async (info: CompletionInfo) => {
+      if (requestId !== this._completionInfoRequest) {
+        if (info && typeof info === "object" && "destroy" in info) {
+          info.destroy?.();
+        }
+        return;
+      }
+
+      if (infoKey !== this._completionInfoKey) {
+        this._renderCompletionInfoContent(info);
+        this._completionInfoKey = infoKey;
+      }
+
+      await popover.updateComplete;
+      popover.active = true;
+      popover.reposition();
+    };
+
+    if ("then" in infoResult) {
+      infoResult.then(showPopover).catch(() => {
+        if (requestId === this._completionInfoRequest) {
+          this._clearCompletionInfo();
+        }
+      });
+      return;
+    }
+
+    showPopover(infoResult).catch(() => {
+      if (requestId === this._completionInfoRequest) {
+        this._clearCompletionInfo();
+      }
+    });
+  };
+
   private _getStates = memoizeOne((states: HassEntities): Completion[] => {
     if (!states) {
       return [];
@@ -608,7 +780,6 @@ export class HaCodeEditor extends ReactiveElement {
       type: "variable",
       label: key,
       detail: states[key].attributes.friendly_name,
-      info: this._renderInfo,
     }));
 
     return options;
@@ -782,7 +953,6 @@ export class HaCodeEditor extends ReactiveElement {
         type: "variable",
         label: `mdi:${icon.name}`,
         detail: icon.keywords.join(", "),
-        info: renderIcon,
       }));
     }
 
@@ -810,6 +980,7 @@ export class HaCodeEditor extends ReactiveElement {
   private _onUpdate = (update: ViewUpdate): void => {
     this._canUndo = !this.readOnly && undoDepth(update.state) > 0;
     this._canRedo = !this.readOnly && redoDepth(update.state) > 0;
+    this._syncCompletionInfoPopover();
     if (!update.docChanged) {
       return;
     }
@@ -929,9 +1100,31 @@ export class HaCodeEditor extends ReactiveElement {
           padding: 8px;
         }
 
+        wa-popup.completion-info-popover {
+          --auto-size-available-width: min(
+            420px,
+            calc(100vw - (2 * var(--ha-space-4, 16px)))
+          );
+        }
+
+        wa-popup.completion-info-popover::part(popup) {
+          padding: 0;
+          color: var(--primary-text-color);
+          background-color: var(
+            --code-editor-background-color,
+            var(--card-background-color)
+          );
+          border: 1px solid var(--divider-color);
+          border-radius: var(--mdc-shape-medium, 4px);
+          box-shadow:
+            0px 5px 5px -3px rgb(0 0 0 / 20%),
+            0px 8px 10px 1px rgb(0 0 0 / 14%),
+            0px 3px 14px 2px rgb(0 0 0 / 12%);
+        }
+
         /* Hide completion info on narrow screens */
         @media (max-width: 600px) {
-          .cm-completionInfo,
+          wa-popup.completion-info-popover,
           .completion-info {
             display: none;
           }

--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -1103,7 +1103,7 @@ export class HaCodeEditor extends ReactiveElement {
         wa-popup.completion-info-popover {
           --auto-size-available-width: min(
             420px,
-            calc(var(--safe-width) - (2 * var(--ha-space-4)))
+            calc(var(--safe-width) - var(--ha-space-8))
           );
         }
 

--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -1103,7 +1103,7 @@ export class HaCodeEditor extends ReactiveElement {
         wa-popup.completion-info-popover {
           --auto-size-available-width: min(
             420px,
-            calc(100vw - (2 * var(--ha-space-4, 16px)))
+            calc(var(--safe-width) - (2 * var(--ha-space-4)))
           );
         }
 

--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -1,3 +1,4 @@
+import "@home-assistant/webawesome/dist/components/popover/popover";
 import type {
   Completion,
   CompletionContext,
@@ -288,6 +289,9 @@ export class HaCodeEditor extends ReactiveElement {
       this._loadedCodeMirror.foldingCompartment.of(
         this._getFoldingExtensions()
       ),
+      this._loadedCodeMirror.tooltips({
+        position: "absolute",
+      }),
       ...(this.placeholder ? [placeholder(this.placeholder)] : []),
     ];
 

--- a/src/resources/codemirror.ts
+++ b/src/resources/codemirror.ts
@@ -32,6 +32,7 @@ export {
   lineNumbers,
   rectangularSelection,
   dropCursor,
+  tooltips,
 } from "@codemirror/view";
 export { indentationMarkers } from "@replit/codemirror-indentation-markers";
 export { tags } from "@lezer/highlight";
@@ -151,8 +152,20 @@ export const haTheme = EditorView.theme({
       "var(--code-editor-background-color, var(--card-background-color))",
     border: "1px solid var(--divider-color)",
     borderRadius: "var(--mdc-shape-medium, 4px)",
+    maxWidth: "min(420px, calc(100vw - (2 * var(--ha-space-4, 16px))))",
+    boxSizing: "border-box",
     boxShadow:
       "0px 5px 5px -3px rgb(0 0 0 / 20%), 0px 8px 10px 1px rgb(0 0 0 / 14%), 0px 3px 14px 2px rgb(0 0 0 / 12%)",
+  },
+
+  ".cm-tooltip.cm-tooltip-autocomplete": {
+    maxWidth:
+      "min(420px, calc(100vw - (2 * var(--ha-space-4, 16px))), calc(100% - var(--ha-space-2, 8px)))",
+  },
+
+  ".cm-tooltip-autocomplete > ul": {
+    maxWidth: "100%",
+    boxSizing: "border-box",
   },
 
   "& .cm-tooltip.cm-tooltip-autocomplete > ul > li": {
@@ -177,13 +190,28 @@ export const haTheme = EditorView.theme({
     color: "var(--text-primary-color)",
   },
 
-  "& .cm-completionInfo.cm-completionInfo-right": {
-    left: "calc(100% + 4px)",
-  },
+  "& .cm-completionInfo.cm-completionInfo-left, & .cm-completionInfo.cm-completionInfo-left-narrow":
+    {
+      left: "var(--ha-space-2, 8px)",
+      right: "auto",
+    },
+
+  "& .cm-completionInfo.cm-completionInfo-right, & .cm-completionInfo.cm-completionInfo-right-narrow":
+    {
+      left: "auto",
+      right: "var(--ha-space-2, 8px)",
+    },
+
+  "& .cm-completionInfo.cm-completionInfo-above, & .cm-completionInfo.cm-completionInfo-below":
+    {
+      left: "var(--ha-space-2, 8px)",
+      right: "auto",
+    },
 
   "& .cm-tooltip.cm-completionInfo": {
     padding: "4px 8px",
     marginTop: "-5px",
+    maxWidth: "calc(100% - (2 * var(--ha-space-2, 8px)))",
   },
 
   ".cm-selectionMatch": {

--- a/src/resources/codemirror.ts
+++ b/src/resources/codemirror.ts
@@ -12,7 +12,7 @@ import type { KeyBinding } from "@codemirror/view";
 import { EditorView } from "@codemirror/view";
 import { tags } from "@lezer/highlight";
 
-export { autocompletion } from "@codemirror/autocomplete";
+export { autocompletion, selectedCompletion } from "@codemirror/autocomplete";
 export { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 export { highlightingFor, foldGutter } from "@codemirror/language";
 export {
@@ -188,30 +188,6 @@ export const haTheme = EditorView.theme({
 
   "li[aria-selected] .cm-completionDetail": {
     color: "var(--text-primary-color)",
-  },
-
-  "& .cm-completionInfo.cm-completionInfo-left, & .cm-completionInfo.cm-completionInfo-left-narrow":
-    {
-      left: "var(--ha-space-2, 8px)",
-      right: "auto",
-    },
-
-  "& .cm-completionInfo.cm-completionInfo-right, & .cm-completionInfo.cm-completionInfo-right-narrow":
-    {
-      left: "auto",
-      right: "var(--ha-space-2, 8px)",
-    },
-
-  "& .cm-completionInfo.cm-completionInfo-above, & .cm-completionInfo.cm-completionInfo-below":
-    {
-      left: "var(--ha-space-2, 8px)",
-      right: "auto",
-    },
-
-  "& .cm-tooltip.cm-completionInfo": {
-    padding: "4px 8px",
-    marginTop: "-5px",
-    maxWidth: "calc(100% - (2 * var(--ha-space-2, 8px)))",
   },
 
   ".cm-selectionMatch": {

--- a/src/resources/codemirror.ts
+++ b/src/resources/codemirror.ts
@@ -152,7 +152,7 @@ export const haTheme = EditorView.theme({
       "var(--code-editor-background-color, var(--card-background-color))",
     border: "1px solid var(--divider-color)",
     borderRadius: "var(--mdc-shape-medium, 4px)",
-    maxWidth: "min(420px, calc(100vw - (2 * var(--ha-space-4, 16px))))",
+    maxWidth: "min(420px, calc(var(--safe-width) - (2 * var(--ha-space-4))))",
     boxSizing: "border-box",
     boxShadow:
       "0px 5px 5px -3px rgb(0 0 0 / 20%), 0px 8px 10px 1px rgb(0 0 0 / 14%), 0px 3px 14px 2px rgb(0 0 0 / 12%)",
@@ -160,7 +160,7 @@ export const haTheme = EditorView.theme({
 
   ".cm-tooltip.cm-tooltip-autocomplete": {
     maxWidth:
-      "min(420px, calc(100vw - (2 * var(--ha-space-4, 16px))), calc(100% - var(--ha-space-2, 8px)))",
+      "min(420px, calc(var(--safe-width) - (2 * var(--ha-space-4))), calc(100% - var(--ha-space-2)))",
   },
 
   ".cm-tooltip-autocomplete > ul": {

--- a/src/resources/codemirror.ts
+++ b/src/resources/codemirror.ts
@@ -152,7 +152,7 @@ export const haTheme = EditorView.theme({
       "var(--code-editor-background-color, var(--card-background-color))",
     border: "1px solid var(--divider-color)",
     borderRadius: "var(--mdc-shape-medium, 4px)",
-    maxWidth: "min(420px, calc(var(--safe-width) - (2 * var(--ha-space-4))))",
+    maxWidth: "min(420px, calc(var(--safe-width) - var(--ha-space-8)))",
     boxSizing: "border-box",
     boxShadow:
       "0px 5px 5px -3px rgb(0 0 0 / 20%), 0px 8px 10px 1px rgb(0 0 0 / 14%), 0px 3px 14px 2px rgb(0 0 0 / 12%)",
@@ -160,7 +160,7 @@ export const haTheme = EditorView.theme({
 
   ".cm-tooltip.cm-tooltip-autocomplete": {
     maxWidth:
-      "min(420px, calc(var(--safe-width) - (2 * var(--ha-space-4))), calc(100% - var(--ha-space-2)))",
+      "min(420px, calc(var(--safe-width) - var(--ha-space-8)), calc(100% - var(--ha-space-2)))",
   },
 
   ".cm-tooltip-autocomplete > ul": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Initially tried to set the parent, this didn't show at all, second was to use position absolute, and then the helper to use `wa-popup`. This works pretty well.

Only loss is the width of the select list to make sure it cannot go outside of the editor/dialog.

May be better to work on a full popover with a vertical split for the selection and helper sections, but this is a lot more involved. For now this is OK and can allow users to keep using the autocomplete as before with the old dialogs

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

<img width="1278" height="701" alt="image" src="https://github.com/user-attachments/assets/67ecf63f-ddc3-4427-99a0-d4ef29fa3c33" />


When the entity is at the bottom of a card code editor, it will introduce scrolling, but it is now visible when scrolling. This was from the `position: absolute` edit:

<img width="1421" height="760" alt="image" src="https://github.com/user-attachments/assets/e74c8c8a-3bbf-47b9-bf51-4af46f1d92eb" />

Non dialogs still compatible (bad screenshot):

<img width="1316" height="765" alt="image" src="https://github.com/user-attachments/assets/13eddf59-928b-4ff4-876c-30a2938335b9" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29764
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
