### PR TITLE
Improve typing on lifestyle functions for changed props (2/5)

### DIFF
--- a/cast/src/receiver/layout/hc-lovelace.ts
+++ b/cast/src/receiver/layout/hc-lovelace.ts
@@ -1,4 +1,5 @@
-import { css, html, LitElement, type TemplateResult } from "lit";
+import type { PropertyValues, TemplateResult } from "lit";
+import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../src/common/dom/fire_event";
 import type { LovelaceConfig } from "../../../../src/data/lovelace/config/types";
@@ -64,7 +65,7 @@ class HcLovelace extends LitElement {
     `;
   }
 
-  protected updated(changedProps) {
+  protected updated(changedProps: PropertyValues<this>) {
     super.updated(changedProps);
 
     if (changedProps.has("viewPath") || changedProps.has("lovelaceConfig")) {

--- a/src/components/ha-filter-labels.ts
+++ b/src/components/ha-filter-labels.ts
@@ -1,7 +1,7 @@
 import { consume } from "@lit/context";
 import type { SelectedDetail } from "@material/mwc-list";
 import { mdiCog, mdiFilterVariantRemove } from "@mdi/js";
-import type { CSSResultGroup } from "lit";
+import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
@@ -133,7 +133,7 @@ export class HaFilterLabels extends LitElement {
     `;
   }
 
-  protected updated(changed) {
+  protected updated(changed: PropertyValues<this>) {
     if (changed.has("expanded") && this.expanded) {
       setTimeout(() => {
         if (!this.expanded) return;

--- a/src/components/ha-filter-states.ts
+++ b/src/components/ha-filter-states.ts
@@ -1,6 +1,6 @@
 import type { List, SelectedDetail } from "@material/mwc-list";
 import { mdiFilterVariantRemove } from "@mdi/js";
-import type { CSSResultGroup } from "lit";
+import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
@@ -86,13 +86,13 @@ export class HaFilterStates extends LitElement {
     `;
   }
 
-  protected willUpdate(changed) {
+  protected willUpdate(changed: PropertyValues<this>) {
     if (changed.has("expanded") && this.expanded) {
       this._shouldRender = true;
     }
   }
 
-  protected updated(changed) {
+  protected updated(changed: PropertyValues<this>) {
     if ((changed.has("expanded") || changed.has("states")) && this.expanded) {
       setTimeout(async () => {
         if (!this.expanded) return;

--- a/src/components/ha-filter-voice-assistants.ts
+++ b/src/components/ha-filter-voice-assistants.ts
@@ -1,6 +1,6 @@
 import type { SelectedDetail } from "@material/mwc-list";
 import { mdiFilterVariantRemove } from "@mdi/js";
-import type { CSSResultGroup } from "lit";
+import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
@@ -84,12 +84,12 @@ export class HaFilterVoiceAssistants extends LitElement {
     `;
   }
 
-  protected firstUpdated(changedProps) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     this._voiceAssistantOptions = Object.keys(voiceAssistants);
   }
 
-  protected updated(changed) {
+  protected updated(changed: PropertyValues<this>) {
     if (changed.has("expanded") && this.expanded) {
       setTimeout(() => {
         if (!this.expanded) return;

--- a/src/components/ha-form/ha-form-float.ts
+++ b/src/components/ha-form/ha-form-float.ts
@@ -60,7 +60,7 @@ export class HaFormFloat extends LitElement implements HaFormElement {
     `;
   }
 
-  protected updated(changedProps: PropertyValues): void {
+  protected updated(changedProps: PropertyValues<this>): void {
     if (changedProps.has("schema")) {
       this.toggleAttribute("own-margin", !!this.schema.required);
     }

--- a/src/components/ha-form/ha-form-grid.ts
+++ b/src/components/ha-form/ha-form-grid.ts
@@ -52,7 +52,7 @@ export class HaFormGrid extends LitElement implements HaFormElement {
     return valid;
   }
 
-  protected updated(changedProps: PropertyValues): void {
+  protected updated(changedProps: PropertyValues<this>): void {
     super.updated(changedProps);
     if (changedProps.has("schema")) {
       if (this.schema.column_min_width) {

--- a/src/components/ha-form/ha-form-integer.ts
+++ b/src/components/ha-form/ha-form-integer.ts
@@ -116,7 +116,7 @@ export class HaFormInteger extends LitElement implements HaFormElement {
     `;
   }
 
-  protected updated(changedProps: PropertyValues): void {
+  protected updated(changedProps: PropertyValues<this>): void {
     if (changedProps.has("schema")) {
       this.toggleAttribute(
         "own-margin",

--- a/src/components/ha-form/ha-form-multi_select.ts
+++ b/src/components/ha-form/ha-form-multi_select.ts
@@ -130,7 +130,7 @@ export class HaFormMultiSelect extends LitElement implements HaFormElement {
     });
   }
 
-  protected updated(changedProps: PropertyValues): void {
+  protected updated(changedProps: PropertyValues<this>): void {
     if (changedProps.has("schema")) {
       this.toggleAttribute(
         "own-margin",

--- a/src/components/ha-form/ha-form-optional_actions.ts
+++ b/src/components/ha-form/ha-form-optional_actions.ts
@@ -59,7 +59,7 @@ export class HaFormOptionalActions extends LitElement implements HaFormElement {
     return form ? form.reportValidity() : true;
   }
 
-  protected updated(changedProps: PropertyValues): void {
+  protected updated(changedProps: PropertyValues<this>): void {
     super.updated(changedProps);
     if (changedProps.has("data")) {
       const displayActions = this._displayActions ?? NO_ACTIONS;

--- a/src/components/ha-form/ha-form-string.ts
+++ b/src/components/ha-form/ha-form-string.ts
@@ -69,7 +69,7 @@ export class HaFormString extends LitElement implements HaFormElement {
     `;
   }
 
-  protected updated(changedProps: PropertyValues): void {
+  protected updated(changedProps: PropertyValues<this>): void {
     if (changedProps.has("schema")) {
       this.toggleAttribute("own-margin", !!this.schema.required);
     }

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -136,7 +136,7 @@ export class HaForm extends LitElement implements HaFormElement {
     return isValid;
   }
 
-  protected willUpdate(changedProps: PropertyValues) {
+  protected willUpdate(changedProps: PropertyValues<this>) {
     if (changedProps.has("schema") && this.schema) {
       this.schema.forEach((item) => {
         if ("selector" in item) {

--- a/src/components/ha-gauge.ts
+++ b/src/components/ha-gauge.ts
@@ -58,7 +58,7 @@ export class HaGauge extends LitElement {
     }
   }
 
-  protected firstUpdated(changedProperties: PropertyValues) {
+  protected firstUpdated(changedProperties: PropertyValues<this>) {
     super.firstUpdated(changedProperties);
     afterNextRender(() => {
       this._updated = true;
@@ -70,7 +70,7 @@ export class HaGauge extends LitElement {
     });
   }
 
-  protected willUpdate(changedProperties: PropertyValues) {
+  protected willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("levels") || changedProperties.has("min")) {
       if (this.levels) {
         this._sortedLevels = [...this.levels].sort((a, b) => a.level - b.level);

--- a/src/components/ha-generic-picker.ts
+++ b/src/components/ha-generic-picker.ts
@@ -143,7 +143,7 @@ export class HaGenericPicker extends PickerMixin(LitElement) {
 
   private _unsubscribeTinyKeys?: () => void;
 
-  protected willUpdate(changedProperties: PropertyValues) {
+  protected willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("value")) {
       this._setUnknownValue();
     }

--- a/src/components/ha-grid-size-picker.ts
+++ b/src/components/ha-grid-size-picker.ts
@@ -1,4 +1,5 @@
 import { mdiRestore } from "@mdi/js";
+import type { PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
@@ -34,7 +35,7 @@ export class HaGridSizeEditor extends LitElement {
 
   @state() public _localValue?: CardGridSize = { rows: 1, columns: 1 };
 
-  protected willUpdate(changedProperties) {
+  protected willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("value")) {
       this._localValue = this.value;
     }

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -120,7 +120,7 @@ class HaHLSPlayer extends LitElement {
     `;
   }
 
-  protected updated(changedProps: PropertyValues) {
+  protected updated(changedProps: PropertyValues<this>) {
     super.updated(changedProps);
 
     const entityChanged = changedProps.has("entityid");

--- a/src/components/ha-hs-color-picker.ts
+++ b/src/components/ha-hs-color-picker.ts
@@ -150,7 +150,7 @@ class HaHsColorPicker extends LitElement {
   @state()
   private _localValue?: [number, number];
 
-  protected firstUpdated(changedProps: PropertyValues): void {
+  protected firstUpdated(changedProps: PropertyValues<this>): void {
     super.firstUpdated(changedProps);
     this._setupListeners();
     this._generateColorWheel();
@@ -179,7 +179,7 @@ class HaHsColorPicker extends LitElement {
     this._destroyListeners();
   }
 
-  protected updated(changedProps: PropertyValues): void {
+  protected updated(changedProps: PropertyValues<this>): void {
     super.updated(changedProps);
     if (
       changedProps.has("colorBrightness") ||

--- a/src/components/ha-icon.ts
+++ b/src/components/ha-icon.ts
@@ -55,7 +55,7 @@ export class HaIcon extends LitElement {
 
   @state() private _legacy = false;
 
-  public willUpdate(changedProps: PropertyValues) {
+  public willUpdate(changedProps: PropertyValues<this>) {
     super.willUpdate(changedProps);
     if (changedProps.has("icon")) {
       this._path = undefined;

--- a/src/components/ha-label-badge.ts
+++ b/src/components/ha-label-badge.ts
@@ -114,7 +114,7 @@ class HaLabelBadge extends LitElement {
     ];
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
     if (changedProperties.has("image")) {
       this.shadowRoot!.getElementById("badge")!.style.backgroundImage = this

--- a/src/components/ha-language-picker.ts
+++ b/src/components/ha-language-picker.ts
@@ -111,7 +111,7 @@ export class HaLanguagePicker extends LitElement {
 
   @query("ha-generic-picker", true) public genericPicker!: HaGenericPicker;
 
-  protected firstUpdated(changedProps: PropertyValues) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     this._computeDefaultLanguageOptions();
   }

--- a/src/components/ha-markdown-element.ts
+++ b/src/components/ha-markdown-element.ts
@@ -53,7 +53,7 @@ class HaMarkdownElement extends ReactiveElement {
 
   private _renderPromise: ReturnType<typeof this._render> = Promise.resolve();
 
-  protected update(changedProps) {
+  protected update(changedProps: PropertyValues<this>) {
     super.update(changedProps);
     if (this.content !== undefined) {
       this._renderPromise = this._render();
@@ -66,7 +66,7 @@ class HaMarkdownElement extends ReactiveElement {
     return true;
   }
 
-  protected willUpdate(_changedProperties: PropertyValues): void {
+  protected willUpdate(_changedProperties: PropertyValues<this>): void {
     if (!this.innerHTML && this.cache) {
       const key = this._computeCacheKey();
       if (markdownCache.has(key)) {

--- a/src/components/ha-marquee-text.ts
+++ b/src/components/ha-marquee-text.ts
@@ -32,7 +32,7 @@ export class HaMarqueeText extends LitElement {
 
   private _pauseTimeout?: number;
 
-  protected firstUpdated(changedProps: PropertyValues) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
 
     this._setupAnimation();

--- a/src/components/ha-menu-button.ts
+++ b/src/components/ha-menu-button.ts
@@ -1,5 +1,6 @@
 import { mdiMenu } from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
+import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
@@ -57,7 +58,7 @@ class HaMenuButton extends LitElement {
     `;
   }
 
-  protected willUpdate(changedProps) {
+  protected willUpdate(changedProps: PropertyValues<this>) {
     super.willUpdate(changedProps);
 
     if (!changedProps.has("narrow") && !changedProps.has("hass")) {

--- a/src/components/ha-navigation-picker.ts
+++ b/src/components/ha-navigation-picker.ts
@@ -424,7 +424,7 @@ export class HaNavigationPicker extends LitElement {
     this._loading = false;
   }
 
-  protected updated(changedProps: PropertyValues) {
+  protected updated(changedProps: PropertyValues<this>) {
     if (changedProps.has("context")) {
       this._loadRelatedItems();
     }

--- a/src/components/ha-qr-code.ts
+++ b/src/components/ha-qr-code.ts
@@ -31,7 +31,7 @@ export class HaQrCode extends LitElement {
 
   @query("canvas") private _canvas?: HTMLCanvasElement;
 
-  protected willUpdate(changedProperties: PropertyValues): void {
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
     if (
       (changedProperties.has("data") ||
@@ -46,7 +46,7 @@ export class HaQrCode extends LitElement {
     }
   }
 
-  updated(changedProperties: PropertyValues) {
+  updated(changedProperties: PropertyValues<this>) {
     const canvas = this._canvas;
     if (
       canvas &&

--- a/src/components/ha-related-items.ts
+++ b/src/components/ha-related-items.ts
@@ -41,7 +41,7 @@ export class HaRelatedItems extends LitElement {
 
   @state() private _related?: RelatedResult;
 
-  protected firstUpdated(changedProps: PropertyValues) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
   }
 
@@ -64,7 +64,7 @@ export class HaRelatedItems extends LitElement {
     this._blueprints = { automation, script };
   }
 
-  protected updated(changedProps: PropertyValues) {
+  protected updated(changedProps: PropertyValues<this>) {
     super.updated(changedProps);
     if (
       (changedProps.has("itemId") || changedProps.has("itemType")) &&

--- a/src/components/ha-relative-time.ts
+++ b/src/components/ha-relative-time.ts
@@ -32,12 +32,12 @@ class HaRelativeTime extends ReactiveElement {
     return this;
   }
 
-  protected firstUpdated(changedProps: PropertyValues) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     this._updateRelative();
   }
 
-  protected update(changedProps: PropertyValues) {
+  protected update(changedProps: PropertyValues<this>) {
     super.update(changedProps);
     this._updateRelative();
   }

--- a/src/components/ha-resizable-bottom-sheet.ts
+++ b/src/components/ha-resizable-bottom-sheet.ts
@@ -1,3 +1,4 @@
+import type { PropertyValues } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, query, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
@@ -56,7 +57,7 @@ export class HaResizableBottomSheet extends LitElement {
     </dialog>`;
   }
 
-  protected firstUpdated(changedProperties) {
+  protected firstUpdated(changedProperties: PropertyValues<this>) {
     super.firstUpdated(changedProperties);
     this._openSheet();
   }

--- a/src/components/ha-selector/ha-selector-area.ts
+++ b/src/components/ha-selector/ha-selector-area.ts
@@ -53,7 +53,7 @@ export class HaAreaSelector extends LitElement {
     );
   }
 
-  protected willUpdate(changedProperties: PropertyValues): void {
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.get("selector") && this.value !== undefined) {
       if (this.selector.area?.multiple && !Array.isArray(this.value)) {
         this.value = [this.value];
@@ -65,7 +65,7 @@ export class HaAreaSelector extends LitElement {
     }
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected updated(changedProperties: PropertyValues<this>): void {
     if (
       changedProperties.has("selector") &&
       this._hasIntegration(this.selector) &&

--- a/src/components/ha-selector/ha-selector-attribute.ts
+++ b/src/components/ha-selector/ha-selector-attribute.ts
@@ -44,7 +44,7 @@ export class HaSelectorAttribute extends LitElement {
     `;
   }
 
-  protected updated(changedProps: PropertyValues): void {
+  protected updated(changedProps: PropertyValues<this>): void {
     super.updated(changedProps);
     if (
       // No need to filter value if no value

--- a/src/components/ha-selector/ha-selector-choose.ts
+++ b/src/components/ha-selector/ha-selector-choose.ts
@@ -30,7 +30,7 @@ export class HaChooseSelector extends LitElement {
 
   @state() public _activeChoice?: string;
 
-  protected willUpdate(changedProperties: PropertyValues): void {
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (
       changedProperties.has("selector") &&
       (!this._activeChoice ||

--- a/src/components/ha-selector/ha-selector-device.ts
+++ b/src/components/ha-selector/ha-selector-device.ts
@@ -57,7 +57,7 @@ export class HaDeviceSelector extends LitElement {
     );
   }
 
-  protected willUpdate(changedProperties: PropertyValues): void {
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.get("selector") && this.value !== undefined) {
       if (this.selector.device?.multiple && !Array.isArray(this.value)) {
         this.value = [this.value];
@@ -69,7 +69,7 @@ export class HaDeviceSelector extends LitElement {
     }
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
     if (
       changedProperties.has("selector") &&

--- a/src/components/ha-selector/ha-selector-entity.ts
+++ b/src/components/ha-selector/ha-selector-entity.ts
@@ -44,7 +44,7 @@ export class HaEntitySelector extends LitElement {
     );
   }
 
-  protected willUpdate(changedProperties: PropertyValues): void {
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.get("selector") && this.value !== undefined) {
       if (this.selector.entity?.multiple && !Array.isArray(this.value)) {
         this.value = [this.value];
@@ -95,7 +95,7 @@ export class HaEntitySelector extends LitElement {
     `;
   }
 
-  protected updated(changedProps: PropertyValues): void {
+  protected updated(changedProps: PropertyValues<this>): void {
     super.updated(changedProps);
     if (
       changedProps.has("selector") &&

--- a/src/components/ha-selector/ha-selector-file.ts
+++ b/src/components/ha-selector/ha-selector-file.ts
@@ -50,7 +50,7 @@ export class HaFileSelector extends LitElement {
     `;
   }
 
-  protected willUpdate(changedProps: PropertyValues) {
+  protected willUpdate(changedProps: PropertyValues<this>) {
     super.willUpdate(changedProps);
     if (
       changedProps.has("value") &&

--- a/src/components/ha-selector/ha-selector-floor.ts
+++ b/src/components/ha-selector/ha-selector-floor.ts
@@ -53,7 +53,7 @@ export class HaFloorSelector extends LitElement {
     );
   }
 
-  protected willUpdate(changedProperties: PropertyValues): void {
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.get("selector") && this.value !== undefined) {
       if (this.selector.floor?.multiple && !Array.isArray(this.value)) {
         this.value = [this.value];
@@ -65,7 +65,7 @@ export class HaFloorSelector extends LitElement {
     }
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected updated(changedProperties: PropertyValues<this>): void {
     if (
       changedProperties.has("selector") &&
       this._hasIntegration(this.selector) &&

--- a/src/components/ha-selector/ha-selector-number.ts
+++ b/src/components/ha-selector/ha-selector-number.ts
@@ -35,7 +35,7 @@ export class HaNumberSelector extends LitElement {
     return this._input?.reportValidity() ?? true;
   }
 
-  protected willUpdate(changedProps: PropertyValues) {
+  protected willUpdate(changedProps: PropertyValues<this>) {
     if (changedProps.has("value")) {
       if (this._valueStr === "" || this.value !== Number(this._valueStr)) {
         this._valueStr =

--- a/src/components/ha-selector/ha-selector-numeric-threshold.ts
+++ b/src/components/ha-selector/ha-selector-numeric-threshold.ts
@@ -70,14 +70,14 @@ export class HaNumericThresholdSelector extends LitElement {
     return this.selector.numeric_threshold?.mode ?? "crossed";
   }
 
-  protected willUpdate(changedProperties: PropertyValues): void {
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("value") || changedProperties.has("selector")) {
       const mode = this._getMode();
       this._type = this.value?.type || DEFAULT_TYPE[mode];
     }
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
     if (
       (changedProperties.has("value") || changedProperties.has("selector")) &&

--- a/src/components/ha-selector/ha-selector-object.ts
+++ b/src/components/ha-selector/ha-selector-object.ts
@@ -289,7 +289,7 @@ export class HaObjectSelector extends LitElement {
     fireEvent(this, "value-changed", { value: newValue });
   }
 
-  protected updated(changedProps: PropertyValues) {
+  protected updated(changedProps: PropertyValues<this>) {
     super.updated(changedProps);
     if (
       changedProps.has("value") &&

--- a/src/components/ha-selector/ha-selector-selector.ts
+++ b/src/components/ha-selector/ha-selector-selector.ts
@@ -170,7 +170,7 @@ export class HaSelectorSelector extends LitElement {
 
   private _yamlMode = false;
 
-  protected shouldUpdate(changedProps: PropertyValues) {
+  protected shouldUpdate(changedProps: PropertyValues<this>) {
     if (changedProps.size === 1 && changedProps.has("hass")) {
       return false;
     }

--- a/src/components/ha-selector/ha-selector-state.ts
+++ b/src/components/ha-selector/ha-selector-state.ts
@@ -1,4 +1,5 @@
 import type { HassServiceTarget } from "home-assistant-js-websocket";
+import type { PropertyValues } from "lit";
 import { html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -53,7 +54,7 @@ export class HaSelectorState extends SubscribeMixin(LitElement) {
     }
   );
 
-  willUpdate(changedProps) {
+  willUpdate(changedProps: PropertyValues<this>) {
     if (changedProps.has("selector") || changedProps.has("context")) {
       this._resolveEntityIds(
         this.selector.state?.entity_id,

--- a/src/components/ha-selector/ha-selector-target.ts
+++ b/src/components/ha-selector/ha-selector-target.ts
@@ -53,7 +53,7 @@ export class HaTargetSelector extends LitElement {
     );
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
     if (
       changedProperties.has("selector") &&

--- a/src/components/ha-selector/ha-selector-template.ts
+++ b/src/components/ha-selector/ha-selector-template.ts
@@ -68,7 +68,7 @@ export class HaTemplateSelector extends LitElement {
     }
   }
 
-  protected updated(changedProps: PropertyValues) {
+  protected updated(changedProps: PropertyValues<this>) {
     if (changedProps.has("value") && this._test) {
       this._subscribeTemplate();
     }

--- a/src/components/ha-selector/ha-selector.ts
+++ b/src/components/ha-selector/ha-selector.ts
@@ -128,7 +128,7 @@ export class HaSelector extends LitElement {
     return type;
   }
 
-  protected willUpdate(changedProps: PropertyValues) {
+  protected willUpdate(changedProps: PropertyValues<this>) {
     if (changedProps.has("selector") && this.selector) {
       LOAD_ELEMENTS[this._type]?.();
     }

--- a/src/components/ha-service-picker.ts
+++ b/src/components/ha-service-picker.ts
@@ -1,6 +1,7 @@
 import type { RenderItemFunction } from "@lit-labs/virtualizer/virtualize";
 import { mdiRoomService } from "@mdi/js";
-import { html, LitElement, nothing, type TemplateResult } from "lit";
+import type { PropertyValues, TemplateResult } from "lit";
+import { html, LitElement, nothing } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../common/dom/fire_event";
@@ -50,7 +51,7 @@ class HaServicePicker extends LitElement {
     await this._picker?.open();
   }
 
-  protected firstUpdated(props) {
+  protected firstUpdated(props: PropertyValues<this>) {
     super.firstUpdated(props);
     this.hass.loadBackendTranslation("services");
     getServiceIcons(this.hass);

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -272,7 +272,7 @@ class HaSidebar extends SubscribeMixin(ScrollableFadeMixin(LitElement)) {
     );
   }
 
-  protected firstUpdated(changedProps: PropertyValues) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     this._subscribePersistentNotifications();
   }
@@ -289,7 +289,7 @@ class HaSidebar extends SubscribeMixin(ScrollableFadeMixin(LitElement)) {
     );
   }
 
-  protected updated(changedProps) {
+  protected updated(changedProps: PropertyValues<this>) {
     super.updated(changedProps);
     if (changedProps.has("alwaysExpand")) {
       toggleAttribute(this, "expanded", this.alwaysExpand);

--- a/src/components/ha-snowflakes.ts
+++ b/src/components/ha-snowflakes.ts
@@ -1,3 +1,4 @@
+import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import type { HomeAssistant } from "../types";
@@ -58,7 +59,7 @@ export class HaSnowflakes extends SubscribeMixin(LitElement) {
     this._snowflakes = snowflakes;
   }
 
-  protected willUpdate(changedProps: Map<string, unknown>) {
+  protected willUpdate(changedProps: PropertyValues) {
     super.willUpdate(changedProps);
     if (changedProps.has("_enabled")) {
       this._generateSnowflakes();

--- a/src/components/ha-spinner.ts
+++ b/src/components/ha-spinner.ts
@@ -7,7 +7,7 @@ import { customElement, property } from "lit/decorators";
 export class HaSpinner extends Spinner {
   @property() public size?: "tiny" | "small" | "medium" | "large";
 
-  protected updated(changedProps: PropertyValues) {
+  protected updated(changedProps: PropertyValues<this>) {
     super.updated(changedProps);
 
     if (changedProps.has("size")) {

--- a/src/components/ha-suggest-with-ai-button.ts
+++ b/src/components/ha-suggest-with-ai-button.ts
@@ -54,7 +54,7 @@ export class HaSuggestWithAIButton extends LitElement {
 
   private _intervalId?: number;
 
-  protected firstUpdated(_changedProperties: PropertyValues): void {
+  protected firstUpdated(_changedProperties: PropertyValues<this>): void {
     super.firstUpdated(_changedProperties);
     if (!this.hass || !isComponentLoaded(this.hass.config, "ai_task")) {
       return;

--- a/src/components/ha-switch.ts
+++ b/src/components/ha-switch.ts
@@ -50,7 +50,7 @@ export class HaSwitch extends Switch {
    */
   @property({ type: Boolean }) public haptic = false;
 
-  public updated(changedProperties: PropertyValues<typeof this>) {
+  public updated(changedProperties: PropertyValues<this>) {
     super.updated(changedProperties);
     if (changedProperties.has("haptic")) {
       if (this.haptic) {

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -154,7 +154,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     ),
   };
 
-  public willUpdate(changedProps: PropertyValues) {
+  public willUpdate(changedProps: PropertyValues<this>) {
     super.willUpdate(changedProps);
 
     if (!this.hasUpdated) {

--- a/src/components/ha-two-pane-top-app-bar-fixed.ts
+++ b/src/components/ha-two-pane-top-app-bar-fixed.ts
@@ -7,6 +7,7 @@ import type { MDCTopAppBarAdapter } from "@material/top-app-bar/adapter";
 import { strings } from "@material/top-app-bar/constants";
 // eslint-disable-next-line import-x/no-named-as-default
 import MDCFixedTopAppBarFoundation from "@material/top-app-bar/fixed/foundation";
+import type { PropertyValues } from "lit";
 import { html, css, nothing } from "lit";
 import { property, query, customElement } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
@@ -153,7 +154,7 @@ export class TopAppBarBaseBase extends BaseElement {
     `;
   }
 
-  protected updated(changedProperties) {
+  protected updated(changedProperties: PropertyValues<this>) {
     super.updated(changedProperties);
     if (
       changedProperties.has("pane") &&

--- a/src/components/ha-vacuum-segment-area-mapper.ts
+++ b/src/components/ha-vacuum-segment-area-mapper.ts
@@ -31,7 +31,7 @@ export class HaVacuumSegmentAreaMapper extends LitElement {
     return this._segments;
   }
 
-  protected willUpdate(changedProps: PropertyValues): void {
+  protected willUpdate(changedProps: PropertyValues<this>): void {
     super.willUpdate(changedProps);
 
     if (changedProps.has("entityId") && this.entityId) {

--- a/src/components/input/ha-input.ts
+++ b/src/components/input/ha-input.ts
@@ -153,7 +153,7 @@ export class HaInput extends WaInputMixin(LitElement) {
   }
 
   protected override async firstUpdated(
-    changedProperties: PropertyValues
+    changedProperties: PropertyValues<this>
   ): Promise<void> {
     super.firstUpdated(changedProperties);
 

--- a/src/components/map/ha-locations-editor.ts
+++ b/src/components/map/ha-locations-editor.ts
@@ -156,7 +156,7 @@ export class HaLocationsEditor extends LitElement {
     }
   );
 
-  public willUpdate(changedProps: PropertyValues): void {
+  public willUpdate(changedProps: PropertyValues<this>): void {
     super.willUpdate(changedProps);
 
     // Still loading.
@@ -169,7 +169,7 @@ export class HaLocationsEditor extends LitElement {
     }
   }
 
-  public updated(changedProps: PropertyValues): void {
+  public updated(changedProps: PropertyValues<this>): void {
     // Still loading.
     if (!this.Leaflet) {
       return;

--- a/src/components/map/ha-locations-editor.ts
+++ b/src/components/map/ha-locations-editor.ts
@@ -169,7 +169,7 @@ export class HaLocationsEditor extends LitElement {
     }
   }
 
-  public updated(changedProps: PropertyValues<this>): void {
+  public updated(changedProps: PropertyValues): void {
     // Still loading.
     if (!this.Leaflet) {
       return;

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -319,7 +319,7 @@ export class HaMediaPlayerBrowse extends LitElement {
     }
   }
 
-  protected shouldUpdate(changedProps: PropertyValues): boolean {
+  protected shouldUpdate(changedProps: PropertyValues<this>): boolean {
     if (changedProps.size > 1 || !changedProps.has("hass")) {
       return true;
     }

--- a/src/components/progress/ha-progress-ring.ts
+++ b/src/components/progress/ha-progress-ring.ts
@@ -1,13 +1,13 @@
 import ProgressRing from "@home-assistant/webawesome/dist/components/progress-ring/progress-ring";
 import { css } from "lit";
-import type { CSSResultGroup } from "lit";
+import type { CSSResultGroup, PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
 
 @customElement("ha-progress-ring")
 export class HaProgressRing extends ProgressRing {
   @property() public size?: "tiny" | "small" | "medium" | "large";
 
-  public updated(changedProps) {
+  public updated(changedProps: PropertyValues<this>) {
     super.updated(changedProps);
 
     if (changedProps.has("size")) {

--- a/src/components/target-picker/ha-target-picker-item-row.ts
+++ b/src/components/target-picker/ha-target-picker-item-row.ts
@@ -109,7 +109,7 @@ export class HaTargetPickerItemRow extends LitElement {
 
   @query("ha-target-picker-item-row") public itemRow?: HaTargetPickerItemRow;
 
-  protected willUpdate(changedProps: PropertyValues) {
+  protected willUpdate(changedProps: PropertyValues<this>) {
     if (!this.subEntry && changedProps.has("itemId")) {
       this._updateItemData();
     }

--- a/src/components/trace/hat-graph-node.ts
+++ b/src/components/trace/hat-graph-node.ts
@@ -27,7 +27,7 @@ export class HatGraphNode extends LitElement {
 
   @property({ reflect: true, type: Number }) badge?: number;
 
-  protected updated(changedProps: PropertyValues) {
+  protected updated(changedProps: PropertyValues<this>) {
     if (changedProps.has("noFocus")) {
       if (!this.hasAttribute("tabindex") && !this.noFocus) {
         this.setAttribute("tabindex", "0");

--- a/src/components/trace/hat-trace-timeline.ts
+++ b/src/components/trace/hat-trace-timeline.ts
@@ -812,7 +812,7 @@ export class HaAutomationTracer extends LitElement {
     return html`${entries}`;
   }
 
-  protected updated(props: PropertyValues) {
+  protected updated(props: PropertyValues<this>) {
     super.updated(props);
 
     // Pick first path when we load a new trace.

--- a/src/components/user/ha-user-picker.ts
+++ b/src/components/user/ha-user-picker.ts
@@ -1,5 +1,5 @@
 import type { RenderItemFunction } from "@lit-labs/virtualizer/virtualize";
-import type { TemplateResult } from "lit";
+import type { TemplateResult, PropertyValues } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -39,7 +39,7 @@ class HaUserPicker extends LitElement {
 
   @property({ type: Boolean }) public disabled = false;
 
-  protected firstUpdated(changedProps) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     if (!this.users) {
       this._fetchUsers();

--- a/src/components/user/ha-users-picker.ts
+++ b/src/components/user/ha-users-picker.ts
@@ -1,3 +1,4 @@
+import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { guard } from "lit/directives/guard";
@@ -28,7 +29,7 @@ class HaUsersPicker extends LitElement {
 
   @property({ type: Boolean }) public disabled = false;
 
-  protected firstUpdated(changedProps) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     if (!this.users) {
       this._fetchUsers();

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -433,7 +433,7 @@ class DataEntryFlowDialog extends LitElement {
     `;
   }
 
-  protected firstUpdated(changedProps: PropertyValues) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     this.addEventListener("flow-update", (ev) => {
       const { step, stepPromise } = ev.detail;

--- a/src/dialogs/config-flow/previews/flow-preview-generic.ts
+++ b/src/dialogs/config-flow/previews/flow-preview-generic.ts
@@ -1,6 +1,6 @@
 import type { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
 import { LitElement, html } from "lit";
-import type { nothing, TemplateResult } from "lit";
+import type { nothing, TemplateResult, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import type { FlowType } from "../../../data/data_entry_flow";
 import type { GenericPreview } from "../../../data/preview";
@@ -41,7 +41,7 @@ export class FlowPreviewGeneric extends LitElement {
     }
   }
 
-  willUpdate(changedProps) {
+  willUpdate(changedProps: PropertyValues<this>) {
     if (changedProps.has("stepData")) {
       this._debouncedSubscribePreview();
     }

--- a/src/dialogs/config-flow/previews/flow-preview-template.ts
+++ b/src/dialogs/config-flow/previews/flow-preview-template.ts
@@ -1,4 +1,5 @@
 import type { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
+import type { PropertyValues } from "lit";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { debounce } from "../../../common/util/debounce";
@@ -43,7 +44,7 @@ class FlowPreviewTemplate extends LitElement {
     }
   }
 
-  willUpdate(changedProps) {
+  willUpdate(changedProps: PropertyValues<this>) {
     if (changedProps.has("stepData")) {
       this._debouncedSubscribePreview();
     }

--- a/src/dialogs/config-flow/step-flow-abort.ts
+++ b/src/dialogs/config-flow/step-flow-abort.ts
@@ -22,7 +22,7 @@ class StepFlowAbort extends LitElement {
 
   @property({ attribute: false }) public handler!: string;
 
-  protected firstUpdated(changed: PropertyValues) {
+  protected firstUpdated(changed: PropertyValues<this>) {
     super.firstUpdated(changed);
     if (this.step.reason === "missing_credentials") {
       this._handleMissingCreds();

--- a/src/dialogs/config-flow/step-flow-create-entry.ts
+++ b/src/dialogs/config-flow/step-flow-create-entry.ts
@@ -63,12 +63,12 @@ class StepFlowCreateEntry extends LitElement {
       )
   );
 
-  protected firstUpdated(changedProps: PropertyValues) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     this._loadDomains();
   }
 
-  protected willUpdate(changedProps: PropertyValues) {
+  protected willUpdate(changedProps: PropertyValues<this>) {
     if (!changedProps.has("devices") && !changedProps.has("hass")) {
       return;
     }

--- a/src/dialogs/config-flow/step-flow-external.ts
+++ b/src/dialogs/config-flow/step-flow-external.ts
@@ -1,4 +1,4 @@
-import type { CSSResultGroup, TemplateResult } from "lit";
+import type { CSSResultGroup, TemplateResult, PropertyValues } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import type { DataEntryFlowStepExternal } from "../../data/data_entry_flow";
@@ -32,7 +32,7 @@ class StepFlowExternal extends LitElement {
     `;
   }
 
-  protected firstUpdated(changedProps) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     window.open(this.step.url);
   }

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -139,7 +139,7 @@ class StepFlowForm extends LitElement {
     this._previewErrors = ev.detail;
   }
 
-  protected firstUpdated(changedProps: PropertyValues) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     this.addEventListener("keydown", this._handleKeyDown);
   }

--- a/src/dialogs/config-flow/step-flow-menu.ts
+++ b/src/dialogs/config-flow/step-flow-menu.ts
@@ -18,7 +18,7 @@ class StepFlowMenu extends LitElement {
 
   @property({ attribute: false }) public step!: DataEntryFlowStepMenu;
 
-  protected shouldUpdate(changedProps: PropertyValues): boolean {
+  protected shouldUpdate(changedProps: PropertyValues<this>): boolean {
     return (
       changedProps.size > 1 ||
       !changedProps.has("hass") ||

--- a/src/dialogs/more-info/components/lights/ha-more-info-light-favorite-colors.ts
+++ b/src/dialogs/more-info/components/lights/ha-more-info-light-favorite-colors.ts
@@ -33,7 +33,7 @@ export class HaMoreInfoLightFavoriteColors extends LitElement {
 
   @state() private _favoriteColors: LightColor[] = [];
 
-  protected updated(changedProps: PropertyValues): void {
+  protected updated(changedProps: PropertyValues<this>): void {
     if (changedProps.has("entry") && this.entry) {
       if (this.entry.options?.light?.favorite_colors) {
         this._favoriteColors = this.entry.options.light.favorite_colors;

--- a/src/dialogs/more-info/components/lights/light-color-temp-picker.ts
+++ b/src/dialogs/more-info/components/lights/light-color-temp-picker.ts
@@ -111,7 +111,7 @@ class LightColorTempPicker extends LitElement {
     }
   }
 
-  public willUpdate(changedProps: PropertyValues) {
+  public willUpdate(changedProps: PropertyValues<this>) {
     super.willUpdate(changedProps);
 
     if (this._isInteracting || !changedProps.has("stateObj")) {

--- a/src/dialogs/more-info/controls/more-info-climate.ts
+++ b/src/dialogs/more-info/controls/more-info-climate.ts
@@ -72,7 +72,7 @@ class MoreInfoClimate extends LitElement {
       .attributeValue=${value}
     ></ha-attribute-icon>`;
 
-  protected willUpdate(changedProps: PropertyValues): void {
+  protected willUpdate(changedProps: PropertyValues<this>): void {
     if (
       changedProps.has("stateObj") &&
       this.stateObj &&

--- a/src/dialogs/more-info/controls/more-info-conversation.ts
+++ b/src/dialogs/more-info/controls/more-info-conversation.ts
@@ -19,7 +19,7 @@ class MoreInfoConversation extends LitElement {
 
   @state() private _errorLoadAssist?: "not_found" | "unknown";
 
-  protected willUpdate(changedProperties: PropertyValues): void {
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
 
     if (!changedProperties.has("stateObj") || !this.stateObj) {

--- a/src/dialogs/more-info/controls/more-info-cover.ts
+++ b/src/dialogs/more-info/controls/more-info-cover.ts
@@ -44,7 +44,7 @@ class MoreInfoCover extends LitElement {
     this._mode = ev.currentTarget.mode;
   }
 
-  protected willUpdate(changedProps: PropertyValues): void {
+  protected willUpdate(changedProps: PropertyValues<this>): void {
     super.willUpdate(changedProps);
     if (changedProps.has("stateObj") && this.stateObj) {
       const entityId = this.stateObj.entity_id;

--- a/src/dialogs/more-info/controls/more-info-fan.ts
+++ b/src/dialogs/more-info/controls/more-info-fan.ts
@@ -101,7 +101,7 @@ class MoreInfoFan extends LitElement {
     });
   }
 
-  protected updated(changedProps: PropertyValues): void {
+  protected updated(changedProps: PropertyValues<this>): void {
     if (changedProps.has("stateObj")) {
       this._presetMode = this.stateObj?.attributes.preset_mode;
     }

--- a/src/dialogs/more-info/controls/more-info-group.ts
+++ b/src/dialogs/more-info/controls/more-info-group.ts
@@ -23,7 +23,7 @@ class MoreInfoGroup extends LitElement {
 
   @state() private _moreInfoType?: string;
 
-  protected updated(changedProperties: PropertyValues) {
+  protected updated(changedProperties: PropertyValues<this>) {
     if (
       !this.hass ||
       !this.stateObj ||

--- a/src/dialogs/more-info/controls/more-info-humidifier.ts
+++ b/src/dialogs/more-info/controls/more-info-humidifier.ts
@@ -31,7 +31,7 @@ class MoreInfoHumidifier extends LitElement {
       .attributeValue=${value}
     ></ha-attribute-icon>`;
 
-  protected willUpdate(changedProps: PropertyValues): void {
+  protected willUpdate(changedProps: PropertyValues<this>): void {
     super.willUpdate(changedProps);
     if (changedProps.has("stateObj")) {
       this._mode = this.stateObj?.attributes.mode;

--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -66,7 +66,7 @@ class MoreInfoLight extends LitElement {
       .attributeValue=${value}
     ></ha-attribute-icon>`;
 
-  protected updated(changedProps: PropertyValues<typeof this>): void {
+  protected updated(changedProps: PropertyValues<this>): void {
     if (changedProps.has("stateObj")) {
       this._effect = this.stateObj?.attributes.effect;
     }

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -90,7 +90,7 @@ class MoreInfoMediaPlayer extends LitElement {
     this._clearProgressInterval();
   }
 
-  protected firstUpdated(_changedProperties: PropertyValues) {
+  protected firstUpdated(_changedProperties: PropertyValues<this>) {
     if (this._positionSlider) {
       this._positionSlider.valueFormatter = (value: number) =>
         this._formatDuration(value);
@@ -682,7 +682,7 @@ class MoreInfoMediaPlayer extends LitElement {
     );
   }
 
-  protected updated(changedProps: PropertyValues): void {
+  protected updated(changedProps: PropertyValues<this>): void {
     super.updated(changedProps);
     if (changedProps.has("stateObj")) {
       this._syncProgressInterval();

--- a/src/dialogs/more-info/controls/more-info-script.ts
+++ b/src/dialogs/more-info/controls/more-info-script.ts
@@ -151,7 +151,7 @@ class MoreInfoScript extends LitElement {
     `;
   }
 
-  protected override willUpdate(changedProperties: PropertyValues): void {
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
 
     if (changedProperties.has("stateObj")) {

--- a/src/dialogs/more-info/controls/more-info-valve.ts
+++ b/src/dialogs/more-info/controls/more-info-valve.ts
@@ -41,7 +41,7 @@ class MoreInfoValve extends LitElement {
     this._mode = ev.currentTarget.mode;
   }
 
-  protected willUpdate(changedProps: PropertyValues): void {
+  protected willUpdate(changedProps: PropertyValues<this>): void {
     super.willUpdate(changedProps);
     if (changedProps.has("stateObj") && this.stateObj) {
       const entityId = this.stateObj.entity_id;

--- a/src/dialogs/more-info/controls/more-info-weather.ts
+++ b/src/dialogs/more-info/controls/more-info-weather.ts
@@ -93,7 +93,7 @@ class MoreInfoWeather extends LitElement {
     this._unsubscribeForecastEvents();
   }
 
-  protected shouldUpdate(changedProps: PropertyValues): boolean {
+  protected shouldUpdate(changedProps: PropertyValues<this>): boolean {
     if (changedProps.has("stateObj")) {
       return true;
     }
@@ -129,7 +129,7 @@ class MoreInfoWeather extends LitElement {
     }
   }
 
-  protected updated(_changedProps: PropertyValues): void {
+  protected updated(_changedProps: PropertyValues<this>): void {
     super.updated(_changedProps);
 
     if (!this.stateObj) {

--- a/src/dialogs/more-info/ha-more-info-details.ts
+++ b/src/dialogs/more-info/ha-more-info-details.ts
@@ -35,7 +35,7 @@ class HaMoreInfoDetails extends LitElement {
 
   @state() private _stateObj?: HassEntity;
 
-  protected willUpdate(changedProps: PropertyValues): void {
+  protected willUpdate(changedProps: PropertyValues<this>): void {
     super.willUpdate(changedProps);
     if (changedProps.has("params") || changedProps.has("hass")) {
       if (this.params?.entityId && this.hass) {

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -899,7 +899,7 @@ export class MoreInfoDialog extends ScrollableFadeMixin(LitElement) {
     `;
   }
 
-  protected firstUpdated(changedProps: PropertyValues) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     this.addEventListener("close-dialog", () => this.closeDialog());
     this.addEventListener("close-child-view", () => this._goBack());

--- a/src/dialogs/more-info/ha-more-info-history-and-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-history-and-logbook.ts
@@ -1,3 +1,4 @@
+import type { PropertyValues } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import type { HomeAssistant } from "../../types";
@@ -22,7 +23,7 @@ export class MoreInfoHistoryAndLogbook extends LitElement {
     this._sensorNumericDeviceClasses = deviceClasses.numeric_device_classes;
   }
 
-  protected firstUpdated(changedProps) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     this._loadNumericDeviceClasses();
   }

--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -107,7 +107,7 @@ export class MoreInfoHistory extends LitElement {
       : ""}`;
   }
 
-  protected willUpdate(changedProps: PropertyValues): void {
+  protected willUpdate(changedProps: PropertyValues<this>): void {
     super.willUpdate(changedProps);
 
     if (changedProps.has("entityId")) {

--- a/src/dialogs/more-info/ha-more-info-info.ts
+++ b/src/dialogs/more-info/ha-more-info-info.ts
@@ -1,4 +1,5 @@
 import type { HassEntity } from "home-assistant-js-websocket";
+import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { computeDomain } from "../../common/entity/compute_domain";
@@ -36,7 +37,7 @@ export class MoreInfoInfo extends LitElement {
     this._sensorNumericDeviceClasses = deviceClasses.numeric_device_classes;
   }
 
-  protected firstUpdated(changedProps) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     this._loadNumericDeviceClasses();
   }

--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -51,7 +51,7 @@ export class MoreInfoLogbook extends LitElement {
     `;
   }
 
-  protected willUpdate(changedProps: PropertyValues): void {
+  protected willUpdate(changedProps: PropertyValues<this>): void {
     super.willUpdate(changedProps);
 
     if (changedProps.has("entityId") && this.entityId) {

--- a/src/dialogs/more-info/ha-more-info-settings.ts
+++ b/src/dialogs/more-info/ha-more-info-settings.ts
@@ -60,7 +60,7 @@ export class HaMoreInfoSettings extends LitElement {
     `;
   }
 
-  public willUpdate(changedProps: PropertyValues) {
+  public willUpdate(changedProps: PropertyValues<this>) {
     if (changedProps.has("entry")) {
       this._loadPlatformSettingTabs();
     }

--- a/src/dialogs/more-info/ha-more-info-settings.ts
+++ b/src/dialogs/more-info/ha-more-info-settings.ts
@@ -60,7 +60,7 @@ export class HaMoreInfoSettings extends LitElement {
     `;
   }
 
-  public willUpdate(changedProps: PropertyValues<this>) {
+  public willUpdate(changedProps: PropertyValues) {
     if (changedProps.has("entry")) {
       this._loadPlatformSettingTabs();
     }

--- a/src/dialogs/notifications/notification-drawer.ts
+++ b/src/dialogs/notifications/notification-drawer.ts
@@ -69,7 +69,7 @@ export class HuiNotificationDrawer extends KeyboardShortcutMixin(LitElement) {
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   };
 
-  public willUpdate(changedProps: PropertyValues): void {
+  public willUpdate(changedProps: PropertyValues<this>): void {
     super.willUpdate(changedProps);
 
     if (!this.hasUpdated) {

--- a/src/dialogs/notifications/notification-item.ts
+++ b/src/dialogs/notifications/notification-item.ts
@@ -14,7 +14,7 @@ export class HuiNotificationItem extends LitElement {
   @property({ attribute: false })
   public notification?: HassEntity | PersistentNotification;
 
-  protected shouldUpdate(changedProps: PropertyValues): boolean {
+  protected shouldUpdate(changedProps: PropertyValues<this>): boolean {
     if (!this.hass || !this.notification || changedProps.has("notification")) {
       return true;
     }

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-dialog.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-dialog.ts
@@ -1,5 +1,5 @@
 import { mdiChevronLeft, mdiMenuDown } from "@mdi/js";
-import type { CSSResultGroup } from "lit";
+import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -82,7 +82,7 @@ export class HaVoiceAssistantSetupDialog extends LitElement {
     this._open = false;
   }
 
-  protected willUpdate(changedProps) {
+  protected willUpdate(changedProps: PropertyValues) {
     if (changedProps.has("_step") && this._step === STEP.PIPELINE) {
       this._getLanguages();
     }

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-check.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-check.ts
@@ -18,7 +18,7 @@ export class HaVoiceAssistantSetupStepCheck extends LitElement {
 
   @state() private _showLoader = false;
 
-  protected override willUpdate(changedProperties: PropertyValues): void {
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
     if (!this.hasUpdated) {
       this._testConnection();

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-local.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-local.ts
@@ -156,7 +156,7 @@ export class HaVoiceAssistantSetupStepLocal extends LitElement {
     </div>`;
   }
 
-  protected override willUpdate(changedProperties: PropertyValues): void {
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
 
     if (!this.hasUpdated) {

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-success.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-success.ts
@@ -50,7 +50,7 @@ export class HaVoiceAssistantSetupStepSuccess extends LitElement {
 
   private _deviceName?: string;
 
-  protected override willUpdate(changedProperties: PropertyValues): void {
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
 
     if (changedProperties.has("assistConfiguration")) {

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-update.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-update.ts
@@ -24,7 +24,7 @@ export class HaVoiceAssistantSetupStepUpdate extends LitElement {
 
   private _refreshTimeout?: number;
 
-  protected override willUpdate(changedProperties: PropertyValues): void {
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
 
     if (!this.updateEntityId) {

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-wake-word.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-wake-word.ts
@@ -42,7 +42,7 @@ export class HaVoiceAssistantSetupStepWakeWord extends LitElement {
     this._stopListeningWakeWord();
   }
 
-  protected override willUpdate(changedProperties: PropertyValues) {
+  protected override willUpdate(changedProperties: PropertyValues<this>) {
     super.willUpdate(changedProperties);
 
     if (changedProperties.has("assistConfiguration")) {

--- a/src/fake_data/entities/base-entity.ts
+++ b/src/fake_data/entities/base-entity.ts
@@ -100,7 +100,10 @@ export class MockBaseEntity {
     }
   }
 
-  public update(changes): void {
+  public update(changes: {
+    state?: string;
+    attributes?: EntityAttributes;
+  }): void {
     this.lastUpdated = now();
     if (changes.state !== undefined && changes.state !== this.state) {
       this.state = changes.state;

--- a/src/fake_data/entities/base-entity.ts
+++ b/src/fake_data/entities/base-entity.ts
@@ -100,10 +100,7 @@ export class MockBaseEntity {
     }
   }
 
-  public update(changes: {
-    state?: string;
-    attributes?: EntityAttributes;
-  }): void {
+  public update(changes): void {
     this.lastUpdated = now();
     if (changes.state !== undefined && changes.state !== this.state) {
       this.state = changes.state;

--- a/src/layouts/hass-router-page.ts
+++ b/src/layouts/hass-router-page.ts
@@ -65,7 +65,7 @@ export class HassRouterPage extends ReactiveElement {
     return this;
   }
 
-  protected update(changedProps: PropertyValues) {
+  protected update(changedProps: PropertyValues<this>) {
     super.update(changedProps);
 
     const routerOptions = this.routerOptions || { routes: {} };
@@ -222,7 +222,7 @@ export class HassRouterPage extends ReactiveElement {
     );
   }
 
-  protected firstUpdated(changedProps: PropertyValues) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
 
     const options = this.routerOptions;

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -210,7 +210,7 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
     this._dataTable.clearSelection();
   }
 
-  protected willUpdate(changedProperties: PropertyValues) {
+  protected willUpdate(changedProperties: PropertyValues<this>) {
     if (
       changedProperties.has("tabs") ||
       (changedProperties.has("hass") &&

--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -135,7 +135,7 @@ export class HassTabsSubpage extends LitElement {
     }
   );
 
-  public willUpdate(changedProperties: PropertyValues) {
+  public willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("route")) {
       const currentPath = `${this.route.prefix}${this.route.path}`;
       this._activeTab = this.tabs.find((tab) =>

--- a/src/layouts/home-assistant-main.ts
+++ b/src/layouts/home-assistant-main.ts
@@ -120,13 +120,13 @@ export class HomeAssistantMain extends LitElement {
     });
   }
 
-  public willUpdate(changedProps: PropertyValues) {
+  public willUpdate(changedProps: PropertyValues<this>) {
     if (changedProps.has("route") && this._sidebarNarrow) {
       this._drawerOpen = false;
     }
   }
 
-  protected updated(changedProps: PropertyValues) {
+  protected updated(changedProps: PropertyValues<this>) {
     super.updated(changedProps);
 
     toggleAttribute(this, "expanded", this.hass.dockedSidebar === "docked");

--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -53,7 +53,7 @@ class PartialPanelResolver extends HassRouterPage {
 
   private _hiddenTimeout?: number;
 
-  protected firstUpdated(changedProps: PropertyValues) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
 
     // Attach listeners for visibility
@@ -65,7 +65,7 @@ class PartialPanelResolver extends HassRouterPage {
     document.addEventListener("resume", () => this._checkVisibility());
   }
 
-  public willUpdate(changedProps: PropertyValues) {
+  public willUpdate(changedProps: PropertyValues<this>) {
     super.willUpdate(changedProps);
 
     if (!changedProps.has("hass")) {

--- a/src/layouts/supervisor-error-screen.ts
+++ b/src/layouts/supervisor-error-screen.ts
@@ -13,13 +13,13 @@ import "./hass-subpage";
 class SupervisorErrorScreen extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  protected firstUpdated(changedProps: PropertyValues) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
 
     this._applyTheme();
   }
 
-  protected updated(changedProps: PropertyValues) {
+  protected updated(changedProps: PropertyValues<this>) {
     super.updated(changedProps);
     const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
     if (!oldHass) {

--- a/src/mixins/prevent-unsaved-mixin.ts
+++ b/src/mixins/prevent-unsaved-mixin.ts
@@ -30,7 +30,7 @@ export const PreventUnsavedMixin = <T extends Constructor<LitElement>>(
       window.removeEventListener("beforeunload", this._handleUnload);
     }
 
-    protected willUpdate(changedProperties: PropertyValues): void {
+    protected willUpdate(changedProperties: PropertyValues<this>): void {
       super.willUpdate(changedProperties);
 
       if (this.isDirty) {

--- a/src/mixins/provide-hass-lit-mixin.ts
+++ b/src/mixins/provide-hass-lit-mixin.ts
@@ -18,7 +18,7 @@ export const ProvideHassLitMixin = <T extends Constructor<ReactiveElement>>(
       el.hass = this.hass;
     }
 
-    protected updated(changedProps: PropertyValues) {
+    protected updated(changedProps: PropertyValues<this>) {
       super.updated(changedProps);
 
       if (changedProps.has("hass")) {

--- a/src/mixins/provide-hass-lit-mixin.ts
+++ b/src/mixins/provide-hass-lit-mixin.ts
@@ -18,7 +18,7 @@ export const ProvideHassLitMixin = <T extends Constructor<ReactiveElement>>(
       el.hass = this.hass;
     }
 
-    protected updated(changedProps: PropertyValues<this>) {
+    protected updated(changedProps: PropertyValues) {
       super.updated(changedProps);
 
       if (changedProps.has("hass")) {

--- a/src/mixins/scrollable-fade-mixin.ts
+++ b/src/mixins/scrollable-fade-mixin.ts
@@ -71,7 +71,7 @@ export const ScrollableFadeMixin = <T extends Constructor<LitElement>>(
       return ScrollableFadeClass.DEFAULT_SCROLLABLE_ELEMENT;
     }
 
-    protected firstUpdated(changedProperties: PropertyValues) {
+    protected firstUpdated(changedProperties: PropertyValues<this>) {
       super.firstUpdated?.(changedProperties);
       if (this.scrollableElement) {
         this._updateScrollableState(this.scrollableElement);
@@ -79,7 +79,7 @@ export const ScrollableFadeMixin = <T extends Constructor<LitElement>>(
       this._attachScrollableElement();
     }
 
-    protected updated(changedProperties: PropertyValues) {
+    protected updated(changedProperties: PropertyValues<this>) {
       super.updated?.(changedProperties);
       this._attachScrollableElement();
     }

--- a/src/mixins/subscribe-mixin.ts
+++ b/src/mixins/subscribe-mixin.ts
@@ -38,7 +38,7 @@ export const SubscribeMixin = <T extends Constructor<ReactiveElement>>(
       }
     }
 
-    protected updated(changedProps: PropertyValues) {
+    protected updated(changedProps: PropertyValues<this>) {
       super.updated(changedProps);
       if (changedProps.has("hass")) {
         this._checkSubscribed();

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -784,7 +784,7 @@ class HaPanelConfig extends HassRouterPage {
     entityRegistryById.clear();
   }
 
-  protected firstUpdated(changedProps: PropertyValues) {
+  protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     this.hass.loadBackendTranslation("title");
     this.hass.loadBackendTranslation("services");


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Improves typing on lit changed properties for `update`/`willUpdate`/`firstUpdated`/`updated` etc.

Those with `private`/`protected` changed props will use looser typing (remove `<this>`) otherwise they should use the recommended default according to https://lit.dev/docs/components/lifecycle/#changed-properties.

First commit uses LLM generated programmatic scripts and tuned afterwards.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
