### PR TITLE
Consider entity precision in adjust-sum dialog

### DIFF
--- a/src/panels/config/developer-tools/statistics/dialog-statistics-adjust-sum.ts
+++ b/src/panels/config/developer-tools/statistics/dialog-statistics-adjust-sum.ts
@@ -62,6 +62,8 @@ export class DialogStatisticsFixUnsupportedUnitMetadata extends LitElement {
     datetime: {},
   };
 
+  private _precision = 2;
+
   private _amountSelector = memoizeOne(
     (unit_of_measurement: string | undefined): NumberSelector => ({
       number: {
@@ -81,6 +83,9 @@ export class DialogStatisticsFixUnsupportedUnitMetadata extends LitElement {
     now.setMinutes(now.getMinutes() - (now.getMinutes() % 5), 0);
     this._moment = formatISO9075(now);
     this._fetchStats();
+
+    const entry = this.hass.entities[params.statistic.statistic_id];
+    this._precision = Math.max(entry?.display_precision ?? 0, 2);
   }
 
   public closeDialog(): void {
@@ -192,7 +197,8 @@ export class DialogStatisticsFixUnsupportedUnitMetadata extends LitElement {
       );
       const rows: TemplateResult[] = [];
       for (const stat of data) {
-        const growth = Math.round(stat.change! * 100) / 100;
+        const multiple = 10 ** this._precision;
+        const growth = Math.round(stat.change! * multiple) / multiple;
         rows.push(html`
           <ha-list-item
             twoline
@@ -248,7 +254,8 @@ export class DialogStatisticsFixUnsupportedUnitMetadata extends LitElement {
 
   private _setChosenStatistic(ev) {
     const stat = ev.currentTarget.stat;
-    const growth = Math.round(stat.change! * 100) / 100;
+    const multiple = 10 ** this._precision;
+    const growth = Math.round(stat.change! * multiple) / multiple;
 
     this._chosenStat = stat;
     this._origAmount = growth;

--- a/src/panels/config/developer-tools/statistics/dialog-statistics-adjust-sum.ts
+++ b/src/panels/config/developer-tools/statistics/dialog-statistics-adjust-sum.ts
@@ -65,9 +65,12 @@ export class DialogStatisticsFixUnsupportedUnitMetadata extends LitElement {
   private _precision = 2;
 
   private _amountSelector = memoizeOne(
-    (unit_of_measurement: string | undefined): NumberSelector => ({
+    (
+      unit_of_measurement: string | undefined,
+      precision: number
+    ): NumberSelector => ({
       number: {
-        step: 0.01,
+        step: 10 ** -precision,
         unit_of_measurement,
         mode: "box",
       },
@@ -318,7 +321,7 @@ export class DialogStatisticsFixUnsupportedUnitMetadata extends LitElement {
           "ui.panel.config.developer-tools.tabs.statistics.fix_issue.adjust_sum.new_value"
         )}
         .hass=${this.hass}
-        .selector=${this._amountSelector(unit || undefined)}
+        .selector=${this._amountSelector(unit || undefined, this._precision)}
         .value=${this._amount}
         .disabled=${this._busy}
         @value-changed=${this._amountChanged}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Consider entity precision setting when choosing how many decimals to render in adjust sum dialog. 

I decided to only use this to increase decimals > 2, instead of using it to also reduce number of shown decimals (to 1 or 0), because I couldn't convince myself if it was a good idea. 

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51617
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
