### PR TITLE
fix flowType in showSubConfigFlowDialog in next_flow flows

### DIFF
--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -516,7 +516,7 @@ class DataEntryFlowDialog extends LitElement {
         }
       } else if (_step.next_flow[0] === "config_subentries_flow") {
         if (_step.type === "create_entry") {
-          showSubConfigFlowDialog(this, _step.result!, _step.next_flow[0], {
+          showSubConfigFlowDialog(this, _step.result!, "", {
             continueFlowId: _step.next_flow[1],
             navigateToResult: this._params!.navigateToResult,
             dialogClosedCallback: this._params!.dialogClosedCallback,

--- a/src/dialogs/config-flow/show-dialog-sub-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-sub-config-flow.ts
@@ -39,6 +39,9 @@ export const showSubConfigFlowDialog = (
     },
     fetchFlow: async (hass, flowId) => {
       const step = await fetchSubConfigFlow(hass, flowId);
+      if (flowType !== step.handler[1]) {
+        flowType = step.handler[1];
+      }
       await hass.loadFragmentTranslation("config");
       await hass.loadBackendTranslation(
         "config_subentries",

--- a/src/dialogs/config-flow/show-dialog-sub-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-sub-config-flow.ts
@@ -39,9 +39,7 @@ export const showSubConfigFlowDialog = (
     },
     fetchFlow: async (hass, flowId) => {
       const step = await fetchSubConfigFlow(hass, flowId);
-      if (flowType !== step.handler[1]) {
-        flowType = step.handler[1];
-      }
+      flowType = (step.handler as unknown as [string, string])[1];
       await hass.loadFragmentTranslation("config");
       await hass.loadBackendTranslation(
         "config_subentries",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
1. The backend currently doesn't support `next_flow` for options or subentry config flows there is a draft PR https://github.com/home-assistant/core/pull/165091 to add this functionality for repair flows that be addressed through a config entry, config subentry, or options flow (for issues other than reauthenication flows).
2. The frontend does support `next_flow` for options or subentry config flows however in testing the `config_subentries` translations weren't being rendered correctly in the dialog because `flowType` was set to `config_subentries_flow` rather than the integration specified subentry type.
3. The PR will change `flowType` to the correct value at the first point the handler information is available i.e. after `fetchSubConfigFlow` returns.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
N/A

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: https://github.com/home-assistant/core/pull/165091 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
