### PR TITLE
Numeric threshold selector fixes

### DIFF
--- a/src/components/ha-form/compute-initial-ha-form-data.ts
+++ b/src/components/ha-form/compute-initial-ha-form-data.ts
@@ -142,6 +142,19 @@ export const computeInitialHaFormData = (
             ])[firstChoice],
           };
         }
+      } else if ("numeric_threshold" in selector) {
+        const mode = selector.numeric_threshold?.mode ?? "crossed";
+        const type = mode === "changed" ? "any" : "above";
+        data[field.name] =
+          type === "any"
+            ? { type }
+            : {
+                type,
+                value: {
+                  number: selector.numeric_threshold?.number?.min ?? 0,
+                  active_choice: "number",
+                },
+              };
       } else {
         throw new Error(
           `Selector ${Object.keys(selector)[0]} not supported in initial form data`

--- a/src/components/ha-selector/ha-selector-numeric-threshold.ts
+++ b/src/components/ha-selector/ha-selector-numeric-threshold.ts
@@ -2,6 +2,7 @@ import memoizeOne from "memoize-one";
 import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { mdiChartBellCurveCumulative } from "@mdi/js";
 import { fireEvent } from "../../common/dom/fire_event";
 import type {
   NumericThresholdSelector,
@@ -73,6 +74,18 @@ export class HaNumericThresholdSelector extends LitElement {
     if (changedProperties.has("value") || changedProperties.has("selector")) {
       const mode = this._getMode();
       this._type = this.value?.type || DEFAULT_TYPE[mode];
+    }
+  }
+
+  protected updated(changedProperties: PropertyValues): void {
+    super.updated(changedProperties);
+    if (
+      (changedProperties.has("value") || changedProperties.has("selector")) &&
+      !this.value
+    ) {
+      const mode = this._getMode();
+      const type = DEFAULT_TYPE[mode];
+      fireEvent(this, "value-changed", { value: { type } });
     }
   }
 
@@ -220,6 +233,7 @@ export class HaNumericThresholdSelector extends LitElement {
       return [
         {
           value: "any",
+          iconPath: mdiChartBellCurveCumulative,
           label: localize(
             "ui.components.selectors.numeric_threshold.changed.any"
           ),
@@ -481,7 +495,7 @@ export class HaNumericThresholdSelector extends LitElement {
     .value-inputs {
       display: flex;
       gap: var(--ha-space-2);
-      align-items: flex-end;
+      align-items: flex-start;
     }
 
     .value-selector {
@@ -495,6 +509,7 @@ export class HaNumericThresholdSelector extends LitElement {
 
     ha-select {
       width: 100%;
+      margin-bottom: var(--ha-space-5);
     }
   `;
 }

--- a/src/components/ha-selector/ha-selector-numeric-threshold.ts
+++ b/src/components/ha-selector/ha-selector-numeric-threshold.ts
@@ -509,7 +509,6 @@ export class HaNumericThresholdSelector extends LitElement {
 
     ha-select {
       width: 100%;
-      margin-bottom: var(--ha-space-5);
     }
   `;
 }


### PR DESCRIPTION


## Proposed change

Changes

Add numeric_threshold support to computeInitialHaFormData — required ha-form fields using the numeric_threshold selector would previously throw a runtime error. The initial value is now computed based on the selector's mode: crossed/is modes default to { type: "above", value: { number: <min>, active_choice: "number" } }, and changed mode defaults to { type: "any" }.

Fix numeric_threshold selector not emitting an initial value — when the selector rendered with no existing value (for example a changed mode field defaulting to any, which has no input fields for the user to interact with), no value-changed event was ever fired and the form data remained empty, resulting in an invalid config. The component now fires value-changed with the default value on first render when value is unset.

Add icon for the any option in changed mode — the type selector's any option now has an icon to be consistent with the other type options.

Fixes alignment of number input and select element for UOM

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
