### PR TITLE
Fix statistics graph card units when using energy collections.

### DIFF
--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -399,6 +399,14 @@ export class StatisticsChart extends LitElement {
       endTime = new Date();
     }
 
+    // Check if we need to display most recent data. Allow 10m of leeway for "now",
+    // because stats are 5 minute aggregated.
+    // Use same now point for all statistics even if processing time means the
+    // state value is actually from a slightly later time. Otherwise the points
+    // end up separated slightly and disappear from the tooltips.
+    const now = new Date();
+    const displayCurrentState = now.getTime() - endTime.getTime() <= 600000;
+
     // Try to determine chart unit if it has not already been set explicitly
     if (!this.unit) {
       let unit: string | undefined | null;
@@ -627,11 +635,6 @@ export class StatisticsChart extends LitElement {
           );
         });
       }
-
-      // Check if we need to display most recent data. Allow 10m of leeway for "now",
-      // because stats are 5 minute aggregated
-      const now = new Date();
-      const displayCurrentState = now.getTime() - endTime.getTime() <= 600000;
 
       // Show current state if required, and units match (or are unknown)
       const statisticUnit = getDisplayUnit(this.hass, statistic_id, meta);

--- a/src/panels/lovelace/cards/hui-statistics-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-statistics-graph-card.ts
@@ -106,14 +106,17 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
       return;
     }
     if (this._config?.energy_date_selection) {
-      this._subscribeEnergy();
+      this._subscribeEnergy(true);
     } else if (this._interval === undefined) {
       this._setFetchStatisticsTimer(true);
     }
   }
 
-  private _subscribeEnergy() {
+  private _subscribeEnergy(performFetch = false) {
     if (!this._energySub) {
+      if (performFetch) {
+        this._fetchInitialStatistics();
+      }
       this._energySub = getEnergyDataCollection(this.hass!, {
         key: this._config?.collection_key,
       }).subscribe((data) => {
@@ -215,7 +218,7 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
 
     if (this.hass) {
       if (this._config.energy_date_selection && !this._energySub) {
-        this._subscribeEnergy();
+        this._subscribeEnergy(true);
         return;
       }
       if (!this._config.energy_date_selection && this._energySub) {
@@ -238,7 +241,11 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
       changedProps.has("_config") &&
       oldConfig?.entities !== this._config.entities
     ) {
-      this._setFetchStatisticsTimer(true);
+      if (this._config.energy_date_selection) {
+        this._fetchInitialStatistics();
+      } else {
+        this._setFetchStatisticsTimer(true);
+      }
       return;
     }
 
@@ -251,6 +258,11 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
     ) {
       this._setFetchStatisticsTimer();
     }
+  }
+
+  private async _fetchInitialStatistics() {
+    await this._getStatisticsMetaData(this._entityIds);
+    await this._getStatistics();
   }
 
   private async _setFetchStatisticsTimer(fetchMetadata = false) {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When using energy collections with the statistics graph card, when the page is first loaded, the statistics metadata doesn't necessarily load due to a race condition in the `willUpdate` logic. This is only really apparent when there are multiple entities on the chart using different units.

Because the metadata is not loaded, the statistics chart is not set to use a specific unit, so when the entities have different units (e.g. W and kW), the entities are not converted to a single comparable unit as intended. In the screenshot below, notice that the kW and W entities both show as W when not using energy collections, but don't when using energy collections even though both use the same data fetching.

To fix this, make sure that we load the metadata when first subscribing to an energy collection, and refresh later if the entities change.

---

Additionally, when there are multiple entities, some of the "now" state value points seem to disappear from the chart tooltip. As it turns out this is because processing of the data for the chart takes a little bit of time, leading to there being multiple time points very close together, each with a different subset of entities.

This is fixed by using the same "now" time value for all of the entities, rather than recalculating it for each entity. Technically this means if data processing took a very long time, it's possible that the now values will be shown as being further into the past than they really are. But given the rest of the data on the chart is 5min/hour/etc, this little bit of rounding in time is unlikely to be relevant.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Metadata loading:

<img width="1018" height="707" alt="image" src="https://github.com/user-attachments/assets/ca4902b8-6f73-4214-8877-3a86f0f8be6a" />

Tooltip missing entities:

<img width="492" height="250" alt="image" src="https://github.com/user-attachments/assets/5ecbda08-1b59-408e-b5b2-6976a6b8c644" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
