### PR TITLE
Add simplified CSS gradient background editor for views

### DIFF
--- a/src/panels/lovelace/editor/view-editor/hui-view-background-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-background-editor.ts
@@ -7,9 +7,8 @@ import "../../../../components/ha-button-toggle-group";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
-import type { HomeAssistant } from "../../../../types";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
-import type { ToggleButton } from "../../../../types";
+import type { HomeAssistant, ToggleButton } from "../../../../types";
 
 import {
   isMediaSourceContentId,
@@ -38,6 +37,8 @@ export class HuiViewBackgroundEditor extends LitElement {
 
   @state() private _mode: BackgroundMode = "image";
 
+  @state() private _gradientLoaded = false;
+
   private _cachedBackground: Record<BackgroundMode, any> = {
     image: undefined,
     gradient: undefined,
@@ -52,10 +53,18 @@ export class HuiViewBackgroundEditor extends LitElement {
       this._mode = _detectMode(config);
       this._cachedBackground[this._mode] = config.background;
       if (this._mode === "gradient") {
-        import("./hui-view-gradient-editor");
+        this._loadGradientEditor();
       }
     }
     this._config = config;
+  }
+
+  private _loadGradientEditor() {
+    if (!this._gradientLoaded) {
+      import("./hui-view-gradient-editor").then(() => {
+        this._gradientLoaded = true;
+      });
+    }
   }
 
   private _localizeValueCallback = (key: string) =>
@@ -214,13 +223,16 @@ export class HuiViewBackgroundEditor extends LitElement {
         @value-changed=${this._modeChanged}
       ></ha-button-toggle-group>
 
-      ${this._mode === "gradient"
+      ${this._gradientLoaded
         ? html`<hui-view-gradient-editor
             .hass=${this.hass}
             .config=${this._config}
+            ?hidden=${this._mode !== "gradient"}
             @view-config-changed=${this._gradientConfigChanged}
           ></hui-view-gradient-editor>`
-        : this._renderImageEditor()}
+        : nothing}
+
+      ${this._mode === "image" ? this._renderImageEditor() : nothing}
     `;
   }
 
@@ -296,7 +308,7 @@ export class HuiViewBackgroundEditor extends LitElement {
     this._mode = newMode;
 
     if (this._mode === "gradient") {
-      import("./hui-view-gradient-editor");
+      this._loadGradientEditor();
     }
 
     const cachedBg = this._cachedBackground[this._mode];
@@ -364,7 +376,10 @@ export class HuiViewBackgroundEditor extends LitElement {
       --file-upload-image-border-radius: var(--ha-border-radius-sm);
     }
     ha-button-toggle-group {
-      margin-bottom: var(--ha-space-4);
+      margin-bottom: var(--ha-space-6);
+    }
+    hui-view-gradient-editor[hidden] {
+      display: none;
     }
     .previewContainer {
       width: 100%;

--- a/src/panels/lovelace/editor/view-editor/hui-view-background-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-background-editor.ts
@@ -36,9 +36,22 @@ export class HuiViewBackgroundEditor extends LitElement {
 
   @state() private _mode: BackgroundMode = "image";
 
+  private _cachedBackground: Record<BackgroundMode, any> = {
+    image: undefined,
+    gradient: undefined,
+  };
+
+  get config(): LovelaceViewConfig {
+    return this._config;
+  }
+
   set config(config: LovelaceViewConfig) {
     if (!this._config) {
       this._mode = _detectMode(config);
+      this._cachedBackground[this._mode] = config.background;
+      if (this._mode === "gradient") {
+        import("./hui-view-gradient-editor");
+      }
     }
     this._config = config;
   }
@@ -273,15 +286,28 @@ export class HuiViewBackgroundEditor extends LitElement {
   );
 
   private _modeChanged(ev: CustomEvent): void {
-    this._mode = ev.detail.value as BackgroundMode;
+    const newMode = ev.detail.value as BackgroundMode;
+    if (newMode === this._mode) return;
+
+    this._cachedBackground[this._mode] = this._config.background;
+
+    this._mode = newMode;
+
     if (this._mode === "gradient") {
       import("./hui-view-gradient-editor");
+    }
+
+    const cachedBg = this._cachedBackground[this._mode];
+    if (cachedBg !== undefined) {
+      const config = { ...this._config, background: cachedBg };
+      fireEvent(this, "view-config-changed", { config });
     }
   }
 
   private _gradientConfigChanged(ev: CustomEvent): void {
     ev.stopPropagation();
     if (ev.detail?.config) {
+      this._cachedBackground.gradient = ev.detail.config.background;
       fireEvent(this, "view-config-changed", { config: ev.detail.config });
     }
   }
@@ -291,6 +317,7 @@ export class HuiViewBackgroundEditor extends LitElement {
       ...this._config,
       background: ev.detail.value,
     };
+    this._cachedBackground.image = ev.detail.value;
     fireEvent(this, "view-config-changed", { config });
   }
 
@@ -335,7 +362,7 @@ export class HuiViewBackgroundEditor extends LitElement {
       --file-upload-image-border-radius: var(--ha-border-radius-sm);
     }
     ha-button-toggle-group {
-      margin-bottom: 16px;
+      margin-bottom: var(--ha-space-4);
     }
     .previewContainer {
       width: 100%;
@@ -346,7 +373,7 @@ export class HuiViewBackgroundEditor extends LitElement {
     img {
       max-width: 100%;
       max-height: 200px;
-      margin-bottom: 4px;
+      margin-bottom: var(--ha-space-1);
       border-radius: var(--file-upload-image-border-radius);
       transition: opacity 0.3s;
       opacity: var(--picture-opacity, 1);

--- a/src/panels/lovelace/editor/view-editor/hui-view-background-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-background-editor.ts
@@ -20,8 +20,10 @@ type BackgroundMode = "image" | "gradient";
 
 function _detectMode(config?: LovelaceViewConfig): BackgroundMode {
   const bg = config?.background;
-  if (typeof bg === "string" && bg.includes("radial-gradient")) {
-    return "gradient";
+  if (typeof bg === "string") {
+    if (bg.includes("radial-gradient") || /^#[0-9a-fA-F]{3,8}$/.test(bg)) {
+      return "gradient";
+    }
   }
   return "image";
 }

--- a/src/panels/lovelace/editor/view-editor/hui-view-background-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-background-editor.ts
@@ -3,16 +3,28 @@ import { LitElement, css, html, nothing } from "lit";
 import type { PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-button-toggle-group";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
+import type { ToggleButton } from "../../../../types";
 
 import {
   isMediaSourceContentId,
   resolveMediaSource,
 } from "../../../../data/media_source";
+
+type BackgroundMode = "image" | "gradient";
+
+function _detectMode(config?: LovelaceViewConfig): BackgroundMode {
+  const bg = config?.background;
+  if (typeof bg === "string" && bg.includes("radial-gradient")) {
+    return "gradient";
+  }
+  return "image";
+}
 
 @customElement("hui-view-background-editor")
 export class HuiViewBackgroundEditor extends LitElement {
@@ -22,7 +34,12 @@ export class HuiViewBackgroundEditor extends LitElement {
 
   @state({ attribute: false }) private _resolvedImage?: string;
 
+  @state() private _mode: BackgroundMode = "image";
+
   set config(config: LovelaceViewConfig) {
+    if (!this._config) {
+      this._mode = _detectMode(config);
+    }
     this._config = config;
   }
 
@@ -125,6 +142,7 @@ export class HuiViewBackgroundEditor extends LitElement {
 
   protected updated(changedProps: PropertyValues) {
     if (
+      this._mode === "image" &&
       this._config &&
       this.hass &&
       (changedProps.has("_config") ||
@@ -151,11 +169,47 @@ export class HuiViewBackgroundEditor extends LitElement {
     }
   }
 
+  private _modeButtons = memoizeOne(
+    (localize: LocalizeFunc): ToggleButton[] => [
+      {
+        value: "image",
+        label: localize(
+          "ui.panel.lovelace.editor.edit_view.background.type_image"
+        ),
+      },
+      {
+        value: "gradient",
+        label: localize(
+          "ui.panel.lovelace.editor.edit_view.background.type_gradient"
+        ),
+      },
+    ]
+  );
+
   protected render() {
     if (!this.hass) {
       return nothing;
     }
 
+    return html`
+      <ha-button-toggle-group
+        full-width
+        .buttons=${this._modeButtons(this.hass.localize)}
+        .active=${this._mode}
+        @value-changed=${this._modeChanged}
+      ></ha-button-toggle-group>
+
+      ${this._mode === "gradient"
+        ? html`<hui-view-gradient-editor
+            .hass=${this.hass}
+            .config=${this._config}
+            @view-config-changed=${this._gradientConfigChanged}
+          ></hui-view-gradient-editor>`
+        : this._renderImageEditor()}
+    `;
+  }
+
+  private _renderImageEditor() {
     const background = this._backgroundData(this._config);
 
     return html`
@@ -218,6 +272,20 @@ export class HuiViewBackgroundEditor extends LitElement {
     }
   );
 
+  private _modeChanged(ev: CustomEvent): void {
+    this._mode = ev.detail.value as BackgroundMode;
+    if (this._mode === "gradient") {
+      import("./hui-view-gradient-editor");
+    }
+  }
+
+  private _gradientConfigChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    if (ev.detail?.config) {
+      fireEvent(this, "view-config-changed", { config: ev.detail.config });
+    }
+  }
+
   private _valueChanged(ev: CustomEvent): void {
     const config = {
       ...this._config,
@@ -265,6 +333,9 @@ export class HuiViewBackgroundEditor extends LitElement {
     :host {
       display: block;
       --file-upload-image-border-radius: var(--ha-border-radius-sm);
+    }
+    ha-button-toggle-group {
+      margin-bottom: 16px;
     }
     .previewContainer {
       width: 100%;

--- a/src/panels/lovelace/editor/view-editor/hui-view-gradient-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-gradient-editor.ts
@@ -1,31 +1,26 @@
-import { mdiDelete, mdiPlus, mdiRefresh } from "@mdi/js";
+import { mdiRefresh } from "@mdi/js";
+import memoizeOne from "memoize-one";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { repeat } from "lit/directives/repeat";
 import { hex2rgb, rgb2hex } from "../../../../common/color/convert-color";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import "../../../../components/ha-icon-button";
-import "../../../../components/ha-slider";
-
+import "../../../../components/ha-button";
+import "../../../../components/ha-button-toggle-group";
+import "../../../../components/ha-svg-icon";
+import "../../../../components/ha-textfield";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
+import type { ToggleButton } from "../../../../types";
+
+type GradientSubMode = "solid" | "random";
 
 interface GradientBlob {
-  id: number;
   color: string;
   opacity: number;
   size: number;
   x: number;
   y: number;
-}
-
-const MAX_BLOBS = 8;
-
-function _randomColor(): string {
-  const h = Math.floor(Math.random() * 360);
-  const s = 70 + Math.floor(Math.random() * 30);
-  const l = 40 + Math.floor(Math.random() * 30);
-  return _hslToHex(h, s, l);
 }
 
 function _hslToHex(h: number, s: number, l: number): string {
@@ -42,55 +37,103 @@ function _hslToHex(h: number, s: number, l: number): string {
   return `#${f(0)}${f(8)}${f(4)}`;
 }
 
-function _parseGradientString(bg: string): {
+function _randomVariant(baseHex: string): string {
+  const [r, g, b] = hex2rgb(baseHex);
+  const shift = () => Math.min(255, Math.max(0, Math.round((Math.random() - 0.5) * 80)));
+  return rgb2hex([
+    Math.min(255, Math.max(0, r + shift())),
+    Math.min(255, Math.max(0, g + shift())),
+    Math.min(255, Math.max(0, b + shift())),
+  ]);
+}
+
+function _generateBlobs(colors: string[]): {
   blobs: GradientBlob[];
   baseColor: string;
 } {
+  const count = 3 + Math.floor(Math.random() * 4);
+  const baseR = Math.floor(Math.random() * 20);
+  const baseG = Math.floor(Math.random() * 20);
+  const baseB = Math.floor(Math.random() * 25);
+  const baseColor = rgb2hex([baseR, baseG, baseB]);
+
+  const palette = colors.filter((c) => c !== "");
   const blobs: GradientBlob[] = [];
-  let baseColor = "#0e1117";
-  let blobId = 1;
-
-  const gradientRegex =
-    /radial-gradient\(\s*at\s+(\d+)%\s+(\d+)%\s*,\s*rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d.]+)\s*\)\s*0px\s*,\s*transparent\s+(\d+)%\s*\)/g;
-
-  let match = gradientRegex.exec(bg);
-  while (match) {
+  for (let i = 0; i < count; i++) {
+    const seedColor =
+      palette.length > 0
+        ? palette[i % palette.length]
+        : _hslToHex(
+            Math.floor(Math.random() * 360),
+            70 + Math.floor(Math.random() * 30),
+            40 + Math.floor(Math.random() * 30)
+          );
     blobs.push({
-      id: blobId++,
-      x: parseInt(match[1], 10),
-      y: parseInt(match[2], 10),
-      color: rgb2hex([
-        parseInt(match[3], 10),
-        parseInt(match[4], 10),
-        parseInt(match[5], 10),
-      ]),
-      opacity: parseFloat(match[6]),
-      size: parseInt(match[7], 10),
+      color: palette.length > 0 ? _randomVariant(seedColor) : seedColor,
+      opacity: +(0.15 + Math.random() * 0.65).toFixed(2),
+      size: 35 + Math.floor(Math.random() * 55),
+      x: Math.round(Math.random() * 80 + 10),
+      y: Math.round(Math.random() * 80 + 10),
     });
-    match = gradientRegex.exec(bg);
   }
-
-  const hexMatch = bg.match(/(#[0-9a-fA-F]{6})\s*$/);
-  if (hexMatch) {
-    baseColor = hexMatch[1];
-  }
-
   return { blobs, baseColor };
+}
+
+function _buildGradientString(blobs: GradientBlob[], baseColor: string): string {
+  const parts = blobs.map((b) => {
+    const [r, g, bVal] = hex2rgb(b.color);
+    return `radial-gradient(at ${b.x}% ${b.y}%, rgba(${r},${g},${bVal},${b.opacity.toFixed(2)}) 0px, transparent ${b.size}%)`;
+  });
+  parts.push(baseColor);
+  return parts.join(",\n  ");
+}
+
+function _detectSubMode(bg: unknown): GradientSubMode {
+  if (typeof bg === "string" && bg.includes("radial-gradient")) {
+    return "random";
+  }
+  return "solid";
+}
+
+function _parseGradientColors(bg: string): string[] {
+  const colors: string[] = [];
+  const regex =
+    /radial-gradient\(\s*at\s+\d+%\s+\d+%\s*,\s*rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,/g;
+
+  let match = regex.exec(bg);
+  while (match) {
+    const hex = rgb2hex([
+      parseInt(match[1], 10),
+      parseInt(match[2], 10),
+      parseInt(match[3], 10),
+    ]);
+    if (!colors.includes(hex)) {
+      colors.push(hex);
+    }
+    match = regex.exec(bg);
+  }
+  return colors.slice(0, 3);
 }
 
 @customElement("hui-view-gradient-editor")
 export class HuiViewGradientEditor extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @state() private _blobs: GradientBlob[] = [];
+  @state() private _subMode: GradientSubMode = "random";
 
-  @state() private _baseColor = "#0e1117";
+  @state() private _solidColor = "#3a5f8c";
 
-  private _dragIndex: number | null = null;
+  @state() private _color1 = "#ec7a41";
+
+  @state() private _color2 = "#4169e1";
+
+  @state() private _color3 = "";
+
+  @state() private _gradientString = "";
 
   private _config?: LovelaceViewConfig;
 
-  private _nextBlobId = 1;
+  private _initialized = false;
 
   get config(): LovelaceViewConfig | undefined {
     return this._config;
@@ -105,39 +148,39 @@ export class HuiViewGradientEditor extends LitElement {
     }
   }
 
-  private _initialized = false;
-
   private _initFromConfig(config: LovelaceViewConfig) {
     const bg = config?.background;
-    if (typeof bg === "string" && bg.includes("radial-gradient")) {
-      const parsed = _parseGradientString(bg);
-      this._blobs = parsed.blobs;
-      this._baseColor = parsed.baseColor;
-      this._nextBlobId =
-        this._blobs.reduce((max, b) => Math.max(max, b.id), 0) + 1;
-    } else if (!this._blobs.length) {
-      this._generateRandomBlobs();
+    this._subMode = _detectSubMode(bg);
+
+    if (this._subMode === "random" && typeof bg === "string") {
+      this._gradientString = bg;
+      const colors = _parseGradientColors(bg);
+      if (colors.length > 0) this._color1 = colors[0];
+      if (colors.length > 1) this._color2 = colors[1];
+      if (colors.length > 2) this._color3 = colors[2];
+    } else if (typeof bg === "string" && bg.startsWith("#")) {
+      this._solidColor = bg;
     }
+
     this._initialized = true;
   }
 
-  private _buildGradientString(): string {
-    const parts = this._blobs.map((b) => {
-      const [r, g, bVal] = hex2rgb(b.color);
-      return `radial-gradient(at ${b.x}% ${b.y}%, rgba(${r},${g},${bVal},${b.opacity.toFixed(2)}) 0px, transparent ${b.size}%)`;
-    });
-    parts.push(this._baseColor);
-    return parts.join(",\n  ");
-  }
-
-  private _fireConfigChanged() {
-    const gradientStr = this._buildGradientString();
-    const config: LovelaceViewConfig = {
-      ...this._config,
-      background: gradientStr,
-    };
-    fireEvent(this, "view-config-changed", { config });
-  }
+  private _subModeButtons = memoizeOne(
+    (localize: LocalizeFunc): ToggleButton[] => [
+      {
+        value: "solid",
+        label: localize(
+          "ui.panel.lovelace.editor.edit_view.background.gradient.mode_solid"
+        ),
+      },
+      {
+        value: "random",
+        label: localize(
+          "ui.panel.lovelace.editor.edit_view.background.gradient.mode_random"
+        ),
+      },
+    ]
+  );
 
   protected render() {
     if (!this.hass) {
@@ -146,309 +189,128 @@ export class HuiViewGradientEditor extends LitElement {
 
     return html`
       <div class="gradient-editor">
-        <div
-          class="preview"
-          style="background: ${this._buildGradientString()}"
-        >
-          ${repeat(
-            this._blobs,
-            (b) => b.id,
-            (b, i) => html`
-              <div
-                class="blob-handle"
-                role="slider"
-                tabindex="0"
-                aria-label=${this.hass.localize(
-                  "ui.panel.lovelace.editor.edit_view.background.gradient.layer",
-                  { number: i + 1 }
-                )}
-                aria-valuetext="X: ${b.x}%, Y: ${b.y}%"
-                data-index=${i}
-                style="left:${b.x}%;top:${b.y}%;background:${b.color}"
-                @pointerdown=${this._onHandlePointerDown}
-                @keydown=${this._onHandleKeyDown}
-              >
-                <span class="handle-label">${i + 1}</span>
-              </div>
-            `
-          )}
-        </div>
+        <ha-button-toggle-group
+          full-width
+          .buttons=${this._subModeButtons(this.hass.localize)}
+          .active=${this._subMode}
+          @value-changed=${this._subModeChanged}
+        ></ha-button-toggle-group>
 
-        <div class="toolbar">
-          <div class="base-color-control">
-            <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.base_color")}</label>
-            <input
-              type="color"
-              .value=${this._baseColor}
-              @input=${this._baseColorChanged}
-            />
-          </div>
-          <div class="toolbar-actions">
-            <ha-icon-button
-              .path=${mdiPlus}
-              .label=${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.add_layer")}
-              .disabled=${this._blobs.length >= MAX_BLOBS}
-              @click=${this._addBlob}
-            ></ha-icon-button>
-            <ha-icon-button
-              .path=${mdiRefresh}
-              .label=${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.randomize")}
-              @click=${this._randomize}
-            ></ha-icon-button>
-          </div>
-        </div>
-
-        <div class="layer-count">
-          ${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.layers_count", { count: this._blobs.length, max: MAX_BLOBS })}
-        </div>
-
-        <div class="blob-list">
-          ${repeat(
-            this._blobs,
-            (b) => b.id,
-            (b, i) => this._renderBlobCard(b, i)
-          )}
-        </div>
+        ${this._subMode === "solid"
+          ? this._renderSolidEditor()
+          : this._renderRandomEditor()}
       </div>
     `;
   }
 
-  private _renderBlobCard(blob: GradientBlob, index: number) {
+  private _renderSolidEditor() {
     return html`
-      <div class="blob-card">
-        <div class="blob-card-header">
-          <span class="blob-card-title">
-            <span
-              class="color-dot"
-              style="background:${blob.color}"
-            ></span>
-            ${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.layer", { number: index + 1 })}
-          </span>
-          <ha-icon-button
-            .path=${mdiDelete}
-            .label=${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.remove_layer")}
-            @click=${() => this._removeBlob(index)}
-          ></ha-icon-button>
-        </div>
-        <div class="blob-card-controls">
-          <div class="control-row">
-            <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.color")}</label>
-            <input
-              type="color"
-              .value=${blob.color}
-              data-index=${index}
-              @input=${this._blobColorChanged}
-            />
-          </div>
-          <div class="control-row">
-            <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.opacity")}</label>
-            <ha-slider
-              min="1"
-              max="100"
-              .value=${Math.round(blob.opacity * 100)}
-              data-index=${index}
-              data-prop="opacity"
-              @change=${this._blobSliderChanged}
-            ></ha-slider>
-            <span class="value-label">${Math.round(blob.opacity * 100)}%</span>
-          </div>
-          <div class="control-row">
-            <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.size")}</label>
-            <ha-slider
-              min="10"
-              max="100"
-              .value=${blob.size}
-              data-index=${index}
-              data-prop="size"
-              @change=${this._blobSliderChanged}
-            ></ha-slider>
-            <span class="value-label">${blob.size}%</span>
-          </div>
-          <div class="control-row">
-            <label>X</label>
-            <ha-slider
-              min="0"
-              max="100"
-              .value=${blob.x}
-              data-index=${index}
-              data-prop="x"
-              @change=${this._blobSliderChanged}
-            ></ha-slider>
-            <span class="value-label">${blob.x}%</span>
-          </div>
-          <div class="control-row">
-            <label>Y</label>
-            <ha-slider
-              min="0"
-              max="100"
-              .value=${blob.y}
-              data-index=${index}
-              data-prop="y"
-              @change=${this._blobSliderChanged}
-            ></ha-slider>
-            <span class="value-label">${blob.y}%</span>
-          </div>
-        </div>
+      <div
+        class="preview"
+        style="background: ${this._solidColor}"
+      ></div>
+      <div class="color-row">
+        <ha-textfield
+          type="color"
+          .value=${this._solidColor}
+          .label=${this.hass.localize(
+            "ui.panel.lovelace.editor.edit_view.background.gradient.color"
+          )}
+          @change=${this._solidColorChanged}
+        ></ha-textfield>
       </div>
     `;
   }
 
-  private _baseColorChanged(ev: Event) {
-    this._baseColor = (ev.target as HTMLInputElement).value;
-    this._fireConfigChanged();
+  private _renderRandomEditor() {
+    const previewBg =
+      this._gradientString || this._solidColor;
+
+    return html`
+      <div
+        class="preview"
+        style="background: ${previewBg}"
+      ></div>
+      <div class="color-inputs">
+        <ha-textfield
+          type="color"
+          .value=${this._color1}
+          .label=${this.hass.localize(
+            "ui.panel.lovelace.editor.edit_view.background.gradient.base_color_1"
+          )}
+          data-index="0"
+          @change=${this._baseColorInputChanged}
+        ></ha-textfield>
+        <ha-textfield
+          type="color"
+          .value=${this._color2}
+          .label=${this.hass.localize(
+            "ui.panel.lovelace.editor.edit_view.background.gradient.base_color_2"
+          )}
+          data-index="1"
+          @change=${this._baseColorInputChanged}
+        ></ha-textfield>
+        <ha-textfield
+          type="color"
+          .value=${this._color3 || "#ffffff"}
+          .label=${this.hass.localize(
+            "ui.panel.lovelace.editor.edit_view.background.gradient.base_color_3"
+          )}
+          data-index="2"
+          @change=${this._baseColorInputChanged}
+        ></ha-textfield>
+      </div>
+      <ha-button @click=${this._randomize}>
+        <ha-svg-icon slot="icon" .path=${mdiRefresh}></ha-svg-icon>
+        ${this.hass.localize(
+          "ui.panel.lovelace.editor.edit_view.background.gradient.randomize"
+        )}
+      </ha-button>
+    `;
   }
 
-  private _blobColorChanged(ev: Event) {
+  private _subModeChanged(ev: CustomEvent) {
+    const newMode = ev.detail.value as GradientSubMode;
+    if (newMode === this._subMode) return;
+    this._subMode = newMode;
+
+    if (newMode === "solid") {
+      this._fireConfigChanged(this._solidColor);
+    } else if (this._gradientString) {
+      this._fireConfigChanged(this._gradientString);
+    }
+  }
+
+  private _solidColorChanged(ev: Event) {
+    this._solidColor = (ev.target as HTMLInputElement).value;
+    this._fireConfigChanged(this._solidColor);
+  }
+
+  private _baseColorInputChanged(ev: Event) {
     const target = ev.target as HTMLInputElement;
     const index = parseInt(target.dataset.index!, 10);
-    this._blobs = this._blobs.map((b, i) =>
-      i === index ? { ...b, color: target.value } : b
-    );
-    this._fireConfigChanged();
-  }
-
-  private _blobSliderChanged(ev: Event) {
-    const target = ev.target as HTMLElement & { value: number };
-    const index = parseInt(target.dataset.index!, 10);
-    const prop = target.dataset.prop!;
     const value = target.value;
 
-    this._blobs = this._blobs.map((b, i) => {
-      if (i !== index) return b;
-      if (prop === "opacity") {
-        return { ...b, opacity: value / 100 };
-      }
-      return { ...b, [prop]: Math.round(value) };
-    });
-    this._fireConfigChanged();
-  }
-
-  private _addBlob() {
-    if (this._blobs.length >= MAX_BLOBS) return;
-    this._blobs = [
-      ...this._blobs,
-      {
-        id: this._nextBlobId++,
-        color: _randomColor(),
-        opacity: 0.3,
-        size: 50,
-        x: Math.round(Math.random() * 80 + 10),
-        y: Math.round(Math.random() * 80 + 10),
-      },
-    ];
-    this._fireConfigChanged();
-  }
-
-  private _removeBlob(index: number) {
-    this._blobs = this._blobs.filter((_, i) => i !== index);
-    this._fireConfigChanged();
-  }
-
-  private _generateRandomBlobs() {
-    const count = 3 + Math.floor(Math.random() * 4);
-    const r = Math.floor(Math.random() * 20);
-    const g = Math.floor(Math.random() * 20);
-    const b = Math.floor(Math.random() * 25);
-    this._baseColor = rgb2hex([r, g, b]);
-
-    const blobs: GradientBlob[] = [];
-    for (let i = 0; i < count; i++) {
-      blobs.push({
-        id: this._nextBlobId++,
-        color: _randomColor(),
-        opacity: +(0.15 + Math.random() * 0.65).toFixed(2),
-        size: 35 + Math.floor(Math.random() * 55),
-        x: Math.round(Math.random() * 80 + 10),
-        y: Math.round(Math.random() * 80 + 10),
-      });
-    }
-    this._blobs = blobs;
+    if (index === 0) this._color1 = value;
+    else if (index === 1) this._color2 = value;
+    else if (index === 2) this._color3 = value;
   }
 
   private _randomize() {
-    this._generateRandomBlobs();
-    this._fireConfigChanged();
+    const colors = [this._color1, this._color2, this._color3].filter(
+      (c) => c !== ""
+    );
+    const { blobs, baseColor } = _generateBlobs(colors);
+    this._gradientString = _buildGradientString(blobs, baseColor);
+    this._fireConfigChanged(this._gradientString);
   }
 
-  private _onHandlePointerDown(ev: PointerEvent) {
-    ev.preventDefault();
-    ev.stopPropagation();
-    const handle = ev.currentTarget as HTMLElement;
-    const index = parseInt(handle.dataset.index!, 10);
-    this._dragIndex = index;
-
-    handle.setPointerCapture(ev.pointerId);
-    handle.addEventListener("pointermove", this._onHandlePointerMove);
-    handle.addEventListener("pointerup", this._onHandlePointerUp);
-    handle.addEventListener("pointercancel", this._onHandlePointerUp);
-  }
-
-  private _onHandlePointerMove = (ev: PointerEvent) => {
-    if (this._dragIndex === null) return;
-
-    const preview = this.shadowRoot!.querySelector(".preview") as HTMLElement;
-    const rect = preview.getBoundingClientRect();
-
-    const x = Math.min(
-      100,
-      Math.max(0, ((ev.clientX - rect.left) / rect.width) * 100)
-    );
-    const y = Math.min(
-      100,
-      Math.max(0, ((ev.clientY - rect.top) / rect.height) * 100)
-    );
-
-    this._blobs = this._blobs.map((b, i) =>
-      i === this._dragIndex ? { ...b, x: Math.round(x), y: Math.round(y) } : b
-    );
-  };
-
-  private _onHandlePointerUp = (ev: PointerEvent) => {
-    const handle = ev.currentTarget as HTMLElement;
-    handle.releasePointerCapture(ev.pointerId);
-    handle.removeEventListener("pointermove", this._onHandlePointerMove);
-    handle.removeEventListener("pointerup", this._onHandlePointerUp);
-    handle.removeEventListener("pointercancel", this._onHandlePointerUp);
-    this._dragIndex = null;
-    this._fireConfigChanged();
-  };
-
-  private _onHandleKeyDown(ev: KeyboardEvent) {
-    const step = ev.shiftKey ? 10 : 1;
-    let dx = 0;
-    let dy = 0;
-
-    switch (ev.key) {
-      case "ArrowLeft":
-        dx = -step;
-        break;
-      case "ArrowRight":
-        dx = step;
-        break;
-      case "ArrowUp":
-        dy = -step;
-        break;
-      case "ArrowDown":
-        dy = step;
-        break;
-      default:
-        return;
-    }
-
-    ev.preventDefault();
-    ev.stopPropagation();
-    const handle = ev.currentTarget as HTMLElement;
-    const index = parseInt(handle.dataset.index!, 10);
-
-    this._blobs = this._blobs.map((b, i) => {
-      if (i !== index) return b;
-      return {
-        ...b,
-        x: Math.min(100, Math.max(0, b.x + dx)),
-        y: Math.min(100, Math.max(0, b.y + dy)),
-      };
-    });
-    this._fireConfigChanged();
+  private _fireConfigChanged(background: string) {
+    const config: LovelaceViewConfig = {
+      ...this._config,
+      background,
+    };
+    fireEvent(this, "view-config-changed", { config });
   }
 
   static styles = css`
@@ -463,183 +325,31 @@ export class HuiViewGradientEditor extends LitElement {
     }
 
     .preview {
-      position: relative;
       width: 100%;
       height: 200px;
       border-radius: var(--ha-border-radius, 12px);
       border: 1px solid var(--divider-color);
-      overflow: hidden;
-      cursor: crosshair;
     }
 
-    .blob-handle {
-      position: absolute;
-      width: 20px;
-      height: 20px;
-      border-radius: 50%;
-      border: 2px solid #fff;
-      transform: translate(-50%, -50%);
-      cursor: grab;
-      z-index: 10;
-      box-shadow:
-        0 0 8px rgba(0, 0, 0, 0.6),
-        0 0 0 1px rgba(0, 0, 0, 0.3);
-      touch-action: none;
+    .color-row {
       display: flex;
-      align-items: center;
-      justify-content: center;
     }
 
-    .blob-handle:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 2px;
-    }
-
-    .blob-handle:active {
-      cursor: grabbing;
-    }
-
-    .handle-label {
-      font-size: 9px;
-      font-weight: 700;
-      color: #fff;
-      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
-      pointer-events: none;
-      user-select: none;
-    }
-
-    .toolbar {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: var(--ha-space-2);
-    }
-
-    .base-color-control {
-      display: flex;
-      align-items: center;
-      gap: var(--ha-space-2);
-    }
-
-    .base-color-control label {
-      font-size: var(--ha-font-size-s);
-      color: var(--primary-text-color);
-    }
-
-    .base-color-control input[type="color"] {
-      -webkit-appearance: none;
-      appearance: none;
-      width: 36px;
-      height: 28px;
-      border: 1px solid var(--divider-color);
-      border-radius: 6px;
-      background: transparent;
-      cursor: pointer;
-      padding: 2px;
-    }
-
-    .base-color-control input[type="color"]::-webkit-color-swatch-wrapper {
-      padding: 0;
-    }
-
-    .base-color-control input[type="color"]::-webkit-color-swatch {
-      border: none;
-      border-radius: 4px;
-    }
-
-    .toolbar-actions {
-      display: flex;
-      gap: var(--ha-space-1);
-    }
-
-    .layer-count {
-      font-size: var(--ha-font-size-s);
-      color: var(--secondary-text-color);
-    }
-
-    .blob-list {
-      display: flex;
-      flex-direction: column;
-      gap: var(--ha-space-2);
-    }
-
-    .blob-card {
-      background: var(--card-background-color);
-      border: 1px solid var(--divider-color);
-      border-radius: var(--ha-border-radius, 12px);
-      padding: var(--ha-space-3);
-    }
-
-    .blob-card-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      margin-bottom: var(--ha-space-2);
-    }
-
-    .blob-card-title {
-      display: flex;
-      align-items: center;
-      gap: var(--ha-space-2);
-      font-size: var(--ha-font-size-m);
-      font-weight: 500;
-    }
-
-    .color-dot {
-      width: 12px;
-      height: 12px;
-      border-radius: 50%;
-      border: 1px solid rgba(255, 255, 255, 0.2);
-    }
-
-    .blob-card-controls {
-      display: flex;
-      flex-direction: column;
-      gap: var(--ha-space-1);
-    }
-
-    .control-row {
-      display: flex;
-      align-items: center;
-      gap: var(--ha-space-2);
-    }
-
-    .control-row label {
-      font-size: var(--ha-font-size-s);
-      color: var(--secondary-text-color);
-      min-width: 52px;
-    }
-
-    .control-row ha-slider {
+    .color-row ha-textfield {
       flex: 1;
     }
 
-    .control-row input[type="color"] {
-      -webkit-appearance: none;
-      appearance: none;
-      width: 36px;
-      height: 24px;
-      border: 1px solid var(--divider-color);
-      border-radius: 4px;
-      background: transparent;
-      cursor: pointer;
-      padding: 2px;
+    .color-inputs {
+      display: flex;
+      gap: var(--ha-space-2);
     }
 
-    .control-row input[type="color"]::-webkit-color-swatch-wrapper {
-      padding: 0;
+    .color-inputs ha-textfield {
+      flex: 1;
     }
 
-    .control-row input[type="color"]::-webkit-color-swatch {
-      border: none;
-      border-radius: 2px;
-    }
-
-    .value-label {
-      font-size: var(--ha-font-size-xs);
-      color: var(--secondary-text-color);
-      min-width: 32px;
-      text-align: right;
+    ha-button {
+      --mdc-theme-primary: var(--primary-color);
     }
   `;
 }

--- a/src/panels/lovelace/editor/view-editor/hui-view-gradient-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-gradient-editor.ts
@@ -1,0 +1,606 @@
+import { mdiDelete, mdiPlus, mdiRefresh } from "@mdi/js";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { repeat } from "lit/directives/repeat";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-icon-button";
+import "../../../../components/ha-slider";
+import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
+import type { HomeAssistant } from "../../../../types";
+
+interface GradientBlob {
+  id: number;
+  color: string;
+  opacity: number;
+  size: number;
+  x: number;
+  y: number;
+}
+
+const MAX_BLOBS = 8;
+
+let nextBlobId = 1;
+
+function _randomColor(): string {
+  const h = Math.floor(Math.random() * 360);
+  const s = 70 + Math.floor(Math.random() * 30);
+  const l = 40 + Math.floor(Math.random() * 30);
+  return _hslToHex(h, s, l);
+}
+
+function _hslToHex(h: number, s: number, l: number): string {
+  const sNorm = s / 100;
+  const lNorm = l / 100;
+  const a = sNorm * Math.min(lNorm, 1 - lNorm);
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12;
+    const color = lNorm - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+    return Math.round(255 * color)
+      .toString(16)
+      .padStart(2, "0");
+  };
+  return `#${f(0)}${f(8)}${f(4)}`;
+}
+
+function _hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const n = parseInt(hex.replace("#", ""), 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+function _rgbToHex(r: number, g: number, b: number): string {
+  return (
+    "#" +
+    [r, g, b].map((v) => Math.round(v).toString(16).padStart(2, "0")).join("")
+  );
+}
+
+/** Parse a CSS gradient background string into blobs + base color */
+function _parseGradientString(bg: string): {
+  blobs: GradientBlob[];
+  baseColor: string;
+} {
+  const blobs: GradientBlob[] = [];
+  let baseColor = "#0e1117";
+
+  const gradientRegex =
+    /radial-gradient\(\s*at\s+(\d+)%\s+(\d+)%\s*,\s*rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d.]+)\s*\)\s*0px\s*,\s*transparent\s+(\d+)%\s*\)/g;
+
+  let match = gradientRegex.exec(bg);
+  while (match) {
+    blobs.push({
+      id: nextBlobId++,
+      x: parseInt(match[1]),
+      y: parseInt(match[2]),
+      color: _rgbToHex(
+        parseInt(match[3]),
+        parseInt(match[4]),
+        parseInt(match[5])
+      ),
+      opacity: parseFloat(match[6]),
+      size: parseInt(match[7]),
+    });
+    match = gradientRegex.exec(bg);
+  }
+
+  // Extract base color (last value, typically a hex color)
+  const hexMatch = bg.match(/(#[0-9a-fA-F]{6})\s*$/);
+  if (hexMatch) {
+    baseColor = hexMatch[1];
+  }
+
+  return { blobs, baseColor };
+}
+
+@customElement("hui-view-gradient-editor")
+export class HuiViewGradientEditor extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _blobs: GradientBlob[] = [];
+
+  @state() private _baseColor = "#0e1117";
+
+  private _dragIndex: number | null = null;
+
+  private _config?: LovelaceViewConfig;
+
+  set config(config: LovelaceViewConfig) {
+    const oldConfig = this._config;
+    this._config = config;
+
+    if (oldConfig !== config && !this._initialized) {
+      this._initFromConfig(config);
+    }
+  }
+
+  private _initialized = false;
+
+  private _initFromConfig(config: LovelaceViewConfig) {
+    const bg = config?.background;
+    if (typeof bg === "string" && bg.includes("radial-gradient")) {
+      const parsed = _parseGradientString(bg);
+      this._blobs = parsed.blobs;
+      this._baseColor = parsed.baseColor;
+    } else if (!this._blobs.length) {
+      // Start with a few random blobs
+      this._randomize();
+    }
+    this._initialized = true;
+  }
+
+  private _buildGradientString(): string {
+    const parts = this._blobs.map((b) => {
+      const rgb = _hexToRgb(b.color);
+      return `radial-gradient(at ${b.x}% ${b.y}%, rgba(${rgb.r},${rgb.g},${rgb.b},${b.opacity.toFixed(2)}) 0px, transparent ${b.size}%)`;
+    });
+    parts.push(this._baseColor);
+    return parts.join(",\n  ");
+  }
+
+  private _fireConfigChanged() {
+    const gradientStr = this._buildGradientString();
+    const config: LovelaceViewConfig = {
+      ...this._config,
+      background: gradientStr,
+    };
+    fireEvent(this, "view-config-changed", { config });
+  }
+
+  protected render() {
+    if (!this.hass) {
+      return nothing;
+    }
+
+    return html`
+      <div class="gradient-editor">
+        <div
+          class="preview"
+          style="background: ${this._buildGradientString()}"
+        >
+          ${repeat(
+            this._blobs,
+            (b) => b.id,
+            (b, i) => html`
+              <div
+                class="blob-handle"
+                data-index=${i}
+                style="left:${b.x}%;top:${b.y}%;background:${b.color}"
+                @pointerdown=${this._onHandlePointerDown}
+              >
+                <span class="handle-label">${i + 1}</span>
+              </div>
+            `
+          )}
+        </div>
+
+        <div class="toolbar">
+          <div class="base-color-control">
+            <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.base_color")}</label>
+            <input
+              type="color"
+              .value=${this._baseColor}
+              @input=${this._baseColorChanged}
+            />
+          </div>
+          <div class="toolbar-actions">
+            <ha-icon-button
+              .path=${mdiPlus}
+              .label=${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.add_layer")}
+              .disabled=${this._blobs.length >= MAX_BLOBS}
+              @click=${this._addBlob}
+            ></ha-icon-button>
+            <ha-icon-button
+              .path=${mdiRefresh}
+              .label=${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.randomize")}
+              @click=${this._randomize}
+            ></ha-icon-button>
+          </div>
+        </div>
+
+        <div class="layer-count">
+          ${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.layers_count", { count: this._blobs.length, max: MAX_BLOBS })}
+        </div>
+
+        <div class="blob-list">
+          ${repeat(
+            this._blobs,
+            (b) => b.id,
+            (b, i) => this._renderBlobCard(b, i)
+          )}
+        </div>
+      </div>
+    `;
+  }
+
+  private _renderBlobCard(blob: GradientBlob, index: number) {
+    return html`
+      <div class="blob-card">
+        <div class="blob-card-header">
+          <span class="blob-card-title">
+            <span
+              class="color-dot"
+              style="background:${blob.color}"
+            ></span>
+            ${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.layer", { number: index + 1 })}
+          </span>
+          <ha-icon-button
+            .path=${mdiDelete}
+            .label=${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.remove_layer")}
+            @click=${() => this._removeBlob(index)}
+          ></ha-icon-button>
+        </div>
+        <div class="blob-card-controls">
+          <div class="control-row">
+            <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.color")}</label>
+            <input
+              type="color"
+              .value=${blob.color}
+              data-index=${index}
+              @input=${this._blobColorChanged}
+            />
+          </div>
+          <div class="control-row">
+            <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.opacity")}</label>
+            <ha-slider
+              min="1"
+              max="100"
+              .value=${Math.round(blob.opacity * 100)}
+              data-index=${index}
+              data-prop="opacity"
+              @change=${this._blobSliderChanged}
+            ></ha-slider>
+            <span class="value-label">${Math.round(blob.opacity * 100)}%</span>
+          </div>
+          <div class="control-row">
+            <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.size")}</label>
+            <ha-slider
+              min="10"
+              max="100"
+              .value=${blob.size}
+              data-index=${index}
+              data-prop="size"
+              @change=${this._blobSliderChanged}
+            ></ha-slider>
+            <span class="value-label">${blob.size}%</span>
+          </div>
+          <div class="control-row">
+            <label>X</label>
+            <ha-slider
+              min="0"
+              max="100"
+              .value=${blob.x}
+              data-index=${index}
+              data-prop="x"
+              @change=${this._blobSliderChanged}
+            ></ha-slider>
+            <span class="value-label">${blob.x}%</span>
+          </div>
+          <div class="control-row">
+            <label>Y</label>
+            <ha-slider
+              min="0"
+              max="100"
+              .value=${blob.y}
+              data-index=${index}
+              data-prop="y"
+              @change=${this._blobSliderChanged}
+            ></ha-slider>
+            <span class="value-label">${blob.y}%</span>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private _baseColorChanged(ev: Event) {
+    this._baseColor = (ev.target as HTMLInputElement).value;
+    this._fireConfigChanged();
+  }
+
+  private _blobColorChanged(ev: Event) {
+    const target = ev.target as HTMLInputElement;
+    const index = parseInt(target.dataset.index!);
+    this._blobs = this._blobs.map((b, i) =>
+      i === index ? { ...b, color: target.value } : b
+    );
+    this._fireConfigChanged();
+  }
+
+  private _blobSliderChanged(ev: Event) {
+    const target = ev.target as HTMLInputElement & {
+      dataset: { index: string; prop: string };
+    };
+    const index = parseInt(target.dataset.index!);
+    const prop = target.dataset.prop!;
+    const value = parseFloat((target as any).value);
+
+    this._blobs = this._blobs.map((b, i) => {
+      if (i !== index) return b;
+      if (prop === "opacity") {
+        return { ...b, opacity: value / 100 };
+      }
+      return { ...b, [prop]: Math.round(value) };
+    });
+    this._fireConfigChanged();
+  }
+
+  private _addBlob() {
+    if (this._blobs.length >= MAX_BLOBS) return;
+    this._blobs = [
+      ...this._blobs,
+      {
+        id: nextBlobId++,
+        color: _randomColor(),
+        opacity: 0.3,
+        size: 50,
+        x: Math.round(Math.random() * 80 + 10),
+        y: Math.round(Math.random() * 80 + 10),
+      },
+    ];
+    this._fireConfigChanged();
+  }
+
+  private _removeBlob(index: number) {
+    this._blobs = this._blobs.filter((_, i) => i !== index);
+    this._fireConfigChanged();
+  }
+
+  private _randomize() {
+    const count = 3 + Math.floor(Math.random() * 4);
+    const r = Math.floor(Math.random() * 20);
+    const g = Math.floor(Math.random() * 20);
+    const b = Math.floor(Math.random() * 25);
+    this._baseColor = _rgbToHex(r, g, b);
+
+    const blobs: GradientBlob[] = [];
+    for (let i = 0; i < count; i++) {
+      blobs.push({
+        id: nextBlobId++,
+        color: _randomColor(),
+        opacity: +(0.15 + Math.random() * 0.65).toFixed(2),
+        size: 35 + Math.floor(Math.random() * 55),
+        x: Math.round(Math.random() * 80 + 10),
+        y: Math.round(Math.random() * 80 + 10),
+      });
+    }
+    this._blobs = blobs;
+    this._fireConfigChanged();
+  }
+
+  // --- Drag & Drop ---
+
+  private _onHandlePointerDown(ev: PointerEvent) {
+    ev.preventDefault();
+    ev.stopPropagation();
+    const handle = ev.currentTarget as HTMLElement;
+    const index = parseInt(handle.dataset.index!);
+    this._dragIndex = index;
+
+    handle.setPointerCapture(ev.pointerId);
+    handle.addEventListener("pointermove", this._onHandlePointerMove);
+    handle.addEventListener("pointerup", this._onHandlePointerUp);
+    handle.addEventListener("pointercancel", this._onHandlePointerUp);
+  }
+
+  private _onHandlePointerMove = (ev: PointerEvent) => {
+    if (this._dragIndex === null) return;
+
+    const preview = this.shadowRoot!.querySelector(".preview") as HTMLElement;
+    const rect = preview.getBoundingClientRect();
+
+    const x = Math.min(
+      100,
+      Math.max(0, ((ev.clientX - rect.left) / rect.width) * 100)
+    );
+    const y = Math.min(
+      100,
+      Math.max(0, ((ev.clientY - rect.top) / rect.height) * 100)
+    );
+
+    this._blobs = this._blobs.map((b, i) =>
+      i === this._dragIndex ? { ...b, x: Math.round(x), y: Math.round(y) } : b
+    );
+  };
+
+  private _onHandlePointerUp = (ev: PointerEvent) => {
+    const handle = ev.currentTarget as HTMLElement;
+    handle.releasePointerCapture(ev.pointerId);
+    handle.removeEventListener("pointermove", this._onHandlePointerMove);
+    handle.removeEventListener("pointerup", this._onHandlePointerUp);
+    handle.removeEventListener("pointercancel", this._onHandlePointerUp);
+    this._dragIndex = null;
+    this._fireConfigChanged();
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .gradient-editor {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .preview {
+      position: relative;
+      width: 100%;
+      height: 200px;
+      border-radius: var(--ha-border-radius, 12px);
+      border: 1px solid var(--divider-color);
+      overflow: hidden;
+      cursor: crosshair;
+    }
+
+    .blob-handle {
+      position: absolute;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      border: 2px solid #fff;
+      transform: translate(-50%, -50%);
+      cursor: grab;
+      z-index: 10;
+      box-shadow:
+        0 0 8px rgba(0, 0, 0, 0.6),
+        0 0 0 1px rgba(0, 0, 0, 0.3);
+      touch-action: none;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .blob-handle:active {
+      cursor: grabbing;
+    }
+
+    .handle-label {
+      font-size: 9px;
+      font-weight: 700;
+      color: #fff;
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+      pointer-events: none;
+      user-select: none;
+    }
+
+    .toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+
+    .base-color-control {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .base-color-control label {
+      font-size: 13px;
+      color: var(--primary-text-color);
+    }
+
+    .base-color-control input[type="color"] {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 36px;
+      height: 28px;
+      border: 1px solid var(--divider-color);
+      border-radius: 6px;
+      background: transparent;
+      cursor: pointer;
+      padding: 2px;
+    }
+
+    .base-color-control input[type="color"]::-webkit-color-swatch-wrapper {
+      padding: 0;
+    }
+
+    .base-color-control input[type="color"]::-webkit-color-swatch {
+      border: none;
+      border-radius: 4px;
+    }
+
+    .toolbar-actions {
+      display: flex;
+      gap: 4px;
+    }
+
+    .layer-count {
+      font-size: 12px;
+      color: var(--secondary-text-color);
+    }
+
+    .blob-list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .blob-card {
+      background: var(--card-background-color);
+      border: 1px solid var(--divider-color);
+      border-radius: var(--ha-border-radius, 12px);
+      padding: 12px;
+    }
+
+    .blob-card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 8px;
+    }
+
+    .blob-card-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .color-dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+    }
+
+    .blob-card-controls {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .control-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .control-row label {
+      font-size: 12px;
+      color: var(--secondary-text-color);
+      min-width: 52px;
+    }
+
+    .control-row ha-slider {
+      flex: 1;
+    }
+
+    .control-row input[type="color"] {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 36px;
+      height: 24px;
+      border: 1px solid var(--divider-color);
+      border-radius: 4px;
+      background: transparent;
+      cursor: pointer;
+      padding: 2px;
+    }
+
+    .control-row input[type="color"]::-webkit-color-swatch-wrapper {
+      padding: 0;
+    }
+
+    .control-row input[type="color"]::-webkit-color-swatch {
+      border: none;
+      border-radius: 2px;
+    }
+
+    .value-label {
+      font-size: 11px;
+      color: var(--secondary-text-color);
+      min-width: 32px;
+      text-align: right;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-view-gradient-editor": HuiViewGradientEditor;
+  }
+}

--- a/src/panels/lovelace/editor/view-editor/hui-view-gradient-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-gradient-editor.ts
@@ -1,104 +1,44 @@
-import { mdiRefresh } from "@mdi/js";
-import memoizeOne from "memoize-one";
+import { mdiDelete, mdiPlus, mdiRefresh } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { hex2rgb, rgb2hex } from "../../../../common/color/convert-color";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-button";
-import "../../../../components/ha-button-toggle-group";
+import "../../../../components/ha-icon-button";
 import "../../../../components/ha-svg-icon";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
-import type { LocalizeFunc } from "../../../../common/translations/localize";
-import type { ToggleButton } from "../../../../types";
 
-type GradientSubMode = "solid" | "random";
+const MAX_COLORS = 5;
 
-interface GradientBlob {
-  color: string;
-  opacity: number;
-  size: number;
-  x: number;
-  y: number;
-}
-
-function _hslToHex(h: number, s: number, l: number): string {
-  const sNorm = s / 100;
-  const lNorm = l / 100;
-  const a = sNorm * Math.min(lNorm, 1 - lNorm);
-  const f = (n: number) => {
-    const k = (n + h / 30) % 12;
-    const color = lNorm - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-    return Math.round(255 * color)
-      .toString(16)
-      .padStart(2, "0");
-  };
-  return `#${f(0)}${f(8)}${f(4)}`;
-}
-
-function _randomVariant(baseHex: string): string {
-  const [r, g, b] = hex2rgb(baseHex);
-  const shift = () => Math.min(255, Math.max(0, Math.round((Math.random() - 0.5) * 80)));
-  return rgb2hex([
-    Math.min(255, Math.max(0, r + shift())),
-    Math.min(255, Math.max(0, g + shift())),
-    Math.min(255, Math.max(0, b + shift())),
-  ]);
-}
-
-function _generateBlobs(colors: string[]): {
-  blobs: GradientBlob[];
-  baseColor: string;
-} {
+function _generateGradientString(colors: string[]): string {
   const count = 3 + Math.floor(Math.random() * 4);
-  const baseR = Math.floor(Math.random() * 20);
-  const baseG = Math.floor(Math.random() * 20);
-  const baseB = Math.floor(Math.random() * 25);
-  const baseColor = rgb2hex([baseR, baseG, baseB]);
+  const baseColor = rgb2hex([
+    Math.floor(Math.random() * 20),
+    Math.floor(Math.random() * 20),
+    Math.floor(Math.random() * 25),
+  ]);
 
-  const palette = colors.filter((c) => c !== "");
-  const blobs: GradientBlob[] = [];
+  const parts: string[] = [];
   for (let i = 0; i < count; i++) {
-    const seedColor =
-      palette.length > 0
-        ? palette[i % palette.length]
-        : _hslToHex(
-            Math.floor(Math.random() * 360),
-            70 + Math.floor(Math.random() * 30),
-            40 + Math.floor(Math.random() * 30)
-          );
-    blobs.push({
-      color: palette.length > 0 ? _randomVariant(seedColor) : seedColor,
-      opacity: +(0.15 + Math.random() * 0.65).toFixed(2),
-      size: 35 + Math.floor(Math.random() * 55),
-      x: Math.round(Math.random() * 80 + 10),
-      y: Math.round(Math.random() * 80 + 10),
-    });
+    const [r, g, b] = hex2rgb(colors[i % colors.length]).map((c) =>
+      Math.min(255, Math.max(0, c + Math.round((Math.random() - 0.5) * 80)))
+    );
+    const opacity = (0.15 + Math.random() * 0.65).toFixed(2);
+    const size = 35 + Math.floor(Math.random() * 55);
+    const x = Math.round(Math.random() * 80 + 10);
+    const y = Math.round(Math.random() * 80 + 10);
+    parts.push(
+      `radial-gradient(at ${x}% ${y}%, rgba(${r},${g},${b},${opacity}) 0px, transparent ${size}%)`
+    );
   }
-  return { blobs, baseColor };
-}
-
-function _buildGradientString(blobs: GradientBlob[], baseColor: string): string {
-  const parts = blobs.map((b) => {
-    const [r, g, bVal] = hex2rgb(b.color);
-    return `radial-gradient(at ${b.x}% ${b.y}%, rgba(${r},${g},${bVal},${b.opacity.toFixed(2)}) 0px, transparent ${b.size}%)`;
-  });
   parts.push(baseColor);
   return parts.join(",\n  ");
 }
 
-function _detectSubMode(bg: unknown): GradientSubMode {
-  if (typeof bg === "string" && bg.includes("radial-gradient")) {
-    return "random";
-  }
-  return "solid";
-}
-
 function _parseGradientColors(bg: string): string[] {
   const colors: string[] = [];
-  const regex =
-    /radial-gradient\(\s*at\s+\d+%\s+\d+%\s*,\s*rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,/g;
-
+  const regex = /rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,/g;
   let match = regex.exec(bg);
   while (match) {
     const hex = rgb2hex([
@@ -106,27 +46,17 @@ function _parseGradientColors(bg: string): string[] {
       parseInt(match[2], 10),
       parseInt(match[3], 10),
     ]);
-    if (!colors.includes(hex)) {
-      colors.push(hex);
-    }
+    if (!colors.includes(hex)) colors.push(hex);
     match = regex.exec(bg);
   }
-  return colors.slice(0, 3);
+  return colors.slice(0, MAX_COLORS);
 }
 
 @customElement("hui-view-gradient-editor")
 export class HuiViewGradientEditor extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @state() private _subMode: GradientSubMode = "random";
-
-  @state() private _solidColor = "#3a5f8c";
-
-  @state() private _color1 = "#ec7a41";
-
-  @state() private _color2 = "#4169e1";
-
-  @state() private _color3 = "";
+  @state() private _colors: string[] = ["#3a5f8c"];
 
   @state() private _gradientString = "";
 
@@ -139,177 +69,130 @@ export class HuiViewGradientEditor extends LitElement {
   }
 
   set config(config: LovelaceViewConfig) {
-    const oldConfig = this._config;
-    this._config = config;
-
-    if (oldConfig !== config && !this._initialized) {
-      this._initFromConfig(config);
+    if (this._config !== config) {
+      this._config = config;
+      if (!this._initialized) {
+        this._initFromConfig(config);
+        this._initialized = true;
+      }
     }
   }
 
   private _initFromConfig(config: LovelaceViewConfig) {
     const bg = config?.background;
-    this._subMode = _detectSubMode(bg);
-
-    if (this._subMode === "random" && typeof bg === "string") {
+    if (typeof bg === "string" && bg.includes("radial-gradient")) {
       this._gradientString = bg;
-      const colors = _parseGradientColors(bg);
-      if (colors.length > 0) this._color1 = colors[0];
-      if (colors.length > 1) this._color2 = colors[1];
-      if (colors.length > 2) this._color3 = colors[2];
+      const parsed = _parseGradientColors(bg);
+      if (parsed.length > 0) this._colors = parsed;
     } else if (typeof bg === "string" && bg.startsWith("#")) {
-      this._solidColor = bg;
+      this._colors = [bg];
     }
-
-    this._initialized = true;
   }
 
-  private _subModeButtons = memoizeOne(
-    (localize: LocalizeFunc): ToggleButton[] => [
-      {
-        value: "solid",
-        label: localize(
-          "ui.panel.lovelace.editor.edit_view.background.gradient.mode_solid"
-        ),
-      },
-      {
-        value: "random",
-        label: localize(
-          "ui.panel.lovelace.editor.edit_view.background.gradient.mode_random"
-        ),
-      },
-    ]
-  );
+  private get _previewBackground(): string {
+    if (this._colors.length === 1) return this._colors[0];
+    return this._gradientString || this._colors[0];
+  }
 
   protected render() {
-    if (!this.hass) {
-      return nothing;
-    }
+    if (!this.hass) return nothing;
 
     return html`
       <div class="gradient-editor">
-        <ha-button-toggle-group
-          size="small"
-          variant="neutral"
-          .buttons=${this._subModeButtons(this.hass.localize)}
-          .active=${this._subMode}
-          @value-changed=${this._subModeChanged}
-        ></ha-button-toggle-group>
+        <div
+          class="preview"
+          style="background: ${this._previewBackground}"
+        ></div>
 
-        ${this._subMode === "solid"
-          ? this._renderSolidEditor()
-          : this._renderRandomEditor()}
-      </div>
-    `;
-  }
-
-  private _renderSolidEditor() {
-    return html`
-      <div
-        class="preview"
-        style="background: ${this._solidColor}"
-      ></div>
-      <div class="color-picker-row">
-        <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.color")}</label>
-        <input
-          type="color"
-          .value=${this._solidColor}
-          @input=${this._solidColorChanged}
-        />
-      </div>
-    `;
-  }
-
-  private _renderRandomEditor() {
-    const previewBg = this._gradientString || this._solidColor;
-
-    return html`
-      <div
-        class="preview"
-        style="background: ${previewBg}"
-      ></div>
-      <div class="color-pickers">
-        <div class="color-picker-row">
-          <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.base_color_1")}</label>
-          <input
-            type="color"
-            .value=${this._color1}
-            data-index="0"
-            @input=${this._baseColorInputChanged}
-          />
-        </div>
-        <div class="color-picker-row">
-          <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.base_color_2")}</label>
-          <input
-            type="color"
-            .value=${this._color2}
-            data-index="1"
-            @input=${this._baseColorInputChanged}
-          />
-        </div>
-        <div class="color-picker-row">
-          <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.base_color_3")}</label>
-          <input
-            type="color"
-            .value=${this._color3 || "#ffffff"}
-            data-index="2"
-            @input=${this._baseColorInputChanged}
-          />
-        </div>
-      </div>
-      <div class="randomize-row">
-        <ha-button @click=${this._randomize}>
-          <ha-svg-icon slot="icon" .path=${mdiRefresh}></ha-svg-icon>
-          ${this.hass.localize(
-            "ui.panel.lovelace.editor.edit_view.background.gradient.randomize"
+        <div class="color-list">
+          ${this._colors.map(
+            (color, i) => html`
+              <div class="color-row">
+                <label>
+                  ${this.hass.localize(
+                    "ui.panel.lovelace.editor.edit_view.background.gradient.color_label",
+                    { number: i + 1 }
+                  )}
+                </label>
+                <input
+                  type="color"
+                  .value=${color}
+                  data-index=${i}
+                  @input=${this._colorChanged}
+                />
+                ${this._colors.length > 1
+                  ? html`<ha-icon-button
+                      .path=${mdiDelete}
+                      .label=${this.hass.localize(
+                        "ui.panel.lovelace.editor.edit_view.background.gradient.remove_color"
+                      )}
+                      data-index=${i}
+                      @click=${this._removeColor}
+                    ></ha-icon-button>`
+                  : nothing}
+              </div>
+            `
           )}
-        </ha-button>
+        </div>
+
+        <div class="actions">
+          ${this._colors.length < MAX_COLORS
+            ? html`<ha-icon-button
+                .path=${mdiPlus}
+                .label=${this.hass.localize(
+                  "ui.panel.lovelace.editor.edit_view.background.gradient.add_color"
+                )}
+                @click=${this._addColor}
+              ></ha-icon-button>`
+            : nothing}
+          ${this._colors.length >= 2
+            ? html`<ha-button @click=${this._randomize}>
+                <ha-svg-icon slot="icon" .path=${mdiRefresh}></ha-svg-icon>
+                ${this.hass.localize(
+                  "ui.panel.lovelace.editor.edit_view.background.gradient.randomize"
+                )}
+              </ha-button>`
+            : nothing}
+        </div>
       </div>
     `;
   }
 
-  private _subModeChanged(ev: CustomEvent) {
-    const newMode = ev.detail.value as GradientSubMode;
-    if (newMode === this._subMode) return;
-    this._subMode = newMode;
-
-    if (newMode === "solid") {
-      this._fireConfigChanged(this._solidColor);
-    } else if (this._gradientString) {
-      this._fireConfigChanged(this._gradientString);
+  private _colorChanged(ev: Event) {
+    const target = ev.target as HTMLInputElement;
+    const index = parseInt(target.dataset.index!, 10);
+    this._colors = this._colors.map((c, i) =>
+      i === index ? target.value : c
+    );
+    if (this._colors.length === 1) {
+      this._fireConfigChanged(this._colors[0]);
     }
   }
 
-  private _solidColorChanged(ev: Event) {
-    this._solidColor = (ev.target as HTMLInputElement).value;
-    this._fireConfigChanged(this._solidColor);
+  private _addColor() {
+    if (this._colors.length >= MAX_COLORS) return;
+    this._colors = [...this._colors, "#ffffff"];
   }
 
-  private _baseColorInputChanged(ev: Event) {
-    const target = ev.target as HTMLInputElement;
+  private _removeColor(ev: Event) {
+    const target = ev.currentTarget as HTMLElement;
     const index = parseInt(target.dataset.index!, 10);
-    const value = target.value;
-
-    if (index === 0) this._color1 = value;
-    else if (index === 1) this._color2 = value;
-    else if (index === 2) this._color3 = value;
+    this._colors = this._colors.filter((_, i) => i !== index);
+    if (this._colors.length === 1) {
+      this._gradientString = "";
+      this._fireConfigChanged(this._colors[0]);
+    }
   }
 
   private _randomize() {
-    const colors = [this._color1, this._color2, this._color3].filter(
-      (c) => c !== ""
-    );
-    const { blobs, baseColor } = _generateBlobs(colors);
-    this._gradientString = _buildGradientString(blobs, baseColor);
+    this._gradientString = _generateGradientString(this._colors);
     this._fireConfigChanged(this._gradientString);
   }
 
   private _fireConfigChanged(background: string) {
-    const config: LovelaceViewConfig = {
-      ...this._config,
-      background,
-    };
-    fireEvent(this, "view-config-changed", { config });
+    fireEvent(this, "view-config-changed", {
+      config: { ...this._config, background },
+    });
   }
 
   static styles = css`
@@ -323,11 +206,6 @@ export class HuiViewGradientEditor extends LitElement {
       gap: var(--ha-space-3);
     }
 
-    .gradient-editor > ha-button-toggle-group {
-      align-self: center;
-      margin-top: var(--ha-space-6);
-    }
-
     .preview {
       width: 100%;
       height: 200px;
@@ -335,25 +213,25 @@ export class HuiViewGradientEditor extends LitElement {
       border: 1px solid var(--divider-color);
     }
 
-    .color-pickers {
+    .color-list {
       display: flex;
       flex-direction: column;
       gap: var(--ha-space-2);
     }
 
-    .color-picker-row {
+    .color-row {
       display: flex;
       align-items: center;
-      justify-content: space-between;
       gap: var(--ha-space-3);
     }
 
-    .color-picker-row label {
+    .color-row label {
+      flex: 1;
       font-size: var(--ha-font-size-m);
       color: var(--primary-text-color);
     }
 
-    .color-picker-row input[type="color"] {
+    .color-row input[type="color"] {
       -webkit-appearance: none;
       appearance: none;
       width: 48px;
@@ -365,18 +243,20 @@ export class HuiViewGradientEditor extends LitElement {
       padding: 2px;
     }
 
-    .color-picker-row input[type="color"]::-webkit-color-swatch-wrapper {
+    .color-row input[type="color"]::-webkit-color-swatch-wrapper {
       padding: 0;
     }
 
-    .color-picker-row input[type="color"]::-webkit-color-swatch {
+    .color-row input[type="color"]::-webkit-color-swatch {
       border: none;
       border-radius: 4px;
     }
 
-    .randomize-row {
+    .actions {
       display: flex;
+      align-items: center;
       justify-content: center;
+      gap: var(--ha-space-2);
     }
 
     ha-button {

--- a/src/panels/lovelace/editor/view-editor/hui-view-gradient-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-gradient-editor.ts
@@ -2,9 +2,11 @@ import { mdiDelete, mdiPlus, mdiRefresh } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
+import { hex2rgb, rgb2hex } from "../../../../common/color/convert-color";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-icon-button";
 import "../../../../components/ha-slider";
+
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
 
@@ -18,8 +20,6 @@ interface GradientBlob {
 }
 
 const MAX_BLOBS = 8;
-
-let nextBlobId = 1;
 
 function _randomColor(): string {
   const h = Math.floor(Math.random() * 360);
@@ -42,25 +42,13 @@ function _hslToHex(h: number, s: number, l: number): string {
   return `#${f(0)}${f(8)}${f(4)}`;
 }
 
-function _hexToRgb(hex: string): { r: number; g: number; b: number } {
-  const n = parseInt(hex.replace("#", ""), 16);
-  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
-}
-
-function _rgbToHex(r: number, g: number, b: number): string {
-  return (
-    "#" +
-    [r, g, b].map((v) => Math.round(v).toString(16).padStart(2, "0")).join("")
-  );
-}
-
-/** Parse a CSS gradient background string into blobs + base color */
 function _parseGradientString(bg: string): {
   blobs: GradientBlob[];
   baseColor: string;
 } {
   const blobs: GradientBlob[] = [];
   let baseColor = "#0e1117";
+  let blobId = 1;
 
   const gradientRegex =
     /radial-gradient\(\s*at\s+(\d+)%\s+(\d+)%\s*,\s*rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d.]+)\s*\)\s*0px\s*,\s*transparent\s+(\d+)%\s*\)/g;
@@ -68,21 +56,20 @@ function _parseGradientString(bg: string): {
   let match = gradientRegex.exec(bg);
   while (match) {
     blobs.push({
-      id: nextBlobId++,
-      x: parseInt(match[1]),
-      y: parseInt(match[2]),
-      color: _rgbToHex(
-        parseInt(match[3]),
-        parseInt(match[4]),
-        parseInt(match[5])
-      ),
+      id: blobId++,
+      x: parseInt(match[1], 10),
+      y: parseInt(match[2], 10),
+      color: rgb2hex([
+        parseInt(match[3], 10),
+        parseInt(match[4], 10),
+        parseInt(match[5], 10),
+      ]),
       opacity: parseFloat(match[6]),
-      size: parseInt(match[7]),
+      size: parseInt(match[7], 10),
     });
     match = gradientRegex.exec(bg);
   }
 
-  // Extract base color (last value, typically a hex color)
   const hexMatch = bg.match(/(#[0-9a-fA-F]{6})\s*$/);
   if (hexMatch) {
     baseColor = hexMatch[1];
@@ -103,6 +90,12 @@ export class HuiViewGradientEditor extends LitElement {
 
   private _config?: LovelaceViewConfig;
 
+  private _nextBlobId = 1;
+
+  get config(): LovelaceViewConfig | undefined {
+    return this._config;
+  }
+
   set config(config: LovelaceViewConfig) {
     const oldConfig = this._config;
     this._config = config;
@@ -120,17 +113,18 @@ export class HuiViewGradientEditor extends LitElement {
       const parsed = _parseGradientString(bg);
       this._blobs = parsed.blobs;
       this._baseColor = parsed.baseColor;
+      this._nextBlobId =
+        this._blobs.reduce((max, b) => Math.max(max, b.id), 0) + 1;
     } else if (!this._blobs.length) {
-      // Start with a few random blobs
-      this._randomize();
+      this._generateRandomBlobs();
     }
     this._initialized = true;
   }
 
   private _buildGradientString(): string {
     const parts = this._blobs.map((b) => {
-      const rgb = _hexToRgb(b.color);
-      return `radial-gradient(at ${b.x}% ${b.y}%, rgba(${rgb.r},${rgb.g},${rgb.b},${b.opacity.toFixed(2)}) 0px, transparent ${b.size}%)`;
+      const [r, g, bVal] = hex2rgb(b.color);
+      return `radial-gradient(at ${b.x}% ${b.y}%, rgba(${r},${g},${bVal},${b.opacity.toFixed(2)}) 0px, transparent ${b.size}%)`;
     });
     parts.push(this._baseColor);
     return parts.join(",\n  ");
@@ -162,9 +156,17 @@ export class HuiViewGradientEditor extends LitElement {
             (b, i) => html`
               <div
                 class="blob-handle"
+                role="slider"
+                tabindex="0"
+                aria-label=${this.hass.localize(
+                  "ui.panel.lovelace.editor.edit_view.background.gradient.layer",
+                  { number: i + 1 }
+                )}
+                aria-valuetext="X: ${b.x}%, Y: ${b.y}%"
                 data-index=${i}
                 style="left:${b.x}%;top:${b.y}%;background:${b.color}"
                 @pointerdown=${this._onHandlePointerDown}
+                @keydown=${this._onHandleKeyDown}
               >
                 <span class="handle-label">${i + 1}</span>
               </div>
@@ -298,7 +300,7 @@ export class HuiViewGradientEditor extends LitElement {
 
   private _blobColorChanged(ev: Event) {
     const target = ev.target as HTMLInputElement;
-    const index = parseInt(target.dataset.index!);
+    const index = parseInt(target.dataset.index!, 10);
     this._blobs = this._blobs.map((b, i) =>
       i === index ? { ...b, color: target.value } : b
     );
@@ -306,12 +308,10 @@ export class HuiViewGradientEditor extends LitElement {
   }
 
   private _blobSliderChanged(ev: Event) {
-    const target = ev.target as HTMLInputElement & {
-      dataset: { index: string; prop: string };
-    };
-    const index = parseInt(target.dataset.index!);
+    const target = ev.target as HTMLElement & { value: number };
+    const index = parseInt(target.dataset.index!, 10);
     const prop = target.dataset.prop!;
-    const value = parseFloat((target as any).value);
+    const value = target.value;
 
     this._blobs = this._blobs.map((b, i) => {
       if (i !== index) return b;
@@ -328,7 +328,7 @@ export class HuiViewGradientEditor extends LitElement {
     this._blobs = [
       ...this._blobs,
       {
-        id: nextBlobId++,
+        id: this._nextBlobId++,
         color: _randomColor(),
         opacity: 0.3,
         size: 50,
@@ -344,17 +344,17 @@ export class HuiViewGradientEditor extends LitElement {
     this._fireConfigChanged();
   }
 
-  private _randomize() {
+  private _generateRandomBlobs() {
     const count = 3 + Math.floor(Math.random() * 4);
     const r = Math.floor(Math.random() * 20);
     const g = Math.floor(Math.random() * 20);
     const b = Math.floor(Math.random() * 25);
-    this._baseColor = _rgbToHex(r, g, b);
+    this._baseColor = rgb2hex([r, g, b]);
 
     const blobs: GradientBlob[] = [];
     for (let i = 0; i < count; i++) {
       blobs.push({
-        id: nextBlobId++,
+        id: this._nextBlobId++,
         color: _randomColor(),
         opacity: +(0.15 + Math.random() * 0.65).toFixed(2),
         size: 35 + Math.floor(Math.random() * 55),
@@ -363,16 +363,18 @@ export class HuiViewGradientEditor extends LitElement {
       });
     }
     this._blobs = blobs;
-    this._fireConfigChanged();
   }
 
-  // --- Drag & Drop ---
+  private _randomize() {
+    this._generateRandomBlobs();
+    this._fireConfigChanged();
+  }
 
   private _onHandlePointerDown(ev: PointerEvent) {
     ev.preventDefault();
     ev.stopPropagation();
     const handle = ev.currentTarget as HTMLElement;
-    const index = parseInt(handle.dataset.index!);
+    const index = parseInt(handle.dataset.index!, 10);
     this._dragIndex = index;
 
     handle.setPointerCapture(ev.pointerId);
@@ -411,6 +413,44 @@ export class HuiViewGradientEditor extends LitElement {
     this._fireConfigChanged();
   };
 
+  private _onHandleKeyDown(ev: KeyboardEvent) {
+    const step = ev.shiftKey ? 10 : 1;
+    let dx = 0;
+    let dy = 0;
+
+    switch (ev.key) {
+      case "ArrowLeft":
+        dx = -step;
+        break;
+      case "ArrowRight":
+        dx = step;
+        break;
+      case "ArrowUp":
+        dy = -step;
+        break;
+      case "ArrowDown":
+        dy = step;
+        break;
+      default:
+        return;
+    }
+
+    ev.preventDefault();
+    ev.stopPropagation();
+    const handle = ev.currentTarget as HTMLElement;
+    const index = parseInt(handle.dataset.index!, 10);
+
+    this._blobs = this._blobs.map((b, i) => {
+      if (i !== index) return b;
+      return {
+        ...b,
+        x: Math.min(100, Math.max(0, b.x + dx)),
+        y: Math.min(100, Math.max(0, b.y + dy)),
+      };
+    });
+    this._fireConfigChanged();
+  }
+
   static styles = css`
     :host {
       display: block;
@@ -419,7 +459,7 @@ export class HuiViewGradientEditor extends LitElement {
     .gradient-editor {
       display: flex;
       flex-direction: column;
-      gap: 12px;
+      gap: var(--ha-space-3);
     }
 
     .preview {
@@ -450,6 +490,11 @@ export class HuiViewGradientEditor extends LitElement {
       justify-content: center;
     }
 
+    .blob-handle:focus-visible {
+      outline: 2px solid var(--primary-color);
+      outline-offset: 2px;
+    }
+
     .blob-handle:active {
       cursor: grabbing;
     }
@@ -467,17 +512,17 @@ export class HuiViewGradientEditor extends LitElement {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 8px;
+      gap: var(--ha-space-2);
     }
 
     .base-color-control {
       display: flex;
       align-items: center;
-      gap: 8px;
+      gap: var(--ha-space-2);
     }
 
     .base-color-control label {
-      font-size: 13px;
+      font-size: var(--ha-font-size-s);
       color: var(--primary-text-color);
     }
 
@@ -504,39 +549,39 @@ export class HuiViewGradientEditor extends LitElement {
 
     .toolbar-actions {
       display: flex;
-      gap: 4px;
+      gap: var(--ha-space-1);
     }
 
     .layer-count {
-      font-size: 12px;
+      font-size: var(--ha-font-size-s);
       color: var(--secondary-text-color);
     }
 
     .blob-list {
       display: flex;
       flex-direction: column;
-      gap: 8px;
+      gap: var(--ha-space-2);
     }
 
     .blob-card {
       background: var(--card-background-color);
       border: 1px solid var(--divider-color);
       border-radius: var(--ha-border-radius, 12px);
-      padding: 12px;
+      padding: var(--ha-space-3);
     }
 
     .blob-card-header {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      margin-bottom: 8px;
+      margin-bottom: var(--ha-space-2);
     }
 
     .blob-card-title {
       display: flex;
       align-items: center;
-      gap: 8px;
-      font-size: 14px;
+      gap: var(--ha-space-2);
+      font-size: var(--ha-font-size-m);
       font-weight: 500;
     }
 
@@ -550,17 +595,17 @@ export class HuiViewGradientEditor extends LitElement {
     .blob-card-controls {
       display: flex;
       flex-direction: column;
-      gap: 4px;
+      gap: var(--ha-space-1);
     }
 
     .control-row {
       display: flex;
       align-items: center;
-      gap: 8px;
+      gap: var(--ha-space-2);
     }
 
     .control-row label {
-      font-size: 12px;
+      font-size: var(--ha-font-size-s);
       color: var(--secondary-text-color);
       min-width: 52px;
     }
@@ -591,7 +636,7 @@ export class HuiViewGradientEditor extends LitElement {
     }
 
     .value-label {
-      font-size: 11px;
+      font-size: var(--ha-font-size-xs);
       color: var(--secondary-text-color);
       min-width: 32px;
       text-align: right;

--- a/src/panels/lovelace/editor/view-editor/hui-view-gradient-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-gradient-editor.ts
@@ -7,7 +7,6 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-button";
 import "../../../../components/ha-button-toggle-group";
 import "../../../../components/ha-svg-icon";
-import "../../../../components/ha-textfield";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../../types";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
@@ -190,7 +189,8 @@ export class HuiViewGradientEditor extends LitElement {
     return html`
       <div class="gradient-editor">
         <ha-button-toggle-group
-          full-width
+          size="small"
+          variant="neutral"
           .buttons=${this._subModeButtons(this.hass.localize)}
           .active=${this._subMode}
           @value-changed=${this._subModeChanged}
@@ -209,63 +209,62 @@ export class HuiViewGradientEditor extends LitElement {
         class="preview"
         style="background: ${this._solidColor}"
       ></div>
-      <div class="color-row">
-        <ha-textfield
+      <div class="color-picker-row">
+        <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.color")}</label>
+        <input
           type="color"
           .value=${this._solidColor}
-          .label=${this.hass.localize(
-            "ui.panel.lovelace.editor.edit_view.background.gradient.color"
-          )}
-          @change=${this._solidColorChanged}
-        ></ha-textfield>
+          @input=${this._solidColorChanged}
+        />
       </div>
     `;
   }
 
   private _renderRandomEditor() {
-    const previewBg =
-      this._gradientString || this._solidColor;
+    const previewBg = this._gradientString || this._solidColor;
 
     return html`
       <div
         class="preview"
         style="background: ${previewBg}"
       ></div>
-      <div class="color-inputs">
-        <ha-textfield
-          type="color"
-          .value=${this._color1}
-          .label=${this.hass.localize(
-            "ui.panel.lovelace.editor.edit_view.background.gradient.base_color_1"
-          )}
-          data-index="0"
-          @change=${this._baseColorInputChanged}
-        ></ha-textfield>
-        <ha-textfield
-          type="color"
-          .value=${this._color2}
-          .label=${this.hass.localize(
-            "ui.panel.lovelace.editor.edit_view.background.gradient.base_color_2"
-          )}
-          data-index="1"
-          @change=${this._baseColorInputChanged}
-        ></ha-textfield>
-        <ha-textfield
-          type="color"
-          .value=${this._color3 || "#ffffff"}
-          .label=${this.hass.localize(
-            "ui.panel.lovelace.editor.edit_view.background.gradient.base_color_3"
-          )}
-          data-index="2"
-          @change=${this._baseColorInputChanged}
-        ></ha-textfield>
+      <div class="color-pickers">
+        <div class="color-picker-row">
+          <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.base_color_1")}</label>
+          <input
+            type="color"
+            .value=${this._color1}
+            data-index="0"
+            @input=${this._baseColorInputChanged}
+          />
+        </div>
+        <div class="color-picker-row">
+          <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.base_color_2")}</label>
+          <input
+            type="color"
+            .value=${this._color2}
+            data-index="1"
+            @input=${this._baseColorInputChanged}
+          />
+        </div>
+        <div class="color-picker-row">
+          <label>${this.hass.localize("ui.panel.lovelace.editor.edit_view.background.gradient.base_color_3")}</label>
+          <input
+            type="color"
+            .value=${this._color3 || "#ffffff"}
+            data-index="2"
+            @input=${this._baseColorInputChanged}
+          />
+        </div>
       </div>
-      <ha-button @click=${this._randomize}>
-        <ha-svg-icon slot="icon" .path=${mdiRefresh}></ha-svg-icon>
-        ${this.hass.localize(
-          "ui.panel.lovelace.editor.edit_view.background.gradient.randomize"
-        )}
-      </ha-button>
+      <div class="randomize-row">
+        <ha-button @click=${this._randomize}>
+          <ha-svg-icon slot="icon" .path=${mdiRefresh}></ha-svg-icon>
+          ${this.hass.localize(
+            "ui.panel.lovelace.editor.edit_view.background.gradient.randomize"
+          )}
+        </ha-button>
+      </div>
     `;
   }
 
@@ -324,6 +323,11 @@ export class HuiViewGradientEditor extends LitElement {
       gap: var(--ha-space-3);
     }
 
+    .gradient-editor > ha-button-toggle-group {
+      align-self: center;
+      margin-top: var(--ha-space-6);
+    }
+
     .preview {
       width: 100%;
       height: 200px;
@@ -331,21 +335,48 @@ export class HuiViewGradientEditor extends LitElement {
       border: 1px solid var(--divider-color);
     }
 
-    .color-row {
+    .color-pickers {
       display: flex;
-    }
-
-    .color-row ha-textfield {
-      flex: 1;
-    }
-
-    .color-inputs {
-      display: flex;
+      flex-direction: column;
       gap: var(--ha-space-2);
     }
 
-    .color-inputs ha-textfield {
-      flex: 1;
+    .color-picker-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--ha-space-3);
+    }
+
+    .color-picker-row label {
+      font-size: var(--ha-font-size-m);
+      color: var(--primary-text-color);
+    }
+
+    .color-picker-row input[type="color"] {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 48px;
+      height: 32px;
+      border: 1px solid var(--divider-color);
+      border-radius: var(--ha-border-radius-sm, 6px);
+      background: transparent;
+      cursor: pointer;
+      padding: 2px;
+    }
+
+    .color-picker-row input[type="color"]::-webkit-color-swatch-wrapper {
+      padding: 0;
+    }
+
+    .color-picker-row input[type="color"]::-webkit-color-swatch {
+      border: none;
+      border-radius: 4px;
+    }
+
+    .randomize-row {
+      display: flex;
+      justify-content: center;
     }
 
     ha-button {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8434,15 +8434,13 @@
               "type_image": "Image",
               "type_gradient": "Gradient",
               "gradient": {
-                "base_color": "Base color",
-                "add_layer": "Add layer",
-                "remove_layer": "Remove layer",
-                "layer": "Layer {number}",
+                "mode_solid": "Solid color",
+                "mode_random": "Random gradient",
                 "color": "Color",
-                "opacity": "Opacity",
-                "size": "Size",
-                "randomize": "Randomize",
-                "layers_count": "{count}/{max} layers"
+                "base_color_1": "Color 1",
+                "base_color_2": "Color 2",
+                "base_color_3": "Color 3 (optional)",
+                "randomize": "Randomize"
               }
             },
             "edit": "Edit view",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8430,6 +8430,19 @@
                   "scroll": "Scroll",
                   "fixed": "Fixed"
                 }
+              },
+              "type_image": "Image",
+              "type_gradient": "Gradient",
+              "gradient": {
+                "base_color": "Base color",
+                "add_layer": "Add layer",
+                "remove_layer": "Remove layer",
+                "layer": "Layer {number}",
+                "color": "Color",
+                "opacity": "Opacity",
+                "size": "Size",
+                "randomize": "Randomize",
+                "layers_count": "{count}/{max} layers"
               }
             },
             "edit": "Edit view",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8432,14 +8432,11 @@
                 }
               },
               "type_image": "Image",
-              "type_gradient": "Gradient",
+              "type_gradient": "Custom",
               "gradient": {
-                "mode_solid": "Solid color",
-                "mode_random": "Random gradient",
-                "color": "Color",
-                "base_color_1": "Color 1",
-                "base_color_2": "Color 2",
-                "base_color_3": "Color 3 (optional)",
+                "color_label": "Color {number}",
+                "add_color": "Add color",
+                "remove_color": "Remove color",
                 "randomize": "Randomize"
               }
             },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
> Follow-up to #30087, addressing feedback from @piitaya and @MindFreeze

### Summary

Adds an **Image / Custom** mode toggle to the view background editor. The Custom tab provides a minimal interface for setting CSS gradient backgrounds without requiring YAML knowledge:

- **Single color**: Pick one color for a solid background
- **Multiple colors (2-5)**: Pick colors, then click **Randomize** to auto-generate radial-gradient blobs
- Users click Randomize repeatedly until they like the result
- Existing YAML-configured gradient backgrounds are parsed and displayed correctly

### What changed from #30087

The original PR added a full gradient editor with per-blob controls (opacity, size, x/y position sliders, drag handles, add/remove layers). Maintainers rejected it as too much UI complexity.

This version removes **all manual blob controls**. The entire interaction is:
1. Pick 1-5 colors
2. Click Randomize (appears when 2+ colors are added)
3. Done

The gradient editor component went from ~650 lines to ~270 lines. No custom sliders, no drag handles, no layer management.

### Technical details

- Gradient editor is lazy-loaded on first use via dynamic `import()`
- Once loaded, the element stays in the DOM (hidden when inactive) to preserve user state across mode switches
- Background values are cached per mode so switching between Image and Custom doesn't lose either configuration
- Uses existing `hex2rgb`/`rgb2hex` from `common/color/convert-color.ts`
- All strings are localized via `en.json`

### Files changed

- `hui-view-background-editor.ts` — Image/Custom mode toggle, lazy-load, per-mode caching
- `hui-view-gradient-editor.ts` — rewritten (~270 lines, down from ~650)
- `en.json` — translation keys for Custom tab UI

### Test plan

- [ ] Switch to Gradient tab, verify Solid Color and Random Gradient sub-modes work
- [ ] Pick colors and click Randomize, verify preview updates
- [ ] Switch between Image and Gradient modes, verify both values are preserved
- [ ] Open an existing view with a `radial-gradient(...)` background, verify it displays correctly
- [ ] Cancel the editor without saving, verify original config is restored

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
SImple BG:
<img width="1007" height="568" alt="image" src="https://github.com/user-attachments/assets/533bd911-ebae-4c76-84f3-26e82e17333a" />
Gradient:
<img width="1003" height="684" alt="image" src="https://github.com/user-attachments/assets/103fdc90-83b8-4c5d-9333-de5175d94eee" />



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
