### PR TITLE
Fix history-graph card not showing first value

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -606,22 +606,29 @@ export class HaChartBase extends LitElement {
       id: "dataZoom",
       type: "inside",
       orient: "horizontal",
-      // "boundaryFilter" is a custom mode added via axis-proxy-patch.ts.
-      // It rescales the Y-axis to the visible data while keeping one point
-      // just outside each boundary to avoid line gaps at the zoom edges.
-      // Only use it for line charts — it causes issues with bar charts.
-      // Use "filter" for bar charts, and "weakFilter" for other types
-      // (e.g. custom/timeline) so bars spanning the visible range are kept.
-      filterMode: (ensureArray(this.data).every((s) => s.type === "line")
-        ? "boundaryFilter"
-        : ensureArray(this.data).some((s) => s.type === "bar")
-          ? "filter"
-          : "weakFilter") as any,
+      filterMode: this._getDataZoomFilterMode() as any,
       xAxisIndex: 0,
       moveOnMouseMove: !this._isTouchDevice || this._isZoomed,
       preventDefaultMouseMove: !this._isTouchDevice || this._isZoomed,
       zoomLock: !this._isTouchDevice && !this._modifierPressed,
     };
+  }
+
+  // "boundaryFilter" is a custom mode added via axis-proxy-patch.ts.
+  // It rescales the Y-axis to the visible data while keeping one point
+  // just outside each boundary to avoid line gaps at the zoom edges.
+  // Use "filter" for bar charts since boundaryFilter causes rendering issues.
+  // Use "weakFilter" for other types (e.g. custom/timeline) so bars
+  // spanning the visible range boundary are kept.
+  private _getDataZoomFilterMode(): string {
+    const series = ensureArray(this.data);
+    if (series.every((s) => s.type === "line")) {
+      return "boundaryFilter";
+    }
+    if (series.some((s) => s.type === "bar")) {
+      return "filter";
+    }
+    return "weakFilter";
   }
 
   private _createOptions(): ECOption {

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -610,9 +610,13 @@ export class HaChartBase extends LitElement {
       // It rescales the Y-axis to the visible data while keeping one point
       // just outside each boundary to avoid line gaps at the zoom edges.
       // Only use it for line charts — it causes issues with bar charts.
+      // Use "filter" for bar charts, and "weakFilter" for other types
+      // (e.g. custom/timeline) so bars spanning the visible range are kept.
       filterMode: (ensureArray(this.data).every((s) => s.type === "line")
         ? "boundaryFilter"
-        : "filter") as any,
+        : ensureArray(this.data).some((s) => s.type === "bar")
+          ? "filter"
+          : "weakFilter") as any,
       xAxisIndex: 0,
       moveOnMouseMove: !this._isTouchDevice || this._isZoomed,
       preventDefaultMouseMove: !this._isTouchDevice || this._isZoomed,


### PR DESCRIPTION
## Proposed change

The `"filter"` dataZoom mode introduced in #51307 removes timeline bars whose start time predates the visible range. This causes the first state bar to be missing in history-graph cards when the state started before `hours_to_show`.

Use a three-tier filterMode: `"boundaryFilter"` for line charts, `"filter"` for bar charts, and `"weakFilter"` for custom/timeline series so bars spanning the range boundary are kept.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51342
- This PR is related to issue or discussion: #51307
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr