### PR TITLE
Extract consumeStateObj / consumeEntityRegistryEntry decorators

### DIFF
--- a/src/common/decorators/consume-context-entry.ts
+++ b/src/common/decorators/consume-context-entry.ts
@@ -6,28 +6,26 @@ import type { EntityRegistryDisplayEntry } from "../../data/entity/entity_regist
 import { transform } from "./transform";
 
 interface ConsumeEntryConfig {
-  entityId: readonly string[];
+  entityIdPath: readonly string[];
 }
 
-const resolveEntityId = (host: unknown, path: readonly string[]) => {
+const resolveAtPath = (host: unknown, path: readonly string[]) => {
   let cur: any = host;
   for (const seg of path) {
     if (cur == null) return undefined;
     cur = cur[seg];
   }
-  return typeof cur === "string" ? cur : undefined;
+  return cur;
 };
 
-const composeContextEntryDecorators = <T, V>(
+const composeDecorator = <T, V>(
   context: Parameters<typeof consume>[0]["context"],
-  config: ConsumeEntryConfig,
-  pick: (value: T, id: string) => V | undefined
+  watchKey: string | undefined,
+  select: (this: unknown, value: T) => V | undefined
 ) => {
-  const watchKey = config.entityId[0];
   const transformDec = transform<T, V | undefined>({
     transformer: function (this: unknown, value) {
-      const id = resolveEntityId(this, config.entityId);
-      return id !== undefined ? pick(value, id) : undefined;
+      return select.call(this, value);
     },
     watch: watchKey ? [watchKey] : [],
   });
@@ -40,26 +38,56 @@ const composeContextEntryDecorators = <T, V>(
 
 /**
  * Consumes `statesContext` and narrows it to the `HassEntity` for the entity
- * ID found at `entityId` on the host (e.g. `["_config", "entity"]`).
+ * ID found at `entityIdPath` on the host (e.g. `["_config", "entity"]`).
  *
  * The first path segment is watched on the host — changes to it re-run the
  * lookup. Deeper segments are traversed at lookup time and short-circuit on
  * nullish values.
  */
-export const consumeStateObj = (config: ConsumeEntryConfig) =>
-  composeContextEntryDecorators<HassEntities, HassEntity>(
+export const consumeEntityState = (config: ConsumeEntryConfig) =>
+  composeDecorator<HassEntities, HassEntity>(
     statesContext,
-    config,
-    (states, id) => states?.[id]
+    config.entityIdPath[0],
+    function (states) {
+      const id = resolveAtPath(this, config.entityIdPath);
+      return typeof id === "string" ? states?.[id] : undefined;
+    }
+  );
+
+/**
+ * Like {@link consumeEntityState} but for an array of entity IDs at
+ * `entityIdPath`. Resolves to a `HassEntity[]` containing one entry per
+ * currently-available entity (missing entities and non-string IDs are
+ * filtered out; original order is preserved).
+ */
+export const consumeEntityStates = (config: ConsumeEntryConfig) =>
+  composeDecorator<HassEntities, HassEntity[]>(
+    statesContext,
+    config.entityIdPath[0],
+    function (states) {
+      const ids = resolveAtPath(this, config.entityIdPath);
+      if (!Array.isArray(ids) || !states) return undefined;
+      const result: HassEntity[] = [];
+      for (const id of ids) {
+        if (typeof id !== "string") continue;
+        const state = states[id];
+        if (state !== undefined) result.push(state);
+      }
+      return result;
+    }
   );
 
 /**
  * Consumes `entitiesContext` and narrows it to the
- * `EntityRegistryDisplayEntry` for the entity ID found at `entityId` on the
- * host. See {@link consumeStateObj} for semantics.
+ * `EntityRegistryDisplayEntry` for the entity ID found at `entityIdPath` on
+ * the host. See {@link consumeEntityState} for semantics.
  */
 export const consumeEntityRegistryEntry = (config: ConsumeEntryConfig) =>
-  composeContextEntryDecorators<
-    HomeAssistant["entities"],
-    EntityRegistryDisplayEntry
-  >(entitiesContext, config, (entities, id) => entities?.[id]);
+  composeDecorator<HomeAssistant["entities"], EntityRegistryDisplayEntry>(
+    entitiesContext,
+    config.entityIdPath[0],
+    function (entities) {
+      const id = resolveAtPath(this, config.entityIdPath);
+      return typeof id === "string" ? entities?.[id] : undefined;
+    }
+  );

--- a/src/common/decorators/consume-context-entry.ts
+++ b/src/common/decorators/consume-context-entry.ts
@@ -27,7 +27,7 @@ const composeContextEntryDecorators = <T, V>(
   const transformDec = transform<T, V | undefined>({
     transformer: function (this: unknown, value) {
       const id = resolveEntityId(this, config.entityId);
-      return id != null ? pick(value, id) : undefined;
+      return id !== undefined ? pick(value, id) : undefined;
     },
     watch: watchKey ? [watchKey] : [],
   });

--- a/src/common/decorators/consume-state-obj.ts
+++ b/src/common/decorators/consume-state-obj.ts
@@ -1,0 +1,65 @@
+import { consume } from "@lit/context";
+import type { HassEntities, HassEntity } from "home-assistant-js-websocket";
+import type { HomeAssistant } from "../../types";
+import { entitiesContext, statesContext } from "../../data/context";
+import type { EntityRegistryDisplayEntry } from "../../data/entity/entity_registry";
+import { transform } from "./transform";
+
+interface ConsumeEntryConfig {
+  entityId: readonly string[];
+}
+
+const resolveEntityId = (host: unknown, path: readonly string[]) => {
+  let cur: any = host;
+  for (const seg of path) {
+    if (cur == null) return undefined;
+    cur = cur[seg];
+  }
+  return typeof cur === "string" ? cur : undefined;
+};
+
+const composeContextEntryDecorators = <T, V>(
+  context: Parameters<typeof consume>[0]["context"],
+  config: ConsumeEntryConfig,
+  pick: (value: T, id: string) => V | undefined
+) => {
+  const watchKey = config.entityId[0];
+  const transformDec = transform<T, V | undefined>({
+    transformer: function (this: unknown, value) {
+      const id = resolveEntityId(this, config.entityId);
+      return id != null ? pick(value, id) : undefined;
+    },
+    watch: watchKey ? [watchKey] : [],
+  });
+  const consumeDec = consume<any>({ context, subscribe: true });
+  return (proto: any, propertyKey: string) => {
+    transformDec(proto, propertyKey);
+    consumeDec(proto, propertyKey);
+  };
+};
+
+/**
+ * Consumes `statesContext` and narrows it to the `HassEntity` for the entity
+ * ID found at `entityId` on the host (e.g. `["_config", "entity"]`).
+ *
+ * The first path segment is watched on the host — changes to it re-run the
+ * lookup. Deeper segments are traversed at lookup time and short-circuit on
+ * nullish values.
+ */
+export const consumeStateObj = (config: ConsumeEntryConfig) =>
+  composeContextEntryDecorators<HassEntities, HassEntity>(
+    statesContext,
+    config,
+    (states, id) => states?.[id]
+  );
+
+/**
+ * Consumes `entitiesContext` and narrows it to the
+ * `EntityRegistryDisplayEntry` for the entity ID found at `entityId` on the
+ * host. See {@link consumeStateObj} for semantics.
+ */
+export const consumeEntityRegistryEntry = (config: ConsumeEntryConfig) =>
+  composeContextEntryDecorators<
+    HomeAssistant["entities"],
+    EntityRegistryDisplayEntry
+  >(entitiesContext, config, (entities, id) => entities?.[id]);

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -9,7 +9,7 @@ import { computeCssColor } from "../../../common/color/compute-color";
 import { DOMAINS_TOGGLE } from "../../../common/const";
 import {
   consumeEntityRegistryEntry,
-  consumeStateObj,
+  consumeEntityState,
 } from "../../../common/decorators/consume-context-entry";
 import { transform } from "../../../common/decorators/transform";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
@@ -94,7 +94,7 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   @state() private _config?: ButtonCardConfig;
 
   @state()
-  @consumeStateObj({ entityId: ["_config", "entity"] })
+  @consumeEntityState({ entityIdPath: ["_config", "entity"] })
   private _stateObj?: HassEntity;
 
   @state()
@@ -105,7 +105,7 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   private _themes!: Themes;
 
   @state()
-  @consumeEntityRegistryEntry({ entityId: ["_config", "entity"] })
+  @consumeEntityRegistryEntry({ entityIdPath: ["_config", "entity"] })
   _entity?: EntityRegistryDisplayEntry;
 
   public getCardSize(): number {

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -1,5 +1,5 @@
-import { consume, type ContextType } from "@lit/context";
-import type { HassEntities, HassEntity } from "home-assistant-js-websocket";
+import { consume } from "@lit/context";
+import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators";
@@ -7,6 +7,10 @@ import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
 import { computeCssColor } from "../../../common/color/compute-color";
 import { DOMAINS_TOGGLE } from "../../../common/const";
+import {
+  consumeEntityRegistryEntry,
+  consumeStateObj,
+} from "../../../common/decorators/consume-state-obj";
 import { transform } from "../../../common/decorators/transform";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { fireEvent } from "../../../common/dom/fire_event";
@@ -22,11 +26,7 @@ import { iconColorCSS } from "../../../common/style/icon_color_css";
 import "../../../components/ha-card";
 import "../../../components/ha-ripple";
 import { CLIMATE_HVAC_ACTION_TO_MODE } from "../../../data/climate";
-import {
-  entitiesContext,
-  statesContext,
-  uiContext,
-} from "../../../data/context";
+import { uiContext } from "../../../data/context";
 import type { EntityRegistryDisplayEntry } from "../../../data/entity/entity_registry";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import type { Themes } from "../../../data/ws-themes";
@@ -94,13 +94,7 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   @state() private _config?: ButtonCardConfig;
 
   @state()
-  @consume<any>({ context: statesContext, subscribe: true })
-  @transform({
-    transformer: function (this: HuiButtonCard, value: HassEntities) {
-      return this._config?.entity ? value?.[this._config?.entity] : undefined;
-    },
-    watch: ["_config"],
-  })
+  @consumeStateObj({ entityId: ["_config", "entity"] })
   private _stateObj?: HassEntity;
 
   @state()
@@ -111,13 +105,7 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   private _themes!: Themes;
 
   @state()
-  @consume<any>({ context: entitiesContext, subscribe: true })
-  @transform<ContextType<typeof entitiesContext>, EntityRegistryDisplayEntry>({
-    transformer: function (this: HuiButtonCard, value) {
-      return this._config?.entity ? value?.[this._config?.entity] : undefined;
-    },
-    watch: ["_config"],
-  })
+  @consumeEntityRegistryEntry({ entityId: ["_config", "entity"] })
   _entity?: EntityRegistryDisplayEntry;
 
   public getCardSize(): number {

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -10,7 +10,7 @@ import { DOMAINS_TOGGLE } from "../../../common/const";
 import {
   consumeEntityRegistryEntry,
   consumeStateObj,
-} from "../../../common/decorators/consume-state-obj";
+} from "../../../common/decorators/consume-context-entry";
 import { transform } from "../../../common/decorators/transform";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { fireEvent } from "../../../common/dom/fire_event";


### PR DESCRIPTION
## Proposed change

Proposal to cut the per-card boilerplate for reading a single entity out of `statesContext` / `entitiesContext`.

Before:

```ts
@state()
@consume<any>({ context: statesContext, subscribe: true })
@transform({
  transformer: function (this: HuiButtonCard, value: HassEntities) {
    return this._config?.entity ? value?.[this._config?.entity] : undefined;
  },
  watch: ["_config"],
})
private _stateObj?: HassEntity;
```

After:

```ts
@state()
@consumeEntityState({ entityIdPath: ["_config", "entity"] })
private _stateObj?: HassEntity;
```

Parallel `@consumeEntityRegistryEntry` covers the `entitiesContext` variant. The first path segment is watched; deeper segments are traversed at lookup time. The `@consume<any>` cast is gone — type bridging is confined to the helper.

Applied to `hui-button-card`.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr