### PR TITLE
Register custom dashboard strategies

### DIFF
--- a/src/data/lovelace_custom_strategies.ts
+++ b/src/data/lovelace_custom_strategies.ts
@@ -1,9 +1,11 @@
 import type { LovelaceStrategyConfigType } from "../panels/lovelace/strategies/get-strategy";
 
-export interface CustomStrategyImages {
+export interface CustomStrategyThemedImages {
   dark: string;
   light: string;
 }
+
+export type CustomStrategyImages = string | CustomStrategyThemedImages;
 
 export interface CustomStrategyEntry {
   type: string;

--- a/src/data/lovelace_custom_strategies.ts
+++ b/src/data/lovelace_custom_strategies.ts
@@ -1,10 +1,16 @@
 import type { LovelaceStrategyConfigType } from "../panels/lovelace/strategies/get-strategy";
 
+export interface CustomStrategyImages {
+  dark: string;
+  light: string;
+}
+
 export interface CustomStrategyEntry {
   type: string;
   name?: string;
   description?: string;
   documentationURL?: string;
+  images?: CustomStrategyImages;
   strategyType: LovelaceStrategyConfigType;
 }
 

--- a/src/data/lovelace_custom_strategies.ts
+++ b/src/data/lovelace_custom_strategies.ts
@@ -1,18 +1,10 @@
 import type { LovelaceStrategyConfigType } from "../panels/lovelace/strategies/get-strategy";
 
-export interface CustomStrategyThemedImages {
-  dark: string;
-  light: string;
-}
-
-export type CustomStrategyImages = string | CustomStrategyThemedImages;
-
 export interface CustomStrategyEntry {
   type: string;
   name?: string;
   description?: string;
   documentationURL?: string;
-  images?: CustomStrategyImages;
   strategyType: LovelaceStrategyConfigType;
 }
 

--- a/src/data/lovelace_custom_strategies.ts
+++ b/src/data/lovelace_custom_strategies.ts
@@ -1,0 +1,22 @@
+export interface CustomStrategyEntry {
+  type: string;
+  name?: string;
+  description?: string;
+  documentationURL?: string;
+}
+
+export interface CustomStrategiesWindow {
+  customDashboardStrategies?: CustomStrategyEntry[];
+}
+
+const customStrategiesWindow = window as CustomStrategiesWindow;
+
+if (!("customDashboardStrategies" in customStrategiesWindow)) {
+  customStrategiesWindow.customDashboardStrategies = [];
+}
+
+export const customDashboardStrategies =
+  customStrategiesWindow.customDashboardStrategies!;
+
+export const getCustomDashboardStrategyEntry = (type: string) =>
+  customDashboardStrategies.find((strategy) => strategy.type === type);

--- a/src/data/lovelace_custom_strategies.ts
+++ b/src/data/lovelace_custom_strategies.ts
@@ -1,22 +1,33 @@
+import type { LovelaceStrategyConfigType } from "../panels/lovelace/strategies/get-strategy";
+
 export interface CustomStrategyEntry {
   type: string;
   name?: string;
   description?: string;
   documentationURL?: string;
+  strategyType: LovelaceStrategyConfigType;
 }
 
 export interface CustomStrategiesWindow {
-  customDashboardStrategies?: CustomStrategyEntry[];
+  customStrategies?: CustomStrategyEntry[];
 }
 
 const customStrategiesWindow = window as CustomStrategiesWindow;
 
-if (!("customDashboardStrategies" in customStrategiesWindow)) {
-  customStrategiesWindow.customDashboardStrategies = [];
+if (!("customStrategies" in customStrategiesWindow)) {
+  customStrategiesWindow.customStrategies = [];
 }
 
-export const customDashboardStrategies =
-  customStrategiesWindow.customDashboardStrategies!;
+export const customStrategies = customStrategiesWindow.customStrategies!;
 
-export const getCustomDashboardStrategyEntry = (type: string) =>
-  customDashboardStrategies.find((strategy) => strategy.type === type);
+export const getCustomStrategiesForType = (
+  strategyType: LovelaceStrategyConfigType
+) => customStrategies.filter((s) => s.strategyType === strategyType);
+
+export const getCustomStrategyEntry = (
+  type: string,
+  strategyType: LovelaceStrategyConfigType
+) =>
+  customStrategies.find(
+    (s) => s.type === type && s.strategyType === strategyType
+  );

--- a/src/panels/config/dashboard/dashboard-card.ts
+++ b/src/panels/config/dashboard/dashboard-card.ts
@@ -56,16 +56,16 @@ export class DashboardCard extends LitElement {
       border: 1px solid var(--divider-color);
     }
     .card-header {
-      padding: 12px;
+      padding: var(--ha-space-3);
       display: block;
       text-align: var(--float-start);
       gap: var(--ha-space-2);
     }
     .preview {
-      padding: 16px;
+      padding: var(--ha-space-4);
     }
     h2 {
-      margin: 0 0 8px 0;
+      margin: 0 0 var(--ha-space-2) 0;
       font-size: 1.2rem;
       color: var(--primary-text-color);
     }

--- a/src/panels/config/dashboard/dashboard-card.ts
+++ b/src/panels/config/dashboard/dashboard-card.ts
@@ -1,4 +1,4 @@
-import { LitElement, css, html } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import "../../../components/ha-ripple";
 
@@ -27,9 +27,17 @@ export class DashboardCard extends LitElement {
             <p>${this.description}</p>
           </div>
         </div>
-        <div class="preview">
-          <img alt=${this.alt} loading="lazy" src=${this.img} />
-        </div>
+        ${this.img
+          ? html`
+              <div class="preview">
+                <img
+                  alt=${this.alt || this.name}
+                  loading="lazy"
+                  src=${this.img}
+                />
+              </div>
+            `
+          : nothing}
         <ha-ripple></ha-ripple>
       </div>
     `;

--- a/src/panels/config/dashboard/dashboard-card.ts
+++ b/src/panels/config/dashboard/dashboard-card.ts
@@ -72,6 +72,9 @@ export class DashboardCard extends LitElement {
     .preview {
       padding: var(--ha-space-4);
     }
+    .preview img {
+      max-height: 160px;
+    }
     h2 {
       margin: 0 0 var(--ha-space-2) 0;
       font-size: 1.2rem;

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -5,6 +5,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../common/dom/fire_event";
+import type { WindowWithPreloads } from "../../../data/preloads";
 import type {
   LocalizeFunc,
   LocalizeKeys,
@@ -311,8 +312,14 @@ class DialogNewDashboard extends LitElement implements HassDialog {
   }
 
   private async _loadCustomStrategies(): Promise<void> {
+    const preloadWindow = window as WindowWithPreloads;
+
+    if (!preloadWindow.llResProm) {
+      preloadWindow.llResProm = fetchResources(this.hass.connection);
+    }
+
     try {
-      const resources = await fetchResources(this.hass.connection);
+      const resources = await preloadWindow.llResProm;
       await loadLovelaceResourcesAndWait(resources, this.hass);
     } catch (_err: unknown) {
       this._customStrategies = getCustomStrategiesForType("dashboard");

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -170,6 +170,7 @@ class DialogNewDashboard extends LitElement implements HassDialog {
                         <dashboard-card
                           .name=${strategy.name || strategy.type}
                           .description=${strategy.description || ""}
+                          .img=${this._customStrategyImage(strategy)}
                           .alt=${strategy.name || strategy.type}
                           @click=${this._selected}
                           .strategy=${CUSTOM_TYPE_PREFIX + strategy.type}
@@ -231,6 +232,7 @@ class DialogNewDashboard extends LitElement implements HassDialog {
                               <dashboard-card
                                 .name=${strategy.name || strategy.type}
                                 .description=${strategy.description || ""}
+                                .img=${this._customStrategyImage(strategy)}
                                 .alt=${strategy.name || strategy.type}
                                 @click=${this._selected}
                                 .strategy=${CUSTOM_TYPE_PREFIX + strategy.type}
@@ -303,6 +305,17 @@ class DialogNewDashboard extends LitElement implements HassDialog {
         type: strategy,
       },
     };
+  }
+
+  private _customStrategyImage(
+    strategy: CustomStrategyEntry
+  ): string | undefined {
+    if (!strategy.images) {
+      return undefined;
+    }
+    return this.hass.themes.darkMode
+      ? strategy.images.dark
+      : strategy.images.light;
   }
 
   private async _selected(ev: Event) {

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -19,7 +19,11 @@ import {
   type CustomStrategyEntry,
 } from "../../../data/lovelace_custom_strategies";
 import { fetchResources } from "../../../data/lovelace/resource";
-import type { LovelaceConfig } from "../../../data/lovelace/config/types";
+import type {
+  LovelaceConfig,
+  LovelaceDashboardStrategyConfig,
+  LovelaceRawConfig,
+} from "../../../data/lovelace/config/types";
 import type { HassDialog } from "../../../dialogs/make-dialog-manager";
 import { haStyleScrollbar } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
@@ -27,6 +31,11 @@ import { loadLovelaceResourcesAndWait } from "../../lovelace/common/load-resourc
 import { generateDefaultView } from "../../lovelace/views/default-view";
 import "./dashboard-card";
 import type { NewDashboardDialogParams } from "./show-dialog-new-dashboard";
+
+type DashboardCardSelectionTarget = EventTarget & {
+  config?: LovelaceRawConfig;
+  strategy?: string;
+};
 
 interface Strategy {
   type: string;
@@ -303,7 +312,9 @@ class DialogNewDashboard extends LitElement implements HassDialog {
     }
   );
 
-  private _generateStrategyConfig(strategy: string) {
+  private _generateStrategyConfig(
+    strategy: string
+  ): LovelaceDashboardStrategyConfig {
     return {
       strategy: {
         type: strategy,
@@ -347,8 +358,12 @@ class DialogNewDashboard extends LitElement implements HassDialog {
   }
 
   private async _selected(ev: Event) {
-    const target = ev.currentTarget as any;
-    let config: any = null;
+    const target = ev.currentTarget as DashboardCardSelectionTarget | null;
+    let config: LovelaceRawConfig | undefined;
+
+    if (!target) {
+      return;
+    }
 
     if (target.config) {
       config = target.config;
@@ -356,7 +371,7 @@ class DialogNewDashboard extends LitElement implements HassDialog {
       config = this._generateStrategyConfig(target.strategy);
     }
 
-    this._params?.selectConfig(config);
+    await this._params?.selectConfig(config);
     this.closeDialog();
   }
 

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -17,10 +17,12 @@ import {
   getCustomStrategiesForType,
   type CustomStrategyEntry,
 } from "../../../data/lovelace_custom_strategies";
+import { fetchResources } from "../../../data/lovelace/resource";
 import type { LovelaceConfig } from "../../../data/lovelace/config/types";
 import type { HassDialog } from "../../../dialogs/make-dialog-manager";
 import { haStyleScrollbar } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
+import { loadLovelaceResourcesAndWait } from "../../lovelace/common/load-resources";
 import { generateDefaultView } from "../../lovelace/views/default-view";
 import "./dashboard-card";
 import type { NewDashboardDialogParams } from "./show-dialog-new-dashboard";
@@ -95,6 +97,7 @@ class DialogNewDashboard extends LitElement implements HassDialog {
       ),
     }));
     this._customStrategies = getCustomStrategiesForType("dashboard");
+    this._loadCustomStrategies();
   }
 
   public closeDialog() {
@@ -305,6 +308,18 @@ class DialogNewDashboard extends LitElement implements HassDialog {
         type: strategy,
       },
     };
+  }
+
+  private async _loadCustomStrategies(): Promise<void> {
+    try {
+      const resources = await fetchResources(this.hass.connection);
+      await loadLovelaceResourcesAndWait(resources, this.hass);
+    } catch (_err: unknown) {
+      this._customStrategies = getCustomStrategiesForType("dashboard");
+      return;
+    }
+
+    this._customStrategies = getCustomStrategiesForType("dashboard");
   }
 
   private _customStrategyImage(

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -335,7 +335,7 @@ class DialogNewDashboard extends LitElement implements HassDialog {
         .cards-container-header {
           font-size: var(--ha-font-size-l);
           font-weight: var(--ha-font-weight-medium);
-          padding: 12px 8px;
+          padding: var(--ha-space-3) var(--ha-space-2);
           margin: 0;
           grid-column: 1 / -1;
           position: sticky;
@@ -356,9 +356,9 @@ class DialogNewDashboard extends LitElement implements HassDialog {
         }
         .cards-container {
           display: grid;
-          grid-gap: 8px 8px;
+          grid-gap: var(--ha-space-2) var(--ha-space-2);
           grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-          margin-top: 20px;
+          margin-top: var(--ha-space-5);
         }
         .content-wrapper {
           flex: 1;

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -183,8 +183,6 @@ class DialogNewDashboard extends LitElement implements HassDialog {
                         <dashboard-card
                           .name=${strategy.name || strategy.type}
                           .description=${strategy.description || ""}
-                          .img=${this._customStrategyImage(strategy)}
-                          .alt=${strategy.name || strategy.type}
                           @click=${this._selected}
                           .strategy=${CUSTOM_TYPE_PREFIX + strategy.type}
                         ></dashboard-card>
@@ -245,8 +243,6 @@ class DialogNewDashboard extends LitElement implements HassDialog {
                               <dashboard-card
                                 .name=${strategy.name || strategy.type}
                                 .description=${strategy.description || ""}
-                                .img=${this._customStrategyImage(strategy)}
-                                .alt=${strategy.name || strategy.type}
                                 @click=${this._selected}
                                 .strategy=${CUSTOM_TYPE_PREFIX + strategy.type}
                               ></dashboard-card>
@@ -339,22 +335,6 @@ class DialogNewDashboard extends LitElement implements HassDialog {
     }
 
     this._customStrategies = getCustomStrategiesForType("dashboard");
-  }
-
-  private _customStrategyImage(
-    strategy: CustomStrategyEntry
-  ): string | undefined {
-    const { images } = strategy;
-
-    if (!images) {
-      return undefined;
-    }
-
-    if (typeof images === "string") {
-      return images;
-    }
-
-    return this.hass.themes.darkMode ? images.dark : images.light;
   }
 
   private async _selected(ev: Event) {

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -12,6 +12,11 @@ import type {
 import "../../../components/ha-dialog";
 import "../../../components/input/ha-input-search";
 import type { HaInputSearch } from "../../../components/input/ha-input-search";
+import { CUSTOM_TYPE_PREFIX } from "../../../data/lovelace_custom_cards";
+import {
+  customDashboardStrategies,
+  type CustomStrategyEntry,
+} from "../../../data/lovelace_custom_strategies";
 import type { LovelaceConfig } from "../../../data/lovelace/config/types";
 import type { HassDialog } from "../../../dialogs/make-dialog-manager";
 import { haStyleScrollbar } from "../../../resources/styles";
@@ -77,6 +82,8 @@ class DialogNewDashboard extends LitElement implements HassDialog {
     localizedDescription: string;
   })[] = [];
 
+  @state() private _customStrategies: CustomStrategyEntry[] = [];
+
   public showDialog(params: NewDashboardDialogParams): void {
     this._open = true;
     this._params = params;
@@ -87,6 +94,7 @@ class DialogNewDashboard extends LitElement implements HassDialog {
         strategy.description as LocalizeKeys
       ),
     }));
+    this._customStrategies = [...customDashboardStrategies];
   }
 
   public closeDialog() {
@@ -154,6 +162,20 @@ class DialogNewDashboard extends LitElement implements HassDialog {
                         ></dashboard-card>
                       `
                     )}
+                    ${this._filterCustomStrategies(
+                      this._customStrategies,
+                      this._filter
+                    ).map(
+                      (strategy) => html`
+                        <dashboard-card
+                          .name=${strategy.name || strategy.type}
+                          .description=${strategy.description || ""}
+                          .alt=${strategy.name || strategy.type}
+                          @click=${this._selected}
+                          .strategy=${CUSTOM_TYPE_PREFIX + strategy.type}
+                        ></dashboard-card>
+                      `
+                    )}
                   </div>
                 `
               : html`
@@ -196,6 +218,28 @@ class DialogNewDashboard extends LitElement implements HassDialog {
                       `
                     )}
                   </div>
+                  ${this._customStrategies.length > 0
+                    ? html`
+                        <div class="cards-container">
+                          <div class="cards-container-header">
+                            ${this.hass.localize(
+                              `ui.panel.config.lovelace.dashboards.dialog_new.heading.custom`
+                            )}
+                          </div>
+                          ${this._customStrategies.map(
+                            (strategy) => html`
+                              <dashboard-card
+                                .name=${strategy.name || strategy.type}
+                                .description=${strategy.description || ""}
+                                .alt=${strategy.name || strategy.type}
+                                @click=${this._selected}
+                                .strategy=${CUSTOM_TYPE_PREFIX + strategy.type}
+                              ></dashboard-card>
+                            `
+                          )}
+                        </div>
+                      `
+                    : nothing}
                 `}
           </div>
         </div>
@@ -223,6 +267,26 @@ class DialogNewDashboard extends LitElement implements HassDialog {
       }
       const options: IFuseOptions<(typeof strategies)[0]> = {
         keys: ["type", "localizedName", "localizedDescription"],
+        isCaseSensitive: false,
+        threshold: 0.3,
+        ignoreLocation: true,
+        minMatchCharLength: Math.min(filter.length, 2),
+      };
+      const fuse = new Fuse(strategies, options);
+      return fuse.search(filter).map((result) => result.item);
+    }
+  );
+
+  private _filterCustomStrategies = memoizeOne(
+    (
+      strategies: CustomStrategyEntry[],
+      filter?: string
+    ): readonly CustomStrategyEntry[] => {
+      if (!filter) {
+        return strategies;
+      }
+      const options: IFuseOptions<CustomStrategyEntry> = {
+        keys: ["type", "name", "description"],
         isCaseSensitive: false,
         threshold: 0.3,
         ignoreLocation: true,

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -310,12 +310,17 @@ class DialogNewDashboard extends LitElement implements HassDialog {
   private _customStrategyImage(
     strategy: CustomStrategyEntry
   ): string | undefined {
-    if (!strategy.images) {
+    const { images } = strategy;
+
+    if (!images) {
       return undefined;
     }
-    return this.hass.themes.darkMode
-      ? strategy.images.dark
-      : strategy.images.light;
+
+    if (typeof images === "string") {
+      return images;
+    }
+
+    return this.hass.themes.darkMode ? images.dark : images.light;
   }
 
   private async _selected(ev: Event) {

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -14,7 +14,7 @@ import "../../../components/input/ha-input-search";
 import type { HaInputSearch } from "../../../components/input/ha-input-search";
 import { CUSTOM_TYPE_PREFIX } from "../../../data/lovelace_custom_cards";
 import {
-  customDashboardStrategies,
+  getCustomStrategiesForType,
   type CustomStrategyEntry,
 } from "../../../data/lovelace_custom_strategies";
 import type { LovelaceConfig } from "../../../data/lovelace/config/types";
@@ -94,7 +94,7 @@ class DialogNewDashboard extends LitElement implements HassDialog {
         strategy.description as LocalizeKeys
       ),
     }));
-    this._customStrategies = [...customDashboardStrategies];
+    this._customStrategies = getCustomStrategiesForType("dashboard");
   }
 
   public closeDialog() {

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -322,6 +322,7 @@ class DialogNewDashboard extends LitElement implements HassDialog {
       const resources = await preloadWindow.llResProm;
       await loadLovelaceResourcesAndWait(resources, this.hass);
     } catch (_err: unknown) {
+      preloadWindow.llResProm = undefined;
       this._customStrategies = getCustomStrategiesForType("dashboard");
       return;
     }

--- a/src/panels/config/dashboard/show-dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/show-dialog-new-dashboard.ts
@@ -1,8 +1,8 @@
 import { fireEvent } from "../../../common/dom/fire_event";
-import type { LovelaceConfig } from "../../../data/lovelace/config/types";
+import type { LovelaceRawConfig } from "../../../data/lovelace/config/types";
 
 export interface NewDashboardDialogParams {
-  selectConfig: (config: LovelaceConfig | undefined) => any;
+  selectConfig: (config: LovelaceRawConfig | undefined) => void | Promise<void>;
 }
 
 export const loadNewDashboardDialog = () => import("./dialog-new-dashboard");

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -457,9 +457,14 @@ export class HaConfigLovelaceDashboards extends LitElement {
       preloadWindow.llResProm = fetchResources(this.hass.connection);
     }
 
-    preloadWindow.llResProm.then((resources) => {
-      loadLovelaceResources(resources, this.hass);
-    });
+    preloadWindow.llResProm
+      .then((resources) => {
+        loadLovelaceResources(resources, this.hass);
+      })
+      .catch((err: unknown) => {
+        // eslint-disable-next-line
+        console.error("Unable to preload Lovelace resources", err);
+      });
 
     this._getDashboards();
   }

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -462,6 +462,7 @@ export class HaConfigLovelaceDashboards extends LitElement {
         loadLovelaceResources(resources, this.hass);
       })
       .catch((err: unknown) => {
+        preloadWindow.llResProm = undefined;
         // eslint-disable-next-line
         console.error("Unable to preload Lovelace resources", err);
       });

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -35,6 +35,7 @@ import {
   isStrategyDashboard,
   saveConfig,
 } from "../../../../data/lovelace/config/types";
+import { fetchResources } from "../../../../data/lovelace/resource";
 import type {
   LovelaceDashboard,
   LovelaceDashboardCreateParams,
@@ -55,9 +56,11 @@ import {
   showAlertDialog,
   showConfirmationDialog,
 } from "../../../../dialogs/generic/show-dialog-box";
+import type { WindowWithPreloads } from "../../../../data/preloads";
 import "../../../../layouts/hass-loading-screen";
 import "../../../../layouts/hass-tabs-subpage-data-table";
 import type { HomeAssistant, Route } from "../../../../types";
+import { loadLovelaceResources } from "../../../lovelace/common/load-resources";
 import { getLovelaceStrategy } from "../../../lovelace/strategies/get-strategy";
 import { showNewDashboardDialog } from "../../dashboard/show-dialog-new-dashboard";
 import { lovelaceTabs } from "../ha-config-lovelace";
@@ -448,6 +451,16 @@ export class HaConfigLovelaceDashboards extends LitElement {
 
   protected firstUpdated(changedProps: PropertyValues) {
     super.firstUpdated(changedProps);
+
+    const preloadWindow = window as WindowWithPreloads;
+    if (!preloadWindow.llResProm) {
+      preloadWindow.llResProm = fetchResources(this.hass.connection);
+    }
+
+    preloadWindow.llResProm.then((resources) => {
+      loadLovelaceResources(resources, this.hass);
+    });
+
     this._getDashboards();
   }
 

--- a/src/panels/lovelace/common/load-resources.ts
+++ b/src/panels/lovelace/common/load-resources.ts
@@ -3,40 +3,65 @@ import type { LovelaceResource } from "../../../data/lovelace/resource";
 import type { HomeAssistant } from "../../../types";
 
 // CSS and JS should only be imported once. Modules and HTML are safe.
-const CSS_CACHE = {};
-const JS_CACHE = {};
+const CSS_CACHE: Record<string, Promise<unknown>> = {};
+const JS_CACHE: Record<string, Promise<unknown>> = {};
+
+const _loadLovelaceResource = (
+  resource: LovelaceResource,
+  hass: HomeAssistant
+): Promise<unknown> | undefined => {
+  const normalizedUrl = new URL(
+    resource.url,
+    hass.auth.data.hassUrl
+  ).toString();
+
+  switch (resource.type) {
+    case "css": {
+      if (normalizedUrl in CSS_CACHE) {
+        return CSS_CACHE[normalizedUrl];
+      }
+
+      const loadTask = loadCSS(normalizedUrl);
+      CSS_CACHE[normalizedUrl] = loadTask;
+      return loadTask;
+    }
+
+    case "js": {
+      if (normalizedUrl in JS_CACHE) {
+        return JS_CACHE[normalizedUrl];
+      }
+
+      const loadTask = loadJS(normalizedUrl);
+      JS_CACHE[normalizedUrl] = loadTask;
+      return loadTask;
+    }
+
+    case "module":
+      return loadModule(normalizedUrl);
+
+    default:
+      // eslint-disable-next-line
+      console.warn(`Unknown resource type specified: ${resource.type}`);
+      return undefined;
+  }
+};
 
 export const loadLovelaceResources = (
   resources: NonNullable<LovelaceResource[]>,
   hass: HomeAssistant
 ) => {
   resources.forEach((resource) => {
-    const normalizedUrl = new URL(
-      resource.url,
-      hass.auth.data.hassUrl
-    ).toString();
-    switch (resource.type) {
-      case "css":
-        if (normalizedUrl in CSS_CACHE) {
-          break;
-        }
-        CSS_CACHE[normalizedUrl] = loadCSS(normalizedUrl);
-        break;
-
-      case "js":
-        if (normalizedUrl in JS_CACHE) {
-          break;
-        }
-        JS_CACHE[normalizedUrl] = loadJS(normalizedUrl);
-        break;
-
-      case "module":
-        loadModule(normalizedUrl);
-        break;
-
-      default:
-        // eslint-disable-next-line
-        console.warn(`Unknown resource type specified: ${resource.type}`);
-    }
+    _loadLovelaceResource(resource, hass);
   });
+};
+
+export const loadLovelaceResourcesAndWait = async (
+  resources: NonNullable<LovelaceResource[]>,
+  hass: HomeAssistant
+): Promise<void> => {
+  const loadTasks = resources
+    .map((resource) => _loadLovelaceResource(resource, hass))
+    .filter((task): task is Promise<unknown> => task !== undefined);
+
+  await Promise.allSettled(loadTasks);
 };

--- a/src/panels/lovelace/common/load-resources.ts
+++ b/src/panels/lovelace/common/load-resources.ts
@@ -2,10 +2,9 @@ import { loadCSS, loadJS, loadModule } from "../../../common/dom/load_resource";
 import type { LovelaceResource } from "../../../data/lovelace/resource";
 import type { HomeAssistant } from "../../../types";
 
-// CSS, JS, and modules should only be imported once.
+// CSS and JS should only be imported once. Modules and HTML are safe.
 const CSS_CACHE: Record<string, Promise<unknown>> = {};
 const JS_CACHE: Record<string, Promise<unknown>> = {};
-const MODULE_CACHE: Record<string, Promise<unknown>> = {};
 
 const _loadLovelaceResource = (
   resource: LovelaceResource,
@@ -37,15 +36,8 @@ const _loadLovelaceResource = (
       return loadTask;
     }
 
-    case "module": {
-      if (normalizedUrl in MODULE_CACHE) {
-        return MODULE_CACHE[normalizedUrl];
-      }
-
-      const loadTask = loadModule(normalizedUrl);
-      MODULE_CACHE[normalizedUrl] = loadTask;
-      return loadTask;
-    }
+    case "module":
+      return loadModule(normalizedUrl);
 
     default:
       // eslint-disable-next-line

--- a/src/panels/lovelace/common/load-resources.ts
+++ b/src/panels/lovelace/common/load-resources.ts
@@ -2,9 +2,10 @@ import { loadCSS, loadJS, loadModule } from "../../../common/dom/load_resource";
 import type { LovelaceResource } from "../../../data/lovelace/resource";
 import type { HomeAssistant } from "../../../types";
 
-// CSS and JS should only be imported once. Modules and HTML are safe.
+// CSS, JS, and modules should only be imported once.
 const CSS_CACHE: Record<string, Promise<unknown>> = {};
 const JS_CACHE: Record<string, Promise<unknown>> = {};
+const MODULE_CACHE: Record<string, Promise<unknown>> = {};
 
 const _loadLovelaceResource = (
   resource: LovelaceResource,
@@ -36,8 +37,15 @@ const _loadLovelaceResource = (
       return loadTask;
     }
 
-    case "module":
-      return loadModule(normalizedUrl);
+    case "module": {
+      if (normalizedUrl in MODULE_CACHE) {
+        return MODULE_CACHE[normalizedUrl];
+      }
+
+      const loadTask = loadModule(normalizedUrl);
+      MODULE_CACHE[normalizedUrl] = loadTask;
+      return loadTask;
+    }
 
     default:
       // eslint-disable-next-line

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4411,7 +4411,8 @@
               },
               "search_dashboards": "Search dashboards",
               "heading": {
-                "default": "Dashboards"
+                "default": "Dashboards",
+                "custom": "Custom dashboards"
               }
             },
             "picker": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4412,7 +4412,7 @@
               "search_dashboards": "Search dashboards",
               "heading": {
                 "default": "Dashboards",
-                "custom": "Custom dashboards"
+                "custom": "Community dashboards"
               }
             },
             "picker": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

- Similar to custom cards, registers `customStrategies` to the `window` object allowing custom dashboard strategies to be registered and used.
- Adds support to add custom strategies to dashboard dialog.
- Supports a single or light and dark images for strategies. See [here](https://github.com/timmo001/ha-dashboard-maintenance/commit/c524f64ec050ea20ba1ae6bb86aacf50298cb911) for implementation

Tested with my custom strategy. See:
- Testing: https://discord.com/channels/330944238910963714/1351536906437005313/1488502969279320255
- Commit to register: https://github.com/timmo001/ha-dashboard-maintenance/commit/b93925cee2f9c91c8cda645e2ebd4cc60ac44562
- Commit to add image to strategy: https://github.com/timmo001/ha-dashboard-maintenance/commit/c524f64ec050ea20ba1ae6bb86aacf50298cb911

Initial work by Paulus / Claude.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
`window.X`:
<img width="1918" height="295" alt="image" src="https://github.com/user-attachments/assets/80e0b426-97a4-4d69-afea-c9b3c3bcc408" />

Add community dashboards:
<img width="1650" height="1456" alt="image" src="https://github.com/user-attachments/assets/57dedf3b-c702-4b5c-8d6a-0b85b458cf34" />
<img width="1595" height="1443" alt="image" src="https://github.com/user-attachments/assets/56681d9a-6f78-46ae-b09b-ff318f45e49e" />



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3023
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
