### PR TITLE
Fix trend and sensor graph when no history

### DIFF
--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -464,6 +464,15 @@ export const convertStatisticsToHistory = (
   return statisticsHistory;
 };
 
+export const limitedHistoryFromStateObj = (
+  state: HassEntity
+): EntityHistoryState[] => [
+  {
+    s: state.state,
+    a: state.attributes,
+    lu: new Date(state.last_updated).getTime() / 1000,
+  },
+];
 export const computeHistory = (
   hass: HomeAssistant,
   stateHistory: HistoryStates,
@@ -484,13 +493,9 @@ export const computeHistory = (
     if (entity in stateHistory) {
       localStateHistory[entity] = stateHistory[entity];
     } else if (hass.states[entity]) {
-      localStateHistory[entity] = [
-        {
-          s: hass.states[entity].state,
-          a: hass.states[entity].attributes,
-          lu: new Date(hass.states[entity].last_updated).getTime() / 1000,
-        },
-      ];
+      localStateHistory[entity] = limitedHistoryFromStateObj(
+        hass.states[entity]
+      );
     }
   });
 

--- a/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
@@ -4,7 +4,10 @@ import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { isNumericFromAttributes } from "../../../common/number/format_number";
 import "../../../components/ha-spinner";
-import { subscribeHistoryStatesTimeWindow } from "../../../data/history";
+import {
+  limitedHistoryFromStateObj,
+  subscribeHistoryStatesTimeWindow,
+} from "../../../data/history";
 import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import type { HomeAssistant } from "../../../types";
 import { coordinatesMinimalResponseCompressedState } from "../common/graph/coordinates";
@@ -127,6 +130,14 @@ class HuiHistoryChartCardFeature
     return subscribeHistoryStatesTimeWindow(
       this.hass!,
       (historyStates) => {
+        const entityId = this.context!.entity_id!;
+        let history = historyStates[entityId];
+        if (!history?.length) {
+          const stateObj = this.hass!.states[entityId];
+          if (stateObj) {
+            history = limitedHistoryFromStateObj(stateObj);
+          }
+        }
         // sample to 1 point per hour for low detail or 1 point per 5 pixels for high detail
         const maxDetails = detail
           ? Math.max(10, this.clientWidth / 5, hourToShow)
@@ -134,7 +145,7 @@ class HuiHistoryChartCardFeature
         const useMean = !detail;
         const { points, yAxisOrigin } =
           coordinatesMinimalResponseCompressedState(
-            historyStates[this.context!.entity_id!],
+            history,
             this.clientWidth,
             this.clientHeight,
             maxDetails,

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -7,7 +7,10 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import "../../../components/ha-spinner";
 import type { HistoryStates } from "../../../data/history";
-import { subscribeHistoryStatesTimeWindow } from "../../../data/history";
+import {
+  limitedHistoryFromStateObj,
+  subscribeHistoryStatesTimeWindow,
+} from "../../../data/history";
 import type { HomeAssistant } from "../../../types";
 import { findEntities } from "../common/find-entities";
 import { coordinatesMinimalResponseCompressedState } from "../common/graph/coordinates";
@@ -165,6 +168,13 @@ export class HuiGraphHeaderFooter
           return;
         }
         this._history = combinedHistory;
+        if (!this._history[this._config.entity]?.length) {
+          const stateObj = this.hass!.states[this._config.entity];
+          if (stateObj) {
+            this._history[this._config.entity] =
+              limitedHistoryFromStateObj(stateObj);
+          }
+        }
         this._computeCoordinates();
       },
       this._config.hours_to_show!,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When history graph plots a sensor that has no recorder datapoints (due to no change in the keep_days window), we use the state object to "plot" the unchanged line, instead of just showing an error. 

This change applies the same logic to tile trend-graph, and graph-header-footer (used in the sensor card). 
Otherwise trend graph just shows an ugly label, and sensor card shows a forever loading spinner that never resolves, I don't think either is good for the UI. The important thing to show is that there is no change in the sensor, not that it has expired in the recorder. 

E.g. current behavior

<img width="440" height="133" alt="image" src="https://github.com/user-attachments/assets/94121353-9dc9-4579-9fce-c3b6aa92baa8" />



## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
