### PR TITLE
Add translation support for nested app configuration schemas

### DIFF
--- a/src/components/ha-selector/ha-selector-object.ts
+++ b/src/components/ha-selector/ha-selector-object.ts
@@ -257,6 +257,7 @@ export class HaObjectSelector extends LitElement {
       schema: this._schema(this.selector),
       data: item,
       computeLabel: this._computeLabel,
+      computeHelper: this._computeHelper,
       submitText: this.hass.localize("ui.common.save"),
     });
 

--- a/src/panels/config/apps/app-view/config/supervisor-app-config.ts
+++ b/src/panels/config/apps/app-view/config/supervisor-app-config.ts
@@ -115,26 +115,51 @@ class SupervisorAppConfig extends LitElement {
 
   private _convertSchema = memoizeOne(
     // Convert supervisor schema to selectors
-    (schema: readonly HaFormSchema[]): HaFormSchema[] =>
-      this._convertSchemaElements(schema)
+    (
+      schema: readonly HaFormSchema[],
+      language: string,
+      translations: HassioAddonDetails["translations"]
+    ): HaFormSchema[] =>
+      this._convertSchemaElements(schema, language, translations)
   );
 
   private _convertSchemaElements(
-    schema: readonly HaFormSchema[]
+    schema: readonly HaFormSchema[],
+    language: string,
+    translations: HassioAddonDetails["translations"],
+    path: string[] = []
   ): HaFormSchema[] {
-    return schema.map((entry) => this._convertSchemaElement(entry));
+    return schema.map((entry) =>
+      this._convertSchemaElement(entry, language, translations, path)
+    );
   }
 
-  private _convertSchemaElement(entry: any): HaFormSchema {
+  private _convertSchemaElement(
+    entry: any,
+    language: string,
+    translations: HassioAddonDetails["translations"],
+    path: string[]
+  ): HaFormSchema {
     if (entry.type === "schema" && !entry.multiple) {
       return {
         name: entry.name,
         type: "expandable",
         required: entry.required,
-        schema: this._convertSchemaElements(entry.schema),
+        schema: this._convertSchemaElements(
+          entry.schema,
+          language,
+          translations,
+          [...path, entry.name]
+        ),
       };
     }
-    const selector = this._convertSchemaElementToSelector(entry, false);
+    const selector = this._convertSchemaElementToSelector(
+      entry,
+      false,
+      language,
+      translations,
+      path
+    );
     if (selector) {
       return {
         name: entry.name,
@@ -147,7 +172,10 @@ class SupervisorAppConfig extends LitElement {
 
   private _convertSchemaElementToSelector(
     entry: any,
-    force: boolean
+    force: boolean,
+    language: string,
+    translations: HassioAddonDetails["translations"],
+    path: string[]
   ): Selector | null {
     if (entry.type === "select") {
       return { select: { options: entry.options } };
@@ -170,10 +198,25 @@ class SupervisorAppConfig extends LitElement {
     }
     if (entry.type === "schema") {
       const fields: NonNullable<ObjectSelector["object"]>["fields"] = {};
-      for (const child_entry of entry.schema) {
-        fields[child_entry.name] = {
-          required: child_entry.required,
-          selector: this._convertSchemaElementToSelector(child_entry, true)!,
+      const childPath = [...path, entry.name];
+      for (const childEntry of entry.schema) {
+        const translation =
+          this._getTranslationEntry(language, childEntry, {
+            path: childPath,
+          }) ||
+          this._getTranslationEntry("en", childEntry, { path: childPath });
+
+        fields[childEntry.name] = {
+          required: childEntry.required,
+          label: translation?.name,
+          description: translation?.description,
+          selector: this._convertSchemaElementToSelector(
+            childEntry,
+            true,
+            language,
+            translations,
+            childPath
+          )!,
         };
       }
       return {
@@ -267,7 +310,9 @@ class SupervisorAppConfig extends LitElement {
                     : this._filteredSchema(
                         this.addon.options,
                         this.addon.schema!
-                      )
+                      ),
+                  this.hass.language,
+                  this.addon.translations
                 )}
               ></ha-form>`
             : html`<ha-yaml-editor


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This add support for translation fields in nested app configuration schemas.

I'm not the first one to noticed that this feature is missing:

* https://community.home-assistant.io/t/creating-ha-addon-translations-descriptions-are-not-working-for-lists/961654
* https://community.home-assistant.io/t/syntax-for-list-items-in-en-yaml-translations-for-add-on-configurations/891303

And the documentation doesn't mention this limitation and the App documentation especially avoids this in the examples:
https://developers.home-assistant.io/docs/apps/configuration


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Before (translation doesn't get applied at all)

<img width="1295" height="707" alt="image" src="https://github.com/user-attachments/assets/1cbf5736-5244-436f-8a88-9a2d371dfe53" />


With this PR:

<img width="1298" height="878" alt="image" src="https://github.com/user-attachments/assets/9cbf1136-4657-4fa7-9136-0663adebb1ab" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

Example App configuration:


```yaml
options:
  global:
    host: "0.0.0.0"
    port: 4521
  pages: []

schema:
  global:
    host: str
    port: "int(1,65535)"
  pages:
    - slug: str
      url: url
      width: "int?"
      height: "int?"
      colorscheme: list(MONO|BWR|BWY|BWRY|BWGBRY|GRAYSCALE_4|GRAYSCALE_8|GRAYSCALE_16)?
      dither_mode: list(NONE|BURKES|FLOYD_STEINBERG|ATKINSON|STUCKI|SIERRA|JARVIS_JUDICE_NINKE)?
```

Example `translations/en.yaml`
```yaml
configuration:
  global:
    name: Global Settings
    description: Base capture, rendering, and scheduling settings used by all pages unless overridden.
    fields:
      host:
        name: Bind Host
        description: Network interface the InkBridge web server should listen on.
      port:
        name: Bind Port
        description: TCP port used by the InkBridge web server.
  pages:
    name: Pages
    description: List of pages to capture and expose as BMP endpoints.
    fields:
      slug:
        name: Endpoint Slug
        description: URL path segment used for this generated BMP endpoint.
      url:
        name: Source URL
        description: Full page URL to open and capture with Playwright.
      width:
        name: Page Width Override
        description: Optional width override in pixels for this page.
      height:
        name: Page Height Override
        description: Optional height override in pixels for this page.
```


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works. (mostly)
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
