### PR TITLE
Add config sub-routes to navigation picker

### DIFF
--- a/src/components/ha-navigation-picker.ts
+++ b/src/components/ha-navigation-picker.ts
@@ -7,7 +7,10 @@ import { caseInsensitiveStringCompare } from "../common/string/compare";
 import { getConfigEntries, type ConfigEntry } from "../data/config_entries";
 import { fetchConfig } from "../data/lovelace/config/types";
 import { SYSTEM_PANELS } from "../data/panel";
-import { computeNavigationPathInfo } from "../data/compute-navigation-path-info";
+import {
+  CONFIG_SUB_ROUTES,
+  computeNavigationPathInfo,
+} from "../data/compute-navigation-path-info";
 import { findRelated, type RelatedResult } from "../data/search";
 import { PANEL_DASHBOARDS } from "../panels/config/lovelace/dashboards/ha-config-lovelace-dashboards";
 import { computeAreaPath } from "../panels/lovelace/strategies/areas/helpers/areas-strategy-helper";
@@ -332,6 +335,19 @@ export class HaNavigationPicker extends LitElement {
           sorting_label: createSortingLabel(viewInfo.label, viewPath),
           group: "views",
         });
+      });
+    }
+
+    for (const [subPath, route] of Object.entries(CONFIG_SUB_ROUTES)) {
+      const path = `/config/${subPath}`;
+      const label = this.hass!.localize(route.translationKey) || subPath;
+      otherRoutes.push({
+        id: path,
+        primary: label,
+        secondary: path,
+        icon_path: route.iconPath,
+        sorting_label: createSortingLabel(label, path),
+        group: "other_routes",
       });
     }
 

--- a/src/data/compute-navigation-path-info.ts
+++ b/src/data/compute-navigation-path-info.ts
@@ -1,4 +1,14 @@
-import { mdiDevices, mdiLink, mdiTextureBox } from "@mdi/js";
+import {
+  mdiDevices,
+  mdiHammer,
+  mdiLink,
+  mdiPalette,
+  mdiPuzzle,
+  mdiRobot,
+  mdiScriptText,
+  mdiShape,
+  mdiTextureBox,
+} from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { isComponentLoaded } from "../common/config/is_component_loaded";
 import { computeDeviceName } from "../common/entity/compute_device_name";
@@ -12,6 +22,7 @@ import {
   getPanelIconPath,
   getPanelTitleFromUrlPath,
 } from "./panel";
+import type { LocalizeKeys } from "../common/translations/localize";
 import type { HomeAssistant } from "../types";
 
 export interface NavigationPathInfo {
@@ -26,6 +37,40 @@ export const DEFAULT_NAVIGATION_PATH_INFO: NavigationPathInfo = {
 };
 
 const AREA_VIEW_PREFIX = "areas-";
+
+export const CONFIG_SUB_ROUTES: Record<
+  string,
+  { translationKey: LocalizeKeys; iconPath: string }
+> = {
+  automation: {
+    translationKey: "ui.components.navigation-picker.route.automations",
+    iconPath: mdiRobot,
+  },
+  scene: {
+    translationKey: "ui.components.navigation-picker.route.scenes",
+    iconPath: mdiPalette,
+  },
+  script: {
+    translationKey: "ui.components.navigation-picker.route.scripts",
+    iconPath: mdiScriptText,
+  },
+  "developer-tools": {
+    translationKey: "ui.components.navigation-picker.route.developer_tools",
+    iconPath: mdiHammer,
+  },
+  integrations: {
+    translationKey: "ui.components.navigation-picker.route.integrations",
+    iconPath: mdiPuzzle,
+  },
+  devices: {
+    translationKey: "ui.components.navigation-picker.route.devices",
+    iconPath: mdiDevices,
+  },
+  entities: {
+    translationKey: "ui.components.navigation-picker.route.entities",
+    iconPath: mdiShape,
+  },
+};
 
 /**
  * Resolve a navigation path to a display label and icon.
@@ -59,6 +104,15 @@ export const computeNavigationPathInfo = (
     segments[3]
   ) {
     return computeDeviceNavigationPathInfo(hass, segments[3]);
+  }
+
+  // /config/{subRoute} (e.g. /config/automation, /config/integrations)
+  if (panelUrlPath === "config" && subPath && subPath in CONFIG_SUB_ROUTES) {
+    const route = CONFIG_SUB_ROUTES[subPath];
+    return {
+      label: hass.localize(route.translationKey) || subPath,
+      iconPath: route.iconPath,
+    };
   }
 
   const panel = panelUrlPath ? hass.panels[panelUrlPath] : undefined;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1435,7 +1435,16 @@
         "related": "Related",
         "views": "Views",
         "area_settings": "{area} - Settings",
-        "other_routes": "Other routes"
+        "other_routes": "Other routes",
+        "route": {
+          "automations": "[%key:ui::panel::config::automation::caption%]",
+          "scenes": "[%key:ui::panel::config::scene::caption%]",
+          "scripts": "[%key:ui::panel::config::script::caption%]",
+          "developer_tools": "[%key:ui::panel::config::dashboard::developer_tools::main%]",
+          "integrations": "[%key:ui::panel::config::integrations::caption%]",
+          "devices": "[%key:ui::panel::config::devices::caption%]",
+          "entities": "[%key:ui::panel::config::entities::caption%]"
+        }
       }
     },
     "dialogs": {


### PR DESCRIPTION
## Proposed change

Add Automations, Scenes, Scripts, Developer Tools, Integrations, Devices, and Entities to the "Other routes" section of the navigation picker. These config sub-routes are now selectable as navigation targets and display with proper translated labels and icons everywhere they appear (shortcut cards, edit overview, etc.).

It's already possible to put in any route, but users might not realize. This adds some popular options to the navigation picker.

Inspired by @MindFreeze's screenshot.

## Screenshots

<img width="822" height="846" alt="CleanShot 2026-04-16 at 11 53 19@2x" src="https://github.com/user-attachments/assets/7c893537-d3cb-4b08-8b6d-f24757a3643a" />


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr