### PR TITLE
Fix entities not updated in device page

### DIFF
--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -3,7 +3,6 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { until } from "lit/directives/until";
-import { computeEntityName } from "../../../../common/entity/compute_entity_name";
 import { stripPrefixFromEntityName } from "../../../../common/entity/strip_prefix_from_entity_name";
 import "../../../../components/ha-button";
 import "../../../../components/ha-card";
@@ -170,11 +169,8 @@ export class HaDeviceEntitiesCard extends LitElement {
     const element = createRowElement(config);
     if (this.hass) {
       element.hass = this.hass;
-      const stateObj = this.hass.states[entry.entity_id];
 
-      let name =
-        computeEntityName(stateObj, this.hass.entities, this.hass.devices) ||
-        this.deviceName;
+      let name = entry.stateName || this.deviceName;
 
       if (entry.hidden_by) {
         name += ` (${this.hass.localize(

--- a/src/state/lazy-context-provider.ts
+++ b/src/state/lazy-context-provider.ts
@@ -178,6 +178,12 @@ export class LazyContextProvider<
     originalCallback: (value: T, unsubscribe?: () => void) => void
   ): (value: T, unsubscribe?: () => void) => void {
     let tracked = false;
+    // Keep stable references so ContextConsumer doesn't think the
+    // subscription changed and call the old disposer (which removes
+    // the subscription from the inner provider's map).
+    let cachedDisposer: (() => void) | undefined;
+    let cachedWrappedDisposer: (() => void) | undefined;
+
     return (value: T, disposer?: () => void) => {
       if (!tracked && disposer) {
         // First call with a disposer — this consumer is now subscribed.
@@ -186,20 +192,23 @@ export class LazyContextProvider<
         this._clearTeardownTimer();
       }
 
-      const wrappedDisposer = disposer
-        ? () => {
-            if (tracked) {
-              tracked = false;
-              this._subscriberCount--;
-              if (this._subscriberCount === 0 && this._loaded) {
-                this._scheduleTeardown();
+      if (disposer !== cachedDisposer) {
+        cachedDisposer = disposer;
+        cachedWrappedDisposer = disposer
+          ? () => {
+              if (tracked) {
+                tracked = false;
+                this._subscriberCount--;
+                if (this._subscriberCount === 0 && this._loaded) {
+                  this._scheduleTeardown();
+                }
               }
+              disposer();
             }
-            disposer();
-          }
-        : undefined;
+          : undefined;
+      }
 
-      originalCallback(value, wrappedDisposer);
+      originalCallback(value, cachedWrappedDisposer);
     };
   }
 


### PR DESCRIPTION
## Proposed change

Fix device page entities not updating when renaming an entity through the entity registry.

Two issues were causing this:

1. Lazy context provider lost subscriptions after the first update. A wrapper function was recreated on every update, causing the context consumer to think the subscription changed and silently unsubscribe. After the first data load, the device page stopped receiving entity registry updates entirely.

2. Device entities card read names from the wrong source. The card was reading entity names from the display registry (`hass.entities`) instead of using the name already provided by the parent component. Since the two registries update independently, the card could render with stale names.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
