### PR TITLE
Show errors loading automation config

### DIFF
--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -674,6 +674,17 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
       this.config = normalizeAutomationConfig(config);
       this._checkValidation();
     } catch (err: any) {
+      if (err.status_code !== 404) {
+        await showAlertDialog(this, {
+          title: this.hass.localize(
+            "ui.panel.config.automation.editor.load_error_unknown",
+            { err_no: err.status_code }
+          ),
+          text: html`<pre>${err.body}</pre>`,
+        });
+        goBack("/config");
+        return;
+      }
       const entity = this._entityRegistry.find(
         (ent) =>
           ent.platform === "automation" && ent.unique_id === this.automationId
@@ -685,15 +696,9 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
         return;
       }
       await showAlertDialog(this, {
-        text:
-          err.status_code === 404
-            ? this.hass.localize(
-                "ui.panel.config.automation.editor.load_error_not_editable"
-              )
-            : this.hass.localize(
-                "ui.panel.config.automation.editor.load_error_unknown",
-                { err_no: err.status_code }
-              ),
+        text: this.hass.localize(
+          "ui.panel.config.automation.editor.load_error_not_editable"
+        ),
       });
       goBack("/config");
     }

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -678,9 +678,9 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
         await showAlertDialog(this, {
           title: this.hass.localize(
             "ui.panel.config.automation.editor.load_error_unknown",
-            { err_no: err.status_code }
+            { err_no: err.status_code ?? "unknown" }
           ),
-          text: html`<pre>${err.body}</pre>`,
+          text: html`<pre>${err.body?.message || err.error || err.body || "Unknown error"}</pre>`,
         });
         goBack("/config");
         return;

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -675,12 +675,14 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
       this._checkValidation();
     } catch (err: any) {
       if (err.status_code !== 404) {
+        const alertText =
+          err.body?.message || err.error || err.body || "Unknown error";
         await showAlertDialog(this, {
           title: this.hass.localize(
             "ui.panel.config.automation.editor.load_error_unknown",
             { err_no: err.status_code ?? "unknown" }
           ),
-          text: html`<pre>${err.body?.message || err.error || err.body || "Unknown error"}</pre>`,
+          text: html`<pre>${alertText}</pre>`,
         });
         goBack("/config");
         return;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
In https://github.com/home-assistant/core/issues/164468 we can see many users saying that all their automations display in read-only with the following banner, unexpectedly:

> "This automation cannot be edited from the UI, because it is not stored in the automations.yaml file, or doesn't have an ID."

This message is inaccurate, as the automation referenced _is_ stored in automations.yaml, and it _does_ have an ID. 

What is really happening here is that anytime the request to read the yaml to the server encounters an error, it throws and we default to displaying this message. Sometimes it throws because the above message is true (which returns a 404), and other times it throws for other reasons, e.g. use of `!secret` in the yaml. Even using !secret in just one automation is sufficient to break the visual editor for _all_ automations in this way. 

This is really hard to find as it doesn't really show up in an obvious error, and still passes the yaml validation check. 

Instead of taking these cases where we get a non-404 exception and displaying the automation with this message in read-only mode, I think it's easier for user if we just surface the exact error message instead of displaying the automation, then it may be easier to track down the issue. E.g.

<img width="1338" height="1027" alt="image" src="https://github.com/user-attachments/assets/4c161847-05eb-4cc7-8f5b-96edfe7c7df4" />

I understand this call stack is pretty ugly here, but I don't really have a better suggestion how to extract something nicer. It does at least explain the problem, which is that secrets are used in the automations.yaml. 

Script editor should have this well, maybe ideally merge it into the shared mixin, but that's a bit tricky due to multiple use of unique functions/strings/types which differ between script/automation in this section of code. Lets agree on this implementation first. 

Even looking in the system logs its pretty hard to figure this out, as the top level error looks extremely generic, it's not even obvious that this is related to automation editor

<img width="1198" height="161" alt="image" src="https://github.com/user-attachments/assets/d30d8ec3-0434-4581-8e49-0600c30b6500" />


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/164468
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
