### PR TITLE
Add people at home summary tile to home overview dashboard

### DIFF
--- a/src/panels/lovelace/cards/hui-home-summary-card.ts
+++ b/src/panels/lovelace/cards/hui-home-summary-card.ts
@@ -43,6 +43,7 @@ const COLORS: Record<HomeSummary, string> = {
   security: "blue-grey",
   media_players: "blue",
   energy: "amber",
+  persons: "green",
 };
 
 @customElement("hui-home-summary-card")
@@ -256,6 +257,21 @@ export class HuiHomeSummaryCard
         const { consumption } = computeConsumptionData(summedData, undefined);
         const totalConsumption = consumption.total.used_total;
         return formatConsumptionShort(this.hass, totalConsumption, "kWh");
+      }
+      case "persons": {
+        const personsFilters = HOME_SUMMARIES_FILTERS.persons.map((filter) =>
+          generateEntityFilter(this.hass!, filter)
+        );
+        const personEntities = findEntities(allEntities, personsFilters);
+        const personsHome = personEntities.filter((entityId) => {
+          const s = this.hass!.states[entityId]?.state;
+          return s === "home";
+        });
+        return personsHome.length
+          ? this.hass.localize("ui.card.home-summary.count_persons_home", {
+              count: personsHome.length,
+            })
+          : this.hass.localize("ui.card.home-summary.nobody_home");
       }
     }
     return "";

--- a/src/panels/lovelace/strategies/home/helpers/home-summaries.ts
+++ b/src/panels/lovelace/strategies/home/helpers/home-summaries.ts
@@ -10,6 +10,7 @@ export const HOME_SUMMARIES = [
   "security",
   "media_players",
   "energy",
+  "persons",
 ] as const;
 
 export type HomeSummary = (typeof HOME_SUMMARIES)[number];
@@ -20,6 +21,7 @@ export const HOME_SUMMARIES_ICONS: Record<HomeSummary, string> = {
   security: "mdi:security",
   media_players: "mdi:multimedia",
   energy: "mdi:lightning-bolt",
+  persons: "mdi:account-multiple",
 };
 
 export const HOME_SUMMARIES_FILTERS: Record<HomeSummary, EntityFilter[]> = {
@@ -28,6 +30,7 @@ export const HOME_SUMMARIES_FILTERS: Record<HomeSummary, EntityFilter[]> = {
   security: securityEntityFilters,
   media_players: [{ domain: "media_player", entity_category: "none" }],
   energy: [], // Uses energy collection data
+  persons: [{ domain: "person" }],
 };
 
 export const getSummaryLabel = (

--- a/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
@@ -222,10 +222,6 @@ export class HomeOverviewViewStrategy extends ReactiveElement {
       generateEntityFilter(hass, filter)
     );
 
-    const personsFilters = HOME_SUMMARIES_FILTERS.persons.map((filter) =>
-      generateEntityFilter(hass, filter)
-    );
-
     const hasLights =
       hass.panels.light && findEntities(allEntities, lightsFilters).length > 0;
     const hasMediaPlayers =
@@ -236,12 +232,6 @@ export class HomeOverviewViewStrategy extends ReactiveElement {
     const hasSecurity =
       hass.panels.security &&
       findEntities(allEntities, securityFilters).length > 0;
-    const hasPersons =
-      hass.panels.map &&
-      findEntities(allEntities, personsFilters).some(
-        (entityId) =>
-          (hass.states[entityId]?.attributes.device_trackers ?? []).length > 0
-      );
 
     const weatherFilter = generateEntityFilter(hass, {
       domain: "weather",
@@ -343,15 +333,6 @@ export class HomeOverviewViewStrategy extends ReactiveElement {
             navigation_path: config.home_panel
               ? "/energy?historyBack=1&backPath=/home"
               : "/energy?historyBack=1",
-          },
-        } satisfies HomeSummaryCard),
-      hasPersons &&
-        ({
-          type: "home-summary",
-          summary: "persons",
-          tap_action: {
-            action: "navigate",
-            navigation_path: "/map?historyBack=1",
           },
         } satisfies HomeSummaryCard),
     ].filter(Boolean) as LovelaceCardConfig[];

--- a/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
@@ -222,6 +222,10 @@ export class HomeOverviewViewStrategy extends ReactiveElement {
       generateEntityFilter(hass, filter)
     );
 
+    const personsFilters = HOME_SUMMARIES_FILTERS.persons.map((filter) =>
+      generateEntityFilter(hass, filter)
+    );
+
     const hasLights =
       hass.panels.light && findEntities(allEntities, lightsFilters).length > 0;
     const hasMediaPlayers =
@@ -232,6 +236,12 @@ export class HomeOverviewViewStrategy extends ReactiveElement {
     const hasSecurity =
       hass.panels.security &&
       findEntities(allEntities, securityFilters).length > 0;
+    const hasPersons =
+      hass.panels.map &&
+      findEntities(allEntities, personsFilters).some(
+        (entityId) =>
+          (hass.states[entityId]?.attributes.device_trackers ?? []).length > 0
+      );
 
     const weatherFilter = generateEntityFilter(hass, {
       domain: "weather",
@@ -333,6 +343,15 @@ export class HomeOverviewViewStrategy extends ReactiveElement {
             navigation_path: config.home_panel
               ? "/energy?historyBack=1&backPath=/home"
               : "/energy?historyBack=1",
+          },
+        } satisfies HomeSummaryCard),
+      hasPersons &&
+        ({
+          type: "home-summary",
+          summary: "persons",
+          tap_action: {
+            action: "navigate",
+            navigation_path: "/map?historyBack=1",
           },
         } satisfies HomeSummaryCard),
     ].filter(Boolean) as LovelaceCardConfig[];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -217,8 +217,8 @@
         "all_secure": "All secure",
         "no_media_playing": "No media playing",
         "count_media_playing": "{count} {count, plural,\n one {playing}\n other {playing}\n}",
-        "count_persons_home": "{count} {count, plural,\n one {person}\n other {persons}\n}",
-        "nobody_home": "Nobody"
+        "count_persons_home": "{count} {count, plural,\n one {person}\n other {people}\n}",
+        "nobody_home": "No one home"
       },
       "toggle-group": {
         "all_off": "All off",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -216,7 +216,9 @@
         "count_alarms_disarmed": "{count} {count, plural,\n one {disarmed}\n other {disarmed}\n}",
         "all_secure": "All secure",
         "no_media_playing": "No media playing",
-        "count_media_playing": "{count} {count, plural,\n one {playing}\n other {playing}\n}"
+        "count_media_playing": "{count} {count, plural,\n one {playing}\n other {playing}\n}",
+        "count_persons_home": "{count} {count, plural,\n one {person}\n other {persons}\n}",
+        "nobody_home": "Nobody"
       },
       "toggle-group": {
         "all_off": "All off",
@@ -8217,7 +8219,8 @@
               "media_players": "Media players",
               "other_devices": "Other devices",
               "weather": "Weather",
-              "energy": "Today's energy"
+              "energy": "Today's energy",
+              "persons": "People at home"
             },
             "welcome_user": "Welcome {user}",
             "summaries": "Summaries",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
### Summary

This PR adds a **"People at home"** tile to the Summary section of the default home dashboard. The tile displays 
how many people are currently home and navigates to the map panel on tap.

### Motivation

The default home dashboard already summarizes key home states — lights, climate, security, media players, and 
energy. Presence information is equally important for day-to-day home awareness, yet it was missing from the 
summary. This tile gives users an at-a-glance view of who is home without having to open the map or the People 
settings.
 
### Changes
#### Modified files
**`src/panels/lovelace/strategies/home/helpers/home-summaries.ts`**
- Added `"persons"` to the `HOME_SUMMARIES` constant array
- Added icon (`mdi:account-multiple`) to `HOME_SUMMARIES_ICONS`
- Added entity filter (`domain: "person"`) to `HOME_SUMMARIES_FILTERS`

**`src/panels/lovelace/strategies/home/home-overview-view-strategy.ts`**
- Added `personsFilters` computation using `HOME_SUMMARIES_FILTERS.persons`
- Added `hasPersons` boolean, gated on `hass.panels.map` and requiring at least one person entity with a tracking 
device assigned
- Added the `home-summary` persons card to `summaryCards`, navigating to `/map?historyBack=1`

**`src/panels/lovelace/cards/hui-home-summary-card.ts`**
- Added `persons` color (`green`) to the `COLORS` record
- Added `case "persons"` to `_computeSummaryState()`: filters person entities to count those with state `"home"`, and returns a localized string
 
**`src/translations/en.json`**
- Added `ui.card.home-summary.count_persons_home` — plural-aware count (e.g. "1 person" / "2 persons")
- Added `ui.card.home-summary.nobody_home` — shown when no persons are home
- Added `ui.panel.lovelace.strategy.home.summary_list.persons` — tile label "People at home"
 
### Technical implementation

The `"persons"` summary follows the exact same pattern as the existing `"light"`, `"security"`, and 
`"media_players"` summaries:

1. **`HomeSummary` type** — `"persons"` is added to the union so all `Record<HomeSummary, ...>` maps are 
exhaustive and type-safe.
2. **Visibility guard** — `hasPersons` requires both `hass.panels.map` (consistent with how light/climate/security
gate on their panel) and at least one person entity with a non-empty `device_trackers` attribute, so the tile is 
hidden for users without presence detection set up.
3. **Navigation** — tapping opens the map panel (`/map?historyBack=1`), which is the natural place to visualize 
presence.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
<img width="329" height="162" alt="Capture d’écran 2026-03-28 à 23 04 21" src="https://github.com/user-attachments/assets/09fbb1b0-d112-408b-9d0a-6ed71f67a1ab" />
<img width="332" height="163" alt="Capture d’écran 2026-03-28 à 23 04 52" src="https://github.com/user-attachments/assets/5d8fa2f6-c004-48d0-8b05-adfc6e54b33d" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

~- This PR fixes or closes issue: fixes #~
~- This PR is related to issue or discussion:~
~- Link to documentation pull request:~
~- Link to developer documentation pull request:~
~- Link to backend pull request:~

- This is a self-contained frontend change. I searched for an existing issue or discussion related to this feature but did not find any.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
