### PR TITLE
Adjust outlier detection algorithm when partial 5minute data exists

### DIFF
--- a/src/panels/config/developer-tools/statistics/dialog-statistics-adjust-sum.ts
+++ b/src/panels/config/developer-tools/statistics/dialog-statistics-adjust-sum.ts
@@ -449,10 +449,10 @@ export class DialogStatisticsFixUnsupportedUnitMetadata extends LitElement {
       }
     };
 
-    // If an hour has no five minute data, add the hour value
+    // If an hour has incomplete five minute data, add the hour value
     // Otherwise, add the 5 minute values and ignore the hour value
     combinedStatsData.forEach((c) => {
-      if (c.fiveMin.length === 0 && c.hour) {
+      if (c.fiveMin.length !== 12 && c.hour) {
         addOutlier(c.hour);
       } else {
         c.fiveMin.forEach((s) => {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Adjust outlier selection logic for hour vs 5minute. Previously we would hide the hour datapoint if there were any overlapping 5min datapoints. Now we show the hour unless we have _complete_ coverage of the hour with 5 minute data. Fixing the hour is more important anyway as that's the one that shows in the main energy dashboard, and the 5minute data is just temporary anyway. 

This fixes a hole where you could have a big spike in hourly readings, but it wouldn't be visible in the outlier detection because the 5 minute data only cover part of the hour, and the spike isn't present in the 5minute data. 

In theory this could maybe backfire around an edge case where you have incomplete data, and there's a spike in 5minute data not in the first 5minute data in the hour. Then we will only show the hourly point for correction. If you adjust that one, then we might get a blip in the five minute data where you have a big jump down in the first datapoint followed by a big jump back to zero in a subsequent datapoint in that hour, but I'm not sure if anyone really cares about outliers in 5minute data anyway. I don't think there's a perfect way to solve this for that case, though I think it might be inconsequential.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #30250
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
