### PR TITLE
Fix entity ID copy to clipboard button not working

### DIFF
--- a/src/common/util/copy-clipboard.ts
+++ b/src/common/util/copy-clipboard.ts
@@ -1,5 +1,24 @@
 import { deepActiveElement } from "../dom/deep-active-element";
 
+const getClipboardFallbackRoot = (): HTMLElement => {
+  const activeElement = deepActiveElement();
+  if (activeElement instanceof HTMLElement) {
+    let root: Node = activeElement.getRootNode();
+    let host: HTMLElement | null = null;
+
+    while (root instanceof ShadowRoot && root.host instanceof HTMLElement) {
+      host = root.host;
+      root = root.host.getRootNode();
+    }
+
+    if (host) {
+      return host;
+    }
+  }
+
+  return document.body;
+};
+
 export const copyToClipboard = async (str, rootEl?: HTMLElement) => {
   if (navigator.clipboard) {
     try {
@@ -10,7 +29,7 @@ export const copyToClipboard = async (str, rootEl?: HTMLElement) => {
     }
   }
 
-  const root = rootEl || deepActiveElement()?.getRootNode() || document.body;
+  const root = rootEl || getClipboardFallbackRoot();
 
   const el = document.createElement("textarea");
   el.value = str;

--- a/test/common/util/copy-clipboard.test.ts
+++ b/test/common/util/copy-clipboard.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { copyToClipboard } from "../../../src/common/util/copy-clipboard";
+
+vi.mock("../../../src/common/dom/deep-active-element", () => ({
+  deepActiveElement: vi.fn(),
+}));
+
+// Must import after vi.mock so we get the mocked version
+const { deepActiveElement } =
+  await import("../../../src/common/dom/deep-active-element");
+
+describe("copyToClipboard", () => {
+  let execCommandMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // jsdom doesn't implement execCommand (deprecated API), so define it manually
+    execCommandMock = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      value: execCommandMock,
+      writable: true,
+      configurable: true,
+    });
+    // navigator is set to {} by setup.ts, so navigator.clipboard is undefined by default
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("navigator.clipboard path", () => {
+    it("uses clipboard API when it succeeds", async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+      await copyToClipboard("hello");
+
+      expect(writeText).toHaveBeenCalledWith("hello");
+      expect(execCommandMock).not.toHaveBeenCalled();
+    });
+
+    it("falls back to textarea when clipboard API throws", async () => {
+      const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+      vi.stubGlobal("navigator", { clipboard: { writeText } });
+      vi.mocked(deepActiveElement).mockReturnValue(null);
+
+      await copyToClipboard("hello");
+
+      expect(writeText).toHaveBeenCalledWith("hello");
+      expect(execCommandMock).toHaveBeenCalledWith("copy");
+    });
+  });
+
+  describe("fallback textarea root selection (no navigator.clipboard)", () => {
+    it("appends to document.body when there is no active element", async () => {
+      vi.mocked(deepActiveElement).mockReturnValue(null);
+      const appendSpy = vi.spyOn(document.body, "appendChild");
+
+      await copyToClipboard("hello");
+
+      expect(appendSpy).toHaveBeenCalledWith(expect.any(HTMLTextAreaElement));
+    });
+
+    it("appends to document.body when active element is in the main document (not in a shadow root)", async () => {
+      // Regression case: getRootNode() returns Document, not ShadowRoot.
+      // The old one-liner passed Document to root.appendChild(), throwing HierarchyRequestError.
+      const el = document.createElement("input");
+      document.body.appendChild(el);
+      vi.mocked(deepActiveElement).mockReturnValue(el);
+      const appendSpy = vi.spyOn(document.body, "appendChild");
+
+      await copyToClipboard("hello");
+
+      expect(appendSpy).toHaveBeenCalledWith(expect.any(HTMLTextAreaElement));
+      document.body.removeChild(el);
+    });
+
+    it("appends to the shadow host when active element is inside a shadow root", async () => {
+      const host = document.createElement("div");
+      document.body.appendChild(host);
+      const shadow = host.attachShadow({ mode: "open" });
+      const inner = document.createElement("input");
+      shadow.appendChild(inner);
+
+      vi.mocked(deepActiveElement).mockReturnValue(inner);
+      const appendSpy = vi.spyOn(host, "appendChild");
+
+      await copyToClipboard("hello");
+
+      expect(appendSpy).toHaveBeenCalledWith(expect.any(HTMLTextAreaElement));
+      document.body.removeChild(host);
+    });
+
+    it("appends to the topmost shadow host for nested shadow roots", async () => {
+      const outerHost = document.createElement("div");
+      document.body.appendChild(outerHost);
+      const outerShadow = outerHost.attachShadow({ mode: "open" });
+      const innerHost = document.createElement("div");
+      outerShadow.appendChild(innerHost);
+      const innerShadow = innerHost.attachShadow({ mode: "open" });
+      const deepEl = document.createElement("input");
+      innerShadow.appendChild(deepEl);
+
+      vi.mocked(deepActiveElement).mockReturnValue(deepEl);
+      const appendSpy = vi.spyOn(outerHost, "appendChild");
+
+      await copyToClipboard("hello");
+
+      expect(appendSpy).toHaveBeenCalledWith(expect.any(HTMLTextAreaElement));
+      document.body.removeChild(outerHost);
+    });
+
+    it("uses provided rootEl and ignores the detected root", async () => {
+      vi.mocked(deepActiveElement).mockReturnValue(null);
+      const customRoot = document.createElement("div");
+      document.body.appendChild(customRoot);
+      const appendSpy = vi.spyOn(customRoot, "appendChild");
+
+      await copyToClipboard("hello", customRoot);
+
+      expect(appendSpy).toHaveBeenCalledWith(expect.any(HTMLTextAreaElement));
+      document.body.removeChild(customRoot);
+    });
+
+    it("copies the correct string value via execCommand", async () => {
+      vi.mocked(deepActiveElement).mockReturnValue(null);
+
+      await copyToClipboard("copy this text");
+
+      expect(execCommandMock).toHaveBeenCalledWith("copy");
+    });
+  });
+});


### PR DESCRIPTION
## Proposed change

Restore the `getClipboardFallbackRoot()` helper that was accidentally removed in a previous refactor. The simplified one-liner replacement used `deepActiveElement()?.getRootNode()` which can return a `Document` object when the active element is in the main document (not in a shadow root). Calling `Document.appendChild()` throws a `HierarchyRequestError`, which propagates out of `copyToClipboard` uncaught — causing the copy button to silently do nothing and the success toast to never appear.

The restored helper correctly traverses up through nested `ShadowRoot`s to find the topmost shadow host element (a real `HTMLElement` in the document tree), ensuring the fallback textarea is always appended to a valid parent. This fallback path is taken in non-HTTPS contexts where `navigator.clipboard` is unavailable, as well as when the browser denies clipboard access due to focus or permissions.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes home-assistant/core#164879
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr