### PR TITLE
Fix gauge segmentLabels, cleanup sorting

### DIFF
--- a/src/components/ha-gauge.ts
+++ b/src/components/ha-gauge.ts
@@ -46,6 +46,8 @@ export class HaGauge extends LitElement {
 
   @state() private _segment_label?: string = "";
 
+  private _sortedLevels?: LevelDefinition[];
+
   protected firstUpdated(changedProperties: PropertyValues) {
     super.firstUpdated(changedProperties);
     afterNextRender(() => {
@@ -56,6 +58,26 @@ export class HaGauge extends LitElement {
       this._segment_label = this._getSegmentLabel();
       this._rescaleSvg();
     });
+  }
+
+  protected willUpdate(changedProperties: PropertyValues) {
+    if (changedProperties.has("levels") || changedProperties.has("min")) {
+      if (this.levels) {
+        this._sortedLevels = [...this.levels].sort((a, b) => a.level - b.level);
+
+        if (
+          this._sortedLevels.length > 0 &&
+          this._sortedLevels[0].level !== this.min
+        ) {
+          this._sortedLevels.unshift({
+            level: this.min,
+            stroke: "var(--info-color)",
+          });
+        }
+      } else {
+        this._sortedLevels = undefined;
+      }
+    }
   }
 
   protected updated(changedProperties: PropertyValues) {
@@ -90,81 +112,56 @@ export class HaGauge extends LitElement {
         />
 
 
-        ${
-          this.levels
-            ? (() => {
-                const sortedLevels = [...this.levels].sort(
-                  (a, b) => a.level - b.level
-                );
+        ${this._sortedLevels?.map((level, i, arr) => {
+          const startLevel = level.level;
+          const endLevel = i + 1 < arr.length ? arr[i + 1].level : this.max;
 
-                if (
-                  sortedLevels.length > 0 &&
-                  sortedLevels[0].level !== this.min
-                ) {
-                  sortedLevels.unshift({
-                    level: this.min,
-                    stroke: "var(--info-color)",
-                  });
-                }
+          const startAngle = getAngle(startLevel, this.min, this.max);
+          const endAngle = getAngle(endLevel, this.min, this.max);
+          const largeArc = endAngle - startAngle > 180 ? 1 : 0;
 
-                return sortedLevels.map((level, i, arr) => {
-                  const startLevel = level.level;
-                  const endLevel =
-                    i + 1 < arr.length ? arr[i + 1].level : this.max;
+          const x1 = -arcRadius * Math.cos((startAngle * Math.PI) / 180);
+          const y1 = -arcRadius * Math.sin((startAngle * Math.PI) / 180);
+          const x2 = -arcRadius * Math.cos((endAngle * Math.PI) / 180);
+          const y2 = -arcRadius * Math.sin((endAngle * Math.PI) / 180);
 
-                  const startAngle = getAngle(startLevel, this.min, this.max);
-                  const endAngle = getAngle(endLevel, this.min, this.max);
-                  const largeArc = endAngle - startAngle > 180 ? 1 : 0;
+          const isFirst = i === 0;
+          const isLast = i === arr.length - 1;
 
-                  const x1 =
-                    -arcRadius * Math.cos((startAngle * Math.PI) / 180);
-                  const y1 =
-                    -arcRadius * Math.sin((startAngle * Math.PI) / 180);
-                  const x2 = -arcRadius * Math.cos((endAngle * Math.PI) / 180);
-                  const y2 = -arcRadius * Math.sin((endAngle * Math.PI) / 180);
+          if (isFirst) {
+            return svg`
+              <path
+                class="level"
+                stroke="${level.stroke}"
+                style="stroke-linecap: butt"
+                d="M ${x1} ${y1} A ${arcRadius} ${arcRadius} 0 ${largeArc} 1 ${x2} ${y2}"
+              />
+            `;
+          }
 
-                  const isFirst = i === 0;
-                  const isLast = i === arr.length - 1;
+          if (isLast) {
+            const offsetAngle = 0.5;
+            const midAngle = endAngle - offsetAngle;
+            const xm = -arcRadius * Math.cos((midAngle * Math.PI) / 180);
+            const ym = -arcRadius * Math.sin((midAngle * Math.PI) / 180);
 
-                  if (isFirst) {
-                    return svg`
-                      <path
-                        class="level"
-                        stroke="${level.stroke}"
-                        style="stroke-linecap: butt"
-                        d="M ${x1} ${y1} A ${arcRadius} ${arcRadius} 0 ${largeArc} 1 ${x2} ${y2}"
-                      />
-                    `;
-                  }
+            return svg`
+                <path class="level" stroke="${level.stroke}" style="stroke-linecap: butt"
+                      d="M ${x1} ${y1} A ${arcRadius} ${arcRadius} 0 ${largeArc} 1 ${xm} ${ym}" />
+                <path class="level" stroke="${level.stroke}" style="stroke-linecap: butt"
+                      d="M ${xm} ${ym} A ${arcRadius} ${arcRadius} 0 0 1 ${x2} ${y2}" />
+            `;
+          }
 
-                  if (isLast) {
-                    const offsetAngle = 0.5;
-                    const midAngle = endAngle - offsetAngle;
-                    const xm =
-                      -arcRadius * Math.cos((midAngle * Math.PI) / 180);
-                    const ym =
-                      -arcRadius * Math.sin((midAngle * Math.PI) / 180);
-
-                    return svg`
-                        <path class="level" stroke="${level.stroke}" style="stroke-linecap: butt"
-                              d="M ${x1} ${y1} A ${arcRadius} ${arcRadius} 0 ${largeArc} 1 ${xm} ${ym}" />
-                        <path class="level" stroke="${level.stroke}" style="stroke-linecap: butt"
-                              d="M ${xm} ${ym} A ${arcRadius} ${arcRadius} 0 0 1 ${x2} ${y2}" />
-                    `;
-                  }
-
-                  return svg`
-                    <path
-                      class="level"
-                      stroke="${level.stroke}"
-                      style="stroke-linecap: butt"
-                      d="M ${x1} ${y1} A ${arcRadius} ${arcRadius} 0 ${largeArc} 1 ${x2} ${y2}"
-                    ></path>
-                  `;
-                });
-              })()
-            : ""
-        }
+          return svg`
+            <path
+              class="level"
+              stroke="${level.stroke}"
+              style="stroke-linecap: butt"
+              d="M ${x1} ${y1} A ${arcRadius} ${arcRadius} 0 ${largeArc} 1 ${x2} ${y2}"
+            ></path>
+          `;
+        })}
 
         ${
           this.needle
@@ -224,11 +221,10 @@ export class HaGauge extends LitElement {
   }
 
   private _getSegmentLabel() {
-    if (this.levels) {
-      [...this.levels].sort((a, b) => a.level - b.level);
-      for (let i = this.levels.length - 1; i >= 0; i--) {
-        if (this.value >= this.levels[i].level) {
-          return this.levels[i].label;
+    if (this._sortedLevels) {
+      for (let i = this._sortedLevels.length - 1; i >= 0; i--) {
+        if (this.value >= this._sortedLevels[i].level) {
+          return this._sortedLevels[i].label;
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
I started this PR simply to fix this bug in segment label generation. We were sorting a copy of levels and then throwing away the sort, meaning that if the lavels are unsorted the wrong segment label was applied because we weren't actually iterating the sorted copy:

```javascript
  private _getSegmentLabel() {
    if (this.levels) {
      [...this.levels].sort((a, b) => a.level - b.level);  //<--- useless sort
      for (let i = this.levels.length - 1; i >= 0; i--) {
```

Then I got to looking at it a little more and notice that we are sorting this.levels 2 times for each render, which is unnecessary, since it only needs to be sorted once when the levels property changes. So I pulled out the sorting into willUpdate and that allowed to clean up a lot of complexity in the render function. So this raw diff looks like a lot more destructive than it really is.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
