### PR TITLE
Tile feature: input_select/select dropdown

### DIFF
--- a/src/panels/lovelace/card-features/hui-input-select-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-input-select-card-feature.ts
@@ -1,0 +1,103 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { computeDomain } from "../../../common/entity/compute_domain";
+import "../../../components/ha-control-select";
+import "../../../components/ha-control-select-menu";
+import type { HomeAssistant } from "../../../types";
+import type { LovelaceCardFeature } from "../types";
+import { cardFeatureStyles } from "./common/card-feature-styles";
+import type {
+  InputSelectCardFeatureConfig,
+  LovelaceCardFeatureContext,
+} from "./types";
+
+export const supportsInputSelectCardFeature = (
+  hass: HomeAssistant,
+  context: LovelaceCardFeatureContext
+) => {
+  const stateObj = context.entity_id
+    ? hass.states[context.entity_id]
+    : undefined;
+  if (!stateObj) return false;
+  const domain = computeDomain(stateObj.entity_id);
+  return ["select", "input_select"].includes(domain);
+};
+
+@customElement("hui-input-select-card-feature")
+class HuiInputSelectCardFeature
+  extends LitElement
+  implements LovelaceCardFeature
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
+
+  @state() private _config?: InputSelectCardFeatureConfig;
+
+  private get _stateObj() {
+    if (!this.hass || !this.context || !this.context.entity_id) {
+      return undefined;
+    }
+    return this.hass.states[this.context.entity_id!] as HassEntity | undefined;
+  }
+
+  static getStubConfig(): InputSelectCardFeatureConfig {
+    return {
+      type: "dropdown",
+    };
+  }
+
+  public setConfig(config: InputSelectCardFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  protected render() {
+    if (
+      !this._config ||
+      !this.hass ||
+      !this.context ||
+      !this._stateObj ||
+      !supportsInputSelectCardFeature(this.hass, this.context)
+    ) {
+      return nothing;
+    }
+
+    const options = this._stateObj.attributes.options ?? [];
+
+    return html`
+      <ha-control-select-menu
+        .value=${this._stateObj.state}
+        .options=${options}
+        .disabled=${this._stateObj.state === "unavailable"}
+        @value-changed=${this._valueChanged}
+      >
+      </ha-control-select-menu>
+    `;
+  }
+
+  static styles = cardFeatureStyles;
+
+  private _valueChanged(ev: CustomEvent) {
+    const value = (ev.detail as any).value;
+    if (isNaN(value)) return;
+
+    if (!this.hass || !this._stateObj) return;
+
+    const domain = computeDomain(this._stateObj.entity_id);
+
+    this.hass.callService(domain, "select_option", {
+      entity_id: this._stateObj!.entity_id,
+      option: value,
+    });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-input-select-card-feature": HuiInputSelectCardFeature;
+  }
+}

--- a/src/panels/lovelace/card-features/hui-select-dropdown-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-select-dropdown-card-feature.ts
@@ -8,11 +8,11 @@ import type { HomeAssistant } from "../../../types";
 import type { LovelaceCardFeature } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
 import type {
-  InputSelectCardFeatureConfig,
+  SelectDropdownCardFeatureConfig,
   LovelaceCardFeatureContext,
 } from "./types";
 
-export const supportsInputSelectCardFeature = (
+export const supportSelectDropdownCardFeature = (
   hass: HomeAssistant,
   context: LovelaceCardFeatureContext
 ) => {
@@ -25,7 +25,7 @@ export const supportsInputSelectCardFeature = (
 };
 
 @customElement("hui-input-select-card-feature")
-class HuiInputSelectCardFeature
+class HuiSelectDropdownCardFeature
   extends LitElement
   implements LovelaceCardFeature
 {
@@ -33,7 +33,7 @@ class HuiInputSelectCardFeature
 
   @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
 
-  @state() private _config?: InputSelectCardFeatureConfig;
+  @state() private _config?: SelectDropdownCardFeatureConfig;
 
   private get _stateObj() {
     if (!this.hass || !this.context || !this.context.entity_id) {
@@ -42,13 +42,13 @@ class HuiInputSelectCardFeature
     return this.hass.states[this.context.entity_id!] as HassEntity | undefined;
   }
 
-  static getStubConfig(): InputSelectCardFeatureConfig {
+  static getStubConfig(): SelectDropdownCardFeatureConfig {
     return {
-      type: "dropdown",
+      type: "select-dropdown",
     };
   }
 
-  public setConfig(config: InputSelectCardFeatureConfig): void {
+  public setConfig(config: SelectDropdownCardFeatureConfig): void {
     if (!config) {
       throw new Error("Invalid configuration");
     }
@@ -61,7 +61,7 @@ class HuiInputSelectCardFeature
       !this.hass ||
       !this.context ||
       !this._stateObj ||
-      !supportsInputSelectCardFeature(this.hass, this.context)
+      !supportSelectDropdownCardFeature(this.hass, this.context)
     ) {
       return nothing;
     }
@@ -83,7 +83,8 @@ class HuiInputSelectCardFeature
 
   private _valueChanged(ev: CustomEvent) {
     const value = (ev.detail as any).value;
-    if (isNaN(value)) return;
+
+    if (!value) return;
 
     if (!this.hass || !this._stateObj) return;
 
@@ -98,6 +99,6 @@ class HuiInputSelectCardFeature
 
 declare global {
   interface HTMLElementTagNameMap {
-    "hui-input-select-card-feature": HuiInputSelectCardFeature;
+    "hui-select-dropdown-card-feature": HuiSelectDropdownCardFeature;
   }
 }

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -34,8 +34,8 @@ export interface CoverTiltFavoriteCardFeatureConfig {
   type: "cover-tilt-favorite";
 }
 
-export interface InputSelectCardFeatureConfig {
-  type: "dropdown";
+export interface SelectDropdownCardFeatureConfig {
+  type: "select-dropdown";
 }
 
 export interface LightBrightnessCardFeatureConfig {
@@ -301,7 +301,6 @@ export type LovelaceCardFeatureConfig =
   | TrendGraphCardFeatureConfig
   | HumidifierToggleCardFeatureConfig
   | HumidifierModesCardFeatureConfig
-  | InputSelectCardFeatureConfig
   | LawnMowerCommandsCardFeatureConfig
   | LightBrightnessCardFeatureConfig
   | LightColorTempCardFeatureConfig
@@ -314,6 +313,7 @@ export type LovelaceCardFeatureConfig =
   | MediaPlayerVolumeButtonsCardFeatureConfig
   | MediaPlayerVolumeSliderCardFeatureConfig
   | NumericInputCardFeatureConfig
+  | SelectDropdownCardFeatureConfig
   | SelectOptionsCardFeatureConfig
   | TrendGraphCardFeatureConfig
   | TargetHumidityCardFeatureConfig

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -34,6 +34,10 @@ export interface CoverTiltFavoriteCardFeatureConfig {
   type: "cover-tilt-favorite";
 }
 
+export interface InputSelectCardFeatureConfig {
+  type: "dropdown";
+}
+
 export interface LightBrightnessCardFeatureConfig {
   type: "light-brightness";
 }
@@ -297,6 +301,7 @@ export type LovelaceCardFeatureConfig =
   | TrendGraphCardFeatureConfig
   | HumidifierToggleCardFeatureConfig
   | HumidifierModesCardFeatureConfig
+  | InputSelectCardFeatureConfig
   | LawnMowerCommandsCardFeatureConfig
   | LightBrightnessCardFeatureConfig
   | LightColorTempCardFeatureConfig


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This adds the original `ha-control-select-menu` as a tile card feature for `input_select` and `select` entities.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
