### PR TITLE
Show device name prefix in entity name field

### DIFF
--- a/src/components/ha-textfield.ts
+++ b/src/components/ha-textfield.ts
@@ -283,6 +283,9 @@ export class HaTextField extends LitElement {
     .prefix {
       padding-top: var(--ha-space-3);
       margin-inline-end: var(--text-field-prefix-padding-right);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   `;
 }

--- a/src/components/input/ha-input.ts
+++ b/src/components/input/ha-input.ts
@@ -228,6 +228,9 @@ export class HaInput extends LitElement {
   @state()
   private _invalid = false;
 
+  @state()
+  private _hasStartSlot = false;
+
   @query("wa-input")
   private _input?: WaInput;
 
@@ -348,7 +351,8 @@ export class HaInput extends LitElement {
           invalid: this.invalid || this._invalid,
           "label-raised":
             (this.value !== undefined && this.value !== "") ||
-            (this.label && this.placeholder),
+            (this.label && this.placeholder) ||
+            this._hasStartSlot,
           "no-label": !this.label,
           "hint-hidden":
             !this.hint &&
@@ -368,7 +372,7 @@ export class HaInput extends LitElement {
               >${this._renderLabel(this.label, this.required)}</slot
             >`
           : nothing}
-        <slot name="start" slot="start" @slotchange=${this._syncStartSlotWidth}>
+        <slot name="start" slot="start" @slotchange=${this._onStartSlotChange}>
           ${this.renderStartDefault()}
         </slot>
         <slot name="end" slot="end"> ${this.renderEndDefault()} </slot>
@@ -432,6 +436,12 @@ export class HaInput extends LitElement {
   private _handleInvalid() {
     this._invalid = true;
   }
+
+  private _onStartSlotChange = (ev: Event) => {
+    const slot = ev.target as HTMLSlotElement;
+    this._hasStartSlot = slot.assignedNodes().length > 0;
+    this._syncStartSlotWidth();
+  };
 
   private _syncStartSlotWidth = () => {
     const startEl = this._input?.shadowRoot?.querySelector(
@@ -577,6 +587,12 @@ export class HaInput extends LitElement {
     :host([appearance="material"])
       wa-input.invalid:not([disabled])::part(base)::after {
       background-color: var(--ha-color-border-danger-normal);
+    }
+
+    wa-input::part(start) {
+      max-width: var(--ha-input-start-max-width, none);
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     wa-input::part(input) {

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -8,6 +8,7 @@ import { until } from "lit/directives/until";
 import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { fireEvent } from "../../../common/dom/fire_event";
+import { computeDeviceName } from "../../../common/entity/compute_device_name";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { computeObjectId } from "../../../common/entity/compute_object_id";
 import { supportsFeature } from "../../../common/entity/supports-feature";
@@ -211,6 +212,12 @@ export class EntityRegistrySettingsEditor extends LitElement {
 
   protected willUpdate(changedProperties: PropertyValues) {
     super.willUpdate(changedProperties);
+    if (changedProperties.has("hass") && this.entry.device_id) {
+      const device = this.hass.devices[this.entry.device_id];
+      if (device !== this._device) {
+        this._device = device;
+      }
+    }
     if (
       !changedProperties.has("entry") ||
       changedProperties.get("entry")?.id === this.entry.id
@@ -388,27 +395,47 @@ export class EntityRegistrySettingsEditor extends LitElement {
       ${this.hideName
         ? nothing
         : html`<ha-textfield
-            class="name"
-            .value=${this._name ?? this.entry.original_name ?? ""}
-            .label=${this.hass.localize(
-              "ui.dialogs.entity_registry.editor.name"
-            )}
-            .disabled=${this.disabled}
-            @input=${this._nameChanged}
-            .iconTrailing=${this._name !== null}
-          >
-            ${this._name !== null
-              ? html`<div class="layout horizontal" slot="trailingIcon">
-                  <ha-icon-button
-                    @click=${this._restoreName}
-                    .path=${mdiRestore}
-                    .label=${this.hass.localize(
-                      "ui.dialogs.entity_registry.editor.restore_name"
-                    )}
-                  ></ha-icon-button>
-                </div>`
-              : nothing}
-          </ha-textfield>`}
+              class="name"
+              .value=${this._name ?? this.entry.original_name ?? ""}
+              .prefix=${this.entry.has_entity_name && this._device
+                ? (computeDeviceName(this._device) ?? "")
+                : ""}
+              .label=${this.hass.localize(
+                "ui.dialogs.entity_registry.editor.name"
+              )}
+              .disabled=${this.disabled}
+              @input=${this._nameChanged}
+              .iconTrailing=${this._name !== null}
+            >
+              ${this._name !== null
+                ? html`<div class="layout horizontal" slot="trailingIcon">
+                    <ha-icon-button
+                      @click=${this._restoreName}
+                      .path=${mdiRestore}
+                      .label=${this.hass.localize(
+                        "ui.dialogs.entity_registry.editor.restore_name"
+                      )}
+                    ></ha-icon-button>
+                  </div>`
+                : nothing}
+            </ha-textfield>
+            ${this.entry.has_entity_name && this._device
+              ? html`<span class="hint">
+                  ${this.hass.localize(
+                    "ui.dialogs.entity_registry.editor.change_device_settings",
+                    {
+                      link: html`<button
+                        class="link"
+                        @click=${this._openDeviceSettings}
+                      >
+                        ${this.hass.localize(
+                          "ui.dialogs.entity_registry.editor.change_device_name_link"
+                        )}
+                      </button>`,
+                    }
+                  )}
+                </span>`
+              : nothing}`}
       ${this.hideIcon
         ? nothing
         : html`
@@ -1611,6 +1638,10 @@ export class EntityRegistrySettingsEditor extends LitElement {
         ha-textfield.entityId {
           --text-field-prefix-padding-right: 0;
         }
+        ha-textfield.name {
+          --text-field-prefix-padding-right: var(--ha-space-1);
+          --ha-input-start-max-width: 50%;
+        }
         ha-textfield.entityId,
         ha-textfield.name {
           --textfield-icon-trailing-padding: 0;
@@ -1636,6 +1667,16 @@ export class EntityRegistrySettingsEditor extends LitElement {
           display: block;
           margin: var(--ha-space-2) 0;
           width: 100%;
+        }
+        .hint {
+          display: block;
+          color: var(--secondary-text-color);
+          font-size: 12px;
+          padding: 0 16px;
+          margin-top: -4px;
+        }
+        .hint .link {
+          direction: var(--direction);
         }
         .menu-item {
           border-radius: var(--ha-border-radius-sm);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1865,6 +1865,7 @@
           },
           "update": "Update",
           "note": "Note: This might not work yet with all integrations.",
+          "change_device_name_link": "change the device name",
           "use_device_area": "Use device area",
           "change_device_settings": "You can {link} in the device settings",
           "change_device_area_link": "change the device area",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When editing an entity that uses `has_entity_name`, the name field now shows the device name as a prefix, making it clear that the entity name is displayed alongside the device name. A hint below the field provides a link to change the device name in the device settings.

This also improves `ha-input` to automatically raise the label when a start slot is present, and adds support for limiting the start slot width via a CSS variable.

## Screenshots

<img width="608" height="244" alt="CleanShot 2026-03-26 at 16 09 24" src="https://github.com/user-attachments/assets/4de35554-9206-43c1-b4b6-bffec5707028" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
