### PR TITLE
Fix fragment translation race condition returning stale localize

### DIFF
--- a/src/panels/energy/strategies/energy-dashboard-strategy.ts
+++ b/src/panels/energy/strategies/energy-dashboard-strategy.ts
@@ -74,11 +74,7 @@ export class EnergyDashboardStrategy extends ReactiveElement {
     _config: EnergyDashboardStrategyConfig,
     hass: HomeAssistant
   ): Promise<LovelaceConfig> {
-    const [prefs, localize] = await Promise.all([
-      fetchEnergyPrefs(hass),
-      hass.loadFragmentTranslation("energy"),
-    ]);
-    const localizeFunc = localize ?? hass.localize;
+    const prefs = await fetchEnergyPrefs(hass);
 
     if (
       !prefs ||
@@ -142,7 +138,7 @@ export class EnergyDashboardStrategy extends ReactiveElement {
         ...view,
         title:
           view.title ||
-          localizeFunc(`ui.panel.energy.title.${view.path}` as LocalizeKeys),
+          hass.localize(`ui.panel.energy.title.${view.path}` as LocalizeKeys),
       })),
     };
   }

--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -66,7 +66,10 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
     // eslint-disable-next-line: variable-name
     private __coreProgress?: string;
 
-    private __loadedFragmentTranslations = new Set<string>();
+    private __loadedFragmentTranslations = new Map<
+      string,
+      Promise<LocalizeFunc>
+    >();
 
     private __loadedTranslations: Record<string, LoadedTranslationCategory> =
       {};
@@ -257,7 +260,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       document.querySelector("html")!.setAttribute("lang", hass.language);
       this._applyDirection(hass);
       this._loadCoreTranslations(hass.language);
-      this.__loadedFragmentTranslations = new Set();
+      this.__loadedFragmentTranslations = new Map();
       this._loadFragmentTranslations(hass.language, hass.panelUrl);
     }
 
@@ -381,11 +384,13 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       }
 
       if (this.__loadedFragmentTranslations.has(fragment)) {
-        return this.hass!.localize;
+        return this.__loadedFragmentTranslations.get(fragment)!;
       }
-      this.__loadedFragmentTranslations.add(fragment);
-      const result = await getTranslation(fragment, language);
-      return this._updateResources(language, result.data);
+      const promise = getTranslation(fragment, language).then((result) =>
+        this._updateResources(language, result.data)
+      );
+      this.__loadedFragmentTranslations.set(fragment, promise);
+      return promise;
     }
 
     private async _loadCoreTranslations(language: string) {


### PR DESCRIPTION
## Proposed change

I finally found the real cause of #51313.

`_loadFragmentTranslations` uses a `Set` to track which fragments have been requested. Once a fragment name is added to the set, any subsequent caller immediately gets `this.hass!.localize` back — even if the original fetch is still in-flight. That returned `localize` is a closure over the **old** resources that don't include the fragment's translations yet.

Here's the race:

1. `translations-mixin.updated()` auto-triggers `_loadFragmentTranslations("energy")` when `panelUrl` changes to `"energy"` — adds `"energy"` to the set and starts the async fetch
2. The energy panel's `_setup()` calls `loadFragmentTranslation("energy")` — sees `"energy"` already in the set, immediately returns the current `this.hass!.localize` (stale, missing energy keys)
3. The energy dashboard strategy generates view titles with this stale `localize` → gets empty strings → tabs show "Unnamed view"

The fix changes `__loadedFragmentTranslations` from a `Set<string>` to a `Map<string, Promise<LocalizeFunc>>`. Instead of returning the stale localize for in-progress loads, concurrent callers now await the same promise and receive the fresh `localize` function once the fetch completes.

This also reverts the workaround from #51376 in the energy dashboard strategy since it's no longer needed.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51313
- This PR is related to issue or discussion: #51327, #51376
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr