### PR TITLE
Fix negative currency display on sensor card

### DIFF
--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -144,18 +144,28 @@ const computeStateToPartsFromEntityAttributes = (
           fraction: "value",
           literal: "literal",
           currency: "unit",
-          minusSign: "value",
         };
 
         const valueParts: ValuePart[] = [];
+        let sign = "";
 
         for (const part of parts) {
+          if (part.type === "minusSign" || part.type === "plusSign") {
+            sign += part.value;
+            continue;
+          }
           const type = TYPE_MAP[part.type];
           if (!type) continue;
           const last = valueParts[valueParts.length - 1];
           // Merge consecutive numeric parts (e.g. "1" + "," + "234" + "." + "56" → "1,234.56")
-          if (type === "value" && last?.type === "value") {
-            last.value += part.value;
+          if (type === "value") {
+            const value = sign + part.value;
+            sign = "";
+            if (last?.type === "value") {
+              last.value += value;
+            } else {
+              valueParts.push({ type, value });
+            }
           } else {
             valueParts.push({ type, value: part.value });
           }

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -142,30 +142,21 @@ const computeStateToPartsFromEntityAttributes = (
           group: "value",
           decimal: "value",
           fraction: "value",
+          minusSign: "value",
+          plusSign: "value",
           literal: "literal",
           currency: "unit",
         };
 
         const valueParts: ValuePart[] = [];
-        let sign = "";
 
         for (const part of parts) {
-          if (part.type === "minusSign" || part.type === "plusSign") {
-            sign += part.value;
-            continue;
-          }
           const type = TYPE_MAP[part.type];
           if (!type) continue;
           const last = valueParts[valueParts.length - 1];
-          // Merge consecutive numeric parts (e.g. "1" + "," + "234" + "." + "56" → "1,234.56")
-          if (type === "value") {
-            const value = sign + part.value;
-            sign = "";
-            if (last?.type === "value") {
-              last.value += value;
-            } else {
-              valueParts.push({ type, value });
-            }
+          // Merge consecutive value parts (e.g. "-" + "12" + "." + "00" → "-12.00")
+          if (type === "value" && last?.type === "value") {
+            last.value += part.value;
           } else {
             valueParts.push({ type, value: part.value });
           }

--- a/src/components/ha-attribute-value.ts
+++ b/src/components/ha-attribute-value.ts
@@ -56,7 +56,10 @@ class HaAttributeValue extends LitElement {
         this.stateObj!,
         this.attribute
       );
-      return parts.find((part) => part.type === "value")?.value;
+      return parts
+        .filter((part) => part.type === "value")
+        .map((part) => part.value)
+        .join("");
     }
 
     return this.hass.formatEntityAttributeValue(this.stateObj!, this.attribute);

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -143,7 +143,10 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
     }
 
     const indexUnit = stateParts.findIndex((part) => part.type === "unit");
-    const indexValue = stateParts.findIndex((part) => part.type === "value");
+    const indexValue = stateParts.reduceRight(
+      (acc, part, i) => (acc === -1 && part.type === "value" ? i : acc),
+      -1
+    );
     const reversedOrder = indexUnit !== -1 && indexUnit < indexValue;
 
     const name = computeLovelaceEntityName(
@@ -209,7 +212,10 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
                   >
                   </ha-attribute-value>`
                 : this.hass.localize("state.default.unknown")
-              : stateParts.find((part) => part.type === "value")?.value}</span
+              : stateParts
+                  .filter((part) => part.type === "value")
+                  .map((part) => part.value)
+                  .join("")}</span
           >${unit
             ? html`<span
                 class=${classMap({

--- a/test/common/entity/compute_state_display.test.ts
+++ b/test/common/entity/compute_state_display.test.ts
@@ -702,7 +702,7 @@ describe("computeStateDisplayFromEntityAttributes with numeric device classes", 
       },
       "-12"
     );
-    // Intl.NumberFormat formats negative currency differently across platforms
+    // Joined output matches native Intl formatting
     const expected = new Intl.NumberFormat("en", {
       style: "currency",
       currency: "USD",

--- a/test/common/entity/compute_state_display.test.ts
+++ b/test/common/entity/compute_state_display.test.ts
@@ -702,7 +702,13 @@ describe("computeStateDisplayFromEntityAttributes with numeric device classes", 
       },
       "-12"
     );
-    expect(result).toBe("-$12.00");
+    // Intl.NumberFormat formats negative currency differently across platforms
+    const expected = new Intl.NumberFormat("en", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+    }).format(-12);
+    expect(result).toBe(expected);
   });
 });
 


### PR DESCRIPTION
## Proposed change

Fix negative currency values not displaying properly on entity/sensor cards (e.g., showing just `-` instead of `-$12.00`).

`Intl.NumberFormat.formatToParts()` emits `minusSign`/`plusSign` as separate parts that weren't mapped in the type conversion, so they were silently dropped. This PR:

1. Maps `minusSign`/`plusSign` as `"value"` parts in `computeStateDisplay`, preserving native Intl formatting order in the joined output.
2. Fixes entity cards and `ha-attribute-value` to collect all `"value"` parts (not just the first), so the sign and digits are combined for display.
3. Uses the last value part index for unit ordering, so the currency symbol position is correct.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #30335
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr