### PR TITLE
Refactor weather forecast card to scroll

### DIFF
--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -16,7 +16,11 @@ import "../../../components/ha-card";
 import "../../../components/ha-svg-icon";
 import { UNAVAILABLE } from "../../../data/entity/entity";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
-import type { ForecastEvent, WeatherEntity } from "../../../data/weather";
+import type {
+  ForecastAttribute,
+  ForecastEvent,
+  WeatherEntity,
+} from "../../../data/weather";
 import {
   WEATHER_TEMPERATURE_ATTRIBUTES,
   getForecast,
@@ -273,6 +277,10 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
 
     const hourly = forecastData?.type === "hourly";
     const dayNight = forecastData?.type === "twice_daily";
+    const compactForecast = this._sizeController.value?.height === "short";
+    const showInlineDayLabel = compactForecast && (hourly || dayNight);
+    const showDayHeader = !compactForecast && (hourly || dayNight);
+    const todayKey = this._dayKeyFromDate(new Date());
 
     const weatherStateIcon = getWeatherStateIcon(stateObj.state, this);
     const name = this.hass.formatEntityName(stateObj, this._config.name);
@@ -411,92 +419,66 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
               <div
                 class=${classMap({
                   forecast: true,
+                  compact: compactForecast,
                   dragging: this._dragScrollController.scrolling,
                 })}
               >
-                ${forecast.map((item) =>
-                  this._showValue(item.templow) ||
-                  this._showValue(item.temperature)
-                    ? html`
-                        <div>
-                          <div>
-                            ${dayNight
-                              ? html`
-                                  ${formatDateWeekdayShort(
-                                    new Date(item.datetime),
-                                    this.hass!.locale,
-                                    this.hass!.config
-                                  )}
-                                  <div class="daynight">
-                                    ${item.is_daytime !== false
-                                      ? this.hass!.localize(
-                                          "ui.card.weather.day"
-                                        )
-                                      : this.hass!.localize(
-                                          "ui.card.weather.night"
-                                        )}<br />
-                                  </div>
-                                `
-                              : hourly
-                                ? html`
-                                    ${formatTime(
-                                      new Date(item.datetime),
-                                      this.hass!.locale,
-                                      this.hass!.config
-                                    )}
-                                  `
-                                : html`
-                                    ${formatDateWeekdayShort(
-                                      new Date(item.datetime),
-                                      this.hass!.locale,
-                                      this.hass!.config
-                                    )}
-                                  `}
-                          </div>
-                          ${this._showValue(item.condition)
-                            ? html`
-                                <div class="forecast-image-icon">
-                                  ${getWeatherStateIcon(
-                                    item.condition!,
-                                    this,
-                                    !(
-                                      item.is_daytime ||
-                                      item.is_daytime === undefined
-                                    )
-                                  )}
-                                </div>
-                              `
-                            : ""}
-                          <div class="temp">
-                            ${this._showValue(item.temperature)
-                              ? html`${formatNumber(
-                                  item.temperature,
-                                  this.hass!.locale,
-                                  {
-                                    maximumFractionDigits:
-                                      temperatureFractionDigits,
-                                  }
-                                )}°`
-                              : "—"}
-                          </div>
-                          <div class="templow">
-                            ${this._showValue(item.templow)
-                              ? html`${formatNumber(
-                                  item.templow!,
-                                  this.hass!.locale,
-                                  {
-                                    maximumFractionDigits:
-                                      temperatureFractionDigits,
-                                  }
-                                )}°`
-                              : hourly
-                                ? ""
-                                : "—"}
+                ${showDayHeader
+                  ? this._groupForecastByDay(forecast).map((dayForecast) => {
+                      const firstItem = dayForecast[0];
+                      const dayHeader = firstItem
+                        ? formatDateWeekdayShort(
+                            new Date(firstItem.datetime),
+                            this.hass!.locale,
+                            this.hass!.config
+                          )
+                        : undefined;
+                      const firstRenderableIndex = dayForecast.findIndex(
+                        (item) =>
+                          this._showValue(item.templow) ||
+                          this._showValue(item.temperature)
+                      );
+
+                      return html`
+                        <div class="forecast-day">
+                          <div class="forecast-day-content">
+                            ${dayForecast.map((item, index) =>
+                              this._renderForecastItem(
+                                item,
+                                hourly,
+                                dayNight,
+                                showDayHeader,
+                                temperatureFractionDigits,
+                                index === firstRenderableIndex
+                                  ? dayHeader
+                                  : undefined
+                              )
+                            )}
                           </div>
                         </div>
+                      `;
+                    })
+                  : forecast.map(
+                      (item, index) => html`
+                        ${showInlineDayLabel
+                          ? this._renderInlineDayGroupLabel(
+                              item,
+                              index,
+                              forecast,
+                              dayNight,
+                              hourly,
+                              todayKey
+                            )
+                          : nothing}
+                        ${this._renderForecastItem(
+                          item,
+                          hourly,
+                          dayNight,
+                          showDayHeader,
+                          temperatureFractionDigits
+                        )}
                       `
-                    : ""
-                )}
+                    )}
               </div>
             `
           : ""}
@@ -505,7 +487,156 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
   }
 
   private _handleAction(ev: ActionHandlerEvent) {
+    if (this._isForecastInteraction(ev)) {
+      return;
+    }
+
     handleAction(this, this.hass!, this._config!, ev.detail.action!);
+  }
+
+  private _isForecastInteraction(ev: Event): boolean {
+    return ev
+      .composedPath()
+      .some(
+        (node) =>
+          node instanceof HTMLElement && node.classList.contains("forecast")
+      );
+  }
+
+  private _groupForecastByDay(forecast: ForecastAttribute[]) {
+    const grouped = new Map<string, ForecastAttribute[]>();
+
+    forecast.forEach((item) => {
+      const date = new Date(item.datetime);
+      const dateKey = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+
+      if (!grouped.has(dateKey)) {
+        grouped.set(dateKey, []);
+      }
+
+      grouped.get(dateKey)!.push(item);
+    });
+
+    return Array.from(grouped.values());
+  }
+
+  private _renderInlineDayGroupLabel(
+    item: ForecastAttribute,
+    index: number,
+    forecast: ForecastAttribute[],
+    dayNight: boolean,
+    hourly: boolean,
+    todayKey: string
+  ) {
+    if (!dayNight && !hourly) {
+      return nothing;
+    }
+
+    const previousItem = forecast[index - 1];
+    const itemDayKey = this._dayKeyForForecast(item);
+    const dayChanged =
+      !previousItem || itemDayKey !== this._dayKeyForForecast(previousItem);
+
+    if (!dayChanged || itemDayKey === todayKey) {
+      return nothing;
+    }
+
+    return html`
+      <div class="forecast-item label-only">
+        <div class="forecast-item-label">
+          ${this._dayLabelForForecast(item)}
+        </div>
+      </div>
+    `;
+  }
+
+  private _renderForecastItem(
+    item: ForecastAttribute,
+    hourly: boolean,
+    dayNight: boolean,
+    showDayHeader: boolean,
+    temperatureFractionDigits: number | undefined,
+    dayHeader?: string
+  ) {
+    if (!this._showValue(item.templow) && !this._showValue(item.temperature)) {
+      return "";
+    }
+
+    return html`
+      <div class="forecast-item">
+        ${showDayHeader
+          ? html`
+              <div class="forecast-day-header-slot">
+                ${dayHeader
+                  ? html`<div class="forecast-day-header">${dayHeader}</div>`
+                  : nothing}
+              </div>
+            `
+          : nothing}
+        <div class="forecast-item-label ${showDayHeader ? "" : "no-header"}">
+          ${dayNight
+            ? html`<div class="daynight">
+                ${item.is_daytime !== false
+                  ? this.hass!.localize("ui.card.weather.day")
+                  : this.hass!.localize("ui.card.weather.night")}
+              </div>`
+            : hourly
+              ? formatTime(
+                  new Date(item.datetime),
+                  this.hass!.locale,
+                  this.hass!.config
+                )
+              : formatDateWeekdayShort(
+                  new Date(item.datetime),
+                  this.hass!.locale,
+                  this.hass!.config
+                )}
+        </div>
+        ${this._showValue(item.condition)
+          ? html`
+              <div class="forecast-image-icon">
+                ${getWeatherStateIcon(
+                  item.condition!,
+                  this,
+                  !(item.is_daytime || item.is_daytime === undefined)
+                )}
+              </div>
+            `
+          : ""}
+        <div class="temp">
+          ${this._showValue(item.temperature)
+            ? html`${formatNumber(item.temperature, this.hass!.locale, {
+                maximumFractionDigits: temperatureFractionDigits,
+              })}°`
+            : "—"}
+        </div>
+        <div class="templow">
+          ${this._showValue(item.templow)
+            ? html`${formatNumber(item.templow!, this.hass!.locale, {
+                maximumFractionDigits: temperatureFractionDigits,
+              })}°`
+            : hourly
+              ? ""
+              : "—"}
+        </div>
+      </div>
+    `;
+  }
+
+  private _dayLabelForForecast(item: ForecastAttribute) {
+    return formatDateWeekdayShort(
+      new Date(item.datetime),
+      this.hass!.locale,
+      this.hass!.config
+    );
+  }
+
+  private _dayKeyForForecast(item: ForecastAttribute) {
+    return this._dayKeyFromDate(new Date(item.datetime));
+  }
+
+  private _dayKeyFromDate(date: Date) {
+    return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
   }
 
   private _showValue(item?: any): boolean {
@@ -668,6 +799,10 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
           pointer-events: none;
         }
 
+        .forecast.compact {
+          --forecast-icon-size: 32px;
+        }
+
         .forecast::-webkit-scrollbar {
           display: none;
         }
@@ -676,6 +811,59 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
           text-align: center;
           min-width: 48px;
           flex: 0 0 auto;
+        }
+
+        .forecast-day {
+          display: flex;
+          flex-direction: column;
+          flex: 0 0 auto;
+        }
+
+        .forecast-day-header-slot {
+          min-height: calc(var(--ha-font-size-s) + var(--ha-space-1));
+        }
+
+        .forecast-day-header {
+          color: var(--secondary-text-color);
+          font-size: var(--ha-font-size-s);
+          font-weight: var(--ha-font-weight-bold);
+          line-height: 1;
+          white-space: nowrap;
+          padding-bottom: var(--ha-space-1);
+        }
+
+        .forecast-day-content {
+          display: flex;
+        }
+
+        .forecast-item {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+          min-width: 48px;
+          padding: 0 8px;
+          flex: 0 0 auto;
+          gap: var(--ha-space-1);
+        }
+
+        .forecast-item.label-only {
+          justify-content: flex-start;
+        }
+
+        .forecast-item.label-only .forecast-item-label {
+          font-weight: var(--ha-font-weight-bold);
+        }
+
+        .forecast-item-label,
+        .forecast .temp {
+          line-height: 1;
+          white-space: nowrap;
+        }
+
+        .forecast-item-label {
+          color: var(--secondary-text-color);
+          font-size: var(--ha-font-size-s);
         }
 
         .forecast .icon,
@@ -695,9 +883,9 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
         }
 
         .forecast-image-icon > * {
-          width: 40px;
-          height: 40px;
-          --mdc-icon-size: 40px;
+          width: var(--forecast-icon-size, 40px);
+          height: var(--forecast-icon-size, 40px);
+          --mdc-icon-size: var(--forecast-icon-size, 40px);
         }
 
         .forecast-icon {

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -559,7 +559,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
     dayHeader?: string
   ) {
     if (!this._showValue(item.templow) && !this._showValue(item.temperature)) {
-      return "";
+      return nothing;
     }
 
     return html`
@@ -602,7 +602,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                 )}
               </div>
             `
-          : ""}
+          : nothing}
         <div class="temp">
           ${this._showValue(item.temperature)
             ? html`${formatNumber(item.temperature, this.hass!.locale, {
@@ -616,7 +616,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                 maximumFractionDigits: temperatureFractionDigits,
               })}°`
             : hourly
-              ? ""
+              ? nothing
               : "—"}
         </div>
       </div>

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -92,7 +92,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
       };
 
       const width = entries[0]?.contentRect.width;
-      if (width < 245) {
+      if (width < 180) {
         result.width = "very-very-narrow";
       } else if (width < 300) {
         result.width = "very-narrow";
@@ -644,13 +644,16 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
   }
 
   public getGridOptions(): LovelaceGridOptions {
+    const showCurrent = this._config?.show_current !== false;
+    const showForecast = this._config?.show_forecast !== false;
+
     let rows = 1;
     let min_rows = 1;
-    if (this._config?.show_current !== false) {
+    if (showCurrent) {
       rows += 1;
       min_rows += 1;
     }
-    if (this._config?.show_forecast !== false) {
+    if (showForecast) {
       rows += 1;
       min_rows += 1;
       if (this._config?.forecast_type === "daily") {
@@ -661,7 +664,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
     return {
       columns: 12,
       rows: rows,
-      min_columns: 6,
+      min_columns: showCurrent && showForecast ? 5 : 4,
       min_rows: min_rows,
     };
   }

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -7,6 +7,7 @@ import { ifDefined } from "lit/directives/if-defined";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { formatDateWeekdayShort } from "../../../common/datetime/format_date";
 import { formatTime } from "../../../common/datetime/format_time";
+import { DragScrollController } from "../../../common/controllers/drag-scroll-controller";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
 import { formatNumber } from "../../../common/number/format_number";
@@ -73,6 +74,11 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
   @state() private _forecastEvent?: ForecastEvent;
 
   @state() private _subscribed?: Promise<() => void>;
+
+  private _dragScrollController = new DragScrollController(this, {
+    selector: ".forecast",
+    enabled: false,
+  });
 
   private _sizeController = new ResizeController(this, {
     callback: (entries) => {
@@ -209,6 +215,21 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
     ) {
       applyThemesOnElement(this, this.hass.themes, this._config.theme);
     }
+
+    const stateObj = this.hass.states[this._config.entity] as
+      | WeatherEntity
+      | undefined;
+
+    this._dragScrollController.enabled = Boolean(
+      stateObj &&
+      stateObj.state !== UNAVAILABLE &&
+      this._config.show_forecast !== false &&
+      getForecast(
+        stateObj.attributes,
+        this._forecastEvent,
+        this._config.forecast_type
+      )?.forecast?.length
+    );
   }
 
   protected render() {
@@ -242,14 +263,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
       this._config?.forecast_type
     );
 
-    let itemsToShow = this._config?.forecast_slots ?? 5;
-    if (this._sizeController.value?.width === "very-very-narrow") {
-      itemsToShow = Math.min(3, itemsToShow);
-    } else if (this._sizeController.value?.width === "very-narrow") {
-      itemsToShow = Math.min(5, itemsToShow);
-    } else if (this._sizeController.value?.width === "narrow") {
-      itemsToShow = Math.min(7, itemsToShow);
-    }
+    const itemsToShow = this._config?.forecast_slots ?? 5;
 
     const forecast =
       this._config?.show_forecast !== false && forecastData?.forecast?.length
@@ -394,7 +408,12 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
           : ""}
         ${forecast
           ? html`
-              <div class="forecast">
+              <div
+                class=${classMap({
+                  forecast: true,
+                  dragging: this._dragScrollController.scrolling,
+                })}
+              >
                 ${forecast.map((item) =>
                   this._showValue(item.templow) ||
                   this._showValue(item.temperature)
@@ -625,10 +644,38 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
           display: flex;
           justify-content: space-around;
           padding: 0 16px;
+          max-width: 100%;
+          overflow-x: auto;
+          overflow-y: hidden;
+          scrollbar-color: var(--scrollbar-thumb-color) transparent;
+          scrollbar-width: none;
+          mask-image: linear-gradient(
+            90deg,
+            transparent 0%,
+            black 16px,
+            black calc(100% - 16px),
+            transparent 100%
+          );
+          user-select: none;
+          cursor: grab;
+        }
+
+        .forecast.dragging {
+          cursor: grabbing;
+        }
+
+        .forecast.dragging * {
+          pointer-events: none;
+        }
+
+        .forecast::-webkit-scrollbar {
+          display: none;
         }
 
         .forecast > div {
           text-align: center;
+          min-width: 48px;
+          flex: 0 0 auto;
         }
 
         .forecast .icon,

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -252,7 +252,7 @@ export class HuiWeatherForecastCardEditor
               },
               {
                 name: "forecast_slots",
-                selector: { number: { min: 1, max: 12 } },
+                selector: { number: { min: 1, max: 72 } },
                 default: 5,
               },
               {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Reuses more info and badges UX to make weather forecast card scroll, instead of removing items dynamically, which has been found to be flaky and tended to overflow instead.

Similar to more info with a draggable area and fixed widths instead of squashing everything as much as possible.

One thing to note, now scrolling is used, the clickable area only works on the rest of the card, not while scrolling to avoid opening more info when not wanted.

Reuses code from closed card feature branch which introduced and tweaked sizing based on available area.

Day headings also added similar to more info forecast. When there is not enough vertical space, moves the added headings to a new column instead. Uses a bold font with secondary color to differentiate but not be too prominent from the other labels.

Increased slider option to max 72 (for 72 hours or items). There's no technical limit to forecasts and you can go further in the input or yaml. With scrolling it makes sense to increase this selector visual

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

### Before

<img width="1796" height="1153" alt="image" src="https://github.com/user-attachments/assets/32296942-bdcf-41c7-b152-0ea0ead6a8bf" />

### After

<img width="1788" height="1140" alt="image" src="https://github.com/user-attachments/assets/284ac2b6-fae9-44eb-931a-98bda869fb52" />

Testing tweaked layout options:

https://github.com/user-attachments/assets/9c5712aa-ccb7-474d-a874-7825373fc705


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #51577
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
