### PR TITLE
Fix water/gas total badge unit when sensor value is zero

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -1526,9 +1526,13 @@ export const computeTotalFlowRate = (
       return;
     }
 
-    const rawValue = parseFloat(stateObj.state);
-    if (isNaN(rawValue) || rawValue <= 0) {
+    let rawValue = parseFloat(stateObj.state);
+    if (isNaN(rawValue)) {
       return;
+    }
+
+    if (rawValue < 0) {
+      rawValue = 0;
     }
 
     const entityUnit = stateObj.attributes.unit_of_measurement;


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

If there is only one flow rate sensor, and it has a value <=0, the badge would be displayed without a unit because the sensor gets skipped.

Instead of skipping sensors with values <=0 which are technically still valid, continue to process the sensor but clamp the value to a minimum of 0.

This ensures if we have just one sensor we always display a unit. It also means if there are multiple sensors with different units, the chosen unit is consistently that of the first one, even if its value drops to zero.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

**Before**

An example, with two sensors. First is in `L/h`, second in `L/min`. When the first sensor has a value >0, the unit is displayed in `L/h`.

<img width="125" height="43" alt="image" src="https://github.com/user-attachments/assets/cce7bca9-a2d0-47bc-92f8-d009aeebe37b" />

When the first sensor drops to zero, displayed unit changes to `L/min`:

<img width="124" height="43" alt="image" src="https://github.com/user-attachments/assets/5963a0be-4e4f-4ffe-923c-5e1170de1872" />

When the second sensor also drops to zero, unit disappears:

<img width="123" height="41" alt="image" src="https://github.com/user-attachments/assets/68a87b5e-41be-446c-8aa3-5d41b8364cdf" />

**After**

With this change, the unit is consistently that of the first sensor:

<img width="125" height="43" alt="image" src="https://github.com/user-attachments/assets/cce7bca9-a2d0-47bc-92f8-d009aeebe37b" />
<img width="127" height="46" alt="image" src="https://github.com/user-attachments/assets/f2f652d2-234c-44ea-ad57-29fb38c04a88" />
<img width="122" height="44" alt="image" src="https://github.com/user-attachments/assets/f15935d4-c188-42e3-acc0-d9ebddf83eb3" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
