### PR TITLE
Fix: Center more-info-media_player component volume buttons

### DIFF
--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -580,7 +580,7 @@ class MoreInfoMediaPlayer extends LitElement {
       align-items: center;
       justify-content: center;
       gap: var(--ha-space-3);
-      margin-left: var(--ha-space-2);
+      padding-inline: var(--ha-space-2);
     }
 
     .volume-slider-container {

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -578,6 +578,7 @@ class MoreInfoMediaPlayer extends LitElement {
     .volume {
       display: flex;
       align-items: center;
+      justify-content: center;
       gap: var(--ha-space-3);
       margin-left: var(--ha-space-2);
     }


### PR DESCRIPTION
## Proposed change

Center volume buttons in `more-info-media_player` lit component.

## Screenshots

| Before | After |
|--------|-------|
| <img width="713" height="865" alt="before" src="https://github.com/user-attachments/assets/7a44b4e2-7233-4ded-bab7-378ee949c738" /> | <img width="718" height="866" alt="image" src="https://github.com/user-attachments/assets/1b0a04b7-4a59-43ec-9ed6-761af5191f05" /> |

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: not found
- This PR is related to issue or discussion: not found

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository:
  - #51378
  - #51515

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
