### PR TITLE
Fix tile secondary info pop in

### DIFF
--- a/src/components/tile/ha-tile-info.ts
+++ b/src/components/tile/ha-tile-info.ts
@@ -1,3 +1,4 @@
+import "@home-assistant/webawesome/dist/components/skeleton/skeleton";
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 
@@ -11,6 +12,8 @@ import { customElement, property } from "lit/decorators";
  *
  * @slot primary - The primary text container.
  * @slot secondary - The secondary text container.
+ *
+ * @property {boolean} secondaryLoading - Whether the secondary text is loading. Shows a skeleton placeholder.
  *
  * @cssprop --ha-tile-info-primary-font-size - The font size of the primary text. defaults to `var(--ha-font-size-m)`.
  * @cssprop --ha-tile-info-primary-font-weight - The font weight of the primary text. defaults to `var(--ha-font-weight-medium)`.
@@ -29,21 +32,31 @@ export class HaTileInfo extends LitElement {
 
   @property() public secondary?: string;
 
+  @property({ type: Boolean, attribute: "secondary-loading" })
+  public secondaryLoading = false;
+
   protected render() {
     return html`
       <div class="info">
         <slot name="primary" class="primary">
           <span>${this.primary}</span>
         </slot>
-        <slot name="secondary" class="secondary">
-          <span>${this.secondary}</span>
-        </slot>
+        ${this.secondaryLoading
+          ? html`<div class="secondary">
+              <wa-skeleton class="placeholder" effect="pulse"></wa-skeleton>
+            </div>`
+          : html`<slot name="secondary" class="secondary">
+              <span>${this.secondary}</span>
+            </slot>`}
       </div>
     `;
   }
 
   static styles = css`
     :host {
+      display: block;
+      width: 100%;
+      min-width: 0;
       --tile-info-primary-font-size: var(
         --ha-tile-info-primary-font-size,
         var(--ha-font-size-m)
@@ -112,6 +125,15 @@ export class HaTileInfo extends LitElement {
       line-height: var(--tile-info-secondary-line-height);
       letter-spacing: var(--tile-info-secondary-letter-spacing);
       color: var(--tile-info-secondary-color);
+      width: 100%;
+    }
+    .placeholder {
+      width: 140px;
+      max-width: 100%;
+      height: var(--tile-info-secondary-font-size);
+      --wa-border-radius-pill: var(--ha-border-radius-sm);
+      --color: var(--ha-color-fill-neutral-normal-hover);
+      --sheen-color: var(--ha-color-fill-neutral-loud-resting);
     }
   `;
 }

--- a/src/components/tile/ha-tile-info.ts
+++ b/src/components/tile/ha-tile-info.ts
@@ -132,7 +132,7 @@ export class HaTileInfo extends LitElement {
       max-width: 100%;
       height: var(--tile-info-secondary-font-size);
       --wa-border-radius-pill: var(--ha-border-radius-sm);
-      --color: var(--ha-color-fill-neutral-normal-hover);
+      --color: var(--ha-color-fill-neutral-normal-resting);
       --sheen-color: var(--ha-color-fill-neutral-loud-resting);
     }
   `;

--- a/src/panels/lovelace/cards/hui-discovered-devices-card.ts
+++ b/src/panels/lovelace/cards/hui-discovered-devices-card.ts
@@ -35,7 +35,7 @@ export class HuiDiscoveredDevicesCard
 
   @state() private _config?: DiscoveredDevicesCardConfig;
 
-  @state() private _discoveredFlows: DataEntryFlowProgress[] = [];
+  @state() private _discoveredFlows?: DataEntryFlowProgress[];
 
   public hassSubscribe(): (UnsubscribeFunc | Promise<UnsubscribeFunc>)[] {
     if (!this.hass!.user?.is_admin) {
@@ -57,7 +57,10 @@ export class HuiDiscoveredDevicesCard
 
           messages.forEach((message) => {
             if (message.type === "removed") {
-              this._discoveredFlows = this._discoveredFlows.filter(
+              const flows = Array.isArray(this._discoveredFlows)
+                ? this._discoveredFlows
+                : [];
+              this._discoveredFlows = flows.filter(
                 (flow) => flow.flow_id !== message.flow_id
               );
               return;
@@ -78,7 +81,10 @@ export class HuiDiscoveredDevicesCard
             return;
           }
 
-          const existingFlows = fullUpdate ? [] : this._discoveredFlows;
+          const existingFlows =
+            fullUpdate || !Array.isArray(this._discoveredFlows)
+              ? []
+              : this._discoveredFlows;
           this._discoveredFlows = [...existingFlows, ...newFlows];
         }
       ),
@@ -138,7 +144,9 @@ export class HuiDiscoveredDevicesCard
     // Update visibility based on admin status and discovered devices count
     const shouldBeHidden = Boolean(
       !this.hass.user?.is_admin ||
-      (this._config.hide_empty && this._discoveredFlows.length === 0)
+      (this._config.hide_empty &&
+        this._discoveredFlows &&
+        this._discoveredFlows.length === 0)
     );
 
     if (shouldBeHidden !== this.hidden) {
@@ -153,7 +161,9 @@ export class HuiDiscoveredDevicesCard
       return nothing;
     }
 
-    const count = this._discoveredFlows.length;
+    const count = Array.isArray(this._discoveredFlows)
+      ? this._discoveredFlows.length
+      : 0;
 
     const label = this.hass.localize("ui.card.discovered-devices.title");
     const secondary =
@@ -162,6 +172,7 @@ export class HuiDiscoveredDevicesCard
             count,
           })
         : this.hass.localize("ui.card.discovered-devices.no_devices");
+    const secondaryLoading = !this._discoveredFlows;
 
     return html`
       <ha-card>
@@ -179,6 +190,7 @@ export class HuiDiscoveredDevicesCard
             slot="info"
             .primary=${label}
             .secondary=${secondary}
+            .secondaryLoading=${secondaryLoading}
           ></ha-tile-info>
         </ha-tile-container>
       </ha-card>

--- a/src/panels/lovelace/cards/hui-home-summary-card.ts
+++ b/src/panels/lovelace/cards/hui-home-summary-card.ts
@@ -3,6 +3,7 @@ import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
+import memoizeOne from "memoize-one";
 import { computeCssColor } from "../../../common/color/compute-color";
 import { calcDate } from "../../../common/datetime/calc_date";
 import { computeDomain } from "../../../common/entity/compute_domain";
@@ -114,6 +115,11 @@ export class HuiHomeSummaryCard
       hasAction(this._config?.double_tap_action)
     );
   }
+
+  private _computeSecondaryLoading = memoizeOne(
+    (summary: HomeSummary, energyData: EnergyData | undefined): boolean =>
+      summary === "energy" && !energyData
+  );
 
   private _computeSummaryState(): string {
     if (!this._config || !this.hass) {
@@ -289,6 +295,10 @@ export class HuiHomeSummaryCard
     };
 
     const secondary = this._computeSummaryState();
+    const secondaryLoading = this._computeSecondaryLoading(
+      this._config.summary,
+      this._energyData
+    );
 
     const label = getSummaryLabel(this.hass.localize, this._config.summary);
     const icon = HOME_SUMMARIES_ICONS[this._config.summary];
@@ -309,6 +319,7 @@ export class HuiHomeSummaryCard
             slot="info"
             .primary=${label}
             .secondary=${secondary}
+            .secondaryLoading=${secondaryLoading}
           ></ha-tile-info>
         </ha-tile-container>
       </ha-card>

--- a/src/panels/lovelace/cards/hui-repairs-card.ts
+++ b/src/panels/lovelace/cards/hui-repairs-card.ts
@@ -31,7 +31,7 @@ export class HuiRepairsCard
 
   @state() private _config?: RepairsCardConfig;
 
-  @state() private _repairsIssues: RepairsIssue[] = [];
+  @state() private _repairsIssues?: RepairsIssue[];
 
   public hassSubscribe(): (UnsubscribeFunc | Promise<UnsubscribeFunc>)[] {
     return [
@@ -99,7 +99,9 @@ export class HuiRepairsCard
     // Update visibility based on admin status and repairs count
     const shouldBeHidden = Boolean(
       !this.hass.user?.is_admin ||
-      (this._config.hide_empty && this._repairsIssues.length === 0)
+      (this._config.hide_empty &&
+        this._repairsIssues &&
+        this._repairsIssues.length === 0)
     );
 
     if (shouldBeHidden !== this.hidden) {
@@ -114,7 +116,9 @@ export class HuiRepairsCard
       return nothing;
     }
 
-    const count = this._repairsIssues.length;
+    const count = Array.isArray(this._repairsIssues)
+      ? this._repairsIssues.length
+      : 0;
 
     const label = this.hass.localize("ui.card.repairs.title");
     const secondary =
@@ -123,6 +127,7 @@ export class HuiRepairsCard
             count,
           })
         : this.hass.localize("ui.card.repairs.no_issues");
+    const secondaryLoading = !this._repairsIssues;
 
     return html`
       <ha-card>
@@ -140,6 +145,7 @@ export class HuiRepairsCard
             slot="info"
             .primary=${label}
             .secondary=${secondary}
+            .secondaryLoading=${secondaryLoading}
           ></ha-tile-info>
         </ha-tile-container>
       </ha-card>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Tiles when loading would pop in and show as without secondary info for a second while loading.

Adds support for a loading state for tile info, and sets while loading data instead of not setting secondary.

A step towards using wa skeleton as placeholder for common ui. Not a huge change for generated dashboards, but more obvious when used in user dashboards 

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

https://github.com/user-attachments/assets/53c2d292-59c1-4e52-bad1-6cf91ff9a832


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
