### PR TITLE
Integrate badges into toolbar support

### DIFF
--- a/src/components/ha-selector/ha-selector-select.ts
+++ b/src/components/ha-selector/ha-selector-select.ts
@@ -93,6 +93,7 @@ export class HaSelectSelector extends LitElement {
         <ha-select-box
           .options=${options}
           .value=${this.value as string | undefined}
+          .disabled=${this.disabled}
           @value-changed=${this._selectChanged}
           .maxColumns=${this.selector.select?.box_max_columns}
           .hass=${this.hass}

--- a/src/data/lovelace/config/view.ts
+++ b/src/data/lovelace/config/view.ts
@@ -35,6 +35,7 @@ export interface LovelaceViewHeaderConfig {
   layout?: "start" | "center" | "responsive";
   badges_position?: "bottom" | "top";
   badges_wrap?: "wrap" | "scroll";
+  badges_floating?: boolean;
 }
 
 export const DEFAULT_FOOTER_MAX_WIDTH_PX = 600;

--- a/src/data/lovelace/config/view.ts
+++ b/src/data/lovelace/config/view.ts
@@ -32,10 +32,9 @@ export interface LovelaceViewBackgroundConfig {
 
 export interface LovelaceViewHeaderConfig {
   card?: LovelaceCardConfig;
-  layout?: "start" | "center" | "responsive";
+  layout?: "start" | "center" | "responsive" | "integrated";
   badges_position?: "bottom" | "top";
   badges_wrap?: "wrap" | "scroll";
-  badges_floating?: boolean;
 }
 
 export const DEFAULT_FOOTER_MAX_WIDTH_PX = 600;

--- a/src/panels/lovelace/editor/view-header/hui-view-header-settings-editor.ts
+++ b/src/panels/lovelace/editor/view-header/hui-view-header-settings-editor.ts
@@ -9,11 +9,8 @@ import type {
   HaFormSchema,
   SchemaUnion,
 } from "../../../../components/ha-form/types";
-import type {
-  LovelaceViewConfig,
-  LovelaceViewHeaderConfig,
-} from "../../../../data/lovelace/config/view";
-import type { HomeAssistant } from "../../../../types";
+import type { LovelaceViewHeaderConfig } from "../../../../data/lovelace/config/view";
+import type { HomeAssistant, ValueChangedEvent } from "../../../../types";
 import {
   DEFAULT_VIEW_HEADER_BADGES_POSITION,
   DEFAULT_VIEW_HEADER_BADGES_WRAP,
@@ -117,6 +114,10 @@ export class HuiViewHeaderSettingsEditor extends LitElement {
             },
           },
         },
+        {
+          name: "badges_floating",
+          selector: { boolean: {} },
+        },
       ] as const satisfies HaFormSchema[]
   );
 
@@ -130,6 +131,7 @@ export class HuiViewHeaderSettingsEditor extends LitElement {
       badges_position:
         this.config?.badges_position || DEFAULT_VIEW_HEADER_BADGES_POSITION,
       badges_wrap: this.config?.badges_wrap || DEFAULT_VIEW_HEADER_BADGES_WRAP,
+      badges_floating: this.config?.badges_floating ?? false,
     };
 
     const narrow = this.narrow;
@@ -147,13 +149,12 @@ export class HuiViewHeaderSettingsEditor extends LitElement {
     `;
   }
 
-  private _valueChanged(ev: CustomEvent): void {
+  private _valueChanged(ev: ValueChangedEvent<LovelaceViewHeaderConfig>): void {
     ev.stopPropagation();
-    const newData = ev.detail.value as LovelaceViewConfig;
 
     const config: LovelaceViewHeaderConfig = {
       ...this.config,
-      ...newData,
+      ...ev.detail.value,
     };
 
     fireEvent(this, "config-changed", { config });
@@ -166,6 +167,7 @@ export class HuiViewHeaderSettingsEditor extends LitElement {
       case "layout":
       case "badges_position":
       case "badges_wrap":
+      case "badges_floating":
         return this.hass.localize(
           `ui.panel.lovelace.editor.edit_view_header.settings.${schema.name}`
         );

--- a/src/panels/lovelace/editor/view-header/hui-view-header-settings-editor.ts
+++ b/src/panels/lovelace/editor/view-header/hui-view-header-settings-editor.ts
@@ -1,3 +1,4 @@
+import type { PropertyValues } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -15,6 +16,7 @@ import {
   DEFAULT_VIEW_HEADER_BADGES_POSITION,
   DEFAULT_VIEW_HEADER_BADGES_WRAP,
   DEFAULT_VIEW_HEADER_LAYOUT,
+  VIEW_HEADER_LAYOUT_INTEGRATED,
 } from "../../views/hui-view-header";
 import { listenMediaQuery } from "../../../../common/dom/media_query";
 
@@ -25,6 +27,8 @@ export class HuiViewHeaderSettingsEditor extends LitElement {
   @property({ attribute: false }) public config?: LovelaceViewHeaderConfig;
 
   @state({ attribute: false }) private narrow = false;
+
+  @state() private _selectedLayout = DEFAULT_VIEW_HEADER_LAYOUT;
 
   private _unsubMql?: () => void;
 
@@ -41,16 +45,32 @@ export class HuiViewHeaderSettingsEditor extends LitElement {
     this._unsubMql = undefined;
   }
 
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has("config")) {
+      this._selectedLayout = this.config?.layout ?? DEFAULT_VIEW_HEADER_LAYOUT;
+    }
+  }
+
   private _schema = memoizeOne(
-    (localize: LocalizeFunc, isRTL: boolean, narrow: boolean) =>
+    (
+      localize: LocalizeFunc,
+      isRTL: boolean,
+      narrow: boolean,
+      integratedLayout: boolean
+    ) =>
       [
         {
           name: "layout",
           selector: {
             select: {
               mode: "box",
-              box_max_columns: narrow ? 1 : 3,
-              options: ["responsive", "start", "center"].map((value) => {
+              box_max_columns: narrow ? 1 : 4,
+              options: [
+                "responsive",
+                "start",
+                "center",
+                VIEW_HEADER_LAYOUT_INTEGRATED,
+              ].map((value) => {
                 const labelKey =
                   value === "start" && isRTL ? `${value}_rtl` : value;
                 return {
@@ -62,8 +82,8 @@ export class HuiViewHeaderSettingsEditor extends LitElement {
                     `ui.panel.lovelace.editor.edit_view_header.settings.layout_options.${value}_description`
                   ),
                   image: {
-                    src: `/static/images/form/view_header_layout_${value}.svg`,
-                    src_dark: `/static/images/form/view_header_layout_${value}_dark.svg`,
+                    src: `/static/images/form/view_header_layout_${value === VIEW_HEADER_LAYOUT_INTEGRATED ? "responsive" : value}.svg`,
+                    src_dark: `/static/images/form/view_header_layout_${value === VIEW_HEADER_LAYOUT_INTEGRATED ? "responsive" : value}_dark.svg`,
                     flip_rtl: true,
                   },
                 };
@@ -73,6 +93,7 @@ export class HuiViewHeaderSettingsEditor extends LitElement {
         },
         {
           name: "badges_position",
+          disabled: integratedLayout,
           selector: {
             select: {
               mode: "box",
@@ -92,6 +113,7 @@ export class HuiViewHeaderSettingsEditor extends LitElement {
         },
         {
           name: "badges_wrap",
+          disabled: integratedLayout,
           selector: {
             select: {
               mode: "box",
@@ -114,10 +136,6 @@ export class HuiViewHeaderSettingsEditor extends LitElement {
             },
           },
         },
-        {
-          name: "badges_floating",
-          selector: { boolean: {} },
-        },
       ] as const satisfies HaFormSchema[]
   );
 
@@ -126,17 +144,27 @@ export class HuiViewHeaderSettingsEditor extends LitElement {
       return nothing;
     }
 
+    const layout = this._selectedLayout;
+    const integratedLayout = layout === VIEW_HEADER_LAYOUT_INTEGRATED;
+
     const data = {
-      layout: this.config?.layout || DEFAULT_VIEW_HEADER_LAYOUT,
-      badges_position:
-        this.config?.badges_position || DEFAULT_VIEW_HEADER_BADGES_POSITION,
-      badges_wrap: this.config?.badges_wrap || DEFAULT_VIEW_HEADER_BADGES_WRAP,
-      badges_floating: this.config?.badges_floating ?? false,
+      layout,
+      badges_position: integratedLayout
+        ? "top"
+        : (this.config?.badges_position ?? DEFAULT_VIEW_HEADER_BADGES_POSITION),
+      badges_wrap: integratedLayout
+        ? "scroll"
+        : (this.config?.badges_wrap ?? DEFAULT_VIEW_HEADER_BADGES_WRAP),
     };
 
     const narrow = this.narrow;
     const isRTL = computeRTL(this.hass);
-    const schema = this._schema(this.hass.localize, isRTL, narrow);
+    const schema = this._schema(
+      this.hass.localize,
+      isRTL,
+      narrow,
+      integratedLayout
+    );
 
     return html`
       <ha-form
@@ -152,10 +180,23 @@ export class HuiViewHeaderSettingsEditor extends LitElement {
   private _valueChanged(ev: ValueChangedEvent<LovelaceViewHeaderConfig>): void {
     ev.stopPropagation();
 
+    const layout =
+      ev.detail.value.layout ??
+      this._selectedLayout ??
+      DEFAULT_VIEW_HEADER_LAYOUT;
+    this._selectedLayout = layout;
+
+    const integratedLayout = layout === VIEW_HEADER_LAYOUT_INTEGRATED;
+
     const config: LovelaceViewHeaderConfig = {
       ...this.config,
       ...ev.detail.value,
     };
+
+    if (integratedLayout) {
+      config.badges_position = "top";
+      config.badges_wrap = "scroll";
+    }
 
     fireEvent(this, "config-changed", { config });
   }
@@ -167,7 +208,6 @@ export class HuiViewHeaderSettingsEditor extends LitElement {
       case "layout":
       case "badges_position":
       case "badges_wrap":
-      case "badges_floating":
         return this.hass.localize(
           `ui.panel.lovelace.editor.edit_view_header.settings.${schema.name}`
         );

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -63,6 +63,7 @@ import {
   fetchDashboards,
   updateDashboard,
 } from "../../data/lovelace/dashboard";
+import { isStrategyView } from "../../data/lovelace/config/view";
 import { fetchLovelaceInfo } from "../../data/lovelace/resource";
 import { getPanelTitle } from "../../data/panel";
 import { createPerson } from "../../data/person";
@@ -549,7 +550,10 @@ class HUIRoot extends LitElement {
 
     const isSubview = curViewConfig?.subview;
     const hasTabViews = views.filter((view) => !view.subview).length > 1;
-    const headerConfig = curViewConfig?.header;
+    const headerConfig =
+      curViewConfig && !isStrategyView(curViewConfig)
+        ? curViewConfig.header
+        : undefined;
     const showToolbarBadges =
       !this._editMode &&
       !this.narrow &&
@@ -871,9 +875,13 @@ class HUIRoot extends LitElement {
       });
     }
 
-    const currentViewHeaderConfig =
+    const currentViewConfig =
       typeof this._curView === "number"
-        ? this.config.views[this._curView]?.header
+        ? this.config.views[this._curView]
+        : undefined;
+    const currentViewHeaderConfig =
+      currentViewConfig && !isStrategyView(currentViewConfig)
+        ? currentViewConfig.header
         : undefined;
     const integratedLayout =
       currentViewHeaderConfig?.layout === VIEW_HEADER_LAYOUT_INTEGRATED;

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -26,6 +26,7 @@ import { ifDefined } from "lit/directives/if-defined";
 import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import { UndoRedoController } from "../../common/controllers/undo-redo-controller";
+import { DragScrollController } from "../../common/controllers/drag-scroll-controller";
 import { fireEvent } from "../../common/dom/fire_event";
 import { goBack, navigate } from "../../common/navigate";
 import type { LocalizeKeys } from "../../common/translations/localize";
@@ -50,6 +51,7 @@ import "../../components/ha-tab-group";
 import "../../components/ha-tab-group-tab";
 import "../../components/ha-tooltip";
 import { createAreaRegistryEntry } from "../../data/area/area_registry";
+import type { LovelaceViewElement } from "../../data/lovelace";
 import type {
   LovelaceConfig,
   LovelaceRawConfig,
@@ -90,11 +92,15 @@ import { showSaveDialog } from "./editor/show-save-config-dialog";
 import { showEditViewDialog } from "./editor/view-editor/show-edit-view-dialog";
 import { getLovelaceStrategy } from "./strategies/get-strategy";
 import { isLegacyStrategyConfig } from "./strategies/legacy-strategy";
+import type { HuiBadge } from "./badges/hui-badge";
 import type { Lovelace } from "./types";
+import "./badges/hui-view-badges";
 import "./views/hui-view";
 import type { HUIView } from "./views/hui-view";
 import "./views/hui-view-background";
 import "./views/hui-view-container";
+
+const VIEW_HEADER_LAYOUT_INTEGRATED = "integrated";
 
 interface ActionItem {
   icon: string;
@@ -157,6 +163,11 @@ class HUIRoot extends LitElement {
   private _configChangedByUndo = false;
 
   private _viewCache: Record<string, HUIView> = {};
+
+  private _toolbarBadgeDragScrollController = new DragScrollController(this, {
+    selector: ".toolbar-badges.scroll",
+    enabled: false,
+  });
 
   private _viewScrollPositions: Record<string, number> = {};
 
@@ -538,6 +549,13 @@ class HUIRoot extends LitElement {
 
     const isSubview = curViewConfig?.subview;
     const hasTabViews = views.filter((view) => !view.subview).length > 1;
+    const headerConfig = curViewConfig?.header;
+    const showToolbarBadges =
+      !this._editMode &&
+      !this.narrow &&
+      headerConfig?.layout === VIEW_HEADER_LAYOUT_INTEGRATED &&
+      typeof this._curView === "number";
+    const toolbarBadges = showToolbarBadges ? this._getCurrentViewBadges() : [];
 
     return html`
       <div
@@ -548,7 +566,12 @@ class HUIRoot extends LitElement {
       >
         <div class="header">
           <slot name="toolbar">
-            <div class="toolbar">
+            <div
+              class=${classMap({
+                toolbar: true,
+                "integrated-badges": showToolbarBadges,
+              })}
+            >
               ${this._editMode
                 ? html`
                     <div class="main-title">
@@ -593,6 +616,27 @@ class HUIRoot extends LitElement {
                               ${views[0]?.title ?? dashboardTitle}
                             </div>
                           `}
+                    ${showToolbarBadges && toolbarBadges.length > 0
+                      ? html`
+                          <div
+                            class=${classMap({
+                              "toolbar-badges": true,
+                              scroll: true,
+                              dragging:
+                                this._toolbarBadgeDragScrollController
+                                  .scrolling,
+                            })}
+                          >
+                            <hui-view-badges
+                              .badges=${toolbarBadges}
+                              .hass=${this.hass}
+                              .lovelace=${this.lovelace!}
+                              .viewIndex=${this._curView as number}
+                              .showAddLabel=${false}
+                            ></hui-view-badges>
+                          </div>
+                        `
+                      : nothing}
                     <div class="action-items">${this._renderActionItems()}</div>
                   `}
             </div>
@@ -826,6 +870,19 @@ class HUIRoot extends LitElement {
         this._selectView(newSelectView);
       });
     }
+
+    const currentViewHeaderConfig =
+      typeof this._curView === "number"
+        ? this.config.views[this._curView]?.header
+        : undefined;
+    const integratedLayout =
+      currentViewHeaderConfig?.layout === VIEW_HEADER_LAYOUT_INTEGRATED;
+    const toolbarBadges = this._getCurrentViewBadges();
+    this._toolbarBadgeDragScrollController.enabled =
+      !this._editMode &&
+      !this.narrow &&
+      integratedLayout &&
+      toolbarBadges.length > 0;
   }
 
   private get config(): LovelaceConfig {
@@ -842,6 +899,16 @@ class HUIRoot extends LitElement {
 
   private get _viewRoot(): HTMLDivElement {
     return this.shadowRoot!.getElementById("view") as HTMLDivElement;
+  }
+
+  private _getCurrentViewBadges(): HuiBadge[] {
+    if (typeof this._curView !== "number") {
+      return [];
+    }
+
+    const view = this._viewCache[this._curView];
+    const layout = view?.firstElementChild as LovelaceViewElement | null;
+    return layout?.badges || [];
   }
 
   private _handleRefresh = () => {
@@ -1323,7 +1390,7 @@ class HUIRoot extends LitElement {
           display: flex;
           align-items: center;
           font-size: var(--ha-font-size-xl);
-          padding: 0px 12px;
+          padding: 0 var(--ha-space-3);
           font-weight: var(--ha-font-weight-normal);
           box-sizing: border-box;
         }
@@ -1331,7 +1398,7 @@ class HUIRoot extends LitElement {
           border-bottom: none;
         }
         .narrow .toolbar {
-          padding: 0 4px;
+          padding: 0 var(--ha-space-1);
         }
         .main-title {
           margin-inline-start: var(--ha-space-6);
@@ -1342,6 +1409,9 @@ class HUIRoot extends LitElement {
           white-space: nowrap;
           min-width: 0;
         }
+        .toolbar.integrated-badges .main-title {
+          flex-grow: 0;
+        }
         .narrow .main-title {
           margin-inline-start: var(--ha-space-2);
         }
@@ -1349,6 +1419,37 @@ class HUIRoot extends LitElement {
           white-space: nowrap;
           display: flex;
           align-items: center;
+        }
+        .toolbar-badges {
+          display: flex;
+          align-items: center;
+          min-width: 0;
+          width: auto;
+          flex: 1 1 0;
+          max-width: none;
+          margin-inline-start: var(--ha-space-4);
+          margin-inline-end: var(--ha-space-1);
+        }
+        .toolbar-badges.scroll {
+          overflow: auto;
+          scrollbar-color: var(--scrollbar-thumb-color) transparent;
+          scrollbar-width: none;
+          mask-image: linear-gradient(
+            90deg,
+            transparent 0%,
+            black 16px,
+            black calc(100% - 16px),
+            transparent 100%
+          );
+        }
+        .toolbar-badges.dragging {
+          pointer-events: none;
+        }
+        .toolbar-badges hui-view-badges {
+          width: 100%;
+          --badges-wrap: nowrap;
+          --badges-aligmnent: flex-start;
+          --badge-padding: var(--ha-space-4);
         }
         ha-tab-group {
           --ha-tab-indicator-color: var(

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -202,6 +202,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
         <hui-view-header
           .hass=${this.hass}
           .badges=${this.badges}
+          .narrow=${this.narrow}
           .lovelace=${this.lovelace}
           .viewIndex=${this.index}
           .config=${this._config?.header}

--- a/src/panels/lovelace/views/hui-view-header.ts
+++ b/src/panels/lovelace/views/hui-view-header.ts
@@ -305,8 +305,9 @@ export class HuiViewHeader extends LitElement {
     :host([floating-badges]) {
       position: sticky;
       top: calc(
-        var(--header-height, 56px) + var(--safe-area-inset-top, 0px) +
-          var(--ha-space-2)
+        var(--header-height, 56px) +
+          var(--safe-area-inset-top, 0px) - var(--row-gap, 0px) +
+          var(--ha-space-1)
       );
       z-index: 4;
     }

--- a/src/panels/lovelace/views/hui-view-header.ts
+++ b/src/panels/lovelace/views/hui-view-header.ts
@@ -23,15 +23,17 @@ import { showEditViewHeaderDialog } from "../editor/view-header/show-edit-view-h
 import type { Lovelace } from "../types";
 
 export const DEFAULT_VIEW_HEADER_LAYOUT = "center";
+export const VIEW_HEADER_LAYOUT_INTEGRATED = "integrated";
 export const DEFAULT_VIEW_HEADER_BADGES_POSITION = "bottom";
 export const DEFAULT_VIEW_HEADER_BADGES_WRAP = "wrap";
-export const DEFAULT_VIEW_HEADER_BADGES_FLOATING = false;
 
 @customElement("hui-view-header")
 export class HuiViewHeader extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public lovelace!: Lovelace;
+
+  @property({ type: Boolean }) public narrow = false;
 
   @property({ attribute: false }) public card?: HuiCard;
 
@@ -86,12 +88,6 @@ export class HuiViewHeader extends LitElement {
     if (changedProperties.has("config") || changedProperties.has("lovelace")) {
       this._dragScrollController.enabled =
         !this.lovelace.editMode && this.config?.badges_wrap === "scroll";
-
-      this.toggleAttribute(
-        "floating-badges",
-        !this.lovelace.editMode &&
-          (this.config?.badges_floating ?? DEFAULT_VIEW_HEADER_BADGES_FLOATING)
-      );
     }
 
     if (changedProperties.has("config")) {
@@ -210,8 +206,8 @@ export class HuiViewHeader extends LitElement {
     const badgesWrap =
       this.config?.badges_wrap ?? DEFAULT_VIEW_HEADER_BADGES_WRAP;
     const badgeDragging = this._dragScrollController.scrolling;
-    const badgesFloating =
-      this.config?.badges_floating ?? DEFAULT_VIEW_HEADER_BADGES_FLOATING;
+    const badgesInToolbar =
+      layout === VIEW_HEADER_LAYOUT_INTEGRATED && !editMode && !this.narrow;
 
     const hasHeading = card !== undefined;
     const hasBadges = this.badges.length > 0;
@@ -271,14 +267,15 @@ export class HuiViewHeader extends LitElement {
                 </div>
               `
             : nothing}
-          ${this.lovelace && (editMode || this.badges.length > 0)
+          ${this.lovelace &&
+          !badgesInToolbar &&
+          (editMode || this.badges.length > 0)
             ? html`
                 <div
                   class=${classMap({
                     badges: true,
                     [badgesPosition]: true,
                     [badgesWrap]: true,
-                    floating: badgesFloating,
                     dragging: badgeDragging,
                   })}
                 >
@@ -300,16 +297,6 @@ export class HuiViewHeader extends LitElement {
   static styles = css`
     :host([hidden]) {
       display: none !important;
-    }
-
-    :host([floating-badges]) {
-      position: sticky;
-      top: calc(
-        var(--header-height, 56px) +
-          var(--safe-area-inset-top, 0px) - var(--row-gap, 0px) +
-          var(--ha-space-1)
-      );
-      z-index: 4;
     }
 
     .container {

--- a/src/panels/lovelace/views/hui-view-header.ts
+++ b/src/panels/lovelace/views/hui-view-header.ts
@@ -25,6 +25,7 @@ import type { Lovelace } from "../types";
 export const DEFAULT_VIEW_HEADER_LAYOUT = "center";
 export const DEFAULT_VIEW_HEADER_BADGES_POSITION = "bottom";
 export const DEFAULT_VIEW_HEADER_BADGES_WRAP = "wrap";
+export const DEFAULT_VIEW_HEADER_BADGES_FLOATING = false;
 
 @customElement("hui-view-header")
 export class HuiViewHeader extends LitElement {
@@ -85,6 +86,12 @@ export class HuiViewHeader extends LitElement {
     if (changedProperties.has("config") || changedProperties.has("lovelace")) {
       this._dragScrollController.enabled =
         !this.lovelace.editMode && this.config?.badges_wrap === "scroll";
+
+      this.toggleAttribute(
+        "floating-badges",
+        !this.lovelace.editMode &&
+          (this.config?.badges_floating ?? DEFAULT_VIEW_HEADER_BADGES_FLOATING)
+      );
     }
 
     if (changedProperties.has("config")) {
@@ -202,9 +209,9 @@ export class HuiViewHeader extends LitElement {
       this.config?.badges_position ?? DEFAULT_VIEW_HEADER_BADGES_POSITION;
     const badgesWrap =
       this.config?.badges_wrap ?? DEFAULT_VIEW_HEADER_BADGES_WRAP;
-    const badgeDragging = this._dragScrollController.scrolling
-      ? "dragging"
-      : "";
+    const badgeDragging = this._dragScrollController.scrolling;
+    const badgesFloating =
+      this.config?.badges_floating ?? DEFAULT_VIEW_HEADER_BADGES_FLOATING;
 
     const hasHeading = card !== undefined;
     const hasBadges = this.badges.length > 0;
@@ -267,7 +274,13 @@ export class HuiViewHeader extends LitElement {
           ${this.lovelace && (editMode || this.badges.length > 0)
             ? html`
                 <div
-                  class="badges ${badgesPosition} ${badgesWrap} ${badgeDragging}"
+                  class=${classMap({
+                    badges: true,
+                    [badgesPosition]: true,
+                    [badgesWrap]: true,
+                    floating: badgesFloating,
+                    dragging: badgeDragging,
+                  })}
                 >
                   <hui-view-badges
                     .badges=${this.badges}
@@ -287,6 +300,15 @@ export class HuiViewHeader extends LitElement {
   static styles = css`
     :host([hidden]) {
       display: none !important;
+    }
+
+    :host([floating-badges]) {
+      position: sticky;
+      top: calc(
+        var(--header-height, 56px) + var(--safe-area-inset-top, 0px) +
+          var(--ha-space-2)
+      );
+      z-index: 4;
     }
 
     .container {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8695,7 +8695,9 @@
                 "start_description": "Always stacked",
                 "start_rtl": "Right aligned",
                 "center": "Centered",
-                "center_description": "Always stacked"
+                "center_description": "Always stacked",
+                "integrated": "Integrated into toolbar",
+                "integrated_description": "Badges are shown in the top app bar on desktop"
               },
               "badges_position": "Badges position",
               "badges_position_options": {
@@ -8707,8 +8709,7 @@
                 "wrap": "Wrap",
                 "scroll": "Scroll",
                 "scroll_description": "Touchscreen-friendly"
-              },
-              "badges_floating": "Floating badges"
+              }
             }
           },
           "edit_view_footer": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8707,7 +8707,8 @@
                 "wrap": "Wrap",
                 "scroll": "Scroll",
                 "scroll_description": "Touchscreen-friendly"
-              }
+              },
+              "badges_floating": "Floating badges"
             }
           },
           "edit_view_footer": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Initially wanted to add sticky (floating) support to badges (and probably header separately), this felt ok, but was kind of in the way, when we have a big empty space above that.

Then thought about using the toolbar to show the badges, this felt way better (after some tweaks) to use the empty space we have available. I think mobile needs considering here, most of my uses for badges are quick references like temperature, humidity, motion etc. and having these to hand when scrolling down dashboards is really nice.

A couple decisions I made were to disable the other 2 options, and force them set to scroll and top in the yaml, as they would be incompatible with this layout option.

If this is something we want, I have a couple TODO items below that are needed before going ahead

## TODO

- Currently re-using the responsive svg on the layout picker, need a new design for this
- Decide on mobile, should we integrate if there is room or not?

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
<details>
<summary>Original concept with floating badges, ended up dropping</summary>

https://github.com/user-attachments/assets/f520319c-2a96-4cf3-be3a-bdf71374b7bd

</details>

Integrated into toolbar:

https://github.com/user-attachments/assets/a90877c4-48c8-4e9e-9944-1601871afae1


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
