### PR TITLE
Fix ZHA device count not including devices without entities

### DIFF
--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -75,18 +75,21 @@ class ZHAConfigDashboard extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const deviceIds = new Set<string>();
+    const devices = this._configEntry
+      ? Object.values(this.hass.devices).filter((device) =>
+          device.config_entries.includes(this._configEntry!.entry_id)
+        )
+      : [];
+    const deviceCount = devices.length;
+
     let entityCount = 0;
     for (const entity of Object.values(this.hass.entities)) {
       if (entity.platform === "zha") {
         entityCount++;
-        if (entity.device_id) {
-          deviceIds.add(entity.device_id);
-        }
       }
     }
     const deviceOnline =
-      this._offlineDevices < deviceIds.size || deviceIds.size === 0;
+      this._offlineDevices < deviceCount || deviceCount === 0;
     return html`
       <hass-subpage
         .hass=${this.hass}
@@ -96,8 +99,8 @@ class ZHAConfigDashboard extends LitElement {
         has-fab
       >
         <div class="container">
-          ${this._renderNetworkStatus(deviceOnline, deviceIds.size)}
-          ${this._renderMyNetworkCard(deviceIds, entityCount)}
+          ${this._renderNetworkStatus(deviceOnline, deviceCount)}
+          ${this._renderMyNetworkCard(deviceCount, entityCount)}
           ${this._renderNavigationCard()} ${this._renderBackupCard()}
         </div>
 
@@ -165,7 +168,7 @@ class ZHAConfigDashboard extends LitElement {
     `;
   }
 
-  private _renderMyNetworkCard(deviceIds: Set<string>, entityCount: number) {
+  private _renderMyNetworkCard(deviceCount: number, entityCount: number) {
     return html`
       <ha-card class="nav-card">
         <div class="card-header">
@@ -189,7 +192,7 @@ class ZHAConfigDashboard extends LitElement {
               <div slot="headline">
                 ${this.hass.localize(
                   "ui.panel.config.zha.configuration_page.device_count",
-                  { count: deviceIds.size }
+                  { count: deviceCount }
                 )}
               </div>
               <ha-icon-next slot="end"></ha-icon-next>


### PR DESCRIPTION
## Proposed change

The ZHA config dashboard counted devices by collecting unique `device_id` values from ZHA entities. Devices without entities (like the coordinator) were not counted, causing a mismatch between the displayed count and the actual device list.

This changes the counting to use the device registry filtered by config entry, matching how the device list page counts devices.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #30394
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr