### PR TITLE
Refactor integration page to build device/sub-entry tree in parent

### DIFF
--- a/src/panels/config/integrations/ha-config-entry-row.ts
+++ b/src/panels/config/integrations/ha-config-entry-row.ts
@@ -19,13 +19,11 @@ import {
   mdiTextBoxOutline,
   mdiWrench,
 } from "@mdi/js";
-import type { PropertyValues, TemplateResult } from "lit";
+import type { TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import memoizeOne from "memoize-one";
-import { computeDeviceNameDisplay } from "../../../common/entity/compute_device_name";
-import { caseInsensitiveStringCompare } from "../../../common/string/compare";
 import { copyToClipboard } from "../../../common/util/copy-clipboard";
 import "../../../components/ha-dropdown";
 import type { HaDropdownSelectEvent } from "../../../components/ha-dropdown";
@@ -35,22 +33,16 @@ import {
   fetchApplicationCredentialsConfigEntry,
 } from "../../../data/application_credential";
 import { getSignedPath } from "../../../data/auth";
-import type {
-  ConfigEntry,
-  DisableConfigEntryResult,
-  SubEntry,
-} from "../../../data/config_entries";
+import type { DisableConfigEntryResult } from "../../../data/config_entries";
 import {
   deleteConfigEntry,
   disableConfigEntry,
   enableConfigEntry,
   ERROR_STATES,
-  getSubEntries,
   RECOVERABLE_STATES,
   reloadConfigEntry,
   updateConfigEntry,
 } from "../../../data/config_entries";
-import type { DeviceRegistryEntry } from "../../../data/device/device_registry";
 import type { DiagnosticInfo } from "../../../data/diagnostics";
 import { getConfigEntryDiagnosticsDownloadUrl } from "../../../data/diagnostics";
 import type { EntityRegistryEntry } from "../../../data/entity/entity_registry";
@@ -75,7 +67,10 @@ import {
   showPromptDialog,
 } from "../../lovelace/custom-card-helpers";
 import "./ha-config-entry-device-row";
-import { renderConfigEntryError } from "./ha-config-integration-page";
+import {
+  renderConfigEntryError,
+  type ConfigEntryData,
+} from "./ha-config-integration-page";
 import "./ha-config-sub-entry-row";
 
 @customElement("ha-config-entry-row")
@@ -90,22 +85,14 @@ export class HaConfigEntryRow extends LitElement {
 
   @property({ attribute: false }) public entities!: EntityRegistryEntry[];
 
-  @property({ attribute: false }) public entry!: ConfigEntry;
+  @property({ attribute: false }) public data!: ConfigEntryData;
 
   @state() private _expanded = true;
 
   @state() private _devicesExpanded = true;
 
-  @state() private _subEntries?: SubEntry[];
-
-  protected willUpdate(changedProperties: PropertyValues): void {
-    if (changedProperties.has("entry")) {
-      this._fetchSubEntries();
-    }
-  }
-
   protected render() {
-    const item = this.entry;
+    const item = this.data.entry;
 
     let stateText: Parameters<typeof this.hass.localize> | undefined;
     let stateTextExtra: TemplateResult | string | undefined;
@@ -128,15 +115,17 @@ export class HaConfigEntryRow extends LitElement {
       stateTextExtra = renderConfigEntryError(this.hass, item);
     }
 
-    const devices = this._getDevices();
-    const services = this._getServices();
     const entities = this._getEntities();
+    const ownDevices = [...this.data.devices, ...this.data.services];
 
-    const ownDevices = [...devices, ...services].filter(
-      (device) =>
-        !device.config_entries_subentries[item.entry_id].length ||
-        device.config_entries_subentries[item.entry_id][0] === null
-    );
+    const allDevices = [
+      ...this.data.devices,
+      ...this.data.subEntries.flatMap((s) => s.devices),
+    ];
+    const allServices = [
+      ...this.data.services,
+      ...this.data.subEntries.flatMap((s) => s.services),
+    ];
 
     const statusLine: (TemplateResult | string)[] = [];
 
@@ -158,7 +147,7 @@ export class HaConfigEntryRow extends LitElement {
           "ui.panel.config.integrations.config_entry.disable_restart_confirm"
         )}.`);
       }
-    } else if (!devices.length && !services.length && entities.length) {
+    } else if (!allDevices.length && !allServices.length && entities.length) {
       statusLine.push(
         html`<a
           href=${`/config/entities/?historyBack=1&config_entry=${item.entry_id}`}
@@ -172,7 +161,7 @@ export class HaConfigEntryRow extends LitElement {
 
     const configPanel = this._configPanel(item.domain, this.hass.panels);
 
-    const subEntries = this._subEntries || [];
+    const subEntries = this.data.subEntries;
 
     return html`<ha-md-list>
       <ha-md-list-item
@@ -246,29 +235,29 @@ export class HaConfigEntryRow extends LitElement {
             .label=${this.hass.localize("ui.common.menu")}
             .path=${mdiDotsVertical}
           ></ha-icon-button>
-          ${devices.length
+          ${allDevices.length
             ? html`
                 <a
-                  href=${devices.length === 1
-                    ? `/config/devices/device/${devices[0].id}`
+                  href=${allDevices.length === 1
+                    ? `/config/devices/device/${allDevices[0].id}`
                     : `/config/devices/dashboard?historyBack=1&config_entry=${item.entry_id}`}
                 >
                   <ha-dropdown-item value="devices">
                     <ha-svg-icon .path=${mdiDevices} slot="icon"></ha-svg-icon>
                     ${this.hass.localize(
                       `ui.panel.config.integrations.config_entry.devices`,
-                      { count: devices.length }
+                      { count: allDevices.length }
                     )}
                     <ha-icon-next slot="details"></ha-icon-next>
                   </ha-dropdown-item>
                 </a>
               `
             : nothing}
-          ${services.length
+          ${allServices.length
             ? html`
                 <a
-                  href=${services.length === 1
-                    ? `/config/devices/device/${services[0].id}`
+                  href=${allServices.length === 1
+                    ? `/config/devices/device/${allServices[0].id}`
                     : `/config/devices/dashboard?historyBack=1&config_entry=${item.entry_id}`}
                 >
                   <ha-dropdown-item value="services">
@@ -278,7 +267,7 @@ export class HaConfigEntryRow extends LitElement {
                     ></ha-svg-icon>
                     ${this.hass.localize(
                       `ui.panel.config.integrations.config_entry.services`,
-                      { count: services.length }
+                      { count: allServices.length }
                     )}
                     <ha-icon-next slot="details"></ha-icon-next>
                   </ha-dropdown-item>
@@ -466,7 +455,7 @@ export class HaConfigEntryRow extends LitElement {
                 </ha-md-list>`
               : nothing}
             ${subEntries.map(
-              (subEntry) => html`
+              (subEntryData) => html`
                 <ha-config-sub-entry-row
                   .hass=${this.hass}
                   .narrow=${this.narrow}
@@ -474,7 +463,7 @@ export class HaConfigEntryRow extends LitElement {
                   .diagnosticHandler=${this.diagnosticHandler}
                   .entities=${this.entities}
                   .entry=${item}
-                  .subEntry=${subEntry}
+                  .data=${subEntryData}
                   data-entry-id=${item.entry_id}
                 ></ha-config-sub-entry-row>
               `
@@ -495,18 +484,6 @@ export class HaConfigEntryRow extends LitElement {
     </ha-md-list>`;
   }
 
-  private async _fetchSubEntries() {
-    this._subEntries = this.entry.num_subentries
-      ? (await getSubEntries(this.hass, this.entry.entry_id)).sort((a, b) =>
-          caseInsensitiveStringCompare(
-            a.title,
-            b.title,
-            this.hass.locale.language
-          )
-        )
-      : undefined;
-  }
-
   private _configPanel = memoizeOne(
     (domain: string, panels: HomeAssistant["panels"]): string | undefined =>
       Object.values(panels).find(
@@ -516,38 +493,8 @@ export class HaConfigEntryRow extends LitElement {
 
   private _getEntities = (): EntityRegistryEntry[] =>
     this.entities.filter(
-      (entity) => entity.config_entry_id === this.entry.entry_id
+      (entity) => entity.config_entry_id === this.data.entry.entry_id
     );
-
-  private _getDevices = (): DeviceRegistryEntry[] =>
-    Object.values(this.hass.devices)
-      .filter(
-        (device) =>
-          device.config_entries.includes(this.entry.entry_id) &&
-          device.entry_type !== "service"
-      )
-      .sort((a, b) =>
-        caseInsensitiveStringCompare(
-          computeDeviceNameDisplay(a, this.hass.localize, this.hass.states),
-          computeDeviceNameDisplay(b, this.hass.localize, this.hass.states),
-          this.hass.locale.language
-        )
-      );
-
-  private _getServices = (): DeviceRegistryEntry[] =>
-    Object.values(this.hass.devices)
-      .filter(
-        (device) =>
-          device.config_entries.includes(this.entry.entry_id) &&
-          device.entry_type === "service"
-      )
-      .sort((a, b) =>
-        caseInsensitiveStringCompare(
-          computeDeviceNameDisplay(a, this.hass.localize, this.hass.states),
-          computeDeviceNameDisplay(b, this.hass.localize, this.hass.states),
-          this.hass.locale.language
-        )
-      );
 
   private _toggleExpand() {
     this._expanded = !this._expanded;
@@ -600,7 +547,7 @@ export class HaConfigEntryRow extends LitElement {
   };
 
   private _showOptions() {
-    showOptionsFlowDialog(this, this.entry, { manifest: this.manifest });
+    showOptionsFlowDialog(this, this.data.entry, { manifest: this.manifest });
   }
 
   // Return an application credentials id for this config entry to prompt the
@@ -665,7 +612,7 @@ export class HaConfigEntryRow extends LitElement {
   }
 
   private _handleReload = async () => {
-    const result = await reloadConfigEntry(this.hass, this.entry.entry_id);
+    const result = await reloadConfigEntry(this.hass, this.data.entry.entry_id);
     const locale_key = result.require_restart
       ? "reload_restart_confirm"
       : "reload_confirm";
@@ -678,16 +625,19 @@ export class HaConfigEntryRow extends LitElement {
 
   private _handleReconfigure = async () => {
     showConfigFlowDialog(this, {
-      startFlowHandler: this.entry.domain,
+      startFlowHandler: this.data.entry.domain,
       showAdvanced: this.hass.userData?.showAdvanced,
-      manifest: await fetchIntegrationManifest(this.hass, this.entry.domain),
-      entryId: this.entry.entry_id,
+      manifest: await fetchIntegrationManifest(
+        this.hass,
+        this.data.entry.domain
+      ),
+      entryId: this.data.entry.entry_id,
       navigateToResult: true,
     });
   };
 
   private _handleCopy = async () => {
-    await copyToClipboard(this.entry.entry_id);
+    await copyToClipboard(this.data.entry.entry_id);
     showToast(this, {
       message:
         this.hass?.localize("ui.common.copied_clipboard") ||
@@ -698,7 +648,7 @@ export class HaConfigEntryRow extends LitElement {
   private _handleRename = async () => {
     const newName = await showPromptDialog(this, {
       title: this.hass.localize("ui.panel.config.integrations.rename_dialog"),
-      defaultValue: this.entry.title,
+      defaultValue: this.data.entry.title,
       inputLabel: this.hass.localize(
         "ui.panel.config.integrations.rename_input_label"
       ),
@@ -706,7 +656,7 @@ export class HaConfigEntryRow extends LitElement {
     if (newName === null) {
       return;
     }
-    await updateConfigEntry(this.hass, this.entry.entry_id, {
+    await updateConfigEntry(this.hass, this.data.entry.entry_id, {
       title: newName,
     });
   };
@@ -722,12 +672,12 @@ export class HaConfigEntryRow extends LitElement {
   }
 
   private _handleDisable = async () => {
-    const entryId = this.entry.entry_id;
+    const entryId = this.data.entry.entry_id;
 
     const confirmed = await showConfirmationDialog(this, {
       title: this.hass.localize(
         "ui.panel.config.integrations.config_entry.disable_confirm_title",
-        { title: this.entry.title }
+        { title: this.data.entry.title }
       ),
       text: this.hass.localize(
         "ui.panel.config.integrations.config_entry.disable_confirm_text"
@@ -762,7 +712,7 @@ export class HaConfigEntryRow extends LitElement {
   };
 
   private _handleEnable = async () => {
-    const entryId = this.entry.entry_id;
+    const entryId = this.data.entry.entry_id;
 
     let result: DisableConfigEntryResult;
     try {
@@ -787,7 +737,7 @@ export class HaConfigEntryRow extends LitElement {
   };
 
   private _handleDelete = async () => {
-    const entryId = this.entry.entry_id;
+    const entryId = this.data.entry.entry_id;
 
     const applicationCredentialsId =
       await this._applicationCredentialForRemove(entryId);
@@ -795,7 +745,7 @@ export class HaConfigEntryRow extends LitElement {
     const confirmed = await showConfirmationDialog(this, {
       title: this.hass.localize(
         "ui.panel.config.integrations.config_entry.delete_confirm_title",
-        { title: this.entry.title }
+        { title: this.data.entry.title }
       ),
       text: this.hass.localize(
         "ui.panel.config.integrations.config_entry.delete_confirm_text"
@@ -824,14 +774,14 @@ export class HaConfigEntryRow extends LitElement {
 
   private _handleSystemOptions = () => {
     showConfigEntrySystemOptionsDialog(this, {
-      entry: this.entry,
+      entry: this.data.entry,
       manifest: this.manifest,
     });
   };
 
   private _addSubEntry = (flowType: string) => {
-    showSubConfigFlowDialog(this, this.entry, flowType, {
-      startFlowHandler: this.entry.entry_id,
+    showSubConfigFlowDialog(this, this.data.entry, flowType, {
+      startFlowHandler: this.data.entry.entry_id,
     });
   };
 

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -30,8 +30,12 @@ import "../../../components/ha-dropdown-item";
 import "../../../components/ha-md-list";
 import "../../../components/ha-md-list-item";
 import { getSignedPath } from "../../../data/auth";
-import type { ConfigEntry } from "../../../data/config_entries";
-import { ERROR_STATES, getConfigEntries } from "../../../data/config_entries";
+import type { ConfigEntry, SubEntry } from "../../../data/config_entries";
+import {
+  ERROR_STATES,
+  getConfigEntries,
+  getSubEntries,
+} from "../../../data/config_entries";
 import { ATTENTION_SOURCES } from "../../../data/config_flow";
 import type { DeviceRegistryEntry } from "../../../data/device/device_registry";
 import type { DiagnosticInfo } from "../../../data/diagnostics";
@@ -69,6 +73,19 @@ import type { HaConfigEntryRow } from "./ha-config-entry-row";
 import type { DataEntryFlowProgressExtended } from "./ha-config-integrations";
 import { showAddIntegrationDialog } from "./show-add-integration-dialog";
 import { showPickConfigEntryDialog } from "./show-pick-config-entry-dialog";
+
+export interface SubEntryData {
+  subEntry: SubEntry;
+  devices: DeviceRegistryEntry[];
+  services: DeviceRegistryEntry[];
+}
+
+export interface ConfigEntryData {
+  entry: ConfigEntry;
+  devices: DeviceRegistryEntry[];
+  services: DeviceRegistryEntry[];
+  subEntries: SubEntryData[];
+}
 
 export const renderConfigEntryError = (
   hass: HomeAssistant,
@@ -137,6 +154,8 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
     window.location.hash.substring(1)
   );
 
+  @state() private _subEntries: Record<string, SubEntry[]> = {};
+
   @state() private _domainEntities: Record<string, string[]> = {};
 
   @queryAll("ha-config-entry-row")
@@ -195,9 +214,20 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
       this.hass.loadBackendTranslation("config", [this.domain]);
       this.hass.loadBackendTranslation("config_subentries", [this.domain]);
       this._extraConfigEntries = undefined;
+      this._subEntries = {};
       this._fetchManifest();
       this._fetchDiagnostics();
       this._fetchEntitySources();
+    }
+    if (
+      changedProperties.has("configEntries") ||
+      changedProperties.has("_extraConfigEntries")
+    ) {
+      const entries = this._domainConfigEntries(
+        this.domain,
+        this._extraConfigEntries || this.configEntries
+      );
+      this._fetchAllSubEntries(entries);
     }
   }
 
@@ -284,6 +314,19 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
           this.hass.locale.language
         );
       });
+
+    const normalData = this._buildEntryData(
+      normalEntries,
+      this.hass.devices,
+      this._subEntries,
+      this.hass.locale.language
+    );
+    const attentionData = this._buildEntryData(
+      attentionEntries,
+      this.hass.devices,
+      this._subEntries,
+      this.hass.locale.language
+    );
 
     const devicesRegs = this._getDevices(configEntries, this.hass.devices);
     const entities = this._getEntities(configEntries, this._entities);
@@ -649,7 +692,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                 </div>
               `
             : nothing}
-          ${attentionFlows.length || attentionEntries.length
+          ${attentionFlows.length || attentionData.length
             ? html`
                 <div class="section">
                   <h3 class="section-header">
@@ -689,8 +732,8 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                         })}
                       </ha-md-list>`
                     : nothing}
-                  ${attentionEntries.map(
-                    (item) =>
+                  ${attentionData.map(
+                    (data) =>
                       html`<ha-config-entry-row
                         class="attention"
                         .hass=${this.hass}
@@ -698,8 +741,8 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                         .manifest=${this._manifest}
                         .diagnosticHandler=${this._diagnosticHandler}
                         .entities=${this._entities}
-                        .entry=${item}
-                        data-entry-id=${item.entry_id}
+                        .data=${data}
+                        data-entry-id=${data.entry.entry_id}
                       ></ha-config-entry-row>`
                   )}
                 </div>
@@ -716,7 +759,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                     `ui.panel.config.integrations.integration_page.entries`
                   )}
             </h3>
-            ${normalEntries.length === 0
+            ${normalData.length === 0
               ? html`<div class="card-content no-entries">
                   ${this._manifest &&
                   !this._manifest.config_flow &&
@@ -731,16 +774,16 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                       )}
                 </div>`
               : html`
-                  ${normalEntries.map(
-                    (item) =>
+                  ${normalData.map(
+                    (data) =>
                       html`<ha-config-entry-row
                         .hass=${this.hass}
                         .narrow=${this.narrow}
                         .manifest=${this._manifest}
                         .diagnosticHandler=${this._diagnosticHandler}
                         .entities=${this._entities}
-                        .entry=${item}
-                        data-entry-id=${item.entry_id}
+                        .data=${data}
+                        data-entry-id=${data.entry.entry_id}
                       ></ha-config-entry-row>`
                   )}
                 `}
@@ -813,6 +856,102 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
       // No issue, as diagnostics are not required
     }
   }
+
+  private async _fetchAllSubEntries(entries: ConfigEntry[]) {
+    const entriesWithSubs = entries.filter((e) => e.num_subentries > 0);
+    if (!entriesWithSubs.length) {
+      this._subEntries = {};
+      return;
+    }
+    const results: Record<string, SubEntry[]> = {};
+    await Promise.all(
+      entriesWithSubs.map(async (entry) => {
+        try {
+          results[entry.entry_id] = (
+            await getSubEntries(this.hass, entry.entry_id)
+          ).sort((a, b) =>
+            caseInsensitiveStringCompare(
+              a.title,
+              b.title,
+              this.hass.locale.language
+            )
+          );
+        } catch {
+          results[entry.entry_id] = [];
+        }
+      })
+    );
+    this._subEntries = results;
+  }
+
+  private _buildEntryData = memoizeOne(
+    (
+      entries: ConfigEntry[],
+      devices: HomeAssistant["devices"],
+      subEntries: Record<string, SubEntry[]>,
+      language: string
+    ): ConfigEntryData[] => {
+      const sortDevices = (a: DeviceRegistryEntry, b: DeviceRegistryEntry) =>
+        caseInsensitiveStringCompare(
+          a.name_by_user || a.name || "",
+          b.name_by_user || b.name || "",
+          language
+        );
+
+      return entries.map((entry) => {
+        const allDevices = Object.values(devices).filter((device) =>
+          device.config_entries.includes(entry.entry_id)
+        );
+
+        const entrySubs = (subEntries[entry.entry_id] || []).map(
+          (sub): SubEntryData => {
+            const subDevs = allDevices
+              .filter(
+                (d) =>
+                  d.config_entries_subentries[entry.entry_id]?.includes(
+                    sub.subentry_id
+                  ) && d.entry_type !== "service"
+              )
+              .sort(sortDevices);
+            const subServices = allDevices
+              .filter(
+                (d) =>
+                  d.config_entries_subentries[entry.entry_id]?.includes(
+                    sub.subentry_id
+                  ) && d.entry_type === "service"
+              )
+              .sort(sortDevices);
+            return { subEntry: sub, devices: subDevs, services: subServices };
+          }
+        );
+
+        const ownDevices = allDevices
+          .filter(
+            (d) =>
+              (!d.config_entries_subentries[entry.entry_id]?.length ||
+                d.config_entries_subentries[entry.entry_id][0] === null) &&
+              d.entry_type !== "service"
+          )
+          .sort(sortDevices);
+
+        const ownServices = allDevices
+          .filter(
+            (d) =>
+              (!d.config_entries_subentries[entry.entry_id]?.length ||
+                d.config_entries_subentries[entry.entry_id][0] === null) &&
+              d.entry_type === "service"
+          )
+          .sort(sortDevices);
+
+        return {
+          entry,
+          devices: ownDevices,
+          services: ownServices,
+          subEntries: entrySubs,
+        };
+      });
+    }
+  );
 
   private async _handleEnableDebugLogging() {
     const integration = this.domain;

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -156,6 +156,8 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
 
   @state() private _subEntries: Record<string, SubEntry[]> = {};
 
+  private _subEntriesFetchId = 0;
+
   @state() private _domainEntities: Record<string, string[]> = {};
 
   @queryAll("ha-config-entry-row")
@@ -858,6 +860,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
   }
 
   private async _fetchAllSubEntries(entries: ConfigEntry[]) {
+    const fetchId = ++this._subEntriesFetchId;
     const entriesWithSubs = entries.filter((e) => e.num_subentries > 0);
     if (!entriesWithSubs.length) {
       this._subEntries = {};
@@ -881,6 +884,9 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         }
       })
     );
+    if (fetchId !== this._subEntriesFetchId) {
+      return;
+    }
     this._subEntries = results;
   }
 

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -22,6 +22,7 @@ import {
   PROTOCOL_INTEGRATIONS,
   protocolIntegrationPicked,
 } from "../../../common/integrations/protocolIntegrationPicked";
+import { computeDeviceName } from "../../../common/entity/compute_device_name";
 import { caseInsensitiveStringCompare } from "../../../common/string/compare";
 import { nextRender } from "../../../common/util/render-status";
 import "../../../components/ha-button";
@@ -317,13 +318,13 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         );
       });
 
-    const normalData = this._buildEntryData(
+    const normalData = this._buildNormalEntryData(
       normalEntries,
       this.hass.devices,
       this._subEntries,
       this.hass.locale.language
     );
-    const attentionData = this._buildEntryData(
+    const attentionData = this._buildAttentionEntryData(
       attentionEntries,
       this.hass.devices,
       this._subEntries,
@@ -890,74 +891,76 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
     this._subEntries = results;
   }
 
-  private _buildEntryData = memoizeOne(
-    (
-      entries: ConfigEntry[],
-      devices: HomeAssistant["devices"],
-      subEntries: Record<string, SubEntry[]>,
-      language: string
-    ): ConfigEntryData[] => {
-      const sortDevices = (a: DeviceRegistryEntry, b: DeviceRegistryEntry) =>
-        caseInsensitiveStringCompare(
-          a.name_by_user || a.name || "",
-          b.name_by_user || b.name || "",
-          language
-        );
+  private _buildEntryData = (
+    entries: ConfigEntry[],
+    devices: HomeAssistant["devices"],
+    subEntries: Record<string, SubEntry[]>,
+    language: string
+  ): ConfigEntryData[] => {
+    const sortDevices = (a: DeviceRegistryEntry, b: DeviceRegistryEntry) =>
+      caseInsensitiveStringCompare(
+        computeDeviceName(a) || "",
+        computeDeviceName(b) || "",
+        language
+      );
 
-      return entries.map((entry) => {
-        const allDevices = Object.values(devices).filter((device) =>
-          device.config_entries.includes(entry.entry_id)
-        );
+    return entries.map((entry) => {
+      const allDevices = Object.values(devices).filter((device) =>
+        device.config_entries.includes(entry.entry_id)
+      );
 
-        const entrySubs = (subEntries[entry.entry_id] || []).map(
-          (sub): SubEntryData => {
-            const subDevs = allDevices
-              .filter(
-                (d) =>
-                  d.config_entries_subentries[entry.entry_id]?.includes(
-                    sub.subentry_id
-                  ) && d.entry_type !== "service"
-              )
-              .sort(sortDevices);
-            const subServices = allDevices
-              .filter(
-                (d) =>
-                  d.config_entries_subentries[entry.entry_id]?.includes(
-                    sub.subentry_id
-                  ) && d.entry_type === "service"
-              )
-              .sort(sortDevices);
-            return { subEntry: sub, devices: subDevs, services: subServices };
-          }
-        );
+      const entrySubs = (subEntries[entry.entry_id] || []).map(
+        (sub): SubEntryData => {
+          const subDevs = allDevices
+            .filter(
+              (d) =>
+                d.config_entries_subentries[entry.entry_id]?.includes(
+                  sub.subentry_id
+                ) && d.entry_type !== "service"
+            )
+            .sort(sortDevices);
+          const subServices = allDevices
+            .filter(
+              (d) =>
+                d.config_entries_subentries[entry.entry_id]?.includes(
+                  sub.subentry_id
+                ) && d.entry_type === "service"
+            )
+            .sort(sortDevices);
+          return { subEntry: sub, devices: subDevs, services: subServices };
+        }
+      );
 
-        const ownDevices = allDevices
-          .filter(
-            (d) =>
-              (!d.config_entries_subentries[entry.entry_id]?.length ||
-                d.config_entries_subentries[entry.entry_id][0] === null) &&
-              d.entry_type !== "service"
-          )
-          .sort(sortDevices);
+      const ownDevices = allDevices
+        .filter(
+          (d) =>
+            (!d.config_entries_subentries[entry.entry_id]?.length ||
+              d.config_entries_subentries[entry.entry_id][0] === null) &&
+            d.entry_type !== "service"
+        )
+        .sort(sortDevices);
 
-        const ownServices = allDevices
-          .filter(
-            (d) =>
-              (!d.config_entries_subentries[entry.entry_id]?.length ||
-                d.config_entries_subentries[entry.entry_id][0] === null) &&
-              d.entry_type === "service"
-          )
-          .sort(sortDevices);
+      const ownServices = allDevices
+        .filter(
+          (d) =>
+            (!d.config_entries_subentries[entry.entry_id]?.length ||
+              d.config_entries_subentries[entry.entry_id][0] === null) &&
+            d.entry_type === "service"
+        )
+        .sort(sortDevices);
 
-        return {
-          entry,
-          devices: ownDevices,
-          services: ownServices,
-          subEntries: entrySubs,
-        };
-      });
-    }
-  );
+      return {
+        entry,
+        devices: ownDevices,
+        services: ownServices,
+        subEntries: entrySubs,
+      };
+    });
+  };
+
+  private _buildNormalEntryData = memoizeOne(this._buildEntryData);
+
+  private _buildAttentionEntryData = memoizeOne(this._buildEntryData);
 
   private async _handleEnableDebugLogging() {
     const integration = this.domain;

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -18,11 +18,11 @@ import { customElement, property, queryAll, state } from "lit/decorators";
 import { until } from "lit/directives/until";
 import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
+import { computeDeviceNameDisplay } from "../../../common/entity/compute_device_name";
 import {
   PROTOCOL_INTEGRATIONS,
   protocolIntegrationPicked,
 } from "../../../common/integrations/protocolIntegrationPicked";
-import { computeDeviceName } from "../../../common/entity/compute_device_name";
 import { caseInsensitiveStringCompare } from "../../../common/string/compare";
 import { nextRender } from "../../../common/util/render-status";
 import "../../../components/ha-button";
@@ -74,6 +74,7 @@ import type { HaConfigEntryRow } from "./ha-config-entry-row";
 import type { DataEntryFlowProgressExtended } from "./ha-config-integrations";
 import { showAddIntegrationDialog } from "./show-add-integration-dialog";
 import { showPickConfigEntryDialog } from "./show-pick-config-entry-dialog";
+import type { LocalizeFunc } from "../../../common/translations/localize";
 
 export interface SubEntryData {
   subEntry: SubEntry;
@@ -322,13 +323,15 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
       normalEntries,
       this.hass.devices,
       this._subEntries,
-      this.hass.locale.language
+      this.hass.locale.language,
+      this.hass.localize
     );
     const attentionData = this._buildAttentionEntryData(
       attentionEntries,
       this.hass.devices,
       this._subEntries,
-      this.hass.locale.language
+      this.hass.locale.language,
+      this.hass.localize
     );
 
     const devicesRegs = this._getDevices(configEntries, this.hass.devices);
@@ -895,12 +898,15 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
     entries: ConfigEntry[],
     devices: HomeAssistant["devices"],
     subEntries: Record<string, SubEntry[]>,
-    language: string
+    language: string,
+    localize: LocalizeFunc
   ): ConfigEntryData[] => {
+    // We intentially don't pass states as parameter as it's only a fallback
+    // and we want to avoid unnecessary recomputations when states change
     const sortDevices = (a: DeviceRegistryEntry, b: DeviceRegistryEntry) =>
       caseInsensitiveStringCompare(
-        computeDeviceName(a) || "",
-        computeDeviceName(b) || "",
+        computeDeviceNameDisplay(a, localize, this.hass.states) || "",
+        computeDeviceNameDisplay(b, localize, this.hass.states) || "",
         language
       );
 

--- a/src/panels/config/integrations/ha-config-sub-entry-row.ts
+++ b/src/panels/config/integrations/ha-config-sub-entry-row.ts
@@ -13,12 +13,12 @@ import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import "../../../components/ha-dropdown";
 import "../../../components/ha-dropdown-item";
-import type { ConfigEntry, SubEntry } from "../../../data/config_entries";
+import type { ConfigEntry } from "../../../data/config_entries";
 import { deleteSubEntry, updateSubEntry } from "../../../data/config_entries";
-import type { DeviceRegistryEntry } from "../../../data/device/device_registry";
 import type { DiagnosticInfo } from "../../../data/diagnostics";
 import type { EntityRegistryEntry } from "../../../data/entity/entity_registry";
 import type { IntegrationManifest } from "../../../data/integration";
+import type { SubEntryData } from "./ha-config-integration-page";
 import { showSubConfigFlowDialog } from "../../../dialogs/config-flow/show-dialog-sub-config-flow";
 import type { HomeAssistant } from "../../../types";
 import {
@@ -41,16 +41,16 @@ class HaConfigSubEntryRow extends LitElement {
 
   @property({ attribute: false }) public entry!: ConfigEntry;
 
-  @property({ attribute: false }) public subEntry!: SubEntry;
+  @property({ attribute: false }) public data!: SubEntryData;
 
   @state() private _expanded = true;
 
   protected render() {
-    const subEntry = this.subEntry;
+    const subEntry = this.data.subEntry;
     const configEntry = this.entry;
 
-    const devices = this._getDevices();
-    const services = this._getServices();
+    const devices = this.data.devices;
+    const services = this.data.services;
     const entities = this._getEntities();
 
     return html`<ha-md-list>
@@ -202,30 +202,19 @@ class HaConfigSubEntryRow extends LitElement {
 
   private _getEntities = (): EntityRegistryEntry[] =>
     this.entities.filter(
-      (entity) => entity.config_subentry_id === this.subEntry.subentry_id
-    );
-
-  private _getDevices = (): DeviceRegistryEntry[] =>
-    Object.values(this.hass.devices).filter(
-      (device) =>
-        device.config_entries_subentries[this.entry.entry_id]?.includes(
-          this.subEntry.subentry_id
-        ) && device.entry_type !== "service"
-    );
-
-  private _getServices = (): DeviceRegistryEntry[] =>
-    Object.values(this.hass.devices).filter(
-      (device) =>
-        device.config_entries_subentries[this.entry.entry_id]?.includes(
-          this.subEntry.subentry_id
-        ) && device.entry_type === "service"
+      (entity) => entity.config_subentry_id === this.data.subEntry.subentry_id
     );
 
   private async _handleReconfigureSub(): Promise<void> {
-    showSubConfigFlowDialog(this, this.entry, this.subEntry.subentry_type, {
-      startFlowHandler: this.entry.entry_id,
-      subEntryId: this.subEntry.subentry_id,
-    });
+    showSubConfigFlowDialog(
+      this,
+      this.entry,
+      this.data.subEntry.subentry_type,
+      {
+        startFlowHandler: this.entry.entry_id,
+        subEntryId: this.data.subEntry.subentry_id,
+      }
+    );
   }
 
   private _handleMenuAction = (ev: CustomEvent) => {
@@ -244,7 +233,7 @@ class HaConfigSubEntryRow extends LitElement {
   private _handleRenameSub = async (): Promise<void> => {
     const newName = await showPromptDialog(this, {
       title: this.hass.localize("ui.common.rename"),
-      defaultValue: this.subEntry.title,
+      defaultValue: this.data.subEntry.title,
       inputLabel: this.hass.localize(
         "ui.panel.config.integrations.rename_input_label"
       ),
@@ -255,7 +244,7 @@ class HaConfigSubEntryRow extends LitElement {
     await updateSubEntry(
       this.hass,
       this.entry.entry_id,
-      this.subEntry.subentry_id,
+      this.data.subEntry.subentry_id,
       { title: newName }
     );
   };
@@ -264,7 +253,7 @@ class HaConfigSubEntryRow extends LitElement {
     const confirmed = await showConfirmationDialog(this, {
       title: this.hass.localize(
         "ui.panel.config.integrations.config_entry.delete_confirm_title",
-        { title: this.subEntry.title }
+        { title: this.data.subEntry.title }
       ),
       text: this.hass.localize(
         "ui.panel.config.integrations.config_entry.delete_confirm_text"
@@ -280,7 +269,7 @@ class HaConfigSubEntryRow extends LitElement {
     await deleteSubEntry(
       this.hass,
       this.entry.entry_id,
-      this.subEntry.subentry_id
+      this.data.subEntry.subentry_id
     );
   };
 


### PR DESCRIPTION
## Proposed change

Refactor the integration detail page to build a complete data tree (entries > sub-entries > devices/services) in the parent component and pass it down to child components.

Previously, each row independently queried `hass.devices` to find devices and services. Sub-entries were fetched separately per entry row. Now, the parent page builds the full hierarchy once via a memoized function and passes the pre-computed objects down. `entities` are still passed as a property as a registry as we don't really need it from filtering.

I did that to prepare a future search bar at the top and the parent needs to have all the data to properly filter (search config entry, sub-entry and devices)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
