### PR TITLE
Fix undefined default value in alarm code input dialog

### DIFF
--- a/src/dialogs/enter-code/dialog-enter-code.ts
+++ b/src/dialogs/enter-code/dialog-enter-code.ts
@@ -87,7 +87,7 @@ export class DialogEnterCode
 
   private _numberClick(e: MouseEvent): void {
     const val = (e.currentTarget! as any).value;
-    this._input!.value = this._input!.value + val;
+    this._input!.value = (this._input!.value ?? "") + val;
     this._showClearButton = true;
   }
 


### PR DESCRIPTION
## Breaking change
None.

## Proposed change
This fixes a regression where the alarm code field could start with `undefined` when entering digits from the keypad.

The issue happened when appending a digit to an uninitialized input value.  
This change coalesces the current value to an empty string before concatenation, so the input is empty by default and behaves as expected.

## Screenshots
N/A (behavioral bugfix, no visual design changes).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51370
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr