### PR TITLE
Propagate schema changes to existing form editor element

### DIFF
--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -38,10 +38,7 @@ import {
 } from "../common/has-changed";
 import { processConfigEntities } from "../common/process-config-entities";
 import type { LovelaceCard, LovelaceGridOptions } from "../types";
-import type {
-  MapCardConfig,
-  MapEntityConfig,
-} from "./types";
+import type { MapCardConfig, MapEntityConfig } from "./types";
 import {
   addEntityToCondition,
   checkConditionsMet,

--- a/src/panels/lovelace/editor/hui-element-editor.ts
+++ b/src/panels/lovelace/editor/hui-element-editor.ts
@@ -62,7 +62,7 @@ export abstract class HuiElementEditor<
 
   @state() private _config?: T;
 
-  @state() private _configElement?: LovelaceGenericElementEditor;
+  @state() protected _configElement?: LovelaceGenericElementEditor;
 
   @state() private _subElementEditorConfig?: SubElementEditorConfig;
 

--- a/src/panels/lovelace/editor/hui-form-element-editor.ts
+++ b/src/panels/lovelace/editor/hui-form-element-editor.ts
@@ -1,3 +1,4 @@
+import type { PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
 import type { HaFormSchema } from "../../../components/ha-form/types";
 import type { LovelaceConfigForm } from "../types";
@@ -9,6 +10,26 @@ export class HuiFormElementEditor extends HuiElementEditor {
 
   protected async getConfigForm(): Promise<LovelaceConfigForm | undefined> {
     return { schema: this.schema };
+  }
+
+  protected updated(changedProperties: PropertyValues): void {
+    super.updated(changedProperties);
+    if (
+      changedProperties.has("schema") &&
+      changedProperties.get("schema") !== undefined
+    ) {
+      // Schema changed after initial load — destroy the old form editor
+      // so loadConfigElement() recreates it with the new schema.
+      // This ensures dynamic schema changes (e.g. disabled flags toggled
+      // when the entity changes) are reflected in the rendered form.
+      this.unloadConfigElement();
+      const currentValue = this.value;
+      if (currentValue) {
+        // Spread to create a new reference so the value setter's
+        // deepEqual guard doesn't short-circuit.
+        this.value = { ...currentValue };
+      }
+    }
   }
 }
 

--- a/src/panels/lovelace/editor/hui-form-element-editor.ts
+++ b/src/panels/lovelace/editor/hui-form-element-editor.ts
@@ -2,6 +2,7 @@ import type { PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
 import type { HaFormSchema } from "../../../components/ha-form/types";
 import type { LovelaceConfigForm } from "../types";
+import type { HuiFormEditor } from "./config-elements/hui-form-editor";
 import { HuiElementEditor } from "./hui-element-editor";
 
 @customElement("hui-form-element-editor")
@@ -14,21 +15,11 @@ export class HuiFormElementEditor extends HuiElementEditor {
 
   protected updated(changedProperties: PropertyValues): void {
     super.updated(changedProperties);
-    if (
-      changedProperties.has("schema") &&
-      changedProperties.get("schema") !== undefined
-    ) {
-      // Schema changed after initial load — destroy the old form editor
-      // so loadConfigElement() recreates it with the new schema.
-      // This ensures dynamic schema changes (e.g. disabled flags toggled
-      // when the entity changes) are reflected in the rendered form.
-      this.unloadConfigElement();
-      const currentValue = this.value;
-      if (currentValue) {
-        // Spread to create a new reference so the value setter's
-        // deepEqual guard doesn't short-circuit.
-        this.value = { ...currentValue };
-      }
+    if (changedProperties.has("schema") && this._configElement) {
+      // Propagate schema changes directly to the existing form editor element
+      // so dynamic changes (e.g. disabled flags based on selected entity) are
+      // reflected without needing to tear down and recreate the editor.
+      (this._configElement as HuiFormEditor).schema = this.schema;
     }
   }
 }


### PR DESCRIPTION
## Proposed change

When a parent passes a new schema to `hui-form-element-editor` (e.g. with updated `disabled` flags after an entity selection changes), the internal `hui-form-editor` was not updated because `loadConfigElement()` returns early once the element already exists.

Fix: make `_configElement` `protected` in `HuiElementEditor` and add an `updated()` hook in `HuiFormElementEditor` that pushes the new schema directly onto the existing config element when it changes.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #29776
- This PR is related to issue or discussion: #29759
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr