### PR TITLE
Allow quick search for non-admins, while hiding inaccessible areas

### DIFF
--- a/src/common/config/filter_navigation_pages.ts
+++ b/src/common/config/filter_navigation_pages.ts
@@ -21,7 +21,7 @@ export const filterNavigationPages = (
     if (page.path === "#external-app-configuration") {
       return hass.auth.external?.config.hasSettingsScreen;
     }
-    if (page.requireAdmin && !hass.user?.is_admin) {
+    if (page.adminOnly && !hass.user?.is_admin) {
       return false;
     }
     // Only show Bluetooth page if there are Bluetooth config entries

--- a/src/common/config/filter_navigation_pages.ts
+++ b/src/common/config/filter_navigation_pages.ts
@@ -21,6 +21,9 @@ export const filterNavigationPages = (
     if (page.path === "#external-app-configuration") {
       return hass.auth.external?.config.hasSettingsScreen;
     }
+    if (page.requireAdmin && !hass.user?.is_admin) {
+      return false;
+    }
     // Only show Bluetooth page if there are Bluetooth config entries
     if (page.component === "bluetooth") {
       return options.hasBluetoothConfigEntries ?? false;

--- a/src/data/quick_bar.ts
+++ b/src/data/quick_bar.ts
@@ -105,10 +105,6 @@ const generateNavigationConfigSectionCommands = (
   hass: HomeAssistant,
   filterOptions: NavigationFilterOptions = {}
 ): BaseNavigationCommand[] => {
-  if (!hass.user?.is_admin) {
-    return [];
-  }
-
   const items: NavigationInfo[] = [];
   const allPages = Object.values(configSections).flat();
   const visiblePages = filterNavigationPages(hass, allPages, filterOptions);

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -104,7 +104,7 @@ export class QuickBar extends LitElement {
       this._translationsLoaded = true;
     }
     this._initialize();
-    this._selectedSection = effectiveQuickBarMode(this.hass, params.mode);
+    this._selectedSection = effectiveQuickBarMode(this.hass.user, params.mode);
     this._showHint = params.showHint ?? false;
 
     this._relatedResult = params.contextItem ? params.related : undefined;

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -57,7 +57,11 @@ import type { HomeAssistant } from "../../types";
 import { isMac } from "../../util/is_mac";
 import { showConfirmationDialog } from "../generic/show-dialog-box";
 import { showShortcutsDialog } from "../shortcuts/show-shortcuts-dialog";
-import type { QuickBarParams, QuickBarSection } from "./show-dialog-quick-bar";
+import {
+  effectiveQuickBarMode,
+  type QuickBarParams,
+  type QuickBarSection,
+} from "./show-dialog-quick-bar";
 
 const SEPARATOR = "________";
 
@@ -100,7 +104,7 @@ export class QuickBar extends LitElement {
       this._translationsLoaded = true;
     }
     this._initialize();
-    this._selectedSection = params.mode;
+    this._selectedSection = effectiveQuickBarMode(this.hass, params.mode);
     this._showHint = params.showHint ?? false;
 
     this._relatedResult = params.contextItem ? params.related : undefined;

--- a/src/dialogs/quick-bar/show-dialog-quick-bar.ts
+++ b/src/dialogs/quick-bar/show-dialog-quick-bar.ts
@@ -28,10 +28,7 @@ export const effectiveQuickBarMode = (
   hass: HomeAssistant,
   mode?: QuickBarSection
 ): QuickBarSection | undefined => {
-  if (mode === undefined) {
-    return undefined;
-  }
-  if (hass.user?.is_admin) {
+  if (mode && hass.user?.is_admin) {
     return mode;
   }
   if (mode === "command" || mode === "device" || mode === "area") {

--- a/src/dialogs/quick-bar/show-dialog-quick-bar.ts
+++ b/src/dialogs/quick-bar/show-dialog-quick-bar.ts
@@ -1,5 +1,6 @@
 import { fireEvent } from "../../common/dom/fire_event";
 import type { ItemType, RelatedResult } from "../../data/search";
+import type { HomeAssistant } from "../../types";
 import { closeDialog } from "../make-dialog-manager";
 
 export type QuickBarSection =
@@ -21,6 +22,23 @@ export interface QuickBarParams {
   contextItem?: QuickBarContextItem;
   related?: RelatedResult;
 }
+
+/** Non-admin users cannot scope the bar to command, device, or area (those sections are admin-only). */
+export const effectiveQuickBarMode = (
+  hass: HomeAssistant,
+  mode?: QuickBarSection
+): QuickBarSection | undefined => {
+  if (mode === undefined) {
+    return undefined;
+  }
+  if (hass.user?.is_admin) {
+    return mode;
+  }
+  if (mode === "command" || mode === "device" || mode === "area") {
+    return undefined;
+  }
+  return mode;
+};
 
 export const loadQuickBar = () => import("./ha-quick-bar");
 

--- a/src/dialogs/quick-bar/show-dialog-quick-bar.ts
+++ b/src/dialogs/quick-bar/show-dialog-quick-bar.ts
@@ -25,7 +25,7 @@ export interface QuickBarParams {
 
 /** Non-admin users cannot scope the bar to command, device, or area (those sections are admin-only). */
 export const effectiveQuickBarMode = (
-  hass: HomeAssistant,
+  user: HomeAssistant["user"],
   mode?: QuickBarSection
 ): QuickBarSection | undefined => {
   if (mode && hass.user?.is_admin) {

--- a/src/dialogs/quick-bar/show-dialog-quick-bar.ts
+++ b/src/dialogs/quick-bar/show-dialog-quick-bar.ts
@@ -28,7 +28,7 @@ export const effectiveQuickBarMode = (
   user: HomeAssistant["user"],
   mode?: QuickBarSection
 ): QuickBarSection | undefined => {
-  if (mode && hass.user?.is_admin) {
+  if (mode && user?.is_admin) {
     return mode;
   }
   if (mode === "command" || mode === "device" || mode === "area") {

--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -34,6 +34,8 @@ export interface PageNavigation {
   not_component?: string | string[];
   core?: boolean;
   advancedOnly?: boolean;
+  /** Hide from non-admin users in filtered navigation and quick bar. */
+  requireAdmin?: boolean;
   iconPath?: string;
   iconSecondaryPath?: string;
   iconViewBox?: string;

--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -35,7 +35,7 @@ export interface PageNavigation {
   core?: boolean;
   advancedOnly?: boolean;
   /** Hide from non-admin users in filtered navigation and quick bar. */
-  requireAdmin?: boolean;
+  adminOnly?: boolean;
   iconPath?: string;
   iconSecondaryPath?: string;
   iconViewBox?: string;

--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -112,12 +112,14 @@ const randomTip = (openFn: any, hass: HomeAssistant, narrow: boolean) => {
       >`,
     };
 
-    tips.push(
-      {
+    if (hass.user?.is_admin) {
+      tips.push({
         content: hass.localize("ui.tips.key_c_tip", localizeParam),
         weight: 1,
         narrow: false,
-      },
+      });
+    }
+    tips.push(
       {
         content: hass.localize("ui.tips.key_m_tip", localizeParam),
         weight: 1,

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -63,6 +63,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiDevices,
       iconColor: "#0D47A1",
       core: true,
+      requireAdmin: true,
     },
     {
       path: "/config/automation",
@@ -70,6 +71,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiRobot,
       iconColor: "#518C43",
       core: true,
+      requireAdmin: true,
     },
     {
       path: "/config/areas",
@@ -77,6 +79,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiSofa,
       iconColor: "#E48629",
       component: "zone",
+      requireAdmin: true,
     },
     {
       path: "/config/apps",
@@ -84,6 +87,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiPuzzle,
       iconColor: "#F1C447",
       core: true,
+      requireAdmin: true,
     },
     {
       path: "/config/lovelace/dashboards",
@@ -91,12 +95,14 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiViewDashboard,
       iconColor: "#B1345C",
       component: "lovelace",
+      requireAdmin: true,
     },
     {
       path: "/config/voice-assistants",
       translationKey: "voice_assistants",
       iconPath: mdiMicrophone,
       iconColor: "#3263C3",
+      requireAdmin: true,
     },
   ],
   dashboard_external_settings: [
@@ -116,6 +122,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#2458B3",
       component: "matter",
       translationKey: "matter",
+      requireAdmin: true,
     },
     {
       path: "/config/zha",
@@ -123,6 +130,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#E74011",
       component: "zha",
       translationKey: "zha",
+      requireAdmin: true,
     },
     {
       path: "/config/zwave_js",
@@ -130,6 +138,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#153163",
       component: "zwave_js",
       translationKey: "zwave_js",
+      requireAdmin: true,
     },
     {
       path: "/knx",
@@ -138,6 +147,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#4EAA66",
       component: "knx",
       translationKey: "knx",
+      requireAdmin: true,
     },
     {
       path: "/config/thread",
@@ -146,6 +156,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#ED7744",
       component: "thread",
       translationKey: "thread",
+      requireAdmin: true,
     },
     {
       path: "/config/bluetooth",
@@ -153,6 +164,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#0082FC",
       component: "bluetooth",
       translationKey: "bluetooth",
+      requireAdmin: true,
     },
     {
       path: "/insteon",
@@ -161,6 +173,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#E4002C",
       component: "insteon",
       translationKey: "insteon",
+      requireAdmin: true,
     },
     {
       path: "/config/tags",
@@ -168,6 +181,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiNfcVariant,
       iconColor: "#616161",
       component: "tag",
+      requireAdmin: true,
     },
   ],
   dashboard_3: [
@@ -177,6 +191,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiAccount,
       iconColor: "#5A87FA",
       component: ["person", "users"],
+      requireAdmin: true,
     },
     {
       path: "/config/system",
@@ -184,6 +199,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiCog,
       iconColor: "#301ABE",
       core: true,
+      requireAdmin: true,
     },
     {
       path: "/config/developer-tools",
@@ -191,6 +207,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiHammer,
       iconColor: "#7A5AA6",
       core: true,
+      requireAdmin: true,
     },
     {
       path: "/config/info",
@@ -198,6 +215,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiInformationOutline,
       iconColor: "#4A5963",
       core: true,
+      requireAdmin: false,
     },
   ],
   backup: [
@@ -207,6 +225,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiBackupRestore,
       iconColor: "#4084CD",
       component: "backup",
+      requireAdmin: true,
     },
   ],
   devices: [
@@ -217,6 +236,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiPuzzle,
       iconColor: "#2D338F",
       core: true,
+      requireAdmin: true,
     },
     {
       component: "devices",
@@ -225,6 +245,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiDevices,
       iconColor: "#2D338F",
       core: true,
+      requireAdmin: true,
     },
     {
       component: "entities",
@@ -233,6 +254,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiShape,
       iconColor: "#2D338F",
       core: true,
+      requireAdmin: true,
     },
     {
       component: "helpers",
@@ -241,6 +263,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiTools,
       iconColor: "#4D2EA4",
       core: true,
+      requireAdmin: true,
     },
   ],
   automations: [
@@ -250,6 +273,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.automation.caption",
       iconPath: mdiRobot,
       iconColor: "#518C43",
+      requireAdmin: true,
     },
     {
       component: "scene",
@@ -257,6 +281,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.scene.caption",
       iconPath: mdiPalette,
       iconColor: "#518C43",
+      requireAdmin: true,
     },
     {
       component: "script",
@@ -264,6 +289,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.script.caption",
       iconPath: mdiScriptText,
       iconColor: "#518C43",
+      requireAdmin: true,
     },
     {
       component: "blueprint",
@@ -271,6 +297,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.blueprint.caption",
       iconPath: mdiPaletteSwatch,
       iconColor: "#518C43",
+      requireAdmin: true,
     },
   ],
   tags: [
@@ -280,6 +307,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.tag.caption",
       iconPath: mdiNfcVariant,
       iconColor: "#616161",
+      requireAdmin: true,
     },
   ],
   voice_assistants: [
@@ -288,6 +316,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.dashboard.voice_assistants.main",
       iconPath: mdiMicrophone,
       iconColor: "#3263C3",
+      requireAdmin: true,
     },
   ],
   developer_tools: [
@@ -297,6 +326,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiHammer,
       iconColor: "#7A5AA6",
       core: true,
+      requireAdmin: true,
     },
   ],
   // Not used as a tab, but this way it will stay in the quick bar
@@ -307,6 +337,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.energy.caption",
       iconPath: mdiLightningBolt,
       iconColor: "#F1C447",
+      requireAdmin: true,
     },
   ],
   // Not used as a tab, but this way it will stay in the quick bar
@@ -317,6 +348,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.network.discovery.dhcp",
       iconPath: mdiNetwork,
       iconColor: "#B1345C",
+      requireAdmin: true,
     },
     {
       component: "ssdp",
@@ -324,6 +356,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.network.discovery.ssdp",
       iconPath: mdiNetwork,
       iconColor: "#B1345C",
+      requireAdmin: true,
     },
     {
       component: "zeroconf",
@@ -331,6 +364,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.network.discovery.zeroconf",
       iconPath: mdiNetwork,
       iconColor: "#B1345C",
+      requireAdmin: true,
     },
   ],
   // Not used as a tab, but this way it will stay in the quick bar
@@ -340,6 +374,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.application_credentials.caption",
       iconPath: mdiPuzzle,
       iconColor: "#2D338F",
+      requireAdmin: true,
     },
   ],
   // Not used as a tab, but this way it will stay in the quick bar
@@ -350,6 +385,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.mqtt.title",
       iconPath: mdiPuzzle,
       iconColor: "#2D338F",
+      requireAdmin: true,
     },
   ],
   lovelace: [
@@ -359,6 +395,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.lovelace.caption",
       iconPath: mdiViewDashboard,
       iconColor: "#B1345C",
+      requireAdmin: true,
     },
   ],
   persons: [
@@ -368,6 +405,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.person.caption",
       iconPath: mdiAccount,
       iconColor: "#5A87FA",
+      requireAdmin: true,
     },
     {
       component: "users",
@@ -377,6 +415,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#5A87FA",
       core: true,
       advancedOnly: true,
+      requireAdmin: true,
     },
   ],
   areas: [
@@ -387,6 +426,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiSofa,
       iconColor: "#2D338F",
       core: true,
+      requireAdmin: true,
     },
     {
       component: "labels",
@@ -395,6 +435,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiLabel,
       iconColor: "#2D338F",
       core: true,
+      requireAdmin: true,
     },
     {
       component: "zone",
@@ -402,6 +443,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.zone.caption",
       iconPath: mdiMapMarkerRadius,
       iconColor: "#E48629",
+      requireAdmin: true,
     },
   ],
   general: [
@@ -411,18 +453,21 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiCog,
       iconColor: "#653249",
       core: true,
+      requireAdmin: true,
     },
     {
       path: "/config/updates",
       translationKey: "updates",
       iconPath: mdiUpdate,
       iconColor: "#3B808E",
+      requireAdmin: true,
     },
     {
       path: "/config/repairs",
       translationKey: "repairs",
       iconPath: mdiScrewdriver,
       iconColor: "#5c995c",
+      requireAdmin: true,
     },
     {
       component: "logs",
@@ -431,6 +476,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiTextBoxOutline,
       iconColor: "#C65326",
       core: true,
+      requireAdmin: true,
     },
     {
       path: "/config/backup",
@@ -438,12 +484,14 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiBackupRestore,
       iconColor: "#0D47A1",
       component: "backup",
+      requireAdmin: true,
     },
     {
       path: "/config/analytics",
       translationKey: "analytics",
       iconPath: mdiShape,
       iconColor: "#f1c447",
+      requireAdmin: true,
     },
     {
       path: "/config/ai-tasks",
@@ -451,6 +499,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiStarFourPoints,
       iconColor: "#8B69E3",
       core: true,
+      requireAdmin: true,
     },
     {
       path: "/config/labs",
@@ -458,12 +507,14 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiFlask,
       iconColor: "#b1b134",
       core: true,
+      requireAdmin: true,
     },
     {
       path: "/config/network",
       translationKey: "network",
       iconPath: mdiNetwork,
       iconColor: "#B1345C",
+      requireAdmin: true,
     },
     {
       path: "/config/storage",
@@ -471,6 +522,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiDatabase,
       iconColor: "#518C43",
       component: "hassio",
+      requireAdmin: true,
     },
     {
       path: "/config/hardware",
@@ -478,6 +530,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiMemory,
       iconColor: "#301A8E",
       component: ["hassio", "hardware"],
+      requireAdmin: true,
     },
   ],
   about: [
@@ -488,6 +541,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiInformationOutline,
       iconColor: "#4A5963",
       core: true,
+      requireAdmin: false,
     },
   ],
 };

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -215,7 +215,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiInformationOutline,
       iconColor: "#4A5963",
       core: true,
-      requireAdmin: false,
+      requireAdmin: true,
     },
   ],
   backup: [
@@ -541,7 +541,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiInformationOutline,
       iconColor: "#4A5963",
       core: true,
-      requireAdmin: false,
+      requireAdmin: true,
     },
   ],
 };

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -63,7 +63,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiDevices,
       iconColor: "#0D47A1",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/automation",
@@ -71,7 +71,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiRobot,
       iconColor: "#518C43",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/areas",
@@ -79,7 +79,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiSofa,
       iconColor: "#E48629",
       component: "zone",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/apps",
@@ -87,7 +87,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiPuzzle,
       iconColor: "#F1C447",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/lovelace/dashboards",
@@ -95,14 +95,14 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiViewDashboard,
       iconColor: "#B1345C",
       component: "lovelace",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/voice-assistants",
       translationKey: "voice_assistants",
       iconPath: mdiMicrophone,
       iconColor: "#3263C3",
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   dashboard_external_settings: [
@@ -122,7 +122,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#2458B3",
       component: "matter",
       translationKey: "matter",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/zha",
@@ -130,7 +130,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#E74011",
       component: "zha",
       translationKey: "zha",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/zwave_js",
@@ -138,7 +138,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#153163",
       component: "zwave_js",
       translationKey: "zwave_js",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/knx",
@@ -147,7 +147,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#4EAA66",
       component: "knx",
       translationKey: "knx",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/thread",
@@ -156,7 +156,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#ED7744",
       component: "thread",
       translationKey: "thread",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/bluetooth",
@@ -164,7 +164,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#0082FC",
       component: "bluetooth",
       translationKey: "bluetooth",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/insteon",
@@ -173,7 +173,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#E4002C",
       component: "insteon",
       translationKey: "insteon",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/tags",
@@ -181,7 +181,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiNfcVariant,
       iconColor: "#616161",
       component: "tag",
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   dashboard_3: [
@@ -191,7 +191,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiAccount,
       iconColor: "#5A87FA",
       component: ["person", "users"],
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/system",
@@ -199,7 +199,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiCog,
       iconColor: "#301ABE",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/developer-tools",
@@ -207,7 +207,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiHammer,
       iconColor: "#7A5AA6",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/info",
@@ -215,7 +215,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiInformationOutline,
       iconColor: "#4A5963",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   backup: [
@@ -225,7 +225,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiBackupRestore,
       iconColor: "#4084CD",
       component: "backup",
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   devices: [
@@ -236,7 +236,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiPuzzle,
       iconColor: "#2D338F",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       component: "devices",
@@ -245,7 +245,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiDevices,
       iconColor: "#2D338F",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       component: "entities",
@@ -254,7 +254,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiShape,
       iconColor: "#2D338F",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       component: "helpers",
@@ -263,7 +263,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiTools,
       iconColor: "#4D2EA4",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   automations: [
@@ -273,7 +273,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.automation.caption",
       iconPath: mdiRobot,
       iconColor: "#518C43",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       component: "scene",
@@ -281,7 +281,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.scene.caption",
       iconPath: mdiPalette,
       iconColor: "#518C43",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       component: "script",
@@ -289,7 +289,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.script.caption",
       iconPath: mdiScriptText,
       iconColor: "#518C43",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       component: "blueprint",
@@ -297,7 +297,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.blueprint.caption",
       iconPath: mdiPaletteSwatch,
       iconColor: "#518C43",
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   tags: [
@@ -307,7 +307,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.tag.caption",
       iconPath: mdiNfcVariant,
       iconColor: "#616161",
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   voice_assistants: [
@@ -316,7 +316,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.dashboard.voice_assistants.main",
       iconPath: mdiMicrophone,
       iconColor: "#3263C3",
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   developer_tools: [
@@ -326,7 +326,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiHammer,
       iconColor: "#7A5AA6",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   // Not used as a tab, but this way it will stay in the quick bar
@@ -337,7 +337,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.energy.caption",
       iconPath: mdiLightningBolt,
       iconColor: "#F1C447",
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   // Not used as a tab, but this way it will stay in the quick bar
@@ -348,7 +348,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.network.discovery.dhcp",
       iconPath: mdiNetwork,
       iconColor: "#B1345C",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       component: "ssdp",
@@ -356,7 +356,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.network.discovery.ssdp",
       iconPath: mdiNetwork,
       iconColor: "#B1345C",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       component: "zeroconf",
@@ -364,7 +364,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.network.discovery.zeroconf",
       iconPath: mdiNetwork,
       iconColor: "#B1345C",
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   // Not used as a tab, but this way it will stay in the quick bar
@@ -374,7 +374,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.application_credentials.caption",
       iconPath: mdiPuzzle,
       iconColor: "#2D338F",
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   // Not used as a tab, but this way it will stay in the quick bar
@@ -385,7 +385,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.mqtt.title",
       iconPath: mdiPuzzle,
       iconColor: "#2D338F",
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   lovelace: [
@@ -395,7 +395,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.lovelace.caption",
       iconPath: mdiViewDashboard,
       iconColor: "#B1345C",
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   persons: [
@@ -405,7 +405,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.person.caption",
       iconPath: mdiAccount,
       iconColor: "#5A87FA",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       component: "users",
@@ -415,7 +415,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconColor: "#5A87FA",
       core: true,
       advancedOnly: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   areas: [
@@ -426,7 +426,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiSofa,
       iconColor: "#2D338F",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       component: "labels",
@@ -435,7 +435,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiLabel,
       iconColor: "#2D338F",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       component: "zone",
@@ -443,7 +443,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       translationKey: "ui.panel.config.zone.caption",
       iconPath: mdiMapMarkerRadius,
       iconColor: "#E48629",
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   general: [
@@ -453,21 +453,21 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiCog,
       iconColor: "#653249",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/updates",
       translationKey: "updates",
       iconPath: mdiUpdate,
       iconColor: "#3B808E",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/repairs",
       translationKey: "repairs",
       iconPath: mdiScrewdriver,
       iconColor: "#5c995c",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       component: "logs",
@@ -476,7 +476,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiTextBoxOutline,
       iconColor: "#C65326",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/backup",
@@ -484,14 +484,14 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiBackupRestore,
       iconColor: "#0D47A1",
       component: "backup",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/analytics",
       translationKey: "analytics",
       iconPath: mdiShape,
       iconColor: "#f1c447",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/ai-tasks",
@@ -499,7 +499,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiStarFourPoints,
       iconColor: "#8B69E3",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/labs",
@@ -507,14 +507,14 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiFlask,
       iconColor: "#b1b134",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/network",
       translationKey: "network",
       iconPath: mdiNetwork,
       iconColor: "#B1345C",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/storage",
@@ -522,7 +522,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiDatabase,
       iconColor: "#518C43",
       component: "hassio",
-      requireAdmin: true,
+      adminOnly: true,
     },
     {
       path: "/config/hardware",
@@ -530,7 +530,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiMemory,
       iconColor: "#301A8E",
       component: ["hassio", "hardware"],
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
   about: [
@@ -541,7 +541,7 @@ export const configSections: Record<string, PageNavigation[]> = {
       iconPath: mdiInformationOutline,
       iconColor: "#4A5963",
       core: true,
-      requireAdmin: true,
+      adminOnly: true,
     },
   ],
 };

--- a/src/state/quick-bar-mixin.ts
+++ b/src/state/quick-bar-mixin.ts
@@ -162,12 +162,10 @@ export default <T extends Constructor<HassElement>>(superClass: T) =>
     private _registerShortcut() {
       const shortcutManager = new ShortcutManager();
       shortcutManager.add({
-        // Those are for latin keyboards that have e, c, m keys
+        // These are for latin keyboards that have e, c, m keys
         e: { handler: (ev) => this._showQuickBar(ev, "entity") },
-        c: { handler: (ev) => this._showQuickBar(ev, "command") },
         m: { handler: (ev) => this._createMyLink(ev) },
         a: { handler: (ev) => this._showVoiceCommandDialog(ev) },
-        d: { handler: (ev) => this._showQuickBar(ev, "device") },
         "$mod+k": {
           handler: (ev) => this._toggleQuickBar(ev),
           allowWhenTextSelected: true,
@@ -175,18 +173,27 @@ export default <T extends Constructor<HassElement>>(superClass: T) =>
         },
         // Workaround see https://github.com/jamiebuilds/tinykeys/issues/130
         "Shift+?": { handler: (ev) => this._showShortcutDialog(ev) },
-        // Those are fallbacks for non-latin keyboards that don't have e, c, m keys (qwerty-based shortcuts)
+        // These are fallbacks for non-latin keyboards that don't have e, c, m keys (qwerty-based shortcuts)
         KeyE: { handler: (ev) => this._showQuickBar(ev, "entity") },
-        KeyC: { handler: (ev) => this._showQuickBar(ev, "command") },
         KeyM: { handler: (ev) => this._createMyLink(ev) },
         KeyA: { handler: (ev) => this._showVoiceCommandDialog(ev) },
-        KeyD: { handler: (ev) => this._showQuickBar(ev, "device") },
         "$mod+KeyK": {
           handler: (ev) => this._toggleQuickBar(ev),
           allowWhenTextSelected: true,
           allowInInput: true,
         },
       });
+
+      if (this.hass?.user?.is_admin) {
+        shortcutManager.add({
+          // Latin keyboards
+          c: { handler: (ev) => this._showQuickBar(ev, "command") },
+          d: { handler: (ev) => this._showQuickBar(ev, "device") },
+          // Non-latin keyboards
+          KeyC: { handler: (ev) => this._showQuickBar(ev, "command") },
+          KeyD: { handler: (ev) => this._showQuickBar(ev, "device") },
+        });
+      }
     }
 
     private _conversation = memoizeOne((_components) =>
@@ -228,7 +235,7 @@ export default <T extends Constructor<HassElement>>(superClass: T) =>
     }
 
     private _toggleQuickBar(e: KeyboardEvent, mode?: QuickBarSection) {
-      if (!this._canToggleQuickBar()) {
+      if (!this.hass?.enableShortcuts) {
         return;
       }
 
@@ -334,13 +341,8 @@ export default <T extends Constructor<HassElement>>(superClass: T) =>
     private _canShowQuickBar(e: KeyboardEvent) {
       return (
         !this._quickBarOpen &&
-        this.hass?.user?.is_admin &&
-        this.hass.enableShortcuts &&
+        !!this.hass?.enableShortcuts &&
         canOverrideAlphanumericInput(e.composedPath())
       );
-    }
-
-    private _canToggleQuickBar() {
-      return this.hass?.user?.is_admin && this.hass.enableShortcuts;
     }
   };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
From #51284

Allows keyboards shortcuts (quick search) but only shows what non-admins can typically see.

Shows navigation and entities, the rest are not returned.

---

This will probably generate another admin (access control) conversation, but all users can technically access these with knowhow (query parameters for more info, generated dashboards which don't need admin etc.). All my users are admins, I am using a test user to specifically test this in fact. This does bring down one barrier, and pages like devices could return in a read-only format later down the line.

TLDR: User `is_admin` is not access control, its a visual interim solution which will be refactored later, once a full architectural design is made

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
Hides admin only dashboards and pages not accessible by non-admins:

<img width="1128" height="983" alt="image" src="https://github.com/user-attachments/assets/bc2ecb63-d05b-4ce4-a3d5-bb0a09123ae5" />
<img width="3783" height="536" alt="image" src="https://github.com/user-attachments/assets/18fe7428-2b4f-4e93-bd08-c2380e5f81f1" />
<img width="1270" height="971" alt="image" src="https://github.com/user-attachments/assets/8fe8e7a3-2c24-4fed-b449-4492e0ea8e81" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51284
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
