### PR TITLE
Fix dialog show animation broken by connectedCallback _open sync

### DIFF
--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -138,7 +138,6 @@ export class HaDialog extends ScrollableFadeMixin(LitElement) {
 
   public connectedCallback(): void {
     super.connectedCallback();
-    this._open = this.open;
     this.addEventListener(
       "dialog-set-fullscreen",
       this._handleFullscreenChanged as EventListener


### PR DESCRIPTION
## Proposed change

Revert the `this._open = this.open` line added to `ha-dialog`'s `connectedCallback` in #51369. Setting `_open` to `true` before the first render caused `wa-dialog` to start already open, skipping the show animation entirely. The `make-dialog-manager` fix from #51369 (skipping redundant `appendChild`) is sufficient to prevent the `next_flow` dialog bug on its own.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue
	- fixes #51425
	- fixes #29477
	- fixes #51403
- This PR is related to issue or discussion: #51369
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr