### PR TITLE
Refactor lovelace view lifecycle to avoid unnecessary DOM rebuilds

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -1142,22 +1142,14 @@ class HUIRoot extends LitElement {
     }
   }
 
-  private _cleanupViewCache(oldLovelace: Lovelace): void {
-    // Clean up cache entries for views that no longer exist
-    const newViewPaths = new Set(
-      this.lovelace!.config.views.map((v, i) => v.path ?? String(i))
-    );
-    const keys = new Set([
-      ...Object.keys(this._viewCache),
-      ...Object.keys(this._viewScrollPositions),
-    ]);
-    for (const key of keys) {
-      const index = Number(key);
-      const oldPath = oldLovelace.config.views[index]?.path ?? String(index);
-      if (!newViewPaths.has(oldPath)) {
-        delete this._viewCache[key];
-        delete this._viewScrollPositions[key];
-      }
+  private _cleanupViewCache(_oldLovelace: Lovelace): void {
+    // Keep only the currently displayed view to avoid UI flash.
+    // All other cached views are cleared and will be recreated on next visit.
+    const currentView =
+      this._curView != null ? this._viewCache[this._curView] : undefined;
+    this._viewCache = {};
+    if (currentView && this._curView != null) {
+      this._viewCache[this._curView] = currentView;
     }
   }
 

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -35,7 +35,6 @@ import {
   extractSearchParamsObject,
   removeSearchParam,
 } from "../../common/url/search-params";
-import { debounce } from "../../common/util/debounce";
 import { afterNextRender } from "../../common/util/render-status";
 import "../../components/ha-button";
 import "../../components/ha-dropdown";
@@ -156,7 +155,7 @@ class HUIRoot extends LitElement {
 
   private _configChangedByUndo = false;
 
-  private _viewCache?: Record<string, HUIView>;
+  private _viewCache: Record<string, HUIView> = {};
 
   private _viewScrollPositions: Record<string, number> = {};
 
@@ -170,22 +169,9 @@ class HUIRoot extends LitElement {
     }),
   });
 
-  private _debouncedConfigChanged: () => void;
-
   private _conversation = memoizeOne((_components) =>
     isComponentLoaded(this.hass, "conversation")
   );
-
-  constructor() {
-    super();
-    // The view can trigger a re-render when it knows that certain
-    // web components have been loaded.
-    this._debouncedConfigChanged = debounce(
-      () => this._selectView(this._curView, true),
-      100,
-      false
-    );
-  }
 
   private _renderActionItems(): TemplateResult {
     const result: TemplateResult[] = [];
@@ -632,7 +618,6 @@ class HUIRoot extends LitElement {
           .hass=${this.hass}
           .theme=${curViewConfig?.theme}
           id="view"
-          @ll-rebuild=${this._debouncedConfigChanged}
         >
           <hui-view-background .hass=${this.hass} .background=${background}>
           </hui-view-background>
@@ -762,7 +747,6 @@ class HUIRoot extends LitElement {
     }
 
     let newSelectView;
-    let force = false;
 
     let viewPath: string | undefined = this.route!.path.split("/")[1];
     viewPath = viewPath ? decodeURI(viewPath) : undefined;
@@ -794,9 +778,8 @@ class HUIRoot extends LitElement {
         | Lovelace
         | undefined;
 
-      if (!oldLovelace || oldLovelace.config !== this.lovelace!.config) {
-        // On config change, recreate the current view from scratch.
-        force = true;
+      if (oldLovelace && oldLovelace.config !== this.lovelace!.config) {
+        this._cleanupViewCache(oldLovelace);
       }
 
       if (!oldLovelace || oldLovelace.editMode !== this.lovelace!.editMode) {
@@ -815,15 +798,12 @@ class HUIRoot extends LitElement {
         }
       }
 
-      if (!force && huiView) {
+      if (huiView) {
         huiView.lovelace = this.lovelace!;
       }
     }
 
-    if (newSelectView !== undefined || force) {
-      if (force && newSelectView === undefined) {
-        newSelectView = this._curView;
-      }
+    if (newSelectView !== undefined) {
       // Will allow for ripples to start rendering
       afterNextRender(() => {
         if (changedProperties.has("route")) {
@@ -835,7 +815,7 @@ class HUIRoot extends LitElement {
             scrollTo({ behavior: "auto", top: position })
           );
         }
-        this._selectView(newSelectView, force);
+        this._selectView(newSelectView);
       });
     }
   }
@@ -1162,8 +1142,27 @@ class HUIRoot extends LitElement {
     }
   }
 
-  private _selectView(viewIndex: HUIRoot["_curView"], force: boolean): void {
-    if (!force && this._curView === viewIndex) {
+  private _cleanupViewCache(oldLovelace: Lovelace): void {
+    // Clean up cache entries for views that no longer exist
+    const newViewPaths = new Set(
+      this.lovelace!.config.views.map((v, i) => v.path ?? String(i))
+    );
+    const keys = new Set([
+      ...Object.keys(this._viewCache),
+      ...Object.keys(this._viewScrollPositions),
+    ]);
+    for (const key of keys) {
+      const index = Number(key);
+      const oldPath = oldLovelace.config.views[index]?.path ?? String(index);
+      if (!newViewPaths.has(oldPath)) {
+        delete this._viewCache[key];
+        delete this._viewScrollPositions[key];
+      }
+    }
+  }
+
+  private _selectView(viewIndex: HUIRoot["_curView"]): void {
+    if (this._curView === viewIndex) {
       return;
     }
 
@@ -1175,11 +1174,6 @@ class HUIRoot extends LitElement {
     viewIndex = viewIndex === undefined ? 0 : viewIndex;
 
     this._curView = viewIndex;
-
-    if (force) {
-      this._viewCache = {};
-      this._viewScrollPositions = {};
-    }
 
     // Recreate a new element to clear the applied themes.
     const root = this._viewRoot;
@@ -1208,12 +1202,12 @@ class HUIRoot extends LitElement {
       return;
     }
 
-    if (!force && this._viewCache![viewIndex]) {
-      view = this._viewCache![viewIndex];
+    if (this._viewCache[viewIndex]) {
+      view = this._viewCache[viewIndex];
     } else {
       view = document.createElement("hui-view");
       view.index = viewIndex;
-      this._viewCache![viewIndex] = view;
+      this._viewCache[viewIndex] = view;
     }
 
     view.lovelace = this.lovelace;

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -779,7 +779,7 @@ class HUIRoot extends LitElement {
         | undefined;
 
       if (oldLovelace && oldLovelace.config !== this.lovelace!.config) {
-        this._cleanupViewCache(oldLovelace);
+        this._cleanupViewCache();
       }
 
       if (!oldLovelace || oldLovelace.editMode !== this.lovelace!.editMode) {
@@ -1142,7 +1142,7 @@ class HUIRoot extends LitElement {
     }
   }
 
-  private _cleanupViewCache(_oldLovelace: Lovelace): void {
+  private _cleanupViewCache(): void {
     // Keep only the currently displayed view to avoid UI flash.
     // All other cached views are cleared and will be recreated on next visit.
     const currentView =

--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -3,6 +3,7 @@ import type { PropertyValues } from "lit";
 import { ReactiveElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { storage } from "../../../common/decorators/storage";
+import { deepEqual } from "../../../common/util/deep-equal";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-svg-icon";
 import type { LovelaceSectionElement } from "../../../data/lovelace";
@@ -165,6 +166,11 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
       ...sectionConfig,
       type: sectionConfig.type || DEFAULT_SECTION_LAYOUT,
     };
+
+    if (isStrategy && deepEqual(sectionConfig, this._config)) {
+      return;
+    }
+
     this._config = sectionConfig;
 
     // Create a new layout element if necessary.

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -24,7 +24,6 @@ declare global {
   interface HASSDomEvents {
     "ll-rebuild": Record<string, unknown>;
     "ll-upgrade": Record<string, unknown>;
-    "ll-badge-rebuild": Record<string, unknown>;
   }
 }
 

--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -275,10 +275,7 @@ export class HUIView extends ReactiveElement {
     };
   }
 
-  private async _setConfig(
-    viewConfig: LovelaceViewConfig,
-    isStrategy: boolean
-  ) {
+  private _setConfig(viewConfig: LovelaceViewConfig, isStrategy: boolean) {
     if (isStrategy && deepEqual(viewConfig, this._config)) {
       return;
     }
@@ -291,6 +288,8 @@ export class HUIView extends ReactiveElement {
     if (!this._layoutElement || this._layoutElementType !== viewConfig.type) {
       addLayoutElement = true;
       this._createLayoutElement(viewConfig);
+    } else {
+      this._layoutElement.setConfig(viewConfig);
     }
     this._createBadges(viewConfig);
     this._createCards(viewConfig);
@@ -328,7 +327,7 @@ export class HUIView extends ReactiveElement {
       "ll-rebuild",
       (ev: Event) => {
         ev.stopPropagation();
-        // Force recreation of the layout element (e.g. custom view just loaded)
+        // Force recreation of the layout element
         this._layoutElementType = undefined;
         this._initializeConfig();
       },

--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -324,6 +324,16 @@ export class HUIView extends ReactiveElement {
   private _createLayoutElement(config: LovelaceViewConfig): void {
     this._layoutElement = createViewElement(config) as LovelaceViewElement;
     this._layoutElementType = config.type;
+    this._layoutElement.addEventListener(
+      "ll-rebuild",
+      (ev: Event) => {
+        ev.stopPropagation();
+        // Force recreation of the layout element (e.g. custom view just loaded)
+        this._layoutElementType = undefined;
+        this._initializeConfig();
+      },
+      { once: true }
+    );
     this._layoutElement.addEventListener("ll-create-card", (ev) => {
       showCreateCardDialog(this, {
         lovelaceConfig: this.lovelace.config,

--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -3,7 +3,7 @@ import type { PropertyValues } from "lit";
 import { ReactiveElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { storage } from "../../../common/decorators/storage";
-import { fireEvent, type HASSDomEvent } from "../../../common/dom/fire_event";
+import type { HASSDomEvent } from "../../../common/dom/fire_event";
 import { debounce } from "../../../common/util/debounce";
 import { deepEqual } from "../../../common/util/deep-equal";
 import "../../../components/entity/ha-state-label-badge";
@@ -90,9 +90,7 @@ export class HUIView extends ReactiveElement {
 
   private _layoutElement?: LovelaceViewElement;
 
-  private _layoutElementConfig?: LovelaceViewConfig;
-
-  private _rendered = false;
+  private _config?: LovelaceViewConfig;
 
   @storage({
     key: "dashboardCardClipboard",
@@ -139,11 +137,8 @@ export class HUIView extends ReactiveElement {
     element.addEventListener(
       "ll-rebuild",
       (ev: Event) => {
-        // In edit mode let it go to hui-root and rebuild whole view.
-        if (!this.lovelace!.editMode) {
-          ev.stopPropagation();
-          this._rebuildSection(element, sectionConfig);
-        }
+        ev.stopPropagation();
+        this._rebuildSection(element, sectionConfig);
       },
       { once: true }
     );
@@ -152,18 +147,6 @@ export class HUIView extends ReactiveElement {
 
   protected createRenderRoot() {
     return this;
-  }
-
-  connectedCallback(): void {
-    super.connectedCallback();
-    this.updateComplete.then(() => {
-      this._rendered = true;
-    });
-  }
-
-  disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this._rendered = false;
   }
 
   public willUpdate(changedProperties: PropertyValues<typeof this>): void {
@@ -201,50 +184,21 @@ export class HUIView extends ReactiveElement {
     const viewConfig = this.lovelace.config.views[this.index];
     if (oldHass && this.hass && this.lovelace && isStrategyView(viewConfig)) {
       if (
-        oldHass.entities !== this.hass.entities ||
-        oldHass.devices !== this.hass.devices ||
-        oldHass.areas !== this.hass.areas ||
-        oldHass.floors !== this.hass.floors
+        this.hass.config.state === "RUNNING" &&
+        (oldHass.entities !== this.hass.entities ||
+          oldHass.devices !== this.hass.devices ||
+          oldHass.areas !== this.hass.areas ||
+          oldHass.floors !== this.hass.floors)
       ) {
-        if (this.hass.config.state === "RUNNING") {
-          // If the page is not rendered yet, we can force the refresh
-          if (this._rendered) {
-            this._debounceRefreshConfig(false);
-          } else {
-            this._refreshConfig(true);
-          }
-        }
+        this._debounceRefreshConfig();
       }
     }
   }
 
   private _debounceRefreshConfig = debounce(
-    (force: boolean) => this._refreshConfig(force),
+    () => this._initializeConfig(),
     200
   );
-
-  private _refreshConfig = async (force: boolean) => {
-    if (!this.hass || !this.lovelace) {
-      return;
-    }
-    const viewConfig = this.lovelace.config.views[this.index];
-
-    if (!isStrategyView(viewConfig)) {
-      return;
-    }
-
-    const oldConfig = this._layoutElementConfig;
-    const newConfig = await this._generateConfig(viewConfig);
-
-    // Don't ask if the config is the same
-    if (!deepEqual(newConfig, oldConfig)) {
-      if (force) {
-        this._setConfig(newConfig, true);
-      } else {
-        fireEvent(this, "strategy-config-changed");
-      }
-    }
-  };
 
   protected update(changedProperties: PropertyValues) {
     super.update(changedProperties);
@@ -325,6 +279,12 @@ export class HUIView extends ReactiveElement {
     viewConfig: LovelaceViewConfig,
     isStrategy: boolean
   ) {
+    if (isStrategy && deepEqual(viewConfig, this._config)) {
+      return;
+    }
+
+    this._config = viewConfig;
+
     // Create a new layout element if necessary.
     let addLayoutElement = false;
 
@@ -332,7 +292,6 @@ export class HUIView extends ReactiveElement {
       addLayoutElement = true;
       this._createLayoutElement(viewConfig);
     }
-    this._layoutElementConfig = viewConfig;
     this._createBadges(viewConfig);
     this._createCards(viewConfig);
     this._createSections(viewConfig);
@@ -355,9 +314,9 @@ export class HUIView extends ReactiveElement {
 
   private async _initializeConfig() {
     const rawConfig = this.lovelace.config.views[this.index];
+    const isStrategy = isStrategyView(rawConfig);
 
     const viewConfig = await this._generateConfig(rawConfig);
-    const isStrategy = isStrategyView(viewConfig);
 
     this._setConfig(viewConfig, isStrategy);
   }


### PR DESCRIPTION
## Proposed change

Views in the lovelace dashboard were being destroyed and recreated from scratch on every config change, including strategy regeneration. This caused a visible flicker when navigating dashboards with strategies.

Views now stay in place and receive config updates directly. A `deepEqual` check prevents unnecessary re-renders when the config hasn't actually changed. Stale view cache entries are cleaned up when views are added or removed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr