### PR TITLE
Minimize Sankey flow crossings with barycenter sort

### DIFF
--- a/src/components/chart/ha-sankey-chart.ts
+++ b/src/components/chart/ha-sankey-chart.ts
@@ -291,20 +291,26 @@ export class HaSankeyChart extends LitElement {
   }
 
   private _findParentIndex(id: string, links: Link[], sections: Node[][]) {
-    const parent = links.find((l) => l.target === id)?.source;
-    if (!parent) {
+    const parents = links.filter((l) => l.target === id).map((l) => l.source);
+    if (parents.length === 0) {
       return -1;
     }
-    let offset = 0;
-    for (let i = sections.length - 1; i >= 0; i--) {
-      const section = sections[i];
-      const index = section.findIndex((n) => n.id === parent);
-      if (index !== -1) {
-        return offset + index;
+    let sum = 0;
+    let count = 0;
+    for (const parent of parents) {
+      let offset = 0;
+      for (let i = sections.length - 1; i >= 0; i--) {
+        const section = sections[i];
+        const index = section.findIndex((n) => n.id === parent);
+        if (index !== -1) {
+          sum += offset + index;
+          count++;
+          break;
+        }
+        offset += section.length;
       }
-      offset += section.length;
     }
-    return -1;
+    return count > 0 ? sum / count : -1;
   }
 
   static styles = css`

--- a/src/resources/echarts/components/sankey/sankey-layout.ts
+++ b/src/resources/echarts/components/sankey/sankey-layout.ts
@@ -107,6 +107,7 @@ function layoutSankey(
   const processedNodes = processNodes(
     filteredNodes,
     passThroughNodes,
+    edges,
     depths,
     width,
     height,
@@ -357,20 +358,6 @@ interface EdgeSegment {
   targetIdx: number;
 }
 
-function collectAllEdges(sections: Node[][]): GraphEdge[] {
-  // Each edge appears in its source node's outEdges and its target node's
-  // inEdges. Scanning only outEdges reaches every edge exactly once.
-  const collected: GraphEdge[] = [];
-  sections.forEach((section) =>
-    section.forEach((node) => {
-      if (!isPassThroughNode(node)) {
-        node.outEdges.forEach((edge) => collected.push(edge));
-      }
-    })
-  );
-  return collected;
-}
-
 function getEdgeSegmentsBetween(
   depthL: number,
   depthR: number,
@@ -469,13 +456,13 @@ const MAX_SORT_ITERATIONS = 4;
 
 export function sortNodesInSections(
   nodesPerSection: Record<number, Node[]>,
-  depths: number[]
+  depths: number[],
+  edges: GraphEdge[]
 ): Record<number, Node[]> {
   const sections: Node[][] = depths.map((d) => [...(nodesPerSection[d] || [])]);
   // Id→index lookup per section, kept in sync with sections. Rebuilt only when
   // a section's order actually changes (inside tryReplace).
   const sectionMaps: Map<string, number>[] = sections.map(buildIdIndexMap);
-  const edges = collectAllEdges(sections);
 
   // Replace a section with a candidate ordering only when crossings strictly
   // drop on either side. This keeps user-intended ordering intact when
@@ -617,6 +604,7 @@ function positionNodesInSection(
 function processNodes(
   nodes: GraphNode[],
   passThroughNodes: PassThroughNode[],
+  edges: GraphEdge[],
   depths: number[],
   width: number,
   height: number,
@@ -632,7 +620,11 @@ function processNodes(
   );
 
   const nodesPerSection = groupNodesBySection(nodes, passThroughNodes);
-  const sortedNodesPerSection = sortNodesInSections(nodesPerSection, depths);
+  const sortedNodesPerSection = sortNodesInSections(
+    nodesPerSection,
+    depths,
+    edges
+  );
   let globalValueToSizeRatio = 0;
 
   const sections = depths.map((depth) => {

--- a/src/resources/echarts/components/sankey/sankey-layout.ts
+++ b/src/resources/echarts/components/sankey/sankey-layout.ts
@@ -372,15 +372,13 @@ function collectAllEdges(sections: Node[][]): GraphEdge[] {
 }
 
 function getEdgeSegmentsBetween(
-  sectionL: Node[],
-  sectionR: Node[],
   depthL: number,
   depthR: number,
   depths: number[],
-  edges: GraphEdge[]
+  edges: GraphEdge[],
+  lMap: Map<string, number>,
+  rMap: Map<string, number>
 ): EdgeSegment[] {
-  const lMap = buildIdIndexMap(sectionL);
-  const rMap = buildIdIndexMap(sectionR);
   const segments: EdgeSegment[] = [];
   edges.forEach((edge) => {
     if (edge.getLayout().value === 0) return;
@@ -435,6 +433,7 @@ function countCrossings(segments: EdgeSegment[]): number {
 function crossingsAdjacentTo(
   sectionIndex: number,
   sections: Node[][],
+  sectionMaps: Map<string, number>[],
   depths: number[],
   edges: GraphEdge[]
 ): number {
@@ -442,24 +441,24 @@ function crossingsAdjacentTo(
   if (sectionIndex > 0) {
     total += countCrossings(
       getEdgeSegmentsBetween(
-        sections[sectionIndex - 1],
-        sections[sectionIndex],
         depths[sectionIndex - 1],
         depths[sectionIndex],
         depths,
-        edges
+        edges,
+        sectionMaps[sectionIndex - 1],
+        sectionMaps[sectionIndex]
       )
     );
   }
   if (sectionIndex < sections.length - 1) {
     total += countCrossings(
       getEdgeSegmentsBetween(
-        sections[sectionIndex],
-        sections[sectionIndex + 1],
         depths[sectionIndex],
         depths[sectionIndex + 1],
         depths,
-        edges
+        edges,
+        sectionMaps[sectionIndex],
+        sectionMaps[sectionIndex + 1]
       )
     );
   }
@@ -473,20 +472,26 @@ export function sortNodesInSections(
   depths: number[]
 ): Record<number, Node[]> {
   const sections: Node[][] = depths.map((d) => [...(nodesPerSection[d] || [])]);
+  // Id→index lookup per section, kept in sync with sections. Rebuilt only when
+  // a section's order actually changes (inside tryReplace).
+  const sectionMaps: Map<string, number>[] = sections.map(buildIdIndexMap);
   const edges = collectAllEdges(sections);
 
   // Replace a section with a candidate ordering only when crossings strictly
   // drop on either side. This keeps user-intended ordering intact when
   // barycenter would shuffle nodes without improving the layout.
   const tryReplace = (i: number, candidate: Node[]): boolean => {
-    const before = crossingsAdjacentTo(i, sections, depths, edges);
-    const snapshot = sections[i];
+    const before = crossingsAdjacentTo(i, sections, sectionMaps, depths, edges);
+    const sectionSnapshot = sections[i];
+    const mapSnapshot = sectionMaps[i];
     sections[i] = candidate;
-    const after = crossingsAdjacentTo(i, sections, depths, edges);
+    sectionMaps[i] = buildIdIndexMap(candidate);
+    const after = crossingsAdjacentTo(i, sections, sectionMaps, depths, edges);
     if (after < before) {
       return true;
     }
-    sections[i] = snapshot;
+    sections[i] = sectionSnapshot;
+    sectionMaps[i] = mapSnapshot;
     return false;
   };
 
@@ -494,10 +499,11 @@ export function sortNodesInSections(
     let changed = false;
 
     for (let i = 1; i < sections.length; i++) {
-      const prevMap = buildIdIndexMap(sections[i - 1]);
       const prevDepth = depths[i - 1];
-      const result = sortSectionByBarycenter(sections[i], prevMap, (node) =>
-        getNeighborIds(node, "source", prevDepth, depths)
+      const result = sortSectionByBarycenter(
+        sections[i],
+        sectionMaps[i - 1],
+        (node) => getNeighborIds(node, "source", prevDepth, depths)
       );
       if (result.changed && tryReplace(i, result.sorted)) {
         changed = true;
@@ -505,10 +511,11 @@ export function sortNodesInSections(
     }
 
     for (let i = sections.length - 2; i >= 0; i--) {
-      const nextMap = buildIdIndexMap(sections[i + 1]);
       const nextDepth = depths[i + 1];
-      const result = sortSectionByBarycenter(sections[i], nextMap, (node) =>
-        getNeighborIds(node, "target", nextDepth, depths)
+      const result = sortSectionByBarycenter(
+        sections[i],
+        sectionMaps[i + 1],
+        (node) => getNeighborIds(node, "target", nextDepth, depths)
       );
       if (result.changed && tryReplace(i, result.sorted)) {
         changed = true;

--- a/src/resources/echarts/components/sankey/sankey-layout.ts
+++ b/src/resources/echarts/components/sankey/sankey-layout.ts
@@ -143,6 +143,14 @@ export function getPassThroughSections(
   return depths.slice(sourceDepthIndex + 1, targetDepthIndex);
 }
 
+export function passThroughNodeId(
+  sourceId: string,
+  targetId: string,
+  depth: number
+): string {
+  return `${sourceId}-${targetId}-${depth}`;
+}
+
 export function createPassThroughNode(
   sourceId: string,
   targetId: string,
@@ -151,7 +159,7 @@ export function createPassThroughNode(
 ): PassThroughNode {
   return {
     passThrough: true,
-    id: `${sourceId}-${targetId}-${depth}`,
+    id: passThroughNodeId(sourceId, targetId, depth),
     value,
     depth,
     sourceId,
@@ -241,76 +249,279 @@ export function groupNodesBySection(
   return nodesPerSection;
 }
 
+interface WeightedNeighbor {
+  id: string;
+  weight: number;
+}
+
+type NeighborDirection = "source" | "target";
+
+function getNeighborIds(
+  node: Node,
+  direction: NeighborDirection,
+  referenceDepth: number,
+  depths: number[]
+): WeightedNeighbor[] {
+  // Passthroughs have one real source and target; the matching neighbor at
+  // referenceDepth is either the real node (when referenceDepth is that end's
+  // depth) or another passthrough in the same chain. We return both candidates
+  // and let the id-index map pick whichever exists.
+  if (isPassThroughNode(node)) {
+    const realEnd = direction === "source" ? node.sourceId : node.targetId;
+    return [
+      { id: realEnd, weight: node.value },
+      {
+        id: passThroughNodeId(node.sourceId, node.targetId, referenceDepth),
+        weight: node.value,
+      },
+    ];
+  }
+
+  const edges = direction === "source" ? node.inEdges : node.outEdges;
+  const results: WeightedNeighbor[] = [];
+  edges.forEach((edge) => {
+    const sourceItem = edge.node1.hostGraph.data.getRawDataItem(
+      edge.node1.dataIndex
+    ) as SankeyNodeItemOption;
+    const targetItem = edge.node2.hostGraph.data.getRawDataItem(
+      edge.node2.dataIndex
+    ) as SankeyNodeItemOption;
+    const neighborEnd = direction === "source" ? edge.node1 : edge.node2;
+    const neighborDepth = getNodeDepthInfo(neighborEnd, depths).depth;
+    const edgeValue = getEdgeValue(edge);
+
+    if (neighborDepth === referenceDepth) {
+      const neighborItem = direction === "source" ? sourceItem : targetItem;
+      results.push({ id: neighborItem.id as string, weight: edgeValue });
+      return;
+    }
+    const spansPastReference =
+      direction === "source"
+        ? neighborDepth < referenceDepth
+        : neighborDepth > referenceDepth;
+    if (spansPastReference) {
+      results.push({
+        id: passThroughNodeId(
+          sourceItem.id as string,
+          targetItem.id as string,
+          referenceDepth
+        ),
+        weight: edgeValue,
+      });
+    }
+  });
+  return results;
+}
+
+export function computeBarycenter(
+  neighbors: WeightedNeighbor[],
+  referenceIdIndexMap: Map<string, number>,
+  fallback: number
+): number {
+  let weightedSum = 0;
+  let totalWeight = 0;
+  neighbors.forEach(({ id, weight }) => {
+    const idx = referenceIdIndexMap.get(id);
+    if (idx !== undefined) {
+      weightedSum += idx * weight;
+      totalWeight += weight;
+    }
+  });
+  return totalWeight > 0 ? weightedSum / totalWeight : fallback;
+}
+
+function buildIdIndexMap(section: Node[]): Map<string, number> {
+  const map = new Map<string, number>();
+  section.forEach((node, index) => map.set(node.id, index));
+  return map;
+}
+
+function sortSectionByBarycenter(
+  section: Node[],
+  referenceMap: Map<string, number>,
+  getNeighbors: (node: Node) => WeightedNeighbor[]
+): { sorted: Node[]; changed: boolean } {
+  const decorated = section.map((node, index) => ({
+    node,
+    index,
+    barycenter: computeBarycenter(getNeighbors(node), referenceMap, index),
+  }));
+  decorated.sort((a, b) => a.barycenter - b.barycenter || a.index - b.index);
+  const sorted = decorated.map((d) => d.node);
+  const changed = sorted.some((n, idx) => n !== section[idx]);
+  return { sorted, changed };
+}
+
+interface EdgeSegment {
+  sourceIdx: number;
+  targetIdx: number;
+}
+
+function collectAllEdges(sections: Node[][]): GraphEdge[] {
+  // Each edge appears in its source node's outEdges and its target node's
+  // inEdges. Scanning only outEdges reaches every edge exactly once.
+  const collected: GraphEdge[] = [];
+  sections.forEach((section) =>
+    section.forEach((node) => {
+      if (!isPassThroughNode(node)) {
+        node.outEdges.forEach((edge) => collected.push(edge));
+      }
+    })
+  );
+  return collected;
+}
+
+function getEdgeSegmentsBetween(
+  sectionL: Node[],
+  sectionR: Node[],
+  depthL: number,
+  depthR: number,
+  depths: number[],
+  edges: GraphEdge[]
+): EdgeSegment[] {
+  const lMap = buildIdIndexMap(sectionL);
+  const rMap = buildIdIndexMap(sectionR);
+  const segments: EdgeSegment[] = [];
+  edges.forEach((edge) => {
+    if (edge.getLayout().value === 0) return;
+    const sourceItem = edge.node1.hostGraph.data.getRawDataItem(
+      edge.node1.dataIndex
+    ) as SankeyNodeItemOption;
+    const targetItem = edge.node2.hostGraph.data.getRawDataItem(
+      edge.node2.dataIndex
+    ) as SankeyNodeItemOption;
+    const sourceDepth = getNodeDepthInfo(edge.node1, depths).depth;
+    const targetDepth = getNodeDepthInfo(edge.node2, depths).depth;
+    if (sourceDepth > depthL || targetDepth < depthR) return;
+    const sourceIdInL =
+      sourceDepth === depthL
+        ? (sourceItem.id as string)
+        : passThroughNodeId(
+            sourceItem.id as string,
+            targetItem.id as string,
+            depthL
+          );
+    const targetIdInR =
+      targetDepth === depthR
+        ? (targetItem.id as string)
+        : passThroughNodeId(
+            sourceItem.id as string,
+            targetItem.id as string,
+            depthR
+          );
+    const s = lMap.get(sourceIdInL);
+    const t = rMap.get(targetIdInR);
+    if (s !== undefined && t !== undefined) {
+      segments.push({ sourceIdx: s, targetIdx: t });
+    }
+  });
+  return segments;
+}
+
+function countCrossings(segments: EdgeSegment[]): number {
+  let crossings = 0;
+  for (let i = 0; i < segments.length; i++) {
+    for (let j = i + 1; j < segments.length; j++) {
+      const a = segments[i];
+      const b = segments[j];
+      if ((a.sourceIdx - b.sourceIdx) * (a.targetIdx - b.targetIdx) < 0) {
+        crossings++;
+      }
+    }
+  }
+  return crossings;
+}
+
+function crossingsAdjacentTo(
+  sectionIndex: number,
+  sections: Node[][],
+  depths: number[],
+  edges: GraphEdge[]
+): number {
+  let total = 0;
+  if (sectionIndex > 0) {
+    total += countCrossings(
+      getEdgeSegmentsBetween(
+        sections[sectionIndex - 1],
+        sections[sectionIndex],
+        depths[sectionIndex - 1],
+        depths[sectionIndex],
+        depths,
+        edges
+      )
+    );
+  }
+  if (sectionIndex < sections.length - 1) {
+    total += countCrossings(
+      getEdgeSegmentsBetween(
+        sections[sectionIndex],
+        sections[sectionIndex + 1],
+        depths[sectionIndex],
+        depths[sectionIndex + 1],
+        depths,
+        edges
+      )
+    );
+  }
+  return total;
+}
+
+const MAX_SORT_ITERATIONS = 4;
+
 export function sortNodesInSections(
   nodesPerSection: Record<number, Node[]>,
   depths: number[]
 ): Record<number, Node[]> {
-  const sortedSections: Record<number, Node[]> = {};
+  const sections: Node[][] = depths.map((d) => [...(nodesPerSection[d] || [])]);
+  const edges = collectAllEdges(sections);
 
-  depths.forEach((depth, depthIndex) => {
-    const sectionNodes = nodesPerSection[depth] || [];
+  // Replace a section with a candidate ordering only when crossings strictly
+  // drop on either side. This keeps user-intended ordering intact when
+  // barycenter would shuffle nodes without improving the layout.
+  const tryReplace = (i: number, candidate: Node[]): boolean => {
+    const before = crossingsAdjacentTo(i, sections, depths, edges);
+    const snapshot = sections[i];
+    sections[i] = candidate;
+    const after = crossingsAdjacentTo(i, sections, depths, edges);
+    if (after < before) {
+      return true;
+    }
+    sections[i] = snapshot;
+    return false;
+  };
 
-    // Sort nodes to minimize crossings
-    const sortedNodes = [...sectionNodes].sort((a, b) => {
-      const aIsPassthrough = isPassThroughNode(a);
-      const bIsPassthrough = isPassThroughNode(b);
+  for (let iter = 0; iter < MAX_SORT_ITERATIONS; iter++) {
+    let changed = false;
 
-      // Both are passthrough nodes - sort by source position
-      if (aIsPassthrough && bIsPassthrough) {
-        // Find positions of source nodes in previous section (use already sorted section)
-        if (depthIndex > 0) {
-          const prevDepth = depths[depthIndex - 1];
-          const prevSection =
-            sortedSections[prevDepth] || nodesPerSection[prevDepth] || [];
-
-          const aSourceIndex = prevSection.findIndex((n) => {
-            const nodeId = isPassThroughNode(n) ? n.id : (n as GraphNode).id;
-            return nodeId === a.sourceId;
-          });
-          const bSourceIndex = prevSection.findIndex((n) => {
-            const nodeId = isPassThroughNode(n) ? n.id : (n as GraphNode).id;
-            return nodeId === b.sourceId;
-          });
-
-          if (
-            aSourceIndex !== bSourceIndex &&
-            aSourceIndex !== -1 &&
-            bSourceIndex !== -1
-          ) {
-            return aSourceIndex - bSourceIndex;
-          }
-        }
-
-        // Fall back to target node positions in next section (not sorted yet, use original)
-        if (depthIndex < depths.length - 1) {
-          const nextDepth = depths[depthIndex + 1];
-          const nextSection = nodesPerSection[nextDepth] || [];
-
-          const aTargetIndex = nextSection.findIndex((n) => {
-            const nodeId = isPassThroughNode(n) ? n.id : (n as GraphNode).id;
-            return nodeId === a.targetId;
-          });
-          const bTargetIndex = nextSection.findIndex((n) => {
-            const nodeId = isPassThroughNode(n) ? n.id : (n as GraphNode).id;
-            return nodeId === b.targetId;
-          });
-
-          if (
-            aTargetIndex !== bTargetIndex &&
-            aTargetIndex !== -1 &&
-            bTargetIndex !== -1
-          ) {
-            return aTargetIndex - bTargetIndex;
-          }
-        }
+    for (let i = 1; i < sections.length; i++) {
+      const prevMap = buildIdIndexMap(sections[i - 1]);
+      const prevDepth = depths[i - 1];
+      const result = sortSectionByBarycenter(sections[i], prevMap, (node) =>
+        getNeighborIds(node, "source", prevDepth, depths)
+      );
+      if (result.changed && tryReplace(i, result.sorted)) {
+        changed = true;
       }
+    }
 
-      return 0;
-    });
+    for (let i = sections.length - 2; i >= 0; i--) {
+      const nextMap = buildIdIndexMap(sections[i + 1]);
+      const nextDepth = depths[i + 1];
+      const result = sortSectionByBarycenter(sections[i], nextMap, (node) =>
+        getNeighborIds(node, "target", nextDepth, depths)
+      );
+      if (result.changed && tryReplace(i, result.sorted)) {
+        changed = true;
+      }
+    }
 
-    sortedSections[depth] = sortedNodes;
+    if (!changed) break;
+  }
+
+  const sortedSections: Record<number, Node[]> = {};
+  depths.forEach((depth, i) => {
+    sortedSections[depth] = sections[i];
   });
-
   return sortedSections;
 }
 

--- a/test/resources/echarts/components/sankey/sankey-layout.test.ts
+++ b/test/resources/echarts/components/sankey/sankey-layout.test.ts
@@ -11,6 +11,8 @@ import {
   getEdgeValue,
   getPassThroughSections,
   createPassThroughNode,
+  computeBarycenter,
+  sortNodesInSections,
 } from "../../../../../src/resources/echarts/components/sankey/sankey-layout";
 
 // Mock types for testing
@@ -337,6 +339,416 @@ describe("Sankey Layout Functions", () => {
         sourceId: "source",
         targetId: "target",
       });
+    });
+  });
+
+  describe("computeBarycenter", () => {
+    it("returns fallback when no neighbor matches", () => {
+      const map = new Map<string, number>();
+      const result = computeBarycenter([{ id: "unknown", weight: 1 }], map, 3);
+      expect(result).toBe(3);
+    });
+
+    it("returns fallback when neighbors list is empty", () => {
+      const map = new Map([["a", 0]]);
+      expect(computeBarycenter([], map, 7)).toBe(7);
+    });
+
+    it("computes unweighted average when weights are equal", () => {
+      const map = new Map([
+        ["a", 0],
+        ["b", 2],
+      ]);
+      const result = computeBarycenter(
+        [
+          { id: "a", weight: 1 },
+          { id: "b", weight: 1 },
+        ],
+        map,
+        0
+      );
+      expect(result).toBe(1);
+    });
+
+    it("lets larger flows pull harder (weighted average)", () => {
+      const map = new Map([
+        ["small", 0],
+        ["big", 4],
+      ]);
+      const result = computeBarycenter(
+        [
+          { id: "small", weight: 1 },
+          { id: "big", weight: 9 },
+        ],
+        map,
+        0
+      );
+      expect(result).toBeCloseTo(3.6);
+    });
+
+    it("ignores neighbors that are not in the reference section", () => {
+      const map = new Map([["a", 2]]);
+      const result = computeBarycenter(
+        [
+          { id: "a", weight: 1 },
+          { id: "missing", weight: 5 },
+        ],
+        map,
+        0
+      );
+      expect(result).toBe(2);
+    });
+  });
+
+  describe("sortNodesInSections", () => {
+    // Minimal mock factories. The barycenter sweep uses:
+    //   - node.id
+    //   - node.inEdges / node.outEdges
+    //   - node.getLayout().depth (via getNodeDepthInfo)
+    //   - getRawDataItem for both nodes (for id) and edges (for value)
+    interface TestNode {
+      id: string;
+      depth: number;
+      value: number;
+      inEdges: TestEdge[];
+      outEdges: TestEdge[];
+    }
+    interface TestEdge {
+      source: string;
+      target: string;
+      value: number;
+    }
+
+    // Snapshot the full shape of sortNodesInSections output: every depth, in
+    // order, with every node's id. Keeps tests readable while still asserting
+    // the entire structure (section count, lengths, and ordering).
+    const sectionIds = (
+      result: Record<number, { id: string }[]>
+    ): Record<number, string[]> =>
+      Object.fromEntries(
+        Object.entries(result).map(([depth, nodes]) => [
+          depth,
+          nodes.map((n) => n.id),
+        ])
+      );
+
+    // Sanity check that sortNodesInSections returns the same node instances,
+    // never invents or drops any. Call with the input map used for the sort.
+    const expectIdentityPreserved = (
+      result: Record<number, { id: string }[]>,
+      input: Record<number, { id: string }[]>
+    ) => {
+      expect(Object.keys(result).sort()).toEqual(Object.keys(input).sort());
+      Object.entries(input).forEach(([depth, inputNodes]) => {
+        const resultNodes = result[Number(depth)];
+        expect(resultNodes).toHaveLength(inputNodes.length);
+        // Same set of node references, ignoring order.
+        expect(new Set(resultNodes)).toEqual(new Set(inputNodes));
+      });
+    };
+
+    const buildGraphNode = (testNodes: Record<string, TestNode>) => {
+      const nodesById: Record<string, any> = {};
+      // First pass: build node shells
+      Object.values(testNodes).forEach((t) => {
+        nodesById[t.id] = {
+          id: t.id,
+          dataIndex: 0,
+          hostGraph: {
+            data: {
+              getRawDataItem: () => ({ depth: t.depth, id: t.id }),
+            },
+          },
+          getLayout: () => ({ depth: t.depth, value: t.value }),
+          inEdges: [] as any[],
+          outEdges: [] as any[],
+        };
+      });
+      // Second pass: wire edges referencing node shells
+      Object.values(testNodes).forEach((t) => {
+        [...t.inEdges, ...t.outEdges].forEach((e) => {
+          const edge = {
+            dataIndex: 0,
+            node1: nodesById[e.source],
+            node2: nodesById[e.target],
+            hostGraph: {
+              edgeData: { getRawDataItem: () => ({ value: e.value }) },
+            },
+            getLayout: () => ({ value: e.value }),
+          };
+          if (t.inEdges.includes(e)) {
+            nodesById[t.id].inEdges.push(edge);
+          }
+          if (t.outEdges.includes(e)) {
+            nodesById[t.id].outEdges.push(edge);
+          }
+        });
+      });
+      return nodesById;
+    };
+
+    it("reorders children to eliminate a crossing (#28764)", () => {
+      // Classic crossed-pair: A→a, B→b with children in reversed order.
+      // Before sort: 1 crossing. After: 0. The sort must fire.
+      const edgeAa = { source: "A", target: "a", value: 1 };
+      const edgeBb = { source: "B", target: "b", value: 1 };
+      const testNodes: Record<string, TestNode> = {
+        A: { id: "A", depth: 0, value: 1, inEdges: [], outEdges: [edgeAa] },
+        B: { id: "B", depth: 0, value: 1, inEdges: [], outEdges: [edgeBb] },
+        a: { id: "a", depth: 1, value: 1, inEdges: [edgeAa], outEdges: [] },
+        b: { id: "b", depth: 1, value: 1, inEdges: [edgeBb], outEdges: [] },
+      };
+      const graph = buildGraphNode(testNodes);
+
+      const input = {
+        0: [graph.A, graph.B],
+        1: [graph.b, graph.a],
+      };
+      const result = sortNodesInSections(input, [0, 1]);
+
+      expect(sectionIds(result)).toEqual({
+        0: ["A", "B"],
+        1: ["a", "b"],
+      });
+      expectIdentityPreserved(result, input);
+    });
+
+    it("does not reorder when crossings would not decrease", () => {
+      // Fully connected pair with no crossing differences possible.
+      // Input order should be preserved verbatim.
+      const edges = {
+        Aa: { source: "A", target: "a", value: 1 },
+        Ab: { source: "A", target: "b", value: 1 },
+        Ba: { source: "B", target: "a", value: 1 },
+        Bb: { source: "B", target: "b", value: 1 },
+      };
+      const testNodes: Record<string, TestNode> = {
+        A: {
+          id: "A",
+          depth: 0,
+          value: 2,
+          inEdges: [],
+          outEdges: [edges.Aa, edges.Ab],
+        },
+        B: {
+          id: "B",
+          depth: 0,
+          value: 2,
+          inEdges: [],
+          outEdges: [edges.Ba, edges.Bb],
+        },
+        a: {
+          id: "a",
+          depth: 1,
+          value: 2,
+          inEdges: [edges.Aa, edges.Ba],
+          outEdges: [],
+        },
+        b: {
+          id: "b",
+          depth: 1,
+          value: 2,
+          inEdges: [edges.Ab, edges.Bb],
+          outEdges: [],
+        },
+      };
+      const graph = buildGraphNode(testNodes);
+
+      const input = { 0: [graph.B, graph.A], 1: [graph.b, graph.a] };
+      const result = sortNodesInSections(input, [0, 1]);
+
+      expect(sectionIds(result)).toEqual({
+        0: ["B", "A"],
+        1: ["b", "a"],
+      });
+      expectIdentityPreserved(result, input);
+    });
+
+    it("aligns pass-through with its source to eliminate crossings (#30164)", () => {
+      // depth 0: A, B
+      // depth 1: Achild, Bchild, A→Z passthrough (at end, where
+      //   generatePassThroughNodes would append it)
+      // depth 2: Z (top of section), Bgrand
+      // The sort must move the passthrough up to kill two crossings.
+      const edgeAChild = { source: "A", target: "Achild", value: 1 };
+      const edgeBChild = { source: "B", target: "Bchild", value: 1 };
+      const edgeAZ = { source: "A", target: "Z", value: 1 };
+      const edgeBchildGrand = {
+        source: "Bchild",
+        target: "Bgrand",
+        value: 1,
+      };
+      const testNodes: Record<string, TestNode> = {
+        A: {
+          id: "A",
+          depth: 0,
+          value: 2,
+          inEdges: [],
+          outEdges: [edgeAChild, edgeAZ],
+        },
+        B: {
+          id: "B",
+          depth: 0,
+          value: 1,
+          inEdges: [],
+          outEdges: [edgeBChild],
+        },
+        Achild: {
+          id: "Achild",
+          depth: 1,
+          value: 1,
+          inEdges: [edgeAChild],
+          outEdges: [],
+        },
+        Bchild: {
+          id: "Bchild",
+          depth: 1,
+          value: 1,
+          inEdges: [edgeBChild],
+          outEdges: [edgeBchildGrand],
+        },
+        Bgrand: {
+          id: "Bgrand",
+          depth: 2,
+          value: 1,
+          inEdges: [edgeBchildGrand],
+          outEdges: [],
+        },
+        Z: {
+          id: "Z",
+          depth: 2,
+          value: 1,
+          inEdges: [edgeAZ],
+          outEdges: [],
+        },
+      };
+      const graph = buildGraphNode(testNodes);
+      const passThrough = createPassThroughNode("A", "Z", 1, 1);
+
+      const input = {
+        0: [graph.A, graph.B],
+        // Input order: real children first, passthrough appended last.
+        1: [graph.Achild, graph.Bchild, passThrough],
+        2: [graph.Z, graph.Bgrand],
+      };
+      const result = sortNodesInSections(input, [0, 1, 2]);
+
+      expect(sectionIds(result)).toEqual({
+        0: ["A", "B"],
+        1: ["Achild", "A-Z-1", "Bchild"],
+        2: ["Z", "Bgrand"],
+      });
+      expectIdentityPreserved(result, input);
+      // The passthrough must pass through untouched (not rebuilt).
+      expect(result[1][1]).toBe(passThrough);
+    });
+
+    it("uses all parents, not just the first link (#51646)", () => {
+      // Child has two parents. The first link in input is from the lower
+      // parent — a naive first-link sort would place it at the bottom. The
+      // barycenter average should keep it near the middle.
+      const edgeTopChild = { source: "top", target: "child", value: 1 };
+      const edgeBottomChild = { source: "bottom", target: "child", value: 1 };
+      const edgeBottomOther = { source: "bottom", target: "other", value: 1 };
+      const testNodes: Record<string, TestNode> = {
+        top: {
+          id: "top",
+          depth: 0,
+          value: 1,
+          inEdges: [],
+          outEdges: [edgeTopChild],
+        },
+        middle: {
+          id: "middle",
+          depth: 0,
+          value: 0,
+          inEdges: [],
+          outEdges: [],
+        },
+        bottom: {
+          id: "bottom",
+          depth: 0,
+          value: 2,
+          inEdges: [],
+          outEdges: [edgeBottomChild, edgeBottomOther],
+        },
+        child: {
+          id: "child",
+          depth: 1,
+          value: 2,
+          inEdges: [edgeBottomChild, edgeTopChild],
+          outEdges: [],
+        },
+        other: {
+          id: "other",
+          depth: 1,
+          value: 1,
+          inEdges: [edgeBottomOther],
+          outEdges: [],
+        },
+      };
+      const graph = buildGraphNode(testNodes);
+
+      const input = {
+        0: [graph.top, graph.middle, graph.bottom],
+        1: [graph.other, graph.child],
+      };
+      const result = sortNodesInSections(input, [0, 1]);
+
+      // child's barycenter = (0 + 2) / 2 = 1; other's = 2. Reordering removes
+      // one crossing, so the sort fires.
+      expect(sectionIds(result)).toEqual({
+        0: ["top", "middle", "bottom"],
+        1: ["child", "other"],
+      });
+      expectIdentityPreserved(result, input);
+    });
+
+    it("is idempotent — running twice yields the same order", () => {
+      const edgeAC = { source: "A", target: "C", value: 2 };
+      const edgeBD = { source: "B", target: "D", value: 1 };
+      const testNodes: Record<string, TestNode> = {
+        A: { id: "A", depth: 0, value: 2, inEdges: [], outEdges: [edgeAC] },
+        B: { id: "B", depth: 0, value: 1, inEdges: [], outEdges: [edgeBD] },
+        C: { id: "C", depth: 1, value: 2, inEdges: [edgeAC], outEdges: [] },
+        D: { id: "D", depth: 1, value: 1, inEdges: [edgeBD], outEdges: [] },
+      };
+      const graph = buildGraphNode(testNodes);
+
+      const input = { 0: [graph.A, graph.B], 1: [graph.D, graph.C] };
+      const once = sortNodesInSections(input, [0, 1]);
+      const twice = sortNodesInSections(once, [0, 1]);
+
+      expect(sectionIds(once)).toEqual({ 0: ["A", "B"], 1: ["C", "D"] });
+      expect(sectionIds(twice)).toEqual(sectionIds(once));
+      expectIdentityPreserved(once, input);
+      expectIdentityPreserved(twice, once);
+    });
+
+    it("keeps orphan nodes in their input position", () => {
+      const edgeAB = { source: "A", target: "B", value: 1 };
+      const testNodes: Record<string, TestNode> = {
+        A: { id: "A", depth: 0, value: 1, inEdges: [], outEdges: [edgeAB] },
+        orphan: {
+          id: "orphan",
+          depth: 0,
+          value: 1,
+          inEdges: [],
+          outEdges: [],
+        },
+        B: { id: "B", depth: 1, value: 1, inEdges: [edgeAB], outEdges: [] },
+      };
+      const graph = buildGraphNode(testNodes);
+
+      const input = { 0: [graph.A, graph.orphan], 1: [graph.B] };
+      const result = sortNodesInSections(input, [0, 1]);
+
+      // Orphan has no neighbors on either side, so it stays in place.
+      expect(sectionIds(result)).toEqual({
+        0: ["A", "orphan"],
+        1: ["B"],
+      });
+      expectIdentityPreserved(result, input);
     });
   });
 });

--- a/test/resources/echarts/components/sankey/sankey-layout.test.ts
+++ b/test/resources/echarts/components/sankey/sankey-layout.test.ts
@@ -447,9 +447,8 @@ describe("Sankey Layout Functions", () => {
       });
     };
 
-    const buildGraphNode = (testNodes: Record<string, TestNode>) => {
+    const buildGraph = (testNodes: Record<string, TestNode>) => {
       const nodesById: Record<string, any> = {};
-      // First pass: build node shells
       Object.values(testNodes).forEach((t) => {
         nodesById[t.id] = {
           id: t.id,
@@ -464,27 +463,34 @@ describe("Sankey Layout Functions", () => {
           outEdges: [] as any[],
         };
       });
-      // Second pass: wire edges referencing node shells
+      // Create one canonical edge object per TestEdge reference, then wire it
+      // into both source.outEdges and target.inEdges so they point at the same
+      // object (matching echarts' Graph shape).
+      const edgeByTestEdge = new Map<TestEdge, any>();
       Object.values(testNodes).forEach((t) => {
         [...t.inEdges, ...t.outEdges].forEach((e) => {
-          const edge = {
-            dataIndex: 0,
-            node1: nodesById[e.source],
-            node2: nodesById[e.target],
-            hostGraph: {
-              edgeData: { getRawDataItem: () => ({ value: e.value }) },
-            },
-            getLayout: () => ({ value: e.value }),
-          };
-          if (t.inEdges.includes(e)) {
-            nodesById[t.id].inEdges.push(edge);
-          }
-          if (t.outEdges.includes(e)) {
-            nodesById[t.id].outEdges.push(edge);
+          if (!edgeByTestEdge.has(e)) {
+            edgeByTestEdge.set(e, {
+              dataIndex: 0,
+              node1: nodesById[e.source],
+              node2: nodesById[e.target],
+              hostGraph: {
+                edgeData: { getRawDataItem: () => ({ value: e.value }) },
+              },
+              getLayout: () => ({ value: e.value }),
+            });
           }
         });
       });
-      return nodesById;
+      Object.values(testNodes).forEach((t) => {
+        t.inEdges.forEach((e) =>
+          nodesById[t.id].inEdges.push(edgeByTestEdge.get(e))
+        );
+        t.outEdges.forEach((e) =>
+          nodesById[t.id].outEdges.push(edgeByTestEdge.get(e))
+        );
+      });
+      return { nodes: nodesById, edges: [...edgeByTestEdge.values()] };
     };
 
     it("reorders children to eliminate a crossing (#28764)", () => {
@@ -498,13 +504,13 @@ describe("Sankey Layout Functions", () => {
         a: { id: "a", depth: 1, value: 1, inEdges: [edgeAa], outEdges: [] },
         b: { id: "b", depth: 1, value: 1, inEdges: [edgeBb], outEdges: [] },
       };
-      const graph = buildGraphNode(testNodes);
+      const { nodes: graph, edges } = buildGraph(testNodes);
 
       const input = {
         0: [graph.A, graph.B],
         1: [graph.b, graph.a],
       };
-      const result = sortNodesInSections(input, [0, 1]);
+      const result = sortNodesInSections(input, [0, 1], edges);
 
       expect(sectionIds(result)).toEqual({
         0: ["A", "B"],
@@ -516,7 +522,7 @@ describe("Sankey Layout Functions", () => {
     it("does not reorder when crossings would not decrease", () => {
       // Fully connected pair with no crossing differences possible.
       // Input order should be preserved verbatim.
-      const edges = {
+      const e = {
         Aa: { source: "A", target: "a", value: 1 },
         Ab: { source: "A", target: "b", value: 1 },
         Ba: { source: "B", target: "a", value: 1 },
@@ -528,34 +534,34 @@ describe("Sankey Layout Functions", () => {
           depth: 0,
           value: 2,
           inEdges: [],
-          outEdges: [edges.Aa, edges.Ab],
+          outEdges: [e.Aa, e.Ab],
         },
         B: {
           id: "B",
           depth: 0,
           value: 2,
           inEdges: [],
-          outEdges: [edges.Ba, edges.Bb],
+          outEdges: [e.Ba, e.Bb],
         },
         a: {
           id: "a",
           depth: 1,
           value: 2,
-          inEdges: [edges.Aa, edges.Ba],
+          inEdges: [e.Aa, e.Ba],
           outEdges: [],
         },
         b: {
           id: "b",
           depth: 1,
           value: 2,
-          inEdges: [edges.Ab, edges.Bb],
+          inEdges: [e.Ab, e.Bb],
           outEdges: [],
         },
       };
-      const graph = buildGraphNode(testNodes);
+      const { nodes: graph, edges } = buildGraph(testNodes);
 
       const input = { 0: [graph.B, graph.A], 1: [graph.b, graph.a] };
-      const result = sortNodesInSections(input, [0, 1]);
+      const result = sortNodesInSections(input, [0, 1], edges);
 
       expect(sectionIds(result)).toEqual({
         0: ["B", "A"],
@@ -622,7 +628,7 @@ describe("Sankey Layout Functions", () => {
           outEdges: [],
         },
       };
-      const graph = buildGraphNode(testNodes);
+      const { nodes: graph, edges } = buildGraph(testNodes);
       const passThrough = createPassThroughNode("A", "Z", 1, 1);
 
       const input = {
@@ -631,7 +637,7 @@ describe("Sankey Layout Functions", () => {
         1: [graph.Achild, graph.Bchild, passThrough],
         2: [graph.Z, graph.Bgrand],
       };
-      const result = sortNodesInSections(input, [0, 1, 2]);
+      const result = sortNodesInSections(input, [0, 1, 2], edges);
 
       expect(sectionIds(result)).toEqual({
         0: ["A", "B"],
@@ -687,13 +693,13 @@ describe("Sankey Layout Functions", () => {
           outEdges: [],
         },
       };
-      const graph = buildGraphNode(testNodes);
+      const { nodes: graph, edges } = buildGraph(testNodes);
 
       const input = {
         0: [graph.top, graph.middle, graph.bottom],
         1: [graph.other, graph.child],
       };
-      const result = sortNodesInSections(input, [0, 1]);
+      const result = sortNodesInSections(input, [0, 1], edges);
 
       // child's barycenter = (0 + 2) / 2 = 1; other's = 2. Reordering removes
       // one crossing, so the sort fires.
@@ -713,11 +719,11 @@ describe("Sankey Layout Functions", () => {
         C: { id: "C", depth: 1, value: 2, inEdges: [edgeAC], outEdges: [] },
         D: { id: "D", depth: 1, value: 1, inEdges: [edgeBD], outEdges: [] },
       };
-      const graph = buildGraphNode(testNodes);
+      const { nodes: graph, edges } = buildGraph(testNodes);
 
       const input = { 0: [graph.A, graph.B], 1: [graph.D, graph.C] };
-      const once = sortNodesInSections(input, [0, 1]);
-      const twice = sortNodesInSections(once, [0, 1]);
+      const once = sortNodesInSections(input, [0, 1], edges);
+      const twice = sortNodesInSections(once, [0, 1], edges);
 
       expect(sectionIds(once)).toEqual({ 0: ["A", "B"], 1: ["C", "D"] });
       expect(sectionIds(twice)).toEqual(sectionIds(once));
@@ -738,10 +744,10 @@ describe("Sankey Layout Functions", () => {
         },
         B: { id: "B", depth: 1, value: 1, inEdges: [edgeAB], outEdges: [] },
       };
-      const graph = buildGraphNode(testNodes);
+      const { nodes: graph, edges } = buildGraph(testNodes);
 
       const input = { 0: [graph.A, graph.orphan], 1: [graph.B] };
-      const result = sortNodesInSections(input, [0, 1]);
+      const result = sortNodesInSections(input, [0, 1], edges);
 
       // Orphan has no neighbors on either side, so it stays in place.
       expect(sectionIds(result)).toEqual({


### PR DESCRIPTION
## Proposed change

Replace the pass-through-only ordering in the custom Sankey layout with a value-weighted barycenter sweep. Two alternating passes (L→R, R→L) iterate up to four times, sorting every node in each section by the weighted average position of its neighbours in the adjacent (already-sorted) section. Real nodes and pass-throughs are handled uniformly, including multi-depth edges via the existing passthrough id format.

Each candidate reorder is gated on a crossing count for the section's adjacent pairs and is only kept when crossings strictly decrease — so user-intended ordering is preserved whenever the barycenter would shuffle nodes without actually improving the layout.

The seed sort in `ha-sankey-chart.ts` now averages across all incoming links rather than only the first, which also improves the starting point.

This means that the order of the devices from the energy configuration is no longer guaranteed but I think it's worth it and, judging by the number of bug reports for crossed connections, looks like others think so too.

Performance will be impacted a bit by this but it shouldn't be a problem unless someone has 1000 devices.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #28764, fixes #30164, fixes #51646
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr