### PR TITLE
Add background color option to dashboard sections

### DIFF
--- a/src/components/ha-color-picker.ts
+++ b/src/components/ha-color-picker.ts
@@ -10,9 +10,12 @@ import type { LocalizeKeys } from "../common/translations/localize";
 import { localizeContext } from "../data/context";
 import type { UiColorExtraOption } from "../data/selector";
 import type { ValueChangedEvent } from "../types";
+import "./ha-combo-box-item";
 import "./ha-generic-picker";
+import "./ha-icon";
 import type { PickerComboBoxItem } from "./ha-picker-combo-box";
 import type { PickerValueRenderer } from "./ha-picker-field";
+import "./ha-svg-icon";
 
 @customElement("ha-color-picker")
 export class HaColorPicker extends LitElement {

--- a/src/components/ha-color-picker.ts
+++ b/src/components/ha-color-picker.ts
@@ -8,6 +8,7 @@ import { computeCssColor, THEME_COLORS } from "../common/color/compute-color";
 import { fireEvent } from "../common/dom/fire_event";
 import type { LocalizeKeys } from "../common/translations/localize";
 import { localizeContext } from "../data/context";
+import type { UiColorExtraOption } from "../data/selector";
 import type { ValueChangedEvent } from "../types";
 import "./ha-generic-picker";
 import type { PickerComboBoxItem } from "./ha-picker-combo-box";
@@ -30,7 +31,23 @@ export class HaColorPicker extends LitElement {
   @property({ type: Boolean, attribute: "include_none" })
   public includeNone = false;
 
+  @property({ attribute: false })
+  public extraOptions?: UiColorExtraOption[];
+
   @property({ type: Boolean }) public disabled = false;
+
+  private _extraOptionsColorMap = memoizeOne(
+    (extraOptions?: UiColorExtraOption[]) => {
+      if (!extraOptions) return undefined;
+      const map = new Map<string, string>();
+      for (const option of extraOptions) {
+        if (option.display_color) {
+          map.set(option.value, option.display_color);
+        }
+      }
+      return map.size > 0 ? map : undefined;
+    }
+  );
 
   @property({ type: Boolean }) public required = false;
 
@@ -71,6 +88,7 @@ export class HaColorPicker extends LitElement {
     const colors = this._getColors(
       this.includeNone,
       this.includeState,
+      this.extraOptions,
       this.defaultColor,
       this.value
     );
@@ -93,6 +111,7 @@ export class HaColorPicker extends LitElement {
     this._getColors(
       this.includeNone,
       this.includeState,
+      this.extraOptions,
       this.defaultColor,
       this.value
     );
@@ -101,6 +120,7 @@ export class HaColorPicker extends LitElement {
     (
       includeNone: boolean,
       includeState: boolean,
+      extraOptions: UiColorExtraOption[] | undefined,
       defaultColor: string | undefined,
       currentValue: string | undefined
     ): PickerComboBoxItem[] => {
@@ -132,6 +152,19 @@ export class HaColorPicker extends LitElement {
         });
       }
 
+      if (extraOptions) {
+        extraOptions.forEach((option) => {
+          items.push({
+            id: option.value,
+            primary: addDefaultSuffix(
+              option.label,
+              defaultColor === option.value
+            ),
+            ...(option.icon ? { icon: option.icon } : {}),
+          });
+        });
+      }
+
       Array.from(THEME_COLORS).forEach((color) => {
         const themeLabel =
           this.localize?.(
@@ -143,14 +176,11 @@ export class HaColorPicker extends LitElement {
         });
       });
 
-      const isSpecial =
-        currentValue === "none" ||
-        currentValue === "state" ||
-        THEME_COLORS.has(currentValue || "");
+      const knownIds = new Set(items.map((item) => item.id));
 
       const hasValue = currentValue && currentValue.length > 0;
 
-      if (hasValue && !isSpecial) {
+      if (hasValue && !knownIds.has(currentValue!)) {
         items.push({
           id: currentValue!,
           primary: currentValue!,
@@ -161,21 +191,27 @@ export class HaColorPicker extends LitElement {
     }
   );
 
+  private _renderItemIcon(item: PickerComboBoxItem) {
+    if (item.icon_path) {
+      return html`<ha-svg-icon
+        slot="start"
+        .path=${item.icon_path}
+      ></ha-svg-icon>`;
+    }
+    if (item.icon) {
+      return html`<ha-icon slot="start" .icon=${item.icon}></ha-icon>`;
+    }
+    const color =
+      this._extraOptionsColorMap(this.extraOptions)?.get(item.id) ?? item.id;
+    return html`<span slot="start">${this._renderColorCircle(color)}</span>`;
+  }
+
   private _rowRenderer: (
     item: PickerComboBoxItem,
     index?: number
   ) => ReturnType<typeof html> = (item) => html`
     <ha-combo-box-item type="button" compact>
-      ${item.id === "none"
-        ? html`<ha-svg-icon
-            slot="start"
-            .path=${mdiInvertColorsOff}
-          ></ha-svg-icon>`
-        : item.id === "state"
-          ? html`<ha-svg-icon slot="start" .path=${mdiPalette}></ha-svg-icon>`
-          : html`<span slot="start">
-              ${this._renderColorCircle(item.id)}
-            </span>`}
+      ${this._renderItemIcon(item)}
       <span slot="headline">${item.primary}</span>
       ${item.secondary
         ? html`<span slot="supporting-text">${item.secondary}</span>`
@@ -201,13 +237,23 @@ export class HaColorPicker extends LitElement {
       `;
     }
 
+    const extraOption = this.extraOptions?.find((o) => o.value === value);
+    const label =
+      extraOption?.label ||
+      this.localize?.(
+        `ui.components.color-picker.colors.${value}` as LocalizeKeys
+      ) ||
+      value;
+
+    const color =
+      this._extraOptionsColorMap(this.extraOptions)?.get(value) ?? value;
+    const startSlot = extraOption?.icon
+      ? html`<ha-icon slot="start" .icon=${extraOption.icon}></ha-icon>`
+      : html`<span slot="start">${this._renderColorCircle(color)}</span>`;
+
     return html`
-      <span slot="start">${this._renderColorCircle(value)}</span>
-      <span slot="headline">
-        ${this.localize?.(
-          `ui.components.color-picker.colors.${value}` as LocalizeKeys
-        ) || value}
-      </span>
+      ${startSlot}
+      <span slot="headline">${label}</span>
     `;
   };
 

--- a/src/components/ha-selector/ha-selector-ui-color.ts
+++ b/src/components/ha-selector/ha-selector-ui-color.ts
@@ -30,6 +30,7 @@ export class HaSelectorUiColor extends LitElement {
         .includeNone=${this.selector.ui_color?.include_none}
         .includeState=${this.selector.ui_color?.include_state}
         .defaultColor=${this.selector.ui_color?.default_color}
+        .extraOptions=${this.selector.ui_color?.extra_options}
         @value-changed=${this._valueChanged}
       ></ha-color-picker>
     `;

--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -2,7 +2,7 @@ import type { Condition } from "../../../panels/lovelace/common/validate-conditi
 import type { LovelaceCardConfig } from "./card";
 import type { LovelaceStrategyConfig } from "./strategy";
 
-export const DEFAULT_SECTION_BACKGROUND_OPACITY = 40;
+export const DEFAULT_SECTION_BACKGROUND_OPACITY = 50;
 
 export interface LovelaceSectionBackgroundConfig {
   color?: string;

--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -2,11 +2,19 @@ import type { Condition } from "../../../panels/lovelace/common/validate-conditi
 import type { LovelaceCardConfig } from "./card";
 import type { LovelaceStrategyConfig } from "./strategy";
 
+export const DEFAULT_SECTION_BACKGROUND_OPACITY = 40;
+
+export interface LovelaceSectionBackgroundConfig {
+  color?: string;
+  opacity?: number;
+}
+
 export interface LovelaceBaseSectionConfig {
   visibility?: Condition[];
   disabled?: boolean;
   column_span?: number;
   row_span?: number;
+  background?: LovelaceSectionBackgroundConfig;
   /**
    * @deprecated Use heading card instead.
    */

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -507,11 +507,19 @@ export interface UiActionSelector {
   } | null;
 }
 
+export interface UiColorExtraOption {
+  value: string;
+  label: string;
+  icon?: string;
+  display_color?: string;
+}
+
 export interface UiColorSelector {
   ui_color: {
     default_color?: string;
     include_none?: boolean;
     include_state?: boolean;
+    extra_options?: UiColorExtraOption[];
   } | null;
 }
 

--- a/src/panels/lovelace/components/hui-badge-edit-mode.ts
+++ b/src/panels/lovelace/components/hui-badge-edit-mode.ts
@@ -220,7 +220,7 @@ export class HuiBadgeEditMode extends LitElement {
     showEditBadgeDialog(this, {
       lovelaceConfig: this.lovelace!.config,
       saveConfig: this.lovelace!.saveConfig,
-      path: containerPath,
+      path: containerPath as [number],
       badgeConfig,
     });
   }

--- a/src/panels/lovelace/components/hui-section-edit-mode.ts
+++ b/src/panels/lovelace/components/hui-section-edit-mode.ts
@@ -118,8 +118,8 @@ export class HuiSectionEditMode extends LitElement {
           justify-content: center;
           transition: opacity 0.2s ease-in-out;
           border-radius: var(
-            --ha-card-border-radius,
-            var(--ha-border-radius-lg)
+            --ha-section-border-radius,
+            var(--ha-border-radius-xl)
           );
           border-bottom-left-radius: 0px;
           border-bottom-right-radius: 0px;
@@ -137,8 +137,8 @@ export class HuiSectionEditMode extends LitElement {
         .section-wrapper {
           padding: 8px;
           border-radius: var(
-            --ha-card-border-radius,
-            var(--ha-border-radius-lg)
+            --ha-section-border-radius,
+            var(--ha-border-radius-xl)
           );
           border-start-end-radius: 0;
           border: 2px dashed var(--divider-color);

--- a/src/panels/lovelace/editor/badge-editor/show-create-badge-dialog.ts
+++ b/src/panels/lovelace/editor/badge-editor/show-create-badge-dialog.ts
@@ -1,11 +1,10 @@
 import { fireEvent } from "../../../../common/dom/fire_event";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
-import type { LovelaceContainerPath } from "../lovelace-path";
 
 export interface CreateBadgeDialogParams {
   lovelaceConfig: LovelaceConfig;
   saveConfig: (config: LovelaceConfig) => void;
-  path: LovelaceContainerPath;
+  path: [number];
   suggestedBadges?: string[];
   entities?: string[]; // We can pass entity id's that will be added to the config when a badge is picked
 }

--- a/src/panels/lovelace/editor/badge-editor/show-edit-badge-dialog.ts
+++ b/src/panels/lovelace/editor/badge-editor/show-edit-badge-dialog.ts
@@ -1,12 +1,11 @@
 import { fireEvent } from "../../../../common/dom/fire_event";
 import type { LovelaceBadgeConfig } from "../../../../data/lovelace/config/badge";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
-import type { LovelaceContainerPath } from "../lovelace-path";
 
 export type EditBadgeDialogParams = {
   lovelaceConfig: LovelaceConfig;
   saveConfig: (config: LovelaceConfig) => void;
-  path: LovelaceContainerPath;
+  path: [number];
 } & (
   | {
       badgeIndex: number;

--- a/src/panels/lovelace/editor/lovelace-path.ts
+++ b/src/panels/lovelace/editor/lovelace-path.ts
@@ -51,7 +51,7 @@ interface FindLovelaceContainer {
     path: LovelaceContainerPath
   ): LovelaceViewRawConfig | LovelaceSectionRawConfig;
 }
-export const findLovelaceContainer: FindLovelaceContainer = (
+export const findLovelaceContainer: FindLovelaceContainer = ((
   config: LovelaceConfig,
   path: LovelaceContainerPath
 ): LovelaceViewRawConfig | LovelaceSectionRawConfig => {
@@ -75,7 +75,7 @@ export const findLovelaceContainer: FindLovelaceContainer = (
     throw new Error("Section does not exist");
   }
   return section;
-};
+}) as FindLovelaceContainer;
 
 export const updateLovelaceContainer = (
   config: LovelaceConfig,
@@ -90,7 +90,7 @@ export const updateLovelaceContainer = (
 
     if (sectionIndex === undefined) {
       updated = true;
-      return containerConfig;
+      return containerConfig as LovelaceViewRawConfig;
     }
 
     if (isStrategyView(view)) {
@@ -104,7 +104,7 @@ export const updateLovelaceContainer = (
     const newSections = view.sections.map((section, sIndex) => {
       if (sIndex !== sectionIndex) return section;
       updated = true;
-      return containerConfig;
+      return containerConfig as LovelaceSectionRawConfig;
     });
     return {
       ...view,

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -1,3 +1,4 @@
+import { mdiPalette } from "@mdi/js";
 import { LitElement, html } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -7,12 +8,19 @@ import type {
   SchemaUnion,
 } from "../../../../components/ha-form/types";
 import "../../../../components/ha-form/ha-form";
-import type { LovelaceSectionRawConfig } from "../../../../data/lovelace/config/section";
+import {
+  DEFAULT_SECTION_BACKGROUND_OPACITY,
+  type LovelaceSectionRawConfig,
+} from "../../../../data/lovelace/config/section";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
 import type { HomeAssistant } from "../../../../types";
 
 interface SettingsData {
   column_span?: number;
+  background_enabled?: boolean;
+  background_color?: string;
+  background_opacity?: number;
 }
 
 @customElement("hui-section-settings-editor")
@@ -24,7 +32,7 @@ export class HuiDialogEditSection extends LitElement {
   @property({ attribute: false }) public viewConfig!: LovelaceViewConfig;
 
   private _schema = memoizeOne(
-    (maxColumns: number) =>
+    (maxColumns: number, backgroundEnabled: boolean, localize: LocalizeFunc) =>
       [
         {
           name: "column_span",
@@ -36,15 +44,71 @@ export class HuiDialogEditSection extends LitElement {
             },
           },
         },
+        {
+          name: "background_enabled",
+          selector: { boolean: {} },
+        },
+        ...(backgroundEnabled
+          ? ([
+              {
+                name: "background",
+                type: "expandable",
+                flatten: true,
+                expanded: true,
+                iconPath: mdiPalette,
+                schema: [
+                  {
+                    name: "background_color",
+                    selector: {
+                      ui_color: {
+                        extra_options: [
+                          {
+                            value: "default",
+                            label: localize(
+                              "ui.panel.lovelace.editor.edit_section.settings.background_color_default"
+                            ),
+                            display_color:
+                              "var(--ha-section-background-color, var(--secondary-background-color))",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  {
+                    name: "background_opacity",
+                    selector: {
+                      number: {
+                        min: 0,
+                        max: 100,
+                        step: 1,
+                        unit_of_measurement: "%",
+                        mode: "slider",
+                      },
+                    },
+                  },
+                ],
+              },
+            ] as const satisfies readonly HaFormSchema[])
+          : []),
       ] as const satisfies HaFormSchema[]
   );
 
   render() {
+    const backgroundEnabled = this.config.background !== undefined;
+
     const data: SettingsData = {
       column_span: this.config.column_span || 1,
+      background_enabled: backgroundEnabled,
+      background_color: this.config.background?.color ?? "default",
+      background_opacity:
+        this.config.background?.opacity ?? DEFAULT_SECTION_BACKGROUND_OPACITY,
     };
 
-    const schema = this._schema(this.viewConfig.max_columns || 4);
+    const schema = this._schema(
+      this.viewConfig.max_columns || 4,
+      backgroundEnabled,
+      this.hass.localize
+    );
 
     return html`
       <ha-form
@@ -80,6 +144,18 @@ export class HuiDialogEditSection extends LitElement {
       ...this.config,
       column_span: newData.column_span,
     };
+
+    if (newData.background_enabled) {
+      newConfig.background = {
+        ...(newData.background_color && newData.background_color !== "default"
+          ? { color: newData.background_color }
+          : {}),
+        opacity:
+          newData.background_opacity ?? DEFAULT_SECTION_BACKGROUND_OPACITY,
+      };
+    } else {
+      delete newConfig.background;
+    }
 
     fireEvent(this, "value-changed", { value: newConfig });
   }

--- a/src/panels/lovelace/sections/hui-section-background.ts
+++ b/src/panels/lovelace/sections/hui-section-background.ts
@@ -1,0 +1,49 @@
+import { css, LitElement, nothing } from "lit";
+import type { PropertyValues } from "lit";
+import { customElement, property } from "lit/decorators";
+import { computeCssColor } from "../../../common/color/compute-color";
+import {
+  DEFAULT_SECTION_BACKGROUND_OPACITY,
+  type LovelaceSectionBackgroundConfig,
+} from "../../../data/lovelace/config/section";
+
+@customElement("hui-section-background")
+export class HuiSectionBackground extends LitElement {
+  @property({ attribute: false })
+  public background?: LovelaceSectionBackgroundConfig;
+
+  protected render() {
+    return nothing;
+  }
+
+  protected willUpdate(changedProperties: PropertyValues<this>) {
+    super.willUpdate(changedProperties);
+    if (changedProperties.has("background") && this.background) {
+      const color = this.background.color
+        ? computeCssColor(this.background.color)
+        : "var(--ha-section-background-color, var(--secondary-background-color))";
+      this.style.setProperty("--section-background", color);
+      const opacity =
+        this.background.opacity ?? DEFAULT_SECTION_BACKGROUND_OPACITY;
+      this.style.setProperty("--section-background-opacity", `${opacity}%`);
+    }
+  }
+
+  static styles = css`
+    :host {
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background-color: var(--section-background, none);
+      opacity: var(--section-background-opacity, 100%);
+      z-index: 0;
+      pointer-events: none;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-section-background": HuiSectionBackground;
+  }
+}

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -1,6 +1,7 @@
-import type {
-  LovelaceSectionConfig,
-  LovelaceStrategySectionConfig,
+import {
+  isStrategySection,
+  type LovelaceSectionConfig,
+  type LovelaceStrategySectionConfig,
 } from "../../../data/lovelace/config/section";
 import type { LovelaceStrategyConfig } from "../../../data/lovelace/config/strategy";
 import type {
@@ -255,7 +256,7 @@ export const expandLovelaceConfigStrategies = async (
       if (newView.sections) {
         newView.sections = await Promise.all(
           newView.sections.map(async (section) => {
-            const newSection = isStrategyView(section)
+            const newSection = isStrategySection(section)
               ? await generateLovelaceSectionStrategy(section, hass)
               : { ...section };
             return newSection;

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -28,6 +28,7 @@ import {
   parseLovelaceCardPath,
 } from "../editor/lovelace-path";
 import type { HuiSection } from "../sections/hui-section";
+import "../sections/hui-section-background";
 import type { Lovelace } from "../types";
 import { generateDefaultSection } from "./default-section";
 import "./hui-view-footer";
@@ -164,6 +165,11 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
     const contentColumnCount =
       hasSidebar && !this.narrow ? Math.max(1, columnCount - 1) : columnCount;
 
+    const sectionNeedsMargin = this._computeSectionsWithBackgroundAlignment(
+      sections,
+      contentColumnCount
+    );
+
     return html`
       <div
         class="wrapper ${classMap({
@@ -230,15 +236,14 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
                   const rowSpan = section.config.row_span || 1;
 
                   return html`
-                <div
-                  class="section"
-                  style=${styleMap({
-                    "--column-span": columnSpan,
-                    "--row-span": rowSpan,
-                  })}
-                >
-                    ${
-                      editMode
+                    <div
+                      class="section"
+                      style=${styleMap({
+                        "--column-span": columnSpan,
+                        "--row-span": rowSpan,
+                      })}
+                    >
+                      ${editMode
                         ? html`
                             <hui-section-edit-mode
                               .hass=${this.hass}
@@ -246,14 +251,18 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
                               .index=${idx}
                               .viewIndex=${this.index}
                             >
-                              ${section}
+                              ${this._renderSection(
+                                section,
+                                sectionNeedsMargin.has(idx)
+                              )}
                             </hui-section-edit-mode>
                           `
-                        : section
-                    }
-                  </div>
-                </div>
-              `;
+                        : this._renderSection(
+                            section,
+                            sectionNeedsMargin.has(idx)
+                          )}
+                    </div>
+                  `;
                 }
               )}
               ${editMode
@@ -387,6 +396,66 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
     })
   );
 
+  private _renderSection(section: HuiSection, alignBackground: boolean) {
+    const hasBackground = section.config.background !== undefined;
+
+    return html`
+      <div
+        class="section-container ${classMap({
+          "has-background": hasBackground,
+          "align-background": alignBackground,
+        })}"
+      >
+        ${hasBackground
+          ? html`<hui-section-background
+              .background=${section.config.background}
+            ></hui-section-background>`
+          : nothing}
+        ${section}
+      </div>
+    `;
+  }
+
+  private _computeSectionsWithBackgroundAlignment(
+    sections: HuiSection[],
+    columnCount: number
+  ): Set<number> {
+    const needsMargin = new Set<number>();
+    if (columnCount <= 1) return needsMargin;
+    let rowColumns = 0;
+    let rowHasBackground = false;
+    let rowIndices: number[] = [];
+
+    const flushRow = () => {
+      if (rowHasBackground) {
+        for (const i of rowIndices) {
+          if (sections[i].config.background === undefined) {
+            needsMargin.add(i);
+          }
+        }
+      }
+      rowColumns = 0;
+      rowIndices = [];
+      rowHasBackground = false;
+    };
+
+    sections.forEach((section, idx) => {
+      if (section.hidden) return;
+      const span = Math.min(section.config.column_span || 1, columnCount);
+      if (rowColumns + span > columnCount) {
+        flushRow();
+      }
+      rowColumns += span;
+      rowIndices.push(idx);
+      if (section.config.background !== undefined) {
+        rowHasBackground = true;
+      }
+    });
+    flushRow();
+
+    return needsMargin;
+  }
+
   private _createSection(): void {
     const newConfig = addSection(
       this.lovelace!.config,
@@ -495,6 +564,20 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
 
     .section:has(hui-section[hidden]) {
       display: none;
+    }
+
+    .section-container {
+      position: relative;
+    }
+
+    .section-container.has-background {
+      padding: var(--ha-space-2);
+      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+    }
+
+    .section-container.align-background {
+      margin-top: var(--ha-space-2);
+      margin-bottom: var(--ha-space-2);
     }
 
     .container {

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -30,6 +30,7 @@ import {
 import type { HuiSection } from "../sections/hui-section";
 import "../sections/hui-section-background";
 import type { Lovelace } from "../types";
+import { computeSectionsBackgroundAlignment } from "./sections-background-alignment";
 import { generateDefaultSection } from "./default-section";
 import "./hui-view-footer";
 import "./hui-view-header";
@@ -165,7 +166,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
     const contentColumnCount =
       hasSidebar && !this.narrow ? Math.max(1, columnCount - 1) : columnCount;
 
-    const sectionNeedsMargin = this._computeSectionsWithBackgroundAlignment(
+    const sectionNeedsMargin = computeSectionsBackgroundAlignment(
       sections,
       contentColumnCount
     );
@@ -414,46 +415,6 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
         ${section}
       </div>
     `;
-  }
-
-  private _computeSectionsWithBackgroundAlignment(
-    sections: HuiSection[],
-    columnCount: number
-  ): Set<number> {
-    const needsMargin = new Set<number>();
-    if (columnCount <= 1) return needsMargin;
-    let rowColumns = 0;
-    let rowHasBackground = false;
-    let rowIndices: number[] = [];
-
-    const flushRow = () => {
-      if (rowHasBackground) {
-        for (const i of rowIndices) {
-          if (sections[i].config.background === undefined) {
-            needsMargin.add(i);
-          }
-        }
-      }
-      rowColumns = 0;
-      rowIndices = [];
-      rowHasBackground = false;
-    };
-
-    sections.forEach((section, idx) => {
-      if (section.hidden) return;
-      const span = Math.min(section.config.column_span || 1, columnCount);
-      if (rowColumns + span > columnCount) {
-        flushRow();
-      }
-      rowColumns += span;
-      rowIndices.push(idx);
-      if (section.config.background !== undefined) {
-        rowHasBackground = true;
-      }
-    });
-    flushRow();
-
-    return needsMargin;
   }
 
   private _createSection(): void {

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -518,7 +518,10 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
     }
 
     .section {
-      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      border-radius: var(
+        --ha-section-border-radius,
+        var(--ha-border-radius-xl)
+      );
       grid-column: span var(--column-span);
       grid-row: span var(--row-span);
     }
@@ -533,7 +536,10 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
 
     .section-container.has-background {
       padding: var(--ha-space-2);
-      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      border-radius: var(
+        --ha-section-border-radius,
+        var(--ha-border-radius-xl)
+      );
     }
 
     .section-container.align-background {
@@ -657,7 +663,10 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
       outline: none;
       background: none;
       cursor: pointer;
-      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      border-radius: var(
+        --ha-section-border-radius,
+        var(--ha-border-radius-xl)
+      );
       border: 2px dashed var(--primary-color);
       height: calc(var(--row-height) + 2 * (var(--row-gap) + 2px));
       padding: 8px;
@@ -682,7 +691,10 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
       outline: none;
       background: none;
       cursor: pointer;
-      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      border-radius: var(
+        --ha-section-border-radius,
+        var(--ha-border-radius-xl)
+      );
       border: 2px dashed var(--primary-color);
       order: 1;
       height: calc(var(--row-height) + 2 * (var(--row-gap) + 2px));
@@ -699,7 +711,10 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
     }
 
     .sortable-ghost {
-      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      border-radius: var(
+        --ha-section-border-radius,
+        var(--ha-border-radius-xl)
+      );
     }
 
     hui-view-header {

--- a/src/panels/lovelace/views/hui-view-footer.ts
+++ b/src/panels/lovelace/views/hui-view-footer.ts
@@ -253,7 +253,10 @@ export class HuiViewFooter extends LitElement {
 
     .container.edit-mode {
       padding: var(--ha-space-2);
-      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      border-radius: var(
+        --ha-section-border-radius,
+        var(--ha-border-radius-xl)
+      );
       border: 2px dashed var(--divider-color);
       border-start-end-radius: 0;
     }
@@ -295,7 +298,10 @@ export class HuiViewFooter extends LitElement {
       align-items: center;
       justify-content: center;
       transition: opacity 0.2s ease-in-out;
-      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      border-radius: var(
+        --ha-section-border-radius,
+        var(--ha-border-radius-xl)
+      );
       border-bottom-left-radius: 0px;
       border-bottom-right-radius: 0px;
       background: var(--secondary-background-color);
@@ -317,7 +323,10 @@ export class HuiViewFooter extends LitElement {
       height: 36px;
       padding: 6px 20px 6px 20px;
       box-sizing: border-box;
-      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      border-radius: var(
+        --ha-section-border-radius,
+        var(--ha-border-radius-xl)
+      );
       background-color: transparent;
       border-width: 2px;
       border-style: dashed;

--- a/src/panels/lovelace/views/hui-view-header.ts
+++ b/src/panels/lovelace/views/hui-view-header.ts
@@ -314,7 +314,10 @@ export class HuiViewHeader extends LitElement {
       align-items: center;
       justify-content: center;
       transition: opacity 0.2s ease-in-out;
-      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      border-radius: var(
+        --ha-section-border-radius,
+        var(--ha-border-radius-xl)
+      );
       border-bottom-left-radius: 0px;
       border-bottom-right-radius: 0px;
       background: var(--secondary-background-color);
@@ -449,7 +452,10 @@ export class HuiViewHeader extends LitElement {
 
     .container.edit-mode {
       padding: 8px;
-      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      border-radius: var(
+        --ha-section-border-radius,
+        var(--ha-border-radius-xl)
+      );
       border: 2px dashed var(--divider-color);
       border-start-end-radius: 0;
     }
@@ -469,7 +475,10 @@ export class HuiViewHeader extends LitElement {
       padding: 6px 20px 6px 20px;
       box-sizing: border-box;
       width: auto;
-      border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg));
+      border-radius: var(
+        --ha-section-border-radius,
+        var(--ha-border-radius-xl)
+      );
       background-color: transparent;
       border-width: 2px;
       border-style: dashed;

--- a/src/panels/lovelace/views/sections-background-alignment.ts
+++ b/src/panels/lovelace/views/sections-background-alignment.ts
@@ -1,0 +1,59 @@
+import type { HuiSection } from "../sections/hui-section";
+
+/**
+ * Determines which sections without a background need vertical margin
+ * to align with adjacent sections that have a background (and padding).
+ *
+ * Simulates CSS grid row placement by accumulating column spans.
+ * For each row, if any section has a background, the sections without
+ * a background in that row need margin to compensate for the padding
+ * added by the background.
+ */
+export function computeSectionsBackgroundAlignment(
+  sections: HuiSection[],
+  columnCount: number
+): Set<number> {
+  const sectionsNeedingMargin = new Set<number>();
+
+  // Single column layout never has side-by-side sections
+  if (columnCount <= 1) return sectionsNeedingMargin;
+
+  // Group visible sections into rows by accumulating column spans
+  const rows: { indices: number[]; hasBackground: boolean }[] = [];
+  let currentRow = { indices: [] as number[], hasBackground: false };
+  let columnsUsed = 0;
+
+  for (let idx = 0; idx < sections.length; idx++) {
+    const section = sections[idx];
+    if (section.hidden) continue;
+
+    const span = Math.min(section.config.column_span || 1, columnCount);
+
+    // Start a new row if this section doesn't fit
+    if (columnsUsed + span > columnCount) {
+      rows.push(currentRow);
+      currentRow = { indices: [], hasBackground: false };
+      columnsUsed = 0;
+    }
+
+    columnsUsed += span;
+    currentRow.indices.push(idx);
+
+    if (section.config.background !== undefined) {
+      currentRow.hasBackground = true;
+    }
+  }
+  rows.push(currentRow);
+
+  // Mark sections without background in rows that contain a background section
+  for (const row of rows) {
+    if (!row.hasBackground) continue;
+    for (const idx of row.indices) {
+      if (sections[idx].config.background === undefined) {
+        sectionsNeedingMargin.add(idx);
+      }
+    }
+  }
+
+  return sectionsNeedingMargin;
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8732,7 +8732,13 @@
             "edit_yaml": "[%key:ui::panel::lovelace::editor::edit_view::edit_yaml%]",
             "settings": {
               "column_span": "Width",
-              "column_span_helper": "Larger sections will be made smaller to fit the display. (e.g. on mobile devices)"
+              "column_span_helper": "Larger sections will be made smaller to fit the display. (e.g. on mobile devices)",
+              "background": "Background options",
+              "background_enabled": "Background",
+              "background_enabled_helper": "Display a colored background behind the section",
+              "background_color": "Color",
+              "background_color_default": "Default",
+              "background_opacity": "Opacity"
             },
             "visibility": {
               "explanation": "The section will be shown when ALL conditions below are fulfilled. If no conditions are set, the section will always be shown."

--- a/test/panels/lovelace/views/sections-background-alignment.test.ts
+++ b/test/panels/lovelace/views/sections-background-alignment.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import type { HuiSection } from "../../../../src/panels/lovelace/sections/hui-section";
+import { computeSectionsBackgroundAlignment } from "../../../../src/panels/lovelace/views/sections-background-alignment";
+
+function mockSection(
+  opts: {
+    background?: {};
+    column_span?: number;
+    hidden?: boolean;
+  } = {}
+): HuiSection {
+  return {
+    hidden: opts.hidden ?? false,
+    config: {
+      background: opts.background,
+      column_span: opts.column_span,
+    },
+  } as unknown as HuiSection;
+}
+
+describe("computeSectionsBackgroundAlignment", () => {
+  it("returns empty set for single column layout", () => {
+    const sections = [mockSection(), mockSection({ background: {} })];
+    const result = computeSectionsBackgroundAlignment(sections, 1);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty set when no sections have background", () => {
+    const sections = [mockSection(), mockSection(), mockSection()];
+    const result = computeSectionsBackgroundAlignment(sections, 2);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty set when all sections have background", () => {
+    const sections = [
+      mockSection({ background: {} }),
+      mockSection({ background: {} }),
+    ];
+    const result = computeSectionsBackgroundAlignment(sections, 2);
+    expect(result.size).toBe(0);
+  });
+
+  it("marks section without background on same row as one with background", () => {
+    const sections = [mockSection(), mockSection({ background: {} })];
+    const result = computeSectionsBackgroundAlignment(sections, 2);
+    expect(result.has(0)).toBe(true);
+    expect(result.has(1)).toBe(false);
+  });
+
+  it("does not mark sections on different rows", () => {
+    // Row 1: section 0 (no bg), Row 2: section 1 (bg)
+    const sections = [mockSection(), mockSection({ background: {} })];
+    const result = computeSectionsBackgroundAlignment(sections, 1);
+    expect(result.size).toBe(0);
+  });
+
+  it("handles column_span correctly", () => {
+    // 4 columns: section 0 (span 2, no bg) + section 1 (span 2, bg) = row 1
+    // section 2 (span 1, no bg) = row 2
+    const sections = [
+      mockSection({ column_span: 2 }),
+      mockSection({ column_span: 2, background: {} }),
+      mockSection(),
+    ];
+    const result = computeSectionsBackgroundAlignment(sections, 4);
+    expect(result.has(0)).toBe(true);
+    expect(result.has(1)).toBe(false);
+    expect(result.has(2)).toBe(false);
+  });
+
+  it("wraps to new row when column_span exceeds remaining space", () => {
+    // 2 columns: section 0 (span 1, bg) on row 1, section 1 (span 2, no bg) on row 2
+    const sections = [
+      mockSection({ background: {} }),
+      mockSection({ column_span: 2 }),
+    ];
+    const result = computeSectionsBackgroundAlignment(sections, 2);
+    expect(result.size).toBe(0);
+  });
+
+  it("skips hidden sections", () => {
+    // section 0 (hidden, bg) should not cause section 1 to need margin
+    const sections = [
+      mockSection({ hidden: true, background: {} }),
+      mockSection(),
+    ];
+    const result = computeSectionsBackgroundAlignment(sections, 2);
+    expect(result.size).toBe(0);
+  });
+
+  it("handles multiple rows with mixed backgrounds", () => {
+    // 2 columns:
+    // Row 1: section 0 (no bg) + section 1 (bg) -> section 0 needs margin
+    // Row 2: section 2 (no bg) + section 3 (no bg) -> no margin needed
+    const sections = [
+      mockSection(),
+      mockSection({ background: {} }),
+      mockSection(),
+      mockSection(),
+    ];
+    const result = computeSectionsBackgroundAlignment(sections, 2);
+    expect(result.has(0)).toBe(true);
+    expect(result.has(1)).toBe(false);
+    expect(result.has(2)).toBe(false);
+    expect(result.has(3)).toBe(false);
+  });
+
+  it("handles empty sections array", () => {
+    const result = computeSectionsBackgroundAlignment([], 4);
+    expect(result.size).toBe(0);
+  });
+
+  it("clamps column_span to columnCount", () => {
+    // section with span 10 in a 2-column layout should be treated as span 2
+    // Row 1: section 0 (span clamped to 2, bg), Row 2: section 1 (no bg)
+    const sections = [
+      mockSection({ column_span: 10, background: {} }),
+      mockSection(),
+    ];
+    const result = computeSectionsBackgroundAlignment(sections, 2);
+    expect(result.has(1)).toBe(false);
+  });
+
+  it("marks multiple sections without background on same row", () => {
+    // 3 columns: section 0 (no bg) + section 1 (bg) + section 2 (no bg)
+    const sections = [
+      mockSection(),
+      mockSection({ background: {} }),
+      mockSection(),
+    ];
+    const result = computeSectionsBackgroundAlignment(sections, 3);
+    expect(result.has(0)).toBe(true);
+    expect(result.has(1)).toBe(false);
+    expect(result.has(2)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Proposed change

Add the ability to set a background color on dashboard sections.

### Section background

- A toggle in section settings enables the background.
- An expandable "Background options" panel lets users pick a color and adjust opacity.
- The default background color is `secondary-background-color` and can be customized using the `ha-section-background-color` variable.

### Color picker

- The color picker includes a "Default" option that uses the theme's background color.
- The color picker displays a list of predefined colors (same as tile card). A hex color code can also be used.
- Adds `extra_options` support to the `ui_color` selector, allowing custom entries in the color picker with optional `display_color` and `icon` properties.

### Layout adjustments

- Sections without a background that share a row with a background section automatically align vertically.
- Adjusted section border radius from `lg` to `xl`. Introduced a new variable `ha-section-border-radius`.

### Bug fix

- Fixed a pre-existing bug where `isStrategyView` was incorrectly used instead of `isStrategySection` for section strategy resolution.

### Related PRs

This PR implements the same features as the first background section PRs (#26651, #26369) with the following improvements:

- **Vertical alignment**: Extra vertical margin is automatically added to sections on the same row.
- **Default background color**: Can be customized using themes via `ha-section-background-color`.
- **Predefined color list**: Still possible to add a hex code if needed.
- **Adjusted border radius**: Updated from `lg` to `xl` with a new `ha-section-border-radius` variable.


## Screenshots

**Colored sections**
<img width="734" height="366" alt="CleanShot 2026-03-19 at 15 08 37" src="https://github.com/user-attachments/assets/a2bb6e64-3931-4447-9870-9a91fee7dbc9" />

**Editor : background disabled**
<img width="609" height="178" alt="CleanShot 2026-03-19 at 14 54 59" src="https://github.com/user-attachments/assets/e7e8cdef-134f-45b6-a410-45d9ea75b46c" />


**Editor : background enabled**
<img width="609" height="472" alt="CleanShot 2026-03-19 at 14 41 59" src="https://github.com/user-attachments/assets/79151b22-b576-4c5c-9e36-a9bfa16477c3" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/492
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
