### PR TITLE
Add apps info page for non-HAOS installations

### DIFF
--- a/src/data/frontend.ts
+++ b/src/data/frontend.ts
@@ -4,6 +4,7 @@ export interface CoreFrontendUserData {
   showAdvanced?: boolean;
   showEntityIdPicker?: boolean;
   default_panel?: string;
+  apps_info_dismissed?: boolean;
 }
 
 export interface SidebarFrontendUserData {

--- a/src/panels/config/apps/ha-config-apps-info.ts
+++ b/src/panels/config/apps/ha-config-apps-info.ts
@@ -1,0 +1,179 @@
+import { mdiOpenInNew, mdiPuzzle } from "@mdi/js";
+import type { CSSResultGroup, TemplateResult } from "lit";
+import { LitElement, css, html } from "lit";
+import { customElement, property } from "lit/decorators";
+import "../../../components/ha-alert";
+import "../../../components/ha-button";
+import "../../../components/ha-card";
+import "../../../components/ha-svg-icon";
+import { saveFrontendUserData } from "../../../data/frontend";
+import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
+import "../../../layouts/hass-subpage";
+import { haStyle } from "../../../resources/styles";
+import type { HomeAssistant } from "../../../types";
+import { documentationUrl } from "../../../util/documentation-url";
+import { navigate } from "../../../common/navigate";
+
+@customElement("ha-config-apps-info")
+class HaConfigAppsInfo extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ type: Boolean }) public narrow = false;
+
+  @property({ attribute: "is-wide", type: Boolean }) public isWide = false;
+
+  protected render(): TemplateResult {
+    return html`
+      <hass-subpage
+        .hass=${this.hass}
+        .narrow=${this.narrow}
+        back-path="/config"
+        .header=${this.hass.localize("ui.panel.config.dashboard.apps.main")}
+      >
+        <div class="content">
+          <ha-card outlined>
+            <div class="card-content">
+              <div class="header">
+                <ha-svg-icon class="icon" .path=${mdiPuzzle}></ha-svg-icon>
+                <h1>
+                  ${this.hass.localize(
+                    "ui.panel.config.apps.info.what_is_an_app"
+                  )}
+                </h1>
+              </div>
+              <p>
+                ${this.hass.localize(
+                  "ui.panel.config.apps.info.what_is_an_app_description"
+                )}
+              </p>
+            </div>
+          </ha-card>
+
+          <ha-card outlined>
+            <div class="card-content">
+              <h2>
+                ${this.hass.localize(
+                  "ui.panel.config.apps.info.why_not_available"
+                )}
+              </h2>
+              <p>
+                ${this.hass.localize(
+                  "ui.panel.config.apps.info.why_not_available_description"
+                )}
+              </p>
+              <ha-alert alert-type="info">
+                ${this.hass.localize(
+                  "ui.panel.config.apps.info.installation_hint"
+                )}
+              </ha-alert>
+            </div>
+            <div class="card-actions">
+              <ha-button
+                appearance="plain"
+                href=${documentationUrl(this.hass, "/apps/")}
+                target="_blank"
+                rel="noreferrer"
+              >
+                ${this.hass.localize("ui.panel.config.apps.info.learn_more")}
+                <ha-svg-icon slot="icon" .path=${mdiOpenInNew}></ha-svg-icon>
+              </ha-button>
+              <ha-button @click=${this._dismiss} variant="danger">
+                ${this.hass.localize("ui.panel.config.apps.info.dismiss")}
+              </ha-button>
+            </div>
+          </ha-card>
+        </div>
+      </hass-subpage>
+    `;
+  }
+
+  private async _dismiss(): Promise<void> {
+    try {
+      await saveFrontendUserData(this.hass.connection, "core", {
+        ...this.hass.userData,
+        apps_info_dismissed: true,
+      });
+    } catch (err) {
+      showAlertDialog(this, { text: (err as Error).message });
+      return;
+    }
+    navigate("/config");
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      css`
+        .content {
+          max-width: 600px;
+          margin: 0 auto;
+          padding: var(--ha-space-4);
+          display: flex;
+          flex-direction: column;
+          gap: var(--ha-space-4);
+        }
+
+        .card-content {
+          padding: var(--ha-space-4);
+        }
+
+        .header {
+          display: flex;
+          align-items: center;
+          gap: var(--ha-space-3);
+          margin-bottom: var(--ha-space-4);
+        }
+
+        .icon {
+          width: 40px;
+          height: 40px;
+          flex-shrink: 0;
+          color: var(--primary-color);
+        }
+
+        h1 {
+          margin: 0;
+          font-size: var(--ha-font-size-xl);
+          font-weight: 500;
+        }
+
+        h2 {
+          margin: 0 0 var(--ha-space-3);
+          font-size: var(--ha-font-size-l);
+          font-weight: 500;
+        }
+
+        p {
+          margin: 0 0 var(--ha-space-3);
+          line-height: var(--ha-line-height-normal);
+          color: var(--secondary-text-color);
+        }
+
+        ha-alert {
+          display: block;
+          margin-top: var(--ha-space-2);
+        }
+
+        .card-actions {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          flex-wrap: wrap;
+          gap: var(--ha-space-2);
+          padding: var(--ha-space-2);
+          border-top: var(--ha-border-width-sm) solid var(--divider-color);
+        }
+
+        a {
+          text-decoration: none;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-config-apps-info": HaConfigAppsInfo;
+  }
+}

--- a/src/panels/config/apps/ha-config-apps-info.ts
+++ b/src/panels/config/apps/ha-config-apps-info.ts
@@ -97,7 +97,7 @@ class HaConfigAppsInfo extends LitElement {
       showAlertDialog(this, { text: (err as Error).message });
       return;
     }
-    navigate("/config");
+    navigate("/config", { replace: true });
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/apps/ha-config-apps.ts
+++ b/src/panels/config/apps/ha-config-apps.ts
@@ -1,4 +1,5 @@
 import { customElement, property } from "lit/decorators";
+import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import type { RouterOptions } from "../../../layouts/hass-router-page";
 import { HassRouterPage } from "../../../layouts/hass-router-page";
 import type { HomeAssistant, Route } from "../../../types";
@@ -15,6 +16,12 @@ class HaConfigApps extends HassRouterPage {
 
   protected routerOptions: RouterOptions = {
     defaultPage: "installed",
+    beforeRender: () => {
+      if (!isComponentLoaded(this.hass.config, "hassio")) {
+        return "info";
+      }
+      return undefined;
+    },
     routes: {
       installed: {
         tag: "ha-config-apps-installed",
@@ -31,6 +38,10 @@ class HaConfigApps extends HassRouterPage {
       registries: {
         tag: "ha-config-apps-registries",
         load: () => import("./ha-config-apps-registries"),
+      },
+      info: {
+        tag: "ha-config-apps-info",
+        load: () => import("./ha-config-apps-info"),
       },
     },
   };

--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -36,6 +36,7 @@ import {
 import { showQuickBar } from "../../../dialogs/quick-bar/show-dialog-quick-bar";
 import { showRestartDialog } from "../../../dialogs/restart/show-dialog-restart";
 import { showShortcutsDialog } from "../../../dialogs/shortcuts/show-shortcuts-dialog";
+import type { PageNavigation } from "../../../layouts/hass-tabs-subpage";
 import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
@@ -169,25 +170,37 @@ class HaConfigDashboard extends SubscribeMixin(LitElement) {
   };
 
   private _pages = memoizeOne(
-    (cloudStatus, isCloudLoaded, hasExternalSettings) => [
-      isCloudLoaded
-        ? [
-            {
-              component: "cloud",
-              path: "/config/cloud",
-              name: "Home Assistant Cloud",
-              info: cloudStatus,
-              iconPath: mdiCloudLock,
-              iconColor: "#3B808E",
-              translationKey: "cloud",
-            },
-            ...configSections.dashboard,
-          ]
-        : configSections.dashboard,
-      hasExternalSettings ? configSections.dashboard_external_settings : [],
-      configSections.dashboard_2,
-      configSections.dashboard_3,
-    ]
+    (
+      cloudStatus,
+      isCloudLoaded,
+      hasExternalSettings,
+      isAppsInfoDismissed,
+      isHassioLoaded
+    ) => {
+      const filterApps = (pages: PageNavigation[]) =>
+        isAppsInfoDismissed && !isHassioLoaded
+          ? pages.filter((page) => page.path !== "/config/apps")
+          : pages;
+      return [
+        isCloudLoaded
+          ? filterApps([
+              {
+                component: "cloud",
+                path: "/config/cloud",
+                name: "Home Assistant Cloud",
+                info: cloudStatus,
+                iconPath: mdiCloudLock,
+                iconColor: "#3B808E",
+                translationKey: "cloud",
+              },
+              ...configSections.dashboard,
+            ])
+          : filterApps(configSections.dashboard),
+        hasExternalSettings ? configSections.dashboard_external_settings : [],
+        configSections.dashboard_2,
+        configSections.dashboard_3,
+      ];
+    }
   );
 
   public hassSubscribe(): UnsubscribeFunc[] {
@@ -338,7 +351,9 @@ class HaConfigDashboard extends SubscribeMixin(LitElement) {
           ${this._pages(
             this.cloudStatus,
             isComponentLoaded(this.hass.config, "cloud"),
-            this.hass.auth.external?.config.hasSettingsScreen
+            this.hass.auth.external?.config.hasSettingsScreen,
+            this.hass.userData?.apps_info_dismissed,
+            isComponentLoaded(this.hass.config, "hassio")
           ).map((categoryPages) =>
             categoryPages.length === 0
               ? nothing

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -83,7 +83,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "apps",
       iconPath: mdiPuzzle,
       iconColor: "#F1C447",
-      component: "hassio",
+      core: true,
     },
     {
       path: "/config/lovelace/dashboards",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2699,6 +2699,15 @@
           "caption": "Apps",
           "description": "Install and manage apps",
           "error_loading": "Error loading apps",
+          "info": {
+            "what_is_an_app": "What is an app?",
+            "what_is_an_app_description": "Apps allow you to extend the functionality around Home Assistant by installing additional applications. They run alongside Home Assistant and provide extra features like network monitoring, code editors, database management, and more.",
+            "why_not_available": "Why you see this page instead of an app store",
+            "why_not_available_description": "Apps are only available if you've used the Home Assistant Operating System installation method. If you installed Home Assistant using any other method then you cannot use apps. Often you can achieve the same result manually, refer to the documentation by the vendor of the application you'd like to install.",
+            "installation_hint": "Apps require the Home Assistant Operating System. Learn more about installation methods in the documentation.",
+            "learn_more": "Learn more",
+            "dismiss": "Don't show again"
+          },
           "state": {
             "update_available": "Update available",
             "installed": "Installed",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

On non-Home Assistant Operating System installations, the Apps item in settings opens a page that explains what apps are and why the user doesn't have access to them, referencing the [Apps](https://www.home-assistant.io/apps/)                                                                                                                                                                       
   
  The page explains:                                                                                                                                                                                             
  - What is an app
  - Why you see this page instead of an app store           
                                                                                                                                                                                                                 
  A "Don't show again" button lets the user dismiss the page and hides the Apps entry from the settings dashboard. If the user later migrates to HAOS, the full app store reappears automatically.


## Screenshots
<img width="1040" height="650" alt="image" src="https://github.com/user-attachments/assets/c4fb88ed-9cfb-4f34-b96a-e9009a5396ea" />
<img width="1040" height="650" alt="image" src="https://github.com/user-attachments/assets/fad70292-7679-4eb8-ae39-1de0d1cc2cfc" />



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29414

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr



## Testing                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  ### Setup                                                                                                                                                                                                      
  For non-HAOS installations only (where the `hassio` component is not loaded).
                                                                                                                                                                                                                 
  ### Test the info page
  1. Navigate to **Settings** and click **Apps**                                                                                                                                                                 
  2. Verify the info page is displayed with:                
     - "What is an app?" section explaining what apps are                                                                                                                                                        
     - "Why you see this page instead of an app store" section
     - An info alert about Home Assistant Operating System                                                                                                                                                       
     - A "Learn more" link pointing to the documentation                                                                                                                                                         
     - A "Don't show again" button                                                                                                                                                                               
                                                                                                                                                                                                                 
  ### Test the dismiss flow                                 
  1. On the info page, click **Don't show again**
  2. Verify you are navigated back to the Settings dashboard                                                                                                                                                     
  3. Verify the **Apps** item is no longer visible in the Settings dashboard
                                                                                                                                                                                                                 
  ### Test reset (to re-show the info page)                                                                                                                                                                      
  Run the following in the browser console:                                                                                                                                                                      
  ```js                                                                                                                                                                                                          
  const ha = document.querySelector("home-assistant").hass; 
  const current = await ha.connection.sendMessagePromise({ type: "frontend/get_user_data", key: "core" });
  await ha.connection.sendMessagePromise({ type: "frontend/set_user_data", key: "core", value: { ...current.value, apps_info_dismissed: false } });
```
 Then refresh the page and verify the Apps item reappears in Settings.                                                                                                                                          
                                                                                                                                                                                                                 
  Test HAOS installations                                                                                                                                                                                        
                                                                                                                                                                                                                 
  1. On an HAOS installation (where hassio is loaded), verify the Apps item navigates to the normal app store as before                                                                                          
  2. Verify the info page is never shown, even if apps_info_dismissed is false