### PR TITLE
Simplify entity name computation

### DIFF
--- a/src/common/entity/compute_entity_name.ts
+++ b/src/common/entity/compute_entity_name.ts
@@ -23,11 +23,15 @@ export const computeEntityName = (
 
 export const computeEntityEntryName = (
   entry: EntityRegistryDisplayEntry | EntityRegistryEntry
-): string | undefined =>
-  entry.name ||
-  ("original_name" in entry && entry.original_name != null
-    ? String(entry.original_name)
-    : undefined);
+): string | undefined => {
+  if (entry.name != null) {
+    return entry.name;
+  }
+  if ("original_name" in entry && entry.original_name != null) {
+    return String(entry.original_name);
+  }
+  return undefined;
+};
 
 export const entityUseDeviceName = (
   stateObj: HassEntity,

--- a/src/common/entity/compute_entity_name.ts
+++ b/src/common/entity/compute_entity_name.ts
@@ -4,14 +4,11 @@ import type {
   EntityRegistryEntry,
 } from "../../data/entity/entity_registry";
 import type { HomeAssistant } from "../../types";
-import { computeDeviceName } from "./compute_device_name";
 import { computeStateName } from "./compute_state_name";
-import { stripPrefixFromEntityName } from "./strip_prefix_from_entity_name";
 
 export const computeEntityName = (
   stateObj: HassEntity,
-  entities: HomeAssistant["entities"],
-  devices: HomeAssistant["devices"]
+  entities: HomeAssistant["entities"]
 ): string | undefined => {
   const entry = entities[stateObj.entity_id] as
     | EntityRegistryDisplayEntry
@@ -21,49 +18,18 @@ export const computeEntityName = (
     // Fall back to state name if not in the entity registry (friendly name)
     return computeStateName(stateObj);
   }
-  return computeEntityEntryName(entry, devices);
+  return computeEntityEntryName(entry);
 };
 
 export const computeEntityEntryName = (
-  entry: EntityRegistryDisplayEntry | EntityRegistryEntry,
-  devices: HomeAssistant["devices"],
-  fallbackStateObj?: HassEntity
-): string | undefined => {
-  const name =
-    entry.name ||
-    ("original_name" in entry && entry.original_name != null
-      ? String(entry.original_name)
-      : undefined);
-
-  const device = entry.device_id ? devices[entry.device_id] : undefined;
-
-  if (!device) {
-    if (name) {
-      return name;
-    }
-    if (fallbackStateObj) {
-      return computeStateName(fallbackStateObj);
-    }
-    return undefined;
-  }
-
-  const deviceName = computeDeviceName(device);
-
-  // If the device name is the same as the entity name, consider empty entity name
-  if (deviceName === name) {
-    return undefined;
-  }
-
-  // Remove the device name from the entity name if it starts with it
-  if (deviceName && name) {
-    return stripPrefixFromEntityName(name, deviceName) || name;
-  }
-
-  return name;
-};
+  entry: EntityRegistryDisplayEntry | EntityRegistryEntry
+): string | undefined =>
+  entry.name ||
+  ("original_name" in entry && entry.original_name != null
+    ? String(entry.original_name)
+    : undefined);
 
 export const entityUseDeviceName = (
   stateObj: HassEntity,
-  entities: HomeAssistant["entities"],
-  devices: HomeAssistant["devices"]
-): boolean => !computeEntityName(stateObj, entities, devices);
+  entities: HomeAssistant["entities"]
+): boolean => !computeEntityName(stateObj, entities);

--- a/src/common/entity/compute_entity_name_display.ts
+++ b/src/common/entity/compute_entity_name_display.ts
@@ -45,7 +45,7 @@ export const computeEntityNameDisplay = (
     return items.map((item) => item.text).join(separator);
   }
 
-  const useDeviceName = entityUseDeviceName(stateObj, entities, devices);
+  const useDeviceName = entityUseDeviceName(stateObj, entities);
 
   // If entity uses device name, and device is not already included, replace it with device name
   if (useDeviceName) {
@@ -91,7 +91,7 @@ export const computeEntityNameList = (
   const names = name.map((item) => {
     switch (item.type) {
       case "entity":
-        return computeEntityName(stateObj, entities, devices);
+        return computeEntityName(stateObj, entities);
       case "device":
         return device ? computeDeviceName(device) : undefined;
       case "area":

--- a/src/components/target-picker/ha-target-picker-item-row.ts
+++ b/src/components/target-picker/ha-target-picker-item-row.ts
@@ -535,7 +535,7 @@ export class HaTargetPickerItemRow extends LitElement {
 
       const stateObject: HassEntity | undefined = this.hass.states[item];
       const entityName = stateObject
-        ? computeEntityName(stateObject, this.hass.entities, this.hass.devices)
+        ? computeEntityName(stateObject, this.hass.entities)
         : item;
       const { area, device } = stateObject
         ? getEntityContext(

--- a/src/data/entity/entity_registry.ts
+++ b/src/data/entity/entity_registry.ts
@@ -73,7 +73,7 @@ export interface ExtEntityRegistryEntry extends EntityRegistryEntry {
   original_icon?: string;
   device_class?: string;
   original_device_class?: string;
-  aliases: string[];
+  aliases: (string | null)[];
 }
 
 export interface UpdateEntityRegistryEntryResult {
@@ -159,7 +159,7 @@ export interface EntityRegistryEntryUpdateParams {
     | WeatherEntityOptions
     | LightEntityOptions
     | VacuumEntityOptions;
-  aliases?: string[];
+  aliases?: (string | null)[];
   labels?: string[];
   categories?: Record<string, string | null>;
 }

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -567,9 +567,9 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
         : undefined;
 
     const entityName = stateObj
-      ? computeEntityName(stateObj, this.hass.entities, this.hass.devices)
+      ? computeEntityName(stateObj, this.hass.entities)
       : this._entry
-        ? computeEntityEntryName(this._entry, this.hass.devices)
+        ? computeEntityEntryName(this._entry)
         : entityId;
 
     const deviceName = context?.device

--- a/src/dialogs/more-info/more-info-content.ts
+++ b/src/dialogs/more-info/more-info-content.ts
@@ -107,11 +107,7 @@ class MoreInfoContent extends LitElement {
         if (!stateObj) {
           return null;
         }
-        const entityName = computeEntityName(
-          stateObj,
-          hass.entities,
-          hass.devices
-        );
+        const entityName = computeEntityName(stateObj, hass.entities);
         const { area } = getEntityContext(
           stateObj,
           hass.entities,

--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -23,7 +23,7 @@ import type {
   LovelaceRow,
   LovelaceRowConfig,
 } from "../../../lovelace/entity-rows/types";
-import type { EntityRegistryDisplayEntry } from "../ha-config-device-page";
+import type { EntityRegistryEntryWithDisplayName } from "../ha-config-device-page";
 
 @customElement("ha-device-entities-card")
 export class HaDeviceEntitiesCard extends LitElement {
@@ -34,7 +34,7 @@ export class HaDeviceEntitiesCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false })
-  public entities!: EntityRegistryDisplayEntry[];
+  public entities!: EntityRegistryEntryWithDisplayName[];
 
   @property({ attribute: "show-hidden", type: Boolean })
   public showHidden = false;
@@ -137,7 +137,9 @@ export class HaDeviceEntitiesCard extends LitElement {
     this.showHidden = !this.showHidden;
   }
 
-  private _renderEntity(entry: EntityRegistryDisplayEntry): TemplateResult {
+  private _renderEntity(
+    entry: EntityRegistryEntryWithDisplayName
+  ): TemplateResult {
     const config: LovelaceRowConfig = {
       entity: entry.entity_id,
     };
@@ -162,7 +164,9 @@ export class HaDeviceEntitiesCard extends LitElement {
     return html` <div>${element}</div> `;
   }
 
-  private _renderEntry(entry: EntityRegistryDisplayEntry): TemplateResult {
+  private _renderEntry(
+    entry: EntityRegistryEntryWithDisplayName
+  ): TemplateResult {
     const name = entry.display_name || this.deviceName;
 
     const icon = until(entryIcon(this.hass, entry));

--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -4,6 +4,7 @@ import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { until } from "lit/directives/until";
 import { stripPrefixFromEntityName } from "../../../../common/entity/strip_prefix_from_entity_name";
+import { computeEntityName } from "../../../../common/entity/compute_entity_name";
 import "../../../../components/ha-button";
 import "../../../../components/ha-card";
 import "../../../../components/ha-icon";
@@ -202,11 +203,7 @@ export class HaDeviceEntitiesCard extends LitElement {
         @click=${this._openEditEntry}
       >
         <ha-icon slot="graphic" .icon=${icon}></ha-icon>
-        <div class="name">
-          ${name
-            ? stripPrefixFromEntityName(name, this.deviceName) || name
-            : entry.entity_id}
-        </div>
+        <div class="name">${name || entry.entity_id}</div>
       </ha-list-item>
     `;
   }

--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -1,17 +1,14 @@
 import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { until } from "lit/directives/until";
-import { stripPrefixFromEntityName } from "../../../../common/entity/strip_prefix_from_entity_name";
-import { computeEntityName } from "../../../../common/entity/compute_entity_name";
 import "../../../../components/ha-button";
 import "../../../../components/ha-card";
 import "../../../../components/ha-icon";
 import "../../../../components/ha-list";
 import "../../../../components/ha-list-item";
-import type { ExtEntityRegistryEntry } from "../../../../data/entity/entity_registry";
-import { getExtendedEntityRegistryEntry } from "../../../../data/entity/entity_registry";
+import type { EntityRegistryEntry } from "../../../../data/entity/entity_registry";
 import { entryIcon } from "../../../../data/icons";
 import { showMoreInfoDialog } from "../../../../dialogs/more-info/show-ha-more-info-dialog";
 import type { HomeAssistant } from "../../../../types";
@@ -26,7 +23,7 @@ import type {
   LovelaceRow,
   LovelaceRowConfig,
 } from "../../../lovelace/entity-rows/types";
-import type { EntityRegistryStateEntry } from "../ha-config-device-page";
+import type { EntityRegistryDisplayEntry } from "../ha-config-device-page";
 
 @customElement("ha-device-entities-card")
 export class HaDeviceEntitiesCard extends LitElement {
@@ -36,15 +33,11 @@ export class HaDeviceEntitiesCard extends LitElement {
 
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property({ attribute: false }) public entities!: EntityRegistryStateEntry[];
+  @property({ attribute: false })
+  public entities!: EntityRegistryDisplayEntry[];
 
   @property({ attribute: "show-hidden", type: Boolean })
   public showHidden = false;
-
-  @state() private _extDisabledEntityEntries?: Record<
-    string,
-    ExtEntityRegistryEntry
-  >;
 
   private _entityRows: (LovelaceRow | HuiErrorCard)[] = [];
 
@@ -70,18 +63,12 @@ export class HaDeviceEntitiesCard extends LitElement {
       `;
     }
 
-    const shownEntities: EntityRegistryStateEntry[] = [];
-    const hiddenEntities: EntityRegistryStateEntry[] = [];
+    const shownEntities: EntityRegistryEntry[] = [];
+    const hiddenEntities: EntityRegistryEntry[] = [];
 
     this.entities.forEach((entry) => {
       if (entry.disabled_by) {
-        if (this._extDisabledEntityEntries) {
-          hiddenEntities.push(
-            this._extDisabledEntityEntries[entry.entity_id] || entry
-          );
-        } else {
-          hiddenEntities.push(entry);
-        }
+        hiddenEntities.push(entry);
       } else {
         shownEntities.push(entry);
       }
@@ -103,27 +90,37 @@ export class HaDeviceEntitiesCard extends LitElement {
             `
           : nothing}
         ${hiddenEntities.length
-          ? html`<div class=${classMap({ "move-up": !shownEntities.length })}>
-              ${!this.showHidden
-                ? html`
-                    <button class="show-more" @click=${this._toggleShowHidden}>
-                      ${this.hass.localize(
-                        "ui.panel.config.devices.entities.disabled_entities",
-                        { count: hiddenEntities.length }
-                      )}
-                    </button>
-                  `
-                : html`
-                    <ha-list>
-                      ${hiddenEntities.map((entry) => this._renderEntry(entry))}
-                    </ha-list>
-                    <button class="show-more" @click=${this._toggleShowHidden}>
-                      ${this.hass.localize(
-                        "ui.panel.config.devices.entities.show_less"
-                      )}
-                    </button>
-                  `}
-            </div>`
+          ? html`
+              <div class=${classMap({ "move-up": !shownEntities.length })}>
+                ${!this.showHidden
+                  ? html`
+                      <button
+                        class="show-more"
+                        @click=${this._toggleShowHidden}
+                      >
+                        ${this.hass.localize(
+                          "ui.panel.config.devices.entities.disabled_entities",
+                          { count: hiddenEntities.length }
+                        )}
+                      </button>
+                    `
+                  : html`
+                      <ha-list>
+                        ${hiddenEntities.map((entry) =>
+                          this._renderEntry(entry)
+                        )}
+                      </ha-list>
+                      <button
+                        class="show-more"
+                        @click=${this._toggleShowHidden}
+                      >
+                        ${this.hass.localize(
+                          "ui.panel.config.devices.entities.show_less"
+                        )}
+                      </button>
+                    `}
+              </div>
+            `
           : nothing}
         <div class="card-actions">
           <ha-button appearance="plain" @click=${this._addToLovelaceView}>
@@ -138,31 +135,9 @@ export class HaDeviceEntitiesCard extends LitElement {
 
   private _toggleShowHidden() {
     this.showHidden = !this.showHidden;
-    if (!this.showHidden || this._extDisabledEntityEntries !== undefined) {
-      return;
-    }
-    this._extDisabledEntityEntries = {};
-    const toFetch = this.entities.filter((entry) => entry.disabled_by);
-
-    const worker = async () => {
-      if (toFetch.length === 0) {
-        return;
-      }
-
-      const entityId = toFetch.pop()!.entity_id;
-      const entry = await getExtendedEntityRegistryEntry(this.hass, entityId);
-      this._extDisabledEntityEntries![entityId] = entry;
-      this.requestUpdate("_extDisabledEntityEntries");
-      worker();
-    };
-
-    // Fetch 3 in parallel
-    worker();
-    worker();
-    worker();
   }
 
-  private _renderEntity(entry: EntityRegistryStateEntry): TemplateResult {
+  private _renderEntity(entry: EntityRegistryDisplayEntry): TemplateResult {
     const config: LovelaceRowConfig = {
       entity: entry.entity_id,
     };
@@ -171,7 +146,7 @@ export class HaDeviceEntitiesCard extends LitElement {
     if (this.hass) {
       element.hass = this.hass;
 
-      let name = entry.stateName || this.deviceName;
+      let name = entry.display_name || this.deviceName;
 
       if (entry.hidden_by) {
         name += ` (${this.hass.localize(
@@ -187,11 +162,8 @@ export class HaDeviceEntitiesCard extends LitElement {
     return html` <div>${element}</div> `;
   }
 
-  private _renderEntry(entry: EntityRegistryStateEntry): TemplateResult {
-    const name =
-      entry.stateName ||
-      entry.name ||
-      (entry as ExtEntityRegistryEntry).original_name;
+  private _renderEntry(entry: EntityRegistryDisplayEntry): TemplateResult {
+    const name = entry.display_name || this.deviceName;
 
     const icon = until(entryIcon(this.hass, entry));
 
@@ -203,7 +175,7 @@ export class HaDeviceEntitiesCard extends LitElement {
         @click=${this._openEditEntry}
       >
         <ha-icon slot="graphic" .icon=${icon}></ha-icon>
-        <div class="name">${name || entry.entity_id}</div>
+        <div class="name">${name}</div>
       </ha-list-item>
     `;
   }

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -95,7 +95,7 @@ import {
   showDeviceRegistryDetailDialog,
 } from "./device-registry-detail/show-dialog-device-registry-detail";
 
-export interface EntityRegistryDisplayEntry extends EntityRegistryEntry {
+export interface EntityRegistryEntryWithDisplayName extends EntityRegistryEntry {
   display_name?: string | null;
 }
 
@@ -216,7 +216,7 @@ export class HaConfigDevicePage extends LitElement {
   private _deviceIdInList = memoizeOne((deviceId: string) => [deviceId]);
 
   private _entityIds = memoizeOne(
-    (entries: EntityRegistryDisplayEntry[]): string[] =>
+    (entries: EntityRegistryEntryWithDisplayName[]): string[] =>
       entries.map((entry) => entry.entity_id)
   );
 
@@ -249,7 +249,7 @@ export class HaConfigDevicePage extends LitElement {
         | "assist"
         | "notify"
         | NonNullable<EntityRegistryEntry["entity_category"]>,
-        EntityRegistryDisplayEntry[]
+        EntityRegistryEntryWithDisplayName[]
       >;
       for (const key of [
         "assist",

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -1274,7 +1274,7 @@ export class HaConfigDevicePage extends LitElement {
   private _computeEntityName(entity: EntityRegistryEntry) {
     const device = this.hass.devices[this.deviceId];
     return (
-      computeEntityEntryName(entity, this.hass.devices) ||
+      computeEntityEntryName(entity) ||
       computeDeviceNameDisplay(device, this.hass)
     );
   }

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -34,6 +34,7 @@ import "../../../components/entity/ha-battery-icon";
 import "../../../components/ha-alert";
 import "../../../components/ha-button";
 import "../../../components/ha-dropdown";
+import type { HaDropdownSelectEvent } from "../../../components/ha-dropdown";
 import "../../../components/ha-dropdown-item";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-icon-next";
@@ -94,10 +95,9 @@ import {
   loadDeviceRegistryDetailDialog,
   showDeviceRegistryDetailDialog,
 } from "./device-registry-detail/show-dialog-device-registry-detail";
-import type { HaDropdownSelectEvent } from "../../../components/ha-dropdown";
 
-export interface EntityRegistryStateEntry extends EntityRegistryEntry {
-  stateName?: string | null;
+export interface EntityRegistryDisplayEntry extends EntityRegistryEntry {
+  display_name?: string | null;
 }
 
 export interface DeviceAction {
@@ -177,17 +177,17 @@ export class HaConfigDevicePage extends LitElement {
     (
       deviceId: string,
       entities: EntityRegistryEntry[]
-    ): EntityRegistryStateEntry[] =>
+    ): EntityRegistryEntry[] =>
       entities
         .filter((entity) => entity.device_id === deviceId)
         .map((entity) => ({
           ...entity,
-          stateName: this._computeEntityName(entity),
+          display_name: computeEntityEntryName(entity),
         }))
         .sort((ent1, ent2) =>
           stringCompare(
-            ent1.stateName || `zzz${ent1.entity_id}`,
-            ent2.stateName || `zzz${ent2.entity_id}`,
+            ent1.display_name || "",
+            ent2.display_name || "",
             this.hass.locale.language
           )
         )
@@ -217,7 +217,7 @@ export class HaConfigDevicePage extends LitElement {
   private _deviceIdInList = memoizeOne((deviceId: string) => [deviceId]);
 
   private _entityIds = memoizeOne(
-    (entries: EntityRegistryStateEntry[]): string[] =>
+    (entries: EntityRegistryDisplayEntry[]): string[] =>
       entries.map((entry) => entry.entity_id)
   );
 
@@ -250,7 +250,7 @@ export class HaConfigDevicePage extends LitElement {
         | "assist"
         | "notify"
         | NonNullable<EntityRegistryEntry["entity_category"]>,
-        EntityRegistryStateEntry[]
+        EntityRegistryDisplayEntry[]
       >;
       for (const key of [
         "assist",
@@ -1271,14 +1271,6 @@ export class HaConfigDevicePage extends LitElement {
     }
   }
 
-  private _computeEntityName(entity: EntityRegistryEntry) {
-    const device = this.hass.devices[this.deviceId];
-    return (
-      computeEntityEntryName(entity) ||
-      computeDeviceNameDisplay(device, this.hass)
-    );
-  }
-
   private _onImageLoad(ev) {
     ev.target.style.display = "inline-block";
   }
@@ -1457,7 +1449,7 @@ export class HaConfigDevicePage extends LitElement {
         const entities = this._entities(this.deviceId, this._entityReg);
 
         const updateProms = entities.map((entity) => {
-          const name = entity.name || entity.stateName;
+          const name = entity.name || entity.entityName;
           let newName: string | null | undefined;
 
           if (entity.has_entity_name && !entity.name) {

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -66,7 +66,6 @@ import type { EntityRegistryEntry } from "../../../data/entity/entity_registry";
 import {
   findBatteryChargingEntity,
   findBatteryEntity,
-  updateEntityRegistryEntry,
 } from "../../../data/entity/entity_registry";
 import type { IntegrationManifest } from "../../../data/integration";
 import { domainToName } from "../../../data/integration";
@@ -1363,8 +1362,6 @@ export class HaConfigDevicePage extends LitElement {
     showDeviceRegistryDetailDialog(this, {
       device,
       updateEntry: async (updates) => {
-        const oldDeviceName = device.name_by_user || device.name;
-        const newDeviceName = updates.name_by_user;
         const disabled =
           updates.disabled_by === "user" && device.disabled_by !== "user";
 
@@ -1436,43 +1433,7 @@ export class HaConfigDevicePage extends LitElement {
             ),
             text: err.message,
           });
-          return;
         }
-
-        if (
-          !oldDeviceName ||
-          !newDeviceName ||
-          oldDeviceName === newDeviceName
-        ) {
-          return;
-        }
-        const entities = this._entities(this.deviceId, this._entityReg);
-
-        const updateProms = entities.map((entity) => {
-          const name = entity.name || entity.entityName;
-          let newName: string | null | undefined;
-
-          if (entity.has_entity_name && !entity.name) {
-            return undefined;
-          }
-
-          if (
-            entity.has_entity_name &&
-            (entity.name === oldDeviceName || entity.name === newDeviceName)
-          ) {
-            // clear name if it matches the device name and it uses the device name (entity naming)
-            newName = null;
-          } else if (name && name.includes(oldDeviceName)) {
-            newName = name.replace(oldDeviceName, newDeviceName);
-          } else {
-            return undefined;
-          }
-
-          return updateEntityRegistryEntry(this.hass!, entity.entity_id, {
-            name: newName,
-          });
-        });
-        await Promise.all(updateProms);
       },
     });
   };

--- a/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
+++ b/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
@@ -140,9 +140,9 @@ export class DialogVacuumSegmentMapping
         : undefined;
 
     const entityName = stateObj
-      ? computeEntityName(stateObj, this.hass.entities, this.hass.devices)
+      ? computeEntityName(stateObj, this.hass.entities)
       : this._entry
-        ? computeEntityEntryName(this._entry, this.hass.devices)
+        ? computeEntityEntryName(this._entry)
         : this._params.entityId;
 
     const deviceName = context?.device

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -884,8 +884,9 @@ export class EntityRegistrySettingsEditor extends LitElement {
           )}</span
         >
         <span slot="secondary">
-          ${this.entry.aliases.length
-            ? [...this.entry.aliases]
+          ${this.entry.aliases.filter((a) => a !== null).length
+            ? this.entry.aliases
+                .filter((a): a is string => a !== null)
                 .sort((a, b) => stringCompare(a, b, this.hass.locale.language))
                 .join(", ")
             : this.hass.localize(

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -153,7 +153,7 @@ export class EntityRegistrySettingsEditor extends LitElement {
 
   @property({ attribute: false }) public helperConfigEntry?: ConfigEntry;
 
-  @state() private _name!: string;
+  @state() private _name!: string | null;
 
   @state() private _icon!: string;
 
@@ -218,7 +218,7 @@ export class EntityRegistrySettingsEditor extends LitElement {
       return;
     }
 
-    this._name = this.entry.name || "";
+    this._name = this.entry.name;
     this._icon = this.entry.icon || "";
     this._deviceClass =
       this.entry.device_class || this.entry.original_device_class;
@@ -388,14 +388,27 @@ export class EntityRegistrySettingsEditor extends LitElement {
       ${this.hideName
         ? nothing
         : html`<ha-textfield
-            .value=${this._name}
+            class="name"
+            .value=${this._name ?? this.entry.original_name ?? ""}
             .label=${this.hass.localize(
               "ui.dialogs.entity_registry.editor.name"
             )}
             .disabled=${this.disabled}
-            .placeholder=${this.entry.original_name}
             @input=${this._nameChanged}
-          ></ha-textfield>`}
+            .iconTrailing=${this._name !== null}
+          >
+            ${this._name !== null
+              ? html`<div class="layout horizontal" slot="trailingIcon">
+                  <ha-icon-button
+                    @click=${this._restoreName}
+                    .path=${mdiRestore}
+                    .label=${this.hass.localize(
+                      "ui.dialogs.entity_registry.editor.restore_name"
+                    )}
+                  ></ha-icon-button>
+                </div>`
+              : nothing}
+          </ha-textfield>`}
       ${this.hideIcon
         ? nothing
         : html`
@@ -1053,7 +1066,7 @@ export class EntityRegistrySettingsEditor extends LitElement {
     }
 
     const params: Partial<EntityRegistryEntryUpdateParams> = {
-      name: this._name.trim() || null,
+      name: this._name?.trim() ?? null,
       icon: this._icon.trim() || null,
       area_id: this._areaId || null,
       labels: this._labels || [],
@@ -1317,6 +1330,11 @@ export class EntityRegistrySettingsEditor extends LitElement {
   private _nameChanged(ev): void {
     fireEvent(this, "change");
     this._name = ev.target.value;
+  }
+
+  private _restoreName(): void {
+    fireEvent(this, "change");
+    this._name = null;
   }
 
   private _iconChanged(ev: CustomEvent): void {
@@ -1593,9 +1611,13 @@ export class EntityRegistrySettingsEditor extends LitElement {
         }
         ha-textfield.entityId {
           --text-field-prefix-padding-right: 0;
+        }
+        ha-textfield.entityId,
+        ha-textfield.name {
           --textfield-icon-trailing-padding: 0;
         }
-        ha-textfield.entityId ha-icon-button {
+        ha-textfield.entityId ha-icon-button,
+        ha-textfield.name ha-icon-button {
           position: relative;
           right: calc(var(--ha-space-2) * -1);
           --ha-icon-button-size: 36px;

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -32,7 +32,10 @@ import {
   getDuplicatedDeviceNames,
 } from "../../../common/entity/compute_device_name";
 import { computeDomain } from "../../../common/entity/compute_domain";
-import { computeEntityEntryName } from "../../../common/entity/compute_entity_name";
+import {
+  computeEntityEntryName,
+  computeEntityName,
+} from "../../../common/entity/compute_entity_name";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import {
   deleteEntity,
@@ -690,9 +693,9 @@ export class HaConfigEntities extends LitElement {
           (lbl) => labelReg!.find((label) => label.label_id === lbl)!
         );
 
-        const entityName =
-          computeEntityEntryName(entry as EntityRegistryEntry) ??
-          (entity ? computeStateName(entity) : undefined);
+        const entityName = entity
+          ? computeEntityName(entity, this.hass.entities)
+          : computeEntityEntryName(entry as EntityRegistryEntry);
 
         const deviceName = device ? computeDeviceName(device) : undefined;
         const areaName = area ? computeAreaName(area) : undefined;

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -690,11 +690,9 @@ export class HaConfigEntities extends LitElement {
           (lbl) => labelReg!.find((label) => label.label_id === lbl)!
         );
 
-        const entityName = computeEntityEntryName(
-          entry as EntityRegistryEntry,
-          this.hass.devices,
-          entity
-        );
+        const entityName =
+          computeEntityEntryName(entry as EntityRegistryEntry) ??
+          (entity ? computeStateName(entity) : undefined);
 
         const deviceName = device ? computeDeviceName(device) : undefined;
         const areaName = area ? computeAreaName(area) : undefined;

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
@@ -12,11 +12,7 @@ import "../../../../../components/ha-card";
 import "../../../../../components/ha-textfield";
 import { updateDeviceRegistryEntry } from "../../../../../data/device/device_registry";
 import type { EntityRegistryEntry } from "../../../../../data/entity/entity_registry";
-import {
-  getAutomaticEntityIds,
-  subscribeEntityRegistry,
-  updateEntityRegistryEntry,
-} from "../../../../../data/entity/entity_registry";
+import { subscribeEntityRegistry } from "../../../../../data/entity/entity_registry";
 import type { ZHADevice } from "../../../../../data/zha";
 import { showAlertDialog } from "../../../../../dialogs/generic/show-dialog-box";
 import { SubscribeMixin } from "../../../../../mixins/subscribe-mixin";
@@ -120,52 +116,11 @@ class ZHADeviceCard extends SubscribeMixin(LitElement) {
     if (!this.hass || !this.device) {
       return;
     }
-    const device = this.device;
-
-    const oldDeviceName = device.user_given_name || device.name;
     const newDeviceName = event.target.value;
     this.device.user_given_name = newDeviceName;
-    await updateDeviceRegistryEntry(this.hass, device.device_reg_id, {
+    await updateDeviceRegistryEntry(this.hass, this.device.device_reg_id, {
       name_by_user: newDeviceName,
     });
-
-    if (!oldDeviceName || !newDeviceName || oldDeviceName === newDeviceName) {
-      return;
-    }
-    const entities = this._deviceEntities(device.device_reg_id, this._entities);
-
-    const entityIdsMapping = await getAutomaticEntityIds(
-      this.hass,
-      entities.map((entity) => entity.entity_id)
-    );
-
-    const updateProms = entities.map((entity) => {
-      const name = entity.name;
-      const newEntityId = entityIdsMapping[entity.entity_id];
-      let newName: string | null | undefined;
-
-      if (entity.has_entity_name && !entity.name) {
-        newName = undefined;
-      } else if (
-        entity.has_entity_name &&
-        (entity.name === oldDeviceName || entity.name === newDeviceName)
-      ) {
-        // clear name if it matches the device name and it uses the device name (entity naming)
-        newName = null;
-      } else if (name && name.includes(oldDeviceName)) {
-        newName = name.replace(oldDeviceName, newDeviceName);
-      }
-
-      if (newName !== undefined && !newEntityId) {
-        return undefined;
-      }
-
-      return updateEntityRegistryEntry(this.hass!, entity.entity_id, {
-        name: newName,
-        new_entity_id: newEntityId || undefined,
-      });
-    });
-    await Promise.all(updateProms);
   }
 
   private _openMoreInfo(ev: MouseEvent): void {

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../../common/dom/fire_event";
-import { computeStateName } from "../../../../../common/entity/compute_state_name";
+import { computeEntityEntryName } from "../../../../../common/entity/compute_entity_name";
 import { stringCompare } from "../../../../../common/string/compare";
 import "../../../../../components/entity/state-badge";
 import "../../../../../components/ha-area-picker";
@@ -22,7 +22,7 @@ import { showAlertDialog } from "../../../../../dialogs/generic/show-dialog-box"
 import { SubscribeMixin } from "../../../../../mixins/subscribe-mixin";
 import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
-import type { EntityRegistryStateEntry } from "../../../devices/ha-config-device-page";
+import type { EntityRegistryDisplayEntry } from "../../../devices/ha-config-device-page";
 
 @customElement("zha-device-card")
 class ZHADeviceCard extends SubscribeMixin(LitElement) {
@@ -38,17 +38,17 @@ class ZHADeviceCard extends SubscribeMixin(LitElement) {
     (
       deviceId: string,
       entities: EntityRegistryEntry[]
-    ): EntityRegistryStateEntry[] =>
+    ): EntityRegistryDisplayEntry[] =>
       entities
         .filter((entity) => entity.device_id === deviceId)
         .map((entity) => ({
           ...entity,
-          stateName: this._computeEntityName(entity),
+          display_name: computeEntityEntryName(entity),
         }))
         .sort((ent1, ent2) =>
           stringCompare(
-            ent1.stateName || `zzz${ent1.entity_id}`,
-            ent2.stateName || `zzz${ent2.entity_id}`,
+            ent1.display_name || "",
+            ent2.display_name || "",
             this.hass.locale.language
           )
         )
@@ -89,7 +89,7 @@ class ZHADeviceCard extends SubscribeMixin(LitElement) {
                 ? html`
                     <state-badge
                       @click=${this._openMoreInfo}
-                      .title=${entity.stateName!}
+                      .title=${entity.display_name || ""}
                       .hass=${this.hass}
                       .stateObj=${this.hass!.states[entity.entity_id]}
                       slot="item-icon"
@@ -172,13 +172,6 @@ class ZHADeviceCard extends SubscribeMixin(LitElement) {
     fireEvent(this, "hass-more-info", {
       entityId: (ev.currentTarget as any).stateObj.entity_id,
     });
-  }
-
-  private _computeEntityName(entity: EntityRegistryEntry): string | null {
-    if (this.hass.states[entity.entity_id]) {
-      return computeStateName(this.hass.states[entity.entity_id]);
-    }
-    return entity.name;
   }
 
   private async _areaPicked(ev: CustomEvent) {

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
@@ -18,7 +18,7 @@ import { showAlertDialog } from "../../../../../dialogs/generic/show-dialog-box"
 import { SubscribeMixin } from "../../../../../mixins/subscribe-mixin";
 import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
-import type { EntityRegistryDisplayEntry } from "../../../devices/ha-config-device-page";
+import type { EntityRegistryEntryWithDisplayName } from "../../../devices/ha-config-device-page";
 
 @customElement("zha-device-card")
 class ZHADeviceCard extends SubscribeMixin(LitElement) {
@@ -34,7 +34,7 @@ class ZHADeviceCard extends SubscribeMixin(LitElement) {
     (
       deviceId: string,
       entities: EntityRegistryEntry[]
-    ): EntityRegistryDisplayEntry[] =>
+    ): EntityRegistryEntryWithDisplayName[] =>
       entities
         .filter((entity) => entity.device_id === deviceId)
         .map((entity) => ({

--- a/src/panels/config/integrations/integration-panels/zwave_js/add-node/dialog-zwave_js-add-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/add-node/dialog-zwave_js-add-node.ts
@@ -890,8 +890,6 @@ class DialogZWaveJSAddNode extends LitElement {
       this._step = "rename_device";
       const nameChanged = this._device.name !== this._deviceOptions?.name;
       if (nameChanged || this._deviceOptions?.area) {
-        const oldDeviceName = this._device.name;
-        const newDeviceName = this._deviceOptions!.name;
         try {
           await updateDeviceRegistryEntry(this.hass, this._device.id, {
             name_by_user: this._deviceOptions!.name,
@@ -899,8 +897,6 @@ class DialogZWaveJSAddNode extends LitElement {
           });
 
           if (nameChanged) {
-            // rename entities
-
             const entities = this._entities.filter(
               (entity) => entity.device_id === this._device!.id
             );
@@ -912,33 +908,14 @@ class DialogZWaveJSAddNode extends LitElement {
 
             await Promise.all(
               entities.map((entity) => {
-                const name = entity.name;
-                let newName: string | null | undefined;
                 const newEntityId = entityIdsMapping[entity.entity_id];
 
-                if (entity.has_entity_name && !entity.name) {
-                  newName = undefined;
-                } else if (
-                  entity.has_entity_name &&
-                  (entity.name === oldDeviceName ||
-                    entity.name === newDeviceName)
-                ) {
-                  // clear name if it matches the device name and it uses the device name (entity naming)
-                  newName = null;
-                } else if (name && name.includes(oldDeviceName)) {
-                  newName = name.replace(oldDeviceName, newDeviceName);
-                }
-
-                if (
-                  (newName === undefined && !newEntityId) ||
-                  newEntityId === entity.entity_id
-                ) {
+                if (!newEntityId || newEntityId === entity.entity_id) {
                   return undefined;
                 }
 
                 return updateEntityRegistryEntry(this.hass!, entity.entity_id, {
-                  name: newName || name,
-                  new_entity_id: newEntityId || undefined,
+                  new_entity_id: newEntityId,
                 });
               })
             );

--- a/src/panels/config/voice-assistants/entity-voice-settings.ts
+++ b/src/panels/config/voice-assistants/entity-voice-settings.ts
@@ -53,7 +53,7 @@ export class EntityVoiceSettings extends SubscribeMixin(LitElement) {
 
   @state() private _cloudStatus?: CloudStatus;
 
-  @state() private _aliases?: string[];
+  @state() private _aliases?: (string | null)[];
 
   @state() private _googleEntity?: GoogleEntity;
 
@@ -289,7 +289,9 @@ export class EntityVoiceSettings extends SubscribeMixin(LitElement) {
           </ha-alert>`
         : html`<ha-aliases-editor
             .hass=${this.hass}
-            .aliases=${this._aliases ?? this.entry.aliases}
+            .aliases=${(this._aliases ?? this.entry.aliases).filter(
+              (a): a is string => a !== null
+            )}
             @value-changed=${this._aliasesChanged}
             @blur=${this._saveAliases}
           ></ha-aliases-editor>`}
@@ -324,10 +326,13 @@ export class EntityVoiceSettings extends SubscribeMixin(LitElement) {
     if (!this._aliases) {
       return;
     }
+    const nullAliases = (this.entry?.aliases ?? []).filter((a) => a === null);
+    const stringAliases = this._aliases
+      .filter((a): a is string => a !== null)
+      .map((alias) => alias.trim())
+      .filter((alias) => alias);
     const result = await updateEntityRegistryEntry(this.hass, this.entityId, {
-      aliases: this._aliases
-        .map((alias) => alias.trim())
-        .filter((alias) => alias),
+      aliases: [...nullAliases, ...stringAliases],
     });
     fireEvent(this, "entity-entry-updated", result.entity_entry);
   }

--- a/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
+++ b/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
@@ -200,15 +200,19 @@ export class VoiceAssistantsExpose extends LitElement {
         ),
         sortable: true,
         filterable: true,
-        template: (entry) =>
-          entry.aliases.length === 0
+        template: (entry) => {
+          const aliases = entry.aliases.filter(
+            (a: string | null) => a !== null
+          );
+          return aliases.length === 0
             ? "-"
-            : entry.aliases.length === 1
-              ? entry.aliases[0]
+            : aliases.length === 1
+              ? aliases[0]
               : this.hass.localize(
                   "ui.panel.config.voice_assistants.expose.aliases",
-                  { count: entry.aliases.length }
-                ),
+                  { count: aliases.length }
+                );
+        },
       },
       remove: {
         title: "",

--- a/src/panels/lovelace/components/hui-entity-editor.ts
+++ b/src/panels/lovelace/components/hui-entity-editor.ts
@@ -40,8 +40,7 @@ export class HuiEntityEditor extends LitElement {
     const stateObj = this.hass.states[item.entity];
 
     const useDeviceName =
-      stateObj &&
-      entityUseDeviceName(stateObj, this.hass.entities, this.hass.devices);
+      stateObj && entityUseDeviceName(stateObj, this.hass.entities);
 
     const isRTL = computeRTL(this.hass);
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1677,6 +1677,7 @@
         "faq": "documentation",
         "editor": {
           "name": "Name",
+          "restore_name": "Restore default name",
           "icon": "Icon",
           "icon_error": "Icons should be in the format 'prefix:iconname', e.g. 'mdi:home'",
           "default_code": "Default code",

--- a/test/common/entity/compute_entity_name.test.ts
+++ b/test/common/entity/compute_entity_name.test.ts
@@ -76,6 +76,15 @@ describe("computeEntityEntryName", () => {
     expect(computeEntityEntryName(entry)).toBeUndefined();
   });
 
+  it("returns empty string if name is empty (does not fallback to original_name)", () => {
+    const entry = mockEntityEntry({
+      entity_id: "light.kitchen",
+      name: "",
+      original_name: "Old Name",
+    });
+    expect(computeEntityEntryName(entry)).toBe("");
+  });
+
   it("returns original_name if present", () => {
     const entry = mockEntityEntry({
       entity_id: "light.kitchen",

--- a/test/common/entity/compute_entity_name.test.ts
+++ b/test/common/entity/compute_entity_name.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import * as computeDeviceNameModule from "../../../src/common/entity/compute_device_name";
 import {
   computeEntityEntryName,
   computeEntityName,
 } from "../../../src/common/entity/compute_entity_name";
 import * as computeStateNameModule from "../../../src/common/entity/compute_state_name";
-import * as stripPrefixModule from "../../../src/common/entity/strip_prefix_from_entity_name";
 import type { HomeAssistant } from "../../../src/types";
 import {
   mockEntity,
@@ -25,11 +23,8 @@ describe("computeEntityName", () => {
     });
     const hass = {
       entities: {},
-      devices: {},
     } as unknown as HomeAssistant;
-    expect(computeEntityName(stateObj, hass.entities, hass.devices)).toBe(
-      "Kitchen Light"
-    );
+    expect(computeEntityName(stateObj, hass.entities)).toBe("Kitchen Light");
     vi.restoreAllMocks();
   });
 
@@ -47,77 +42,38 @@ describe("computeEntityName", () => {
           labels: [],
         },
       },
-      devices: {},
       states: {
         "light.kitchen": stateObj,
       },
     } as unknown as HomeAssistant;
-    expect(computeEntityName(stateObj, hass.entities, hass.devices)).toBe(
-      "Ceiling Light"
-    );
+    expect(computeEntityName(stateObj, hass.entities)).toBe("Ceiling Light");
   });
 });
 
 describe("computeEntityEntryName", () => {
-  it("returns entry.name if no device", () => {
+  it("returns entry.name if present", () => {
     const entry = mockEntity({
       entity_id: "light.kitchen",
       name: "Ceiling Light",
     });
-    const hass = { devices: {}, states: {} };
-    expect(computeEntityEntryName(entry, hass.devices)).toBe("Ceiling Light");
+    expect(computeEntityEntryName(entry)).toBe("Ceiling Light");
   });
 
-  it("returns device-stripped name if device present", () => {
-    vi.spyOn(computeDeviceNameModule, "computeDeviceName").mockReturnValue(
-      "Kitchen"
-    );
-    vi.spyOn(stripPrefixModule, "stripPrefixFromEntityName").mockImplementation(
-      (name, prefix) => name.replace(prefix + " ", "")
-    );
+  it("returns entity name as-is when device present", () => {
     const entry = mockEntity({
       entity_id: "light.kitchen",
-      name: "Kitchen Light",
+      name: "Light",
       device_id: "dev1",
     });
-    const hass = {
-      devices: { dev1: {} },
-      states: {},
-    } as unknown as HomeAssistant;
-    expect(computeEntityEntryName(entry, hass.devices)).toBe("Light");
-    vi.restoreAllMocks();
+    expect(computeEntityEntryName(entry)).toBe("Light");
   });
 
-  it("returns undefined if device name equals entity name", () => {
-    vi.spyOn(computeDeviceNameModule, "computeDeviceName").mockReturnValue(
-      "Kitchen Light"
-    );
+  it("returns undefined if entity has no name (uses device name)", () => {
     const entry = mockEntity({
       entity_id: "light.kitchen",
-      name: "Kitchen Light",
       device_id: "dev1",
     });
-    const hass = {
-      devices: { dev1: {} },
-      states: {},
-    } as unknown as HomeAssistant;
-    expect(computeEntityEntryName(entry, hass.devices)).toBeUndefined();
-    vi.restoreAllMocks();
-  });
-
-  it("falls back to state name if no name and no device", () => {
-    vi.spyOn(computeStateNameModule, "computeStateName").mockReturnValue(
-      "Fallback Name"
-    );
-    const entry = mockEntity({ entity_id: "light.kitchen" });
-    const hass = {
-      devices: {},
-    } as unknown as HomeAssistant;
-    const stateObj = mockStateObj({ entity_id: "light.kitchen" });
-    expect(computeEntityEntryName(entry, hass.devices, stateObj)).toBe(
-      "Fallback Name"
-    );
-    vi.restoreAllMocks();
+    expect(computeEntityEntryName(entry)).toBeUndefined();
   });
 
   it("returns original_name if present", () => {
@@ -125,27 +81,15 @@ describe("computeEntityEntryName", () => {
       entity_id: "light.kitchen",
       original_name: "Old Name",
     });
-    const hass = {
-      devices: {},
-      states: {},
-    } as unknown as HomeAssistant;
-    expect(computeEntityEntryName(entry, hass.devices)).toBe("Old Name");
+    expect(computeEntityEntryName(entry)).toBe("Old Name");
   });
 
-  it("returns undefined if no name, original_name, or device", () => {
+  it("returns undefined if no name or original_name", () => {
     const entry = mockEntity({ entity_id: "light.kitchen" });
-    const hass = {
-      devices: {},
-      states: {},
-    } as unknown as HomeAssistant;
-    expect(computeEntityEntryName(entry, hass.devices)).toBeUndefined();
+    expect(computeEntityEntryName(entry)).toBeUndefined();
   });
 
   it("handles entities with numeric original_name (real bug from issue #25363)", () => {
-    vi.spyOn(computeDeviceNameModule, "computeDeviceName").mockReturnValue(
-      "Texas Instruments CC2652"
-    );
-
     const entry = {
       entity_id: "sensor.texas_instruments_cc2652_2",
       name: null, // null name
@@ -153,37 +97,21 @@ describe("computeEntityEntryName", () => {
       device_id: "dev1",
       has_entity_name: true,
     };
-    const hass = {
-      devices: { dev1: {} },
-      states: {},
-    };
 
     // Should not throw an error and should return the stringified number
-    expect(() =>
-      computeEntityEntryName(entry as any, hass as any)
-    ).not.toThrow();
-    expect(computeEntityEntryName(entry as any, hass as any)).toBe("2");
-    vi.restoreAllMocks();
+    expect(() => computeEntityEntryName(entry as any)).not.toThrow();
+    expect(computeEntityEntryName(entry as any)).toBe("2");
   });
 
   it("returns undefined when entity has device but no name or original_name", () => {
-    vi.spyOn(computeDeviceNameModule, "computeDeviceName").mockReturnValue(
-      "Kitchen Device"
-    );
-
     const entry = {
       entity_id: "sensor.kitchen_sensor",
       // No name property
       // No original_name property
       device_id: "dev1",
     };
-    const hass = {
-      devices: { dev1: {} },
-      states: {},
-    };
 
     // Should return undefined to maintain function contract
-    expect(computeEntityEntryName(entry as any, hass as any)).toBeUndefined();
-    vi.restoreAllMocks();
+    expect(computeEntityEntryName(entry as any)).toBeUndefined();
   });
 });

--- a/test/common/entity/compute_entity_name_display.test.ts
+++ b/test/common/entity/compute_entity_name_display.test.ts
@@ -94,7 +94,6 @@ describe("computeEntityNameDisplay", () => {
       entities: {
         "light.kitchen": mockEntity({
           entity_id: "light.kitchen",
-          name: "Kitchen Device",
           device_id: "dev1",
         }),
       },
@@ -120,13 +119,12 @@ describe("computeEntityNameDisplay", () => {
     expect(result).toBe("Kitchen Device");
   });
 
-  it("does not replace entity with device when device is already included", () => {
+  it("does not duplicate device name when entity uses device name and device is included", () => {
     const stateObj = mockStateObj({ entity_id: "light.kitchen" });
     const hass = {
       entities: {
         "light.kitchen": mockEntity({
           entity_id: "light.kitchen",
-          name: "Kitchen Device",
           device_id: "dev1",
         }),
       },
@@ -149,8 +147,8 @@ describe("computeEntityNameDisplay", () => {
       hass.floors
     );
 
-    // Since entity name equals device name, entity returns undefined
-    // So we only get the device name
+    // Entity has no name (uses device name), device is already included
+    // So we only get the device name once
     expect(result).toBe("Kitchen Device");
   });
 


### PR DESCRIPTION
## Proposed change

Remove device dependency from `computeEntityName` and `computeEntityEntryName`. Entity names are now returned directly from the registry without stripping device name prefixes. Also simplifies the device entities card by removing the unnecessary extended entity registry fetch for disabled entities.

It will need rebase with https://github.com/home-assistant/frontend/pull/30138 is merged.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: https://github.com/home-assistant/core/pull/162763

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
