### PR TITLE
Remove core-only development checklist from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -69,7 +69,6 @@
 - [ ] I understand the code I am submitting and can explain how it works.
 - [ ] The code change is tested and works locally.
 - [ ] There is no commented out code in this PR.
-- [ ] I have followed the [development checklist][dev-checklist]
 - [ ] I have followed the [perfect PR recommendations][perfect-pr]
 - [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.
 
@@ -105,6 +104,5 @@ To help with the load of incoming pull requests:
 
   Below, some useful links you could explore:
 -->
-[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
 [docs-repository]: https://github.com/home-assistant/home-assistant.io
 [perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


### PR DESCRIPTION
## Proposed change

The PR template includes a checklist item asking contributors to follow the [development checklist](https://developers.home-assistant.io/docs/development_checklist/), but that page only covers core/Python-specific items:

- External Python libraries on pypi
- `requirements_all.txt`
- `CODEOWNERS`
- `.strict-typing`
- Ruff formatting

None of these apply to the frontend repository. There is no equivalent frontend-specific development checklist page.

This PR removes the checklist item and its link reference. The "perfect PR recommendations" item already covers general PR best practices and remains in the template.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.
