### PR TITLE
Skip plotting state value on statistic graph if units mismatch

### DIFF
--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -27,6 +27,7 @@ import {
   getDisplayUnit,
   getStatisticLabel,
   getStatisticMetadata,
+  isExternalStatistic,
   statisticsHaveType,
 } from "../../data/recorder";
 import type { ECOption } from "../../resources/echarts/echarts";
@@ -628,8 +629,8 @@ export class StatisticsChart extends LitElement {
       // allow 10m of leeway for "now", because stats are 5 minute aggregated
       const isUpToNow = now.getTime() - endTime.getTime() <= 600000;
       if (isUpToNow) {
-        // Skip external statistics (they have ":" in the ID)
-        if (!statistic_id.includes(":")) {
+        // Skip external statistics
+        if (!isExternalStatistic(statistic_id)) {
           const stateObj = this.hass.states[statistic_id];
           if (stateObj) {
             const currentValue = parseFloat(stateObj.state);

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -544,7 +544,7 @@ export class StatisticsChart extends LitElement {
               (series as LineSeriesOption).areaStyle = undefined;
             } else {
               series.stackOrder = "seriesAsc";
-              if (drawBands && type === bandTop) {
+              if (type === bandTop) {
                 (series as LineSeriesOption).areaStyle = {
                   color: color + "3F",
                 };

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -405,13 +405,11 @@ export class StatisticsChart extends LitElement {
       statisticsData.forEach(([statistic_id, _stats]) => {
         const meta = statisticsMetaData?.[statistic_id];
         const statisticUnit = getDisplayUnit(this.hass, statistic_id, meta);
-        if (!this.unit) {
-          if (unit === undefined) {
-            unit = statisticUnit;
-          } else if (unit !== null && unit !== statisticUnit) {
-            // Clear unit if not all statistics have same unit
-            unit = null;
-          }
+        if (unit === undefined) {
+          unit = statisticUnit;
+        } else if (unit !== null && unit !== statisticUnit) {
+          // Clear unit if not all statistics have same unit
+          unit = null;
         }
       });
       if (unit) {

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -399,7 +399,25 @@ export class StatisticsChart extends LitElement {
       endTime = new Date();
     }
 
-    let unit: string | undefined | null;
+    // Try to determine chart unit if it has not already been set explicitly
+    if (!this.unit) {
+      let unit: string | undefined | null;
+      statisticsData.forEach(([statistic_id, _stats]) => {
+        const meta = statisticsMetaData?.[statistic_id];
+        const statisticUnit = getDisplayUnit(this.hass, statistic_id, meta);
+        if (!this.unit) {
+          if (unit === undefined) {
+            unit = statisticUnit;
+          } else if (unit !== null && unit !== statisticUnit) {
+            // Clear unit if not all statistics have same unit
+            unit = null;
+          }
+        }
+      });
+      if (unit) {
+        this.unit = unit;
+      }
+    }
 
     const names = this.names || {};
     statisticsData.forEach(([statistic_id, stats]) => {
@@ -407,18 +425,6 @@ export class StatisticsChart extends LitElement {
       let name = names[statistic_id];
       if (name === undefined) {
         name = getStatisticLabel(this.hass, statistic_id, meta);
-      }
-
-      if (!this.unit) {
-        if (unit === undefined) {
-          unit = getDisplayUnit(this.hass, statistic_id, meta);
-        } else if (
-          unit !== null &&
-          unit !== getDisplayUnit(this.hass, statistic_id, meta)
-        ) {
-          // Clear unit if not all statistics have same unit
-          unit = null;
-        }
       }
 
       // array containing [value1, value2, etc]
@@ -624,11 +630,17 @@ export class StatisticsChart extends LitElement {
         });
       }
 
-      // Append current state if viewing recent data
+      // Check if we need to display most recent data. Allow 10m of leeway for "now",
+      // because stats are 5 minute aggregated
       const now = new Date();
-      // allow 10m of leeway for "now", because stats are 5 minute aggregated
-      const isUpToNow = now.getTime() - endTime.getTime() <= 600000;
-      if (isUpToNow) {
+      const displayCurrentState = now.getTime() - endTime.getTime() <= 600000;
+
+      // Show current state if required, and units match (or are unknown)
+      const statisticUnit = getDisplayUnit(this.hass, statistic_id, meta);
+      if (
+        displayCurrentState &&
+        (!this.unit || !statisticUnit || this.unit === statisticUnit)
+      ) {
         // Skip external statistics
         if (!isExternalStatistic(statistic_id)) {
           const stateObj = this.hass.states[statistic_id];
@@ -670,10 +682,6 @@ export class StatisticsChart extends LitElement {
       Array.prototype.push.apply(totalDataSets, statDataSets);
       Array.prototype.push.apply(legendData, statLegendData);
     });
-
-    if (unit) {
-      this.unit = unit;
-    }
 
     legendData.forEach(({ id, name, color, borderColor }) => {
       // Add an empty series for the legend


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

For example plotting a *F sensor on a *C chart - statistic data will be converted to *C by the backend, but the state value will still be in *F so the displayed point is wrong. Similarly if plotting a kW sensor on a W chart, the same is true - statistics get converted to W by recorder, but the state value would still be in kW so again the plotted point is complete nonsense.

If the units of the statistic state don't match the units of the graph, we should therefore skip displaying the state value on the graph. 

Ideally we would do unit conversion, but I don't see a clean way to do this in the front end at the moment.

To accomplish this, pull the automatic calculation of chart unit out of the statistics iteration loop so that we know the final unit when it comes to adding in the state value.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Before - notice how the "state" point drops to "near" zero. This is because Device 1 Power kW is in a different unit to Device 1 Power. The actual statistic data was harmonised by recorder in the backend.

<img width="513" height="352" alt="image" src="https://github.com/user-attachments/assets/d05ed048-1a27-4b0b-992f-afa64a3d91e1" />

After - omit the faulty point, plotting only those whose state match the charts unit.

<img width="517" height="355" alt="image" src="https://github.com/user-attachments/assets/a7df697a-66ce-4976-ba07-bababc9c11b8" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/issues/29993#issuecomment-4084771362
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
