### PR TITLE
Fix energy dashboard date picker opening direction

### DIFF
--- a/src/panels/energy/strategies/energy-overview-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-overview-view-strategy.ts
@@ -25,6 +25,8 @@ export class EnergyOverviewViewStrategy extends ReactiveElement {
         card: {
           type: "energy-date-selection",
           collection_key: collectionKey,
+          opening_direction: "right",
+          vertical_opening_direction: "up",
         },
       },
     };

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -33,6 +33,8 @@ export class EnergyViewStrategy extends ReactiveElement {
         card: {
           type: "energy-date-selection",
           collection_key: collectionKey,
+          opening_direction: "right",
+          vertical_opening_direction: "up",
         },
       },
     };

--- a/src/panels/energy/strategies/gas-view-strategy.ts
+++ b/src/panels/energy/strategies/gas-view-strategy.ts
@@ -24,6 +24,8 @@ export class GasViewStrategy extends ReactiveElement {
         card: {
           type: "energy-date-selection",
           collection_key: collectionKey,
+          opening_direction: "right",
+          vertical_opening_direction: "up",
         },
       },
     };

--- a/src/panels/energy/strategies/water-view-strategy.ts
+++ b/src/panels/energy/strategies/water-view-strategy.ts
@@ -25,6 +25,8 @@ export class WaterViewStrategy extends ReactiveElement {
         card: {
           type: "energy-date-selection",
           collection_key: collectionKey,
+          opening_direction: "right",
+          vertical_opening_direction: "up",
         },
       },
     };

--- a/src/panels/lovelace/cards/energy/hui-energy-date-selection-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-date-selection-card.ts
@@ -6,7 +6,7 @@ import type { HomeAssistant } from "../../../../types";
 import { hasConfigChanged } from "../../common/has-changed";
 import "../../components/hui-energy-period-selector";
 import type { LovelaceCard, LovelaceGridOptions } from "../../types";
-import type { EnergyCardBaseConfig } from "../types";
+import type { EnergyDateSelectorCardConfig } from "../types";
 
 @customElement("hui-energy-date-selection-card")
 export class HuiEnergyDateSelectionCard
@@ -15,7 +15,7 @@ export class HuiEnergyDateSelectionCard
 {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @state() private _config?: EnergyCardBaseConfig;
+  @state() private _config?: EnergyDateSelectorCardConfig;
 
   public getCardSize(): Promise<number> | number {
     return 1;
@@ -28,7 +28,7 @@ export class HuiEnergyDateSelectionCard
     };
   }
 
-  public setConfig(config: EnergyCardBaseConfig): void {
+  public setConfig(config: EnergyDateSelectorCardConfig): void {
     this._config = config;
   }
 
@@ -45,12 +45,25 @@ export class HuiEnergyDateSelectionCard
       return nothing;
     }
 
+    const verticalOpeningDirection =
+      this._config.vertical_opening_direction === "auto"
+        ? undefined
+        : this._config.vertical_opening_direction;
+
+    const openingDirection =
+      this._config.opening_direction === "auto"
+        ? undefined
+        : this._config.opening_direction;
+
     return html`
       <ha-card>
         <div class="card-content">
           <hui-energy-period-selector
             .hass=${this.hass}
             .collectionKey=${this._config.collection_key}
+            .verticalOpeningDirection=${verticalOpeningDirection}
+            .openingDirection=${openingDirection}
+            .allowCompare=${!this._config.disable_compare}
           ></hui-energy-period-selector>
         </div>
       </ha-card>

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -169,6 +169,12 @@ export interface EnergyCardBaseConfig extends LovelaceCardConfig {
   collection_key?: string;
 }
 
+export interface EnergyDateSelectorCardConfig extends EnergyCardBaseConfig {
+  vertical_opening_direction?: "auto" | "up" | "down";
+  opening_direction?: "auto" | "right" | "left" | "center" | "inline";
+  disable_compare?: boolean;
+}
+
 export interface EnergyDistributionCardConfig extends EnergyCardBaseConfig {
   type: "energy-distribution";
   title?: string;


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The date selector on the energy dashboard is unable to properly determine which way to open leading to it appearing behind the sidebar on narrow screens. This was previously fixed by forcing the direction of opening.

When #29867 moved it to loading a footer card, the forced direction config was lost.

This PR restores that forced direction by adding in `opening-direction` and `vertical-opening-direction` config options for the date picker card, and setting those on the energy dashboard to the required values to match the original behaviour.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Before:
<img width="463" height="582" alt="image" src="https://github.com/user-attachments/assets/24bf5015-640c-4f62-a4bb-739a802303c0" />

After:
<img width="666" height="593" alt="image" src="https://github.com/user-attachments/assets/c428a7c4-146a-4501-9370-5b1f472143c7" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

The changes to add the date picker config have been cherry-picked from #29483 to allow this to be fixed sooner.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
