### PR TITLE
Add `inverted` option to cover-position, cover-tilt-position, and valve-position card features

### DIFF
--- a/src/panels/lovelace/card-features/hui-cover-position-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-cover-position-card-feature.ts
@@ -92,6 +92,11 @@ class HuiCoverPositionCardFeature
       "--state-cover-inactive-color": openColor,
     };
 
+    // inverted defaults to true to preserve existing behavior (left = fully open)
+    // set inverted: false for horizontal sliding covers such as curtains and gates
+    // where the open direction is to the right
+    const inverted = this._config.inverted !== false;
+
     return html`
       <ha-control-slider
         style=${styleMap(style)}
@@ -99,7 +104,7 @@ class HuiCoverPositionCardFeature
         min="0"
         max="100"
         step="1"
-        inverted
+        ?inverted=${inverted}
         show-handle
         @value-changed=${this._valueChanged}
         .label=${computeAttributeNameDisplay(

--- a/src/panels/lovelace/card-features/hui-cover-tilt-position-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-cover-tilt-position-card-feature.ts
@@ -94,6 +94,10 @@ class HuiCoverTiltPositionCardFeature
       "--state-cover-inactive-color": openColor,
     };
 
+    // inverted defaults to true to preserve existing behavior (left = fully open)
+    // set inverted: false for horizontal sliding covers where open direction is right
+    const inverted = this._config.inverted !== false;
+
     return html`
       <ha-control-slider
         style=${styleMap(style)}
@@ -101,7 +105,7 @@ class HuiCoverTiltPositionCardFeature
         min="0"
         max="100"
         mode="cursor"
-        inverted
+        ?inverted=${inverted}
         @value-changed=${this._valueChanged}
         .label=${computeAttributeNameDisplay(
           this.hass.localize,

--- a/src/panels/lovelace/card-features/hui-valve-position-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-valve-position-card-feature.ts
@@ -96,6 +96,10 @@ class HuiValvePositionCardFeature
       "--state-valve-inactive-color": openColor,
     };
 
+    // inverted defaults to true to preserve existing behavior (left = fully open)
+    // set inverted: false for sliding valves/gates where open direction is right
+    const inverted = this._config.inverted !== false;
+
     return html`
       <ha-control-slider
         style=${styleMap(style)}
@@ -103,7 +107,7 @@ class HuiValvePositionCardFeature
         min="0"
         max="100"
         step="1"
-        inverted
+        ?inverted=${inverted}
         show-handle
         @value-changed=${this._valueChanged}
         .label=${computeAttributeNameDisplay(

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -16,6 +16,7 @@ export interface CoverOpenCloseCardFeatureConfig {
 
 export interface CoverPositionCardFeatureConfig {
   type: "cover-position";
+  inverted?: boolean;
 }
 
 export interface CoverTiltCardFeatureConfig {
@@ -24,6 +25,7 @@ export interface CoverTiltCardFeatureConfig {
 
 export interface CoverTiltPositionCardFeatureConfig {
   type: "cover-tilt-position";
+  inverted?: boolean;
 }
 
 export interface CoverPositionFavoriteCardFeatureConfig {
@@ -215,6 +217,7 @@ export interface ValveOpenCloseCardFeatureConfig {
 
 export interface ValvePositionCardFeatureConfig {
   type: "valve-position";
+  inverted?: boolean;
 }
 
 export interface ValvePositionFavoriteCardFeatureConfig {


### PR DESCRIPTION
## Problem

The `cover-position`, `cover-tilt-position`, and `valve-position` tile card features hardcode `inverted` on `ha-control-slider`, meaning the slider always presents as **left = fully open (100%)**, **right = fully closed (0%)**.

This convention works well for vertical blinds, shades, and awnings — where "up" intuitively maps to "open". However, it produces a confusing UX for **horizontal sliding covers** such as curtains and sliding gates, where the cover physically opens to the right. For these devices, a slider that moves left to open is backwards relative to physical reality.

There is currently no supported way to flip the slider direction without resorting to CSS hacks (`transform: scaleX(-1)`), which visually inverts the slider but does not invert the pointer event coordinates — making drag interaction move in the opposite direction of the thumb.

## Solution

Add an optional `inverted` boolean config key to `CoverPositionCardFeatureConfig`, `CoverTiltPositionCardFeatureConfig`, and `ValvePositionCardFeatureConfig`.

- **`inverted: true`** (default) — preserves existing behavior. Left = fully open. Backward-compatible; no change for existing dashboards.
- **`inverted: false`** — removes the inversion. Right = fully open. Intended for horizontal sliding covers and sliding gates.

The implementation uses Lit's `?inverted=${inverted}` boolean attribute binding, so the `inverted` attribute is cleanly absent from the DOM (not set to `false`) when disabled.

## Example Usage

```yaml
features:
  - type: cover-position
    inverted: false   # right curtain that opens rightward
```

```yaml
features:
  - type: valve-position
    inverted: false   # sliding gate that opens to the right
```

## Real-World Use Case

Two Tuya curtain motors on a sliding glass door. The right motor opens the curtain rightward. With `inverted: true` (current default), dragging left opens the curtain — the opposite of the physical motion. With `inverted: false`, dragging right opens it, matching the real-world direction.

## Affected Features

| Feature | Change |
|---|---|
| `cover-position` | `inverted?: boolean` config option added |
| `cover-tilt-position` | `inverted?: boolean` config option added |
| `valve-position` | `inverted?: boolean` config option added |

All other features are unchanged. Default behavior is preserved in all cases.

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass with `script/tests`
- [x] There is no commented out code in this PR
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] The code follows the [style guidelines](https://developers.home-assistant.io/docs/frontend/development/#styleguide)
- [x] README/documentation is updated (config option is self-documenting; no separate doc page needed for a boolean flag)
- [x] I will be happy to be mentioned as a code author on all commits in this PR