### PR TITLE
Add config entry row collapse state persistence

### DIFF
--- a/src/panels/config/integrations/ha-config-entry-row.ts
+++ b/src/panels/config/integrations/ha-config-entry-row.ts
@@ -23,6 +23,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import memoizeOne from "memoize-one";
+import { storage } from "../../../common/decorators/storage";
 import { computeDeviceNameDisplay } from "../../../common/entity/compute_device_name";
 import { caseInsensitiveStringCompare } from "../../../common/string/compare";
 import { copyToClipboard } from "../../../common/util/copy-clipboard";
@@ -77,6 +78,9 @@ import "./ha-config-entry-device-row";
 import { renderConfigEntryError } from "./ha-config-integration-page";
 import "./ha-config-sub-entry-row";
 
+const storageId = (type: "entry" | "devices" | "subentry", id: string) =>
+  `${type}:${id}`;
+
 @customElement("ha-config-entry-row")
 export class HaConfigEntryRow extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -97,8 +101,16 @@ export class HaConfigEntryRow extends LitElement {
 
   @state() private _subEntries?: SubEntry[];
 
+  @storage({
+    key: "integration-config-row-collapsed",
+    state: false,
+    subscribe: false,
+  })
+  private _collapsedRows: string[] = [];
+
   protected willUpdate(changedProperties: PropertyValues): void {
     if (changedProperties.has("entry")) {
+      this._restoreExpandedState();
       this._fetchSubEntries();
     }
   }
@@ -458,6 +470,13 @@ export class HaConfigEntryRow extends LitElement {
                   .entities=${this.entities}
                   .entry=${item}
                   .subEntry=${subEntry}
+                  .expanded=${this._isRowExpanded(
+                    storageId(
+                      "subentry",
+                      `${item.entry_id}:${subEntry.subentry_id}`
+                    )
+                  )}
+                  @expanded-changed=${this._handleSubEntryExpandedChanged}
                   data-entry-id=${item.entry_id}
                 ></ha-config-sub-entry-row>
               `
@@ -534,10 +553,51 @@ export class HaConfigEntryRow extends LitElement {
 
   private _toggleExpand() {
     this._expanded = !this._expanded;
+    this._storeRowExpanded(
+      storageId("entry", this.entry.entry_id),
+      this._expanded
+    );
   }
 
   private _toggleOwnDevices() {
     this._devicesExpanded = !this._devicesExpanded;
+    this._storeRowExpanded(
+      storageId("devices", this.entry.entry_id),
+      this._devicesExpanded
+    );
+  }
+
+  private _restoreExpandedState() {
+    this._expanded = this._isRowExpanded(
+      storageId("entry", this.entry.entry_id)
+    );
+    this._devicesExpanded = this._isRowExpanded(
+      storageId("devices", this.entry.entry_id)
+    );
+  }
+
+  private _isRowExpanded(id: string): boolean {
+    return !this._collapsedRows.includes(id);
+  }
+
+  private _storeRowExpanded(id: string, value: boolean) {
+    this._collapsedRows = value
+      ? this._collapsedRows.filter((item) => item !== id)
+      : [...this._collapsedRows.filter((item) => item !== id), id];
+  }
+
+  private _handleSubEntryExpandedChanged(
+    ev: CustomEvent<{
+      entryId: string;
+      subEntryId: string;
+      expanded: boolean;
+    }>
+  ) {
+    ev.stopPropagation();
+    this._storeRowExpanded(
+      storageId("subentry", `${ev.detail.entryId}:${ev.detail.subEntryId}`),
+      ev.detail.expanded
+    );
   }
 
   private _handleMenuAction = (ev: HaDropdownSelectEvent) => {

--- a/src/panels/config/integrations/ha-config-sub-entry-row.ts
+++ b/src/panels/config/integrations/ha-config-sub-entry-row.ts
@@ -8,6 +8,7 @@ import {
   mdiRenameBox,
   mdiShapeOutline,
 } from "@mdi/js";
+import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
@@ -43,11 +44,23 @@ class HaConfigSubEntryRow extends LitElement {
 
   @property({ attribute: false }) public subEntry!: SubEntry;
 
-  @state() private _expanded = true;
+  @property({ type: Boolean }) public expanded = true;
+
+  @state() private _optimisticExpanded?: boolean;
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    if (
+      changedProps.has("expanded") &&
+      this._optimisticExpanded === this.expanded
+    ) {
+      this._optimisticExpanded = undefined;
+    }
+  }
 
   protected render() {
     const subEntry = this.subEntry;
     const configEntry = this.entry;
+    const expanded = this._optimisticExpanded ?? this.expanded;
 
     const devices = this._getDevices();
     const services = this._getServices();
@@ -62,7 +75,7 @@ class HaConfigSubEntryRow extends LitElement {
       >
         ${devices.length || services.length
           ? html`<ha-icon-button
-              class="expand-button ${classMap({ expanded: this._expanded })}"
+              class="expand-button ${classMap({ expanded })}"
               .path=${mdiChevronDown}
               slot="start"
               @click=${this._toggleExpand}
@@ -169,7 +182,7 @@ class HaConfigSubEntryRow extends LitElement {
           </ha-dropdown-item>
         </ha-dropdown>
       </ha-md-list-item>
-      ${this._expanded
+      ${expanded
         ? html`
             ${devices.map(
               (device) =>
@@ -197,7 +210,17 @@ class HaConfigSubEntryRow extends LitElement {
   }
 
   private _toggleExpand() {
-    this._expanded = !this._expanded;
+    const expanded = !(this._optimisticExpanded ?? this.expanded);
+    this._optimisticExpanded = expanded;
+    this.dispatchEvent(
+      new CustomEvent("expanded-changed", {
+        detail: {
+          entryId: this.entry.entry_id,
+          subEntryId: this.subEntry.subentry_id,
+          expanded,
+        },
+      })
+    );
   }
 
   private _getEntities = (): EntityRegistryEntry[] =>


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Persist the config entry (and subentry) row collapse state to the local storage.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #30203
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
