### PR TITLE
Fix gallery integration card crash from invalid mock hassUrl

### DIFF
--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -196,7 +196,7 @@ export const provideHass = (
     // Home Assistant properties
     auth: {
       data: {
-        hassUrl: "",
+        hassUrl: location.origin,
       },
     } as any,
     connection: {


### PR DESCRIPTION
## Proposed change

Fix the gallery integration card page (`#misc/integration-card`) crashing with `URL constructor: is not a valid URL`.

The gallery mock in `provide_hass.ts` set `hass.auth.data.hassUrl` to an empty string `""`. When `brandsUrl()` passes this to `new URL(base, "")`, it throws because `""` is not a valid URL base. In production, `hassUrl` is always a valid URL (like `http://homeassistant.local:8123`), so the mock now uses `location.origin` to match real behavior.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr