### PR TITLE
Reduce heading button badge font size and fix alignement

### DIFF
--- a/src/panels/lovelace/heading-badges/hui-button-heading-badge.ts
+++ b/src/panels/lovelace/heading-badges/hui-button-heading-badge.ts
@@ -112,7 +112,7 @@ export class HuiButtonHeadingBadge
       width: auto;
       height: var(--ha-heading-badge-size, 26px);
       min-width: var(--ha-heading-badge-size, 26px);
-      font-size: var(--ha-heading-badge-font-size, var(--ha-font-size-m));
+      font-size: var(--ha-heading-badge-font-size, var(--ha-font-size-s));
       font-weight: var(--ha-font-weight-medium);
     }
     ha-control-button.with-text {
@@ -133,6 +133,9 @@ export class HuiButtonHeadingBadge
     }
     .text {
       padding: 0 var(--ha-space-1);
+      line-height: 1;
+    }
+    ha-icon {
       line-height: 1;
     }
   `;


### PR DESCRIPTION
## Proposed change

Reduce the font size of heading card button badges to make them visually more consistent with other badge sizes. Also align the icon line-height for better vertical alignment with the text.

## Screenshots

**Before**
<img width="409" height="204" alt="CleanShot 2026-03-30 at 11 51 58" src="https://github.com/user-attachments/assets/578d8c37-df82-4c59-acea-b325c8fd2924" />

**After**
<img width="409" height="204" alt="CleanShot 2026-03-30 at 11 53 10" src="https://github.com/user-attachments/assets/f173c399-ce0c-4b9f-8e05-30edeec2db64" />

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
