### PR TITLE
Expand ha-slider touch target for volume slider usability

### DIFF
--- a/src/components/ha-slider.ts
+++ b/src/components/ha-slider.ts
@@ -61,6 +61,12 @@ export class HaSlider extends Slider {
           width: 200px;
         }
 
+        /* Expand slider touch target to 32px */
+        #slider {
+          padding-block: 14px;
+          margin-block: -14px;
+        }
+
         #thumb {
           border: none;
           background-color: var(--ha-slider-thumb-color, var(--primary-color));

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -586,12 +586,6 @@ class MoreInfoMediaPlayer extends LitElement {
       width: 100%;
     }
 
-    @media (pointer: coarse) {
-      .volume-slider {
-        pointer-events: none;
-      }
-    }
-
     .volume ha-svg-icon {
       padding: var(--ha-space-1);
       height: 16px;


### PR DESCRIPTION
## Proposed change

Expand the touch target of `ha-slider` to 32px by adding padding to the internal `#slider` element. This makes sliders much easier to interact with on touch devices.

Also removes the `pointer-events: none` workaround on the volume slider in the media player more-info dialog, added in #29075. This workaround disabled touch interaction entirely on coarse pointer devices, which is no longer needed now that the slider has an adequately sized touch target.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #29441
- This PR is related to issue or discussion: #29075
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr