### PR TITLE
use a simpler calculation in the SolarGaugeCard

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -1357,88 +1357,15 @@ export const formatConsumptionShort = (
 };
 
 export const calculateSolarConsumedGauge = (
-  hasBattery: boolean,
-  data: EnergySumData
+  sum: EnergySumData,
+  consumption: EnergyConsumptionData
 ): number | undefined => {
-  if (!data.total.solar) {
+  if (!sum.total.solar || consumption.total.solar_to_grid === undefined) {
     return undefined;
   }
-  const { consumption, compareConsumption: _ } = computeConsumptionData(
-    data,
-    undefined
+  return (
+    Math.max(0, 1 - consumption.total.solar_to_grid / sum.total.solar) * 100
   );
-  if (!hasBattery) {
-    const solarProduction = data.total.solar;
-    return (consumption.total.used_solar / solarProduction) * 100;
-  }
-
-  let solarConsumed = 0;
-  let solarReturned = 0;
-  const batteryLifo: { type: "solar" | "grid"; value: number }[] = [];
-
-  // Here we will attempt to track consumed solar energy, as it routes through the battery and ultimately to consumption or grid.
-  // At each timestamp we will track energy added to the battery (and its source), and we will drain this in Last-in/First-out order.
-  // Energy leaving the battery when the stack is empty will just be ignored, as we cannot determine where it came from.
-  // This is likely energy stored during a previous period.
-
-  data.timestamps.forEach((t) => {
-    solarConsumed += consumption.used_solar[t] ?? 0;
-    solarReturned += consumption.solar_to_grid[t] ?? 0;
-
-    if (consumption.grid_to_battery[t]) {
-      batteryLifo.push({
-        type: "grid",
-        value: consumption.grid_to_battery[t],
-      });
-    }
-    if (consumption.solar_to_battery[t]) {
-      batteryLifo.push({
-        type: "solar",
-        value: consumption.solar_to_battery[t],
-      });
-    }
-
-    let batteryToGrid = consumption.battery_to_grid[t] ?? 0;
-    let usedBattery = consumption.used_battery[t] ?? 0;
-
-    const drainBattery = function (amount: number): {
-      energy: number;
-      type: "solar" | "grid";
-    } {
-      const lastLifo = batteryLifo[batteryLifo.length - 1];
-      const type = lastLifo.type;
-      if (amount >= lastLifo.value) {
-        const energy = lastLifo.value;
-        batteryLifo.pop();
-        return { energy, type };
-      }
-      lastLifo.value -= amount;
-      return { energy: amount, type };
-    };
-
-    while (usedBattery > 0 && batteryLifo.length) {
-      const { energy, type } = drainBattery(usedBattery);
-      if (type === "solar") {
-        solarConsumed += energy;
-      }
-      usedBattery -= energy;
-    }
-
-    while (batteryToGrid > 0 && batteryLifo.length) {
-      const { energy, type } = drainBattery(batteryToGrid);
-      if (type === "solar") {
-        solarReturned += energy;
-      }
-      batteryToGrid -= energy;
-    }
-  });
-
-  const totalProduction = solarConsumed + solarReturned;
-  const hasSolarProduction = !!totalProduction;
-  if (hasSolarProduction) {
-    return (solarConsumed / totalProduction) * 100;
-  }
-  return undefined;
 };
 
 /**

--- a/src/panels/lovelace/cards/energy/hui-energy-solar-consumed-gauge-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-solar-consumed-gauge-card.ts
@@ -9,6 +9,7 @@ import "../../../../components/ha-gauge";
 import "../../../../components/ha-svg-icon";
 import type { EnergyData } from "../../../../data/energy";
 import {
+  computeConsumptionData,
   calculateSolarConsumedGauge,
   getEnergyDataCollection,
   getSummedData,
@@ -102,8 +103,11 @@ class HuiEnergySolarGaugeCard
 
     let value: number | undefined;
     if (productionReturnedToGrid !== null) {
-      const hasBattery = !!summedData.to_battery || !!summedData.from_battery;
-      value = calculateSolarConsumedGauge(hasBattery, summedData);
+      const { consumption, compareConsumption: __ } = computeConsumptionData(
+        summedData,
+        undefined
+      );
+      value = calculateSolarConsumedGauge(summedData, consumption);
     }
 
     return html`

--- a/test/data/energy.test.ts
+++ b/test/data/energy.test.ts
@@ -593,264 +593,133 @@ describe("Energy Usage Calculation Tests", () => {
 });
 
 describe("Self-consumed solar gauge tests", () => {
-  it("no battery", () => {
-    const hasBattery = false;
+  it("missing parameters", () => {
     assert.deepEqual(
-      calculateSolarConsumedGauge(hasBattery, {
-        total: {},
-        timestamps: [0],
-      }),
+      calculateSolarConsumedGauge(
+        {
+          total: {},
+          timestamps: [0],
+        },
+        {
+          // @ts-expect-error TS2740
+          total: {},
+        }
+      ),
       undefined
     );
     assert.deepEqual(
-      calculateSolarConsumedGauge(hasBattery, {
-        solar: {
-          "0": 0,
+      calculateSolarConsumedGauge(
+        {
+          total: {
+            solar: 1,
+          },
+          timestamps: [0],
         },
-        total: {
-          solar: 0,
-        },
-        timestamps: [0],
-      }),
+        {
+          // @ts-expect-error TS2740
+          total: {},
+        }
+      ),
       undefined
     );
     assert.deepEqual(
-      calculateSolarConsumedGauge(hasBattery, {
-        solar: {
-          "0": 1,
-          "1": 3,
+      calculateSolarConsumedGauge(
+        {
+          total: {},
+          timestamps: [0],
         },
-        total: {
-          solar: 4,
+        {
+          // @ts-expect-error TS2740
+          total: {},
+        }
+      ),
+      undefined
+    );
+    assert.deepEqual(
+      calculateSolarConsumedGauge(
+        {
+          total: {
+            solar: 0,
+          },
+          timestamps: [0],
         },
-        timestamps: [0, 1],
-      }),
+        {
+          // @ts-expect-error TS2740
+          total: {},
+        }
+      ),
+      undefined
+    );
+  });
+
+  it("solar production", () => {
+    assert.deepEqual(
+      calculateSolarConsumedGauge(
+        {
+          total: {
+            solar: 4,
+          },
+          timestamps: [0],
+        },
+        {
+          // @ts-expect-error TS2740
+          total: {
+            solar_to_grid: 0,
+          },
+        }
+      ),
       100
     );
     assert.deepEqual(
-      calculateSolarConsumedGauge(hasBattery, {
-        solar: {
-          "0": 1,
-          "1": 3,
+      calculateSolarConsumedGauge(
+        {
+          total: {
+            solar: 4,
+          },
+          timestamps: [0],
         },
-        to_grid: {
-          "1": 1,
-        },
-        total: {
-          solar: 4,
-          to_grid: 1,
-        },
-        timestamps: [0, 1],
-      }),
+        {
+          // @ts-expect-error TS2740
+          total: {
+            solar_to_grid: 1,
+          },
+        }
+      ),
       75
     );
     assert.deepEqual(
-      calculateSolarConsumedGauge(hasBattery, {
-        solar: {
-          "0": 1,
-          "1": 3,
+      calculateSolarConsumedGauge(
+        {
+          total: {
+            solar: 4,
+          },
+          timestamps: [0],
         },
-        to_grid: {
-          "0": 1,
-          "1": 3,
-        },
-        total: {
-          solar: 4,
-          to_grid: 4,
-        },
-        timestamps: [0, 1],
-      }),
+        {
+          // @ts-expect-error TS2740
+          total: {
+            solar_to_grid: 4,
+          },
+        }
+      ),
       0
     );
-  });
-  it("with battery", () => {
-    const hasBattery = true;
     assert.deepEqual(
-      calculateSolarConsumedGauge(hasBattery, {
-        total: {},
-        timestamps: [0],
-      }),
-      undefined
-    );
-    assert.deepEqual(
-      calculateSolarConsumedGauge(hasBattery, {
-        solar: {
-          "0": 0,
+      calculateSolarConsumedGauge(
+        {
+          total: {
+            solar: 2,
+          },
+          timestamps: [0],
         },
-        total: {
-          solar: 0,
-        },
-        timestamps: [0],
-      }),
-      undefined
-    );
-    assert.deepEqual(
-      calculateSolarConsumedGauge(hasBattery, {
-        solar: {
-          "0": 1,
-          "1": 3,
-        },
-        total: {
-          solar: 4,
-        },
-        timestamps: [0, 1],
-      }),
-      100
-    );
-    assert.deepEqual(
-      calculateSolarConsumedGauge(hasBattery, {
-        solar: {
-          "0": 1,
-          "1": 3,
-        },
-        to_grid: {
-          "1": 1,
-        },
-        total: {
-          solar: 4,
-        },
-        timestamps: [0, 1],
-      }),
-      75
-    );
-    assert.deepEqual(
-      calculateSolarConsumedGauge(hasBattery, {
-        solar: {
-          "10": 1,
-        },
-        to_grid: {
-          "0": 1,
-          "1": 1,
-          "2": 1,
-          "3": 1,
-        },
-        from_battery: {
-          "0": 1,
-          "1": 1,
-          "2": 1,
-          "3": 1,
-        },
-        total: {
-          solar: 1,
-        },
-        timestamps: [0, 1, 2, 3, 10],
-      }),
-      // As the battery is discharged from unknown source, it does not affect solar production number.
-      100
-    );
-    assert.deepEqual(
-      calculateSolarConsumedGauge(hasBattery, {
-        solar: {
-          "0": 10,
-        },
-        to_battery: {
-          "0": 10,
-        },
-        to_grid: {
-          "1": 3,
-          "3": 1,
-        },
-        from_battery: {
-          "1": 3,
-          "2": 2,
-          "3": 2,
-          "4": 3,
-          "5": 100, // Unknown source, not counted
-        },
-        total: {
-          solar: 10,
-        },
-        timestamps: [0, 1, 2, 3, 4, 5],
-      }),
-      // As the battery is discharged from unknown source, it does not affect solar production number.
-      60
-    );
-  });
-  it("complex battery/solar/grid", () => {
-    const hasBattery = true;
-
-    const value = calculateSolarConsumedGauge(hasBattery, {
-      solar: {
-        "1": 6,
-        "2": 0,
-        "3": 7,
-      },
-      to_battery: {
-        "1": 5,
-        "2": 5,
-        "3": 7,
-      },
-      to_grid: {
-        "0": 5,
-        "10": 1,
-        "11": 1,
-        "12": 5,
-        "13": 3,
-      },
-      from_grid: {
-        "2": 5,
-      },
-      from_battery: {
-        "0": 5,
-        "10": 3,
-        "11": 4,
-        "12": 5,
-        "13": 5,
-      },
-      total: {
-        // Total is mostly don't care when hasBattery, only hourly values are used
-        solar: 13,
-      },
-      timestamps: [0, 1, 2, 3, 10, 11, 12, 13],
-    });
-    // "1"  - consumed 1 solar, 5 sent to battery
-    // "10" - consumed 2/3 of solar energy stored in battery
-    // "11" - consumed 3/4 of solar energy stored in battery
-    // "12" - skipped as this is energy from grid, not counted
-    // "13" - consumed 2/5 of solar energy stored in battery
-    const expectedNumerator = 1 + 2 + 3 + 0 + 2; // 8
-    const expectedDenominator = 1 + 3 + 4 + 0 + 5; // 13
-    assert.equal(
-      Math.round(value!),
-      Math.round((expectedNumerator / expectedDenominator) * 100)
-    );
-  });
-
-  it("complex battery/solar/grid #2", () => {
-    const hasBattery = true;
-    const value = calculateSolarConsumedGauge(hasBattery, {
-      solar: {
-        "0": 100,
-        "2": 100,
-      },
-      to_battery: {
-        "0": 100,
-        "1": 100,
-        "2": 100,
-      },
-      to_grid: {
-        "10": 50,
-      },
-      from_grid: {
-        "1": 100,
-      },
-      from_battery: {
-        "10": 300,
-      },
-      total: {
-        solar: 200,
-        to_battery: 300,
-        to_grid: 50,
-        from_grid: 100,
-        from_battery: 300,
-      },
-      timestamps: [0, 1, 2, 10],
-    });
-    const expectedNumerator = 200 - 50;
-    const expectedDenominator = 200; // ignoring 100 from grid
-    assert.equal(
-      Math.round(value!),
-      Math.round((expectedNumerator / expectedDenominator) * 100)
+        {
+          // @ts-expect-error TS2740
+          total: {
+            solar_to_grid: 4,
+          },
+        }
+      ),
+      0
     );
   });
 });


### PR DESCRIPTION
## Proposed change
In the tooltip, the formula is described simply as ratio between used and fed in solar energy, but the calculations included the battery storage. That formula reduced the self consumption ratio artificially if the batteries are not 100% efficient, which they can't ever be.

This commit uses the following formula:

`100% - (total grid export / total solar production) * 100%`

This is more logical (you can calculate this ratio easily for yourself with only the displayed data) and is now consistent with the tooltip. This tripped me, when I tried to calculate the ratio for myself and got different values than displayed in the dashboard. My storage system is about 85% efficient (as they mostly are), so the gauge was consistently about 10% too low. Also, I think this gauge should be specific to one day and shouldn't include stored energy, as the tooltip is right: this should be an indicator if controllable loads and a storage system are a good idea or not.

I also adjusted the tests and prohibited for division-by-zero errors.

## Breaking change
This PR propopses a different formula for the solar self consumption gauge. I'm not sure if this constitutes as "Breaking Change". It generally goes up compared to the original formula if you have a storage system, for all other cases it stays the same.

## Screenshots
<img width="347" height="475" alt="Bildschirmfoto_20260404_124839" src="https://github.com/user-attachments/assets/0da74fe2-80e2-487c-bf71-719060a9b8b8" />

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]