### PR TITLE
Improve box shadow design tokens with multi-layer shadows

### DIFF
--- a/gallery/src/pages/misc/box-shadow.markdown
+++ b/gallery/src/pages/misc/box-shadow.markdown
@@ -1,0 +1,3 @@
+---
+title: Box shadow
+---

--- a/gallery/src/pages/misc/box-shadow.ts
+++ b/gallery/src/pages/misc/box-shadow.ts
@@ -2,7 +2,7 @@ import { css, html, LitElement } from "lit";
 import { customElement } from "lit/decorators";
 import { applyThemesOnElement } from "../../../../src/common/dom/apply_themes_on_element";
 
-const SHADOWS = ["s", "m", "l", "xl"] as const;
+const SHADOWS = ["s", "m", "l"] as const;
 
 @customElement("demo-misc-box-shadow")
 export class DemoMiscBoxShadow extends LitElement {

--- a/gallery/src/pages/misc/box-shadow.ts
+++ b/gallery/src/pages/misc/box-shadow.ts
@@ -1,0 +1,98 @@
+import { css, html, LitElement } from "lit";
+import { customElement } from "lit/decorators";
+import { applyThemesOnElement } from "../../../../src/common/dom/apply_themes_on_element";
+
+const SHADOWS = ["s", "m", "l", "xl"] as const;
+
+@customElement("demo-misc-box-shadow")
+export class DemoMiscBoxShadow extends LitElement {
+  protected render() {
+    return html`
+      ${["light", "dark"].map(
+        (mode) => html`
+          <div class=${mode}>
+            <h2>${mode}</h2>
+            <div class="grid">
+              ${SHADOWS.map(
+                (size) => html`
+                  <div
+                    class="box"
+                    style="box-shadow: var(--ha-box-shadow-${size})"
+                  >
+                    ${size}
+                  </div>
+                `
+              )}
+            </div>
+          </div>
+        `
+      )}
+    `;
+  }
+
+  firstUpdated(changedProps) {
+    super.firstUpdated(changedProps);
+    applyThemesOnElement(
+      this.shadowRoot!.querySelector(".dark"),
+      {
+        default_theme: "default",
+        default_dark_theme: "default",
+        themes: {},
+        darkMode: true,
+        theme: "default",
+      },
+      undefined,
+      undefined,
+      true
+    );
+  }
+
+  static styles = css`
+    :host {
+      display: flex;
+      flex-direction: row;
+      gap: 48px;
+      padding: 48px;
+    }
+
+    .light,
+    .dark {
+      flex: 1;
+      background-color: var(--primary-background-color);
+      border-radius: 16px;
+      padding: 32px;
+    }
+
+    h2 {
+      margin: 0 0 24px;
+      font-size: 18px;
+      font-weight: 500;
+      color: var(--primary-text-color);
+      text-transform: capitalize;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 32px;
+    }
+
+    .box {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 120px;
+      border-radius: 12px;
+      background-color: var(--card-background-color);
+      color: var(--primary-text-color);
+      font-size: 16px;
+      font-weight: 500;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-misc-box-shadow": DemoMiscBoxShadow;
+  }
+}

--- a/src/panels/config/automation/add-automation-element/ha-automation-add-from-target.ts
+++ b/src/panels/config/automation/add-automation-element/ha-automation-add-from-target.ts
@@ -1491,9 +1491,7 @@ export default class HaAutomationAddFromTarget extends LitElement {
       bottom: 0;
       width: 100%;
       padding-bottom: var(--ha-space-2);
-      box-shadow: inset var(--ha-shadow-offset-x-lg)
-        calc(var(--ha-shadow-offset-y-lg) * -1) var(--ha-shadow-blur-lg)
-        var(--ha-shadow-spread-lg) var(--ha-color-shadow-light);
+      box-shadow: inset 0 -8px 12px 0 rgba(0, 0, 0, 0.06);
       z-index: 2;
     }
 

--- a/src/panels/config/core/ha-config-analytics.ts
+++ b/src/panels/config/core/ha-config-analytics.ts
@@ -322,7 +322,7 @@ class ConfigAnalytics extends SubscribeMixin(LitElement) {
           0% {
             box-shadow:
               0 0 0 var(--ha-border-width-md) var(--primary-color),
-              0 0 var(--ha-shadow-blur-lg) rgba(var(--rgb-primary-color), 0.4);
+              0 0 12px rgba(var(--rgb-primary-color), 0.4);
           }
           100% {
             box-shadow:

--- a/src/panels/config/labs/ha-config-labs.ts
+++ b/src/panels/config/labs/ha-config-labs.ts
@@ -426,7 +426,7 @@ class HaConfigLabs extends SubscribeMixin(LitElement) {
         0% {
           box-shadow:
             0 0 0 var(--ha-border-width-md) var(--primary-color),
-            0 0 var(--ha-shadow-blur-lg) rgba(var(--rgb-primary-color), 0.4);
+            0 0 12px rgba(var(--rgb-primary-color), 0.4);
         }
         100% {
           box-shadow:

--- a/src/panels/lovelace/views/hui-view-footer.ts
+++ b/src/panels/lovelace/views/hui-view-footer.ts
@@ -236,7 +236,10 @@ export class HuiViewFooter extends LitElement {
     }
 
     .wrapper:not(.edit-mode) {
-      --ha-card-box-shadow: var(--ha-box-shadow-l);
+      --ha-card-box-shadow: var(
+        --ha-view-footer-box-shadow,
+        var(--ha-box-shadow-xl)
+      );
     }
 
     .container {

--- a/src/panels/lovelace/views/hui-view-footer.ts
+++ b/src/panels/lovelace/views/hui-view-footer.ts
@@ -238,7 +238,7 @@ export class HuiViewFooter extends LitElement {
     .wrapper:not(.edit-mode) {
       --ha-card-box-shadow: var(
         --ha-view-footer-box-shadow,
-        var(--ha-box-shadow-xl)
+        var(--ha-box-shadow-l)
       );
     }
 

--- a/src/resources/theme/color/core.globals.ts
+++ b/src/resources/theme/color/core.globals.ts
@@ -74,10 +74,6 @@ export const coreColorStyles = css`
     --ha-color-green-80: #93da98;
     --ha-color-green-90: #c2f2c1;
     --ha-color-green-95: #e3f9e3;
-
-    /* shadow */
-    --ha-color-shadow-light: #00000014;
-    --ha-color-shadow-dark: #00000046;
   }
 `;
 

--- a/src/resources/theme/core.globals.ts
+++ b/src/resources/theme/core.globals.ts
@@ -42,19 +42,6 @@ export const coreStyles = css`
     --ha-space-19: 76px;
     --ha-space-20: 80px;
 
-    --ha-shadow-offset-x-sm: 0;
-    --ha-shadow-offset-x-md: 0;
-    --ha-shadow-offset-x-lg: 0;
-    --ha-shadow-offset-y-sm: 2px;
-    --ha-shadow-offset-y-md: 4px;
-    --ha-shadow-offset-y-lg: 8px;
-    --ha-shadow-blur-sm: 4px;
-    --ha-shadow-blur-md: 8px;
-    --ha-shadow-blur-lg: 12px;
-    --ha-shadow-spread-sm: 0;
-    --ha-shadow-spread-md: 0;
-    --ha-shadow-spread-lg: 0;
-
     --ha-animation-duration-none: 1ms;
     --ha-animation-duration-instant: 75ms;
     --ha-animation-duration-fast: 150ms;

--- a/src/resources/theme/semantic.globals.ts
+++ b/src/resources/theme/semantic.globals.ts
@@ -7,17 +7,19 @@ import { extractVars } from "../../common/style/derived-css-vars";
  */
 export const semanticStyles = css`
   html {
-    --ha-box-shadow-s: var(--ha-shadow-offset-x-sm) var(--ha-shadow-offset-y-sm) var(--ha-shadow-blur-sm) var(--ha-shadow-spread-sm) var(--ha-color-shadow-light);
-    --ha-box-shadow-m: var(--ha-shadow-offset-x-md) var(--ha-shadow-offset-y-md) var(--ha-shadow-blur-md) var(--ha-shadow-spread-md) var(--ha-color-shadow-light);
-    --ha-box-shadow-l: var(--ha-shadow-offset-x-lg) var(--ha-shadow-offset-y-lg) var(--ha-shadow-blur-lg) var(--ha-shadow-spread-lg) var(--ha-color-shadow-light);
+    --ha-box-shadow-s: 0 1px 2px 0 rgba(0, 0, 0, 0.08), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
+    --ha-box-shadow-m: 0 2px 4px -1px rgba(0, 0, 0, 0.1), 0 4px 8px 0 rgba(0, 0, 0, 0.14);
+    --ha-box-shadow-l: 0 4px 8px -2px rgba(0, 0, 0, 0.12), 0 12px 24px -4px rgba(0, 0, 0, 0.18);
+    --ha-box-shadow-xl: 0 8px 16px -4px rgba(0, 0, 0, 0.15), 0 24px 48px -8px rgba(0, 0, 0, 0.25);
   }
 `;
 
 export const darkSemanticStyles = css`
   html {
-    --ha-box-shadow-s: var(--ha-shadow-offset-x-sm) var(--ha-shadow-offset-y-sm) var(--ha-shadow-blur-sm) var(--ha-shadow-spread-sm) var(--ha-color-shadow-dark);
-    --ha-box-shadow-m: var(--ha-shadow-offset-x-md) var(--ha-shadow-offset-y-md) var(--ha-shadow-blur-md) var(--ha-shadow-spread-md) var(--ha-color-shadow-dark);
-    --ha-box-shadow-l: var(--ha-shadow-offset-x-lg) var(--ha-shadow-offset-y-lg) var(--ha-shadow-blur-lg) var(--ha-shadow-spread-lg) var(--ha-color-shadow-dark);
+    --ha-box-shadow-s: 0 1px 2px 0 rgba(0, 0, 0, 0.4), 0 1px 3px 0 rgba(0, 0, 0, 0.5);
+    --ha-box-shadow-m: 0 2px 4px -1px rgba(0, 0, 0, 0.4), 0 4px 8px 0 rgba(0, 0, 0, 0.5);
+    --ha-box-shadow-l: 0 4px 8px -2px rgba(0, 0, 0, 0.4), 0 12px 24px -4px rgba(0, 0, 0, 0.55);
+    --ha-box-shadow-xl: 0 8px 16px -4px rgba(0, 0, 0, 0.45), 0 24px 48px -8px rgba(0, 0, 0, 0.6);
   }
 `;
 

--- a/src/resources/theme/semantic.globals.ts
+++ b/src/resources/theme/semantic.globals.ts
@@ -8,18 +8,16 @@ import { extractVars } from "../../common/style/derived-css-vars";
 export const semanticStyles = css`
   html {
     --ha-box-shadow-s: 0 1px 2px 0 rgba(0, 0, 0, 0.08), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
-    --ha-box-shadow-m: 0 2px 4px -1px rgba(0, 0, 0, 0.1), 0 4px 8px 0 rgba(0, 0, 0, 0.14);
-    --ha-box-shadow-l: 0 4px 8px -2px rgba(0, 0, 0, 0.12), 0 12px 24px -4px rgba(0, 0, 0, 0.18);
-    --ha-box-shadow-xl: 0 8px 16px -4px rgba(0, 0, 0, 0.15), 0 24px 48px -8px rgba(0, 0, 0, 0.25);
+    --ha-box-shadow-m: 0 3px 6px -1px rgba(0, 0, 0, 0.1), 0 8px 16px -2px rgba(0, 0, 0, 0.15);
+    --ha-box-shadow-l: 0 6px 12px -3px rgba(0, 0, 0, 0.12), 0 16px 32px -6px rgba(0, 0, 0, 0.2);
   }
 `;
 
 export const darkSemanticStyles = css`
   html {
     --ha-box-shadow-s: 0 1px 2px 0 rgba(0, 0, 0, 0.4), 0 1px 3px 0 rgba(0, 0, 0, 0.5);
-    --ha-box-shadow-m: 0 2px 4px -1px rgba(0, 0, 0, 0.4), 0 4px 8px 0 rgba(0, 0, 0, 0.5);
-    --ha-box-shadow-l: 0 4px 8px -2px rgba(0, 0, 0, 0.4), 0 12px 24px -4px rgba(0, 0, 0, 0.55);
-    --ha-box-shadow-xl: 0 8px 16px -4px rgba(0, 0, 0, 0.45), 0 24px 48px -8px rgba(0, 0, 0, 0.6);
+    --ha-box-shadow-m: 0 3px 6px -1px rgba(0, 0, 0, 0.35), 0 8px 16px -2px rgba(0, 0, 0, 0.45);
+    --ha-box-shadow-l: 0 6px 12px -3px rgba(0, 0, 0, 0.4), 0 16px 32px -6px rgba(0, 0, 0, 0.55);
   }
 `;
 

--- a/src/resources/theme/wa.globals.ts
+++ b/src/resources/theme/wa.globals.ts
@@ -37,6 +37,7 @@ export const waMainStyles = css`
     --wa-shadow-s: var(--ha-box-shadow-s);
     --wa-shadow-m: var(--ha-box-shadow-m);
     --wa-shadow-l: var(--ha-box-shadow-l);
+    --wa-shadow-xl: var(--ha-box-shadow-xl);
 
     --wa-form-control-padding-block: 0.75em;
     --wa-form-control-value-line-height: var(--wa-line-height-condensed);

--- a/src/resources/theme/wa.globals.ts
+++ b/src/resources/theme/wa.globals.ts
@@ -37,7 +37,6 @@ export const waMainStyles = css`
     --wa-shadow-s: var(--ha-box-shadow-s);
     --wa-shadow-m: var(--ha-box-shadow-m);
     --wa-shadow-l: var(--ha-box-shadow-l);
-    --wa-shadow-xl: var(--ha-box-shadow-xl);
 
     --wa-form-control-padding-block: 0.75em;
     --wa-form-control-value-line-height: var(--wa-line-height-condensed);


### PR DESCRIPTION
## Breaking change

The individual shadow sub-variables (`--ha-shadow-offset-x-*`, `--ha-shadow-offset-y-*`, `--ha-shadow-blur-*`, `--ha-shadow-spread-*`) and shadow color variables (`--ha-color-shadow-light`, `--ha-color-shadow-dark`) have been removed. The `--ha-box-shadow-xl` token has also been removed. Use the `--ha-box-shadow-s`, `--ha-box-shadow-m`, or `--ha-box-shadow-l` tokens directly instead.

## Proposed change

Redesign the box shadow system to use multi-layer shadows inspired by major design systems (Material Design, Fluent, Tailwind). Each shadow level now uses two layers: a tight shadow for edge definition and a softer shadow for depth, providing a more realistic and visible elevation effect.

The previous box shadow was too subtle to be visible (e.g. view footer). The `xl` shadow level has been removed as three levels (s, m, l) provide sufficient range. A `--ha-view-footer-box-shadow` variable has been added to allow customizing the footer shadow via themes.

### New shadow values

**Light mode:**

| Token | Layer 1 (edge) | Layer 2 (depth) |
|---|---|---|
| `s` | `0 1px 2px 0` @ 8% | `0 1px 3px 0` @ 12% |
| `m` | `0 3px 6px -1px` @ 10% | `0 8px 16px -2px` @ 15% |
| `l` | `0 6px 12px -3px` @ 12% | `0 16px 32px -6px` @ 20% |

**Dark mode:**

| Token | Layer 1 (edge) | Layer 2 (depth) |
|---|---|---|
| `s` | `0 1px 2px 0` @ 40% | `0 1px 3px 0` @ 50% |
| `m` | `0 3px 6px -1px` @ 35% | `0 8px 16px -2px` @ 45% |
| `l` | `0 6px 12px -3px` @ 40% | `0 16px 32px -6px` @ 55% |

### Design system reference

Shadow opacity used for highest elevation elements:

| Design System | Level | Opacity |
|---|---|---|
| Material Design 3 | Level 5 (modals) | 15% + 30% (2 layers) |
| Fluent 2 (light) | shadow64 (dialogs) | 20% + 24% (2 layers) |
| Fluent 2 (dark) | shadow64 (dialogs) | 40% + 48% (2 layers) |
| Tailwind | shadow-2xl | 25% |
| Carbon / IBM | Dropdowns | 30% |
| Ant Design | Dropdowns | 8% + 12% + 5% (3 layers) |

## Screenshots

<img width="942" height="433" alt="CleanShot 2026-04-13 at 09 31 56" src="https://github.com/user-attachments/assets/a7439987-8da2-4daf-92bf-e911d739751e" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr