### PR TITLE
Consistent 'If' prefix for automation condition strings (#23190)

### DIFF
--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -1115,7 +1115,14 @@ const describeLegacyCondition = (
     );
   }
 
-  // Numeric State Condition
+  // Numeric State Condition - Fallback for no entity
+  if (condition.condition === "numeric_state" && !condition.entity_id) {
+    return hass.localize(
+      `${conditionsTranslationBaseKey}.numeric_state.description.no_conditions`
+    );
+  }
+
+  // Numeric State Condition - Full handler with entity
   if (condition.condition === "numeric_state" && condition.entity_id) {
     const entity_ids = ensureArray(condition.entity_id);
     const stateObj = hass.states[entity_ids[0]] as HassEntity | undefined;
@@ -1171,6 +1178,10 @@ const describeLegacyCondition = (
         }
       );
     }
+    // Fallback for no bounds set
+    return hass.localize(
+      `${conditionsTranslationBaseKey}.numeric_state.description.no_conditions`
+    );
   }
 
   // Time condition
@@ -1241,6 +1252,10 @@ const describeLegacyCondition = (
         }
       );
     }
+    // Fallback for no time settings selected
+    return hass.localize(
+      `${conditionsTranslationBaseKey}.time.description.no_conditions`
+    );
   }
 
   // Sun condition
@@ -1279,9 +1294,22 @@ const describeLegacyCondition = (
       }
     );
   }
+  if (condition.condition === "sun") {
+    // Fallback for no sun settings selected
+    return hass.localize(
+      `${conditionsTranslationBaseKey}.sun.description.no_conditions`
+    );
+  }
 
   // Zone condition
-  if (condition.condition === "zone" && condition.entity_id && condition.zone) {
+  if (condition.condition === "zone") {
+    if (!condition.entity_id || !condition.zone) {
+      // Fallback for missing entity or zone
+      return hass.localize(
+        `${conditionsTranslationBaseKey}.zone.description.no_conditions`
+      );
+    }
+
     const entities: string[] = [];
     const zones: string[] = [];
 
@@ -1328,7 +1356,13 @@ const describeLegacyCondition = (
     );
   }
 
-  if (condition.condition === "device" && condition.device_id) {
+  if (condition.condition === "device") {
+    if (!condition.device_id) {
+      // Fallback for no device selected
+      return hass.localize(
+        `${conditionsTranslationBaseKey}.device.description.no_conditions`
+      );
+    }
     const config = condition as DeviceCondition;
     const localized = localizeDeviceAutomationCondition(
       hass,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5322,7 +5322,8 @@
                   "label": "Device",
                   "condition": "Condition",
                   "description": {
-                    "picker": "Set of conditions provided by a device. Great way to start."
+                    "picker": "Set of conditions provided by a device. Great way to start.",
+                    "no_conditions": "If device condition is confirmed"
                   }
                 },
                 "not": {
@@ -5347,7 +5348,8 @@
                     "picker": "Tests if the numeric value of an entity's state (or attribute's value) is above or below a given threshold.",
                     "above": "If {attribute, select, \n undefined {} \n other {{attribute} from }\n }{entity} {numberOfEntities, plural,\n one {is}\n other {are}\n} above {above}",
                     "below": "If {attribute, select, \n undefined {} \n other {{attribute} from }\n }{entity} {numberOfEntities, plural,\n one {is}\n other {are}\n} below {below}",
-                    "above-below": "If {attribute, select, \n undefined {} \n other {{attribute} from }\n }{entity} {numberOfEntities, plural,\n one {is}\n other {are}\n} above {above} and below {below}"
+                    "above-below": "If {attribute, select, \n undefined {} \n other {{attribute} from }\n }{entity} {numberOfEntities, plural,\n one {is}\n other {are}\n} above {above} and below {below}",
+                    "no_conditions": "If numeric state is confirmed"
                   }
                 },
                 "or": {
@@ -5377,7 +5379,8 @@
                   "sunset": "Sunset",
                   "description": {
                     "picker": "Tests if the sun is above or below the horizon.",
-                    "full": "If the sun{afterChoice, select, \n sunrise { after sunrise}\n sunset { after sunset}\n other {}\n}{afterOffsetChoice, select, \n offset { offset by {afterOffset}}\n other {}\n}{beforeChoice, select, \n sunrise { before sunrise}\n sunset { before sunset}\n other {}\n}{beforeOffsetChoice, select, \n offset { offset by {beforeOffset}}\n other {}\n}"
+                    "full": "If the sun{afterChoice, select, \n sunrise { after sunrise}\n sunset { after sunset}\n other {}\n}{afterOffsetChoice, select, \n offset { offset by {afterOffset}}\n other {}\n}{beforeChoice, select, \n sunrise { before sunrise}\n sunset { before sunset}\n other {}\n}{beforeOffsetChoice, select, \n offset { offset by {beforeOffset}}\n other {}\n}",
+                    "no_conditions": "If the sun's state is confirmed"
                   }
                 },
                 "template": {
@@ -5408,7 +5411,8 @@
                   },
                   "description": {
                     "picker": "Tests if the current time is before or after a specified time.",
-                    "full": "If the {hasTime, select, \n after {time is after {time_after}}\n before {time is before {time_before}}\n after_before {time is after {time_after} and before {time_before}}\n after_before_or {time is after {time_after} or before {time_before}} \n other {}\n }{hasTimeAndDay, select, \n true { and the }\n other {}\n}{hasDay, select, \n true { day is {day}}\n other {}\n}"
+                    "full": "If the {hasTime, select, \n after {time is after {time_after}}\n before {time is before {time_before}}\n after_before {time is after {time_after} and before {time_before}}\n after_before_or {time is after {time_after} or before {time_before}} \n other {}\n }{hasTimeAndDay, select, \n true { and the }\n other {}\n}{hasDay, select, \n true { day is {day}}\n other {}\n}",
+                    "no_conditions": "If the time is confirmed"
                   }
                 },
                 "trigger": {
@@ -5426,7 +5430,8 @@
                   "zone": "[%key:ui::panel::config::automation::editor::triggers::type::zone::label%]",
                   "description": {
                     "picker": "Tests if someone (or something) is in a zone.",
-                    "full": "If {entity} {numberOfEntities, plural,\n one {is}\n other {are}\n} in {zone} {numberOfZones, plural,\n one {zone} \n other {zones}\n}"
+                    "full": "If {entity} {numberOfEntities, plural,\n one {is}\n other {are}\n} in {zone} {numberOfZones, plural,\n one {zone} \n other {zones}\n}",
+                    "no_conditions": "If an entity is in a zone"
                   }
                 }
               }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR introduces support for an "empty state" summary string (no_conditions) for non block conditions in automation. 

I have added new translation keys to en.json to support empty states in the condition editor. This ensures a consistent 'If...' summary even before the condition is fully configured.

The goal is to address the inconsistency reported in #23190 where several condition types lacked a proper "If..." statement before being fully configured. By adding this localized placeholder, the UI now provides a consistent "If..." lead-in as soon as a condition is added, which improves the flow in the automation editor.

**Limitations**:
I've focused on implementing the infrastructure for these summary strings. However, some types like Device lacks summary strings for multiple conditions and lacks proper "If..." statements for their descriptions, which makes them difficult to localize perfectly at this stage. Despite this, adding no_conditions support is a significant improvement over the current state and provides a better foundation for future localization efforts.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

<img width="717" height="765" alt="image" src="https://github.com/user-attachments/assets/32c634c7-96a3-485e-b480-19788123f959" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #23190
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
