### PR TITLE
Fix Fill example data inserting incorrect datetime format

### DIFF
--- a/src/panels/config/developer-tools/action/developer-tools-action.ts
+++ b/src/panels/config/developer-tools/action/developer-tools-action.ts
@@ -1,7 +1,7 @@
 import { mdiHelpCircleOutline } from "@mdi/js";
 import type { HassService } from "home-assistant-js-websocket";
 import { ERR_CONNECTION_LOST } from "home-assistant-js-websocket";
-import { dump, load } from "js-yaml";
+import { dump, JSON_SCHEMA, load } from "js-yaml";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
@@ -652,7 +652,7 @@ class HaPanelDevAction extends LitElement {
       if (field.example) {
         let value: any = "";
         try {
-          value = load(field.example);
+          value = load(field.example, { schema: JSON_SCHEMA });
         } catch (_err: any) {
           value =
             this.hass.localize(


### PR DESCRIPTION
## Proposed change

Use `JSON_SCHEMA` instead of js-yaml's default `DEFAULT_SCHEMA` when parsing service field examples in "Fill example data". The default schema includes a timestamp type resolver that converts datetime strings (like `1970-01-01 00:00:00`) into JavaScript Date objects, which then get serialized as ISO 8601 (`1970-01-01T00:00:00.000Z`) — a format incompatible with the datetime selector.

`JSON_SCHEMA` preserves datetime strings as-is while still correctly parsing numbers, booleans, lists, and objects.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51297
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr