### PR TITLE
Add registryDependencies to strategies for selective regeneration

### DIFF
--- a/src/panels/energy/strategies/energy-dashboard-strategy.ts
+++ b/src/panels/energy/strategies/energy-dashboard-strategy.ts
@@ -7,6 +7,7 @@ import type { LovelaceConfig } from "../../../data/lovelace/config/types";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { LocalizeKeys } from "../../../common/translations/localize";
 import type { HomeAssistant } from "../../../types";
+import type { LovelaceStrategyRegistryKey } from "../../lovelace/strategies/types";
 import {
   DEFAULT_ENERGY_COLLECTION_KEY,
   DEFAULT_POWER_COLLECTION_KEY,
@@ -70,6 +71,8 @@ export interface EnergyDashboardStrategyConfig extends LovelaceStrategyConfig {
 
 @customElement("energy-dashboard-strategy")
 export class EnergyDashboardStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+
   static async generate(
     _config: EnergyDashboardStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/energy/strategies/energy-dashboard-strategy.ts
+++ b/src/panels/energy/strategies/energy-dashboard-strategy.ts
@@ -7,7 +7,7 @@ import type { LovelaceConfig } from "../../../data/lovelace/config/types";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { LocalizeKeys } from "../../../common/translations/localize";
 import type { HomeAssistant } from "../../../types";
-import type { LovelaceStrategyRegistryKey } from "../../lovelace/strategies/types";
+import type { LovelaceStrategyDependency } from "../../lovelace/strategies/types";
 import {
   DEFAULT_ENERGY_COLLECTION_KEY,
   DEFAULT_POWER_COLLECTION_KEY,
@@ -71,7 +71,7 @@ export interface EnergyDashboardStrategyConfig extends LovelaceStrategyConfig {
 
 @customElement("energy-dashboard-strategy")
 export class EnergyDashboardStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [];
 
   static async generate(
     _config: EnergyDashboardStrategyConfig,

--- a/src/panels/energy/strategies/energy-overview-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-overview-view-strategy.ts
@@ -9,6 +9,8 @@ import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 
 @customElement("energy-overview-view-strategy")
 export class EnergyOverviewViewStrategy extends ReactiveElement {
+  static registryDependencies = [];
+
   static async generate(
     _config: LovelaceStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/energy/strategies/energy-overview-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-overview-view-strategy.ts
@@ -5,10 +5,13 @@ import { getEnergyDataCollection } from "../../../data/energy";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { LovelaceStrategyConfig } from "../../../data/lovelace/config/strategy";
+import type { LovelaceStrategyRegistryKey } from "../../lovelace/strategies/types";
 import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 
 @customElement("energy-overview-view-strategy")
 export class EnergyOverviewViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+
   static async generate(
     _config: LovelaceStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/energy/strategies/energy-overview-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-overview-view-strategy.ts
@@ -5,12 +5,12 @@ import { getEnergyDataCollection } from "../../../data/energy";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { LovelaceStrategyConfig } from "../../../data/lovelace/config/strategy";
-import type { LovelaceStrategyRegistryKey } from "../../lovelace/strategies/types";
+import type { LovelaceStrategyDependency } from "../../lovelace/strategies/types";
 import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 
 @customElement("energy-overview-view-strategy")
 export class EnergyOverviewViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [];
 
   static async generate(
     _config: LovelaceStrategyConfig,

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -15,6 +15,8 @@ import {
 
 @customElement("energy-view-strategy")
 export class EnergyViewStrategy extends ReactiveElement {
+  static registryDependencies = [];
+
   static async generate(
     _config: LovelaceStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -12,11 +12,11 @@ import {
   LARGE_SCREEN_CONDITION,
   SMALL_SCREEN_CONDITION,
 } from "../../lovelace/strategies/helpers/view-columns-conditions";
-import type { LovelaceStrategyRegistryKey } from "../../lovelace/strategies/types";
+import type { LovelaceStrategyDependency } from "../../lovelace/strategies/types";
 
 @customElement("energy-view-strategy")
 export class EnergyViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [];
 
   static async generate(
     _config: LovelaceStrategyConfig,

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -12,9 +12,12 @@ import {
   LARGE_SCREEN_CONDITION,
   SMALL_SCREEN_CONDITION,
 } from "../../lovelace/strategies/helpers/view-columns-conditions";
+import type { LovelaceStrategyRegistryKey } from "../../lovelace/strategies/types";
 
 @customElement("energy-view-strategy")
 export class EnergyViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+
   static async generate(
     _config: LovelaceStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/energy/strategies/gas-view-strategy.ts
+++ b/src/panels/energy/strategies/gas-view-strategy.ts
@@ -9,6 +9,8 @@ import type { LovelaceSectionConfig } from "../../../data/lovelace/config/sectio
 
 @customElement("gas-view-strategy")
 export class GasViewStrategy extends ReactiveElement {
+  static registryDependencies = [];
+
   static async generate(
     _config: LovelaceStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/energy/strategies/gas-view-strategy.ts
+++ b/src/panels/energy/strategies/gas-view-strategy.ts
@@ -6,11 +6,11 @@ import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { LovelaceStrategyConfig } from "../../../data/lovelace/config/strategy";
 import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 import type { LovelaceSectionConfig } from "../../../data/lovelace/config/section";
-import type { LovelaceStrategyRegistryKey } from "../../lovelace/strategies/types";
+import type { LovelaceStrategyDependency } from "../../lovelace/strategies/types";
 
 @customElement("gas-view-strategy")
 export class GasViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [];
 
   static async generate(
     _config: LovelaceStrategyConfig,

--- a/src/panels/energy/strategies/gas-view-strategy.ts
+++ b/src/panels/energy/strategies/gas-view-strategy.ts
@@ -6,9 +6,12 @@ import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { LovelaceStrategyConfig } from "../../../data/lovelace/config/strategy";
 import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 import type { LovelaceSectionConfig } from "../../../data/lovelace/config/section";
+import type { LovelaceStrategyRegistryKey } from "../../lovelace/strategies/types";
 
 @customElement("gas-view-strategy")
 export class GasViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+
   static async generate(
     _config: LovelaceStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/energy/strategies/power-view-strategy.ts
+++ b/src/panels/energy/strategies/power-view-strategy.ts
@@ -11,6 +11,8 @@ import type { LovelaceBadgeConfig } from "../../../data/lovelace/config/badge";
 
 @customElement("power-view-strategy")
 export class PowerViewStrategy extends ReactiveElement {
+  static registryDependencies = [];
+
   static async generate(
     _config: LovelaceStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/energy/strategies/power-view-strategy.ts
+++ b/src/panels/energy/strategies/power-view-strategy.ts
@@ -8,11 +8,11 @@ import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 import { shouldShowFloorsAndAreas } from "./show-floors-and-areas";
 import type { LovelaceSectionConfig } from "../../../data/lovelace/config/section";
 import type { LovelaceBadgeConfig } from "../../../data/lovelace/config/badge";
-import type { LovelaceStrategyRegistryKey } from "../../lovelace/strategies/types";
+import type { LovelaceStrategyDependency } from "../../lovelace/strategies/types";
 
 @customElement("power-view-strategy")
 export class PowerViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [];
 
   static async generate(
     _config: LovelaceStrategyConfig,

--- a/src/panels/energy/strategies/power-view-strategy.ts
+++ b/src/panels/energy/strategies/power-view-strategy.ts
@@ -8,9 +8,12 @@ import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 import { shouldShowFloorsAndAreas } from "./show-floors-and-areas";
 import type { LovelaceSectionConfig } from "../../../data/lovelace/config/section";
 import type { LovelaceBadgeConfig } from "../../../data/lovelace/config/badge";
+import type { LovelaceStrategyRegistryKey } from "../../lovelace/strategies/types";
 
 @customElement("power-view-strategy")
 export class PowerViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+
   static async generate(
     _config: LovelaceStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/energy/strategies/water-view-strategy.ts
+++ b/src/panels/energy/strategies/water-view-strategy.ts
@@ -10,6 +10,8 @@ import { shouldShowFloorsAndAreas } from "./show-floors-and-areas";
 
 @customElement("water-view-strategy")
 export class WaterViewStrategy extends ReactiveElement {
+  static registryDependencies = [];
+
   static async generate(
     _config: LovelaceStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/energy/strategies/water-view-strategy.ts
+++ b/src/panels/energy/strategies/water-view-strategy.ts
@@ -5,11 +5,14 @@ import type { LovelaceSectionConfig } from "../../../data/lovelace/config/sectio
 import type { LovelaceStrategyConfig } from "../../../data/lovelace/config/strategy";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
+import type { LovelaceStrategyRegistryKey } from "../../lovelace/strategies/types";
 import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 import { shouldShowFloorsAndAreas } from "./show-floors-and-areas";
 
 @customElement("water-view-strategy")
 export class WaterViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+
   static async generate(
     _config: LovelaceStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/energy/strategies/water-view-strategy.ts
+++ b/src/panels/energy/strategies/water-view-strategy.ts
@@ -5,13 +5,13 @@ import type { LovelaceSectionConfig } from "../../../data/lovelace/config/sectio
 import type { LovelaceStrategyConfig } from "../../../data/lovelace/config/strategy";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
-import type { LovelaceStrategyRegistryKey } from "../../lovelace/strategies/types";
+import type { LovelaceStrategyDependency } from "../../lovelace/strategies/types";
 import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 import { shouldShowFloorsAndAreas } from "./show-floors-and-areas";
 
 @customElement("water-view-strategy")
 export class WaterViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [];
 
   static async generate(
     _config: LovelaceStrategyConfig,

--- a/src/panels/home/ha-panel-home.ts
+++ b/src/panels/home/ha-panel-home.ts
@@ -7,7 +7,6 @@ import { styleMap } from "lit/directives/style-map";
 import { atLeastVersion } from "../../common/config/version";
 import { navigate } from "../../common/navigate";
 import { debounce } from "../../common/util/debounce";
-import { deepEqual } from "../../common/util/deep-equal";
 import "../../components/ha-button";
 import "../../components/ha-svg-icon";
 import { updateAreaRegistryEntry } from "../../data/area/area_registry";
@@ -26,7 +25,10 @@ import { showDeviceRegistryDetailDialog } from "../config/devices/device-registr
 import { showAddIntegrationDialog } from "../config/integrations/show-add-integration-dialog";
 import "../lovelace/hui-root";
 import type { ExtraActionItem } from "../lovelace/hui-root";
-import { expandLovelaceConfigStrategies } from "../lovelace/strategies/get-strategy";
+import {
+  checkStrategyShouldRegenerate,
+  generateLovelaceDashboardStrategy,
+} from "../lovelace/strategies/get-strategy";
 import type { Lovelace } from "../lovelace/types";
 import { showEditHomeDialog } from "./dialogs/show-dialog-edit-home";
 import { showNewOverviewDialog } from "./dialogs/show-dialog-new-overview";
@@ -95,26 +97,19 @@ class PanelHome extends LitElement {
       return;
     }
 
-    if (oldHass && this.hass) {
-      // If the entity registry changed, ask the user if they want to refresh the config
-      if (
-        oldHass.entities !== this.hass.entities ||
-        oldHass.devices !== this.hass.devices ||
-        oldHass.areas !== this.hass.areas ||
-        oldHass.floors !== this.hass.floors ||
-        oldHass.panels !== this.hass.panels
-      ) {
-        if (this.hass.config.state === "RUNNING") {
-          this._debounceRegistriesChanged();
-          return;
-        }
-      }
-      // If ha started, refresh the config
-      if (
-        this.hass.config.state === "RUNNING" &&
-        oldHass.config.state !== "RUNNING"
-      ) {
+    if (oldHass && this.hass && this.hass.config.state === "RUNNING") {
+      if (oldHass.config.state !== "RUNNING") {
         this._setup();
+        return;
+      }
+      const shouldRegenerate = checkStrategyShouldRegenerate(
+        "dashboard",
+        this._strategyConfig.strategy,
+        oldHass,
+        this.hass
+      );
+      if (shouldRegenerate) {
+        this._debounceRegenerateStrategy();
       }
     }
   }
@@ -135,12 +130,12 @@ class PanelHome extends LitElement {
     this._setLovelace();
   }
 
-  private _debounceRegistriesChanged = debounce(
-    () => this._registriesChanged(),
+  private _debounceRegenerateStrategy = debounce(
+    () => this._regenerateStrategyConfig(),
     200
   );
 
-  private _registriesChanged = async () => {
+  private _regenerateStrategyConfig() {
     // If on an area view that no longer exists, redirect to overview
     const path = this.route?.path?.split("/")[1];
     if (path?.startsWith("areas-")) {
@@ -151,7 +146,7 @@ class PanelHome extends LitElement {
       }
     }
     this._setLovelace();
-  };
+  }
 
   private _updateExtraActionItems() {
     const path = this.route?.path?.split("/")[1];
@@ -312,23 +307,21 @@ class PanelHome extends LitElement {
     });
   }
 
-  private async _setLovelace() {
-    const strategyConfig: LovelaceDashboardStrategyConfig = {
+  private get _strategyConfig(): LovelaceDashboardStrategyConfig {
+    return {
       strategy: {
         type: "home",
         favorite_entities: this._config.favorite_entities,
         home_panel: true,
       },
     };
+  }
 
-    const config = await expandLovelaceConfigStrategies(
-      strategyConfig,
+  private async _setLovelace() {
+    const config = await generateLovelaceDashboardStrategy(
+      this._strategyConfig,
       this.hass
     );
-
-    if (deepEqual(config, this._lovelace?.config)) {
-      return;
-    }
 
     this._lovelace = {
       config: config,

--- a/src/panels/home/ha-panel-home.ts
+++ b/src/panels/home/ha-panel-home.ts
@@ -95,26 +95,37 @@ class PanelHome extends LitElement {
       return;
     }
 
-    const oldHass = changedProps.get("hass") as this["hass"];
-    if (oldHass && oldHass.localize !== this.hass.localize) {
+    const oldHass = changedProps.get("hass") as this["hass"] | undefined;
+    if (!oldHass) {
+      return;
+    }
+
+    // Locale changed: regenerate to refresh translated content
+    if (oldHass.localize !== this.hass.localize) {
       this._setLovelace();
       return;
     }
 
-    if (oldHass && this.hass && this.hass.config.state === "RUNNING") {
-      if (oldHass.config.state !== "RUNNING") {
-        this._setup();
-        return;
-      }
-      const shouldRegenerate = checkStrategyShouldRegenerate(
+    if (this.hass.config.state !== "RUNNING") {
+      return;
+    }
+
+    // Home Assistant just started: run the full setup
+    if (oldHass.config.state !== "RUNNING") {
+      this._setup();
+      return;
+    }
+
+    // A registry the strategy depends on changed: regenerate
+    if (
+      checkStrategyShouldRegenerate(
         "dashboard",
         this._strategyConfig.strategy,
         oldHass,
         this.hass
-      );
-      if (shouldRegenerate) {
-        this._debounceRegenerateStrategy();
-      }
+      )
+    ) {
+      this._debounceRegenerateStrategy();
     }
   }
 

--- a/src/panels/home/ha-panel-home.ts
+++ b/src/panels/home/ha-panel-home.ts
@@ -7,7 +7,6 @@ import { styleMap } from "lit/directives/style-map";
 import { atLeastVersion } from "../../common/config/version";
 import { navigate } from "../../common/navigate";
 import { debounce } from "../../common/util/debounce";
-import { deepEqual } from "../../common/util/deep-equal";
 import "../../components/ha-button";
 import "../../components/ha-svg-icon";
 import { updateAreaRegistryEntry } from "../../data/area/area_registry";
@@ -26,7 +25,10 @@ import { showDeviceRegistryDetailDialog } from "../config/devices/device-registr
 import { showAddIntegrationDialog } from "../config/integrations/show-add-integration-dialog";
 import "../lovelace/hui-root";
 import type { ExtraActionItem } from "../lovelace/hui-root";
-import { expandLovelaceConfigStrategies } from "../lovelace/strategies/get-strategy";
+import {
+  checkStrategyShouldRegenerate,
+  generateLovelaceDashboardStrategy,
+} from "../lovelace/strategies/get-strategy";
 import type { Lovelace } from "../lovelace/types";
 import { showEditHomeDialog } from "./dialogs/show-dialog-edit-home";
 import { showNewOverviewDialog } from "./dialogs/show-dialog-new-overview";
@@ -99,26 +101,19 @@ class PanelHome extends LitElement {
       return;
     }
 
-    if (oldHass && this.hass) {
-      // If the entity registry changed, ask the user if they want to refresh the config
-      if (
-        oldHass.entities !== this.hass.entities ||
-        oldHass.devices !== this.hass.devices ||
-        oldHass.areas !== this.hass.areas ||
-        oldHass.floors !== this.hass.floors ||
-        oldHass.panels !== this.hass.panels
-      ) {
-        if (this.hass.config.state === "RUNNING") {
-          this._debounceRegistriesChanged();
-          return;
-        }
-      }
-      // If ha started, refresh the config
-      if (
-        this.hass.config.state === "RUNNING" &&
-        oldHass.config.state !== "RUNNING"
-      ) {
+    if (oldHass && this.hass && this.hass.config.state === "RUNNING") {
+      if (oldHass.config.state !== "RUNNING") {
         this._setup();
+        return;
+      }
+      const shouldRegenerate = checkStrategyShouldRegenerate(
+        "dashboard",
+        this._strategyConfig.strategy,
+        oldHass,
+        this.hass
+      );
+      if (shouldRegenerate) {
+        this._debounceRegenerateStrategy();
       }
     }
   }
@@ -144,12 +139,12 @@ class PanelHome extends LitElement {
     }
   }
 
-  private _debounceRegistriesChanged = debounce(
-    () => this._registriesChanged(),
+  private _debounceRegenerateStrategy = debounce(
+    () => this._regenerateStrategyConfig(),
     200
   );
 
-  private _registriesChanged = async () => {
+  private _regenerateStrategyConfig() {
     // If on an area view that no longer exists, redirect to overview
     const path = this.route?.path?.split("/")[1];
     if (path?.startsWith("areas-")) {
@@ -160,7 +155,7 @@ class PanelHome extends LitElement {
       }
     }
     this._setLovelace();
-  };
+  }
 
   private _updateExtraActionItems() {
     const path = this.route?.path?.split("/")[1];
@@ -320,11 +315,8 @@ class PanelHome extends LitElement {
     });
   }
 
-  private async _setLovelace() {
-    if (this._loadConfigPromise) {
-      await this._loadConfigPromise;
-    }
-    const strategyConfig: LovelaceDashboardStrategyConfig = {
+  private get _strategyConfig(): LovelaceDashboardStrategyConfig {
+    return {
       strategy: {
         type: "home",
         favorite_entities: this._config.favorite_entities,
@@ -334,15 +326,16 @@ class PanelHome extends LitElement {
         shortcuts: this._config.shortcuts,
       },
     };
+  }
 
-    const config = await expandLovelaceConfigStrategies(
-      strategyConfig,
+  private async _setLovelace() {
+    if (this._loadConfigPromise) {
+      await this._loadConfigPromise;
+    }
+    const config = await generateLovelaceDashboardStrategy(
+      this._strategyConfig,
       this.hass
     );
-
-    if (deepEqual(config, this._lovelace?.config)) {
-      return;
-    }
 
     this._lovelace = {
       config: config,

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -12,7 +12,6 @@ import {
   removeSearchParam,
 } from "../../common/url/search-params";
 import { debounce } from "../../common/util/debounce";
-import { deepEqual } from "../../common/util/deep-equal";
 import "../../components/ha-button";
 import { domainToName } from "../../data/integration";
 import { subscribeLovelaceUpdates } from "../../data/lovelace";
@@ -36,7 +35,10 @@ import { checkLovelaceConfig } from "./common/check-lovelace-config";
 import { loadLovelaceResources } from "./common/load-resources";
 import { showSaveDialog } from "./editor/show-save-config-dialog";
 import "./hui-root";
-import { generateLovelaceDashboardStrategy } from "./strategies/get-strategy";
+import {
+  checkStrategyShouldRegenerate,
+  generateLovelaceDashboardStrategy,
+} from "./strategies/get-strategy";
 import type { Lovelace } from "./types";
 import { generateDefaultView } from "./views/default-view";
 import { fetchDashboards } from "../../data/lovelace/dashboard";
@@ -49,12 +51,6 @@ interface LovelacePanelConfig {
 
 let editorLoaded = false;
 let resourcesLoaded = false;
-
-declare global {
-  interface HASSDomEvents {
-    "strategy-config-changed": undefined;
-  }
-}
 
 @customElement("ha-panel-lovelace")
 export class LovelacePanel extends LitElement {
@@ -129,7 +125,6 @@ export class LovelacePanel extends LitElement {
           .route=${this.route}
           .narrow=${this.narrow}
           @config-refresh=${this._forceFetchConfig}
-          @strategy-config-changed=${this._strategyConfigChanged}
         ></hui-root>
       `;
     }
@@ -195,60 +190,25 @@ export class LovelacePanel extends LitElement {
       this.lovelace &&
       isStrategyDashboard(this.lovelace.rawConfig)
     ) {
-      // If the entity registry changed, ask the user if they want to refresh the config
-      if (
-        oldHass.entities !== this.hass.entities ||
-        oldHass.devices !== this.hass.devices ||
-        oldHass.areas !== this.hass.areas ||
-        oldHass.floors !== this.hass.floors
-      ) {
-        if (this.hass.config.state === "RUNNING") {
-          this._debounceRegistriesChanged();
-        }
-      }
-      // If ha started, refresh the config
       if (
         this.hass.config.state === "RUNNING" &&
-        oldHass.config.state !== "RUNNING"
+        (oldHass.config.state !== "RUNNING" ||
+          checkStrategyShouldRegenerate(
+            "dashboard",
+            this.lovelace.rawConfig.strategy,
+            oldHass,
+            this.hass
+          ))
       ) {
-        this._regenerateStrategyConfig();
+        this._debounceRegenerateStrategy();
       }
     }
   }
 
-  private _debounceRegistriesChanged = debounce(
-    () => this._registriesChanged(),
+  private _debounceRegenerateStrategy = debounce(
+    () => this._regenerateStrategyConfig(),
     200
   );
-
-  private _registriesChanged = async () => {
-    if (!this.hass || !this.lovelace) {
-      return;
-    }
-    const rawConfig = this.lovelace.rawConfig;
-
-    if (!isStrategyDashboard(rawConfig)) {
-      return;
-    }
-
-    const oldConfig = this.lovelace.config;
-    const generatedConfig = await generateLovelaceDashboardStrategy(
-      rawConfig,
-      this.hass!
-    );
-
-    const newConfig = checkLovelaceConfig(generatedConfig) as LovelaceConfig;
-
-    // Regenerate if the config changed
-    if (!deepEqual(newConfig, oldConfig)) {
-      this._regenerateStrategyConfig();
-    }
-  };
-
-  private _strategyConfigChanged = (ev: CustomEvent) => {
-    ev.stopPropagation();
-    this._regenerateStrategyConfig();
-  };
 
   private async _regenerateStrategyConfig() {
     if (!this.hass || !this.lovelace) {

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -787,7 +787,7 @@ class HUIRoot extends LitElement {
         | undefined;
 
       if (oldLovelace && oldLovelace.config !== this.lovelace!.config) {
-        this._cleanupViewCache(oldLovelace);
+        this._cleanupViewCache();
       }
 
       if (!oldLovelace || oldLovelace.editMode !== this.lovelace!.editMode) {
@@ -1146,22 +1146,14 @@ class HUIRoot extends LitElement {
     }
   }
 
-  private _cleanupViewCache(oldLovelace: Lovelace): void {
-    // Clean up cache entries for views that no longer exist
-    const newViewPaths = new Set(
-      this.lovelace!.config.views.map((v, i) => v.path ?? String(i))
-    );
-    const keys = new Set([
-      ...Object.keys(this._viewCache),
-      ...Object.keys(this._viewScrollPositions),
-    ]);
-    for (const key of keys) {
-      const index = Number(key);
-      const oldPath = oldLovelace.config.views[index]?.path ?? String(index);
-      if (!newViewPaths.has(oldPath)) {
-        delete this._viewCache[key];
-        delete this._viewScrollPositions[key];
-      }
+  private _cleanupViewCache(): void {
+    // Keep only the currently displayed view to avoid UI flash.
+    // All other cached views are cleared and will be recreated on next visit.
+    const currentView =
+      this._curView != null ? this._viewCache[this._curView] : undefined;
+    this._viewCache = {};
+    if (currentView && this._curView != null) {
+      this._viewCache[this._curView] = currentView;
     }
   }
 

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -787,7 +787,7 @@ class HUIRoot extends LitElement {
         | undefined;
 
       if (oldLovelace && oldLovelace.config !== this.lovelace!.config) {
-        this._cleanupViewCache();
+        this._cleanupViewCache(oldLovelace);
       }
 
       if (!oldLovelace || oldLovelace.editMode !== this.lovelace!.editMode) {
@@ -1146,14 +1146,22 @@ class HUIRoot extends LitElement {
     }
   }
 
-  private _cleanupViewCache(): void {
-    // Keep only the currently displayed view to avoid UI flash.
-    // All other cached views are cleared and will be recreated on next visit.
-    const currentView =
-      this._curView != null ? this._viewCache[this._curView] : undefined;
-    this._viewCache = {};
-    if (currentView && this._curView != null) {
-      this._viewCache[this._curView] = currentView;
+  private _cleanupViewCache(oldLovelace: Lovelace): void {
+    // Clean up cache entries for views that no longer exist
+    const newViewPaths = new Set(
+      this.lovelace!.config.views.map((v, i) => v.path ?? String(i))
+    );
+    const keys = new Set([
+      ...Object.keys(this._viewCache),
+      ...Object.keys(this._viewScrollPositions),
+    ]);
+    for (const key of keys) {
+      const index = Number(key);
+      const oldPath = oldLovelace.config.views[index]?.path ?? String(index);
+      if (!newViewPaths.has(oldPath)) {
+        delete this._viewCache[key];
+        delete this._viewScrollPositions[key];
+      }
     }
   }
 

--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -5,6 +5,7 @@ import { customElement, property, state } from "lit/decorators";
 import { storage } from "../../../common/decorators/storage";
 import { deepEqual } from "../../../common/util/deep-equal";
 import { fireEvent } from "../../../common/dom/fire_event";
+import { debounce } from "../../../common/util/debounce";
 import "../../../components/ha-svg-icon";
 import type { LovelaceSectionElement } from "../../../data/lovelace";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
@@ -24,7 +25,10 @@ import { showEditCardDialog } from "../editor/card-editor/show-edit-card-dialog"
 import { addCard, replaceCard } from "../editor/config-util";
 import { performDeleteCard } from "../editor/delete-card";
 import { parseLovelaceCardPath } from "../editor/lovelace-path";
-import { generateLovelaceSectionStrategy } from "../strategies/get-strategy";
+import {
+  checkStrategyShouldRegenerate,
+  generateLovelaceSectionStrategy,
+} from "../strategies/get-strategy";
 import type { Lovelace } from "../types";
 import { DEFAULT_SECTION_LAYOUT } from "./const";
 
@@ -105,8 +109,35 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
       (!oldConfig || this.config !== oldConfig)
     ) {
       this._initializeConfig();
+      return;
+    }
+
+    if (!changedProperties.has("hass")) {
+      return;
+    }
+
+    const oldHass = changedProperties.get("hass") as HomeAssistant | undefined;
+    if (
+      oldHass &&
+      this.hass &&
+      isStrategySection(this.config) &&
+      this.hass.config.state === "RUNNING" &&
+      (oldHass.config.state !== "RUNNING" ||
+        checkStrategyShouldRegenerate(
+          "section",
+          this.config.strategy,
+          oldHass,
+          this.hass
+        ))
+    ) {
+      this._debounceRefreshConfig();
     }
   }
+
+  private _debounceRefreshConfig = debounce(
+    () => this._initializeConfig(),
+    200
+  );
 
   public disconnectedCallback() {
     super.disconnectedCallback();

--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -6,6 +6,7 @@ import { storage } from "../../../common/decorators/storage";
 import { deepEqual } from "../../../common/util/deep-equal";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { fireEvent } from "../../../common/dom/fire_event";
+import { debounce } from "../../../common/util/debounce";
 import "../../../components/ha-svg-icon";
 import type { LovelaceSectionElement } from "../../../data/lovelace";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
@@ -25,7 +26,10 @@ import { showEditCardDialog } from "../editor/card-editor/show-edit-card-dialog"
 import { addCard, replaceCard } from "../editor/config-util";
 import { performDeleteCard } from "../editor/delete-card";
 import { parseLovelaceCardPath } from "../editor/lovelace-path";
-import { generateLovelaceSectionStrategy } from "../strategies/get-strategy";
+import {
+  checkStrategyShouldRegenerate,
+  generateLovelaceSectionStrategy,
+} from "../strategies/get-strategy";
 import type { Lovelace } from "../types";
 import { DEFAULT_SECTION_LAYOUT } from "./const";
 
@@ -106,8 +110,35 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
       (!oldConfig || this.config !== oldConfig)
     ) {
       this._initializeConfig();
+      return;
+    }
+
+    if (!changedProperties.has("hass")) {
+      return;
+    }
+
+    const oldHass = changedProperties.get("hass") as HomeAssistant | undefined;
+    if (
+      oldHass &&
+      this.hass &&
+      isStrategySection(this.config) &&
+      this.hass.config.state === "RUNNING" &&
+      (oldHass.config.state !== "RUNNING" ||
+        checkStrategyShouldRegenerate(
+          "section",
+          this.config.strategy,
+          oldHass,
+          this.hass
+        ))
+    ) {
+      this._debounceRefreshConfig();
     }
   }
+
+  private _debounceRefreshConfig = debounce(
+    () => this._initializeConfig(),
+    200
+  );
 
   public disconnectedCallback() {
     super.disconnectedCallback();

--- a/src/panels/lovelace/strategies/areas/area-view-strategy.ts
+++ b/src/panels/lovelace/strategies/areas/area-view-strategy.ts
@@ -34,6 +34,8 @@ const computeHeadingCard = (
 
 @customElement("area-view-strategy")
 export class AreaViewStrategy extends ReactiveElement {
+  static registryDependencies = ["entities", "devices", "areas"];
+
   static async generate(
     config: AreaViewStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/areas/area-view-strategy.ts
+++ b/src/panels/lovelace/strategies/areas/area-view-strategy.ts
@@ -6,7 +6,7 @@ import type { LovelaceCardConfig } from "../../../../data/lovelace/config/card";
 import type { LovelaceSectionRawConfig } from "../../../../data/lovelace/config/section";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
-import type { LovelaceStrategyRegistryKey } from "../types";
+import type { LovelaceStrategyDependency } from "../types";
 import {
   AREA_STRATEGY_GROUP_ICONS,
   computeAreaTileCardConfig,
@@ -35,7 +35,7 @@ const computeHeadingCard = (
 
 @customElement("area-view-strategy")
 export class AreaViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [
     "entities",
     "devices",
     "areas",

--- a/src/panels/lovelace/strategies/areas/area-view-strategy.ts
+++ b/src/panels/lovelace/strategies/areas/area-view-strategy.ts
@@ -6,6 +6,7 @@ import type { LovelaceCardConfig } from "../../../../data/lovelace/config/card";
 import type { LovelaceSectionRawConfig } from "../../../../data/lovelace/config/section";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
+import type { LovelaceStrategyRegistryKey } from "../types";
 import {
   AREA_STRATEGY_GROUP_ICONS,
   computeAreaTileCardConfig,
@@ -34,6 +35,12 @@ const computeHeadingCard = (
 
 @customElement("area-view-strategy")
 export class AreaViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+    "entities",
+    "devices",
+    "areas",
+  ];
+
   static async generate(
     config: AreaViewStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/areas/areas-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/areas/areas-dashboard-strategy.ts
@@ -31,6 +31,8 @@ export interface AreasDashboardStrategyConfig {
 
 @customElement("areas-dashboard-strategy")
 export class AreasDashboardStrategy extends ReactiveElement {
+  static registryDependencies = ["areas"];
+
   static async generate(
     config: AreasDashboardStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/areas/areas-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/areas/areas-dashboard-strategy.ts
@@ -6,7 +6,7 @@ import type { LovelaceViewRawConfig } from "../../../../data/lovelace/config/vie
 import type { HomeAssistant } from "../../../../types";
 import type {
   LovelaceStrategyEditor,
-  LovelaceStrategyRegistryKey,
+  LovelaceStrategyDependency,
 } from "../types";
 import type {
   AreaViewStrategyConfig,
@@ -34,7 +34,7 @@ export interface AreasDashboardStrategyConfig {
 
 @customElement("areas-dashboard-strategy")
 export class AreasDashboardStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [
     "areas",
   ];
 

--- a/src/panels/lovelace/strategies/areas/areas-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/areas/areas-dashboard-strategy.ts
@@ -4,7 +4,10 @@ import { customElement } from "lit/decorators";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
 import type { LovelaceViewRawConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
-import type { LovelaceStrategyEditor } from "../types";
+import type {
+  LovelaceStrategyEditor,
+  LovelaceStrategyRegistryKey,
+} from "../types";
 import type {
   AreaViewStrategyConfig,
   EntitiesDisplay,
@@ -31,6 +34,10 @@ export interface AreasDashboardStrategyConfig {
 
 @customElement("areas-dashboard-strategy")
 export class AreasDashboardStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+    "areas",
+  ];
+
   static async generate(
     config: AreasDashboardStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/areas/areas-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/areas/areas-overview-view-strategy.ts
@@ -10,6 +10,7 @@ import {
   type AreaControlDomain,
 } from "../../card-features/types";
 import type { AreaCardConfig, HeadingCardConfig } from "../../cards/types";
+import type { LovelaceStrategyRegistryKey } from "../types";
 import type { EntitiesDisplay } from "./area-view-strategy";
 import {
   computeAreaPath,
@@ -38,6 +39,13 @@ export interface AreasViewStrategyConfig {
 
 @customElement("areas-overview-view-strategy")
 export class AreasOverviewViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+    "entities",
+    "devices",
+    "areas",
+    "floors",
+  ];
+
   static async generate(
     config: AreasViewStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/areas/areas-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/areas/areas-overview-view-strategy.ts
@@ -10,7 +10,7 @@ import {
   type AreaControlDomain,
 } from "../../card-features/types";
 import type { AreaCardConfig, HeadingCardConfig } from "../../cards/types";
-import type { LovelaceStrategyRegistryKey } from "../types";
+import type { LovelaceStrategyDependency } from "../types";
 import type { EntitiesDisplay } from "./area-view-strategy";
 import {
   computeAreaPath,
@@ -39,7 +39,7 @@ export interface AreasViewStrategyConfig {
 
 @customElement("areas-overview-view-strategy")
 export class AreasOverviewViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [
     "entities",
     "devices",
     "areas",

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -19,6 +19,7 @@ import type { AsyncReturnType, HomeAssistant } from "../../../types";
 import { cleanLegacyStrategyConfig, isLegacyStrategy } from "./legacy-strategy";
 import type {
   LovelaceDashboardStrategy,
+  LovelaceStrategyRegistryKey,
   LovelaceSectionStrategy,
   LovelaceStrategy,
   LovelaceViewStrategy,
@@ -26,6 +27,13 @@ import type {
 
 const MAX_WAIT_STRATEGY_LOAD = 5000;
 const CUSTOM_PREFIX = "custom:";
+
+const DEFAULT_REGISTRY_DEPENDENCIES: readonly LovelaceStrategyRegistryKey[] = [
+  "entities",
+  "devices",
+  "areas",
+  "floors",
+];
 
 const STRATEGIES: Record<LovelaceStrategyConfigType, Record<string, any>> = {
   dashboard: {
@@ -235,6 +243,45 @@ export const generateLovelaceSectionStrategy = async (
     ...base,
     ...generated,
   };
+};
+
+/**
+ * Synchronously checks whether a strategy needs regeneration.
+ * Falls back to checking common registries if the strategy doesn't implement shouldRegenerate.
+ */
+export const checkStrategyShouldRegenerate = (
+  configType: LovelaceStrategyConfigType,
+  strategyConfig: LovelaceStrategyConfig,
+  oldHass: HomeAssistant,
+  newHass: HomeAssistant
+): boolean => {
+  const strategyType = strategyConfig.type;
+  if (!strategyType) {
+    return false;
+  }
+
+  let strategy: LovelaceStrategy | undefined;
+
+  if (strategyType in STRATEGIES[configType]) {
+    const tag = `${strategyType}-${configType}-strategy`;
+    strategy = customElements.get(tag) as unknown as
+      | LovelaceStrategy
+      | undefined;
+  } else if (strategyType.startsWith(CUSTOM_PREFIX)) {
+    const name = strategyType.slice(CUSTOM_PREFIX.length);
+    const tag = `ll-strategy-${configType}-${name}`;
+    const legacyTag = `ll-strategy-${name}`;
+    strategy = (customElements.get(tag) ??
+      customElements.get(legacyTag)) as unknown as LovelaceStrategy | undefined;
+  }
+
+  if (strategy?.shouldRegenerate) {
+    return strategy.shouldRegenerate(strategyConfig, oldHass, newHass);
+  }
+
+  const dependencies =
+    strategy?.registryDependencies ?? DEFAULT_REGISTRY_DEPENDENCIES;
+  return dependencies.some((key) => oldHass[key] !== newHass[key]);
 };
 
 /**

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -90,28 +90,46 @@ type StrategyConfig<T extends LovelaceStrategyConfigType> = AsyncReturnType<
   Strategies[T]["generate"]
 >;
 
+// Resolves the custom element tag(s) for a strategy. Returns the legacy tag as
+// well for custom strategies. `undefined` means the type is neither built-in
+// nor a custom strategy.
+const getStrategyTags = (
+  configType: LovelaceStrategyConfigType,
+  strategyType: string
+): { tag: string; legacyTag?: string } | undefined => {
+  if (strategyType in STRATEGIES[configType]) {
+    return { tag: `${strategyType}-${configType}-strategy` };
+  }
+  if (strategyType.startsWith(CUSTOM_PREFIX)) {
+    const name = strategyType.slice(CUSTOM_PREFIX.length);
+    return {
+      tag: `ll-strategy-${configType}-${name}`,
+      legacyTag: `ll-strategy-${name}`,
+    };
+  }
+  return undefined;
+};
+
 export const getLovelaceStrategy = async <T extends LovelaceStrategyConfigType>(
   configType: T,
   strategyType: string
 ): Promise<LovelaceStrategy> => {
-  if (strategyType in STRATEGIES[configType]) {
-    await STRATEGIES[configType][strategyType]();
-    const tag = `${strategyType}-${configType}-strategy`;
-    return customElements.get(tag) as unknown as Strategies[T];
-  }
+  const tags = getStrategyTags(configType, strategyType);
 
-  if (!strategyType.startsWith(CUSTOM_PREFIX)) {
+  if (!tags) {
     throw new Error("Unknown strategy");
   }
 
-  const legacyTag = `ll-strategy-${strategyType.slice(CUSTOM_PREFIX.length)}`;
-  const tag = `ll-strategy-${configType}-${strategyType.slice(
-    CUSTOM_PREFIX.length
-  )}`;
+  const { tag, legacyTag } = tags;
+
+  if (strategyType in STRATEGIES[configType]) {
+    await STRATEGIES[configType][strategyType]();
+    return customElements.get(tag) as unknown as Strategies[T];
+  }
 
   if (
     (await Promise.race([
-      customElements.whenDefined(legacyTag),
+      customElements.whenDefined(legacyTag!),
       customElements.whenDefined(tag),
       new Promise((resolve) => {
         setTimeout(() => resolve(true), MAX_WAIT_STRATEGY_LOAD);
@@ -124,7 +142,7 @@ export const getLovelaceStrategy = async <T extends LovelaceStrategyConfigType>(
   }
 
   return (customElements.get(tag) ??
-    customElements.get(legacyTag)) as unknown as Strategies[T];
+    customElements.get(legacyTag!)) as unknown as Strategies[T];
 };
 
 const generateStrategy = async <T extends LovelaceStrategyConfigType>(
@@ -267,20 +285,13 @@ export const checkStrategyShouldRegenerate = (
     return false;
   }
 
-  let strategy: LovelaceStrategy | undefined;
-
-  if (strategyType in STRATEGIES[configType]) {
-    const tag = `${strategyType}-${configType}-strategy`;
-    strategy = customElements.get(tag) as unknown as
-      | LovelaceStrategy
-      | undefined;
-  } else if (strategyType.startsWith(CUSTOM_PREFIX)) {
-    const name = strategyType.slice(CUSTOM_PREFIX.length);
-    const tag = `ll-strategy-${configType}-${name}`;
-    const legacyTag = `ll-strategy-${name}`;
-    strategy = (customElements.get(tag) ??
-      customElements.get(legacyTag)) as unknown as LovelaceStrategy | undefined;
-  }
+  const tags = getStrategyTags(configType, strategyType);
+  const strategy = tags
+    ? ((customElements.get(tags.tag) ??
+        (tags.legacyTag
+          ? customElements.get(tags.legacyTag)
+          : undefined)) as unknown as LovelaceStrategy | undefined)
+    : undefined;
 
   if (strategy?.shouldRegenerate) {
     return strategy.shouldRegenerate(strategyConfig, oldHass, newHass);

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -23,14 +23,14 @@ import type {
   LovelaceDashboardStrategyGetCreateSuggestions,
   LovelaceSectionStrategy,
   LovelaceStrategy,
-  LovelaceStrategyRegistryKey,
+  LovelaceStrategyDependency,
   LovelaceViewStrategy,
 } from "./types";
 
 const MAX_WAIT_STRATEGY_LOAD = 5000;
 const CUSTOM_PREFIX = "custom:";
 
-const DEFAULT_REGISTRY_DEPENDENCIES: readonly LovelaceStrategyRegistryKey[] = [
+const DEFAULT_REGISTRY_DEPENDENCIES: readonly LovelaceStrategyDependency[] = [
   "entities",
   "devices",
   "areas",

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -23,11 +23,19 @@ import type {
   LovelaceDashboardStrategyGetCreateSuggestions,
   LovelaceSectionStrategy,
   LovelaceStrategy,
+  LovelaceStrategyRegistryKey,
   LovelaceViewStrategy,
 } from "./types";
 
 const MAX_WAIT_STRATEGY_LOAD = 5000;
 const CUSTOM_PREFIX = "custom:";
+
+const DEFAULT_REGISTRY_DEPENDENCIES: readonly LovelaceStrategyRegistryKey[] = [
+  "entities",
+  "devices",
+  "areas",
+  "floors",
+];
 
 const STRATEGIES: Record<LovelaceStrategyConfigType, Record<string, any>> = {
   dashboard: {
@@ -239,6 +247,48 @@ export const generateLovelaceSectionStrategy = async (
     ...base,
     ...generated,
   };
+};
+
+/**
+ * Synchronously checks whether a strategy needs regeneration.
+ * Strategies can implement `shouldRegenerate` for custom logic or declare
+ * `registryDependencies` to opt in to the default reference-equality check.
+ * The default list (entities, devices, areas, floors) is used when neither is
+ * provided, preserving the previous behavior for third-party strategies.
+ */
+export const checkStrategyShouldRegenerate = (
+  configType: LovelaceStrategyConfigType,
+  strategyConfig: LovelaceStrategyConfig,
+  oldHass: HomeAssistant,
+  newHass: HomeAssistant
+): boolean => {
+  const strategyType = strategyConfig.type;
+  if (!strategyType) {
+    return false;
+  }
+
+  let strategy: LovelaceStrategy | undefined;
+
+  if (strategyType in STRATEGIES[configType]) {
+    const tag = `${strategyType}-${configType}-strategy`;
+    strategy = customElements.get(tag) as unknown as
+      | LovelaceStrategy
+      | undefined;
+  } else if (strategyType.startsWith(CUSTOM_PREFIX)) {
+    const name = strategyType.slice(CUSTOM_PREFIX.length);
+    const tag = `ll-strategy-${configType}-${name}`;
+    const legacyTag = `ll-strategy-${name}`;
+    strategy = (customElements.get(tag) ??
+      customElements.get(legacyTag)) as unknown as LovelaceStrategy | undefined;
+  }
+
+  if (strategy?.shouldRegenerate) {
+    return strategy.shouldRegenerate(strategyConfig, oldHass, newHass);
+  }
+
+  const dependencies =
+    strategy?.registryDependencies ?? DEFAULT_REGISTRY_DEPENDENCIES;
+  return dependencies.some((key) => oldHass[key] !== newHass[key]);
 };
 
 /**

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -90,19 +90,24 @@ type StrategyConfig<T extends LovelaceStrategyConfigType> = AsyncReturnType<
   Strategies[T]["generate"]
 >;
 
-// Resolves the custom element tag(s) for a strategy. Returns the legacy tag as
-// well for custom strategies. `undefined` means the type is neither built-in
-// nor a custom strategy.
-const getStrategyTags = (
+type StrategyTag =
+  | { type: "builtin"; tag: string }
+  | { type: "custom"; tag: string; legacyTag: string };
+
+// Resolves the custom element tag(s) for a strategy. Custom strategies also
+// expose a legacy tag. `undefined` means the type is neither built-in nor a
+// custom strategy.
+const getStrategyTag = (
   configType: LovelaceStrategyConfigType,
   strategyType: string
-): { tag: string; legacyTag?: string } | undefined => {
+): StrategyTag | undefined => {
   if (strategyType in STRATEGIES[configType]) {
-    return { tag: `${strategyType}-${configType}-strategy` };
+    return { type: "builtin", tag: `${strategyType}-${configType}-strategy` };
   }
   if (strategyType.startsWith(CUSTOM_PREFIX)) {
     const name = strategyType.slice(CUSTOM_PREFIX.length);
     return {
+      type: "custom",
       tag: `ll-strategy-${configType}-${name}`,
       legacyTag: `ll-strategy-${name}`,
     };
@@ -114,22 +119,22 @@ export const getLovelaceStrategy = async <T extends LovelaceStrategyConfigType>(
   configType: T,
   strategyType: string
 ): Promise<LovelaceStrategy> => {
-  const tags = getStrategyTags(configType, strategyType);
+  const tags = getStrategyTag(configType, strategyType);
 
   if (!tags) {
     throw new Error("Unknown strategy");
   }
 
-  const { tag, legacyTag } = tags;
-
-  if (strategyType in STRATEGIES[configType]) {
+  if (tags.type === "builtin") {
     await STRATEGIES[configType][strategyType]();
-    return customElements.get(tag) as unknown as Strategies[T];
+    return customElements.get(tags.tag) as unknown as Strategies[T];
   }
+
+  const { tag, legacyTag } = tags;
 
   if (
     (await Promise.race([
-      customElements.whenDefined(legacyTag!),
+      customElements.whenDefined(legacyTag),
       customElements.whenDefined(tag),
       new Promise((resolve) => {
         setTimeout(() => resolve(true), MAX_WAIT_STRATEGY_LOAD);
@@ -142,7 +147,7 @@ export const getLovelaceStrategy = async <T extends LovelaceStrategyConfigType>(
   }
 
   return (customElements.get(tag) ??
-    customElements.get(legacyTag!)) as unknown as Strategies[T];
+    customElements.get(legacyTag)) as unknown as Strategies[T];
 };
 
 const generateStrategy = async <T extends LovelaceStrategyConfigType>(
@@ -285,10 +290,10 @@ export const checkStrategyShouldRegenerate = (
     return false;
   }
 
-  const tags = getStrategyTags(configType, strategyType);
+  const tags = getStrategyTag(configType, strategyType);
   const strategy = tags
     ? ((customElements.get(tags.tag) ??
-        (tags.legacyTag
+        (tags.type === "custom"
           ? customElements.get(tags.legacyTag)
           : undefined)) as unknown as LovelaceStrategy | undefined)
     : undefined;

--- a/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
@@ -32,6 +32,8 @@ export interface HomeAreaViewStrategyConfig {
 
 @customElement("home-area-view-strategy")
 export class HomeAreaViewStrategy extends ReactiveElement {
+  static registryDependencies = ["entities", "devices", "areas", "panels"];
+
   static async generate(
     config: HomeAreaViewStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
@@ -17,6 +17,7 @@ import type {
 } from "../../cards/types";
 import type { ButtonHeadingBadgeConfig } from "../../heading-badges/types";
 import { computeAreaTileCardConfig } from "../areas/helpers/areas-strategy-helper";
+import type { LovelaceStrategyRegistryKey } from "../types";
 import {
   getSummaryLabel,
   HOME_SUMMARIES,
@@ -33,6 +34,13 @@ export interface HomeAreaViewStrategyConfig {
 
 @customElement("home-area-view-strategy")
 export class HomeAreaViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+    "entities",
+    "devices",
+    "areas",
+    "panels",
+  ];
+
   static async generate(
     config: HomeAreaViewStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
@@ -17,7 +17,7 @@ import type {
 } from "../../cards/types";
 import type { ButtonHeadingBadgeConfig } from "../../heading-badges/types";
 import { computeAreaTileCardConfig } from "../areas/helpers/areas-strategy-helper";
-import type { LovelaceStrategyRegistryKey } from "../types";
+import type { LovelaceStrategyDependency } from "../types";
 import {
   getSummaryLabel,
   HOME_SUMMARIES,
@@ -34,7 +34,7 @@ export interface HomeAreaViewStrategyConfig {
 
 @customElement("home-area-view-strategy")
 export class HomeAreaViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [
     "entities",
     "devices",
     "areas",

--- a/src/panels/lovelace/strategies/home/home-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-dashboard-strategy.ts
@@ -21,6 +21,8 @@ export interface HomeDashboardStrategyConfig {
 
 @customElement("home-dashboard-strategy")
 export class HomeDashboardStrategy extends ReactiveElement {
+  static registryDependencies = ["areas"];
+
   static async generate(
     config: HomeDashboardStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/home/home-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-dashboard-strategy.ts
@@ -6,7 +6,7 @@ import type { LovelaceViewRawConfig } from "../../../../data/lovelace/config/vie
 import type { HomeAssistant } from "../../../../types";
 import type {
   LovelaceStrategyEditor,
-  LovelaceStrategyRegistryKey,
+  LovelaceStrategyDependency,
 } from "../types";
 import {
   getSummaryLabel,
@@ -28,7 +28,7 @@ export interface HomeDashboardStrategyConfig {
 
 @customElement("home-dashboard-strategy")
 export class HomeDashboardStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [
     "areas",
   ];
 

--- a/src/panels/lovelace/strategies/home/home-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-dashboard-strategy.ts
@@ -4,7 +4,10 @@ import { customElement } from "lit/decorators";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
 import type { LovelaceViewRawConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
-import type { LovelaceStrategyEditor } from "../types";
+import type {
+  LovelaceStrategyEditor,
+  LovelaceStrategyRegistryKey,
+} from "../types";
 import {
   getSummaryLabel,
   HOME_SUMMARIES_ICONS,
@@ -25,6 +28,10 @@ export interface HomeDashboardStrategyConfig {
 
 @customElement("home-dashboard-strategy")
 export class HomeDashboardStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+    "areas",
+  ];
+
   static async generate(
     config: HomeDashboardStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/home/home-media-players-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-media-players-view-strategy.ts
@@ -10,6 +10,7 @@ import type { LovelaceSectionRawConfig } from "../../../../data/lovelace/config/
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
 import type { MediaControlCardConfig } from "../../cards/types";
+import type { LovelaceStrategyRegistryKey } from "../types";
 import { getAreasFloorHierarchy } from "../../../../common/areas/areas-floor-hierarchy";
 import { HOME_SUMMARIES_FILTERS } from "./helpers/home-summaries";
 
@@ -80,6 +81,13 @@ const processUnassignedEntities = (
 
 @customElement("home-media-players-view-strategy")
 export class HomeMMediaPlayersViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+    "entities",
+    "devices",
+    "areas",
+    "floors",
+  ];
+
   static async generate(
     _config: HomeMediaPlayersViewStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/home/home-media-players-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-media-players-view-strategy.ts
@@ -10,7 +10,7 @@ import type { LovelaceSectionRawConfig } from "../../../../data/lovelace/config/
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
 import type { MediaControlCardConfig } from "../../cards/types";
-import type { LovelaceStrategyRegistryKey } from "../types";
+import type { LovelaceStrategyDependency } from "../types";
 import { getAreasFloorHierarchy } from "../../../../common/areas/areas-floor-hierarchy";
 import { HOME_SUMMARIES_FILTERS } from "./helpers/home-summaries";
 
@@ -81,7 +81,7 @@ const processUnassignedEntities = (
 
 @customElement("home-media-players-view-strategy")
 export class HomeMMediaPlayersViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [
     "entities",
     "devices",
     "areas",

--- a/src/panels/lovelace/strategies/home/home-other-devices-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-other-devices-view-strategy.ts
@@ -15,7 +15,7 @@ import type {
   EntitiesCardConfig,
   HeadingCardConfig,
 } from "../../cards/types";
-import type { LovelaceStrategyRegistryKey } from "../types";
+import type { LovelaceStrategyDependency } from "../types";
 import { OTHER_DEVICES_FILTERS } from "./helpers/other-devices-filters";
 
 export interface HomeOtherDevicesViewStrategyConfig {
@@ -25,7 +25,7 @@ export interface HomeOtherDevicesViewStrategyConfig {
 
 @customElement("home-other-devices-view-strategy")
 export class HomeOtherDevicesViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [
     "entities",
     "devices",
     "areas",

--- a/src/panels/lovelace/strategies/home/home-other-devices-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-other-devices-view-strategy.ts
@@ -15,6 +15,7 @@ import type {
   EntitiesCardConfig,
   HeadingCardConfig,
 } from "../../cards/types";
+import type { LovelaceStrategyRegistryKey } from "../types";
 import { OTHER_DEVICES_FILTERS } from "./helpers/other-devices-filters";
 
 export interface HomeOtherDevicesViewStrategyConfig {
@@ -24,6 +25,13 @@ export interface HomeOtherDevicesViewStrategyConfig {
 
 @customElement("home-other-devices-view-strategy")
 export class HomeOtherDevicesViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+    "entities",
+    "devices",
+    "areas",
+    "floors",
+  ];
+
   static async generate(
     config: HomeOtherDevicesViewStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
@@ -72,6 +72,14 @@ const computeAreaCard = (
 
 @customElement("home-overview-view-strategy")
 export class HomeOverviewViewStrategy extends ReactiveElement {
+  static registryDependencies = [
+    "entities",
+    "devices",
+    "areas",
+    "floors",
+    "panels",
+  ];
+
   static async generate(
     config: HomeOverviewViewStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
@@ -35,7 +35,7 @@ import {
   LARGE_SCREEN_CONDITION,
   SMALL_SCREEN_CONDITION,
 } from "../helpers/view-columns-conditions";
-import type { LovelaceStrategyRegistryKey } from "../types";
+import type { LovelaceStrategyDependency } from "../types";
 import type { CommonControlsSectionStrategyConfig } from "../usage_prediction/common-controls-section-strategy";
 import { HOME_SUMMARIES_FILTERS } from "./helpers/home-summaries";
 import { OTHER_DEVICES_FILTERS } from "./helpers/other-devices-filters";
@@ -80,7 +80,7 @@ const computeAreaCard = (
 
 @customElement("home-overview-view-strategy")
 export class HomeOverviewViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [
     "entities",
     "devices",
     "areas",

--- a/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
@@ -35,6 +35,7 @@ import {
   LARGE_SCREEN_CONDITION,
   SMALL_SCREEN_CONDITION,
 } from "../helpers/view-columns-conditions";
+import type { LovelaceStrategyRegistryKey } from "../types";
 import type { CommonControlsSectionStrategyConfig } from "../usage_prediction/common-controls-section-strategy";
 import { HOME_SUMMARIES_FILTERS } from "./helpers/home-summaries";
 import { OTHER_DEVICES_FILTERS } from "./helpers/other-devices-filters";
@@ -79,6 +80,14 @@ const computeAreaCard = (
 
 @customElement("home-overview-view-strategy")
 export class HomeOverviewViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+    "entities",
+    "devices",
+    "areas",
+    "floors",
+    "panels",
+  ];
+
   static async generate(
     config: HomeOverviewViewStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/iframe/iframe-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/iframe/iframe-dashboard-strategy.ts
@@ -8,6 +8,8 @@ export type IframeDashboardStrategyConfig = IframeViewStrategyConfig;
 
 @customElement("iframe-dashboard-strategy")
 export class IframeDashboardStrategy extends ReactiveElement {
+  static registryDependencies = [];
+
   static async generate(
     config: IframeDashboardStrategyConfig
   ): Promise<LovelaceConfig> {

--- a/src/panels/lovelace/strategies/iframe/iframe-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/iframe/iframe-dashboard-strategy.ts
@@ -3,7 +3,7 @@ import { customElement } from "lit/decorators";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
 import type {
   LovelaceStrategyEditor,
-  LovelaceStrategyRegistryKey,
+  LovelaceStrategyDependency,
 } from "../types";
 import type { IframeViewStrategyConfig } from "./iframe-view-strategy";
 
@@ -11,7 +11,7 @@ export type IframeDashboardStrategyConfig = IframeViewStrategyConfig;
 
 @customElement("iframe-dashboard-strategy")
 export class IframeDashboardStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [];
 
   static async generate(
     config: IframeDashboardStrategyConfig

--- a/src/panels/lovelace/strategies/iframe/iframe-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/iframe/iframe-dashboard-strategy.ts
@@ -1,13 +1,18 @@
 import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
-import type { LovelaceStrategyEditor } from "../types";
+import type {
+  LovelaceStrategyEditor,
+  LovelaceStrategyRegistryKey,
+} from "../types";
 import type { IframeViewStrategyConfig } from "./iframe-view-strategy";
 
 export type IframeDashboardStrategyConfig = IframeViewStrategyConfig;
 
 @customElement("iframe-dashboard-strategy")
 export class IframeDashboardStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+
   static async generate(
     config: IframeDashboardStrategyConfig
   ): Promise<LovelaceConfig> {

--- a/src/panels/lovelace/strategies/iframe/iframe-view-strategy.ts
+++ b/src/panels/lovelace/strategies/iframe/iframe-view-strategy.ts
@@ -11,6 +11,8 @@ export interface IframeViewStrategyConfig {
 
 @customElement("iframe-view-strategy")
 export class IframeViewStrategy extends ReactiveElement {
+  static registryDependencies = [];
+
   static async generate(
     config: IframeViewStrategyConfig
   ): Promise<LovelaceViewConfig> {

--- a/src/panels/lovelace/strategies/iframe/iframe-view-strategy.ts
+++ b/src/panels/lovelace/strategies/iframe/iframe-view-strategy.ts
@@ -2,7 +2,7 @@ import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { IframeCardConfig } from "../../cards/types";
-import type { LovelaceStrategyRegistryKey } from "../types";
+import type { LovelaceStrategyDependency } from "../types";
 
 export interface IframeViewStrategyConfig {
   type: "iframe";
@@ -12,7 +12,7 @@ export interface IframeViewStrategyConfig {
 
 @customElement("iframe-view-strategy")
 export class IframeViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [];
 
   static async generate(
     config: IframeViewStrategyConfig

--- a/src/panels/lovelace/strategies/iframe/iframe-view-strategy.ts
+++ b/src/panels/lovelace/strategies/iframe/iframe-view-strategy.ts
@@ -2,6 +2,7 @@ import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { IframeCardConfig } from "../../cards/types";
+import type { LovelaceStrategyRegistryKey } from "../types";
 
 export interface IframeViewStrategyConfig {
   type: "iframe";
@@ -11,6 +12,8 @@ export interface IframeViewStrategyConfig {
 
 @customElement("iframe-view-strategy")
 export class IframeViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+
   static async generate(
     config: IframeViewStrategyConfig
   ): Promise<LovelaceViewConfig> {

--- a/src/panels/lovelace/strategies/map/map-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/map/map-dashboard-strategy.ts
@@ -7,6 +7,8 @@ export type MapDashboardStrategyConfig = MapViewStrategyConfig;
 
 @customElement("map-dashboard-strategy")
 export class MapDashboardStrategy extends ReactiveElement {
+  static registryDependencies = [];
+
   static async generate(
     config: MapDashboardStrategyConfig
   ): Promise<LovelaceConfig> {

--- a/src/panels/lovelace/strategies/map/map-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/map/map-dashboard-strategy.ts
@@ -3,14 +3,14 @@ import { customElement } from "lit/decorators";
 import type { LovelaceDashboardSuggestions } from "../../../../data/lovelace/dashboard";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
 import type { HomeAssistant } from "../../../../types";
-import type { LovelaceStrategyRegistryKey } from "../types";
+import type { LovelaceStrategyDependency } from "../types";
 import type { MapViewStrategyConfig } from "./map-view-strategy";
 
 export type MapDashboardStrategyConfig = MapViewStrategyConfig;
 
 @customElement("map-dashboard-strategy")
 export class MapDashboardStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [];
 
   static async generate(
     config: MapDashboardStrategyConfig

--- a/src/panels/lovelace/strategies/map/map-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/map/map-dashboard-strategy.ts
@@ -3,12 +3,15 @@ import { customElement } from "lit/decorators";
 import type { LovelaceDashboardSuggestions } from "../../../../data/lovelace/dashboard";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
 import type { HomeAssistant } from "../../../../types";
+import type { LovelaceStrategyRegistryKey } from "../types";
 import type { MapViewStrategyConfig } from "./map-view-strategy";
 
 export type MapDashboardStrategyConfig = MapViewStrategyConfig;
 
 @customElement("map-dashboard-strategy")
 export class MapDashboardStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+
   static async generate(
     config: MapDashboardStrategyConfig
   ): Promise<LovelaceConfig> {

--- a/src/panels/lovelace/strategies/map/map-view-strategy.ts
+++ b/src/panels/lovelace/strategies/map/map-view-strategy.ts
@@ -10,6 +10,8 @@ export interface MapViewStrategyConfig {
 
 @customElement("map-view-strategy")
 export class MapViewStrategy extends ReactiveElement {
+  static registryDependencies = [];
+
   static async generate(
     _config: MapViewStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/map/map-view-strategy.ts
+++ b/src/panels/lovelace/strategies/map/map-view-strategy.ts
@@ -3,6 +3,7 @@ import { customElement } from "lit/decorators";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
 import type { MapCardConfig } from "../../cards/types";
+import type { LovelaceStrategyRegistryKey } from "../types";
 
 export interface MapViewStrategyConfig {
   type: "map";
@@ -10,6 +11,8 @@ export interface MapViewStrategyConfig {
 
 @customElement("map-view-strategy")
 export class MapViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+
   static async generate(
     _config: MapViewStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/map/map-view-strategy.ts
+++ b/src/panels/lovelace/strategies/map/map-view-strategy.ts
@@ -3,7 +3,7 @@ import { customElement } from "lit/decorators";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
 import type { MapCardConfig } from "../../cards/types";
-import type { LovelaceStrategyRegistryKey } from "../types";
+import type { LovelaceStrategyDependency } from "../types";
 
 export interface MapViewStrategyConfig {
   type: "map";
@@ -11,7 +11,7 @@ export interface MapViewStrategyConfig {
 
 @customElement("map-view-strategy")
 export class MapViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [];
 
   static async generate(
     _config: MapViewStrategyConfig,

--- a/src/panels/lovelace/strategies/original-states/original-states-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states/original-states-dashboard-strategy.ts
@@ -9,6 +9,8 @@ export type OriginalStatesDashboardStrategyConfig =
 
 @customElement("original-states-dashboard-strategy")
 export class OriginalStatesDashboardStrategy extends ReactiveElement {
+  static registryDependencies = [];
+
   static async generate(
     config: OriginalStatesDashboardStrategyConfig
   ): Promise<LovelaceConfig> {

--- a/src/panels/lovelace/strategies/original-states/original-states-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states/original-states-dashboard-strategy.ts
@@ -3,7 +3,7 @@ import { customElement } from "lit/decorators";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
 import type {
   LovelaceStrategyEditor,
-  LovelaceStrategyRegistryKey,
+  LovelaceStrategyDependency,
 } from "../types";
 import type { OriginalStatesViewStrategyConfig } from "./original-states-view-strategy";
 
@@ -12,7 +12,7 @@ export type OriginalStatesDashboardStrategyConfig =
 
 @customElement("original-states-dashboard-strategy")
 export class OriginalStatesDashboardStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [];
 
   static async generate(
     config: OriginalStatesDashboardStrategyConfig

--- a/src/panels/lovelace/strategies/original-states/original-states-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states/original-states-dashboard-strategy.ts
@@ -1,7 +1,10 @@
 import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
-import type { LovelaceStrategyEditor } from "../types";
+import type {
+  LovelaceStrategyEditor,
+  LovelaceStrategyRegistryKey,
+} from "../types";
 import type { OriginalStatesViewStrategyConfig } from "./original-states-view-strategy";
 
 export type OriginalStatesDashboardStrategyConfig =
@@ -9,6 +12,8 @@ export type OriginalStatesDashboardStrategyConfig =
 
 @customElement("original-states-dashboard-strategy")
 export class OriginalStatesDashboardStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+
   static async generate(
     config: OriginalStatesDashboardStrategyConfig
   ): Promise<LovelaceConfig> {

--- a/src/panels/lovelace/strategies/original-states/original-states-view-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states/original-states-view-strategy.ts
@@ -9,7 +9,7 @@ import type { HomeAssistant } from "../../../../types";
 import type { EmptyStateCardConfig } from "../../cards/types";
 import { generateDefaultViewConfig } from "../../common/generate-lovelace-config";
 import { computeDomain } from "../../../../common/entity/compute_domain";
-import type { LovelaceStrategyRegistryKey } from "../types";
+import type { LovelaceStrategyDependency } from "../types";
 
 export interface OriginalStatesViewStrategyConfig {
   type: "original-states";
@@ -20,7 +20,7 @@ export interface OriginalStatesViewStrategyConfig {
 
 @customElement("original-states-view-strategy")
 export class OriginalStatesViewStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [
     "entities",
     "devices",
     "areas",

--- a/src/panels/lovelace/strategies/original-states/original-states-view-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states/original-states-view-strategy.ts
@@ -9,6 +9,7 @@ import type { HomeAssistant } from "../../../../types";
 import type { EmptyStateCardConfig } from "../../cards/types";
 import { generateDefaultViewConfig } from "../../common/generate-lovelace-config";
 import { computeDomain } from "../../../../common/entity/compute_domain";
+import type { LovelaceStrategyRegistryKey } from "../types";
 
 export interface OriginalStatesViewStrategyConfig {
   type: "original-states";
@@ -19,6 +20,13 @@ export interface OriginalStatesViewStrategyConfig {
 
 @customElement("original-states-view-strategy")
 export class OriginalStatesViewStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [
+    "entities",
+    "devices",
+    "areas",
+    "floors",
+  ];
+
   static async generate(
     config: OriginalStatesViewStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/types.ts
+++ b/src/panels/lovelace/strategies/types.ts
@@ -5,8 +5,22 @@ import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceGenericElementEditor } from "../types";
 
+export type LovelaceStrategyRegistryKey =
+  | "entities"
+  | "devices"
+  | "areas"
+  | "floors"
+  | "labels"
+  | "panels";
+
 export interface LovelaceStrategy<T = any> {
   generate(config: LovelaceStrategyConfig, hass: HomeAssistant): Promise<T>;
+  shouldRegenerate?(
+    config: LovelaceStrategyConfig,
+    oldHass: HomeAssistant,
+    newHass: HomeAssistant
+  ): boolean;
+  registryDependencies?: readonly LovelaceStrategyRegistryKey[];
   getConfigElement?: () => LovelaceStrategyEditor;
   noEditor?: boolean;
   configRequired?: boolean;

--- a/src/panels/lovelace/strategies/types.ts
+++ b/src/panels/lovelace/strategies/types.ts
@@ -6,7 +6,7 @@ import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceGenericElementEditor } from "../types";
 
-export type LovelaceStrategyRegistryKey =
+export type LovelaceStrategyDependency =
   | "entities"
   | "devices"
   | "areas"
@@ -21,7 +21,7 @@ export interface LovelaceStrategy<T = any> {
     oldHass: HomeAssistant,
     newHass: HomeAssistant
   ): boolean;
-  registryDependencies?: readonly LovelaceStrategyRegistryKey[];
+  registryDependencies?: readonly LovelaceStrategyDependency[];
   getConfigElement?: () => LovelaceStrategyEditor;
   noEditor?: boolean;
   configRequired?: boolean;

--- a/src/panels/lovelace/strategies/types.ts
+++ b/src/panels/lovelace/strategies/types.ts
@@ -6,8 +6,22 @@ import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceGenericElementEditor } from "../types";
 
+export type LovelaceStrategyRegistryKey =
+  | "entities"
+  | "devices"
+  | "areas"
+  | "floors"
+  | "labels"
+  | "panels";
+
 export interface LovelaceStrategy<T = any> {
   generate(config: LovelaceStrategyConfig, hass: HomeAssistant): Promise<T>;
+  shouldRegenerate?(
+    config: LovelaceStrategyConfig,
+    oldHass: HomeAssistant,
+    newHass: HomeAssistant
+  ): boolean;
+  registryDependencies?: readonly LovelaceStrategyRegistryKey[];
   getConfigElement?: () => LovelaceStrategyEditor;
   noEditor?: boolean;
   configRequired?: boolean;

--- a/src/panels/lovelace/strategies/usage_prediction/common-controls-section-strategy.ts
+++ b/src/panels/lovelace/strategies/usage_prediction/common-controls-section-strategy.ts
@@ -26,6 +26,8 @@ export interface CommonControlSectionStrategyConfig {
 
 @customElement("common-controls-section-strategy")
 export class CommonControlsSectionStrategy extends ReactiveElement {
+  static registryDependencies = [];
+
   static async generate(
     config: CommonControlSectionStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/strategies/usage_prediction/common-controls-section-strategy.ts
+++ b/src/panels/lovelace/strategies/usage_prediction/common-controls-section-strategy.ts
@@ -6,7 +6,7 @@ import { getCommonControlsUsagePrediction } from "../../../../data/usage_predict
 import type { HomeAssistant } from "../../../../types";
 import type { HeadingCardConfig, TileCardConfig } from "../../cards/types";
 import type { Condition } from "../../common/validate-condition";
-import type { LovelaceStrategyRegistryKey } from "../types";
+import type { LovelaceStrategyDependency } from "../types";
 
 const DEFAULT_LIMIT = 8;
 
@@ -34,7 +34,7 @@ const toTileCard = (entity: string): TileCardConfig => ({
 
 @customElement("common-controls-section-strategy")
 export class CommonControlsSectionStrategy extends ReactiveElement {
-  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+  static registryDependencies: readonly LovelaceStrategyDependency[] = [];
 
   static async generate(
     config: CommonControlsSectionStrategyConfig,

--- a/src/panels/lovelace/strategies/usage_prediction/common-controls-section-strategy.ts
+++ b/src/panels/lovelace/strategies/usage_prediction/common-controls-section-strategy.ts
@@ -6,6 +6,7 @@ import { getCommonControlsUsagePrediction } from "../../../../data/usage_predict
 import type { HomeAssistant } from "../../../../types";
 import type { HeadingCardConfig, TileCardConfig } from "../../cards/types";
 import type { Condition } from "../../common/validate-condition";
+import type { LovelaceStrategyRegistryKey } from "../types";
 
 const DEFAULT_LIMIT = 8;
 
@@ -33,6 +34,8 @@ const toTileCard = (entity: string): TileCardConfig => ({
 
 @customElement("common-controls-section-strategy")
 export class CommonControlsSectionStrategy extends ReactiveElement {
+  static registryDependencies: readonly LovelaceStrategyRegistryKey[] = [];
+
   static async generate(
     config: CommonControlsSectionStrategyConfig,
     hass: HomeAssistant

--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -5,7 +5,6 @@ import { customElement, property, state } from "lit/decorators";
 import { storage } from "../../../common/decorators/storage";
 import type { HASSDomEvent } from "../../../common/dom/fire_event";
 import { debounce } from "../../../common/util/debounce";
-import { deepEqual } from "../../../common/util/deep-equal";
 import "../../../components/entity/ha-state-label-badge";
 import "../../../components/ha-svg-icon";
 import type { LovelaceViewElement } from "../../../data/lovelace";
@@ -42,7 +41,10 @@ import { parseLovelaceCardPath } from "../editor/lovelace-path";
 import { createErrorSectionConfig } from "../sections/hui-error-section";
 import "../sections/hui-section";
 import type { HuiSection } from "../sections/hui-section";
-import { generateLovelaceViewStrategy } from "../strategies/get-strategy";
+import {
+  checkStrategyShouldRegenerate,
+  generateLovelaceViewStrategy,
+} from "../strategies/get-strategy";
 import type { Lovelace } from "../types";
 import { getViewType } from "./get-view-type";
 
@@ -185,10 +187,13 @@ export class HUIView extends ReactiveElement {
     if (oldHass && this.hass && this.lovelace && isStrategyView(viewConfig)) {
       if (
         this.hass.config.state === "RUNNING" &&
-        (oldHass.entities !== this.hass.entities ||
-          oldHass.devices !== this.hass.devices ||
-          oldHass.areas !== this.hass.areas ||
-          oldHass.floors !== this.hass.floors)
+        (oldHass.config.state !== "RUNNING" ||
+          checkStrategyShouldRegenerate(
+            "view",
+            viewConfig.strategy,
+            oldHass,
+            this.hass
+          ))
       ) {
         this._debounceRefreshConfig();
       }

--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -42,7 +42,10 @@ import { parseLovelaceCardPath } from "../editor/lovelace-path";
 import { createErrorSectionConfig } from "../sections/hui-error-section";
 import "../sections/hui-section";
 import type { HuiSection } from "../sections/hui-section";
-import { generateLovelaceViewStrategy } from "../strategies/get-strategy";
+import {
+  checkStrategyShouldRegenerate,
+  generateLovelaceViewStrategy,
+} from "../strategies/get-strategy";
 import type { Lovelace } from "../types";
 import { getViewType } from "./get-view-type";
 
@@ -185,10 +188,13 @@ export class HUIView extends ReactiveElement {
     if (oldHass && this.hass && this.lovelace && isStrategyView(viewConfig)) {
       if (
         this.hass.config.state === "RUNNING" &&
-        (oldHass.entities !== this.hass.entities ||
-          oldHass.devices !== this.hass.devices ||
-          oldHass.areas !== this.hass.areas ||
-          oldHass.floors !== this.hass.floors)
+        (oldHass.config.state !== "RUNNING" ||
+          checkStrategyShouldRegenerate(
+            "view",
+            viewConfig.strategy,
+            oldHass,
+            this.hass
+          ))
       ) {
         this._debounceRefreshConfig();
       }


### PR DESCRIPTION
## Proposed change

> **Note:** this PR stacks on top of #30101.

Strategies currently regenerate whenever any registry changes (entities, devices, areas, floors), even for strategies like iframe or map that don't depend on any registry data.

Each strategy can now declare which registries it depends on via a static `registryDependencies` property. Regeneration only happens when relevant data changes. Strategies with no dependencies never regenerate; strategies like the home dashboard only regenerate when areas change.

Regeneration checks are also extended to views and sections, not just dashboards.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr