### PR TITLE
Fix empty entity name display

### DIFF
--- a/src/common/entity/compute_entity_name_display.ts
+++ b/src/common/entity/compute_entity_name_display.ts
@@ -3,7 +3,7 @@ import type { HomeAssistant } from "../../types";
 import { ensureArray } from "../array/ensure-array";
 import { computeAreaName } from "./compute_area_name";
 import { computeDeviceName } from "./compute_device_name";
-import { computeEntityName, entityUseDeviceName } from "./compute_entity_name";
+import { computeEntityName } from "./compute_entity_name";
 import { computeFloorName } from "./compute_floor_name";
 import { computeStateName } from "./compute_state_name";
 import { getEntityContext } from "./context/get_entity_context";
@@ -46,23 +46,13 @@ export const computeEntityNameDisplay = (
     return computeStateName(stateObj);
   }
 
-  let items = ensureArray(name);
+  const items = ensureArray(name);
 
   const separator = options?.separator ?? DEFAULT_SEPARATOR;
 
   // If all items are text, just join them
   if (items.every((n) => n.type === "text")) {
     return items.map((item) => item.text).join(separator);
-  }
-
-  const useDeviceName = entityUseDeviceName(stateObj, entities, devices);
-
-  // If entity uses device name, and device is not already included, replace it with device name
-  if (useDeviceName) {
-    const hasDevice = items.some((n) => n.type === "device");
-    if (!hasDevice) {
-      items = items.map((n) => (n.type === "entity" ? { type: "device" } : n));
-    }
   }
 
   const names = computeEntityNameList(

--- a/src/components/entity/state-info.ts
+++ b/src/components/entity/state-info.ts
@@ -21,7 +21,9 @@ class StateInfo extends LitElement {
       return nothing;
     }
 
-    const name = this.hass.formatEntityName(this.stateObj, { type: "entity" });
+    const name =
+      this.hass.formatEntityName(this.stateObj, { type: "entity" }) ||
+      this.hass.formatEntityName(this.stateObj, { type: "device" });
 
     return html`<state-badge
         .hass=${this.hass}

--- a/test/common/entity/compute_entity_name_display.test.ts
+++ b/test/common/entity/compute_entity_name_display.test.ts
@@ -109,7 +109,7 @@ describe("computeEntityNameDisplay", () => {
     expect(result).toBe("Kitchen Light");
   });
 
-  it("replaces entity with device name when entity uses device name", () => {
+  it("returns empty for entity type when entity name is empty", () => {
     const stateObj = mockStateObj({ entity_id: "light.kitchen" });
     const hass = {
       entities: {
@@ -138,10 +138,10 @@ describe("computeEntityNameDisplay", () => {
       hass.floors
     );
 
-    expect(result).toBe("Kitchen Device");
+    expect(result).toBe("");
   });
 
-  it("does not replace entity with device when device is already included", () => {
+  it("returns device name when entity uses device name and device is included", () => {
     const stateObj = mockStateObj({ entity_id: "light.kitchen" });
     const hass = {
       entities: {
@@ -170,8 +170,6 @@ describe("computeEntityNameDisplay", () => {
       hass.floors
     );
 
-    // Since entity name equals device name, entity returns undefined
-    // So we only get the device name
     expect(result).toBe("Kitchen Device");
   });
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Fix empty entity name display.

When an entity has empty entity name, the displayed name would change unpredictably. For example, with a "Device" device and "Kitchen" area:
- `[device, area]` -> "Device Kitchen"
- `[area, entity]` -> "Kitchen Device"
- `[device, area, entity]` -> "Device Kitchen"

In comparison for the same device with entity "Power":
- `[device, area]` -> "Device Kitchen"
- `[area, entity]` -> "Kitchen Power"
- `[device, area, entity]` -> "Device Kitchen Power"

Now entity always resolves to the entity's own name. If the entity has empty name, it resolves to nothing, the device name only appears where it's explicitly configured.

Backwards compatibility for `state-info` was also added, as it already exists in other places. As a side note I think we should instead show it in some special way everywhere, and not just duplicate device name, as it leads to user confusion.

It also now causes compatibility issues with the new `entity_name` template function.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
