### PR TITLE
Fix toast race condition causing stuck notifications

### DIFF
--- a/src/managers/notification-manager.ts
+++ b/src/managers/notification-manager.ts
@@ -36,9 +36,17 @@ class NotificationManager extends LitElement {
   @query("ha-toast")
   private _toast!: HTMLElementTagNameMap["ha-toast"] | undefined;
 
+  private _showDialogId = 0;
+
   public async showDialog(parameters: ShowToastParams) {
+    const showId = ++this._showDialogId;
+
     if (!parameters.id || this._parameters?.id !== parameters.id) {
       await this._toast?.hide();
+    }
+
+    if (showId !== this._showDialogId) {
+      return;
     }
 
     if (parameters.duration === 0) {
@@ -56,6 +64,11 @@ class NotificationManager extends LitElement {
     }
 
     await this.updateComplete;
+
+    if (showId !== this._showDialogId) {
+      return;
+    }
+
     this._toast?.show();
   }
 


### PR DESCRIPTION
## Proposed change

Fix a race condition in `notification-manager.ts` where rapid successive toast calls could cause an earlier toast to overwrite a later one.

The fix adds a monotonic counter (same pattern as `ha-toast.ts`'s `_transitionId`) so that only the most recent `showDialog` call proceeds past `await` points — stale calls bail out.

Not 100% sure this is the fix as the race condition is difficult to reproduce.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51433
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr