### PR TITLE
Fix duplicate 'triggered' text in Logbook context messages (#23083)

### DIFF
--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -422,14 +422,6 @@ class HaLogbookRenderer extends LitElement {
       item.context_event_type === "automation_triggered" ||
       item.context_event_type === "script_started"
     ) {
-      // context_source is available in 2022.6 and later
-      const triggerMsg = item.context_source
-        ? item.context_source
-        : item.context_message.replace("triggered by ", "");
-      const contextTriggerSource = localizeTriggerSource(
-        this.hass.localize,
-        triggerMsg
-      );
       return html`${this.hass.localize(
         item.context_event_type === "automation_triggered"
           ? "ui.components.logbook.triggered_by_automation"
@@ -439,22 +431,17 @@ class HaLogbookRenderer extends LitElement {
         item.context_entity_id,
         item.context_entity_id_name,
         noLink
-      )}
-      ${item.context_message
-        ? this._formatMessageWithPossibleEntity(
-            contextTriggerSource,
-            seenEntityIds,
-            undefined,
-            noLink
-          )
-        : ""}`;
+      )} `;
     }
     // Generic externally described logbook platform
     // These are not localizable
+    // Check if the message is just a repeat of "triggered"
+    const cleanMessage =
+      item.context_message === "triggered" ? "" : item.context_message;
     return html` ${this.hass.localize("ui.components.logbook.triggered_by")}
     ${item.context_name}
     ${this._formatMessageWithPossibleEntity(
-      item.context_message,
+      cleanMessage,
       seenEntityIds,
       item.context_entity_id,
       noLink


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR improves the readability of Logbook entries by removing redundant "triggered" text that often appears twice when automations are run manually or via certain services.

In many languages (like Swedish or German), this creates grammatically awkward sentences where a localized "Triggered by" is followed by a hardcoded English "triggered" from the backend. By filtering out the exact string "triggered" from the context_message, the UI remains clean while still allowing other important context messages to be displayed.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Before in German:
<img width="653" height="499" alt="image" src="https://github.com/user-attachments/assets/151cc78d-7890-41c3-a631-2804f14d4ef0" />

After in German:
<img width="600" height="517" alt="image" src="https://github.com/user-attachments/assets/51ff354c-9a11-442c-92aa-8b410a8fb791" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #23083
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
