### PR TITLE
Use explicit default name in entity name picker and lovelace cards

### DIFF
--- a/src/components/entity/ha-entity-name-picker.ts
+++ b/src/components/entity/ha-entity-name-picker.ts
@@ -6,7 +6,10 @@ import { repeat } from "lit/directives/repeat";
 import memoizeOne from "memoize-one";
 import { ensureArray } from "../../common/array/ensure-array";
 import { fireEvent } from "../../common/dom/fire_event";
-import type { EntityNameItem } from "../../common/entity/compute_entity_name_display";
+import {
+  DEFAULT_ENTITY_NAME,
+  type EntityNameItem,
+} from "../../common/entity/compute_entity_name_display";
 import { getEntityContext } from "../../common/entity/context/get_entity_context";
 import type { EntityNameType } from "../../common/translations/entity-state";
 import type { LocalizeKeys } from "../../common/translations/localize";
@@ -293,13 +296,13 @@ export class HaEntityNamePicker extends LitElement {
       }
       return [{ type: "text", text: value } satisfies EntityNameItem];
     }
-    return value ? ensureArray(value) : [];
+    return value ? ensureArray(value) : [...DEFAULT_ENTITY_NAME];
   });
 
   private _toValue = memoizeOne(
     (items: EntityNameItem[]): typeof this.value => {
       if (items.length === 0) {
-        return undefined;
+        return "";
       }
       if (items.length === 1) {
         const item = items[0];

--- a/src/panels/lovelace/common/entity/compute-lovelace-entity-name.ts
+++ b/src/panels/lovelace/common/entity/compute-lovelace-entity-name.ts
@@ -1,7 +1,9 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import { ensureArray } from "../../../../common/array/ensure-array";
-import type { EntityNameItem } from "../../../../common/entity/compute_entity_name_display";
-import { computeStateName } from "../../../../common/entity/compute_state_name";
+import {
+  DEFAULT_ENTITY_NAME,
+  type EntityNameItem,
+} from "../../../../common/entity/compute_entity_name_display";
 import type { HomeAssistant } from "../../../../types";
 
 /**
@@ -17,15 +19,14 @@ export const computeLovelaceEntityName = (
   stateObj: HassEntity | undefined,
   config: string | EntityNameItem | EntityNameItem[] | undefined
 ): string => {
-  // If no config is provided, fall back to the default state name
-  if (!config) {
-    return stateObj ? computeStateName(stateObj) : "";
-  }
-  if (typeof config !== "object") {
-    return String(config);
+  if (typeof config === "string") {
+    return config;
   }
   if (stateObj) {
-    return hass.formatEntityName(stateObj, config);
+    return hass.formatEntityName(stateObj, config ?? DEFAULT_ENTITY_NAME);
+  }
+  if (!config) {
+    return "";
   }
   // If entity is not found, fall back to text parts in config
   // This allows for static names even when the entity is missing

--- a/test/panels/lovelace/common/entity/compute-lovelace-entity-name.test.ts
+++ b/test/panels/lovelace/common/entity/compute-lovelace-entity-name.test.ts
@@ -22,7 +22,7 @@ describe("computeLovelaceEntityName", () => {
     expect(mockFormatEntityName).not.toHaveBeenCalled();
   });
 
-  it("return state name when nameConfig is empty string", () => {
+  it("returns empty string when nameConfig is empty string", () => {
     const mockFormatEntityName = vi.fn();
     const hass = createMockHass(mockFormatEntityName);
     const stateObj = mockStateObj({
@@ -32,11 +32,11 @@ describe("computeLovelaceEntityName", () => {
 
     const result = computeLovelaceEntityName(hass, stateObj, "");
 
-    expect(result).toBe("Kitchen Light");
+    expect(result).toBe("");
     expect(mockFormatEntityName).not.toHaveBeenCalled();
   });
 
-  it("return state name when nameConfig is undefined", () => {
+  it("calls formatEntityName with DEFAULT_ENTITY_NAME when nameConfig is undefined", () => {
     const mockFormatEntityName = vi.fn(() => "Formatted Name");
     const hass = createMockHass(mockFormatEntityName);
     const stateObj = mockStateObj({
@@ -46,8 +46,12 @@ describe("computeLovelaceEntityName", () => {
 
     const result = computeLovelaceEntityName(hass, stateObj, undefined);
 
-    expect(result).toBe("Kitchen Light");
-    expect(mockFormatEntityName).not.toHaveBeenCalled();
+    expect(result).toBe("Formatted Name");
+    expect(mockFormatEntityName).toHaveBeenCalledTimes(1);
+    expect(mockFormatEntityName).toHaveBeenCalledWith(stateObj, [
+      { type: "device" },
+      { type: "entity" },
+    ]);
   });
 
   it("calls formatEntityName with EntityNameItem config", () => {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The entity name picker (`ha-entity-name-picker`) now shows the default name composition (Device + Entity chips) when no custom name is configured, instead of showing an empty field. This helps users understand what the default entity name will look like and gives them a starting point to customize from.

Additionally, `computeLovelaceEntityName` now uses the same default (device + entity) format via `formatEntityName` when no name config is provided, ensuring consistent naming across lovelace cards and badges.
The default is now `device` + `entity` names instead of `friendly_name`. This will not be change because the frontend and the backend logic as been already updated with https://github.com/home-assistant/frontend/pull/30147.

## Screenshots

### Before
<img width="1002" height="369" alt="CleanShot 2026-03-17 at 15 27 16" src="https://github.com/user-attachments/assets/14c662d7-6594-4bc7-a25f-b85f78550dc3" />

### After
<img width="1001" height="368" alt="CleanShot 2026-03-17 at 15 14 04" src="https://github.com/user-attachments/assets/a6f0296c-c181-43b9-81c2-4cb7596f9082" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
