### PR TITLE
Show related entities warning when deleting helpers

### DIFF
--- a/src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts
+++ b/src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts
@@ -4,6 +4,7 @@ import { customElement, property, query, state } from "lit/decorators";
 import { isComponentLoaded } from "../../../../../common/config/is_component_loaded";
 import { dynamicElement } from "../../../../../common/dom/dynamic-element-directive";
 import { fireEvent } from "../../../../../common/dom/fire_event";
+import { computeEntityEntryName } from "../../../../../common/entity/compute_entity_name";
 import "../../../../../components/ha-button";
 import type { ExtEntityRegistryEntry } from "../../../../../data/entity/entity_registry";
 import { removeEntityRegistryEntry } from "../../../../../data/entity/entity_registry";
@@ -24,6 +25,7 @@ import "../../../helpers/forms/ha-timer-form";
 import "../../../voice-assistants/entity-voice-settings";
 import "../../entity-registry-settings-editor";
 import type { EntityRegistrySettingsEditor } from "../../entity-registry-settings-editor";
+import { getDeleteConfirmationText } from "../../get-delete-confirmation-text";
 
 @customElement("entity-settings-helper-tab")
 export class EntitySettingsHelperTab extends LitElement {
@@ -162,11 +164,19 @@ export class EntitySettingsHelperTab extends LitElement {
   }
 
   private async _confirmDeleteItem(): Promise<void> {
+    const name = computeEntityEntryName(this.entry);
+    const confirmationText = await getDeleteConfirmationText(
+      this.hass,
+      this.entry,
+      name
+    );
+
     if (
       !(await showConfirmationDialog(this, {
-        text: this.hass.localize(
-          "ui.dialogs.entity_registry.editor.confirm_delete"
+        title: this.hass.localize(
+          "ui.dialogs.entity_registry.editor.confirm_delete_title"
         ),
+        text: confirmationText,
         confirmText: this.hass.localize("ui.common.delete"),
         dismissText: this.hass.localize("ui.common.cancel"),
         destructive: true,

--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -1,9 +1,11 @@
 import type { HassEntity } from "home-assistant-js-websocket";
-import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
+import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
-import { formatListWithAnds } from "../../../common/string/format-list";
 import { fireEvent } from "../../../common/dom/fire_event";
+import { computeDeviceName } from "../../../common/entity/compute_device_name";
+import { computeEntityEntryName } from "../../../common/entity/compute_entity_name";
+import { getEntityEntryContext } from "../../../common/entity/context/get_entity_context";
 import "../../../components/ha-alert";
 import "../../../components/ha-button";
 import type { ConfigEntry } from "../../../data/config_entries";
@@ -17,7 +19,6 @@ import {
   removeEntityRegistryEntry,
   updateEntityRegistryEntry,
 } from "../../../data/entity/entity_registry";
-import { findRelated } from "../../../data/search";
 import { fetchIntegrationManifest } from "../../../data/integration";
 import {
   showAlertDialog,
@@ -29,9 +30,7 @@ import type { HomeAssistant } from "../../../types";
 import { showDeviceRegistryDetailDialog } from "../devices/device-registry-detail/show-dialog-device-registry-detail";
 import "./entity-registry-settings-editor";
 import type { EntityRegistrySettingsEditor } from "./entity-registry-settings-editor";
-import { computeEntityEntryName } from "../../../common/entity/compute_entity_name";
-
-const RELATED_ENTITY_DOMAINS = ["automation", "script", "group", "scene"];
+import { getDeleteConfirmationText } from "./get-delete-confirmation-text";
 
 @customElement("entity-registry-settings")
 export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
@@ -214,7 +213,25 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
   }
 
   private async _confirmDeleteEntry(): Promise<void> {
-    const confirmationText = await this._getDeleteConfirmationText();
+    let name = computeEntityEntryName(this.entry);
+    if (!name) {
+      const { device } = getEntityEntryContext(
+        this.entry,
+        this.hass.entities,
+        this.hass.devices,
+        this.hass.areas,
+        this.hass.floors
+      );
+      if (device) {
+        name = computeDeviceName(device);
+      }
+    }
+
+    const confirmationText = await getDeleteConfirmationText(
+      this.hass,
+      this.entry,
+      name
+    );
 
     if (
       !(await showConfirmationDialog(this, {
@@ -241,46 +258,6 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
       fireEvent(this, "close-dialog");
     } finally {
       this._submitting = false;
-    }
-  }
-
-  private async _getDeleteConfirmationText(): Promise<string | TemplateResult> {
-    const mainText = this.hass.localize(
-      "ui.dialogs.entity_registry.editor.confirm_delete",
-      { entity_name: computeEntityEntryName(this.entry) }
-    );
-
-    try {
-      const related = await findRelated(
-        this.hass,
-        "entity",
-        this.entry.entity_id
-      );
-
-      const relatedItems = RELATED_ENTITY_DOMAINS.map((domain) => {
-        const count = related[domain]?.length || 0;
-        if (count === 0) {
-          return undefined;
-        }
-        return this.hass.localize(
-          `ui.dialogs.entity_registry.editor.confirm_delete_count.${domain}`,
-          { count }
-        );
-      }).filter((item): item is string => Boolean(item));
-
-      if (relatedItems.length === 0) {
-        return mainText;
-      }
-
-      return html`${mainText} <br /><br />
-        ${this.hass.localize(
-          "ui.dialogs.entity_registry.editor.confirm_delete_related",
-          {
-            items: formatListWithAnds(this.hass.locale, relatedItems),
-          }
-        )}`;
-    } catch (_err) {
-      return mainText;
     }
   }
 

--- a/src/panels/config/entities/get-delete-confirmation-text.ts
+++ b/src/panels/config/entities/get-delete-confirmation-text.ts
@@ -1,0 +1,48 @@
+import type { TemplateResult } from "lit";
+import { html } from "lit";
+import { formatListWithAnds } from "../../../common/string/format-list";
+import type { ExtEntityRegistryEntry } from "../../../data/entity/entity_registry";
+import { findRelated } from "../../../data/search";
+import type { HomeAssistant } from "../../../types";
+
+const RELATED_ENTITY_DOMAINS = ["automation", "script", "group", "scene"];
+
+export const getDeleteConfirmationText = async (
+  hass: HomeAssistant,
+  entry: ExtEntityRegistryEntry,
+  name: string | undefined
+): Promise<string | TemplateResult> => {
+  const mainText = hass.localize(
+    "ui.dialogs.entity_registry.editor.confirm_delete",
+    { entity_name: name }
+  );
+
+  try {
+    const related = await findRelated(hass, "entity", entry.entity_id);
+
+    const relatedItems = RELATED_ENTITY_DOMAINS.map((domain) => {
+      const count = related[domain]?.length || 0;
+      if (count === 0) {
+        return undefined;
+      }
+      return hass.localize(
+        `ui.dialogs.entity_registry.editor.confirm_delete_count.${domain}`,
+        { count }
+      );
+    }).filter((item): item is string => Boolean(item));
+
+    if (relatedItems.length === 0) {
+      return mainText;
+    }
+
+    return html`${mainText} <br /><br />
+      ${hass.localize(
+        "ui.dialogs.entity_registry.editor.confirm_delete_related",
+        {
+          items: formatListWithAnds(hass.locale, relatedItems),
+        }
+      )}`;
+  } catch (_err) {
+    return mainText;
+  }
+};


### PR DESCRIPTION
## Proposed change

When deleting a helper entity, the confirmation dialog now shows related automations, scripts, groups, and scenes that reference it (same as https://github.com/home-assistant/frontend/pull/30293)

The shared logic has been extracted into a reusable function so both the entity settings and helper settings dialogs use the same behavior.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
