### PR TITLE
Filter ResizeObserver loop errors from dev server overlay

### DIFF
--- a/build-scripts/gulp/rspack.js
+++ b/build-scripts/gulp/rspack.js
@@ -57,6 +57,12 @@ const runDevServer = async ({
         directory: contentBase,
         watch: true,
       },
+      client: {
+        overlay: {
+          runtimeErrors: (error) =>
+            !error?.message?.includes("ResizeObserver loop"),
+        },
+      },
       proxy,
     },
     compiler


### PR DESCRIPTION
## Proposed change

Filter benign ResizeObserver loop errors from the rspack dev server overlay. These errors originate from `lit-virtualizer` (used by `ha-data-table`) and just mean not all resize observations could be delivered in a single animation frame — the library's own [README confirms this is expected and harmless](https://www.npmjs.com/package/@lit-labs/virtualizer#user-content-resizeobserver-loop-limit-exceeded-errors). The overlay catches them before the existing suppression in `logging-mixin.ts` can handle them, causing a full-screen crash overlay that blocks development.

Adds a `client.overlay.runtimeErrors` filter to the `RspackDevServer` config that rejects ResizeObserver loop messages while still surfacing all real runtime errors.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr