### PR TITLE
Fix duplicate "Add custom path" entry in navigation picker

### DIFF
--- a/src/components/ha-navigation-picker.ts
+++ b/src/components/ha-navigation-picker.ts
@@ -1,5 +1,5 @@
 import Fuse from "fuse.js";
-import { mdiDevices, mdiPlus, mdiTextureBox } from "@mdi/js";
+import { mdiDevices, mdiTextureBox } from "@mdi/js";
 import { html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -234,22 +234,6 @@ export class HaNavigationPicker extends LitElement {
     addGroup("dashboards", dashboards);
     addGroup("views", views);
     addGroup("other_routes", otherRoutes);
-
-    if (
-      searchString &&
-      !this._navigationItems.some((navItem) => navItem.id === searchString)
-    ) {
-      items.push({
-        id: searchString,
-        primary: this.hass.localize(
-          "ui.components.navigation-picker.add_custom_path"
-        ),
-        secondary: `"${searchString}"`,
-        icon_path: mdiPlus,
-        sorting_label: searchString,
-        group: "other_routes",
-      });
-    }
 
     return items;
   };


### PR DESCRIPTION
## Proposed change

The navigation picker can sometimes show two "Add custom path" entries when typing a search string. This happens because both `ha-navigation-picker` and `ha-picker-combo-box` were each adding their own "Add custom path" item independently.

The combo box already handles this automatically when `allowCustomValue` and `customValueLabel` are set, so the manual addition in the navigation picker's `_getItems` was redundant. This PR removes the duplicate entry from `ha-navigation-picker`.

Validated by cherry-picking on top of https://github.com/home-assistant/frontend/compare/add-custom-pages-summaries

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr