### PR TITLE
Resolve add-on name and icon for shortcut card /app/ navigation

### DIFF
--- a/src/data/compute-navigation-path-info.ts
+++ b/src/data/compute-navigation-path-info.ts
@@ -1,10 +1,13 @@
 import { mdiDevices, mdiLink, mdiTextureBox } from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
+import { isComponentLoaded } from "../common/config/is_component_loaded";
 import { computeDeviceName } from "../common/entity/compute_device_name";
+import { getAddonPanelInfoCollection } from "./hassio/addon";
 import { getLovelaceCollection } from "./lovelace";
 import type { LovelaceRawConfig } from "./lovelace/config/types";
 import { computeViewIcon, computeViewTitle } from "./lovelace/config/view";
 import {
+  APP_PANEL,
   getPanelIcon,
   getPanelIconPath,
   getPanelTitleFromUrlPath,
@@ -142,6 +145,26 @@ export const subscribeNavigationPathInfo = (
       if (newInfo.label !== current.label || newInfo.icon !== current.icon) {
         current = newInfo;
         onChange(newInfo);
+      }
+    });
+  }
+
+  // /app/{addonSlug}
+  if (
+    panelUrlPath === APP_PANEL &&
+    segments[1] &&
+    isComponentLoaded(hass.config, "hassio")
+  ) {
+    const addonSlug = segments[1];
+    const collection = getAddonPanelInfoCollection(hass.connection);
+    return collection.subscribe((addonMap) => {
+      const addon = addonMap[addonSlug];
+      if (addon) {
+        onChange({
+          label: addon.title,
+          icon: addon.icon,
+          iconPath: info.iconPath,
+        });
       }
     });
   }

--- a/src/data/compute-navigation-path-info.ts
+++ b/src/data/compute-navigation-path-info.ts
@@ -2,7 +2,7 @@ import { mdiDevices, mdiLink, mdiTextureBox } from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { isComponentLoaded } from "../common/config/is_component_loaded";
 import { computeDeviceName } from "../common/entity/compute_device_name";
-import { getAddonPanelInfoCollection } from "./hassio/addon";
+import { getIngressPanelInfoCollection } from "./hassio/ingress";
 import { getLovelaceCollection } from "./lovelace";
 import type { LovelaceRawConfig } from "./lovelace/config/types";
 import { computeViewIcon, computeViewTitle } from "./lovelace/config/view";
@@ -156,7 +156,7 @@ export const subscribeNavigationPathInfo = (
     isComponentLoaded(hass.config, "hassio")
   ) {
     const addonSlug = segments[1];
-    const collection = getAddonPanelInfoCollection(hass.connection);
+    const collection = getIngressPanelInfoCollection(hass.connection);
     return collection.subscribe((addonMap) => {
       const addon = addonMap[addonSlug];
       if (addon) {

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -1,14 +1,9 @@
-import { getCollection, type Connection } from "home-assistant-js-websocket";
 import { atLeastVersion } from "../../common/config/version";
 import type { HaFormSchema } from "../../components/ha-form/types";
 import type { HomeAssistant, TranslationDict } from "../../types";
 import { supervisorApiCall } from "../supervisor/common";
 import type { StoreAddonDetails } from "../supervisor/store";
-import {
-  supervisorApiWsRequest,
-  type Supervisor,
-  type SupervisorArch,
-} from "../supervisor/supervisor";
+import type { Supervisor, SupervisorArch } from "../supervisor/supervisor";
 import type { HassioResponse } from "./common";
 import { extractApiErrorMessage, hassioApiResultExtractor } from "./common";
 
@@ -410,32 +405,6 @@ export const fetchAddonInfo = (
       ? `/store/addons/${addonSlug}` // Use /store/addons when app is not installed
       : `/addons/${addonSlug}/info` // Use /addons when app is installed
   );
-
-export interface AddonPanelInfo {
-  title: string;
-  icon: string;
-}
-
-type AddonPanelInfoMap = Record<string, AddonPanelInfo>;
-
-interface IngressPanelsResponse {
-  panels: Record<string, { title: string; icon: string }>;
-}
-
-export const getAddonPanelInfoCollection = (conn: Connection) =>
-  getCollection<AddonPanelInfoMap>(conn, "_addonPanelInfo", async (conn2) => {
-    const result = await supervisorApiWsRequest<IngressPanelsResponse>(conn2, {
-      endpoint: "/ingress/panels",
-    });
-    const map: AddonPanelInfoMap = {};
-    for (const [slug, panel] of Object.entries(result.panels)) {
-      map[slug] = {
-        title: panel.title,
-        icon: panel.icon,
-      };
-    }
-    return map;
-  });
 
 export const rebuildLocalAddon = async (
   hass: HomeAssistant,

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -1,9 +1,14 @@
+import { getCollection, type Connection } from "home-assistant-js-websocket";
 import { atLeastVersion } from "../../common/config/version";
 import type { HaFormSchema } from "../../components/ha-form/types";
 import type { HomeAssistant, TranslationDict } from "../../types";
 import { supervisorApiCall } from "../supervisor/common";
 import type { StoreAddonDetails } from "../supervisor/store";
-import type { Supervisor, SupervisorArch } from "../supervisor/supervisor";
+import {
+  supervisorApiWsRequest,
+  type Supervisor,
+  type SupervisorArch,
+} from "../supervisor/supervisor";
 import type { HassioResponse } from "./common";
 import { extractApiErrorMessage, hassioApiResultExtractor } from "./common";
 
@@ -405,6 +410,32 @@ export const fetchAddonInfo = (
       ? `/store/addons/${addonSlug}` // Use /store/addons when app is not installed
       : `/addons/${addonSlug}/info` // Use /addons when app is installed
   );
+
+export interface AddonPanelInfo {
+  title: string;
+  icon: string;
+}
+
+type AddonPanelInfoMap = Record<string, AddonPanelInfo>;
+
+interface IngressPanelsResponse {
+  panels: Record<string, { title: string; icon: string }>;
+}
+
+export const getAddonPanelInfoCollection = (conn: Connection) =>
+  getCollection<AddonPanelInfoMap>(conn, "_addonPanelInfo", async (conn2) => {
+    const result = await supervisorApiWsRequest<IngressPanelsResponse>(conn2, {
+      endpoint: "/ingress/panels",
+    });
+    const map: AddonPanelInfoMap = {};
+    for (const [slug, panel] of Object.entries(result.panels)) {
+      map[slug] = {
+        title: panel.title,
+        icon: panel.icon,
+      };
+    }
+    return map;
+  });
 
 export const rebuildLocalAddon = async (
   hass: HomeAssistant,

--- a/src/data/hassio/ingress.ts
+++ b/src/data/hassio/ingress.ts
@@ -1,5 +1,7 @@
+import { getCollection, type Connection } from "home-assistant-js-websocket";
 import { atLeastVersion } from "../../common/config/version";
 import type { HomeAssistant } from "../../types";
+import { supervisorApiWsRequest } from "../supervisor/supervisor";
 import type { HassioResponse } from "./common";
 import type { CreateSessionResponse } from "./supervisor";
 
@@ -27,6 +29,25 @@ export const createHassioSession = async (
   >("POST", "hassio/ingress/session");
   return setIngressCookie(restResponse.data.session);
 };
+
+export interface IngressPanelInfo {
+  title: string;
+  icon: string;
+}
+
+type IngressPanelInfoMap = Record<string, IngressPanelInfo>;
+
+export const getIngressPanelInfoCollection = (conn: Connection) =>
+  getCollection<IngressPanelInfoMap>(
+    conn,
+    "_ingressPanelInfo",
+    async (conn2) => {
+      const result = await supervisorApiWsRequest<{
+        panels: IngressPanelInfoMap;
+      }>(conn2, { endpoint: "/ingress/panels" });
+      return result.panels;
+    }
+  );
 
 export const validateHassioSession = async (
   hass: HomeAssistant,


### PR DESCRIPTION
## Breaking change

N/A

## Proposed change

When a shortcut card or badge has a navigate action pointing to an add-on path like `/app/d5369777_music_assistant_nightly`, it currently shows the generic "app" panel info with no meaningful name or icon.

This change fetches the add-on's panel info (title and icon) from the supervisor's `/ingress/panels` endpoint and displays it on the shortcut card/badge. The data is cached per connection using `getCollection` so it's only fetched once.

## Screenshot

<img width="1606" height="562" alt="CleanShot 2026-04-15 at 15 32 02@2x" src="https://github.com/user-attachments/assets/bb7759ef-416e-4ceb-9a29-61bba9275591" />


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr