### PR TITLE
Guard discovered devices flow subscription for non-admin users

### DIFF
--- a/src/panels/lovelace/cards/hui-discovered-devices-card.ts
+++ b/src/panels/lovelace/cards/hui-discovered-devices-card.ts
@@ -38,14 +38,14 @@ export class HuiDiscoveredDevicesCard
   @state() private _discoveredFlows: DataEntryFlowProgress[] = [];
 
   public hassSubscribe(): (UnsubscribeFunc | Promise<UnsubscribeFunc>)[] {
-    if (!this.hass || !this.hass.user?.is_admin) {
+    if (!this.hass!.user?.is_admin) {
       this._discoveredFlows = [];
       return [];
     }
 
     return [
       subscribeConfigFlowInProgress(
-        this.hass,
+        this.hass!,
         (messages: ConfigFlowInProgressMessage[]) => {
           if (messages.length === 0) {
             this._discoveredFlows = [];

--- a/src/panels/lovelace/cards/hui-discovered-devices-card.ts
+++ b/src/panels/lovelace/cards/hui-discovered-devices-card.ts
@@ -38,9 +38,14 @@ export class HuiDiscoveredDevicesCard
   @state() private _discoveredFlows: DataEntryFlowProgress[] = [];
 
   public hassSubscribe(): (UnsubscribeFunc | Promise<UnsubscribeFunc>)[] {
+    if (!this.hass || !this.hass.user?.is_admin) {
+      this._discoveredFlows = [];
+      return [];
+    }
+
     return [
       subscribeConfigFlowInProgress(
-        this.hass!,
+        this.hass,
         (messages: ConfigFlowInProgressMessage[]) => {
           if (messages.length === 0) {
             this._discoveredFlows = [];


### PR DESCRIPTION
## Proposed change

Prevent non-admin users from subscribing to config entry flow updates in `hui-discovered-devices-card`.

`/home/overview` includes the `discovered-devices` card via the Home strategy. Today, `hassSubscribe()` subscribes to `config_entries/flow/subscribe` before any admin guard, while visibility is gated later in `willUpdate()`. Because `connectedWhileHidden = true`, non-admin sessions can still attempt this subscription and trigger websocket `Unauthorized` errors.

This patch adds an early guard in `hassSubscribe()`:
- If `!this.hass || !this.hass.user?.is_admin`, clear `_discoveredFlows` and return `[]`.
- Otherwise subscribe as before.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Related issue

Closes #30100

## Testing

- Reproduced issue on Core `2026.3.1` with non-admin users opening `/home/overview`.
- Verified command-level trigger in websocket logs: `config_entries/flow/subscribe` unauthorized for non-admin.
- Ran file-level eslint:
  - `corepack yarn eslint src/panels/lovelace/cards/hui-discovered-devices-card.ts`

