### PR TITLE
Show energy date picker previous/next on smaller screens

### DIFF
--- a/src/panels/lovelace/components/hui-energy-period-selector.ts
+++ b/src/panels/lovelace/components/hui-energy-period-selector.ts
@@ -126,7 +126,7 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
 
   private _measure() {
     this.narrow = this.offsetWidth < 425;
-    this._collapseButtons = this.offsetWidth < 300;
+    this._collapseButtons = this.offsetWidth < 275;
   }
 
   private async _attachObserver(): Promise<void> {
@@ -692,6 +692,10 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
     }
     ha-ripple {
       border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+    }
+    :host([narrow]) ha-date-range-picker {
+      --ha-icon-button-size: 24px;
+      --mdc-icon-size: 16px;
     }
     .backdrop {
       position: fixed;

--- a/src/panels/lovelace/components/hui-energy-period-selector.ts
+++ b/src/panels/lovelace/components/hui-energy-period-selector.ts
@@ -684,8 +684,8 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
       align-items: center;
     }
     ha-button {
-      margin-left: 8px;
-      margin-inline-start: 8px;
+      margin-left: var(--ha-space-2);
+      margin-inline-start: var(--ha-space-2);
       margin-inline-end: initial;
       flex-shrink: 0;
       --ha-button-theme-color: currentColor;

--- a/src/panels/lovelace/components/hui-energy-period-selector.ts
+++ b/src/panels/lovelace/components/hui-energy-period-selector.ts
@@ -126,7 +126,7 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
 
   private _measure() {
     this.narrow = this.offsetWidth < 425;
-    this._collapseButtons = this.offsetWidth < 320;
+    this._collapseButtons = this.offsetWidth < 300;
   }
 
   private async _attachObserver(): Promise<void> {
@@ -644,7 +644,7 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
     }
     .date-range {
       flex: 1;
-      padding: 2px var(--ha-space-2);
+      padding: 2px var(--ha-space-2) 2px 0px;
       display: flex;
       flex-direction: column;
       justify-content: center;


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The energy date picker redesign in #29321 moved the previous/next buttons into the overflow menu when the screen width was too narrow to fit the largest displayable date range on the energy picker. When optimising this minimum size, the additional padding around the card was not taken fully into account meaning the smallest screen size before hiding was actually ~370px wide. As a large number of android devices are 360px resolution this makes the change problematic for a potentially large number of users.

To improve usability, this PR addresses that by adjusting the element sizes to allow the previous/next buttons to display down to a 325px display width which should hopefully suit the vast majority of mobile device users.

This is achieved primarily by reducing the size of the calendar icon for narrower displays. Given the entire text label for the date picker can be tapped on to open the calendar select, this icon doesn't need to meet the size requirements for normal buttons. The smaller sized icon also matches visually with the smaller font text used on the narrower toolbar.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

<img width="480" height="212" alt="image" src="https://github.com/user-attachments/assets/0e9e7fa2-9226-4c46-a3ad-af5bcce1e63d" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #30012
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
