### PR TITLE
Improve sections view spacing and heading card grid options

### DIFF
--- a/src/panels/lovelace/cards/hui-heading-card.ts
+++ b/src/panels/lovelace/cards/hui-heading-card.ts
@@ -67,7 +67,7 @@ export class HuiHeadingCard extends LitElement implements LovelaceCard {
   public getGridOptions(): LovelaceGridOptions {
     return {
       columns: "full",
-      rows: this._config?.heading_style === "subtitle" ? "auto" : 1,
+      rows: "auto",
       min_columns: 3,
     };
   }

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -485,10 +485,11 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
   static styles = css`
     :host {
       --row-height: var(--ha-view-sections-row-height, 56px);
-      --row-gap: var(--ha-view-sections-row-gap, 8px);
+      --row-gap: var(--ha-view-sections-row-gap, 24px);
       --column-gap: var(--ha-view-sections-column-gap, 32px);
       --column-max-width: var(--ha-view-sections-column-max-width, 500px);
       --column-min-width: var(--ha-view-sections-column-min-width, 320px);
+      --narrow-column-gap: var(--ha-view-sections-narrow-column-gap, 8px);
       --top-margin: var(--ha-view-sections-extra-top-margin, 80px);
       display: block;
       flex: 1;
@@ -496,7 +497,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
 
     @media (max-width: 600px) {
       :host {
-        --column-gap: var(--ha-view-sections-narrow-column-gap, var(--row-gap));
+        --column-gap: var(--narrow-column-gap);
       }
     }
 
@@ -504,7 +505,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
       display: flex;
       flex-direction: column;
       min-height: calc(100% - 2 * var(--row-gap));
-      padding: var(--row-gap) var(--column-gap);
+      padding: 0 var(--column-gap);
       box-sizing: content-box;
       margin: 0 auto;
       max-width: calc(

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -504,7 +504,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
     .wrapper {
       display: flex;
       flex-direction: column;
-      min-height: calc(100% - 2 * var(--row-gap));
+      min-height: 100%;
       padding: 0 var(--column-gap);
       box-sizing: content-box;
       margin: 0 auto;

--- a/src/panels/lovelace/views/hui-view-header.ts
+++ b/src/panels/lovelace/views/hui-view-header.ts
@@ -334,10 +334,6 @@ export class HuiViewHeader extends LitElement {
       --spacing: 8px;
     }
 
-    .layout.has-heading {
-      margin-top: var(--spacing);
-    }
-
     .heading {
       position: relative;
       flex: 1;
@@ -438,15 +434,10 @@ export class HuiViewHeader extends LitElement {
       flex-direction: column-reverse;
     }
 
-    .layout.badges-top.has-badges {
-      margin-top: 0;
-    }
-
     @media (min-width: 768px) {
       .layout.responsive.badges-top.has-heading {
         flex-direction: row;
         align-items: flex-start;
-        margin-top: var(--spacing);
       }
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

The default grid row size for the heading card changed from 1 to auto, making it shorter (half row). This is only noticeable for headings placed between other cards. Headings at the top of a section are unaffected thanks to the updated grid padding.

The user can be restored the previous row gap between section by settings the `ha-view-sections-row-gap` theme variable to `8px` if more compact layout is wanted.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

- Use `auto` row height for all heading card styles, not just subtitle style
- Increase the default row gap in sections view from 8px to 24px for better visual spacing.
- Separate narrow column gap into its own CSS variable for cleaner responsive behavior
- Remove top/bottom padding from the sections container, keeping only horizontal padding
- Remove extra margin in heading section

## Screenshots

**Before**
<img width="869" height="616" alt="CleanShot 2026-03-24 at 13 27 50" src="https://github.com/user-attachments/assets/414cd302-c47d-422a-a205-60f4a9b477a0" />

**After** 
<img width="869" height="616" alt="CleanShot 2026-03-24 at 13 27 43" src="https://github.com/user-attachments/assets/6b4a6e79-8cc5-43c9-aca0-7117571673db" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
