### PR TITLE
Refactor device entities card to use Lit directive

### DIFF
--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -1,7 +1,8 @@
-import type { PropertyValues, TemplateResult } from "lit";
+import type { TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import { repeat } from "lit/directives/repeat";
 import { until } from "lit/directives/until";
 import "../../../../components/ha-button";
 import "../../../../components/ha-card";
@@ -12,18 +13,13 @@ import type { EntityRegistryEntry } from "../../../../data/entity/entity_registr
 import { entryIcon } from "../../../../data/icons";
 import { showMoreInfoDialog } from "../../../../dialogs/more-info/show-ha-more-info-dialog";
 import type { HomeAssistant } from "../../../../types";
-import type { HuiErrorCard } from "../../../lovelace/cards/hui-error-card";
 import {
   computeCards,
   computeSection,
 } from "../../../lovelace/common/generate-lovelace-config";
-import { createRowElement } from "../../../lovelace/create-element/create-row-element";
 import { addEntitiesToLovelaceView } from "../../../lovelace/editor/add-entities-to-view";
-import type {
-  LovelaceRow,
-  LovelaceRowConfig,
-} from "../../../lovelace/entity-rows/types";
 import type { EntityRegistryEntryWithDisplayName } from "../ha-config-device-page";
+import { entityRowElement } from "../../../lovelace/entity-rows/entity-row-element-directive";
 
 @customElement("ha-device-entities-card")
 export class HaDeviceEntitiesCard extends LitElement {
@@ -38,19 +34,6 @@ export class HaDeviceEntitiesCard extends LitElement {
 
   @property({ attribute: "show-hidden", type: Boolean })
   public showHidden = false;
-
-  private _entityRows: (LovelaceRow | HuiErrorCard)[] = [];
-
-  protected shouldUpdate(changedProps: PropertyValues) {
-    if (changedProps.has("hass") && changedProps.size === 1) {
-      this._entityRows.forEach((element) => {
-        element.hass = this.hass;
-      });
-      return false;
-    }
-    this._entityRows = [];
-    return true;
-  }
 
   protected render(): TemplateResult {
     if (!this.entities.length) {
@@ -80,10 +63,13 @@ export class HaDeviceEntitiesCard extends LitElement {
           ? html`
               <div id="entities" class="move-up">
                 <ha-list>
-                  ${shownEntities.map((entry) =>
-                    this.hass.states[entry.entity_id]
-                      ? this._renderEntity(entry)
-                      : this._renderEntry(entry)
+                  ${repeat(
+                    shownEntities,
+                    (entry) => entry.entity_id,
+                    (entry) =>
+                      this.hass.states[entry.entity_id]
+                        ? this._renderEntity(entry)
+                        : this._renderEntry(entry)
                   )}
                 </ha-list>
               </div>
@@ -140,28 +126,15 @@ export class HaDeviceEntitiesCard extends LitElement {
   private _renderEntity(
     entry: EntityRegistryEntryWithDisplayName
   ): TemplateResult {
-    const config: LovelaceRowConfig = {
-      entity: entry.entity_id,
-    };
-
-    const element = createRowElement(config);
-    if (this.hass) {
-      element.hass = this.hass;
-
-      let name = entry.display_name || this.deviceName;
-
-      if (entry.hidden_by) {
-        name += ` (${this.hass.localize(
-          "ui.panel.config.devices.entities.hidden"
-        )})`;
-      }
-
-      config.name = name;
+    let name = entry.display_name || this.deviceName;
+    if (entry.hidden_by) {
+      name += ` (${this.hass.localize(
+        "ui.panel.config.devices.entities.hidden"
+      )})`;
     }
-    // @ts-ignore
-    element.entry = entry;
-    this._entityRows.push(element);
-    return html` <div>${element}</div> `;
+    return html`<div>
+      ${entityRowElement(entry.entity_id, name, this.hass)}
+    </div>`;
   }
 
   private _renderEntry(

--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -46,67 +46,67 @@ export class HaDeviceEntitiesCard extends LitElement {
       `;
     }
 
-    const shownEntities: EntityRegistryEntry[] = [];
-    const hiddenEntities: EntityRegistryEntry[] = [];
+    const enabledEntities: EntityRegistryEntry[] = [];
+    const disabledEntities: EntityRegistryEntry[] = [];
 
     this.entities.forEach((entry) => {
       if (entry.disabled_by) {
-        hiddenEntities.push(entry);
+        disabledEntities.push(entry);
       } else {
-        shownEntities.push(entry);
+        enabledEntities.push(entry);
       }
     });
 
     return html`
       <ha-card outlined .header=${this.header}>
-        ${shownEntities.length
+        ${enabledEntities.length
           ? html`
               <div id="entities" class="move-up">
                 <ha-list>
                   ${repeat(
-                    shownEntities,
+                    enabledEntities,
                     (entry) => entry.entity_id,
                     (entry) =>
                       this.hass.states[entry.entity_id]
                         ? this._renderEntity(entry)
-                        : this._renderEntry(entry)
+                        : this._renderUnavailableEntity(entry)
                   )}
                 </ha-list>
               </div>
             `
           : nothing}
-        ${hiddenEntities.length
-          ? html`
-              <div class=${classMap({ "move-up": !shownEntities.length })}>
-                ${!this.showHidden
-                  ? html`
-                      <button
-                        class="show-more"
-                        @click=${this._toggleShowHidden}
-                      >
-                        ${this.hass.localize(
-                          "ui.panel.config.devices.entities.disabled_entities",
-                          { count: hiddenEntities.length }
-                        )}
-                      </button>
-                    `
-                  : html`
-                      <ha-list>
-                        ${hiddenEntities.map((entry) =>
-                          this._renderEntry(entry)
-                        )}
-                      </ha-list>
-                      <button
-                        class="show-more"
-                        @click=${this._toggleShowHidden}
-                      >
-                        ${this.hass.localize(
-                          "ui.panel.config.devices.entities.show_less"
-                        )}
-                      </button>
-                    `}
-              </div>
-            `
+        ${disabledEntities.length
+          ? html`<div
+              class=${classMap({ "move-up": !enabledEntities.length })}
+            >
+              ${!this.showHidden
+                ? html`
+                    <button
+                      class="show-more"
+                      @click=${this._toggleShowHidden}
+                    >
+                      ${this.hass.localize(
+                        "ui.panel.config.devices.entities.disabled_entities",
+                        { count: disabledEntities.length }
+                      )}
+                    </button>
+                  `
+                : html`
+                    <ha-list>
+                      ${disabledEntities.map((entry) =>
+                        this._renderUnavailableEntity(entry)
+                      )}
+                    </ha-list>
+                    <button
+                      class="show-more"
+                      @click=${this._toggleShowHidden}
+                    >
+                      ${this.hass.localize(
+                        "ui.panel.config.devices.entities.show_less"
+                      )}
+                    </button>
+                  `}
+            </div>`
           : nothing}
         <div class="card-actions">
           <ha-button appearance="plain" @click=${this._addToLovelaceView}>
@@ -137,7 +137,7 @@ export class HaDeviceEntitiesCard extends LitElement {
     </div>`;
   }
 
-  private _renderEntry(
+  private _renderUnavailableEntity(
     entry: EntityRegistryEntryWithDisplayName
   ): TemplateResult {
     const name = entry.display_name || this.deviceName;
@@ -212,6 +212,9 @@ export class HaDeviceEntitiesCard extends LitElement {
     }
     #entities > ha-list {
       margin: 0 16px 0 8px;
+    }
+    #entities > ha-list > ha-list-item {
+      padding: 0 16px 0 12px;
     }
     .name {
       font-size: var(--ha-font-size-m);

--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -76,15 +76,10 @@ export class HaDeviceEntitiesCard extends LitElement {
             `
           : nothing}
         ${disabledEntities.length
-          ? html`<div
-              class=${classMap({ "move-up": !enabledEntities.length })}
-            >
+          ? html`<div class=${classMap({ "move-up": !enabledEntities.length })}>
               ${!this.showHidden
                 ? html`
-                    <button
-                      class="show-more"
-                      @click=${this._toggleShowHidden}
-                    >
+                    <button class="show-more" @click=${this._toggleShowHidden}>
                       ${this.hass.localize(
                         "ui.panel.config.devices.entities.disabled_entities",
                         { count: disabledEntities.length }
@@ -97,10 +92,7 @@ export class HaDeviceEntitiesCard extends LitElement {
                         this._renderUnavailableEntity(entry)
                       )}
                     </ha-list>
-                    <button
-                      class="show-more"
-                      @click=${this._toggleShowHidden}
-                    >
+                    <button class="show-more" @click=${this._toggleShowHidden}>
                       ${this.hass.localize(
                         "ui.panel.config.devices.entities.show_less"
                       )}

--- a/src/panels/lovelace/entity-rows/entity-row-element-directive.ts
+++ b/src/panels/lovelace/entity-rows/entity-row-element-directive.ts
@@ -1,0 +1,30 @@
+import { Directive, directive } from "lit/directive";
+import type { HomeAssistant } from "../../../types";
+import type { HuiErrorCard } from "../cards/hui-error-card";
+import { createRowElement } from "../create-element/create-row-element";
+import type { LovelaceRow, LovelaceRowConfig } from "./types";
+
+class EntityRowDirective extends Directive {
+  private _element?: LovelaceRow | HuiErrorCard;
+
+  private _name?: string;
+
+  render(entityId: string, name: string, hass: HomeAssistant) {
+    if (!this._element) {
+      this._element = createRowElement({
+        entity: entityId,
+        name,
+      } as LovelaceRowConfig);
+    } else if (this._name !== name) {
+      (this._element as LovelaceRow).setConfig?.({
+        entity: entityId,
+        name,
+      } as LovelaceRowConfig);
+    }
+    this._name = name;
+    this._element.hass = hass;
+    return this._element;
+  }
+}
+
+export const entityRowElement = directive(EntityRowDirective);

--- a/src/panels/lovelace/entity-rows/entity-row-element-directive.ts
+++ b/src/panels/lovelace/entity-rows/entity-row-element-directive.ts
@@ -1,4 +1,5 @@
 import { Directive, directive } from "lit/directive";
+import { computeDomain } from "../../../common/entity/compute_domain";
 import type { HomeAssistant } from "../../../types";
 import type { HuiErrorCard } from "../cards/hui-error-card";
 import { createRowElement } from "../create-element/create-row-element";
@@ -7,20 +8,27 @@ import type { LovelaceRow, LovelaceRowConfig } from "./types";
 class EntityRowDirective extends Directive {
   private _element?: LovelaceRow | HuiErrorCard;
 
+  private _entityId?: string;
+
   private _name?: string;
 
   render(entityId: string, name: string, hass: HomeAssistant) {
-    if (!this._element) {
+    if (
+      !this._element ||
+      (this._entityId !== entityId &&
+        computeDomain(entityId) !== computeDomain(this._entityId!))
+    ) {
       this._element = createRowElement({
         entity: entityId,
         name,
       } as LovelaceRowConfig);
-    } else if (this._name !== name) {
+    } else if (this._entityId !== entityId || this._name !== name) {
       (this._element as LovelaceRow).setConfig?.({
         entity: entityId,
         name,
       } as LovelaceRowConfig);
     }
+    this._entityId = entityId;
     this._name = name;
     this._element.hass = hass;
     return this._element;


### PR DESCRIPTION
## Proposed change

The device entities card used an imperative pattern to render entity rows: a `shouldUpdate` override that intercepted hass-only changes, an `_entityRows` array that elements were pushed into during render, and a `_renderEntity` method that created new elements on every non-hass render without reuse.

This replaces that with a cleaner declarative approach:
- A reusable Lit `Directive` (`entityRowElement`) that caches Lovelace row elements and only calls `setConfig` when the name changes
- `repeat` directive for stable keying by entity ID, ensuring proper element reuse

I also updated method name and fixed a padding issue for entities without state.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue or discussion: #30136
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr