### PR TITLE
Use dedicated tab copy in automation add dialogs

### DIFF
--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -502,9 +502,7 @@ class DialogAddAutomationElement
 
     const tabButtons = [
       {
-        label: this.hass.localize(
-          `ui.panel.config.automation.editor.tabs.${automationElementType}` as LocalizeKeys
-        ),
+        label: this.hass.localize("ui.panel.config.automation.editor.tabs.type"),
         value: "groups",
       },
     ];

--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -503,7 +503,7 @@ class DialogAddAutomationElement
     const tabButtons = [
       {
         label: this.hass.localize(
-          `ui.panel.config.automation.editor.${automationElementType}s.name`
+          `ui.panel.config.automation.editor.tabs.${automationElementType}` as LocalizeKeys
         ),
         value: "groups",
       },
@@ -511,7 +511,9 @@ class DialogAddAutomationElement
 
     if (this._newTriggersAndConditions) {
       tabButtons.unshift({
-        label: this.hass.localize(`ui.panel.config.automation.editor.targets`),
+        label: this.hass.localize(
+          "ui.panel.config.automation.editor.tabs.target"
+        ),
         value: "targets",
       });
     }

--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -502,7 +502,9 @@ class DialogAddAutomationElement
 
     const tabButtons = [
       {
-        label: this.hass.localize("ui.panel.config.automation.editor.tabs.type"),
+        label: this.hass.localize(
+          "ui.panel.config.automation.editor.tabs.type"
+        ),
         value: "groups",
       },
     ];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4919,6 +4919,12 @@
             "home": "Home",
             "unassigned": "Unassigned",
             "blocks": "Blocks",
+            "tabs": {
+              "target": "By target",
+              "trigger": "By trigger",
+              "condition": "By condition",
+              "action": "By action"
+            },
             "show_more": "Show more",
             "unassigned_entities": "Unassigned entities",
             "unassigned_devices": "Unassigned devices",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4921,9 +4921,7 @@
             "blocks": "Blocks",
             "tabs": {
               "target": "By target",
-              "trigger": "By trigger",
-              "condition": "By condition",
-              "action": "By action"
+              "type": "By type"
             },
             "show_more": "Show more",
             "unassigned_entities": "Unassigned entities",


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

Add dedicated translation keys for the automation add-dialog tabs so the new "By target" and "By type" copy is only used in the tab buttons.
The shared "Targets", "Triggers", "Conditions", and "Actions" labels remain unchanged for list headings, search sections, and validation messages.

## Screenshots

Not included yet. This is a small UI copy change in the automation add dialogs.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: none
- This PR is related to issue or discussion: none
- Link to documentation pull request: none
- Link to developer documentation pull request: none
- Link to backend pull request: none

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr