### PR TITLE
Fix device page entity names not refreshing after device rename

### DIFF
--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -176,13 +176,14 @@ export class HaConfigDevicePage extends LitElement {
   private _entities = memoizeOne(
     (
       deviceId: string,
-      entities: EntityRegistryEntry[]
+      entities: EntityRegistryEntry[],
+      devices: HomeAssistant["devices"]
     ): EntityRegistryStateEntry[] =>
       entities
         .filter((entity) => entity.device_id === deviceId)
         .map((entity) => ({
           ...entity,
-          stateName: this._computeEntityName(entity),
+          stateName: this._computeEntityName(entity, devices),
         }))
         .sort((ent1, ent2) =>
           stringCompare(
@@ -340,7 +341,11 @@ export class HaConfigDevicePage extends LitElement {
       this.entries,
       this.manifests
     );
-    const entities = this._entities(this.deviceId, this._entityReg);
+    const entities = this._entities(
+      this.deviceId,
+      this._entityReg,
+      this.hass.devices
+    );
     const entitiesByCategory = this._entitiesByCategory(entities);
     const batteryEntity = this._batteryEntity(entities);
     const batteryChargingEntity = this._batteryChargingEntity(entities);
@@ -1144,7 +1149,11 @@ export class HaConfigDevicePage extends LitElement {
       });
     }
 
-    const entities = this._entities(this.deviceId, this._entityReg);
+    const entities = this._entities(
+      this.deviceId,
+      this._entityReg,
+      this.hass.devices
+    );
 
     const assistSatellite = entities.find(
       (ent) => computeDomain(ent.entity_id) === "assist_satellite"
@@ -1271,10 +1280,13 @@ export class HaConfigDevicePage extends LitElement {
     }
   }
 
-  private _computeEntityName(entity: EntityRegistryEntry) {
-    const device = this.hass.devices[this.deviceId];
+  private _computeEntityName(
+    entity: EntityRegistryEntry,
+    devices: HomeAssistant["devices"]
+  ) {
+    const device = devices[this.deviceId];
     return (
-      computeEntityEntryName(entity, this.hass.devices) ||
+      computeEntityEntryName(entity, devices) ||
       computeDeviceNameDisplay(device, this.hass)
     );
   }
@@ -1293,9 +1305,11 @@ export class HaConfigDevicePage extends LitElement {
 
   private _createScene() {
     const entities: SceneEntities = {};
-    this._entities(this.deviceId, this._entityReg).forEach((entity) => {
-      entities[entity.entity_id] = "";
-    });
+    this._entities(this.deviceId, this._entityReg, this.hass.devices).forEach(
+      (entity) => {
+        entities[entity.entity_id] = "";
+      }
+    );
     showSceneEditor({
       entities,
     });
@@ -1360,9 +1374,11 @@ export class HaConfigDevicePage extends LitElement {
   }
 
   private _resetEntityIds = () => {
-    const entities = this._entities(this.deviceId, this._entityReg).map(
-      (e) => e.entity_id
-    );
+    const entities = this._entities(
+      this.deviceId,
+      this._entityReg,
+      this.hass.devices
+    ).map((e) => e.entity_id);
     regenerateEntityIds(this, this.hass, entities);
   };
 
@@ -1454,7 +1470,11 @@ export class HaConfigDevicePage extends LitElement {
         ) {
           return;
         }
-        const entities = this._entities(this.deviceId, this._entityReg);
+        const entities = this._entities(
+          this.deviceId,
+          this._entityReg,
+          this.hass.devices
+        );
 
         const updateProms = entities.map((entity) => {
           const name = entity.name || entity.stateName;


### PR DESCRIPTION
## Proposed change

Fix entity names on the device page not updating after editing the device name without a page reload.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
