### PR TITLE
Fix section config not propagating to layout element

### DIFF
--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -210,6 +210,8 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
     ) {
       addLayoutElement = true;
       this._createLayoutElement(this._config);
+    } else {
+      this._layoutElement.setConfig(sectionConfig);
     }
 
     this._createCards(sectionConfig);


### PR DESCRIPTION
## Proposed change

Fix the Masonry to Sections migration flow where dragging cards from the imported cards footer into a section would lose cards, duplicate others, or throw an error.

`hui-section` recreated its cards when the config changed but never propagated the new config to the existing section layout element. The section kept rendering from the stale `_config.cards` while reading from the fresh (shorter) `cards` array, causing the arrays to drift apart.

Only the imported-cards section was affected because it's rendered inline in `hui-sections-view`, while regular sections are rebuilt from scratch on every config change via `_createSections`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51612
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
