### PR TITLE
Allow boolean option to section background

### DIFF
--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -14,7 +14,7 @@ export interface LovelaceBaseSectionConfig {
   disabled?: boolean;
   column_span?: number;
   row_span?: number;
-  background?: LovelaceSectionBackgroundConfig;
+  background?: boolean | LovelaceSectionBackgroundConfig;
   /**
    * @deprecated Use heading card instead.
    */
@@ -33,6 +33,15 @@ export interface LovelaceStrategySectionConfig extends LovelaceBaseSectionConfig
 export type LovelaceSectionRawConfig =
   | LovelaceSectionConfig
   | LovelaceStrategySectionConfig;
+
+export function resolveSectionBackground(
+  background: boolean | LovelaceSectionBackgroundConfig | undefined
+): LovelaceSectionBackgroundConfig | undefined {
+  if (typeof background === "boolean") {
+    return background ? {} : undefined;
+  }
+  return background;
+}
 
 export function isStrategySection(
   section: LovelaceSectionRawConfig

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -3,17 +3,18 @@ import { LitElement, html } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
+import "../../../../components/ha-form/ha-form";
 import type {
   HaFormSchema,
   SchemaUnion,
 } from "../../../../components/ha-form/types";
-import "../../../../components/ha-form/ha-form";
 import {
   DEFAULT_SECTION_BACKGROUND_OPACITY,
+  resolveSectionBackground,
   type LovelaceSectionRawConfig,
 } from "../../../../data/lovelace/config/section";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
-import type { LocalizeFunc } from "../../../../common/translations/localize";
 import type { HomeAssistant } from "../../../../types";
 
 interface SettingsData {
@@ -95,13 +96,14 @@ export class HuiDialogEditSection extends LitElement {
 
   render() {
     const backgroundEnabled = this.config.background !== undefined;
+    const background = resolveSectionBackground(this.config.background);
 
     const data: SettingsData = {
       column_span: this.config.column_span || 1,
       background_enabled: backgroundEnabled,
-      background_color: this.config.background?.color ?? "default",
+      background_color: background?.color ?? "default",
       background_opacity:
-        this.config.background?.opacity ?? DEFAULT_SECTION_BACKGROUND_OPACITY,
+        background?.opacity ?? DEFAULT_SECTION_BACKGROUND_OPACITY,
     };
 
     const schema = this._schema(
@@ -146,12 +148,13 @@ export class HuiDialogEditSection extends LitElement {
     };
 
     if (newData.background_enabled) {
+      const hasCustomColor =
+        newData.background_color !== undefined &&
+        newData.background_color !== "default";
+
       newConfig.background = {
-        ...(newData.background_color && newData.background_color !== "default"
-          ? { color: newData.background_color }
-          : {}),
-        opacity:
-          newData.background_opacity ?? DEFAULT_SECTION_BACKGROUND_OPACITY,
+        ...(hasCustomColor ? { color: newData.background_color } : {}),
+        opacity: newData.background_opacity!,
       };
     } else {
       delete newConfig.background;

--- a/src/panels/lovelace/sections/hui-section-background.ts
+++ b/src/panels/lovelace/sections/hui-section-background.ts
@@ -1,16 +1,17 @@
-import { css, LitElement, nothing } from "lit";
+import { css, LitElement, nothing, unsafeCSS } from "lit";
 import type { PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
 import { computeCssColor } from "../../../common/color/compute-color";
 import {
   DEFAULT_SECTION_BACKGROUND_OPACITY,
+  resolveSectionBackground,
   type LovelaceSectionBackgroundConfig,
 } from "../../../data/lovelace/config/section";
 
 @customElement("hui-section-background")
 export class HuiSectionBackground extends LitElement {
   @property({ attribute: false })
-  public background?: LovelaceSectionBackgroundConfig;
+  public background?: boolean | LovelaceSectionBackgroundConfig;
 
   protected render() {
     return nothing;
@@ -18,14 +19,15 @@ export class HuiSectionBackground extends LitElement {
 
   protected willUpdate(changedProperties: PropertyValues<this>) {
     super.willUpdate(changedProperties);
-    if (changedProperties.has("background") && this.background) {
-      const color = this.background.color
-        ? computeCssColor(this.background.color)
-        : "var(--ha-section-background-color, var(--secondary-background-color))";
-      this.style.setProperty("--section-background", color);
-      const opacity =
-        this.background.opacity ?? DEFAULT_SECTION_BACKGROUND_OPACITY;
-      this.style.setProperty("--section-background-opacity", `${opacity}%`);
+    if (changedProperties.has("background")) {
+      const resolved = resolveSectionBackground(this.background);
+      if (resolved) {
+        const color = resolved.color ? computeCssColor(resolved.color) : null;
+        this.style.setProperty("--section-background-color", color);
+        const opacity =
+          resolved.opacity !== undefined ? `${resolved.opacity}%` : null;
+        this.style.setProperty("--section-background-opacity", opacity);
+      }
     }
   }
 
@@ -34,8 +36,14 @@ export class HuiSectionBackground extends LitElement {
       position: absolute;
       inset: 0;
       border-radius: inherit;
-      background-color: var(--section-background, none);
-      opacity: var(--section-background-opacity, 100%);
+      background-color: var(
+        --section-background-color,
+        var(--ha-section-background-color, var(--secondary-background-color))
+      );
+      opacity: var(
+        --section-background-opacity,
+        ${unsafeCSS(DEFAULT_SECTION_BACKGROUND_OPACITY)}%
+      );
       z-index: 0;
       pointer-events: none;
     }

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -30,11 +30,11 @@ import {
 import type { HuiSection } from "../sections/hui-section";
 import "../sections/hui-section-background";
 import type { Lovelace } from "../types";
-import { computeSectionsBackgroundAlignment } from "./sections-background-alignment";
 import { generateDefaultSection } from "./default-section";
 import "./hui-view-footer";
 import "./hui-view-header";
 import "./hui-view-sidebar";
+import { computeSectionsBackgroundAlignment } from "./sections-background-alignment";
 
 export const DEFAULT_MAX_COLUMNS = 4;
 

--- a/test/panels/lovelace/views/sections-background-alignment.test.ts
+++ b/test/panels/lovelace/views/sections-background-alignment.test.ts
@@ -4,7 +4,7 @@ import { computeSectionsBackgroundAlignment } from "../../../../src/panels/lovel
 
 function mockSection(
   opts: {
-    background?: {};
+    background?: boolean;
     column_span?: number;
     hidden?: boolean;
   } = {}
@@ -20,7 +20,7 @@ function mockSection(
 
 describe("computeSectionsBackgroundAlignment", () => {
   it("returns empty set for single column layout", () => {
-    const sections = [mockSection(), mockSection({ background: {} })];
+    const sections = [mockSection(), mockSection({ background: true })];
     const result = computeSectionsBackgroundAlignment(sections, 1);
     expect(result.size).toBe(0);
   });
@@ -33,15 +33,15 @@ describe("computeSectionsBackgroundAlignment", () => {
 
   it("returns empty set when all sections have background", () => {
     const sections = [
-      mockSection({ background: {} }),
-      mockSection({ background: {} }),
+      mockSection({ background: true }),
+      mockSection({ background: true }),
     ];
     const result = computeSectionsBackgroundAlignment(sections, 2);
     expect(result.size).toBe(0);
   });
 
   it("marks section without background on same row as one with background", () => {
-    const sections = [mockSection(), mockSection({ background: {} })];
+    const sections = [mockSection(), mockSection({ background: true })];
     const result = computeSectionsBackgroundAlignment(sections, 2);
     expect(result.has(0)).toBe(true);
     expect(result.has(1)).toBe(false);
@@ -49,7 +49,7 @@ describe("computeSectionsBackgroundAlignment", () => {
 
   it("does not mark sections on different rows", () => {
     // Row 1: section 0 (no bg), Row 2: section 1 (bg)
-    const sections = [mockSection(), mockSection({ background: {} })];
+    const sections = [mockSection(), mockSection({ background: true })];
     const result = computeSectionsBackgroundAlignment(sections, 1);
     expect(result.size).toBe(0);
   });
@@ -59,7 +59,7 @@ describe("computeSectionsBackgroundAlignment", () => {
     // section 2 (span 1, no bg) = row 2
     const sections = [
       mockSection({ column_span: 2 }),
-      mockSection({ column_span: 2, background: {} }),
+      mockSection({ column_span: 2, background: true }),
       mockSection(),
     ];
     const result = computeSectionsBackgroundAlignment(sections, 4);
@@ -71,7 +71,7 @@ describe("computeSectionsBackgroundAlignment", () => {
   it("wraps to new row when column_span exceeds remaining space", () => {
     // 2 columns: section 0 (span 1, bg) on row 1, section 1 (span 2, no bg) on row 2
     const sections = [
-      mockSection({ background: {} }),
+      mockSection({ background: true }),
       mockSection({ column_span: 2 }),
     ];
     const result = computeSectionsBackgroundAlignment(sections, 2);
@@ -81,7 +81,7 @@ describe("computeSectionsBackgroundAlignment", () => {
   it("skips hidden sections", () => {
     // section 0 (hidden, bg) should not cause section 1 to need margin
     const sections = [
-      mockSection({ hidden: true, background: {} }),
+      mockSection({ hidden: true, background: true }),
       mockSection(),
     ];
     const result = computeSectionsBackgroundAlignment(sections, 2);
@@ -94,7 +94,7 @@ describe("computeSectionsBackgroundAlignment", () => {
     // Row 2: section 2 (no bg) + section 3 (no bg) -> no margin needed
     const sections = [
       mockSection(),
-      mockSection({ background: {} }),
+      mockSection({ background: true }),
       mockSection(),
       mockSection(),
     ];
@@ -114,7 +114,7 @@ describe("computeSectionsBackgroundAlignment", () => {
     // section with span 10 in a 2-column layout should be treated as span 2
     // Row 1: section 0 (span clamped to 2, bg), Row 2: section 1 (no bg)
     const sections = [
-      mockSection({ column_span: 10, background: {} }),
+      mockSection({ column_span: 10, background: true }),
       mockSection(),
     ];
     const result = computeSectionsBackgroundAlignment(sections, 2);
@@ -125,7 +125,7 @@ describe("computeSectionsBackgroundAlignment", () => {
     // 3 columns: section 0 (no bg) + section 1 (bg) + section 2 (no bg)
     const sections = [
       mockSection(),
-      mockSection({ background: {} }),
+      mockSection({ background: true }),
       mockSection(),
     ];
     const result = computeSectionsBackgroundAlignment(sections, 3);


### PR DESCRIPTION
## Proposed change

Allow `background: true` as a YAML shorthand to enable the default section background, instead of requiring an object. This makes the configuration more intuitive:
- `background: true` — enable with default color and opacity
- `background: { color: "red", opacity: 80 }` — enable with custom settings
- No `background` key — disabled

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
