### PR TITLE
Remove resources from hass object

### DIFF
--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -15,7 +15,7 @@ import {
   TimeZone,
 } from "../data/translation";
 import { translationMetadata } from "../resources/translations-metadata";
-import type { HomeAssistant, ValuePart } from "../types";
+import type { HomeAssistant, Resources, ValuePart } from "../types";
 import { getLocalLanguage, getTranslation } from "../util/common-translation";
 import { demoConfig } from "./demo_config";
 import { demoPanels } from "./demo_panels";
@@ -78,6 +78,7 @@ export const provideHass = (
   const restResponses: [string | RegExp, MockRestCallback][] = [];
   const eventListeners: Record<string, ((event) => void)[]> = {};
   const entities = {};
+  let resources: Resources = {};
 
   async function updateTranslations(
     fragment: null | string,
@@ -94,17 +95,14 @@ export const provideHass = (
     language?: string
   ) {
     const lang = language || getLocalLanguage();
-    const resources = {
+    resources = {
       [lang]: {
-        ...(hass().resources && hass().resources[lang]),
+        ...resources[lang],
         ...translations,
       },
     };
     hass().updateHass({
-      resources,
-    });
-    hass().updateHass({
-      localize: await computeLocalize(elements[0], lang, hass().resources),
+      localize: await computeLocalize(elements[0], lang, resources),
     });
     fireEvent(window, "translations-updated");
   }
@@ -291,7 +289,6 @@ export const provideHass = (
       time_zone: TimeZone.local,
       first_weekday: FirstWeekday.language,
     },
-    resources: null as any,
     localize: () => "",
 
     translationMetadata: translationMetadata as any,

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -80,7 +80,6 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
           time_zone: TimeZone.local,
           first_weekday: FirstWeekday.language,
         },
-        resources: null as any,
         localize: () => "",
         translationMetadata,
         kioskMode: false,

--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -23,7 +23,7 @@ import {
   subscribeTranslationPreferences,
 } from "../data/translation";
 import { translationMetadata } from "../resources/translations-metadata";
-import type { Constructor, HomeAssistant } from "../types";
+import type { Constructor, HomeAssistant, Resources } from "../types";
 import {
   getLocalLanguage,
   getTranslation,
@@ -76,6 +76,8 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
 
     private __loadedTranslations: Record<string, LoadedTranslationCategory> =
       {};
+
+    private __resources: Resources = {};
 
     protected firstUpdated(changedProps: PropertyValues<this>) {
       super.firstUpdated(changedProps);
@@ -447,13 +449,13 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
 
       const resources = {
         [language]: {
-          ...(this.hass ?? this._pendingHass)?.resources?.[language],
+          ...this.__resources[language],
           ...data,
         },
       };
 
       // Update resources immediately, so when a new update comes in we don't miss values
-      this._updateHass({ resources });
+      this.__resources = resources;
 
       const localize = await computeLocalize(this, language, resources);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -339,7 +339,6 @@ export interface HomeAssistant
     HomeAssistantConfig {
   states: HassEntities;
   services: HassServices;
-  resources: Resources;
 }
 
 export interface Route {


### PR DESCRIPTION
## Proposed change

The `HomeAssistant.resources` field held translation resources that were only ever read by the translation system itself — every consumer goes through `hass.localize()`. This moves the storage to a private field on the translations mixin (and a closure in the demo mock), keeping the hass interface focused on public state.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51468
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr