### PR TITLE
Support suggested name and icon for dashboards, add to map

### DIFF
--- a/src/data/lovelace/config/strategy.ts
+++ b/src/data/lovelace/config/strategy.ts
@@ -2,3 +2,21 @@ export interface LovelaceStrategyConfig {
   type: string;
   [key: string]: any;
 }
+
+/** Must stay aligned with `STRATEGIES.dashboard` in `panels/lovelace/strategies/get-strategy.ts`. */
+export const LOVELACE_BUILTIN_DASHBOARD_STRATEGY_TYPES = [
+  "original-states",
+  "map",
+  "iframe",
+  "areas",
+  "home",
+  "energy",
+] as const;
+
+export type LovelaceBuiltinDashboardStrategyType =
+  (typeof LOVELACE_BUILTIN_DASHBOARD_STRATEGY_TYPES)[number];
+
+/** Dashboard strategy id from the new-dashboard picker: built-in key or `custom:…`. */
+export type LovelaceDashboardStrategyTypeId =
+  | LovelaceBuiltinDashboardStrategyType
+  | `custom:${string}`;

--- a/src/data/lovelace/dashboard.ts
+++ b/src/data/lovelace/dashboard.ts
@@ -34,8 +34,8 @@ export interface LovelaceDashboardCreateParams extends LovelaceDashboardMutableP
   mode: "storage";
 }
 
-/** Optional suggested values for dashboard create form fields (for example from a strategy). */
-export interface LovelaceDashboardFieldSuggestions {
+/** Optional suggested values for dashboard creation (for example from a strategy). */
+export interface LovelaceDashboardSuggestions {
   title?: string;
   icon?: string;
 }

--- a/src/data/lovelace/dashboard.ts
+++ b/src/data/lovelace/dashboard.ts
@@ -34,6 +34,12 @@ export interface LovelaceDashboardCreateParams extends LovelaceDashboardMutableP
   mode: "storage";
 }
 
+/** Optional suggested values for dashboard create form fields (for example from a strategy). */
+export interface LovelaceDashboardFieldSuggestions {
+  title?: string;
+  icon?: string;
+}
+
 export const fetchDashboards = (
   hass: HomeAssistant
 ): Promise<LovelaceDashboard[]> =>

--- a/src/panels/config/dashboard/dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/dialog-new-dashboard.ts
@@ -19,6 +19,7 @@ import {
   type CustomStrategyEntry,
 } from "../../../data/lovelace_custom_strategies";
 import { fetchResources } from "../../../data/lovelace/resource";
+import type { LovelaceDashboardStrategyTypeId } from "../../../data/lovelace/config/strategy";
 import type {
   LovelaceConfig,
   LovelaceDashboardStrategyConfig,
@@ -345,13 +346,15 @@ class DialogNewDashboard extends LitElement implements HassDialog {
       return;
     }
 
+    let strategyType: LovelaceDashboardStrategyTypeId | undefined;
     if (target.config) {
       config = target.config;
     } else if (target.strategy) {
+      strategyType = target.strategy as LovelaceDashboardStrategyTypeId;
       config = this._generateStrategyConfig(target.strategy);
     }
 
-    await this._params?.selectConfig(config);
+    await this._params?.selectConfig({ config, strategyType });
     this.closeDialog();
   }
 

--- a/src/panels/config/dashboard/show-dialog-new-dashboard.ts
+++ b/src/panels/config/dashboard/show-dialog-new-dashboard.ts
@@ -1,8 +1,16 @@
 import { fireEvent } from "../../../common/dom/fire_event";
+import type { LovelaceDashboardStrategyTypeId } from "../../../data/lovelace/config/strategy";
 import type { LovelaceRawConfig } from "../../../data/lovelace/config/types";
 
+/** Payload when the user picks a dashboard template in the new-dashboard dialog. */
+export interface NewDashboardSelection {
+  config: LovelaceRawConfig | undefined;
+  /** Strategy id when the user chose a strategy (built-in or custom); omitted for an empty dashboard. */
+  strategyType?: LovelaceDashboardStrategyTypeId;
+}
+
 export interface NewDashboardDialogParams {
-  selectConfig: (config: LovelaceRawConfig | undefined) => void | Promise<void>;
+  selectConfig: (selection: NewDashboardSelection) => void | Promise<void>;
 }
 
 export const loadNewDashboardDialog = () => import("./dialog-new-dashboard");

--- a/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
@@ -43,7 +43,7 @@ export class DialogLovelaceDashboardDetail extends LitElement {
     if (this._params.dashboard) {
       this._data = this._params.dashboard;
     } else {
-      const suggestions = this._params.fieldSuggestions;
+      const suggestions = this._params.suggestions;
       this._data = {
         show_in_sidebar: true,
         icon: suggestions?.icon,

--- a/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
@@ -17,6 +17,7 @@ import type {
 import { haStyleDialog } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import type { LovelaceDashboardDetailsDialogParams } from "./show-dialog-lovelace-dashboard-detail";
+import { pickAvailableDashboardUrlPath } from "./pick-available-dashboard-url-path";
 
 @customElement("dialog-lovelace-dashboard-detail")
 export class DialogLovelaceDashboardDetail extends LitElement {
@@ -259,11 +260,17 @@ export class DialogLovelaceDashboardDetail extends LitElement {
     }
 
     const slugifyTitle = slugify(title, "-");
+    const baseSlug = slugifyTitle.includes("-")
+      ? slugifyTitle
+      : `dashboard-${slugifyTitle}`;
+    const taken = this._params?.takenUrlPaths;
+    const url_path =
+      taken !== undefined
+        ? pickAvailableDashboardUrlPath(baseSlug, taken)
+        : baseSlug;
     this._data = {
       ...this._data,
-      url_path: slugifyTitle.includes("-")
-        ? slugifyTitle
-        : `dashboard-${slugifyTitle}`,
+      url_path,
     };
   }
 

--- a/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
@@ -42,13 +42,17 @@ export class DialogLovelaceDashboardDetail extends LitElement {
     if (this._params.dashboard) {
       this._data = this._params.dashboard;
     } else {
+      const suggestions = this._params.fieldSuggestions;
       this._data = {
         show_in_sidebar: true,
-        icon: undefined,
-        title: "",
+        icon: suggestions?.icon,
+        title: suggestions?.title ?? "",
         require_admin: false,
         mode: "storage",
       };
+      if (suggestions?.title) {
+        this._fillUrlPath(suggestions.title);
+      }
     }
   }
 

--- a/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
@@ -264,13 +264,12 @@ export class DialogLovelaceDashboardDetail extends LitElement {
       ? slugifyTitle
       : `dashboard-${slugifyTitle}`;
     const taken = this._params?.takenUrlPaths;
-    const url_path =
-      taken !== undefined
-        ? pickAvailableDashboardUrlPath(baseSlug, taken)
-        : baseSlug;
     this._data = {
       ...this._data,
-      url_path,
+      url_path:
+        taken !== undefined
+          ? pickAvailableDashboardUrlPath(baseSlug, taken)
+          : baseSlug,
     };
   }
 

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -39,7 +39,7 @@ import { fetchResources } from "../../../../data/lovelace/resource";
 import type {
   LovelaceDashboard,
   LovelaceDashboardCreateParams,
-  LovelaceDashboardFieldSuggestions,
+  LovelaceDashboardSuggestions,
 } from "../../../../data/lovelace/dashboard";
 import {
   createDashboard,
@@ -568,7 +568,7 @@ export class HaConfigLovelaceDashboards extends LitElement {
   private async _addDashboard() {
     showNewDashboardDialog(this, {
       selectConfig: async ({ config }: NewDashboardSelection) => {
-        let fieldSuggestions: LovelaceDashboardFieldSuggestions | undefined;
+        let fieldSuggestions: LovelaceDashboardSuggestions | undefined;
 
         if (config && isStrategyDashboard(config)) {
           const { strategyClass, fieldSuggestions: suggested } =
@@ -608,7 +608,7 @@ export class HaConfigLovelaceDashboards extends LitElement {
     dashboard?: LovelaceDashboard,
     urlPath?: string,
     defaultConfig?: LovelaceRawConfig,
-    fieldSuggestions?: LovelaceDashboardFieldSuggestions
+    fieldSuggestions?: LovelaceDashboardSuggestions
   ): Promise<void> {
     const defaultPanel = this.hass.systemData?.default_panel || DEFAULT_PANEL;
     showDashboardDetailDialog(this, {

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -62,7 +62,7 @@ import "../../../../layouts/hass-loading-screen";
 import "../../../../layouts/hass-tabs-subpage-data-table";
 import type { HomeAssistant, Route } from "../../../../types";
 import { loadLovelaceResources } from "../../../lovelace/common/load-resources";
-import { getLovelaceStrategy } from "../../../lovelace/strategies/get-strategy";
+import { loadDashboardStrategyWithCreateSuggestions } from "../../../lovelace/strategies/get-strategy";
 import type { NewDashboardSelection } from "../../dashboard/show-dialog-new-dashboard";
 import { showNewDashboardDialog } from "../../dashboard/show-dialog-new-dashboard";
 import { lovelaceTabs } from "../ha-config-lovelace";
@@ -568,24 +568,30 @@ export class HaConfigLovelaceDashboards extends LitElement {
   private async _addDashboard() {
     showNewDashboardDialog(this, {
       selectConfig: async ({ config }: NewDashboardSelection) => {
-        const fieldSuggestions: LovelaceDashboardFieldSuggestions | undefined =
-          undefined;
+        let fieldSuggestions: LovelaceDashboardFieldSuggestions | undefined;
+
         if (config && isStrategyDashboard(config)) {
-          const strategyType = config.strategy.type;
-          const strategyClass = await getLovelaceStrategy(
-            "dashboard",
-            strategyType
-          );
+          const { strategyClass, fieldSuggestions: suggested } =
+            await loadDashboardStrategyWithCreateSuggestions(
+              this.hass,
+              config.strategy.type
+            );
+          fieldSuggestions = suggested;
 
           if (strategyClass.configRequired) {
             showDashboardConfigureStrategyDialog(this, {
               config: config,
               saveConfig: async (updatedConfig) => {
+                const { fieldSuggestions: afterConfigure } =
+                  await loadDashboardStrategyWithCreateSuggestions(
+                    this.hass,
+                    updatedConfig.strategy.type
+                  );
                 this._openDetailDialog(
                   undefined,
                   undefined,
                   updatedConfig,
-                  fieldSuggestions
+                  afterConfigure
                 );
               },
             });

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -616,6 +616,9 @@ export class HaConfigLovelaceDashboards extends LitElement {
       urlPath,
       isDefault: dashboard?.url_path === defaultPanel,
       fieldSuggestions,
+      takenUrlPaths: dashboard
+        ? undefined
+        : this._collectTakenDashboardUrlPaths(),
       createDashboard: async (values: LovelaceDashboardCreateParams) => {
         const created = await createDashboard(this.hass!, values);
         this._dashboards = this._dashboards!.concat(created).sort(
@@ -647,6 +650,18 @@ export class HaConfigLovelaceDashboards extends LitElement {
         return this._deleteDashboard(dashboard);
       },
     });
+  }
+
+  private _collectTakenDashboardUrlPaths(): ReadonlySet<string> {
+    const taken = new Set<string>();
+    for (const d of this._dashboards ?? []) {
+      taken.add(d.url_path);
+    }
+    for (const path of Object.keys(this.hass.panels)) {
+      taken.add(path);
+    }
+    taken.add("lovelace");
+    return taken;
   }
 
   private async _deleteDashboard(

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -615,7 +615,7 @@ export class HaConfigLovelaceDashboards extends LitElement {
       dashboard,
       urlPath,
       isDefault: dashboard?.url_path === defaultPanel,
-      fieldSuggestions,
+      suggestions: fieldSuggestions,
       takenUrlPaths: dashboard
         ? undefined
         : this._collectTakenDashboardUrlPaths(),

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -39,6 +39,7 @@ import { fetchResources } from "../../../../data/lovelace/resource";
 import type {
   LovelaceDashboard,
   LovelaceDashboardCreateParams,
+  LovelaceDashboardFieldSuggestions,
 } from "../../../../data/lovelace/dashboard";
 import {
   createDashboard,
@@ -62,6 +63,7 @@ import "../../../../layouts/hass-tabs-subpage-data-table";
 import type { HomeAssistant, Route } from "../../../../types";
 import { loadLovelaceResources } from "../../../lovelace/common/load-resources";
 import { getLovelaceStrategy } from "../../../lovelace/strategies/get-strategy";
+import type { NewDashboardSelection } from "../../dashboard/show-dialog-new-dashboard";
 import { showNewDashboardDialog } from "../../dashboard/show-dialog-new-dashboard";
 import { lovelaceTabs } from "../ha-config-lovelace";
 import { showDashboardConfigureStrategyDialog } from "./show-dialog-lovelace-dashboard-configure-strategy";
@@ -565,7 +567,9 @@ export class HaConfigLovelaceDashboards extends LitElement {
 
   private async _addDashboard() {
     showNewDashboardDialog(this, {
-      selectConfig: async (config) => {
+      selectConfig: async ({ config }: NewDashboardSelection) => {
+        const fieldSuggestions: LovelaceDashboardFieldSuggestions | undefined =
+          undefined;
         if (config && isStrategyDashboard(config)) {
           const strategyType = config.strategy.type;
           const strategyClass = await getLovelaceStrategy(
@@ -577,14 +581,19 @@ export class HaConfigLovelaceDashboards extends LitElement {
             showDashboardConfigureStrategyDialog(this, {
               config: config,
               saveConfig: async (updatedConfig) => {
-                this._openDetailDialog(undefined, undefined, updatedConfig);
+                this._openDetailDialog(
+                  undefined,
+                  undefined,
+                  updatedConfig,
+                  fieldSuggestions
+                );
               },
             });
             return;
           }
         }
 
-        this._openDetailDialog(undefined, undefined, config);
+        this._openDetailDialog(undefined, undefined, config, fieldSuggestions);
       },
     });
   }
@@ -592,13 +601,15 @@ export class HaConfigLovelaceDashboards extends LitElement {
   private async _openDetailDialog(
     dashboard?: LovelaceDashboard,
     urlPath?: string,
-    defaultConfig?: LovelaceRawConfig
+    defaultConfig?: LovelaceRawConfig,
+    fieldSuggestions?: LovelaceDashboardFieldSuggestions
   ): Promise<void> {
     const defaultPanel = this.hass.systemData?.default_panel || DEFAULT_PANEL;
     showDashboardDetailDialog(this, {
       dashboard,
       urlPath,
       isDefault: dashboard?.url_path === defaultPanel,
+      fieldSuggestions,
       createDashboard: async (values: LovelaceDashboardCreateParams) => {
         const created = await createDashboard(this.hass!, values);
         this._dashboards = this._dashboards!.concat(created).sort(

--- a/src/panels/config/lovelace/dashboards/pick-available-dashboard-url-path.ts
+++ b/src/panels/config/lovelace/dashboards/pick-available-dashboard-url-path.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns `baseSlug` if it is not in `taken`, otherwise `baseSlug-2`, `baseSlug-3`, …
+ */
+export function pickAvailableDashboardUrlPath(
+  baseSlug: string,
+  taken: ReadonlySet<string>
+): string {
+  if (!taken.has(baseSlug)) {
+    return baseSlug;
+  }
+  let n = 2;
+  while (taken.has(`${baseSlug}-${n}`)) {
+    n += 1;
+  }
+  return `${baseSlug}-${n}`;
+}

--- a/src/panels/config/lovelace/dashboards/show-dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/show-dialog-lovelace-dashboard-detail.ts
@@ -2,6 +2,7 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import type {
   LovelaceDashboard,
   LovelaceDashboardCreateParams,
+  LovelaceDashboardFieldSuggestions,
   LovelaceDashboardMutableParams,
 } from "../../../../data/lovelace/dashboard";
 
@@ -9,6 +10,8 @@ export interface LovelaceDashboardDetailsDialogParams {
   dashboard?: LovelaceDashboard;
   urlPath?: string;
   isDefault?: boolean;
+  /** Create flow only; optional suggested values for the form. */
+  fieldSuggestions?: LovelaceDashboardFieldSuggestions;
   createDashboard?: (values: LovelaceDashboardCreateParams) => Promise<unknown>;
   updateDashboard: (
     updates: Partial<LovelaceDashboardMutableParams>

--- a/src/panels/config/lovelace/dashboards/show-dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/show-dialog-lovelace-dashboard-detail.ts
@@ -12,6 +12,11 @@ export interface LovelaceDashboardDetailsDialogParams {
   isDefault?: boolean;
   /** Create flow only; optional suggested values for the form. */
   fieldSuggestions?: LovelaceDashboardSuggestions;
+  /**
+   * Create flow only; reserved url paths (dashboards, panels, and so on) so
+   * auto-generated paths avoid collisions by appending -2, -3, and so on.
+   */
+  takenUrlPaths?: ReadonlySet<string>;
   createDashboard?: (values: LovelaceDashboardCreateParams) => Promise<unknown>;
   updateDashboard: (
     updates: Partial<LovelaceDashboardMutableParams>

--- a/src/panels/config/lovelace/dashboards/show-dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/show-dialog-lovelace-dashboard-detail.ts
@@ -11,7 +11,7 @@ export interface LovelaceDashboardDetailsDialogParams {
   urlPath?: string;
   isDefault?: boolean;
   /** Create flow only; optional suggested values for the form. */
-  fieldSuggestions?: LovelaceDashboardSuggestions;
+  suggestions?: LovelaceDashboardSuggestions;
   /**
    * Create flow only; reserved url paths (dashboards, panels, and so on) so
    * auto-generated paths avoid collisions by appending -2, -3, and so on.

--- a/src/panels/config/lovelace/dashboards/show-dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/show-dialog-lovelace-dashboard-detail.ts
@@ -2,7 +2,7 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import type {
   LovelaceDashboard,
   LovelaceDashboardCreateParams,
-  LovelaceDashboardFieldSuggestions,
+  LovelaceDashboardSuggestions,
   LovelaceDashboardMutableParams,
 } from "../../../../data/lovelace/dashboard";
 
@@ -11,7 +11,7 @@ export interface LovelaceDashboardDetailsDialogParams {
   urlPath?: string;
   isDefault?: boolean;
   /** Create flow only; optional suggested values for the form. */
-  fieldSuggestions?: LovelaceDashboardFieldSuggestions;
+  fieldSuggestions?: LovelaceDashboardSuggestions;
   createDashboard?: (values: LovelaceDashboardCreateParams) => Promise<unknown>;
   updateDashboard: (
     updates: Partial<LovelaceDashboardMutableParams>

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -15,10 +15,12 @@ import type {
   LovelaceViewConfig,
 } from "../../../data/lovelace/config/view";
 import { isStrategyView } from "../../../data/lovelace/config/view";
+import type { LovelaceDashboardFieldSuggestions } from "../../../data/lovelace/dashboard";
 import type { AsyncReturnType, HomeAssistant } from "../../../types";
 import { cleanLegacyStrategyConfig, isLegacyStrategy } from "./legacy-strategy";
 import type {
   LovelaceDashboardStrategy,
+  LovelaceDashboardStrategyGetCreateFieldSuggestions,
   LovelaceSectionStrategy,
   LovelaceStrategy,
   LovelaceViewStrategy,
@@ -273,3 +275,38 @@ export const expandLovelaceConfigStrategies = async (
 
   return newConfig;
 };
+
+interface DashboardStrategyClassWithSuggestions {
+  getDashboardCreateFieldSuggestions?: LovelaceDashboardStrategyGetCreateFieldSuggestions;
+}
+
+async function readDashboardCreateFieldSuggestions(
+  hass: HomeAssistant,
+  strategyClass: object
+): Promise<LovelaceDashboardFieldSuggestions | undefined> {
+  const fn = (strategyClass as DashboardStrategyClassWithSuggestions)
+    .getDashboardCreateFieldSuggestions;
+  if (typeof fn !== "function") {
+    return undefined;
+  }
+  return fn.call(strategyClass, hass);
+}
+
+/** Loads a dashboard strategy and any optional create-dialog field suggestions. */
+export async function loadDashboardStrategyWithCreateSuggestions(
+  hass: HomeAssistant,
+  strategyType: string
+): Promise<{
+  strategyClass: LovelaceDashboardStrategy;
+  fieldSuggestions: LovelaceDashboardFieldSuggestions | undefined;
+}> {
+  const strategyClass = (await getLovelaceStrategy(
+    "dashboard",
+    strategyType
+  )) as LovelaceDashboardStrategy;
+  const fieldSuggestions = await readDashboardCreateFieldSuggestions(
+    hass,
+    strategyClass
+  );
+  return { strategyClass, fieldSuggestions };
+}

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -276,16 +276,15 @@ export const expandLovelaceConfigStrategies = async (
   return newConfig;
 };
 
-interface DashboardStrategyClassWithSuggestions {
+interface DashboardStrategyClassWithSuggestions extends LovelaceDashboardStrategy {
   getCreateSuggestions?: LovelaceDashboardStrategyGetCreateSuggestions;
 }
 
 async function readDashboardCreateSuggestions(
   hass: HomeAssistant,
-  strategyClass: object
+  strategyClass: DashboardStrategyClassWithSuggestions
 ): Promise<LovelaceDashboardSuggestions | undefined> {
-  const fn = (strategyClass as DashboardStrategyClassWithSuggestions)
-    .getCreateSuggestions;
+  const fn = strategyClass.getCreateSuggestions;
   if (typeof fn !== "function") {
     return undefined;
   }

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -15,12 +15,12 @@ import type {
   LovelaceViewConfig,
 } from "../../../data/lovelace/config/view";
 import { isStrategyView } from "../../../data/lovelace/config/view";
-import type { LovelaceDashboardFieldSuggestions } from "../../../data/lovelace/dashboard";
+import type { LovelaceDashboardSuggestions } from "../../../data/lovelace/dashboard";
 import type { AsyncReturnType, HomeAssistant } from "../../../types";
 import { cleanLegacyStrategyConfig, isLegacyStrategy } from "./legacy-strategy";
 import type {
   LovelaceDashboardStrategy,
-  LovelaceDashboardStrategyGetCreateFieldSuggestions,
+  LovelaceDashboardStrategyGetCreateSuggestions,
   LovelaceSectionStrategy,
   LovelaceStrategy,
   LovelaceViewStrategy,
@@ -277,15 +277,15 @@ export const expandLovelaceConfigStrategies = async (
 };
 
 interface DashboardStrategyClassWithSuggestions {
-  getDashboardCreateFieldSuggestions?: LovelaceDashboardStrategyGetCreateFieldSuggestions;
+  getCreateSuggestions?: LovelaceDashboardStrategyGetCreateSuggestions;
 }
 
-async function readDashboardCreateFieldSuggestions(
+async function readDashboardCreateSuggestions(
   hass: HomeAssistant,
   strategyClass: object
-): Promise<LovelaceDashboardFieldSuggestions | undefined> {
+): Promise<LovelaceDashboardSuggestions | undefined> {
   const fn = (strategyClass as DashboardStrategyClassWithSuggestions)
-    .getDashboardCreateFieldSuggestions;
+    .getCreateSuggestions;
   if (typeof fn !== "function") {
     return undefined;
   }
@@ -298,13 +298,13 @@ export async function loadDashboardStrategyWithCreateSuggestions(
   strategyType: string
 ): Promise<{
   strategyClass: LovelaceDashboardStrategy;
-  fieldSuggestions: LovelaceDashboardFieldSuggestions | undefined;
+  fieldSuggestions: LovelaceDashboardSuggestions | undefined;
 }> {
   const strategyClass = (await getLovelaceStrategy(
     "dashboard",
     strategyType
   )) as LovelaceDashboardStrategy;
-  const fieldSuggestions = await readDashboardCreateFieldSuggestions(
+  const fieldSuggestions = await readDashboardCreateSuggestions(
     hass,
     strategyClass
   );

--- a/src/panels/lovelace/strategies/map/map-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/map/map-dashboard-strategy.ts
@@ -1,6 +1,8 @@
 import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
+import type { LovelaceDashboardSuggestions } from "../../../../data/lovelace/dashboard";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
+import type { HomeAssistant } from "../../../../types";
 import type { MapViewStrategyConfig } from "./map-view-strategy";
 
 export type MapDashboardStrategyConfig = MapViewStrategyConfig;
@@ -20,6 +22,15 @@ export class MapDashboardStrategy extends ReactiveElement {
   }
 
   static noEditor = true;
+
+  static getCreateSuggestions(
+    hass: HomeAssistant
+  ): LovelaceDashboardSuggestions {
+    return {
+      title: hass.localize("panel.map"),
+      icon: "mdi:map",
+    };
+  }
 }
 
 declare global {

--- a/src/panels/lovelace/strategies/types.ts
+++ b/src/panels/lovelace/strategies/types.ts
@@ -1,3 +1,4 @@
+import type { LovelaceDashboardFieldSuggestions } from "../../../data/lovelace/dashboard";
 import type { LovelaceSectionConfig } from "../../../data/lovelace/config/section";
 import type { LovelaceStrategyConfig } from "../../../data/lovelace/config/strategy";
 import type { LovelaceConfig } from "../../../data/lovelace/config/types";
@@ -13,6 +14,16 @@ export interface LovelaceStrategy<T = any> {
 }
 
 export interface LovelaceDashboardStrategy extends LovelaceStrategy<LovelaceConfig> {}
+
+/**
+ * Optional static `getDashboardCreateFieldSuggestions` on dashboard strategy classes.
+ * Used when opening the dashboard create dialog; see `loadDashboardStrategyWithCreateSuggestions`.
+ */
+export type LovelaceDashboardStrategyGetCreateFieldSuggestions = (
+  hass: HomeAssistant
+) =>
+  | LovelaceDashboardFieldSuggestions
+  | Promise<LovelaceDashboardFieldSuggestions>;
 
 export interface LovelaceViewStrategy extends LovelaceStrategy<LovelaceViewConfig> {}
 

--- a/src/panels/lovelace/strategies/types.ts
+++ b/src/panels/lovelace/strategies/types.ts
@@ -1,4 +1,4 @@
-import type { LovelaceDashboardFieldSuggestions } from "../../../data/lovelace/dashboard";
+import type { LovelaceDashboardSuggestions } from "../../../data/lovelace/dashboard";
 import type { LovelaceSectionConfig } from "../../../data/lovelace/config/section";
 import type { LovelaceStrategyConfig } from "../../../data/lovelace/config/strategy";
 import type { LovelaceConfig } from "../../../data/lovelace/config/types";
@@ -16,14 +16,12 @@ export interface LovelaceStrategy<T = any> {
 export interface LovelaceDashboardStrategy extends LovelaceStrategy<LovelaceConfig> {}
 
 /**
- * Optional static `getDashboardCreateFieldSuggestions` on dashboard strategy classes.
+ * Optional static `getCreateSuggestions` on dashboard strategy classes.
  * Used when opening the dashboard create dialog; see `loadDashboardStrategyWithCreateSuggestions`.
  */
-export type LovelaceDashboardStrategyGetCreateFieldSuggestions = (
+export type LovelaceDashboardStrategyGetCreateSuggestions = (
   hass: HomeAssistant
-) =>
-  | LovelaceDashboardFieldSuggestions
-  | Promise<LovelaceDashboardFieldSuggestions>;
+) => LovelaceDashboardSuggestions | Promise<LovelaceDashboardSuggestions>;
 
 export interface LovelaceViewStrategy extends LovelaceStrategy<LovelaceViewConfig> {}
 

--- a/test/panels/config/lovelace/dashboards/pick-available-dashboard-url-path.test.ts
+++ b/test/panels/config/lovelace/dashboards/pick-available-dashboard-url-path.test.ts
@@ -1,0 +1,31 @@
+import { assert, describe, it } from "vitest";
+import { pickAvailableDashboardUrlPath } from "../../../../../src/panels/config/lovelace/dashboards/pick-available-dashboard-url-path";
+
+describe("pickAvailableDashboardUrlPath", () => {
+  it("returns base when free", () => {
+    assert.strictEqual(
+      pickAvailableDashboardUrlPath("dashboard-map", new Set(["config"])),
+      "dashboard-map"
+    );
+  });
+
+  it("appends -2 when base is taken", () => {
+    assert.strictEqual(
+      pickAvailableDashboardUrlPath(
+        "dashboard-map",
+        new Set(["dashboard-map"])
+      ),
+      "dashboard-map-2"
+    );
+  });
+
+  it("increments until a free path is found", () => {
+    assert.strictEqual(
+      pickAvailableDashboardUrlPath(
+        "dashboard-map",
+        new Set(["dashboard-map", "dashboard-map-2", "dashboard-map-3"])
+      ),
+      "dashboard-map-4"
+    );
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Adds support for dashboards to suggest creation details. Currently name and icon are supported. URL is generated as if typed in if title is set.

A dashboard can suggest its own data by adding this function:

```ts
  static getCreateSuggestions(
    hass: HomeAssistant
  ): LovelaceDashboardSuggestions {
    return {
      title: hass.localize("panel.map"),
      icon: "mdi:map",
    };
  }
```

This has been added for the map dashboard.

Also works for [custom dashboards](https://github.com/timmo001/ha-dashboard-maintenance/commit/acb5f1adc5b9641dafae0023e762b47ea26527bb).


Also added a helper function to check available paths from the existing set, appends `-2`, `-3` incrementally until one is available. Makes a little more user friendly, when adding multiple of the same dashboard (or one of the same title suggestion)

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

https://github.com/user-attachments/assets/a264c398-f513-41ef-ad00-d32306b890c7

<details>
<summary>Longer video, before url generation `-2`, `-X` checks</summary>

https://github.com/user-attachments/assets/66e6b027-63ee-46c9-9bf0-9813d277e90b

</details>

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #51316
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3056
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
