### PR TITLE
Fix next_flow dialog closing immediately after rendering

### DIFF
--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -138,6 +138,7 @@ export class HaDialog extends ScrollableFadeMixin(LitElement) {
 
   public connectedCallback(): void {
     super.connectedCallback();
+    this._open = this.open;
     this.addEventListener(
       "dialog-set-fullscreen",
       this._handleFullscreenChanged as EventListener

--- a/src/dialogs/make-dialog-manager.ts
+++ b/src/dialogs/make-dialog-manager.ts
@@ -177,7 +177,10 @@ export const showDialog = async (
     throw new Error("Unknown dialog type loaded");
   }
 
-  (parentElement || element).shadowRoot!.appendChild(dialogElement!);
+  const targetParent = (parentElement || element).shadowRoot!;
+  if (dialogElement!.parentNode !== targetParent) {
+    targetParent.appendChild(dialogElement!);
+  }
 
   return true;
 };


### PR DESCRIPTION
## Proposed change

Fix the `next_flow` dialog closing immediately after briefly rendering. When a config flow completes with `next_flow`, the dialog manager re-shows the same `dialog-data-entry-flow` element by calling `appendChild` — but since the element is already in the correct parent, this triggers an unnecessary `disconnectedCallback`/`connectedCallback` cycle. During disconnect, `ha-dialog` sets its internal `_open` to `false`, and on reconnect it's never synced back because the public `open` property hasn't changed (so Lit's `updated()` doesn't fire for it).

Two fixes:
- **`make-dialog-manager.ts`**: Skip `appendChild` when the element is already in the correct parent
- **`ha-dialog.ts`**: Sync `_open = this.open` in `connectedCallback` as a defensive measure against stale state after reconnection

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51345
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: https://github.com/home-assistant/core/pull/165091

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr