### PR TITLE
Use whole months for "Last 12 Months" on Energy Date Picker

### DIFF
--- a/src/common/datetime/calc_date_range.ts
+++ b/src/common/datetime/calc_date_range.ts
@@ -93,8 +93,8 @@ export const calcDateRange = (
       ];
     case "now-12m":
       return [
-        calcDate(today, subMonths, hass.locale, hass.config, 12),
-        calcDate(today, subMonths, hass.locale, hass.config, 0),
+        calcDate(subMonths(today, 11), startOfMonth, hass.locale, hass.config),
+        calcDate(today, endOfMonth, hass.locale, hass.config),
       ];
     case "now-1h":
       return [

--- a/src/common/datetime/calc_date_range.ts
+++ b/src/common/datetime/calc_date_range.ts
@@ -93,7 +93,12 @@ export const calcDateRange = (
       ];
     case "now-12m":
       return [
-        calcDate(subMonths(today, 11), startOfMonth, hass.locale, hass.config),
+        calcDate(
+          today,
+          (date) => subMonths(startOfMonth(date), 11),
+          hass.locale,
+          hass.config
+        ),
         calcDate(today, endOfMonth, hass.locale, hass.config),
       ];
     case "now-1h":

--- a/src/common/datetime/format_date.ts
+++ b/src/common/datetime/format_date.ts
@@ -166,6 +166,21 @@ const formatDateMonthMem = memoizeOne(
     })
 );
 
+// Aug
+export const formatDateMonthShort = (
+  dateObj: Date,
+  locale: FrontendLocaleData,
+  config: HassConfig
+) => formatDateMonthShortMem(locale, config.time_zone).format(dateObj);
+
+const formatDateMonthShortMem = memoizeOne(
+  (locale: FrontendLocaleData, serverTimeZone: string) =>
+    new Intl.DateTimeFormat(locale.language, {
+      month: "short",
+      timeZone: resolveTimeZone(locale.time_zone, serverTimeZone),
+    })
+);
+
 // 2021
 export const formatDateYear = (
   dateObj: Date,

--- a/src/panels/lovelace/components/hui-energy-period-selector.ts
+++ b/src/panels/lovelace/components/hui-energy-period-selector.ts
@@ -8,17 +8,21 @@ import {
   mdiHomeClock,
 } from "@mdi/js";
 import {
+  differenceInCalendarMonths,
   differenceInCalendarYears,
   differenceInDays,
   differenceInMonths,
   endOfDay,
+  endOfMonth,
   endOfToday,
   endOfWeek,
   isFirstDayOfMonth,
   isLastDayOfMonth,
   startOfDay,
+  startOfMonth,
   startOfWeek,
   subDays,
+  subMonths,
 } from "date-fns";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
@@ -286,27 +290,39 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
                     this.hass.locale,
                     this.hass.config
                   )}`
-                : html`${simpleRange === "month"
+                : html`${simpleRange === "12month" ||
+                  simpleRange === "months" ||
+                  simpleRange === "quarter"
                     ? html`${formatDateMonth(
                         this._startDate,
                         this.hass.locale,
                         this.hass.config
+                      )}&ndash;${formatDateMonth(
+                        this._endDate || new Date(),
+                        this.hass.locale,
+                        this.hass.config
                       )}`
-                    : simpleRange === "day"
-                      ? html`${formatDateVeryShort(
-                          this._startDate,
-                          this.hass.locale,
-                          this.hass.config
-                        )}`
-                      : html`${formatDateVeryShort(
-                          this._startDate,
-                          this.hass.locale,
-                          this.hass.config
-                        )}&ndash;${formatDateVeryShort(
-                          this._endDate || new Date(),
-                          this.hass.locale,
-                          this.hass.config
-                        )}`}`}
+                    : html`${simpleRange === "month"
+                        ? html`${formatDateMonth(
+                            this._startDate,
+                            this.hass.locale,
+                            this.hass.config
+                          )}`
+                        : simpleRange === "day"
+                          ? html`${formatDateVeryShort(
+                              this._startDate,
+                              this.hass.locale,
+                              this.hass.config
+                            )}`
+                          : html`${formatDateVeryShort(
+                              this._startDate,
+                              this.hass.locale,
+                              this.hass.config
+                            )}&ndash;${formatDateVeryShort(
+                              this._endDate || new Date(),
+                              this.hass.locale,
+                              this.hass.config
+                            )}`}`}`}
             </div>
             ${showSubtitleYear
               ? html`<div class="header-subtitle">
@@ -386,6 +402,7 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
       if (differenceInDays(endDate!, startDate!) === 0) {
         return "day";
       }
+      // Check if range is one or more whole months
       if (
         (calcDateProperty(
           startDate,
@@ -404,6 +421,7 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
             config
           ) as number) === 0
         ) {
+          // Single month
           return "month";
         }
         if (
@@ -416,29 +434,37 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
           ) as number) === 2 &&
           startDate.getMonth() % 3 === 0
         ) {
+          // Quarter year
           return "quarter";
         }
+        if (
+          calcDateDifferenceProperty(
+            endDate,
+            startDate,
+            differenceInMonths,
+            locale,
+            config
+          ) === 11
+        ) {
+          if (
+            calcDateDifferenceProperty(
+              endDate,
+              startDate,
+              differenceInCalendarYears,
+              locale,
+              config
+            ) === 0
+          ) {
+            // Exact year
+            return "year";
+          }
+          // Last 12 months
+          return "12month";
+        }
+        // Otherwise some number of whole months
+        return "months";
       }
-      if (
-        calcDateProperty(startDate, isFirstDayOfMonth, locale, config) &&
-        calcDateProperty(endDate, isLastDayOfMonth, locale, config) &&
-        calcDateDifferenceProperty(
-          endDate,
-          startDate,
-          differenceInCalendarYears,
-          locale,
-          config
-        ) === 0 &&
-        calcDateDifferenceProperty(
-          endDate,
-          startDate,
-          differenceInMonths,
-          locale,
-          config
-        ) === 11
-      ) {
-        return "year";
-      }
+      // Unnamed date range
       return "other";
     }
   );
@@ -508,6 +534,30 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
       );
     } else if (range === "year") {
       [this._startDate, this._endDate] = calcDateRange(this.hass, "this_year");
+    } else if (range === "12month") {
+      [this._startDate, this._endDate] = calcDateRange(this.hass, "now-12m");
+    } else if (range === "months") {
+      // Custom month range
+      const difference = calcDateDifferenceProperty(
+        this._endDate!,
+        this._startDate,
+        differenceInCalendarMonths,
+        this.hass.locale,
+        this.hass.config
+      ) as number;
+      this._startDate = calcDate(
+        calcDate(today, startOfMonth, this.hass.locale, this.hass.config),
+        subMonths,
+        this.hass.locale,
+        this.hass.config,
+        difference
+      );
+      this._endDate = calcDate(
+        today,
+        endOfMonth,
+        this.hass.locale,
+        this.hass.config
+      );
     } else {
       const weekStartsOn = firstWeekdayIndex(this.hass.locale);
       const weekStart = calcDate(

--- a/src/panels/lovelace/components/hui-energy-period-selector.ts
+++ b/src/panels/lovelace/components/hui-energy-period-selector.ts
@@ -43,6 +43,7 @@ import { calcDateRange } from "../../../common/datetime/calc_date_range";
 import { firstWeekdayIndex } from "../../../common/datetime/first_weekday";
 import {
   formatDateMonth,
+  formatDateMonthShort,
   formatDateVeryShort,
   formatDateYear,
 } from "../../../common/datetime/format_date";
@@ -293,11 +294,11 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
                 : html`${simpleRange === "12month" ||
                   simpleRange === "months" ||
                   simpleRange === "quarter"
-                    ? html`${formatDateMonth(
+                    ? html`${formatDateMonthShort(
                         this._startDate,
                         this.hass.locale,
                         this.hass.config
-                      )}&ndash;${formatDateMonth(
+                      )}&ndash;${formatDateMonthShort(
                         this._endDate || new Date(),
                         this.hass.locale,
                         this.hass.config


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This is potentially breaking in that the function that calculates `now-12m` has been changed to use the logic proposed here - selecting 12 whole months up to and including the current month - rather than the original behaviour of selecting the ~365 individual days up to and including today.

However the `now-12m` option seems to be only used by the energy date picker so I don't think this is a particular problem.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Currently the "Last 12 Months" date function selects 12 months worth of days back from the current day. So if today is March 10, then it would retrieve April 11 to March 10.

For the energy dashboard, previously this would select those days but they the ECharts would display them as aggregated monthly bars. This changed recently (see #30089) meaning we now see all those individual days.

This doesn't seem like a particularly useful range - particularly for comparing month on month data.

I'm proposing we change the meaning of the "Last 12 Months" to imply whole months up to and including the current month - i.e. treat "now" to mean (currently) "March", so the last 12 months selects Apr 1 to March 31. This means the quick action of selecting that range picks whole numbers of months so renders nicely and makes comparison of monthly data neater.

The changes here also improve the rendering of whole-month ranges on the energy date picker to shorten to just the month name - so would say "Apr-Mar" (with year shown where needed) rather than "1 Apr-31 Mar" for consistency with the way selecting a single month displays.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Last 12 Months:
<img width="472" height="64" alt="image" src="https://github.com/user-attachments/assets/1965ad34-df4c-48ed-ad3b-33d364110077" />

This Quarter:
<img width="470" height="66" alt="image" src="https://github.com/user-attachments/assets/2206533d-acd9-4e6d-a910-91fd31bead62" />

Other manually selected monthly ranges (e.g. 4 months) also show as month names now not short dates:
<img width="470" height="64" alt="image" src="https://github.com/user-attachments/assets/d8dcc408-242b-47eb-a031-1fa8d6e3da60" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #30089
- This PR is related to issue or discussion: #30089
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
