### PR TITLE
Hide section when all cards are hidden

### DIFF
--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -110,11 +110,19 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
 
   public disconnectedCallback() {
     super.disconnectedCallback();
+    this.removeEventListener(
+      "card-visibility-changed",
+      this._cardVisibilityChanged
+    );
   }
 
   public connectedCallback() {
     super.connectedCallback();
     this._updateVisibility();
+    this.addEventListener(
+      "card-visibility-changed",
+      this._cardVisibilityChanged
+    );
   }
 
   protected update(changedProperties) {
@@ -144,7 +152,11 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
       if (changedProperties.has("_cards")) {
         this._layoutElement.cards = this._cards;
       }
-      if (changedProperties.has("hass") || changedProperties.has("preview")) {
+      if (
+        changedProperties.has("hass") ||
+        changedProperties.has("preview") ||
+        changedProperties.has("_cards")
+      ) {
         this._updateVisibility();
       }
     }
@@ -200,6 +212,10 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
     }
   }
 
+  private _cardVisibilityChanged = () => {
+    this._updateVisibility();
+  };
+
   protected _updateVisibility(conditionsMet?: boolean) {
     if (!this._layoutElement || !this._config) {
       return;
@@ -220,7 +236,16 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
       (!this._config.visibility ||
         checkConditionsMet(this._config.visibility, this.hass));
 
-    this._setElementVisibility(visible);
+    if (!visible) {
+      this._setElementVisibility(false);
+      return;
+    }
+
+    // Hide section when all cards are conditionally hidden
+    const allCardsHidden =
+      this._cards.length > 0 && this._cards.every((card) => card.hidden);
+
+    this._setElementVisibility(!allCardsHidden);
   }
 
   private _setElementVisibility(visible: boolean) {
@@ -232,9 +257,9 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
       fireEvent(this, "section-visibility-changed", { value: visible });
     }
 
-    if (!visible && this._layoutElement.parentElement) {
-      this.removeChild(this._layoutElement);
-    } else if (visible && !this._layoutElement.parentElement) {
+    // Always keep layout element connected so cards can still update
+    // their visibility and bubble events back to the section.
+    if (!this._layoutElement.parentElement) {
       this.appendChild(this._layoutElement);
     }
   }


### PR DESCRIPTION
## Proposed change

Hide the section when all its cards are conditionally hidden, instead of leaving an empty shell with the background still visible.

The layout element is always kept connected so cards can notify the section when their visibility changes. This has no big performance impact since hidden cards were already receiving updates, and `display: none` prevents any layout or paint cost.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #30392
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
