### PR TITLE
Fix supervisor My redirects for Container installs

### DIFF
--- a/src/panels/my/ha-panel-my.ts
+++ b/src/panels/my/ha-panel-my.ts
@@ -336,12 +336,15 @@ export const getMyRedirects = (): Redirects => ({
     redirect: "/config/info",
   },
   supervisor_store: {
+    component: "hassio",
     redirect: "/config/apps/available",
   },
   supervisor_addons: {
+    component: "hassio",
     redirect: "/config/apps",
   },
   supervisor_app: {
+    component: "hassio",
     redirect: "/config/app",
     params: {
       app: "string",
@@ -351,6 +354,7 @@ export const getMyRedirects = (): Redirects => ({
     },
   },
   supervisor_addon: {
+    component: "hassio",
     redirect: "/config/app",
     params: {
       addon: "string",
@@ -360,6 +364,7 @@ export const getMyRedirects = (): Redirects => ({
     },
   },
   supervisor_add_addon_repository: {
+    component: "hassio",
     redirect: "/config/apps/available",
     params: {
       repository_url: "url",
@@ -410,20 +415,8 @@ class HaPanelMy extends LitElement {
       1,
       this.route.path.endsWith("/") ? this.route.path.length - 1 : undefined
     );
-    const hasSupervisor = isComponentLoaded(this.hass.config, "hassio");
 
     this._redirect = getRedirect(path);
-
-    if (path.startsWith("supervisor") && this._redirect === undefined) {
-      if (!hasSupervisor) {
-        this._error = "no_supervisor";
-        return;
-      }
-      navigate(`/hassio/_my_redirect/${path}${window.location.search}`, {
-        replace: true,
-      });
-      return;
-    }
 
     if (!this._redirect) {
       this._error = "not_supported";
@@ -444,7 +437,10 @@ class HaPanelMy extends LitElement {
       !isComponentLoaded(this.hass.config, this._redirect.component)
     ) {
       this.hass.loadBackendTranslation("title", this._redirect.component);
-      this._error = "no_component";
+      this._error =
+        this._redirect.component === "hassio"
+          ? "no_supervisor"
+          : "no_component";
       const component = this._redirect.component;
       if ((PROTOCOL_INTEGRATIONS as readonly string[]).includes(component)) {
         const params = extractSearchParamsObject();

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2526,7 +2526,7 @@
       "my": {
         "not_supported": "This redirect is not supported by your Home Assistant instance. Check the {link} for the supported redirects and the version they where introduced.",
         "component_not_loaded": "This redirect is not supported by your Home Assistant instance. You need the integration {integration} to use this redirect.",
-        "no_supervisor": "This redirect is not supported by your Home Assistant installation. It needs either the Home Assistant OS or Home Assistant Supervised installation method. For more information, see the {docs_link}.",
+        "no_supervisor": "This redirect is not supported by your Home Assistant installation. It needs the Home Assistant OS installation method. For more information, see the {docs_link}.",
         "not_app": "This redirect only works from a mobile device that has the Home Assistant Companion app installed. {link}.",
         "url_error": "The provided URL is invalid.",
         "documentation": "documentation",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The supervisor_* My redirects (supervisor_store, supervisor_addons, supervisor_app, supervisor_addon, supervisor_add_addon_repository) had no component gate, so on Container installations they silently navigated to broken pages. Gate them on the hassio component and route the missing-hassio case through the existing no_supervisor error message, which now links directly to the installation docs.

Also remove the unreachable /hassio/_my_redirect/ fallback that was left behind by the standalone hassio panel removal (#29132), and update the no_supervisor string: Home Assistant Supervised is no longer a supported installation method (see architecture discussion home-assistant/architecture#1198), only Home Assistant OS.


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

On a Container installation, before:
<img width="604" height="204" alt="Screenshot From 2026-04-20 16-12-27" src="https://github.com/user-attachments/assets/7b26d5ff-dd2e-4494-ae5f-43160f9e5c51" />


After:
<img width="1116" height="111" alt="Screenshot From 2026-04-20 17-01-15" src="https://github.com/user-attachments/assets/a245658f-87f0-489f-a6b7-a8932f374064" />



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
