### PR TITLE
Use boundaryFilter data zoom mode only for line charts

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -609,7 +609,10 @@ export class HaChartBase extends LitElement {
       // "boundaryFilter" is a custom mode added via axis-proxy-patch.ts.
       // It rescales the Y-axis to the visible data while keeping one point
       // just outside each boundary to avoid line gaps at the zoom edges.
-      filterMode: "boundaryFilter" as any,
+      // Only use it for line charts — it causes issues with bar charts.
+      filterMode: (ensureArray(this.data).every((s) => s.type === "line")
+        ? "boundaryFilter"
+        : "filter") as any,
       xAxisIndex: 0,
       moveOnMouseMove: !this._isTouchDevice || this._isZoomed,
       preventDefaultMouseMove: !this._isTouchDevice || this._isZoomed,


### PR DESCRIPTION
## Proposed change

The custom `boundaryFilter` data zoom mode (added via `axis-proxy-patch.ts`) keeps one data point just outside each zoom boundary to prevent line gaps at zoom edges. However, this mode causes rendering issues for bar charts.

This change makes `filterMode` conditional: use `boundaryFilter` only when all series are line charts, and fall back to the standard `filter` mode otherwise.

Prompted from this comment https://github.com/home-assistant/frontend/pull/30325#issuecomment-4161141319

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr