### PR TITLE
Fix history/sensor cards stuck loading after backend restart

### DIFF
--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -138,7 +138,8 @@ export const subscribeHistory = (
   const stream = new HistoryStream(hass);
   return hass.connection.subscribeMessage<HistoryStreamMessage>(
     (message) => callbackFunction(stream.processMessage(message)),
-    params
+    params,
+    { resubscribe: false }
   );
 };
 
@@ -256,7 +257,8 @@ export const subscribeHistoryStatesTimeWindow = (
   const stream = new HistoryStream(hass, hoursToShow);
   return hass.connection.subscribeMessage<HistoryStreamMessage>(
     (message) => callbackFunction(stream.processMessage(message)),
-    params
+    params,
+    { resubscribe: false }
   );
 };
 

--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -3,6 +3,7 @@ import type {
   HassEntities,
   HassEntity,
   HassEntityAttributeBase,
+  MessageBase,
 } from "home-assistant-js-websocket";
 import { computeDomain } from "../common/entity/compute_domain";
 import { computeStateDisplayFromEntityAttributes } from "../common/entity/compute_state_display";
@@ -124,8 +125,8 @@ export const subscribeHistory = (
   startTime: Date,
   endTime: Date,
   entityIds: string[]
-): Promise<() => Promise<void>> => {
-  const params = {
+): Promise<() => Promise<void>> =>
+  subscribeHistoryStream(hass, callbackFunction, () => ({
     type: "history/stream",
     entity_ids: entityIds,
     start_time: startTime.toISOString(),
@@ -134,14 +135,7 @@ export const subscribeHistory = (
     no_attributes: !entityIds.some((entityId) =>
       entityIdHistoryNeedsAttributes(hass, entityId)
     ),
-  };
-  const stream = new HistoryStream(hass);
-  return hass.connection.subscribeMessage<HistoryStreamMessage>(
-    (message) => callbackFunction(stream.processMessage(message)),
-    params,
-    { resubscribe: false }
-  );
-};
+  }));
 
 export class HistoryStream {
   hass: HomeAssistant;
@@ -239,27 +233,81 @@ export const subscribeHistoryStatesTimeWindow = (
   noAttributes?: boolean,
   minimalResponse = true,
   significantChangesOnly = true
-): Promise<() => Promise<void>> => {
-  const params = {
-    type: "history/stream",
-    entity_ids: entityIds,
-    start_time: new Date(
-      new Date().getTime() - 60 * 60 * hoursToShow * 1000
-    ).toISOString(),
-    minimal_response: minimalResponse,
-    significant_changes_only: significantChangesOnly,
-    no_attributes:
-      noAttributes ??
-      !entityIds.some((entityId) =>
-        entityIdHistoryNeedsAttributes(hass, entityId)
-      ),
-  };
-  const stream = new HistoryStream(hass, hoursToShow);
-  return hass.connection.subscribeMessage<HistoryStreamMessage>(
-    (message) => callbackFunction(stream.processMessage(message)),
-    params,
-    { resubscribe: false }
+): Promise<() => Promise<void>> =>
+  subscribeHistoryStream(
+    hass,
+    callbackFunction,
+    () => ({
+      type: "history/stream",
+      entity_ids: entityIds,
+      // Recomputed on every (re)subscribe so the replay window stays anchored
+      // to "now" after a reconnect instead of replaying a stale window.
+      start_time: new Date(
+        new Date().getTime() - 60 * 60 * hoursToShow * 1000
+      ).toISOString(),
+      minimal_response: minimalResponse,
+      significant_changes_only: significantChangesOnly,
+      no_attributes:
+        noAttributes ??
+        !entityIds.some((entityId) =>
+          entityIdHistoryNeedsAttributes(hass, entityId)
+        ),
+    }),
+    hoursToShow
   );
+
+/**
+ * Subscribe to a history stream with transparent reconnect handling.
+ *
+ * Auto-resubscribe in home-assistant-js-websocket replays the original
+ * `subscribeMessage` call, which reuses the `HistoryStream` (its
+ * `combinedHistory` would merge stale state with the replayed stream) and the
+ * original `start_time` (which is stale after a disconnect for time-window
+ * subscriptions). Instead, we disable the library's auto-resubscribe and
+ * reimplement it here: on every `ready` event we build fresh params and start
+ * a fresh `HistoryStream`, so consumers don't need to listen for reconnects.
+ */
+const subscribeHistoryStream = async (
+  hass: HomeAssistant,
+  callbackFunction: (data: HistoryStates) => void,
+  buildParams: () => MessageBase,
+  hoursToShow?: number
+): Promise<() => Promise<void>> => {
+  let currentUnsub: (() => Promise<void>) | undefined;
+  let disposed = false;
+
+  const doSubscribe = async () => {
+    const stream = new HistoryStream(hass, hoursToShow);
+    const unsub = await hass.connection.subscribeMessage<HistoryStreamMessage>(
+      (message) => callbackFunction(stream.processMessage(message)),
+      buildParams(),
+      { resubscribe: false }
+    );
+    if (disposed) {
+      unsub().catch(() => undefined);
+      return;
+    }
+    currentUnsub = unsub;
+  };
+
+  const onReady = () => {
+    if (disposed) return;
+    currentUnsub = undefined;
+    // Reconnect failures (e.g. history component not yet loaded) are swallowed;
+    // consumers retry via their own component-availability logic.
+    doSubscribe().catch(() => undefined);
+  };
+
+  await doSubscribe();
+  hass.connection.addEventListener("ready", onReady);
+
+  return async () => {
+    disposed = true;
+    hass.connection.removeEventListener("ready", onReady);
+    if (currentUnsub) {
+      await currentUnsub();
+    }
+  };
 };
 
 const equalState = (obj1: LineChartState, obj2: LineChartState) =>

--- a/src/data/sensor.ts
+++ b/src/data/sensor.ts
@@ -33,10 +33,10 @@ export const getSensorNumericDeviceClasses = async (
     return sensorNumericDeviceClassesCache;
   }
   sensorNumericDeviceClassesCache = hass
-    .callWS({
+    .callWS<SensorNumericDeviceClasses>({
       type: "sensor/numeric_device_classes",
     })
-    .catch((err) => {
+    .catch((err: Error) => {
       sensorNumericDeviceClassesCache = undefined;
       throw err;
     });

--- a/src/data/sensor.ts
+++ b/src/data/sensor.ts
@@ -32,8 +32,13 @@ export const getSensorNumericDeviceClasses = async (
   if (sensorNumericDeviceClassesCache) {
     return sensorNumericDeviceClassesCache;
   }
-  sensorNumericDeviceClassesCache = hass.callWS({
-    type: "sensor/numeric_device_classes",
-  });
+  sensorNumericDeviceClassesCache = hass
+    .callWS({
+      type: "sensor/numeric_device_classes",
+    })
+    .catch((err) => {
+      sensorNumericDeviceClassesCache = undefined;
+      throw err;
+    });
   return sensorNumericDeviceClassesCache!;
 };

--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -7,6 +7,7 @@ import { computeDomain } from "../../common/entity/compute_domain";
 import { createSearchParam } from "../../common/url/search-params";
 import "../../components/chart/state-history-charts";
 import "../../components/chart/statistics-chart";
+import "../../components/ha-alert";
 import type { HistoryResult } from "../../data/history";
 import {
   computeHistory,
@@ -48,7 +49,7 @@ export class MoreInfoHistory extends LitElement {
 
   private _subscribed?: Promise<(() => Promise<void>) | undefined>;
 
-  private _error?: string;
+  @state() private _error?: { code: string; message: string };
 
   private _metadata?: Record<string, StatisticsMetaData>;
 
@@ -80,7 +81,10 @@ export class MoreInfoHistory extends LitElement {
                 >`}
           </div>
           ${this._error
-            ? html`<div class="errors">${this._error}</div>`
+            ? html`<ha-alert alert-type="error">
+                ${this.hass.localize("ui.components.history_charts.error")}:
+                ${this._error.message || this._error.code}
+              </ha-alert>`
             : this._statistics
               ? html`<statistics-chart
                   .hass=${this.hass}

--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -123,6 +123,22 @@ export class MoreInfoHistory extends LitElement {
       this._showMoreHref = `/history?${createSearchParam(params)}`;
 
       this._getStateHistory();
+    } else if (
+      changedProps.has("hass") &&
+      this.entityId &&
+      !this._subscribed &&
+      !this._stateHistory &&
+      !this._statistics &&
+      !this._error
+    ) {
+      // Retry when components become available after backend restart
+      const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+      if (
+        oldHass &&
+        oldHass.config.components !== this.hass.config.components
+      ) {
+        this._getStateHistory();
+      }
     }
   }
 
@@ -131,17 +147,34 @@ export class MoreInfoHistory extends LitElement {
     if (this.hasUpdated && this.entityId) {
       this._getStateHistory();
     }
+    window.addEventListener("connection-status", this._handleConnectionStatus);
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._unsubscribeHistory();
+    window.removeEventListener(
+      "connection-status",
+      this._handleConnectionStatus
+    );
   }
+
+  private _handleConnectionStatus = (ev: Event) => {
+    if ((ev as CustomEvent).detail === "connected") {
+      this._unsubscribeHistory();
+      this._stateHistory = undefined;
+      this._statistics = undefined;
+      this._error = undefined;
+      if (this.entityId) {
+        this._getStateHistory();
+      }
+    }
+  };
 
   private _unsubscribeHistory() {
     clearInterval(this._interval);
     if (this._subscribed) {
-      this._subscribed.then((unsub) => unsub?.());
+      this._subscribed.then((unsub) => unsub?.()).catch(() => undefined);
       this._subscribed = undefined;
     }
   }
@@ -228,8 +261,27 @@ export class MoreInfoHistory extends LitElement {
       this._unsubscribeHistory();
     }
 
-    const { numeric_device_classes: sensorNumericDeviceClasses } =
-      await getSensorNumericDeviceClasses(this.hass);
+    // Mark as subscribing before the await to prevent re-entrant calls
+    const sentinel = Promise.resolve(undefined) as NonNullable<
+      typeof this._subscribed
+    >;
+    this._subscribed = sentinel;
+
+    let sensorNumericDeviceClasses: string[];
+    try {
+      ({ numeric_device_classes: sensorNumericDeviceClasses } =
+        await getSensorNumericDeviceClasses(this.hass));
+    } catch (_err) {
+      if (this._subscribed === sentinel) {
+        this._subscribed = undefined;
+      }
+      return;
+    }
+
+    // Bail out if a newer call replaced our sentinel while we were awaiting
+    if (this._subscribed !== sentinel) {
+      return;
+    }
 
     this._subscribed = subscribeHistoryStatesTimeWindow(
       this.hass!,

--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -3,6 +3,8 @@ import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
+import type { HASSDomEvent } from "../../common/dom/fire_event";
+import type { ConnectionStatus } from "../../data/connection-status";
 import { computeDomain } from "../../common/entity/compute_domain";
 import { createSearchParam } from "../../common/url/search-params";
 import "../../components/chart/state-history-charts";
@@ -159,8 +161,8 @@ export class MoreInfoHistory extends LitElement {
     );
   }
 
-  private _handleConnectionStatus = (ev: Event) => {
-    if ((ev as CustomEvent).detail === "connected") {
+  private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
+    if (ev.detail === "connected") {
       this._unsubscribeHistory();
       this._stateHistory = undefined;
       this._statistics = undefined;

--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -129,8 +129,6 @@ export class MoreInfoHistory extends LitElement {
       changedProps.has("hass") &&
       this.entityId &&
       !this._subscribed &&
-      !this._stateHistory &&
-      !this._statistics &&
       !this._error
     ) {
       // Retry when components become available after backend restart

--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -3,8 +3,6 @@ import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
-import type { HASSDomEvent } from "../../common/dom/fire_event";
-import type { ConnectionStatus } from "../../data/connection-status";
 import { computeDomain } from "../../common/entity/compute_domain";
 import { createSearchParam } from "../../common/url/search-params";
 import "../../components/chart/state-history-charts";
@@ -147,29 +145,12 @@ export class MoreInfoHistory extends LitElement {
     if (this.hasUpdated && this.entityId) {
       this._getStateHistory();
     }
-    window.addEventListener("connection-status", this._handleConnectionStatus);
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._unsubscribeHistory();
-    window.removeEventListener(
-      "connection-status",
-      this._handleConnectionStatus
-    );
   }
-
-  private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
-    if (ev.detail === "connected") {
-      this._unsubscribeHistory();
-      this._stateHistory = undefined;
-      this._statistics = undefined;
-      this._error = undefined;
-      if (this.entityId) {
-        this._getStateHistory();
-      }
-    }
-  };
 
   private _unsubscribeHistory() {
     clearInterval(this._interval);

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -88,7 +88,7 @@ class HaPanelHistory extends LitElement {
   @query("state-history-charts")
   private _stateHistoryCharts?: StateHistoryCharts;
 
-  private _subscribed?: Promise<UnsubscribeFunc>;
+  private _subscribed?: Promise<UnsubscribeFunc | undefined>;
 
   private _interval?: number;
 
@@ -124,6 +124,8 @@ class HaPanelHistory extends LitElement {
   private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
     if (ev.detail === "connected") {
       this._unsubscribeHistory();
+      this._stateHistory = undefined;
+      this._statisticsHistory = undefined;
       this._getHistory();
       this._getStats();
     }
@@ -333,18 +335,28 @@ class HaPanelHistory extends LitElement {
     // graph to start at 7AM, need to fetch the statistic from 6AM.
     statsStartDate.setHours(statsStartDate.getHours() - 1);
 
-    const statistics = await fetchStatistics(
-      this.hass!,
-      statsStartDate,
-      this._endDate,
-      statisticIds,
-      "hour",
-      undefined,
-      ["mean", "state"]
-    );
+    let statistics;
+    try {
+      statistics = await fetchStatistics(
+        this.hass!,
+        statsStartDate,
+        this._endDate,
+        statisticIds,
+        "hour",
+        undefined,
+        ["mean", "state"]
+      );
+    } catch (_err) {
+      return;
+    }
 
-    const { numeric_device_classes: sensorNumericDeviceClasses } =
-      await getSensorNumericDeviceClasses(this.hass);
+    let sensorNumericDeviceClasses: string[];
+    try {
+      ({ numeric_device_classes: sensorNumericDeviceClasses } =
+        await getSensorNumericDeviceClasses(this.hass));
+    } catch (_err) {
+      return;
+    }
 
     this._statisticsHistory = convertStatisticsToHistory(
       this.hass!,
@@ -371,8 +383,28 @@ class HaPanelHistory extends LitElement {
 
     const now = new Date();
 
-    const { numeric_device_classes: sensorNumericDeviceClasses } =
-      await getSensorNumericDeviceClasses(this.hass);
+    // Mark as subscribing before the await to prevent re-entrant calls
+    const sentinel = Promise.resolve(undefined) as NonNullable<
+      typeof this._subscribed
+    >;
+    this._subscribed = sentinel;
+
+    let sensorNumericDeviceClasses: string[];
+    try {
+      ({ numeric_device_classes: sensorNumericDeviceClasses } =
+        await getSensorNumericDeviceClasses(this.hass));
+    } catch (_err) {
+      if (this._subscribed === sentinel) {
+        this._subscribed = undefined;
+        this._isLoading = false;
+      }
+      return;
+    }
+
+    // Bail out if a newer call replaced our sentinel while we were awaiting
+    if (this._subscribed !== sentinel) {
+      return;
+    }
 
     this._subscribed = subscribeHistory(
       this.hass,

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -407,7 +407,7 @@ class HaPanelHistory extends LitElement {
       this._interval = undefined;
     }
     if (this._subscribed) {
-      this._subscribed.then((unsub) => unsub?.());
+      this._subscribed.then((unsub) => unsub?.()).catch(() => undefined);
       this._subscribed = undefined;
     }
   }

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -16,8 +16,6 @@ import memoizeOne from "memoize-one";
 import { ensureArray } from "../../common/array/ensure-array";
 import { storage } from "../../common/decorators/storage";
 import { computeDomain } from "../../common/entity/compute_domain";
-import type { HASSDomEvent } from "../../common/dom/fire_event";
-import type { ConnectionStatus } from "../../data/connection-status";
 import { goBack, navigate } from "../../common/navigate";
 import { constructUrlCurrentPath } from "../../common/url/construct-url";
 import {
@@ -109,27 +107,12 @@ class HaPanelHistory extends LitElement {
     if (this.hasUpdated) {
       this._getHistory();
     }
-    window.addEventListener("connection-status", this._handleConnectionStatus);
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._unsubscribeHistory();
-    window.removeEventListener(
-      "connection-status",
-      this._handleConnectionStatus
-    );
   }
-
-  private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
-    if (ev.detail === "connected") {
-      this._unsubscribeHistory();
-      this._stateHistory = undefined;
-      this._statisticsHistory = undefined;
-      this._getHistory();
-      this._getStats();
-    }
-  };
 
   private _goBack(): void {
     goBack();

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -16,6 +16,8 @@ import memoizeOne from "memoize-one";
 import { ensureArray } from "../../common/array/ensure-array";
 import { storage } from "../../common/decorators/storage";
 import { computeDomain } from "../../common/entity/compute_domain";
+import type { HASSDomEvent } from "../../common/dom/fire_event";
+import type { ConnectionStatus } from "../../data/connection-status";
 import { goBack, navigate } from "../../common/navigate";
 import { constructUrlCurrentPath } from "../../common/url/construct-url";
 import {
@@ -107,12 +109,25 @@ class HaPanelHistory extends LitElement {
     if (this.hasUpdated) {
       this._getHistory();
     }
+    window.addEventListener("connection-status", this._handleConnectionStatus);
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._unsubscribeHistory();
+    window.removeEventListener(
+      "connection-status",
+      this._handleConnectionStatus
+    );
   }
+
+  private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
+    if (ev.detail === "connected") {
+      this._unsubscribeHistory();
+      this._getHistory();
+      this._getStats();
+    }
+  };
 
   private _goBack(): void {
     goBack();

--- a/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
@@ -1,14 +1,17 @@
+import type { UnsubscribeFunc } from "home-assistant-js-websocket";
+import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
+import type { HASSDomEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { isNumericFromAttributes } from "../../../common/number/format_number";
 import "../../../components/ha-spinner";
+import type { ConnectionStatus } from "../../../data/connection-status";
 import {
   limitedHistoryFromStateObj,
   subscribeHistoryStatesTimeWindow,
 } from "../../../data/history";
-import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import type { HomeAssistant } from "../../../types";
 import { coordinatesMinimalResponseCompressedState } from "../common/graph/coordinates";
 import "../components/hui-graph-base";
@@ -34,7 +37,7 @@ export const DEFAULT_HOURS_TO_SHOW = 24;
 
 @customElement("hui-trend-graph-card-feature")
 class HuiHistoryChartCardFeature
-  extends SubscribeMixin(LitElement)
+  extends LitElement
   implements LovelaceCardFeature
 {
   @property({ attribute: false, hasChanged: () => false })
@@ -47,6 +50,10 @@ class HuiHistoryChartCardFeature
   @state() private _coordinates?: [number, number][];
 
   @state() private _yAxisOrigin?: number;
+
+  @state() private _error?: Error;
+
+  private _subscribed?: Promise<UnsubscribeFunc | undefined>;
 
   private _interval?: number;
 
@@ -73,15 +80,24 @@ class HuiHistoryChartCardFeature
     // redraw the graph every minute to update the time axis
     clearInterval(this._interval);
     this._interval = window.setInterval(() => this.requestUpdate(), 1000 * 60);
+    if (this.hasUpdated) {
+      this._subscribeHistory();
+    }
+    window.addEventListener("connection-status", this._handleConnectionStatus);
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     clearInterval(this._interval);
+    this._unsubscribeHistory();
+    window.removeEventListener(
+      "connection-status",
+      this._handleConnectionStatus
+    );
   }
 
-  protected hassSubscribe() {
-    return [this._subscribeHistory()];
+  protected firstUpdated() {
+    this._subscribeHistory();
   }
 
   protected render() {
@@ -115,19 +131,55 @@ class HuiHistoryChartCardFeature
     `;
   }
 
-  private async _subscribeHistory(): Promise<() => Promise<void>> {
+  private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
+    if (ev.detail === "connected") {
+      this._unsubscribeHistory();
+      this._coordinates = undefined;
+      this._error = undefined;
+      this._subscribeHistory();
+    }
+  };
+
+  private _unsubscribeHistory() {
+    if (this._subscribed) {
+      this._subscribed.then((unsub) => unsub?.()).catch(() => undefined);
+      this._subscribed = undefined;
+    }
+  }
+
+  protected updated(changedProps: PropertyValues) {
+    if (
+      !this._subscribed &&
+      !this._error &&
+      this._config &&
+      this.context?.entity_id &&
+      changedProps.has("hass")
+    ) {
+      const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+      if (
+        oldHass &&
+        oldHass.config.components !== this.hass!.config.components
+      ) {
+        // Retry subscription when components become available after backend restart
+        this._subscribeHistory();
+      }
+    }
+  }
+
+  private async _subscribeHistory() {
     if (
       !isComponentLoaded(this.hass!.config, "history") ||
       !this.context?.entity_id ||
-      !this._config
+      !this._config ||
+      this._subscribed
     ) {
-      return () => Promise.resolve();
+      return;
     }
 
     const hourToShow = this._config.hours_to_show ?? DEFAULT_HOURS_TO_SHOW;
     const detail = this._config.detail !== false; // default to true (high detail)
 
-    return subscribeHistoryStatesTimeWindow(
+    this._subscribed = subscribeHistoryStatesTimeWindow(
       this.hass!,
       (historyStates) => {
         const entityId = this.context!.entity_id!;
@@ -157,7 +209,11 @@ class HuiHistoryChartCardFeature
       },
       hourToShow,
       [this.context!.entity_id!]
-    );
+    ).catch((err) => {
+      this._subscribed = undefined;
+      this._error = err;
+      return undefined;
+    });
   }
 
   static styles = css`

--- a/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
@@ -49,7 +49,7 @@ class HuiHistoryChartCardFeature
 
   @state() private _yAxisOrigin?: number;
 
-  @state() private _error?: Error;
+  @state() private _error?: { code: string; message: string };
 
   private _subscribed?: Promise<UnsubscribeFunc | undefined>;
 
@@ -101,6 +101,13 @@ class HuiHistoryChartCardFeature
       !supportsTrendGraphCardFeature(this.hass, this.context)
     ) {
       return nothing;
+    }
+    if (this._error) {
+      return html`
+        <div class="container">
+          <div class="info">${this._error.message || this._error.code}</div>
+        </div>
+      `;
     }
     if (!this._coordinates) {
       return html`

--- a/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
@@ -3,11 +3,9 @@ import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
-import type { HASSDomEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { isNumericFromAttributes } from "../../../common/number/format_number";
 import "../../../components/ha-spinner";
-import type { ConnectionStatus } from "../../../data/connection-status";
 import {
   limitedHistoryFromStateObj,
   subscribeHistoryStatesTimeWindow,
@@ -83,17 +81,12 @@ class HuiHistoryChartCardFeature
     if (this.hasUpdated) {
       this._subscribeHistory();
     }
-    window.addEventListener("connection-status", this._handleConnectionStatus);
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     clearInterval(this._interval);
     this._unsubscribeHistory();
-    window.removeEventListener(
-      "connection-status",
-      this._handleConnectionStatus
-    );
   }
 
   protected firstUpdated() {
@@ -130,15 +123,6 @@ class HuiHistoryChartCardFeature
       ></hui-graph-base>
     `;
   }
-
-  private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
-    if (ev.detail === "connected") {
-      this._unsubscribeHistory();
-      this._coordinates = undefined;
-      this._error = undefined;
-      this._subscribeHistory();
-    }
-  };
 
   private _unsubscribeHistory() {
     if (this._subscribed) {

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -3,6 +3,8 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
+import type { HASSDomEvent } from "../../../common/dom/fire_event";
+import type { ConnectionStatus } from "../../../data/connection-status";
 import { createSearchParam } from "../../../common/url/search-params";
 import "../../../components/chart/state-history-charts";
 import "../../../components/ha-alert";
@@ -134,8 +136,8 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
     );
   }
 
-  private _handleConnectionStatus = (ev: Event) => {
-    if ((ev as CustomEvent).detail === "connected") {
+  private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
+    if (ev.detail === "connected") {
       this._unsubscribeHistory();
       this._error = undefined;
       this._subscribeHistory();

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -139,6 +139,8 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
   private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
     if (ev.detail === "connected") {
       this._unsubscribeHistory();
+      this._stateHistory = undefined;
+      this._statisticsHistory = undefined;
       this._error = undefined;
       this._subscribeHistory();
     }

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -3,8 +3,6 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
-import type { HASSDomEvent } from "../../../common/dom/fire_event";
-import type { ConnectionStatus } from "../../../data/connection-status";
 import { createSearchParam } from "../../../common/url/search-params";
 import "../../../components/chart/state-history-charts";
 import "../../../components/ha-alert";
@@ -124,27 +122,12 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
     if (this.hasUpdated) {
       this._subscribeHistory();
     }
-    window.addEventListener("connection-status", this._handleConnectionStatus);
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._unsubscribeHistory();
-    window.removeEventListener(
-      "connection-status",
-      this._handleConnectionStatus
-    );
   }
-
-  private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
-    if (ev.detail === "connected") {
-      this._unsubscribeHistory();
-      this._stateHistory = undefined;
-      this._statisticsHistory = undefined;
-      this._error = undefined;
-      this._subscribeHistory();
-    }
-  };
 
   private async _subscribeHistory() {
     if (!isComponentLoaded(this.hass!.config, "history") || this._subscribed) {

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -122,23 +122,53 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
     if (this.hasUpdated) {
       this._subscribeHistory();
     }
+    window.addEventListener("connection-status", this._handleConnectionStatus);
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._unsubscribeHistory();
+    window.removeEventListener(
+      "connection-status",
+      this._handleConnectionStatus
+    );
   }
+
+  private _handleConnectionStatus = (ev: Event) => {
+    if ((ev as CustomEvent).detail === "connected") {
+      this._unsubscribeHistory();
+      this._error = undefined;
+      this._subscribeHistory();
+    }
+  };
 
   private async _subscribeHistory() {
     if (!isComponentLoaded(this.hass!.config, "history") || this._subscribed) {
       return;
     }
 
-    const { numeric_device_classes: sensorNumericDeviceClasses } =
-      await getSensorNumericDeviceClasses(this.hass!);
+    // Mark as subscribing before the first await to prevent re-entrant calls
+    const sentinel = Promise.resolve(undefined) as NonNullable<
+      typeof this._subscribed
+    >;
+    this._subscribed = sentinel;
 
-    if (!this.isConnected) {
-      return; // Skip subscribe if we already disconnected while awaiting
+    let sensorNumericDeviceClasses: string[];
+    try {
+      ({ numeric_device_classes: sensorNumericDeviceClasses } =
+        await getSensorNumericDeviceClasses(this.hass!));
+    } catch (_err) {
+      if (this._subscribed === sentinel) {
+        this._subscribed = undefined;
+      }
+      return;
+    }
+
+    if (!this.isConnected || this._subscribed !== sentinel) {
+      if (this._subscribed === sentinel) {
+        this._subscribed = undefined;
+      }
+      return;
     }
 
     this._subscribed = subscribeHistoryStatesTimeWindow(
@@ -230,12 +260,27 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
   private _unsubscribeHistory() {
     clearInterval(this._interval);
     if (this._subscribed) {
-      this._subscribed.then((unsub) => unsub?.());
+      this._subscribed.then((unsub) => unsub?.()).catch(() => undefined);
       this._subscribed = undefined;
     }
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
+    // Allow update when components list changes so we can retry subscription
+    if (
+      !this._subscribed &&
+      !this._error &&
+      this._config &&
+      changedProps.has("hass")
+    ) {
+      const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+      if (
+        oldHass &&
+        oldHass.config.components !== this.hass!.config.components
+      ) {
+        return true;
+      }
+    }
     return (
       hasConfigOrEntitiesChanged(this, changedProps) ||
       changedProps.size > 1 ||
@@ -268,6 +313,9 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
         oldConfig?.hours_to_show !== this._config.hours_to_show)
     ) {
       this._unsubscribeHistory();
+      this._subscribeHistory();
+    } else if (!this._subscribed && !this._error && changedProps.has("hass")) {
+      // Retry subscription when components become available after backend restart
       this._subscribeHistory();
     }
   }

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -356,6 +356,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
   private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
     if (ev.detail === "connected") {
       this._unsubscribeHistory();
+      this._stateHistory = undefined;
       this._error = undefined;
       if (this._configEntities?.length) {
         this._subscribeHistory();

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -270,6 +270,16 @@ class HuiMapCard extends LitElement implements LovelaceCard {
       return true;
     }
 
+    // Allow update when components list changes so we can retry subscription
+    if (
+      !this._subscribed &&
+      !this._error &&
+      this._config &&
+      oldHass.config.components !== this.hass.config.components
+    ) {
+      return true;
+    }
+
     if (changedProps.has("_stateHistory")) {
       return true;
     }
@@ -329,12 +339,27 @@ class HuiMapCard extends LitElement implements LovelaceCard {
     if (this.hasUpdated && this._configEntities?.length) {
       this._subscribeHistory();
     }
+    window.addEventListener("connection-status", this._handleConnectionStatus);
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._unsubscribeHistory();
+    window.removeEventListener(
+      "connection-status",
+      this._handleConnectionStatus
+    );
   }
+
+  private _handleConnectionStatus = (ev: Event) => {
+    if ((ev as CustomEvent).detail === "connected") {
+      this._unsubscribeHistory();
+      this._error = undefined;
+      if (this._configEntities?.length) {
+        this._subscribeHistory();
+      }
+    }
+  };
 
   private _subscribeHistory() {
     if (
@@ -367,14 +392,14 @@ class HuiMapCard extends LitElement implements LovelaceCard {
 
   private _unsubscribeHistory() {
     if (this._subscribed) {
-      this._subscribed.then((unsub) => unsub?.());
+      this._subscribed.then((unsub) => unsub?.()).catch(() => undefined);
       this._subscribed = undefined;
     }
   }
 
   protected updated(changedProps: PropertyValues): void {
     if (this._configEntities?.length) {
-      if (!this._subscribed || changedProps.has("_config")) {
+      if ((!this._subscribed && !this._error) || changedProps.has("_config")) {
         this._unsubscribeHistory();
         this._subscribeHistory();
       }

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -12,8 +12,6 @@ import memoizeOne from "memoize-one";
 import { getColorByIndex } from "../../../common/color/colors";
 import { resolveThemeColor } from "../../../common/color/compute-color";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
-import type { HASSDomEvent } from "../../../common/dom/fire_event";
-import type { ConnectionStatus } from "../../../data/connection-status";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { computeStateDomain } from "../../../common/entity/compute_state_domain";
 import { computeStateName } from "../../../common/entity/compute_state_name";
@@ -341,28 +339,12 @@ class HuiMapCard extends LitElement implements LovelaceCard {
     if (this.hasUpdated && this._configEntities?.length) {
       this._subscribeHistory();
     }
-    window.addEventListener("connection-status", this._handleConnectionStatus);
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._unsubscribeHistory();
-    window.removeEventListener(
-      "connection-status",
-      this._handleConnectionStatus
-    );
   }
-
-  private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
-    if (ev.detail === "connected") {
-      this._unsubscribeHistory();
-      this._stateHistory = undefined;
-      this._error = undefined;
-      if (this._configEntities?.length) {
-        this._subscribeHistory();
-      }
-    }
-  };
 
   private _subscribeHistory() {
     if (

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -12,6 +12,8 @@ import memoizeOne from "memoize-one";
 import { getColorByIndex } from "../../../common/color/colors";
 import { resolveThemeColor } from "../../../common/color/compute-color";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
+import type { HASSDomEvent } from "../../../common/dom/fire_event";
+import type { ConnectionStatus } from "../../../data/connection-status";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { computeStateDomain } from "../../../common/entity/compute_state_domain";
 import { computeStateName } from "../../../common/entity/compute_state_name";
@@ -351,8 +353,8 @@ class HuiMapCard extends LitElement implements LovelaceCard {
     );
   }
 
-  private _handleConnectionStatus = (ev: Event) => {
-    if ((ev as CustomEvent).detail === "connected") {
+  private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
+    if (ev.detail === "connected") {
       this._unsubscribeHistory();
       this._error = undefined;
       if (this._configEntities?.length) {

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -145,12 +145,25 @@ export class HuiGraphHeaderFooter
     if (this.hasUpdated && this._config) {
       this._subscribeHistory();
     }
+    window.addEventListener("connection-status", this._handleConnectionStatus);
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._unsubscribeHistory();
+    window.removeEventListener(
+      "connection-status",
+      this._handleConnectionStatus
+    );
   }
+
+  private _handleConnectionStatus = (ev: Event) => {
+    if ((ev as CustomEvent).detail === "connected") {
+      this._unsubscribeHistory();
+      this._error = undefined;
+      this._subscribeHistory();
+    }
+  };
 
   private _subscribeHistory() {
     if (
@@ -264,24 +277,29 @@ export class HuiGraphHeaderFooter
   private _unsubscribeHistory() {
     clearInterval(this._interval);
     if (this._subscribed) {
-      this._subscribed.then((unsub) => unsub?.());
+      this._subscribed.then((unsub) => unsub?.()).catch(() => undefined);
       this._subscribed = undefined;
     }
     this._history = undefined;
   }
 
   protected updated(changedProps: PropertyValues) {
-    if (!this._config || !this.hass || !changedProps.has("_config")) {
+    if (!this._config || !this.hass) {
       return;
     }
 
-    const oldConfig = changedProps.get("_config") as GraphHeaderFooterConfig;
-    if (
-      !oldConfig ||
-      !this._subscribed ||
-      oldConfig.entity !== this._config.entity
-    ) {
-      this._unsubscribeHistory();
+    if (changedProps.has("_config")) {
+      const oldConfig = changedProps.get("_config") as GraphHeaderFooterConfig;
+      if (
+        !oldConfig ||
+        !this._subscribed ||
+        oldConfig.entity !== this._config.entity
+      ) {
+        this._unsubscribeHistory();
+        this._subscribeHistory();
+      }
+    } else if (!this._subscribed && !this._error && changedProps.has("hass")) {
+      // Retry subscription when components become available after backend restart
       this._subscribeHistory();
     }
   }

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -5,6 +5,7 @@ import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
+import "../../../components/ha-alert";
 import "../../../components/ha-spinner";
 import type { HistoryStates } from "../../../data/history";
 import {
@@ -68,7 +69,7 @@ export class HuiGraphHeaderFooter
 
   @state() private _coordinates?: [number, number][];
 
-  private _error?: string;
+  @state() private _error?: { code: string; message: string };
 
   private _history?: HistoryStates;
 
@@ -109,7 +110,12 @@ export class HuiGraphHeaderFooter
     }
 
     if (this._error) {
-      return html`<div class="errors">${this._error}</div>`;
+      return html`
+        <ha-alert alert-type="error">
+          ${this.hass.localize("ui.components.history_charts.error")}:
+          ${this._error.message || this._error.code}
+        </ha-alert>
+      `;
     }
 
     if (!this._coordinates) {

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -3,8 +3,7 @@ import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
-import type { ConnectionStatus } from "../../../data/connection-status";
-import { fireEvent, type HASSDomEvent } from "../../../common/dom/fire_event";
+import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import "../../../components/ha-spinner";
 import type { HistoryStates } from "../../../data/history";
@@ -146,25 +145,12 @@ export class HuiGraphHeaderFooter
     if (this.hasUpdated && this._config) {
       this._subscribeHistory();
     }
-    window.addEventListener("connection-status", this._handleConnectionStatus);
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._unsubscribeHistory();
-    window.removeEventListener(
-      "connection-status",
-      this._handleConnectionStatus
-    );
   }
-
-  private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
-    if (ev.detail === "connected") {
-      this._unsubscribeHistory();
-      this._error = undefined;
-      this._subscribeHistory();
-    }
-  };
 
   private _subscribeHistory() {
     if (

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -3,7 +3,8 @@ import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
-import { fireEvent } from "../../../common/dom/fire_event";
+import type { ConnectionStatus } from "../../../data/connection-status";
+import { fireEvent, type HASSDomEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import "../../../components/ha-spinner";
 import type { HistoryStates } from "../../../data/history";
@@ -157,8 +158,8 @@ export class HuiGraphHeaderFooter
     );
   }
 
-  private _handleConnectionStatus = (ev: Event) => {
-    if ((ev as CustomEvent).detail === "connected") {
+  private _handleConnectionStatus = (ev: HASSDomEvent<ConnectionStatus>) => {
+    if (ev.detail === "connected") {
       this._unsubscribeHistory();
       this._error = undefined;
       this._subscribeHistory();


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

After a backend restart, history graph cards, map cards with history paths, graph header/footers, and the more-info history dialog would get stuck in a loading state and never recover without a full page refresh.

This happened because of a 3-part failure:
1. On reconnect, the WebSocket library would auto-resubscribe history streams, but the `HistoryStream` object holds mutable internal state that becomes corrupt when resubscribed with stale data.
2. Lovelace cards are destroyed and recreated on reconnect. The new cards call `isComponentLoaded("history")` which returns `false` because the full component list hasn't arrived yet.
3. `shouldUpdate()` blocks hass-only updates, so `updated()` never fires to retry the subscription when components become available.

This PR fixes all three issues:
- Adds `{ resubscribe: false }` to history stream subscriptions to prevent corrupt auto-resubscription
- Adds `connection-status` event handlers to all affected components to cleanly re-subscribe on reconnect
- Adds retry logic in `shouldUpdate`/`updated`/`willUpdate` to subscribe once the history component becomes available
- Adds a sentinel pattern to prevent race conditions from re-entrant async subscription calls
- Clears the sensor device classes cache on WebSocket errors so retries can succeed
- Adds `.catch()` to unsubscribe calls to handle dead server-side subscriptions gracefully
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
