### PR TITLE
Fix resize clock overflows card space

### DIFF
--- a/src/panels/lovelace/cards/clock/hui-clock-card-analog.ts
+++ b/src/panels/lovelace/cards/clock/hui-clock-card-analog.ts
@@ -253,7 +253,7 @@ export class HuiClockCardAnalog extends LitElement {
       width: min(
         100%,
         var(--clock-size)
-      ); // Account for user choice while keeping it responsive to layout size
+      ); /* Account for user choice while keeping it responsive to layout size */
       aspect-ratio: 1;
       background: var(--ha-clock-card-analog-face-background, none);
       border-radius: var(--ha-clock-card-analog-face-border-radius, none);

--- a/src/panels/lovelace/cards/clock/hui-clock-card-analog.ts
+++ b/src/panels/lovelace/cards/clock/hui-clock-card-analog.ts
@@ -241,6 +241,8 @@ export class HuiClockCardAnalog extends LitElement {
       display: flex;
       align-items: center;
       justify-content: center;
+      width: 100%;
+      height: 100%;
     }
 
     .analog-clock {
@@ -248,8 +250,11 @@ export class HuiClockCardAnalog extends LitElement {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: var(--clock-size);
-      height: var(--clock-size);
+      width: min(
+        100%,
+        var(--clock-size)
+      ); // Account for user choice while keeping it responsive to layout size
+      aspect-ratio: 1;
       background: var(--ha-clock-card-analog-face-background, none);
       border-radius: var(--ha-clock-card-analog-face-border-radius, none);
       padding: var(--ha-clock-card-analog-face-padding, none);
@@ -292,7 +297,7 @@ export class HuiClockCardAnalog extends LitElement {
       left: 50%;
       transform: translateX(-50%);
       width: 1px;
-      height: calc(var(--clock-size) * 0.04);
+      height: 4%;
       background: var(--primary-text-color);
       opacity: 0.5;
       border-radius: 1px;
@@ -300,18 +305,18 @@ export class HuiClockCardAnalog extends LitElement {
 
     .tick.hour .line {
       width: 2px;
-      height: calc(var(--clock-size) * 0.07);
+      height: 7%;
       opacity: 0.8;
     }
 
     .tick.hour .line.numbers,
     .tick.hour .line.roman {
-      height: calc(var(--clock-size) * 0.03);
+      height: 3%;
     }
 
     .tick.minute .line.numbers,
     .tick.minute .line.roman {
-      height: calc(var(--clock-size) * 0.015);
+      height: 1.5%;
     }
 
     .tick .number {
@@ -368,7 +373,7 @@ export class HuiClockCardAnalog extends LitElement {
 
     .hand.hour {
       width: 4px;
-      height: calc(var(--clock-size) * 0.25); /* 25% of the clock size */
+      height: 25%;
       background: var(--primary-text-color);
       box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.2);
       z-index: 1;
@@ -377,7 +382,7 @@ export class HuiClockCardAnalog extends LitElement {
 
     .hand.minute {
       width: 3px;
-      height: calc(var(--clock-size) * 0.35); /* 35% of the clock size */
+      height: 35%;
       background: var(--primary-text-color);
       box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.2);
       opacity: 0.9;
@@ -387,7 +392,7 @@ export class HuiClockCardAnalog extends LitElement {
 
     .hand.second {
       width: 2px;
-      height: calc(var(--clock-size) * 0.42); /* 42% of the clock size */
+      height: 42%;
       background: var(--ha-color-border-danger-normal);
       box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.2);
       opacity: 0.8;

--- a/src/panels/lovelace/cards/clock/hui-clock-card-digital.ts
+++ b/src/panels/lovelace/cards/clock/hui-clock-card-digital.ts
@@ -8,6 +8,21 @@ import { resolveTimeZone } from "../../../../common/datetime/resolve-time-zone";
 
 const INTERVAL = 1000;
 
+const TIME_SIZES: Record<NonNullable<ClockCardConfig["clock_size"]>, string> = {
+  small: "1.5rem",
+  medium: "3rem",
+  large: "4rem",
+};
+
+const OPTIONAL_ELEMENTS_SIZES: Record<
+  NonNullable<ClockCardConfig["clock_size"]>,
+  { margin: string; fontSize: string }
+> = {
+  small: { margin: "0.25rem", fontSize: "var(--ha-font-size-xs)" },
+  medium: { margin: "0.375rem", fontSize: "var(--ha-font-size-l)" },
+  large: { margin: "0.5rem", fontSize: "var(--ha-font-size-2xl)" },
+};
+
 @customElement("hui-clock-card-digital")
 export class HuiClockCardDigital extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
@@ -98,14 +113,22 @@ export class HuiClockCardDigital extends LitElement {
   render() {
     if (!this.config) return nothing;
 
-    const sizeClass = this.config.clock_size
-      ? `size-${this.config.clock_size}`
-      : "";
+    const mappedFontSize = TIME_SIZES[this.config.clock_size || "small"];
+    const optionalFontSize =
+      OPTIONAL_ELEMENTS_SIZES[this.config.clock_size || "small"].fontSize;
+    const optionalMargin =
+      OPTIONAL_ELEMENTS_SIZES[this.config.clock_size || "small"].margin;
 
     return html`
-      <div class="time-parts ${sizeClass}">
-        <div class="time-part hour">${this._timeHour}</div>
-        <div class="time-part minute">${this._timeMinute}</div>
+      <div
+        class="time-parts"
+        style="--font-size:${mappedFontSize};--optional-font-size:${optionalFontSize};--optional-margin:${optionalMargin}"
+      >
+        <div class="time-part hour-and-minute">
+          <span>${this._timeHour}</span>
+          <span>:</span>
+          <span>${this._timeMinute}</span>
+        </div>
         ${this._timeSecond !== undefined
           ? html`<div class="time-part second">${this._timeSecond}</div>`
           : nothing}
@@ -119,51 +142,71 @@ export class HuiClockCardDigital extends LitElement {
   static styles = css`
     :host {
       display: block;
+      container-name: digital-time;
+      container-type: inline-size;
+      width: 100%;
+      overflow: hidden;
     }
 
     .time-parts {
       align-items: center;
       display: grid;
       grid-template-areas:
-        "hour minute second"
-        "hour minute am-pm";
-
-      font-size: 1.5rem;
+        "hour-and-minute second"
+        "hour-and-minute am-pm";
       font-weight: var(--ha-font-weight-medium);
+      // font-size: clamp is used keeping in mind design choice while resizing
+      font-size: clamp(1rem, calc(1.5rem + 10cqw), var(--font-size));
       line-height: 0.8;
       direction: ltr;
     }
 
-    .time-title + .time-parts {
-      font-size: 1.5rem;
+    .time-parts .time-part.second,
+    .time-parts .time-part.am-pm {
+      font-size: clamp(
+        var(--ha-font-size-xs),
+        0.75rem + 1cqw,
+        var(--optional-font-size)
+      );
+      margin-left: var(--optional-margin);
     }
 
-    .time-parts.size-medium {
-      font-size: 3rem;
+    @container digital-time (inline-size > 9rem) {
+      .time-parts {
+        font-size: clamp(1rem, calc(1.5rem + 13cqw), var(--font-size));
+      }
+      .time-parts .time-part.second,
+      .time-parts .time-part.am-pm {
+        font-size: clamp(
+          var(--ha-font-size-xs),
+          0.75rem + 3cqw,
+          var(--optional-font-size)
+        );
+      }
     }
 
-    .time-parts.size-large {
-      font-size: 4rem;
+    @container digital-time (inline-size > 12rem) {
+      .time-parts {
+        font-size: clamp(1rem, calc(1.5rem + 17cqw), var(--font-size));
+      }
+      .time-parts .time-part.second,
+      .time-parts .time-part.am-pm {
+        font-size: clamp(
+          var(--ha-font-size-xs),
+          0.75rem + 7cqw,
+          var(--optional-font-size)
+        );
+      }
     }
 
-    .time-parts.size-medium .time-part.second,
-    .time-parts.size-medium .time-part.am-pm {
-      font-size: var(--ha-font-size-l);
-      margin-left: 6px;
+    .time-parts .time-part.hour-and-minute {
+      grid-area: hour-and-minute;
+      justify-self: end;
     }
 
-    .time-parts.size-large .time-part.second,
-    .time-parts.size-large .time-part.am-pm {
-      font-size: var(--ha-font-size-2xl);
-      margin-left: 8px;
-    }
-
-    .time-parts .time-part.hour {
-      grid-area: hour;
-    }
-
-    .time-parts .time-part.minute {
-      grid-area: minute;
+    .hour-and-minute {
+      display: flex;
+      gap: 0.125rem;
     }
 
     .time-parts .time-part.second {
@@ -176,17 +219,6 @@ export class HuiClockCardDigital extends LitElement {
       grid-area: am-pm;
       line-height: 0.9;
       opacity: 0.6;
-    }
-
-    .time-parts .time-part.second,
-    .time-parts .time-part.am-pm {
-      font-size: var(--ha-font-size-xs);
-      margin-left: 4px;
-    }
-
-    .time-parts .time-part.hour:after {
-      content: ":";
-      margin: 0 2px;
     }
   `;
 }

--- a/src/panels/lovelace/cards/clock/hui-clock-card-digital.ts
+++ b/src/panels/lovelace/cards/clock/hui-clock-card-digital.ts
@@ -155,7 +155,7 @@ export class HuiClockCardDigital extends LitElement {
         "hour-and-minute second"
         "hour-and-minute am-pm";
       font-weight: var(--ha-font-weight-medium);
-      // font-size: clamp is used keeping in mind design choice while resizing
+      /* font-size: clamp is used keeping in mind design choice while resizing */
       font-size: clamp(1rem, calc(1.5rem + 10cqw), var(--font-size));
       line-height: 0.8;
       direction: ltr;


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Implemented overflow prevention and responsiveness in `Analog Clock` and `Digital Clock` components through two approaches: the first constrains computed dimensions using `min()`, while the second uses fluid typography with `clamp()` and container queries; both respecting user choice and HASS design.


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
I would've liked to post two videos to show the difference in intermediate stages, I have only posted before and after in key breakpoints `(320, 768, 1024)`, with `clock_size: "large"`.
<img width="318" height="391" alt="320_after" src="https://github.com/user-attachments/assets/b5f68be9-fe99-4b1c-adf4-1b8dfa8d96cc" />
<img width="315" height="391" alt="320_before" src="https://github.com/user-attachments/assets/a9d3e61c-1928-4978-841d-0e9a2bf6afbd" />
<img width="767" height="385" alt="768_after" src="https://github.com/user-attachments/assets/f08b28f6-dad2-441a-be15-a57b544a6b82" />
<img width="760" height="396" alt="768_before" src="https://github.com/user-attachments/assets/195b49b7-d446-4693-b5cb-059499c379e4" />
<img width="1023" height="451" alt="1024_after" src="https://github.com/user-attachments/assets/01ab6985-71e6-466b-bfd9-a4ad37ee862a" />
<img width="1020" height="406" alt="1024_before" src="https://github.com/user-attachments/assets/30419be4-0e55-40e4-9615-ba371d59fe18" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #30400 
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
