### PR TITLE
Add search bar to integration page

### DIFF
--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -1328,7 +1328,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         }
         ha-input-search {
           width: 100%;
-          margin-bottom: 16px;
+          margin-bottom: var(--ha-space-4);
         }
         .section {
           width: 100%;

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -30,6 +30,7 @@ import "../../../components/ha-dropdown";
 import "../../../components/ha-dropdown-item";
 import "../../../components/ha-md-list";
 import "../../../components/ha-md-list-item";
+import "../../../components/input/ha-input-search";
 import { getSignedPath } from "../../../data/auth";
 import type { ConfigEntry, SubEntry } from "../../../data/config_entries";
 import {
@@ -64,6 +65,7 @@ import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-error-screen";
 import "../../../layouts/hass-subpage";
 import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
+import { multiTermSearch } from "../../../resources/fuseMultiTerm";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 import { brandsUrl } from "../../../util/brands-url";
@@ -156,6 +158,8 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
     window.location.hash.substring(1)
   );
 
+  @state() private _filter = "";
+
   @state() private _subEntries: Record<string, SubEntry[]> = {};
 
   private _subEntriesFetchId = 0;
@@ -218,6 +222,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
       this.hass.loadBackendTranslation("config", [this.domain]);
       this.hass.loadBackendTranslation("config_subentries", [this.domain]);
       this._extraConfigEntries = undefined;
+      this._filter = "";
       this._subEntries = {};
       this._fetchManifest();
       this._fetchDiagnostics();
@@ -319,19 +324,35 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         );
       });
 
-    const normalData = this._buildNormalEntryData(
-      normalEntries,
-      this.hass.devices,
-      this._subEntries,
-      this.hass.locale.language,
-      this.hass.localize
+    const normalData = this._filterNormalTree(
+      this._buildNormalEntryData(
+        normalEntries,
+        this.hass.devices,
+        this._subEntries,
+        this.hass.locale.language,
+        this.hass.localize
+      ),
+      this._filter,
+      this.hass.areas
     );
-    const attentionData = this._buildAttentionEntryData(
-      attentionEntries,
-      this.hass.devices,
-      this._subEntries,
-      this.hass.locale.language,
-      this.hass.localize
+    const attentionData = this._filterAttentionTree(
+      this._buildAttentionEntryData(
+        attentionEntries,
+        this.hass.devices,
+        this._subEntries,
+        this.hass.locale.language,
+        this.hass.localize
+      ),
+      this._filter,
+      this.hass.areas
+    );
+    const filteredDiscoveryFlows = this._filterFlows(
+      discoveryFlows,
+      this._filter
+    );
+    const filteredAttentionFlows = this._filterFlows(
+      attentionFlows,
+      this._filter
     );
 
     const devicesRegs = this._getDevices(configEntries, this.hass.devices);
@@ -652,6 +673,12 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
             </div>
           </div>
 
+          <ha-input-search
+            appearance="outlined"
+            .value=${this._filter}
+            @input=${this._handleSearchChange}
+          ></ha-input-search>
+
           ${this._logInfo?.level === LogSeverity.DEBUG
             ? html`<div class="section">
                 <ha-alert alert-type="warning">
@@ -670,7 +697,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                 </ha-alert>
               </div>`
             : nothing}
-          ${discoveryFlows.length
+          ${filteredDiscoveryFlows.length
             ? html`
                 <div class="section">
                   <h3 class="section-header">
@@ -679,7 +706,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                     )}
                   </h3>
                   <ha-md-list class="discovered">
-                    ${discoveryFlows.map(
+                    ${filteredDiscoveryFlows.map(
                       (flow) =>
                         html`<ha-md-list-item class="discovered">
                           ${flow.localized_title}
@@ -698,7 +725,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                 </div>
               `
             : nothing}
-          ${attentionFlows.length || attentionData.length
+          ${filteredAttentionFlows.length || attentionData.length
             ? html`
                 <div class="section">
                   <h3 class="section-header">
@@ -706,9 +733,9 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                       `ui.panel.config.integrations.integration_page.attention_entries`
                     )}
                   </h3>
-                  ${attentionFlows.length
+                  ${filteredAttentionFlows.length
                     ? html`<ha-md-list class="attention">
-                        ${attentionFlows.map((flow) => {
+                        ${filteredAttentionFlows.map((flow) => {
                           const attention = ATTENTION_SOURCES.includes(
                             flow.context.source
                           );
@@ -767,17 +794,21 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
             </h3>
             ${normalData.length === 0
               ? html`<div class="card-content no-entries">
-                  ${this._manifest &&
-                  !this._manifest.config_flow &&
-                  this.hass.config.components.find(
-                    (comp) => comp.split(".")[0] === this.domain
-                  )
+                  ${this._filter
                     ? this.hass.localize(
-                        "ui.panel.config.integrations.integration_page.yaml_entry"
+                        "ui.panel.config.integrations.none_found"
                       )
-                    : this.hass.localize(
-                        "ui.panel.config.integrations.integration_page.no_entries"
-                      )}
+                    : this._manifest &&
+                        !this._manifest.config_flow &&
+                        this.hass.config.components.find(
+                          (comp) => comp.split(".")[0] === this.domain
+                        )
+                      ? this.hass.localize(
+                          "ui.panel.config.integrations.integration_page.yaml_entry"
+                        )
+                      : this.hass.localize(
+                          "ui.panel.config.integrations.integration_page.no_entries"
+                        )}
                 </div>`
               : html`
                   ${normalData.map(
@@ -967,6 +998,129 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
   private _buildNormalEntryData = memoizeOne(this._buildEntryData);
 
   private _buildAttentionEntryData = memoizeOne(this._buildEntryData);
+
+  private _filterTree = memoizeOne(
+    (
+      data: ConfigEntryData[],
+      filter: string,
+      areas: HomeAssistant["areas"]
+    ): ConfigEntryData[] => {
+      if (!filter) {
+        return data;
+      }
+
+      const DEVICE_KEYS = [
+        "name",
+        "manufacturer",
+        "model",
+        "sw_version",
+        "area",
+      ];
+
+      const buildDeviceSearchable = (device: DeviceRegistryEntry) => ({
+        device,
+        name: device.name_by_user || device.name || "",
+        manufacturer: device.manufacturer || "",
+        model: device.model || "",
+        sw_version: device.sw_version || "",
+        area: device.area_id ? areas[device.area_id]?.name || "" : "",
+      });
+
+      const matchDevices = (devices: DeviceRegistryEntry[]) =>
+        multiTermSearch(
+          devices.map(buildDeviceSearchable),
+          filter,
+          DEVICE_KEYS,
+          undefined,
+          { keys: DEVICE_KEYS }
+        ).map((r) => r.device);
+
+      const TITLE_KEYS = ["title"];
+
+      const titleMatches = (title: string) =>
+        multiTermSearch([{ title }], filter, TITLE_KEYS, undefined, {
+          keys: TITLE_KEYS,
+        }).length > 0;
+
+      const result: ConfigEntryData[] = [];
+
+      for (const entryData of data) {
+        if (titleMatches(entryData.entry.title)) {
+          result.push(entryData);
+          continue;
+        }
+
+        const filteredDevices = matchDevices(entryData.devices);
+        const filteredServices = matchDevices(entryData.services);
+
+        const filteredSubEntries = entryData.subEntries
+          .map((subData): SubEntryData | null => {
+            if (titleMatches(subData.subEntry.title)) {
+              return subData;
+            }
+            const subDevices = matchDevices(subData.devices);
+            const subServices = matchDevices(subData.services);
+            if (subDevices.length || subServices.length) {
+              return {
+                subEntry: subData.subEntry,
+                devices: subDevices,
+                services: subServices,
+              };
+            }
+            return null;
+          })
+          .filter((s): s is SubEntryData => s !== null);
+
+        if (
+          filteredDevices.length ||
+          filteredServices.length ||
+          filteredSubEntries.length
+        ) {
+          result.push({
+            entry: entryData.entry,
+            devices: filteredDevices,
+            services: filteredServices,
+            subEntries: filteredSubEntries,
+          });
+        }
+      }
+
+      return result;
+    }
+  );
+
+  private _filterNormalTree = memoizeOne(
+    (data: ConfigEntryData[], filter: string, areas: HomeAssistant["areas"]) =>
+      this._filterTree(data, filter, areas)
+  );
+
+  private _filterAttentionTree = memoizeOne(
+    (data: ConfigEntryData[], filter: string, areas: HomeAssistant["areas"]) =>
+      this._filterTree(data, filter, areas)
+  );
+
+  private _filterFlows = memoizeOne(
+    (
+      flows: DataEntryFlowProgressExtended[],
+      filter: string
+    ): DataEntryFlowProgressExtended[] => {
+      if (!filter) {
+        return flows;
+      }
+      const KEYS = ["title"];
+      return multiTermSearch(
+        flows.map((flow) => ({ flow, title: flow.localized_title || "" })),
+        filter,
+        KEYS,
+        undefined,
+        { keys: KEYS }
+      ).map((r) => r.flow);
+    }
+  );
+
+  private _handleSearchChange(ev: InputEvent) {
+    this._filter = (ev.target as HTMLInputElement).value ?? "";
+  }
 
   private async _handleEnableDebugLogging() {
     const integration = this.domain;
@@ -1197,6 +1351,10 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
           display: flex;
           flex-wrap: wrap;
           gap: var(--ha-space-2);
+        }
+        ha-input-search {
+          width: 100%;
+          margin-bottom: 16px;
         }
         .section {
           width: 100%;

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -324,37 +324,30 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         );
       });
 
-    const normalData = this._filterNormalTree(
-      this._buildNormalEntryData(
-        normalEntries,
-        this.hass.devices,
-        this._subEntries,
-        this.hass.locale.language,
-        this.hass.localize
-      ),
+    const normalData = this._buildNormalEntryData(
+      normalEntries,
+      this.hass.devices,
+      this._subEntries,
+      this.hass.locale.language,
+      this.hass.localize
+    );
+    const attentionData = this._buildAttentionEntryData(
+      attentionEntries,
+      this.hass.devices,
+      this._subEntries,
+      this.hass.locale.language,
+      this.hass.localize
+    );
+    const filteredNormalData = this._filterNormalTree(
+      normalData,
       this._filter,
       this.hass.areas
     );
-    const attentionData = this._filterAttentionTree(
-      this._buildAttentionEntryData(
-        attentionEntries,
-        this.hass.devices,
-        this._subEntries,
-        this.hass.locale.language,
-        this.hass.localize
-      ),
+    const filteredAttentionData = this._filterAttentionTree(
+      attentionData,
       this._filter,
       this.hass.areas
     );
-    const filteredDiscoveryFlows = this._filterFlows(
-      discoveryFlows,
-      this._filter
-    );
-    const filteredAttentionFlows = this._filterFlows(
-      attentionFlows,
-      this._filter
-    );
-
     const devicesRegs = this._getDevices(configEntries, this.hass.devices);
     const entities = this._getEntities(configEntries, this._entities);
     let numberOfEntities = entities.length;
@@ -697,7 +690,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                 </ha-alert>
               </div>`
             : nothing}
-          ${filteredDiscoveryFlows.length
+          ${discoveryFlows.length
             ? html`
                 <div class="section">
                   <h3 class="section-header">
@@ -706,7 +699,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                     )}
                   </h3>
                   <ha-md-list class="discovered">
-                    ${filteredDiscoveryFlows.map(
+                    ${discoveryFlows.map(
                       (flow) =>
                         html`<ha-md-list-item class="discovered">
                           ${flow.localized_title}
@@ -725,7 +718,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                 </div>
               `
             : nothing}
-          ${filteredAttentionFlows.length || attentionData.length
+          ${attentionFlows.length || filteredAttentionData.length
             ? html`
                 <div class="section">
                   <h3 class="section-header">
@@ -733,9 +726,9 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                       `ui.panel.config.integrations.integration_page.attention_entries`
                     )}
                   </h3>
-                  ${filteredAttentionFlows.length
+                  ${attentionFlows.length
                     ? html`<ha-md-list class="attention">
-                        ${filteredAttentionFlows.map((flow) => {
+                        ${attentionFlows.map((flow) => {
                           const attention = ATTENTION_SOURCES.includes(
                             flow.context.source
                           );
@@ -765,7 +758,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                         })}
                       </ha-md-list>`
                     : nothing}
-                  ${attentionData.map(
+                  ${filteredAttentionData.map(
                     (data) =>
                       html`<ha-config-entry-row
                         class="attention"
@@ -792,7 +785,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                     `ui.panel.config.integrations.integration_page.entries`
                   )}
             </h3>
-            ${normalData.length === 0
+            ${filteredNormalData.length === 0
               ? html`<div class="card-content no-entries">
                   ${this._filter
                     ? this.hass.localize(
@@ -811,7 +804,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                         )}
                 </div>`
               : html`
-                  ${normalData.map(
+                  ${filteredNormalData.map(
                     (data) =>
                       html`<ha-config-entry-row
                         .hass=${this.hass}
@@ -1097,25 +1090,6 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
   private _filterAttentionTree = memoizeOne(
     (data: ConfigEntryData[], filter: string, areas: HomeAssistant["areas"]) =>
       this._filterTree(data, filter, areas)
-  );
-
-  private _filterFlows = memoizeOne(
-    (
-      flows: DataEntryFlowProgressExtended[],
-      filter: string
-    ): DataEntryFlowProgressExtended[] => {
-      if (!filter) {
-        return flows;
-      }
-      const KEYS = ["title"];
-      return multiTermSearch(
-        flows.map((flow) => ({ flow, title: flow.localized_title || "" })),
-        filter,
-        KEYS,
-        undefined,
-        { keys: KEYS }
-      ).map((r) => r.flow);
-    }
   );
 
   private _handleSearchChange(ev: InputEvent) {

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -24,6 +24,7 @@ import {
   protocolIntegrationPicked,
 } from "../../../common/integrations/protocolIntegrationPicked";
 import { caseInsensitiveStringCompare } from "../../../common/string/compare";
+import type { LocalizeFunc } from "../../../common/translations/localize";
 import { nextRender } from "../../../common/util/render-status";
 import "../../../components/ha-button";
 import "../../../components/ha-dropdown";
@@ -31,6 +32,7 @@ import "../../../components/ha-dropdown-item";
 import "../../../components/ha-md-list";
 import "../../../components/ha-md-list-item";
 import "../../../components/input/ha-input-search";
+import type { HaInputSearch } from "../../../components/input/ha-input-search";
 import { getSignedPath } from "../../../data/auth";
 import type { ConfigEntry, SubEntry } from "../../../data/config_entries";
 import {
@@ -76,7 +78,6 @@ import type { HaConfigEntryRow } from "./ha-config-entry-row";
 import type { DataEntryFlowProgressExtended } from "./ha-config-integrations";
 import { showAddIntegrationDialog } from "./show-add-integration-dialog";
 import { showPickConfigEntryDialog } from "./show-pick-config-entry-dialog";
-import type { LocalizeFunc } from "../../../common/translations/localize";
 
 export interface SubEntryData {
   subEntry: SubEntry;
@@ -666,12 +667,13 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
             </div>
           </div>
 
-          <ha-input-search
-            appearance="outlined"
-            .value=${this._filter}
-            @input=${this._handleSearchChange}
-          ></ha-input-search>
-
+          ${normalData.length + attentionData.length > 0
+            ? html`<ha-input-search
+                appearance="outlined"
+                .value=${this._filter}
+                @input=${this._handleSearchChange}
+              ></ha-input-search>`
+            : nothing}
           ${this._logInfo?.level === LogSeverity.DEBUG
             ? html`<div class="section">
                 <ha-alert alert-type="warning">
@@ -1093,7 +1095,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
   );
 
   private _handleSearchChange(ev: InputEvent) {
-    this._filter = (ev.target as HTMLInputElement).value ?? "";
+    this._filter = (ev.target as HaInputSearch).value ?? "";
   }
 
   private async _handleEnableDebugLogging() {


### PR DESCRIPTION
## Proposed change

Add a search bar to the integration detail page that lets users quickly find entries, devices, and sub-entries.

The search filters across all displayed data:
- Entry titles
- Device names, manufacturers, models, software versions, and areas
- Sub-entry titles
- Discovery and attention flow titles

When the entry title matches, all its children remain visible. When only a child matches (device or sub-entry), the parent entry is shown with only the matching children.

## Screenshots

<img width="1058" height="470" alt="CleanShot 2026-04-09 at 11 26 02" src="https://github.com/user-attachments/assets/4756637f-d011-41f9-9c22-d747566ba73b" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
