### PR TITLE
Add select source card feature for supported media players

### DIFF
--- a/src/panels/lovelace/card-features/hui-media-player-source-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-media-player-source-card-feature.ts
@@ -128,7 +128,6 @@ class HuiMediaPlayerSourceCardFeature
       <ha-control-select-menu
         .hass=${this.hass}
         show-arrow
-        hide-label
         .label=${this.hass.localize("ui.card.media_player.source")}
         .value=${this._currentSource}
         .disabled=${this._stateObj.state === UNAVAILABLE}

--- a/src/panels/lovelace/card-features/hui-media-player-source-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-media-player-source-card-feature.ts
@@ -11,6 +11,7 @@ import {
   type MediaPlayerEntity,
 } from "../../../data/media-player";
 import type { HomeAssistant } from "../../../types";
+import { hasConfigChanged } from "../common/has-changed";
 import type { LovelaceCardFeature } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
 import type {
@@ -81,6 +82,21 @@ class HuiMediaPlayerSourceCardFeature
         this._currentSource = this._stateObj.attributes.source;
       }
     }
+  }
+
+  protected shouldUpdate(changedProps: PropertyValues): boolean {
+    const entityId = this.context?.entity_id;
+    const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+
+    return (
+      changedProps.has("_currentSource") ||
+      changedProps.has("context") ||
+      hasConfigChanged(this, changedProps) ||
+      (changedProps.has("hass") &&
+        (!oldHass ||
+          !entityId ||
+          oldHass.states[entityId] !== this.hass?.states[entityId]))
+    );
   }
 
   private async _valueChanged(ev: HaDropdownSelectEvent) {

--- a/src/panels/lovelace/card-features/hui-media-player-source-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-media-player-source-card-feature.ts
@@ -1,0 +1,151 @@
+import type { PropertyValues } from "lit";
+import { html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { computeDomain } from "../../../common/entity/compute_domain";
+import { supportsFeature } from "../../../common/entity/supports-feature";
+import type { HaDropdownSelectEvent } from "../../../components/ha-dropdown";
+import "../../../components/ha-control-select-menu";
+import "../../../components/ha-list-item";
+import { UNAVAILABLE } from "../../../data/entity/entity";
+import {
+  MediaPlayerEntityFeature,
+  type MediaPlayerEntity,
+} from "../../../data/media-player";
+import type { HomeAssistant } from "../../../types";
+import type { LovelaceCardFeature } from "../types";
+import { cardFeatureStyles } from "./common/card-feature-styles";
+import type {
+  LovelaceCardFeatureContext,
+  MediaPlayerSourceCardFeatureConfig,
+} from "./types";
+
+export const supportsMediaPlayerSourceCardFeature = (
+  hass: HomeAssistant,
+  context: LovelaceCardFeatureContext
+) => {
+  const stateObj = context.entity_id
+    ? hass.states[context.entity_id]
+    : undefined;
+  if (!stateObj) return false;
+  const domain = computeDomain(stateObj.entity_id);
+  return (
+    domain === "media_player" &&
+    supportsFeature(stateObj, MediaPlayerEntityFeature.SELECT_SOURCE) &&
+    !!stateObj.attributes.source_list?.length
+  );
+};
+
+@customElement("hui-media-player-source-card-feature")
+class HuiMediaPlayerSourceCardFeature
+  extends LitElement
+  implements LovelaceCardFeature
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
+
+  @state() private _config?: MediaPlayerSourceCardFeatureConfig;
+
+  @state() private _currentSource?: string;
+
+  private get _stateObj() {
+    if (!this.hass || !this.context || !this.context.entity_id) {
+      return undefined;
+    }
+    return this.hass.states[this.context.entity_id!] as
+      | MediaPlayerEntity
+      | undefined;
+  }
+
+  static getStubConfig(): MediaPlayerSourceCardFeatureConfig {
+    return {
+      type: "media-player-source",
+    };
+  }
+
+  public setConfig(config: MediaPlayerSourceCardFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+    if (
+      (changedProps.has("hass") || changedProps.has("context")) &&
+      this._stateObj
+    ) {
+      const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+      const oldStateObj = oldHass?.states[this.context!.entity_id!];
+      if (oldStateObj !== this._stateObj) {
+        this._currentSource = this._stateObj.attributes.source;
+      }
+    }
+  }
+
+  private async _valueChanged(ev: HaDropdownSelectEvent) {
+    const source = ev.detail.item?.value;
+    const oldSource = this._stateObj!.attributes.source;
+
+    if (source === oldSource || !source) {
+      return;
+    }
+
+    this._currentSource = source;
+
+    try {
+      await this.hass!.callService("media_player", "select_source", {
+        entity_id: this._stateObj!.entity_id,
+        source: source,
+      });
+    } catch (_err) {
+      this._currentSource = oldSource;
+    }
+  }
+
+  protected render() {
+    if (
+      !this._config ||
+      !this.hass ||
+      !this.context ||
+      !this._stateObj ||
+      !supportsMediaPlayerSourceCardFeature(this.hass, this.context)
+    ) {
+      return nothing;
+    }
+
+    const options = this._stateObj.attributes.source_list!.map((source) => ({
+      value: source,
+      label: this.hass!.formatEntityAttributeValue(
+        this._stateObj!,
+        "source",
+        source
+      ),
+    }));
+
+    return html`
+      <ha-control-select-menu
+        .hass=${this.hass}
+        show-arrow
+        hide-label
+        .label=${this.hass.localize("ui.card.media_player.source")}
+        .value=${this._currentSource}
+        .disabled=${this._stateObj.state === UNAVAILABLE}
+        .options=${options}
+        @wa-select=${this._valueChanged}
+      >
+      </ha-control-select-menu>
+    `;
+  }
+
+  static get styles() {
+    return cardFeatureStyles;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-media-player-source-card-feature": HuiMediaPlayerSourceCardFeature;
+  }
+}

--- a/src/panels/lovelace/card-features/hui-media-player-source-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-media-player-source-card-feature.ts
@@ -5,7 +5,6 @@ import { computeDomain } from "../../../common/entity/compute_domain";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import type { HaDropdownSelectEvent } from "../../../components/ha-dropdown";
 import "../../../components/ha-control-select-menu";
-import "../../../components/ha-list-item";
 import { UNAVAILABLE } from "../../../data/entity/entity";
 import {
   MediaPlayerEntityFeature,
@@ -126,7 +125,6 @@ class HuiMediaPlayerSourceCardFeature
 
     return html`
       <ha-control-select-menu
-        .hass=${this.hass}
         show-arrow
         .label=${this.hass.localize("ui.card.media_player.source")}
         .value=${this._currentSource}

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -58,6 +58,10 @@ export interface MediaPlayerPlaybackCardFeatureConfig {
   type: "media-player-playback";
 }
 
+export interface MediaPlayerSourceCardFeatureConfig {
+  type: "media-player-source";
+}
+
 export interface MediaPlayerVolumeSliderCardFeatureConfig {
   type: "media-player-volume-slider";
 }
@@ -286,6 +290,7 @@ export type LovelaceCardFeatureConfig =
   | LockOpenDoorCardFeatureConfig
   | MediaPlayerPlaybackCardFeatureConfig
   | MediaPlayerSoundModeCardFeatureConfig
+  | MediaPlayerSourceCardFeatureConfig
   | MediaPlayerVolumeButtonsCardFeatureConfig
   | MediaPlayerVolumeSliderCardFeatureConfig
   | NumericInputCardFeatureConfig

--- a/src/panels/lovelace/create-element/create-card-feature-element.ts
+++ b/src/panels/lovelace/create-element/create-card-feature-element.ts
@@ -27,6 +27,7 @@ import "../card-features/hui-lock-commands-card-feature";
 import "../card-features/hui-lock-open-door-card-feature";
 import "../card-features/hui-media-player-playback-card-feature";
 import "../card-features/hui-media-player-sound-mode-card-feature";
+import "../card-features/hui-media-player-source-card-feature";
 import "../card-features/hui-media-player-volume-buttons-card-feature";
 import "../card-features/hui-media-player-volume-slider-card-feature";
 import "../card-features/hui-numeric-input-card-feature";
@@ -82,6 +83,7 @@ const TYPES = new Set<LovelaceCardFeatureConfig["type"]>([
   "lock-open-door",
   "media-player-playback",
   "media-player-sound-mode",
+  "media-player-source",
   "media-player-volume-buttons",
   "media-player-volume-slider",
   "numeric-input",

--- a/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
@@ -54,6 +54,7 @@ import { supportsLockCommandsCardFeature } from "../../card-features/hui-lock-co
 import { supportsLockOpenDoorCardFeature } from "../../card-features/hui-lock-open-door-card-feature";
 import { supportsMediaPlayerPlaybackCardFeature } from "../../card-features/hui-media-player-playback-card-feature";
 import { supportsMediaPlayerSoundModeCardFeature } from "../../card-features/hui-media-player-sound-mode-card-feature";
+import { supportsMediaPlayerSourceCardFeature } from "../../card-features/hui-media-player-source-card-feature";
 import { supportsMediaPlayerVolumeButtonsCardFeature } from "../../card-features/hui-media-player-volume-buttons-card-feature";
 import { supportsMediaPlayerVolumeSliderCardFeature } from "../../card-features/hui-media-player-volume-slider-card-feature";
 import { supportsNumericInputCardFeature } from "../../card-features/hui-numeric-input-card-feature";
@@ -114,6 +115,7 @@ const UI_FEATURE_TYPES = [
   "lock-open-door",
   "media-player-playback",
   "media-player-sound-mode",
+  "media-player-source",
   "media-player-volume-buttons",
   "media-player-volume-slider",
   "numeric-input",
@@ -194,6 +196,7 @@ const SUPPORTS_FEATURE_TYPES: Record<
   "lock-open-door": supportsLockOpenDoorCardFeature,
   "media-player-playback": supportsMediaPlayerPlaybackCardFeature,
   "media-player-sound-mode": supportsMediaPlayerSoundModeCardFeature,
+  "media-player-source": supportsMediaPlayerSourceCardFeature,
   "media-player-volume-buttons": supportsMediaPlayerVolumeButtonsCardFeature,
   "media-player-volume-slider": supportsMediaPlayerVolumeSliderCardFeature,
   "numeric-input": supportsNumericInputCardFeature,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9716,6 +9716,9 @@
               "media-player-sound-mode": {
                 "label": "Media player sound mode"
               },
+              "media-player-source": {
+                "label": "Media player source"
+              },
               "media-player-volume-buttons": {
                 "label": "Media player volume buttons",
                 "step": "Step size"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Adds a card feature for supported media players with the `SELECT_SOURCE` feature.

Raised from a suggestion in discord, see #51280 for link

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
<img width="371" height="235" alt="image" src="https://github.com/user-attachments/assets/a9d73460-6f3b-4b4c-b1cb-00c022c3345b" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: Closes #51280 
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44400
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
