### PR TITLE
Media browser: show different message for AI-generated image option

### DIFF
--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -907,22 +907,38 @@ export class HaMediaPlayerBrowse extends LitElement {
   }
 
   private _renderError(err: { message: string; code: string }) {
-    if (err.message === "Media directory does not exist.") {
+    if (
+      err.message === "Media directory does not exist." ||
+      err.message.includes("No AI-generated images")
+    ) {
+      const isAIGeneratedImages =
+        err.message.includes("AI-generated images") ||
+        (this._currentItem &&
+          this._currentItem.media_content_id &&
+          this._currentItem.media_content_id.startsWith(
+            "media-source://ai_task"
+          ));
+
+      const docPath = isAIGeneratedImages
+        ? "/integrations/ai_task/#action-ai_taskgenerate_image"
+        : "/more-info/local-media/setup-media";
+
+      const helpKey = isAIGeneratedImages
+        ? "ui.components.media-browser.ai_task_help"
+        : "ui.components.media-browser.setup_local_help";
+
       return html`
         <h2>
           ${this.hass.localize(
-            "ui.components.media-browser.no_local_media_found"
+            isAIGeneratedImages
+              ? "ui.components.media-browser.no_ai_generated_images"
+              : "ui.components.media-browser.no_local_media_found"
           )}
         </h2>
         <p>
-          ${this.hass.localize("ui.components.media-browser.no_media_folder")}
-          <br />
-          ${this.hass.localize("ui.components.media-browser.setup_local_help", {
+          ${this.hass.localize(helpKey, {
             documentation: html`<a
-              href=${documentationUrl(
-                this.hass,
-                "/more-info/local-media/setup-media"
-              )}
+              href=${documentationUrl(this.hass, docPath)}
               target="_blank"
               rel="noreferrer"
               >${this.hass.localize(
@@ -930,8 +946,6 @@ export class HaMediaPlayerBrowse extends LitElement {
               )}</a
             >`,
           })}
-          <br />
-          ${this.hass.localize("ui.components.media-browser.local_media_files")}
         </p>
       `;
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1198,6 +1198,8 @@
         "documentation": "documentation",
         "no_local_media_found": "No local media found",
         "no_media_folder": "It looks like you have not yet created a media directory.",
+        "no_ai_generated_images": "No AI-generated images found yet. Generate images using the ai_task.generate_image action to see them here.",
+        "ai_task_help": "To generate AI images, use the {documentation}. You can create images programmatically in your automations and scripts.",
         "setup_local_help": "Check the {documentation} on how to set up local media.",
         "file_management": {
           "title": "Media management",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Currently, in the media browser, if the AI-generated images option is selected, but no images have been generated yet, the error message points to
https://www.home-assistant.io/more-info/local-media/setup-media, and claims the media folder has not been set up. 
<img width="261" height="148" alt="image" src="https://github.com/user-attachments/assets/e8b600eb-319d-4d92-92d8-7ba3665c79ec" />
<img width="950" height="207" alt="image" src="https://github.com/user-attachments/assets/b10e4884-3fa6-4a24-a66d-3c0da7d0bc1b" />



Instead, it should point to a different help page and say that no AI images have been generated yet.

This PR adds a message for that AI-generated images case and adds the link to the proper documentation, (which should be https://www.home-assistant.io/integrations/ai_task/#action-ai_taskgenerate_image)

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: https://github.com/home-assistant/core/pull/168973

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
