### PR TITLE
Fix tag dialog

### DIFF
--- a/src/panels/config/tags/dialog-tag-detail.ts
+++ b/src/panels/config/tags/dialog-tag-detail.ts
@@ -35,6 +35,8 @@ class DialogTagDetail
 
   @state() private _open = false;
 
+  @state() private _qrReady = false;
+
   public showDialog(params: TagDetailDialogParams): void {
     this._params = params;
     this._error = undefined;
@@ -45,6 +47,11 @@ class DialogTagDetail
       this._id = "";
       this._name = "";
     }
+
+    // Defer QR until dialog has had a chance to apply styles
+    requestAnimationFrame(() => {
+      this._qrReady = true;
+    });
   }
 
   public closeDialog(): boolean {
@@ -54,6 +61,7 @@ class DialogTagDetail
 
   private _dialogClosed() {
     this._params = undefined;
+    this._qrReady = false;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
@@ -125,13 +133,17 @@ class DialogTagDetail
                   </p>
                 </div>
                 <div id="qr">
-                  <ha-qr-code
-                    .data=${`${documentationUrl(this.hass, "/tag/")}${this._params!.entry!.id}`}
-                    center-image="/static/icons/favicon-192x192.png"
-                    error-correction-level="quartile"
-                    scale="5"
-                  >
-                  </ha-qr-code>
+                  ${this._qrReady
+                    ? html`
+                        <ha-qr-code
+                          .data=${`${documentationUrl(this.hass, "/tag/")}${this._params!.entry!.id}`}
+                          center-image="/static/icons/favicon-192x192.png"
+                          error-correction-level="quartile"
+                          scale="5"
+                        >
+                        </ha-qr-code>
+                      `
+                    : nothing}
                 </div>
               `
             : ``}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Since switch to wa-dialog, the tag dialog doesn't render the QR code. Something is off about the timing of wa-dialog as when the qr code component runs its first render pass our global custom css properties are not available, meaning colors can't be fetched and the QR code dies with an error about NaN colors. 


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/30173
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
