### PR TITLE
Fix media-player mock attrs for gallery seek slider

### DIFF
--- a/src/fake_data/entities/media-player-entity.ts
+++ b/src/fake_data/entities/media-player-entity.ts
@@ -1,3 +1,4 @@
+import type { EntityAttributes } from "./types";
 import { MockBaseEntity, BASE_CAPABILITY_ATTRIBUTES } from "./base-entity";
 
 export class MockMediaPlayerEntity extends MockBaseEntity {
@@ -6,6 +7,51 @@ export class MockMediaPlayerEntity extends MockBaseEntity {
     "source_list",
     "sound_mode_list",
   ]);
+
+  protected _getCapabilityAttributes(): EntityAttributes {
+    const attrs = this.attributes;
+    const capabilityAttrs: EntityAttributes = {};
+
+    if (attrs.source_list !== undefined) {
+      capabilityAttrs.source_list = attrs.source_list;
+    }
+    if (attrs.sound_mode_list !== undefined) {
+      capabilityAttrs.sound_mode_list = attrs.sound_mode_list;
+    }
+
+    return capabilityAttrs;
+  }
+
+  protected _getStateAttributes(): EntityAttributes {
+    const attrs = this.attributes;
+    const isOff = this.state === "off";
+    const stateAttrs: EntityAttributes = {};
+
+    const stateKeys = [
+      "media_content_type",
+      "media_title",
+      "media_artist",
+      "media_album_name",
+      "media_series_title",
+      "media_duration",
+      "media_position",
+      "media_position_updated_at",
+      "app_name",
+      "volume_level",
+      "is_volume_muted",
+      "sound_mode",
+      "source",
+      "group_members",
+    ];
+
+    for (const key of stateKeys) {
+      if (attrs[key] !== undefined) {
+        stateAttrs[key] = isOff ? null : attrs[key];
+      }
+    }
+
+    return stateAttrs;
+  }
 
   public async handleService(
     domain: string,

--- a/test/fake_data/entities/media-player-entity.test.ts
+++ b/test/fake_data/entities/media-player-entity.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { MockMediaPlayerEntity } from "../../../src/fake_data/entities/media-player-entity";
+
+describe("MockMediaPlayerEntity", () => {
+  it("exposes capability and state attributes for active states", () => {
+    const entity = new MockMediaPlayerEntity({
+      entity_id: "media_player.demo",
+      state: "playing",
+      attributes: {
+        friendly_name: "Demo player",
+        supported_features: 64063,
+        source_list: ["TV", "Chromecast"],
+        sound_mode_list: ["Movie", "Music"],
+        media_content_type: "music",
+        media_title: "Song",
+        media_artist: "Artist",
+        media_album_name: "Album",
+        media_series_title: "Series",
+        media_duration: 300,
+        media_position: 45,
+        media_position_updated_at: "2026-03-12T18:00:00Z",
+        app_name: "Spotify",
+        volume_level: 0.45,
+        is_volume_muted: false,
+        sound_mode: "Movie",
+        source: "TV",
+        group_members: ["media_player.kitchen"],
+      },
+    });
+
+    const state = entity.toState();
+
+    expect(state.attributes.source_list).toEqual(["TV", "Chromecast"]);
+    expect(state.attributes.sound_mode_list).toEqual(["Movie", "Music"]);
+    expect(state.attributes.media_duration).toBe(300);
+    expect(state.attributes.media_position).toBe(45);
+    expect(state.attributes.volume_level).toBe(0.45);
+    expect(state.attributes.source).toBe("TV");
+  });
+
+  it("keeps capability attributes while nulling state attributes when off", () => {
+    const entity = new MockMediaPlayerEntity({
+      entity_id: "media_player.demo",
+      state: "off",
+      attributes: {
+        friendly_name: "Demo player",
+        supported_features: 64063,
+        source_list: ["TV", "Chromecast"],
+        sound_mode_list: ["Movie", "Music"],
+        media_duration: 300,
+        media_position: 45,
+        volume_level: 0.45,
+        is_volume_muted: false,
+        source: "TV",
+      },
+    });
+
+    const state = entity.toState();
+
+    expect(state.attributes.source_list).toEqual(["TV", "Chromecast"]);
+    expect(state.attributes.sound_mode_list).toEqual(["Movie", "Music"]);
+    expect(state.attributes.media_duration).toBeNull();
+    expect(state.attributes.media_position).toBeNull();
+    expect(state.attributes.volume_level).toBeNull();
+    expect(state.attributes.is_volume_muted).toBeNull();
+    expect(state.attributes.source).toBeNull();
+  });
+});


### PR DESCRIPTION
## Proposed change

Fix the gallery media-player mock so media state attributes are exposed through the mock entity hook model (`_getCapabilityAttributes` / `_getStateAttributes`) instead of being dropped.

This restores seek/position slider rendering for mock music players in gallery demos by correctly providing attributes like `media_duration` and `media_position`, while keeping behavior consistent with other mock entities (including off-state nulling for state attrs).

Also adds focused unit tests for `MockMediaPlayerEntity` attribute behavior.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
