### PR TITLE
Add energy/cost toggle to energy device cards

### DIFF
--- a/src/data/energy_device_cost.ts
+++ b/src/data/energy_device_cost.ts
@@ -1,10 +1,11 @@
 import type {
+  DeviceConsumptionEnergyPreference,
   EnergyData,
   EnergyInfo,
   EnergyPreferences,
   GridSourceTypeEnergyPreference,
 } from "./energy";
-import type { Statistics, StatisticValue } from "./recorder";
+import type { Statistics } from "./recorder";
 
 export type EnergyUnitMode = "energy" | "cost";
 
@@ -87,6 +88,46 @@ export const computeGridCostRatios = (
   return ratios;
 };
 
+// Period-wide average cost ratio: Σimport_cost / Σimport_kWh over every bucket
+// in `stats`. Used as a fallback when per-hour ratios are missing (e.g. hours
+// where grid import was 0 because solar covered everything, but we still want
+// to price the untracked residual at something sensible).
+export const computePeriodAverageRatio = (
+  stats: Statistics,
+  info: EnergyInfo,
+  prefs: EnergyPreferences
+): number => {
+  let totalEnergy = 0;
+  let totalCost = 0;
+  for (const source of prefs.energy_sources) {
+    if (source.type !== "grid") {
+      continue;
+    }
+    if (source.stat_energy_from) {
+      const energyStats = stats[source.stat_energy_from];
+      if (energyStats) {
+        for (const value of energyStats) {
+          if (value.change != null) {
+            totalEnergy += value.change;
+          }
+        }
+      }
+    }
+    const costStatId = resolveImportCostStatId(source, info);
+    if (costStatId) {
+      const costStats = stats[costStatId];
+      if (costStats) {
+        for (const value of costStats) {
+          if (value.change != null) {
+            totalCost += value.change;
+          }
+        }
+      }
+    }
+  }
+  return totalEnergy > 0 ? totalCost / totalEnergy : 0;
+};
+
 // True iff at least one bucket has both grid import kWh and grid cost. Checks
 // both live and compare stats so the availability signal is stable when only
 // the compare window has data.
@@ -135,25 +176,50 @@ export const calculateDeviceCostGrowth = (
   return total;
 };
 
-// Synthetic StatisticValue[] with change = device_kWh(h) * ratio(h). Lets the
-// detail chart's existing `for (const point of stats)` loop run unchanged.
-// Buckets without a ratio emit change = 0 so the chart preserves the x-axis
-// spacing.
-export const deviceCostSeries = (
+// Per-hour cost of the "untracked" residual: used_total(h) minus the sum of
+// tracked device consumption that hour, priced at grid rate. Buckets where
+// tracked > used_total are clamped to 0 so we never subtract cost. When a
+// bucket has no per-hour ratio (e.g. grid import was 0 that hour because
+// solar covered it), fall back to the period-average ratio so untracked
+// energy still gets priced at something sensible.
+export const calculateUntrackedCost = (
   stats: Statistics,
-  deviceStatId: string,
-  ratios: Map<number, number>
-): StatisticValue[] => {
-  const values = stats[deviceStatId];
-  if (!values) {
-    return [];
+  ratios: Map<number, number>,
+  usedTotalPerHour: Record<string, number>,
+  devices: DeviceConsumptionEnergyPreference[],
+  fallbackRatio = 0
+): number => {
+  // Pre-build one Map<start, change> per device so the per-hour inner loop
+  // is O(1) lookups instead of O(n) linear searches.
+  const deviceBuckets: Map<number, number>[] = [];
+  for (const device of devices) {
+    const deviceStats = stats[device.stat_consumption];
+    if (!deviceStats) {
+      continue;
+    }
+    const map = new Map<number, number>();
+    for (const v of deviceStats) {
+      if (v.change != null) {
+        map.set(v.start, v.change);
+      }
+    }
+    deviceBuckets.push(map);
   }
-  return values.map((value) => ({
-    start: value.start,
-    end: value.end,
-    change:
-      value.change == null
-        ? null
-        : value.change * (ratios.get(value.start) ?? 0),
-  }));
+  let total = 0;
+  for (const [timeStr, hourUsedTotal] of Object.entries(usedTotalPerHour)) {
+    const time = Number(timeStr);
+    const ratio = ratios.get(time) ?? fallbackRatio;
+    if (ratio === 0) {
+      continue;
+    }
+    let trackedThisHour = 0;
+    for (const map of deviceBuckets) {
+      trackedThisHour += map.get(time) ?? 0;
+    }
+    const untrackedKwh = hourUsedTotal - trackedThisHour;
+    if (untrackedKwh > 0) {
+      total += untrackedKwh * ratio;
+    }
+  }
+  return total;
 };

--- a/src/data/energy_device_cost.ts
+++ b/src/data/energy_device_cost.ts
@@ -1,0 +1,159 @@
+import type {
+  EnergyData,
+  EnergyInfo,
+  EnergyPreferences,
+  GridSourceTypeEnergyPreference,
+} from "./energy";
+import type { Statistics, StatisticValue } from "./recorder";
+
+export type EnergyUnitMode = "energy" | "cost";
+
+export const ENERGY_UNIT_MODE_STORAGE_KEY = "energy-unit-mode";
+
+const resolveImportCostStatId = (
+  source: GridSourceTypeEnergyPreference,
+  info: EnergyInfo
+): string | undefined => {
+  if (source.stat_cost) {
+    return source.stat_cost;
+  }
+  if (source.stat_energy_from) {
+    return info.cost_sensors[source.stat_energy_from];
+  }
+  return undefined;
+};
+
+// Bucket-start -> cost ratio. ratio(h) = Σimport_cost(h) / Σimport_kWh(h).
+// Buckets with no import energy or no cost data are omitted. Export
+// compensation is intentionally excluded: it's a rebate on the bill, not a
+// price of kWh consumed by devices.
+export const computeGridCostRatios = (
+  stats: Statistics,
+  info: EnergyInfo,
+  prefs: EnergyPreferences
+): Map<number, number> => {
+  const energyByBucket = new Map<number, number>();
+  const costByBucket = new Map<number, number>();
+
+  for (const source of prefs.energy_sources) {
+    if (source.type !== "grid") {
+      continue;
+    }
+    const grid = source;
+
+    if (grid.stat_energy_from) {
+      const energyStats = stats[grid.stat_energy_from];
+      if (energyStats) {
+        for (const value of energyStats) {
+          if (value.change == null) {
+            continue;
+          }
+          energyByBucket.set(
+            value.start,
+            (energyByBucket.get(value.start) || 0) + value.change
+          );
+        }
+      }
+    }
+
+    const costStatId = resolveImportCostStatId(grid, info);
+    if (costStatId) {
+      const costStats = stats[costStatId];
+      if (costStats) {
+        for (const value of costStats) {
+          if (value.change == null) {
+            continue;
+          }
+          costByBucket.set(
+            value.start,
+            (costByBucket.get(value.start) || 0) + value.change
+          );
+        }
+      }
+    }
+  }
+
+  const ratios = new Map<number, number>();
+  for (const [bucket, energy] of energyByBucket) {
+    if (energy <= 0) {
+      continue;
+    }
+    const cost = costByBucket.get(bucket);
+    if (cost == null) {
+      continue;
+    }
+    ratios.set(bucket, cost / energy);
+  }
+  return ratios;
+};
+
+// True iff at least one bucket has both grid import kWh and grid cost. Checks
+// both live and compare stats so the availability signal is stable when only
+// the compare window has data.
+export const hasGridCostData = (energyData: EnergyData): boolean => {
+  if (
+    computeGridCostRatios(energyData.stats, energyData.info, energyData.prefs)
+      .size > 0
+  ) {
+    return true;
+  }
+  if (
+    energyData.statsCompare &&
+    computeGridCostRatios(
+      energyData.statsCompare,
+      energyData.info,
+      energyData.prefs
+    ).size > 0
+  ) {
+    return true;
+  }
+  return false;
+};
+
+// Σ device_kWh(h) * ratio(h). Buckets without a ratio contribute 0. Returns
+// null when the device stat is absent (mirrors calculateStatisticSumGrowth).
+export const calculateDeviceCostGrowth = (
+  stats: Statistics,
+  deviceStatId: string,
+  ratios: Map<number, number>
+): number | null => {
+  const values = stats[deviceStatId];
+  if (!values) {
+    return null;
+  }
+  let total: number | null = null;
+  for (const value of values) {
+    if (value.change == null) {
+      continue;
+    }
+    const ratio = ratios.get(value.start);
+    if (ratio == null) {
+      continue;
+    }
+    total = (total ?? 0) + value.change * ratio;
+  }
+  return total;
+};
+
+// Synthetic StatisticValue[] with change = device_kWh(h) * ratio(h). Lets the
+// detail chart's existing `for (const point of stats)` loop run unchanged.
+// Buckets without a ratio emit change = 0 so the chart preserves the x-axis
+// spacing.
+export const deviceCostSeries = (
+  stats: Statistics,
+  deviceStatId: string,
+  ratios: Map<number, number>
+): StatisticValue[] => {
+  const values = stats[deviceStatId];
+  if (!values) {
+    return [];
+  }
+  return values.map((value) => ({
+    start: value.start,
+    end: value.end,
+    change:
+      value.change == null
+        ? null
+        : value.change * (ratios.get(value.start) ?? 0),
+  }));
+};

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
@@ -23,7 +23,7 @@ import {
 import type { EnergyUnitMode } from "../../../../data/energy_device_cost";
 import {
   computeGridCostRatios,
-  deviceCostSeries,
+  computePeriodAverageRatio,
   ENERGY_UNIT_MODE_STORAGE_KEY,
   hasGridCostData,
 } from "../../../../data/energy_device_cost";
@@ -50,7 +50,6 @@ import type { ECOption } from "../../../../resources/echarts/echarts";
 import { formatNumber } from "../../../../common/number/format_number";
 import type { CustomLegendOption } from "../../../../components/chart/ha-chart-base";
 import "../../../../components/ha-button-toggle-group";
-import "../../../../components/ha-tooltip";
 
 @customElement("hui-energy-devices-detail-graph-card")
 export class HuiEnergyDevicesDetailGraphCard
@@ -112,6 +111,10 @@ export class HuiEnergyDevicesDetailGraphCard
 
   private _costRatiosCompare = new Map<number, number>();
 
+  private _costAvgRatio = 0;
+
+  private _costAvgRatioCompare = 0;
+
   protected hassSubscribeRequiredHostProps = ["_config"];
 
   public hassSubscribe(): UnsubscribeFunc[] {
@@ -120,7 +123,8 @@ export class HuiEnergyDevicesDetailGraphCard
         key: this._config?.collection_key,
       }).subscribe((data) => {
         this._data = data;
-        this._costAvailable = hasGridCostData(data);
+        this._costAvailable =
+          hasGridCostData(data) && !!this.hass.config.currency;
         if (!this._costAvailable && this._unitMode === "cost") {
           this._unitMode = "energy";
         }
@@ -132,6 +136,14 @@ export class HuiEnergyDevicesDetailGraphCard
         this._costRatiosCompare = data.statsCompare
           ? computeGridCostRatios(data.statsCompare, data.info, data.prefs)
           : new Map();
+        this._costAvgRatio = computePeriodAverageRatio(
+          data.stats,
+          data.info,
+          data.prefs
+        );
+        this._costAvgRatioCompare = data.statsCompare
+          ? computePeriodAverageRatio(data.statsCompare, data.info, data.prefs)
+          : 0;
       }),
     ];
   }
@@ -173,8 +185,12 @@ export class HuiEnergyDevicesDetailGraphCard
     return html`
       <ha-card>
         <div class="card-header">
-          <h1>${this._config.title ?? ""}</h1>
-          ${this._renderUnitToggle()}
+          <span
+            >${this._config.title
+              ? html`<h1>${this._config.title}</h1>`
+              : nothing}</span
+          >
+          <div class="header-actions">${this._renderUnitToggle()}</div>
         </div>
         <div class="content has-header">
           <ha-chart-base
@@ -220,6 +236,9 @@ export class HuiEnergyDevicesDetailGraphCard
   };
 
   private _renderUnitToggle() {
+    if (!this._costAvailable) {
+      return nothing;
+    }
     const buttons: ToggleButton[] = [
       {
         label: this.hass.localize(
@@ -234,31 +253,16 @@ export class HuiEnergyDevicesDetailGraphCard
         value: "cost",
       },
     ];
-    const toggle = html`<ha-button-toggle-group
-      id="unit-mode-toggle"
+    return html`<ha-button-toggle-group
       .buttons=${buttons}
       .active=${this._unitMode}
       size="small"
       @value-changed=${this._unitModeChanged}
     ></ha-button-toggle-group>`;
-    if (this._costAvailable) {
-      return toggle;
-    }
-    return html`${toggle}
-      <ha-tooltip for="unit-mode-toggle">
-        ${this.hass.localize(
-          "ui.panel.lovelace.cards.energy.device_unit_mode.cost_unavailable"
-        )}
-      </ha-tooltip>`;
   }
 
   private _unitModeChanged(ev: CustomEvent<{ value: string }>): void {
-    const value = ev.detail.value as EnergyUnitMode;
-    if (value === "cost" && !this._costAvailable) {
-      this.requestUpdate();
-      return;
-    }
-    this._unitMode = value;
+    this._unitMode = ev.detail.value as EnergyUnitMode;
   }
 
   // ha-chart-base will track hidden per ID (so it will have two entries for ID and compare-ID)
@@ -340,35 +344,14 @@ export class HuiEnergyDevicesDetailGraphCard
     this._compareStart = energyData.startCompare;
     this._compareEnd = energyData.endCompare;
 
-    const rawData = energyData.stats;
-    const rawCompareData = energyData.statsCompare;
+    const data = energyData.stats;
+    const compareData = energyData.statsCompare;
 
     const computedStyle = getComputedStyle(this);
 
     const devices = energyData.prefs.device_consumption;
 
     const costMode = this._unitMode === "cost";
-    const scaleDeviceStats = (
-      stats: Statistics,
-      ratios: Map<number, number>
-    ): Statistics => {
-      if (!costMode) {
-        return stats;
-      }
-      const scaled: Statistics = { ...stats };
-      for (const device of devices) {
-        scaled[device.stat_consumption] = deviceCostSeries(
-          stats,
-          device.stat_consumption,
-          ratios
-        );
-      }
-      return scaled;
-    };
-    const data = scaleDeviceStats(rawData, this._costRatios);
-    const compareData = rawCompareData
-      ? scaleDeviceStats(rawCompareData, this._costRatiosCompare)
-      : rawCompareData;
 
     const childMap: Record<string, string[]> = {};
     devices.forEach((d) => {
@@ -409,10 +392,9 @@ export class HuiEnergyDevicesDetailGraphCard
     const { summedData, compareSummedData } = getSummedData(energyData);
 
     const showUntracked =
-      !costMode &&
-      ("from_grid" in summedData ||
-        "solar" in summedData ||
-        "from_battery" in summedData);
+      "from_grid" in summedData ||
+      "solar" in summedData ||
+      "from_battery" in summedData;
 
     const {
       consumption: consumptionData,
@@ -491,6 +473,47 @@ export class HuiEnergyDevicesDetailGraphCard
           borderColor: untrackedData.itemStyle?.borderColor as string,
         },
       });
+    }
+
+    if (costMode) {
+      const scaleDataset = (
+        ds: BarSeriesOption,
+        ratios: Map<number, number>,
+        fallback: number
+      ) => {
+        if (!ds.data || !Array.isArray(ds.data)) {
+          return;
+        }
+        ds.data = (ds.data as EnergyDataPoint[]).map((dp) => [
+          dp[0],
+          dp[1] * (ratios.get(dp[2]) ?? fallback),
+          dp[2],
+        ]);
+      };
+      for (const ds of datasets) {
+        if (!ds.id) {
+          continue;
+        }
+        const idStr = String(ds.id);
+        const isCompare = idStr.startsWith("compare-");
+        // Untracked residual is priced at period average when the per-hour
+        // ratio is missing (typically hours where solar covered all grid
+        // import). Tracked devices keep strict per-hour pricing — a device
+        // running during a pure-solar hour is "free".
+        const isUntracked =
+          idStr.startsWith("untracked-") ||
+          idStr.startsWith("compare-untracked-");
+        const fallback = isUntracked
+          ? isCompare
+            ? this._costAvgRatioCompare
+            : this._costAvgRatio
+          : 0;
+        scaleDataset(
+          ds,
+          isCompare ? this._costRatiosCompare : this._costRatios,
+          fallback
+        );
+      }
     }
 
     fillDataGapsAndRoundCaps(datasets);
@@ -686,18 +709,17 @@ export class HuiEnergyDevicesDetailGraphCard
       justify-content: space-between;
       align-items: center;
       padding-bottom: 0;
-      gap: var(--ha-space-2);
     }
     .card-header h1 {
       margin: 0;
-      flex: 1;
-      min-width: 0;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
     }
-    .card-header h1:empty {
-      display: none;
+    .header-actions {
+      display: flex;
+      align-items: center;
+      gap: var(--ha-space-2);
     }
     .content {
       padding: 16px;

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
@@ -3,7 +3,6 @@ import type { HassConfig, UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { classMap } from "lit/directives/class-map";
 import memoizeOne from "memoize-one";
 import type { BarSeriesOption } from "echarts/charts";
 import { getGraphColorByIndex } from "../../../../common/color/colors";
@@ -21,6 +20,13 @@ import {
   computeConsumptionData,
   validateEnergyCollectionKey,
 } from "../../../../data/energy";
+import type { EnergyUnitMode } from "../../../../data/energy_device_cost";
+import {
+  computeGridCostRatios,
+  deviceCostSeries,
+  ENERGY_UNIT_MODE_STORAGE_KEY,
+  hasGridCostData,
+} from "../../../../data/energy_device_cost";
 import type { Statistics, StatisticsMetaData } from "../../../../data/recorder";
 import {
   calculateStatisticSumGrowth,
@@ -28,7 +34,7 @@ import {
 } from "../../../../data/recorder";
 import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
-import type { HomeAssistant } from "../../../../types";
+import type { HomeAssistant, ToggleButton } from "../../../../types";
 import type { LovelaceCard } from "../../types";
 import type { EnergyDevicesDetailGraphCardConfig } from "../types";
 import { hasConfigChanged } from "../../common/has-changed";
@@ -43,8 +49,8 @@ import { storage } from "../../../../common/decorators/storage";
 import type { ECOption } from "../../../../resources/echarts/echarts";
 import { formatNumber } from "../../../../common/number/format_number";
 import type { CustomLegendOption } from "../../../../components/chart/ha-chart-base";
-
-const UNIT = "kWh";
+import "../../../../components/ha-button-toggle-group";
+import "../../../../components/ha-tooltip";
 
 @customElement("hui-energy-devices-detail-graph-card")
 export class HuiEnergyDevicesDetailGraphCard
@@ -92,6 +98,20 @@ export class HuiEnergyDevicesDetailGraphCard
   })
   private _hiddenStats: string[] = [];
 
+  @state()
+  @storage({
+    key: ENERGY_UNIT_MODE_STORAGE_KEY,
+    state: true,
+    subscribe: true,
+  })
+  private _unitMode: EnergyUnitMode = "energy";
+
+  @state() private _costAvailable = false;
+
+  private _costRatios = new Map<number, number>();
+
+  private _costRatiosCompare = new Map<number, number>();
+
   protected hassSubscribeRequiredHostProps = ["_config"];
 
   public hassSubscribe(): UnsubscribeFunc[] {
@@ -100,6 +120,18 @@ export class HuiEnergyDevicesDetailGraphCard
         key: this._config?.collection_key,
       }).subscribe((data) => {
         this._data = data;
+        this._costAvailable = hasGridCostData(data);
+        if (!this._costAvailable && this._unitMode === "cost") {
+          this._unitMode = "energy";
+        }
+        this._costRatios = computeGridCostRatios(
+          data.stats,
+          data.info,
+          data.prefs
+        );
+        this._costRatiosCompare = data.statsCompare
+          ? computeGridCostRatios(data.statsCompare, data.info, data.prefs)
+          : new Map();
       }),
     ];
   }
@@ -124,7 +156,11 @@ export class HuiEnergyDevicesDetailGraphCard
   }
 
   protected willUpdate(changedProps: PropertyValues) {
-    if (changedProps.has("_config") || changedProps.has("_data")) {
+    if (
+      changedProps.has("_config") ||
+      changedProps.has("_data") ||
+      changedProps.has("_unitMode")
+    ) {
       this._processStatistics();
     }
   }
@@ -136,14 +172,11 @@ export class HuiEnergyDevicesDetailGraphCard
 
     return html`
       <ha-card>
-        ${this._config.title
-          ? html`<h1 class="card-header">${this._config.title}</h1>`
-          : ""}
-        <div
-          class="content ${classMap({
-            "has-header": !!this._config.title,
-          })}"
-        >
+        <div class="card-header">
+          <h1>${this._config.title ?? ""}</h1>
+          ${this._renderUnitToggle()}
+        </div>
+        <div class="content has-header">
           <ha-chart-base
             .hass=${this.hass}
             .data=${this._chartData}
@@ -152,7 +185,7 @@ export class HuiEnergyDevicesDetailGraphCard
               this._end,
               this.hass.locale,
               this.hass.config,
-              UNIT,
+              this._unitSymbol,
               this._compareStart,
               this._compareEnd
             )}
@@ -164,11 +197,69 @@ export class HuiEnergyDevicesDetailGraphCard
     `;
   }
 
-  private _formatTotal = (total: number) =>
-    this.hass.localize(
+  private get _unitSymbol(): string {
+    return this._unitMode === "cost" ? this.hass.config.currency : "kWh";
+  }
+
+  private _formatTotal = (total: number) => {
+    if (this._unitMode === "cost") {
+      return this.hass.localize(
+        "ui.panel.lovelace.cards.energy.device_unit_mode.total_cost",
+        {
+          num: formatNumber(total, this.hass.locale, {
+            style: "currency",
+            currency: this.hass.config.currency,
+          }),
+        }
+      );
+    }
+    return this.hass.localize(
       "ui.panel.lovelace.cards.energy.energy_usage_graph.total_consumed",
-      { num: formatNumber(total, this.hass.locale), unit: UNIT }
+      { num: formatNumber(total, this.hass.locale), unit: "kWh" }
     );
+  };
+
+  private _renderUnitToggle() {
+    const buttons: ToggleButton[] = [
+      {
+        label: this.hass.localize(
+          "ui.panel.lovelace.cards.energy.device_unit_mode.energy"
+        ),
+        value: "energy",
+      },
+      {
+        label: this.hass.localize(
+          "ui.panel.lovelace.cards.energy.device_unit_mode.cost"
+        ),
+        value: "cost",
+      },
+    ];
+    const toggle = html`<ha-button-toggle-group
+      id="unit-mode-toggle"
+      .buttons=${buttons}
+      .active=${this._unitMode}
+      size="small"
+      @value-changed=${this._unitModeChanged}
+    ></ha-button-toggle-group>`;
+    if (this._costAvailable) {
+      return toggle;
+    }
+    return html`${toggle}
+      <ha-tooltip for="unit-mode-toggle">
+        ${this.hass.localize(
+          "ui.panel.lovelace.cards.energy.device_unit_mode.cost_unavailable"
+        )}
+      </ha-tooltip>`;
+  }
+
+  private _unitModeChanged(ev: CustomEvent<{ value: string }>): void {
+    const value = ev.detail.value as EnergyUnitMode;
+    if (value === "cost" && !this._costAvailable) {
+      this.requestUpdate();
+      return;
+    }
+    this._unitMode = value;
+  }
 
   // ha-chart-base will track hidden per ID (so it will have two entries for ID and compare-ID)
   // But it will only fire the event for the primary ID, and we will convert and store a list of statistic ids only
@@ -249,12 +340,35 @@ export class HuiEnergyDevicesDetailGraphCard
     this._compareStart = energyData.startCompare;
     this._compareEnd = energyData.endCompare;
 
-    const data = energyData.stats;
-    const compareData = energyData.statsCompare;
+    const rawData = energyData.stats;
+    const rawCompareData = energyData.statsCompare;
 
     const computedStyle = getComputedStyle(this);
 
     const devices = energyData.prefs.device_consumption;
+
+    const costMode = this._unitMode === "cost";
+    const scaleDeviceStats = (
+      stats: Statistics,
+      ratios: Map<number, number>
+    ): Statistics => {
+      if (!costMode) {
+        return stats;
+      }
+      const scaled: Statistics = { ...stats };
+      for (const device of devices) {
+        scaled[device.stat_consumption] = deviceCostSeries(
+          stats,
+          device.stat_consumption,
+          ratios
+        );
+      }
+      return scaled;
+    };
+    const data = scaleDeviceStats(rawData, this._costRatios);
+    const compareData = rawCompareData
+      ? scaleDeviceStats(rawCompareData, this._costRatiosCompare)
+      : rawCompareData;
 
     const childMap: Record<string, string[]> = {};
     devices.forEach((d) => {
@@ -295,9 +409,10 @@ export class HuiEnergyDevicesDetailGraphCard
     const { summedData, compareSummedData } = getSummedData(energyData);
 
     const showUntracked =
-      "from_grid" in summedData ||
-      "solar" in summedData ||
-      "from_battery" in summedData;
+      !costMode &&
+      ("from_grid" in summedData ||
+        "solar" in summedData ||
+        "from_battery" in summedData);
 
     const {
       consumption: consumptionData,
@@ -567,7 +682,22 @@ export class HuiEnergyDevicesDetailGraphCard
 
   static styles = css`
     .card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
       padding-bottom: 0;
+      gap: var(--ha-space-2);
+    }
+    .card-header h1 {
+      margin: 0;
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .card-header h1:empty {
+      display: none;
     }
     .content {
       padding: 16px;

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
@@ -23,7 +23,9 @@ import {
 import type { EnergyUnitMode } from "../../../../data/energy_device_cost";
 import {
   calculateDeviceCostGrowth,
+  calculateUntrackedCost,
   computeGridCostRatios,
+  computePeriodAverageRatio,
   ENERGY_UNIT_MODE_STORAGE_KEY,
   hasGridCostData,
 } from "../../../../data/energy_device_cost";
@@ -44,7 +46,6 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import { measureTextWidth } from "../../../../util/text";
 import "../../../../components/ha-icon-button";
 import "../../../../components/ha-button-toggle-group";
-import "../../../../components/ha-tooltip";
 import { storage } from "../../../../common/decorators/storage";
 import { listenMediaQuery } from "../../../../common/dom/media_query";
 import { getEnergyColor } from "./common/color";
@@ -114,6 +115,10 @@ export class HuiEnergyDevicesGraphCard
 
   private _costRatiosCompare = new Map<number, number>();
 
+  private _costAvgRatio = 0;
+
+  private _costAvgRatioCompare = 0;
+
   protected hassSubscribeRequiredHostProps = ["_config"];
 
   public hassSubscribe(): UnsubscribeFunc[] {
@@ -122,7 +127,8 @@ export class HuiEnergyDevicesGraphCard
         key: this._config?.collection_key,
       }).subscribe((data) => {
         this._data = data;
-        this._costAvailable = hasGridCostData(data);
+        this._costAvailable =
+          hasGridCostData(data) && !!this.hass.config.currency;
         if (!this._costAvailable && this._unitMode === "cost") {
           this._unitMode = "energy";
         }
@@ -134,6 +140,14 @@ export class HuiEnergyDevicesGraphCard
         this._costRatiosCompare = data.statsCompare
           ? computeGridCostRatios(data.statsCompare, data.info, data.prefs)
           : new Map();
+        this._costAvgRatio = computePeriodAverageRatio(
+          data.stats,
+          data.info,
+          data.prefs
+        );
+        this._costAvgRatioCompare = data.statsCompare
+          ? computePeriodAverageRatio(data.statsCompare, data.info, data.prefs)
+          : 0;
         this._getStatistics(data);
       }),
       listenMediaQuery(
@@ -261,6 +275,9 @@ export class HuiEnergyDevicesGraphCard
   }
 
   private _renderUnitToggle() {
+    if (!this._costAvailable) {
+      return nothing;
+    }
     const buttons: ToggleButton[] = [
       {
         label: this.hass.localize(
@@ -275,41 +292,30 @@ export class HuiEnergyDevicesGraphCard
         value: "cost",
       },
     ];
-    const toggle = html`<ha-button-toggle-group
-      id="unit-mode-toggle"
+    return html`<ha-button-toggle-group
       .buttons=${buttons}
       .active=${this._unitMode}
       size="small"
       @value-changed=${this._unitModeChanged}
     ></ha-button-toggle-group>`;
-    if (this._costAvailable) {
-      return toggle;
-    }
-    return html`${toggle}
-      <ha-tooltip for="unit-mode-toggle">
-        ${this.hass.localize(
-          "ui.panel.lovelace.cards.energy.device_unit_mode.cost_unavailable"
-        )}
-      </ha-tooltip>`;
   }
 
   private _unitModeChanged(ev: CustomEvent<{ value: string }>): void {
-    const value = ev.detail.value as EnergyUnitMode;
-    if (value === "cost" && !this._costAvailable) {
-      this.requestUpdate();
-      return;
-    }
-    this._unitMode = value;
+    this._unitMode = ev.detail.value as EnergyUnitMode;
   }
 
   private _renderTooltip(params: any) {
     const deviceName = filterXSS(this._getDeviceName(params.name));
     const title = `<h4 style="text-align: center; margin: 0;">${deviceName}</h4>`;
     const rawValue = params.value[0] as number;
-    const formattedValue = this._formatValue(
-      rawValue,
-      rawValue < 0.1 ? { maximumFractionDigits: 3 } : undefined
-    );
+    // Only bump kWh precision for tiny values — currency formatting already
+    // respects the target currency's minimum fraction digits, so leave it to
+    // Intl in cost mode.
+    const extraOpts =
+      this._unitMode === "energy" && rawValue < 0.1
+        ? { maximumFractionDigits: 3 }
+        : undefined;
+    const formattedValue = this._formatValue(rawValue, extraOpts);
     const value = `${formattedValue} ${params.percent ? `(${params.percent} %)` : ""}`;
     return `${title}${params.marker} ${params.seriesName}: <div style="direction:ltr; display: inline;">${value}</div>`;
   }
@@ -565,17 +571,35 @@ export class HuiEnergyDevicesGraphCard
         summedData,
         compareSummedData
       );
-      const totalUsed = consumption.total.used_total;
       const showUntracked =
-        !costMode &&
-        ("from_grid" in summedData ||
-          "solar" in summedData ||
-          "from_battery" in summedData);
+        "from_grid" in summedData ||
+        "solar" in summedData ||
+        "from_battery" in summedData;
+      const computeUntracked = (
+        cons: typeof consumption,
+        stats: Statistics,
+        periodRatios: Map<number, number>,
+        fallbackRatio: number,
+        pieValues: number[]
+      ): number => {
+        if (costMode) {
+          return calculateUntrackedCost(
+            stats,
+            periodRatios,
+            cons.used_total,
+            devices,
+            fallbackRatio
+          );
+        }
+        return cons.total.used_total - pieValues.reduce((acc, v) => acc + v, 0);
+      };
       const untracked = showUntracked
-        ? totalUsed -
-          pieChartData.reduce(
-            (acc: number, d) => acc + (d as PieDataItemOption).value![0],
-            0
+        ? computeUntracked(
+            consumption,
+            data,
+            this._costRatios,
+            this._costAvgRatio,
+            pieChartData.map((d) => (d as PieDataItemOption).value![0])
           )
         : 0;
       if (untracked > 0) {
@@ -598,12 +622,13 @@ export class HuiEnergyDevicesGraphCard
           },
         });
         if (compareData) {
-          const compareUntracked =
-            compareConsumption!.total.used_total -
-            chartDataCompare.reduce(
-              (acc: number, d: any) => acc + d.value[0],
-              0
-            );
+          const compareUntracked = computeUntracked(
+            compareConsumption!,
+            compareData,
+            this._costRatiosCompare,
+            this._costAvgRatioCompare,
+            chartDataCompare.map((d: any) => d.value[0])
+          );
           if (compareUntracked > 0) {
             chartDataCompare.push({
               id: "untracked",

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
@@ -20,13 +20,21 @@ import {
   getSummedData,
   validateEnergyCollectionKey,
 } from "../../../../data/energy";
+import type { EnergyUnitMode } from "../../../../data/energy_device_cost";
+import {
+  calculateDeviceCostGrowth,
+  computeGridCostRatios,
+  ENERGY_UNIT_MODE_STORAGE_KEY,
+  hasGridCostData,
+} from "../../../../data/energy_device_cost";
+import type { Statistics } from "../../../../data/recorder";
 import {
   calculateStatisticSumGrowth,
   getStatisticLabel,
   isExternalStatistic,
 } from "../../../../data/recorder";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
-import type { HomeAssistant } from "../../../../types";
+import type { HomeAssistant, ToggleButton } from "../../../../types";
 import type { LovelaceCard } from "../../types";
 import type { EnergyDevicesGraphCardConfig } from "../types";
 import { hasConfigChanged } from "../../common/has-changed";
@@ -35,6 +43,8 @@ import "../../../../components/ha-card";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { measureTextWidth } from "../../../../util/text";
 import "../../../../components/ha-icon-button";
+import "../../../../components/ha-button-toggle-group";
+import "../../../../components/ha-tooltip";
 import { storage } from "../../../../common/decorators/storage";
 import { listenMediaQuery } from "../../../../common/dom/media_query";
 import { getEnergyColor } from "./common/color";
@@ -86,9 +96,23 @@ export class HuiEnergyDevicesGraphCard
   })
   private _hiddenStats: string[] = [];
 
+  @state()
+  @storage({
+    key: ENERGY_UNIT_MODE_STORAGE_KEY,
+    state: true,
+    subscribe: true,
+  })
+  private _unitMode: EnergyUnitMode = "energy";
+
+  @state() private _costAvailable = false;
+
   @state() private _isMobile = false;
 
   private _compoundStats: string[] = [];
+
+  private _costRatios = new Map<number, number>();
+
+  private _costRatiosCompare = new Map<number, number>();
 
   protected hassSubscribeRequiredHostProps = ["_config"];
 
@@ -98,6 +122,18 @@ export class HuiEnergyDevicesGraphCard
         key: this._config?.collection_key,
       }).subscribe((data) => {
         this._data = data;
+        this._costAvailable = hasGridCostData(data);
+        if (!this._costAvailable && this._unitMode === "cost") {
+          this._unitMode = "energy";
+        }
+        this._costRatios = computeGridCostRatios(
+          data.stats,
+          data.info,
+          data.prefs
+        );
+        this._costRatiosCompare = data.statsCompare
+          ? computeGridCostRatios(data.statsCompare, data.info, data.prefs)
+          : new Map();
         this._getStatistics(data);
       }),
       listenMediaQuery(
@@ -147,6 +183,10 @@ export class HuiEnergyDevicesGraphCard
         this._chartType = allowedModes[0];
       }
     }
+
+    if (changedProps.has("_unitMode") && this._data) {
+      this._getStatistics(this._data);
+    }
   }
 
   protected render() {
@@ -160,19 +200,22 @@ export class HuiEnergyDevicesGraphCard
       <ha-card>
         <div class="card-header">
           <span>${this._config.title ? this._config.title : nothing}</span>
-          ${modes.length > 1
-            ? html`
-                <ha-icon-button
-                  .path=${this._chartType === "pie"
-                    ? mdiChartBar
-                    : mdiChartDonut}
-                  .label=${this.hass.localize(
-                    "ui.panel.lovelace.cards.energy.energy_devices_graph.change_chart_type"
-                  )}
-                  @click=${this._handleChartTypeChange}
-                ></ha-icon-button>
-              `
-            : nothing}
+          <div class="header-actions">
+            ${this._renderUnitToggle()}
+            ${modes.length > 1
+              ? html`
+                  <ha-icon-button
+                    .path=${this._chartType === "pie"
+                      ? mdiChartBar
+                      : mdiChartDonut}
+                    .label=${this.hass.localize(
+                      "ui.panel.lovelace.cards.energy.energy_devices_graph.change_chart_type"
+                    )}
+                    @click=${this._handleChartTypeChange}
+                  ></ha-icon-button>
+                `
+              : nothing}
+          </div>
         </div>
         <div
           class="content ${classMap({
@@ -185,7 +228,8 @@ export class HuiEnergyDevicesGraphCard
             .options=${this._createOptions(
               this._chartData,
               this._chartType,
-              this._legendData
+              this._legendData,
+              this._unitSymbol
             )}
             .height=${`${Math.max(modes.includes("pie") ? 300 : 100, (this._legendData?.length || 0) * 28 + 50)}px`}
             .extraComponents=${[PieChart]}
@@ -198,14 +242,75 @@ export class HuiEnergyDevicesGraphCard
     `;
   }
 
+  private get _unitSymbol(): string {
+    return this._unitMode === "cost" ? this.hass.config.currency : "kWh";
+  }
+
+  private _formatValue(
+    value: number,
+    options?: Intl.NumberFormatOptions
+  ): string {
+    if (this._unitMode === "cost") {
+      return formatNumber(value, this.hass.locale, {
+        ...options,
+        style: "currency",
+        currency: this.hass.config.currency,
+      });
+    }
+    return `${formatNumber(value, this.hass.locale, options)} kWh`;
+  }
+
+  private _renderUnitToggle() {
+    const buttons: ToggleButton[] = [
+      {
+        label: this.hass.localize(
+          "ui.panel.lovelace.cards.energy.device_unit_mode.energy"
+        ),
+        value: "energy",
+      },
+      {
+        label: this.hass.localize(
+          "ui.panel.lovelace.cards.energy.device_unit_mode.cost"
+        ),
+        value: "cost",
+      },
+    ];
+    const toggle = html`<ha-button-toggle-group
+      id="unit-mode-toggle"
+      .buttons=${buttons}
+      .active=${this._unitMode}
+      size="small"
+      @value-changed=${this._unitModeChanged}
+    ></ha-button-toggle-group>`;
+    if (this._costAvailable) {
+      return toggle;
+    }
+    return html`${toggle}
+      <ha-tooltip for="unit-mode-toggle">
+        ${this.hass.localize(
+          "ui.panel.lovelace.cards.energy.device_unit_mode.cost_unavailable"
+        )}
+      </ha-tooltip>`;
+  }
+
+  private _unitModeChanged(ev: CustomEvent<{ value: string }>): void {
+    const value = ev.detail.value as EnergyUnitMode;
+    if (value === "cost" && !this._costAvailable) {
+      this.requestUpdate();
+      return;
+    }
+    this._unitMode = value;
+  }
+
   private _renderTooltip(params: any) {
     const deviceName = filterXSS(this._getDeviceName(params.name));
     const title = `<h4 style="text-align: center; margin: 0;">${deviceName}</h4>`;
-    const value = `${formatNumber(
-      params.value[0] as number,
-      this.hass.locale,
-      params.value < 0.1 ? { maximumFractionDigits: 3 } : undefined
-    )} kWh ${params.percent ? `(${params.percent} %)` : ""}`;
+    const rawValue = params.value[0] as number;
+    const formattedValue = this._formatValue(
+      rawValue,
+      rawValue < 0.1 ? { maximumFractionDigits: 3 } : undefined
+    );
+    const value = `${formattedValue} ${params.percent ? `(${params.percent} %)` : ""}`;
     return `${title}${params.marker} ${params.seriesName}: <div style="direction:ltr; display: inline;">${value}</div>`;
   }
 
@@ -213,7 +318,8 @@ export class HuiEnergyDevicesGraphCard
     (
       data: (BarSeriesOption | PieSeriesOption)[],
       chartType: "bar" | "pie",
-      legendData: typeof this._legendData
+      legendData: typeof this._legendData,
+      unitSymbol: string
     ): ECOption => {
       const options: ECOption = {
         grid: {
@@ -235,7 +341,7 @@ export class HuiEnergyDevicesGraphCard
         options.xAxis = {
           show: true,
           type: "value",
-          name: "kWh",
+          name: unitSymbol,
           axisPointer: {
             show: false,
           },
@@ -368,22 +474,41 @@ export class HuiEnergyDevicesGraphCard
       .filter(Boolean) as string[];
 
     const devices = energyData.prefs.device_consumption;
+    const costMode = this._unitMode === "cost";
+    const ratios = this._costRatios;
+    const ratiosCompare = this._costRatiosCompare;
+    const deviceTotal = (stats: Statistics, id: string): number => {
+      if (!(id in stats)) {
+        return 0;
+      }
+      if (costMode) {
+        return calculateDeviceCostGrowth(stats, id, ratios) || 0;
+      }
+      return calculateStatisticSumGrowth(stats[id]) || 0;
+    };
+    const deviceTotalCompare = (stats: Statistics, id: string): number => {
+      if (!(id in stats)) {
+        return 0;
+      }
+      if (costMode) {
+        return calculateDeviceCostGrowth(stats, id, ratiosCompare) || 0;
+      }
+      return calculateStatisticSumGrowth(stats[id]) || 0;
+    };
     const devicesTotals: Record<string, number> = {};
     devices.forEach((device) => {
-      devicesTotals[device.stat_consumption] =
-        device.stat_consumption in data
-          ? calculateStatisticSumGrowth(data[device.stat_consumption]) || 0
-          : 0;
+      devicesTotals[device.stat_consumption] = deviceTotal(
+        data,
+        device.stat_consumption
+      );
     });
     const devicesTotalsCompare: Record<string, number> = {};
     if (compareData) {
       devices.forEach((device) => {
-        devicesTotalsCompare[device.stat_consumption] =
-          device.stat_consumption in compareData
-            ? calculateStatisticSumGrowth(
-                compareData[device.stat_consumption]
-              ) || 0
-            : 0;
+        devicesTotalsCompare[device.stat_consumption] = deviceTotalCompare(
+          compareData,
+          device.stat_consumption
+        );
       });
     }
     devices.forEach((device, idx) => {
@@ -412,12 +537,7 @@ export class HuiEnergyDevicesGraphCard
       });
 
       if (compareData) {
-        let compareValue =
-          device.stat_consumption in compareData
-            ? calculateStatisticSumGrowth(
-                compareData[device.stat_consumption]
-              ) || 0
-            : 0;
+        let compareValue = devicesTotalsCompare[device.stat_consumption] || 0;
         const compareChildSum = devices.reduce((acc, d) => {
           if (d.included_in_stat === device.stat_consumption) {
             return acc + devicesTotalsCompare[d.stat_consumption];
@@ -447,9 +567,10 @@ export class HuiEnergyDevicesGraphCard
       );
       const totalUsed = consumption.total.used_total;
       const showUntracked =
-        "from_grid" in summedData ||
-        "solar" in summedData ||
-        "from_battery" in summedData;
+        !costMode &&
+        ("from_grid" in summedData ||
+          "solar" in summedData ||
+          "from_battery" in summedData);
       const untracked = showUntracked
         ? totalUsed -
           pieChartData.reduce(
@@ -519,7 +640,7 @@ export class HuiEnergyDevicesGraphCard
           fontSize: computedStyle.getPropertyValue("--ha-font-size-m"),
           lineHeight: 24,
           fontWeight: "bold",
-          formatter: `{a}\n${formatNumber(totalChart, this.hass.locale)} kWh`,
+          formatter: `{a}\n${this._formatValue(totalChart)}`,
         },
         cursor: "default",
         itemStyle: {
@@ -542,7 +663,7 @@ export class HuiEnergyDevicesGraphCard
     this._legendData = chartData.map((d) => ({
       ...d,
       name: this._getDeviceName(d.name),
-      value: `${formatNumber(d.value[0], this.hass.locale)} kWh`,
+      value: this._formatValue(d.value[0]),
     }));
     // filter out hidden stats in place
     for (let i = chartData.length - 1; i >= 0; i--) {
@@ -612,6 +733,11 @@ export class HuiEnergyDevicesGraphCard
       justify-content: space-between;
       align-items: center;
       padding-bottom: 0;
+    }
+    .header-actions {
+      display: flex;
+      align-items: center;
+      gap: var(--ha-space-2);
     }
     .content {
       padding: 16px;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8513,6 +8513,13 @@
               "untracked": "untracked",
               "other": "Other"
             },
+            "device_unit_mode": {
+              "label": "Display unit",
+              "energy": "Energy",
+              "cost": "Cost",
+              "cost_unavailable": "Cost is unavailable. Configure a grid source with cost tracking to see device costs.",
+              "total_cost": "Total cost {num}"
+            },
             "carbon_consumed_gauge": {
               "card_indicates_energy_used": "This card indicates how much of the electricity consumed by your home was generated using non-fossil fuels like solar, wind, and nuclear. The higher, the better!",
               "low_carbon_energy_consumed": "Low-carbon electricity consumed",

--- a/test/data/energy_device_cost.test.ts
+++ b/test/data/energy_device_cost.test.ts
@@ -1,0 +1,265 @@
+import { assert, describe, it } from "vitest";
+import type {
+  EnergyData,
+  EnergyInfo,
+  EnergyPreferences,
+} from "../../src/data/energy";
+import {
+  calculateDeviceCostGrowth,
+  computeGridCostRatios,
+  deviceCostSeries,
+  hasGridCostData,
+} from "../../src/data/energy_device_cost";
+import type { Statistics } from "../../src/data/recorder";
+
+const bucket = (start: number, change: number | null) => ({
+  start,
+  end: start + 3_600_000,
+  change,
+});
+
+const prefs = (
+  overrides: Partial<EnergyPreferences> = {}
+): EnergyPreferences => ({
+  energy_sources: [],
+  device_consumption: [],
+  device_consumption_water: [],
+  ...overrides,
+});
+
+const info = (
+  cost_sensors: Record<string, string> = {},
+  overrides: Partial<EnergyInfo> = {}
+): EnergyInfo => ({
+  cost_sensors,
+  solar_forecast_domains: [],
+  ...overrides,
+});
+
+describe("computeGridCostRatios", () => {
+  it("returns an empty map when no grid source is configured", () => {
+    const ratios = computeGridCostRatios({}, info(), prefs());
+    assert.equal(ratios.size, 0);
+  });
+
+  it("divides total grid cost by total grid kWh per bucket", () => {
+    const stats: Statistics = {
+      grid_kwh: [bucket(1, 2), bucket(2, 4)],
+      grid_cost: [bucket(1, 0.4), bucket(2, 1.2)],
+    };
+    const p = prefs({
+      energy_sources: [
+        {
+          type: "grid",
+          stat_energy_from: "grid_kwh",
+          stat_energy_to: null,
+          stat_cost: "grid_cost",
+          entity_energy_price: null,
+          number_energy_price: null,
+          stat_compensation: null,
+          entity_energy_price_export: null,
+          number_energy_price_export: null,
+          cost_adjustment_day: 0,
+        },
+      ],
+    });
+    const ratios = computeGridCostRatios(stats, info(), p);
+    assert.equal(ratios.size, 2);
+    assert.closeTo(ratios.get(1)!, 0.2, 1e-9);
+    assert.closeTo(ratios.get(2)!, 0.3, 1e-9);
+  });
+
+  it("resolves the cost sensor via info.cost_sensors when stat_cost is missing", () => {
+    const stats: Statistics = {
+      grid_kwh: [bucket(1, 5)],
+      sensor_cost: [bucket(1, 1.0)],
+    };
+    const p = prefs({
+      energy_sources: [
+        {
+          type: "grid",
+          stat_energy_from: "grid_kwh",
+          stat_energy_to: null,
+          stat_cost: null,
+          entity_energy_price: null,
+          number_energy_price: null,
+          stat_compensation: null,
+          entity_energy_price_export: null,
+          number_energy_price_export: null,
+          cost_adjustment_day: 0,
+        },
+      ],
+    });
+    const ratios = computeGridCostRatios(
+      stats,
+      info({ grid_kwh: "sensor_cost" }),
+      p
+    );
+    assert.closeTo(ratios.get(1)!, 0.2, 1e-9);
+  });
+
+  it("omits buckets with zero or negative grid energy", () => {
+    const stats: Statistics = {
+      grid_kwh: [bucket(1, 0), bucket(2, -1), bucket(3, 2)],
+      grid_cost: [bucket(1, 0.1), bucket(2, 0.1), bucket(3, 0.6)],
+    };
+    const p = prefs({
+      energy_sources: [
+        {
+          type: "grid",
+          stat_energy_from: "grid_kwh",
+          stat_energy_to: null,
+          stat_cost: "grid_cost",
+          entity_energy_price: null,
+          number_energy_price: null,
+          stat_compensation: null,
+          entity_energy_price_export: null,
+          number_energy_price_export: null,
+          cost_adjustment_day: 0,
+        },
+      ],
+    });
+    const ratios = computeGridCostRatios(stats, info(), p);
+    assert.equal(ratios.size, 1);
+    assert.closeTo(ratios.get(3)!, 0.3, 1e-9);
+  });
+
+  it("aggregates multiple grid sources into a single ratio per bucket", () => {
+    const stats: Statistics = {
+      grid_a_kwh: [bucket(1, 2)],
+      grid_a_cost: [bucket(1, 0.4)],
+      grid_b_kwh: [bucket(1, 2)],
+      grid_b_cost: [bucket(1, 0.2)],
+    };
+    const p = prefs({
+      energy_sources: [
+        {
+          type: "grid",
+          stat_energy_from: "grid_a_kwh",
+          stat_energy_to: null,
+          stat_cost: "grid_a_cost",
+          entity_energy_price: null,
+          number_energy_price: null,
+          stat_compensation: null,
+          entity_energy_price_export: null,
+          number_energy_price_export: null,
+          cost_adjustment_day: 0,
+        },
+        {
+          type: "grid",
+          stat_energy_from: "grid_b_kwh",
+          stat_energy_to: null,
+          stat_cost: "grid_b_cost",
+          entity_energy_price: null,
+          number_energy_price: null,
+          stat_compensation: null,
+          entity_energy_price_export: null,
+          number_energy_price_export: null,
+          cost_adjustment_day: 0,
+        },
+      ],
+    });
+    const ratios = computeGridCostRatios(stats, info(), p);
+    // (0.4 + 0.2) / (2 + 2) = 0.15
+    assert.closeTo(ratios.get(1)!, 0.15, 1e-9);
+  });
+});
+
+describe("hasGridCostData", () => {
+  it("returns false when the period has no grid cost data", () => {
+    const data: EnergyData = {
+      start: new Date(0),
+      prefs: prefs(),
+      info: info(),
+      stats: {},
+      statsMetadata: {},
+      statsCompare: {},
+      waterUnit: "L",
+      gasUnit: "m³",
+    };
+    assert.equal(hasGridCostData(data), false);
+  });
+
+  it("returns true when the compare window has cost data even if the main window is empty", () => {
+    const p = prefs({
+      energy_sources: [
+        {
+          type: "grid",
+          stat_energy_from: "grid_kwh",
+          stat_energy_to: null,
+          stat_cost: "grid_cost",
+          entity_energy_price: null,
+          number_energy_price: null,
+          stat_compensation: null,
+          entity_energy_price_export: null,
+          number_energy_price_export: null,
+          cost_adjustment_day: 0,
+        },
+      ],
+    });
+    const data: EnergyData = {
+      start: new Date(0),
+      prefs: p,
+      info: info(),
+      stats: {},
+      statsMetadata: {},
+      statsCompare: {
+        grid_kwh: [bucket(1, 2)],
+        grid_cost: [bucket(1, 0.5)],
+      },
+      waterUnit: "L",
+      gasUnit: "m³",
+    };
+    assert.equal(hasGridCostData(data), true);
+  });
+});
+
+describe("calculateDeviceCostGrowth", () => {
+  const ratios = new Map<number, number>([
+    [1, 0.2],
+    [2, 0.3],
+  ]);
+
+  it("returns null when the device stat is absent", () => {
+    assert.equal(calculateDeviceCostGrowth({}, "device", ratios), null);
+  });
+
+  it("sums device_kWh * ratio per bucket, skipping buckets without a ratio", () => {
+    const stats: Statistics = {
+      device: [
+        bucket(1, 1.5), // 1.5 * 0.2 = 0.3
+        bucket(2, 2.0), // 2.0 * 0.3 = 0.6
+        bucket(3, 5.0), // no ratio => skipped
+      ],
+    };
+    const total = calculateDeviceCostGrowth(stats, "device", ratios);
+    assert.closeTo(total!, 0.9, 1e-9);
+  });
+
+  it("ignores null changes", () => {
+    const stats: Statistics = {
+      device: [bucket(1, null), bucket(2, 1.0)],
+    };
+    const total = calculateDeviceCostGrowth(stats, "device", ratios);
+    assert.closeTo(total!, 0.3, 1e-9);
+  });
+});
+
+describe("deviceCostSeries", () => {
+  it("returns an empty array when the device stat is absent", () => {
+    const ratios = new Map<number, number>();
+    assert.deepEqual(deviceCostSeries({}, "device", ratios), []);
+  });
+
+  it("applies ratio per bucket and emits 0 for buckets without a ratio", () => {
+    const ratios = new Map<number, number>([[1, 0.5]]);
+    const stats: Statistics = {
+      device: [bucket(1, 2), bucket(2, 4), bucket(3, null)],
+    };
+    const series = deviceCostSeries(stats, "device", ratios);
+    assert.equal(series.length, 3);
+    assert.equal(series[0].change, 1);
+    assert.equal(series[1].change, 0);
+    assert.equal(series[2].change, null);
+  });
+});

--- a/test/data/energy_device_cost.test.ts
+++ b/test/data/energy_device_cost.test.ts
@@ -1,13 +1,15 @@
 import { assert, describe, it } from "vitest";
 import type {
+  DeviceConsumptionEnergyPreference,
   EnergyData,
   EnergyInfo,
   EnergyPreferences,
 } from "../../src/data/energy";
 import {
   calculateDeviceCostGrowth,
+  calculateUntrackedCost,
   computeGridCostRatios,
-  deviceCostSeries,
+  computePeriodAverageRatio,
   hasGridCostData,
 } from "../../src/data/energy_device_cost";
 import type { Statistics } from "../../src/data/recorder";
@@ -245,21 +247,97 @@ describe("calculateDeviceCostGrowth", () => {
   });
 });
 
-describe("deviceCostSeries", () => {
-  it("returns an empty array when the device stat is absent", () => {
-    const ratios = new Map<number, number>();
-    assert.deepEqual(deviceCostSeries({}, "device", ratios), []);
+describe("computePeriodAverageRatio", () => {
+  it("returns 0 when there are no grid sources", () => {
+    assert.equal(computePeriodAverageRatio({}, info(), prefs()), 0);
   });
 
-  it("applies ratio per bucket and emits 0 for buckets without a ratio", () => {
-    const ratios = new Map<number, number>([[1, 0.5]]);
+  it("returns Σcost / Σenergy across all grid buckets", () => {
     const stats: Statistics = {
-      device: [bucket(1, 2), bucket(2, 4), bucket(3, null)],
+      grid_kwh: [bucket(1, 2), bucket(2, 3)],
+      grid_cost: [bucket(1, 0.4), bucket(2, 1.2)],
     };
-    const series = deviceCostSeries(stats, "device", ratios);
-    assert.equal(series.length, 3);
-    assert.equal(series[0].change, 1);
-    assert.equal(series[1].change, 0);
-    assert.equal(series[2].change, null);
+    const p = prefs({
+      energy_sources: [
+        {
+          type: "grid",
+          stat_energy_from: "grid_kwh",
+          stat_energy_to: null,
+          stat_cost: "grid_cost",
+          entity_energy_price: null,
+          number_energy_price: null,
+          stat_compensation: null,
+          entity_energy_price_export: null,
+          number_energy_price_export: null,
+          cost_adjustment_day: 0,
+        },
+      ],
+    });
+    // total cost 1.6 / total energy 5 = 0.32
+    assert.closeTo(computePeriodAverageRatio(stats, info(), p), 0.32, 1e-9);
+  });
+});
+
+describe("calculateUntrackedCost", () => {
+  const devices: DeviceConsumptionEnergyPreference[] = [
+    { stat_consumption: "d1" },
+    { stat_consumption: "d2" },
+  ];
+
+  it("returns 0 when no ratios and no usage are provided", () => {
+    assert.equal(calculateUntrackedCost({}, new Map(), {}, devices), 0);
+  });
+
+  it("sums (used_total - tracked) * ratio per hour", () => {
+    const stats: Statistics = {
+      d1: [bucket(1, 1), bucket(2, 2)],
+      d2: [bucket(1, 1), bucket(2, 0)],
+    };
+    const ratios = new Map<number, number>([
+      [1, 0.2], // used 5, tracked 2, untracked 3 -> 0.6
+      [2, 0.3], // used 4, tracked 2, untracked 2 -> 0.6
+    ]);
+    const used = { "1": 5, "2": 4 };
+    const total = calculateUntrackedCost(stats, ratios, used, devices);
+    assert.closeTo(total, 1.2, 1e-9);
+  });
+
+  it("clamps to 0 when tracked exceeds used_total in a bucket", () => {
+    const stats: Statistics = {
+      d1: [bucket(1, 10)],
+      d2: [bucket(1, 10)],
+    };
+    const ratios = new Map<number, number>([[1, 0.2]]);
+    const used = { "1": 5 };
+    const total = calculateUntrackedCost(stats, ratios, used, devices);
+    assert.equal(total, 0);
+  });
+
+  it("skips buckets without a ratio", () => {
+    const stats: Statistics = {
+      d1: [bucket(1, 1), bucket(2, 1)],
+    };
+    const ratios = new Map<number, number>([[2, 0.5]]);
+    const used = { "1": 5, "2": 3 };
+    // Only bucket 2 counted: (3 - 1) * 0.5 = 1
+    assert.closeTo(
+      calculateUntrackedCost(stats, ratios, used, devices),
+      1,
+      1e-9
+    );
+  });
+
+  it("uses fallback ratio for buckets without a per-hour ratio", () => {
+    const stats: Statistics = {
+      d1: [bucket(1, 1), bucket(2, 1)],
+    };
+    const ratios = new Map<number, number>([[2, 0.5]]);
+    const used = { "1": 5, "2": 3 };
+    // Bucket 1: (5-1) * 0.2 (fallback) = 0.8; bucket 2: (3-1) * 0.5 = 1.0
+    assert.closeTo(
+      calculateUntrackedCost(stats, ratios, used, devices, 0.2),
+      1.8,
+      1e-9
+    );
   });
 });


### PR DESCRIPTION
## Proposed change

Add an **Energy ↔ Cost** toggle to the two "Individual devices" cards on the energy dashboard, so you can see at a glance how much each device is costing rather than just its kWh.

The toggle is shared across both cards (and persisted across reloads) via the existing `@storage({ subscribe: true })` decorator — no changes to the energy collection wiring.

Per-device cost is computed in the frontend only, no backend change. For each statistics bucket: `device_cost(h) = device_kWh(h) × (Σgrid_cost(h) / Σgrid_kWh(h))`. Multiple grid sources sum first, so a user with two grid imports gets a single ratio per hour. Untracked consumption is included in cost mode: per-hour where the bucket has a grid ratio, period-average where it doesn't (typically hours fully covered by solar). Helpers and unit tests live in `src/data/energy_device_cost.ts`.

The toggle only appears when a grid cost source is configured **and** `hass.config.currency` is set, so `Intl.NumberFormat({ style: "currency" })` never gets an empty code.

## Screenshots

_Added below._

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/architecture/discussions/790, https://github.com/home-assistant/home-assistant.io/issues/43454, https://github.com/home-assistant/frontend/pull/13396
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

### Design notes / known limitations

- **Devices on self-produced solar show 0 cost per hour.** The `ratio = grid_cost / grid_kWh` formula only prices grid imports; a device running entirely off solar that hour gets a strict 0. Deliberate.
- **Untracked uses a period-average fallback.** Untracked residual energy is often consumed during the very hours where `grid_kWh = 0`. A strict per-hour ratio would drop those buckets to 0 and the untracked series would mostly disappear in cost mode. Falling back to the period-average rate keeps the series visible, at the cost of slight inaccuracy for ToU/dynamic tariffs.
- **Sidesteps the 2022 multi-grid objection.** The earlier attempt (#13396, core#76925) got stuck in `architecture#790` on the "parent grid" concept. This PR never allocates devices to grids — every grid source's cost and kWh are aggregated first, then one ratio is applied, so `balloob`'s point that HA doesn't model multiple grid networks no longer applies.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
