### PR TITLE
Load energy translations in dashboard strategy before generating view titles

### DIFF
--- a/src/panels/energy/strategies/energy-dashboard-strategy.ts
+++ b/src/panels/energy/strategies/energy-dashboard-strategy.ts
@@ -74,7 +74,11 @@ export class EnergyDashboardStrategy extends ReactiveElement {
     _config: EnergyDashboardStrategyConfig,
     hass: HomeAssistant
   ): Promise<LovelaceConfig> {
-    const prefs = await fetchEnergyPrefs(hass);
+    const [prefs, localize] = await Promise.all([
+      fetchEnergyPrefs(hass),
+      hass.loadFragmentTranslation("energy"),
+    ]);
+    const localizeFunc = localize ?? hass.localize;
 
     if (
       !prefs ||
@@ -138,7 +142,7 @@ export class EnergyDashboardStrategy extends ReactiveElement {
         ...view,
         title:
           view.title ||
-          hass.localize(`ui.panel.energy.title.${view.path}` as LocalizeKeys),
+          localizeFunc(`ui.panel.energy.title.${view.path}` as LocalizeKeys),
       })),
     };
   }


### PR DESCRIPTION
## Proposed change

This is a speculative quick fix. I haven't been able to reproduce this outside of production even with prod build of the exact release tag.

Edit: Managed to test the fix on prod with the `development_pr` option and it does seem to work.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51313
- This PR is related to issue or discussion: #51327
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr