### PR TITLE
Only use inflight map for pending fragment translation loads

### DIFF
--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -66,7 +66,9 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
     // eslint-disable-next-line: variable-name
     private __coreProgress?: string;
 
-    private __loadedFragmentTranslations = new Map<
+    private __loadedFragmentTranslations = new Set<string>();
+
+    private __inflightFragmentTranslations = new Map<
       string,
       Promise<LocalizeFunc>
     >();
@@ -260,7 +262,8 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       document.querySelector("html")!.setAttribute("lang", hass.language);
       this._applyDirection(hass);
       this._loadCoreTranslations(hass.language);
-      this.__loadedFragmentTranslations = new Map();
+      this.__loadedFragmentTranslations = new Set();
+      this.__inflightFragmentTranslations = new Map();
       this._loadFragmentTranslations(hass.language, hass.panelUrl);
     }
 
@@ -383,13 +386,19 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         return undefined;
       }
 
+      if (this.__inflightFragmentTranslations.has(fragment)) {
+        return this.__inflightFragmentTranslations.get(fragment)!;
+      }
       if (this.__loadedFragmentTranslations.has(fragment)) {
-        return this.__loadedFragmentTranslations.get(fragment)!;
+        return this.hass!.localize;
       }
       const promise = getTranslation(fragment, language).then((result) =>
-        this._updateResources(language, result.data)
+        this._updateResources(language, result.data).finally(() => {
+          this.__inflightFragmentTranslations.delete(fragment);
+          this.__loadedFragmentTranslations.add(fragment);
+        })
       );
-      this.__loadedFragmentTranslations.set(fragment, promise);
+      this.__inflightFragmentTranslations.set(fragment, promise);
       return promise;
     }
 


### PR DESCRIPTION
## Proposed change

Follow-up to #51381 based on @bramkragten's [review feedback](https://github.com/home-assistant/frontend/pull/51381#discussion_r3031960542).

The previous fix stored the resolved promise in the Map permanently. Once resolved, that promise returns a `localize` function that's frozen in time — it doesn't include translations from fragments loaded after it. So calling `loadFragmentTranslation("energy")` after it had already completed could return a `localize` missing translations from e.g. the `config` fragment loaded later.

This splits the tracking into two structures:

- **`__inflightFragmentTranslations`** (`Map<string, Promise<LocalizeFunc>>`): Only holds in-flight promises. Concurrent callers await the same promise. Cleared once the load completes.
- **`__loadedFragmentTranslations`** (`Set<string>`): Tracks completed loads. Returns the current `this.hass!.localize` which always has the latest translations from all loaded fragments.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51313
- This PR is related to issue or discussion: #51381
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr