### PR TITLE
ZHA group settings UI improvements, localization

### DIFF
--- a/src/panels/config/integrations/integration-panels/zha/zha-device-endpoint-data-table.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-endpoint-data-table.ts
@@ -15,6 +15,7 @@ import type {
 import type { HomeAssistant } from "../../../../../types";
 import { getAreaTableColumn } from "../../../common/data-table-columns";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
+import type { AreaRegistryEntry } from "../../../../../data/area/area_registry";
 
 export interface DeviceEndpointRowData extends DataTableRowData {
   id: string;
@@ -40,15 +41,18 @@ export class ZHADeviceEndpointDataTable extends LitElement {
   @query("ha-data-table", true) private _dataTable!: HaDataTable;
 
   private _deviceEndpoints = memoizeOne(
-    (deviceEndpoints: ZHADeviceEndpoint[]) => {
+    (
+      deviceEndpoints: ZHADeviceEndpoint[],
+      areas: Record<string, AreaRegistryEntry>
+    ) => {
       const outputDevices: DeviceEndpointRowData[] = [];
       deviceEndpoints.forEach((deviceEndpoint) => {
         outputDevices.push({
           name:
             deviceEndpoint.device.user_given_name || deviceEndpoint.device.name,
           area: deviceEndpoint.device.area_id
-            ? this.hass.areas[deviceEndpoint.device.area_id].name
-            : deviceEndpoint.device.area_id,
+            ? areas[deviceEndpoint.device.area_id].name
+            : undefined,
           model: deviceEndpoint.device.model,
           manufacturer: deviceEndpoint.device.manufacturer,
           id: deviceEndpoint.device.ieee + "_" + deviceEndpoint.endpoint_id,
@@ -156,7 +160,7 @@ export class ZHADeviceEndpointDataTable extends LitElement {
       <ha-data-table
         .hass=${this.hass}
         .columns=${this._columns(this.hass.localize, this.narrow)}
-        .data=${this._deviceEndpoints(this.deviceEndpoints)}
+        .data=${this._deviceEndpoints(this.deviceEndpoints, this.hass.areas)}
         .selectable=${this.selectable}
         auto-height
         .searchLabel=${this.hass.localize("ui.components.data-table.search")}

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-endpoint-data-table.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-endpoint-data-table.ts
@@ -68,7 +68,7 @@ export class ZHADeviceEndpointDataTable extends LitElement {
       narrow
         ? {
             name: {
-              title: "Devices",
+              title: localize("ui.panel.config.zha.groups.members"),
               sortable: true,
               filterable: true,
               direction: "asc",
@@ -88,14 +88,14 @@ export class ZHADeviceEndpointDataTable extends LitElement {
               `,
             },
             endpoint_id: {
-              title: "Endpoint",
+              title: localize("ui.panel.config.zha.groups.endpoint"),
               sortable: true,
               filterable: true,
             },
           }
         : {
             name: {
-              title: "Name",
+              title: localize("ui.panel.config.zha.groups.members"),
               sortable: true,
               filterable: true,
               direction: "asc",
@@ -108,12 +108,12 @@ export class ZHADeviceEndpointDataTable extends LitElement {
             },
             area: getAreaTableColumn(localize),
             endpoint_id: {
-              title: "Endpoint",
+              title: localize("ui.panel.config.zha.groups.endpoint"),
               sortable: true,
               filterable: true,
             },
             entities: {
-              title: "Associated Entities",
+              title: localize("ui.panel.config.zha.groups.associated_entities"),
               sortable: false,
               filterable: false,
               flex: 2,
@@ -130,7 +130,7 @@ export class ZHADeviceEndpointDataTable extends LitElement {
                                 ${entity.name || entity.original_name}
                               </div>`
                           )}
-                        <div>And ${device.entities.length - 2} more...</div>`
+                        <div>+${device.entities.length - 2}</div>`
                     : device.entities.map(
                         (entity) =>
                           html`<div
@@ -139,7 +139,9 @@ export class ZHADeviceEndpointDataTable extends LitElement {
                             ${entity.name || entity.original_name}
                           </div>`
                       )
-                  : "This endpoint has no associated entities"}
+                  : localize(
+                      "ui.panel.config.zha.groups.no_associated_entities"
+                    )}
               `,
             },
           }

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-endpoint-data-table.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-endpoint-data-table.ts
@@ -1,5 +1,5 @@
 import type { CSSResultGroup, TemplateResult } from "lit";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import "../../../../../components/data-table/ha-data-table";
@@ -13,10 +13,13 @@ import type {
   ZHAEntityReference,
 } from "../../../../../data/zha";
 import type { HomeAssistant } from "../../../../../types";
+import { getAreaTableColumn } from "../../../common/data-table-columns";
+import type { LocalizeFunc } from "../../../../../common/translations/localize";
 
 export interface DeviceEndpointRowData extends DataTableRowData {
   id: string;
   name: string;
+  area: string | undefined;
   model: string;
   manufacturer: string;
   endpoint_id: number;
@@ -39,11 +42,13 @@ export class ZHADeviceEndpointDataTable extends LitElement {
   private _deviceEndpoints = memoizeOne(
     (deviceEndpoints: ZHADeviceEndpoint[]) => {
       const outputDevices: DeviceEndpointRowData[] = [];
-
       deviceEndpoints.forEach((deviceEndpoint) => {
         outputDevices.push({
           name:
             deviceEndpoint.device.user_given_name || deviceEndpoint.device.name,
+          area: deviceEndpoint.device.area_id
+            ? this.hass.areas[deviceEndpoint.device.area_id].name
+            : deviceEndpoint.device.area_id,
           model: deviceEndpoint.device.model,
           manufacturer: deviceEndpoint.device.manufacturer,
           id: deviceEndpoint.device.ieee + "_" + deviceEndpoint.endpoint_id,
@@ -59,7 +64,7 @@ export class ZHADeviceEndpointDataTable extends LitElement {
   );
 
   private _columns = memoizeOne(
-    (narrow: boolean): DataTableColumnContainer =>
+    (localize: LocalizeFunc, narrow: boolean): DataTableColumnContainer =>
       narrow
         ? {
             name: {
@@ -71,6 +76,14 @@ export class ZHADeviceEndpointDataTable extends LitElement {
               template: (device) => html`
                 <a href=${`/config/devices/device/${device.dev_id}`}>
                   ${device.name}
+                  ${device.area
+                    ? html` <br />
+                        <span
+                          style="font-size: var(--ha-font-size-s);color: var(--ha-color-text-secondary);"
+                        >
+                          ${device.area}
+                        </span>`
+                    : nothing}
                 </a>
               `,
             },
@@ -93,6 +106,7 @@ export class ZHADeviceEndpointDataTable extends LitElement {
                 </a>
               `,
             },
+            area: getAreaTableColumn(localize),
             endpoint_id: {
               title: "Endpoint",
               sortable: true,
@@ -139,7 +153,7 @@ export class ZHADeviceEndpointDataTable extends LitElement {
     return html`
       <ha-data-table
         .hass=${this.hass}
-        .columns=${this._columns(this.narrow)}
+        .columns=${this._columns(this.hass.localize, this.narrow)}
         .data=${this._deviceEndpoints(this.deviceEndpoints)}
         .selectable=${this.selectable}
         auto-height

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7058,7 +7058,8 @@
             "creating_group": "Creating group",
             "delete": "Delete group",
             "endpoint": "Endpoint",
-            "associated_entities": "Assiciated Entities"
+            "associated_entities": "Associated entities",
+            "no_associated_entities": "This endpoint has no associated entities"
           },
           "visualization": {
             "header": "Zigbee visualization",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7056,7 +7056,9 @@
             "create_group": "Create group",
             "create": "Create group",
             "creating_group": "Creating group",
-            "delete": "Delete group"
+            "delete": "Delete group",
+            "endpoint": "Endpoint",
+            "associated_entities": "Assiciated Entities"
           },
           "visualization": {
             "header": "Zigbee visualization",


### PR DESCRIPTION
## Proposed change

Add a device area column to the ZHA data table, which most notably adds
the column to the "create [ZigBee] group" view".

The column is only show on wider screens to allow for ordering, whilst
narrower screens will show the area as a subtitle to the device's name.

Additionally localize the ZHA group data table.

Without the area, it's really difficult to create groups in large
installations where groups have the biggest impact.

## Screenshots

<img width="1414" height="929" alt="image" src="https://github.com/user-attachments/assets/2b87e44d-5dd0-400c-9b53-6ad32f1036d3" />

<img width="505" height="914" alt="image" src="https://github.com/user-attachments/assets/fdba79c3-29df-474b-af1c-5b3732c6f96a" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr