### PR TITLE
Add delay before revoking URL on Android

### DIFF
--- a/src/panels/config/automation/ha-automation-trace.ts
+++ b/src/panels/config/automation/ha-automation-trace.ts
@@ -464,7 +464,6 @@ export class HaAutomationTrace extends LitElement {
       url,
       `trace ${this._entityId} ${this._trace!.timestamp.start}.json`
     );
-    URL.revokeObjectURL(url);
   }
 
   private _importTrace() {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -806,7 +806,6 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
           url,
           `zwave_js_backup_${new Date().toISOString().replace(/[:.]/g, "-")}.bin`
         );
-        URL.revokeObjectURL(url);
       } catch (err: any) {
         showAlertDialog(this, {
           title: this.hass.localize(

--- a/src/panels/config/script/ha-script-trace.ts
+++ b/src/panels/config/script/ha-script-trace.ts
@@ -479,7 +479,6 @@ export class HaScriptTrace extends LitElement {
       url,
       `trace ${this._entityId} ${this._trace!.timestamp.start}.json`
     );
-    URL.revokeObjectURL(url);
   }
 
   private _importTrace() {

--- a/src/util/file_download.ts
+++ b/src/util/file_download.ts
@@ -1,3 +1,9 @@
+// 10 seconds gives the Android WebView download listener enough time
+// to open the blob before it is revoked, while still freeing memory
+// promptly. Revoking immediately would invalidate the URL before the
+// native layer can read it.
+const BLOB_REVOKE_DELAY_MS = 10_000;
+
 export const fileDownload = (href: string, filename = ""): void => {
   const element = document.createElement("a");
   element.target = "_blank";
@@ -12,11 +18,6 @@ export const fileDownload = (href: string, filename = ""): void => {
     // Revoke blob URLs after a delay on Android so the WebView download
     // listener has time to fetch the blob before it becomes invalid.
     if (window.externalApp) {
-      // 10 seconds gives the Android WebView download listener enough time
-      // to open the blob before it is revoked, while still freeing memory
-      // promptly. Revoking immediately would invalidate the URL before the
-      // native layer can read it.
-      const BLOB_REVOKE_DELAY_MS = 10_000;
       setTimeout(() => URL.revokeObjectURL(href), BLOB_REVOKE_DELAY_MS);
     } else {
       URL.revokeObjectURL(href);

--- a/src/util/file_download.ts
+++ b/src/util/file_download.ts
@@ -7,4 +7,19 @@ export const fileDownload = (href: string, filename = ""): void => {
   document.body.appendChild(element);
   element.dispatchEvent(new MouseEvent("click"));
   document.body.removeChild(element);
+
+  if (href.startsWith("blob:")) {
+    // Revoke blob URLs after a delay on Android so the WebView download
+    // listener has time to fetch the blob before it becomes invalid.
+    if (window.externalApp) {
+      // 10 seconds gives the Android WebView download listener enough time
+      // to open the blob before it is revoked, while still freeing memory
+      // promptly. Revoking immediately would invalidate the URL before the
+      // native layer can read it.
+      const BLOB_REVOKE_DELAY_MS = 10_000;
+      setTimeout(() => URL.revokeObjectURL(href), BLOB_REVOKE_DELAY_MS);
+    } else {
+      URL.revokeObjectURL(href);
+    }
+  }
 };

--- a/test/util/file_download.test.ts
+++ b/test/util/file_download.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fileDownload } from "../../src/util/file_download";
+
+describe("fileDownload", () => {
+  let appendChildSpy: ReturnType<typeof vi.spyOn>;
+  let removeChildSpy: ReturnType<typeof vi.spyOn>;
+  let dispatchEventSpy: ReturnType<typeof vi.spyOn>;
+  let createdElement: HTMLAnchorElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    createdElement = document.createElement("a");
+    vi.spyOn(createdElement, "dispatchEvent");
+    vi.spyOn(document, "createElement").mockReturnValue(createdElement);
+    appendChildSpy = vi
+      .spyOn(document.body, "appendChild")
+      .mockImplementation((node) => node);
+    removeChildSpy = vi
+      .spyOn(document.body, "removeChild")
+      .mockImplementation((node) => node);
+    dispatchEventSpy = vi.spyOn(createdElement, "dispatchEvent");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (window as any).externalApp;
+  });
+
+  it("sets href, download, and triggers a click", () => {
+    fileDownload("https://example.com/file.json", "file.json");
+
+    expect(createdElement.href).toBe("https://example.com/file.json");
+    expect(createdElement.download).toBe("file.json");
+    expect(appendChildSpy).toHaveBeenCalledWith(createdElement);
+    expect(dispatchEventSpy).toHaveBeenCalledWith(expect.any(MouseEvent));
+    expect(removeChildSpy).toHaveBeenCalledWith(createdElement);
+  });
+
+  it("defaults filename to empty string", () => {
+    fileDownload("https://example.com/file.json");
+    expect(createdElement.download).toBe("");
+  });
+
+  it("does not revoke non-blob URLs", () => {
+    fileDownload("https://example.com/file.json", "file.json");
+    vi.runAllTimers();
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("revokes blob URLs immediately outside Android", () => {
+    fileDownload("blob:http://localhost/abc-123", "file.json");
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(
+      "blob:http://localhost/abc-123"
+    );
+  });
+
+  it("revokes blob URL after delay on Android", () => {
+    (window as any).externalApp = {};
+    fileDownload("blob:http://localhost/abc-123", "file.json");
+    vi.advanceTimersByTime(9_999);
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(
+      "blob:http://localhost/abc-123"
+    );
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
We have an issue in the android application where we are not able to download blobs because they are deleted before the Webview was able to get it. It is due to the fact that the webview is getting the blob in an async manner which is not what the current frontend expect. 

See https://github.com/home-assistant/android/issues/6291 for more details of the error.

This PR does add a delay when we are within the android app before revoking the object URL. I've settled on 10s even if it should be only few ms, just because on old devices when under memory pressure it might need quite some time.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
