### PR TITLE
Refactor home panel editor

### DIFF
--- a/src/common/entity/compute_entity_name_display.ts
+++ b/src/common/entity/compute_entity_name_display.ts
@@ -1,6 +1,7 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import type { HomeAssistant } from "../../types";
 import { ensureArray } from "../array/ensure-array";
+import { computeRTL } from "../util/compute_rtl";
 import { computeAreaName } from "./compute_area_name";
 import { computeDeviceName } from "./compute_device_name";
 import { computeEntityName, entityUseDeviceName } from "./compute_entity_name";
@@ -116,4 +117,33 @@ export const computeEntityNameList = (
   });
 
   return names;
+};
+
+export interface EntityPickerDisplay {
+  primary: string;
+  secondary?: string;
+}
+
+export const computeEntityPickerDisplay = (
+  hass: HomeAssistant,
+  stateObj: HassEntity
+): EntityPickerDisplay => {
+  const [entityName, deviceName, areaName] = computeEntityNameList(
+    stateObj,
+    [{ type: "entity" }, { type: "device" }, { type: "area" }],
+    hass.entities,
+    hass.devices,
+    hass.areas,
+    hass.floors
+  );
+
+  const isRTL = computeRTL(hass);
+
+  const primary = entityName || deviceName || stateObj.entity_id;
+  const secondary =
+    [areaName, entityName ? deviceName : undefined]
+      .filter(Boolean)
+      .join(isRTL ? " ◂ " : " ▸ ") || undefined;
+
+  return { primary, secondary };
 };

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -4,9 +4,8 @@ import { html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../common/dom/fire_event";
-import { computeEntityNameList } from "../../common/entity/compute_entity_name_display";
+import { computeEntityPickerDisplay } from "../../common/entity/compute_entity_name_display";
 import { isValidEntityId } from "../../common/entity/valid_entity_id";
-import { computeRTL } from "../../common/util/compute_rtl";
 import type { HaEntityPickerEntityFilterFunc } from "../../data/entity/entity";
 import {
   entityComboBoxKeys,
@@ -143,21 +142,10 @@ export class HaEntityPicker extends LitElement {
       `;
     }
 
-    const [entityName, deviceName, areaName] = computeEntityNameList(
-      stateObj,
-      [{ type: "entity" }, { type: "device" }, { type: "area" }],
-      this.hass.entities,
-      this.hass.devices,
-      this.hass.areas,
-      this.hass.floors
+    const { primary, secondary } = computeEntityPickerDisplay(
+      this.hass,
+      stateObj
     );
-
-    const isRTL = computeRTL(this.hass);
-
-    const primary = entityName || deviceName || entityId;
-    const secondary = [areaName, entityName ? deviceName : undefined]
-      .filter(Boolean)
-      .join(isRTL ? " ◂ " : " ▸ ");
 
     return html`
       <state-badge

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -117,6 +117,8 @@ export class HaEntityPicker extends LitElement {
   @property({ attribute: "add-button", type: Boolean })
   public addButton = false;
 
+  @property({ attribute: "add-button-label" }) public addButtonLabel?: string;
+
   @query("ha-generic-picker") private _picker?: HaGenericPicker;
 
   protected firstUpdated(changedProperties: PropertyValues<this>): void {
@@ -293,7 +295,8 @@ export class HaEntityPicker extends LitElement {
         .searchKeys=${entityComboBoxKeys}
         use-top-label
         .addButtonLabel=${this.addButton
-          ? this.hass.localize("ui.components.entity.entity-picker.add")
+          ? (this.addButtonLabel ??
+            this.hass.localize("ui.components.entity.entity-picker.add"))
           : undefined}
         .unknownItemText=${this.hass.localize(
           "ui.components.entity.entity-picker.unknown"

--- a/src/data/usage_prediction.ts
+++ b/src/data/usage_prediction.ts
@@ -1,10 +1,10 @@
 import type { HomeAssistant } from "../types";
 
-export interface CommonControlResult {
+export interface CommonControlsResult {
   entities: string[];
 }
 
-export const getCommonControlUsagePrediction = (hass: HomeAssistant) =>
-  hass.callWS<CommonControlResult>({
+export const getCommonControlsUsagePrediction = (hass: HomeAssistant) =>
+  hass.callWS<CommonControlsResult>({
     type: "usage_prediction/common_control",
   });

--- a/src/panels/home/components/home-custom-shortcuts-editor.ts
+++ b/src/panels/home/components/home-custom-shortcuts-editor.ts
@@ -3,6 +3,7 @@ import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
 import { fireEvent, type HASSDomEvent } from "../../../common/dom/fire_event";
+import type { HaNavigationPicker } from "../../../components/ha-navigation-picker";
 import "../../../components/ha-navigation-picker";
 import "../../../components/ha-sortable";
 import "../../../components/ha-svg-icon";
@@ -77,7 +78,7 @@ export class HomeCustomShortcutsEditor extends LitElement {
     const path = ev.detail.value as string;
     if (!path) return;
 
-    (ev.currentTarget as any).value = "";
+    (ev.currentTarget as HaNavigationPicker).value = "";
 
     if (this.shortcuts.some((item) => item.path === path)) return;
 

--- a/src/panels/home/components/home-custom-shortcuts-editor.ts
+++ b/src/panels/home/components/home-custom-shortcuts-editor.ts
@@ -8,7 +8,7 @@ import "../../../components/ha-navigation-picker";
 import "../../../components/ha-sortable";
 import "../../../components/ha-svg-icon";
 import type { CustomShortcutItem } from "../../../data/frontend";
-import type { HomeAssistant } from "../../../types";
+import type { HomeAssistant, ValueChangedEvent } from "../../../types";
 import { showEditShortcutDialog } from "../dialogs/show-dialog-edit-shortcut";
 import "./home-shortcut-list-item";
 
@@ -73,9 +73,9 @@ export class HomeCustomShortcutsEditor extends LitElement {
     fireEvent(this, "value-changed", { value: next });
   }
 
-  private _addShortcut(ev: CustomEvent): void {
+  private _addShortcut(ev: ValueChangedEvent<string>): void {
     ev.stopPropagation();
-    const path = ev.detail.value as string;
+    const path = ev.detail.value;
     if (!path) return;
 
     (ev.currentTarget as HaNavigationPicker).value = "";
@@ -107,7 +107,7 @@ export class HomeCustomShortcutsEditor extends LitElement {
     this._update(next);
   }
 
-  private _shortcutMoved(ev: CustomEvent): void {
+  private _shortcutMoved(ev: HASSDomEvent<HASSDomEvents["item-moved"]>): void {
     ev.stopPropagation();
     const { oldIndex, newIndex } = ev.detail;
     const next = [...this.shortcuts];

--- a/src/panels/home/components/home-custom-shortcuts-editor.ts
+++ b/src/panels/home/components/home-custom-shortcuts-editor.ts
@@ -1,0 +1,150 @@
+import { mdiDragHorizontalVariant } from "@mdi/js";
+import { css, html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import { repeat } from "lit/directives/repeat";
+import { fireEvent, type HASSDomEvent } from "../../../common/dom/fire_event";
+import "../../../components/ha-navigation-picker";
+import "../../../components/ha-sortable";
+import "../../../components/ha-svg-icon";
+import type { CustomShortcutItem } from "../../../data/frontend";
+import type { HomeAssistant } from "../../../types";
+import { showEditShortcutDialog } from "../dialogs/show-dialog-edit-shortcut";
+import "./home-shortcut-list-item";
+
+// Paths already covered by built-in summaries
+const SUMMARY_PANEL_PATHS = [
+  "/home",
+  "/light",
+  "/climate",
+  "/security",
+  "/energy",
+  "/maintenance",
+];
+
+@customElement("home-custom-shortcuts-editor")
+export class HomeCustomShortcutsEditor extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public shortcuts: CustomShortcutItem[] = [];
+
+  protected render() {
+    const excludePaths = [
+      ...SUMMARY_PANEL_PATHS,
+      ...this.shortcuts.map((s) => s.path),
+    ];
+
+    return html`
+      <ha-sortable handle-selector=".handle" @item-moved=${this._shortcutMoved}>
+        <div class="home-list">
+          ${repeat(
+            this.shortcuts,
+            (item) => item.path,
+            (item, index) => html`
+              <div class="home-list-item shortcut-row">
+                <div class="handle">
+                  <ha-svg-icon .path=${mdiDragHorizontalVariant}></ha-svg-icon>
+                </div>
+                <home-shortcut-list-item
+                  class="shortcut-content"
+                  .hass=${this.hass}
+                  .item=${item}
+                  .index=${index}
+                  @edit-shortcut=${this._editShortcut}
+                  @delete-shortcut=${this._removeShortcut}
+                ></home-shortcut-list-item>
+              </div>
+            `
+          )}
+        </div>
+      </ha-sortable>
+      <ha-navigation-picker
+        .hass=${this.hass}
+        .addButtonLabel=${this.hass.localize(
+          "ui.panel.home.editor.add_custom_shortcut"
+        )}
+        .excludePaths=${excludePaths}
+        @value-changed=${this._addShortcut}
+      ></ha-navigation-picker>
+    `;
+  }
+
+  private _update(next: CustomShortcutItem[]): void {
+    fireEvent(this, "value-changed", { value: next });
+  }
+
+  private _addShortcut(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const path = ev.detail.value as string;
+    if (!path) return;
+
+    (ev.currentTarget as any).value = "";
+
+    if (this.shortcuts.some((item) => item.path === path)) return;
+
+    this._update([...this.shortcuts, { path }]);
+  }
+
+  private _editShortcut(ev: HASSDomEvent<{ index: number }>): void {
+    const { index } = ev.detail;
+    const item = this.shortcuts[index];
+    if (!item) return;
+
+    showEditShortcutDialog(this, {
+      item,
+      saveCallback: (updated) => {
+        const next = [...this.shortcuts];
+        next[index] = updated;
+        this._update(next);
+      },
+    });
+  }
+
+  private _removeShortcut(ev: HASSDomEvent<{ index: number }>): void {
+    const { index } = ev.detail;
+    const next = [...this.shortcuts];
+    next.splice(index, 1);
+    this._update(next);
+  }
+
+  private _shortcutMoved(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const { oldIndex, newIndex } = ev.detail;
+    const next = [...this.shortcuts];
+    const [moved] = next.splice(oldIndex, 1);
+    next.splice(newIndex, 0, moved);
+    this._update(next);
+  }
+
+  static styles = css`
+    .home-list {
+      display: flex;
+      flex-direction: column;
+    }
+    .shortcut-row {
+      display: flex;
+      align-items: center;
+      gap: var(--ha-space-2);
+    }
+    .shortcut-content {
+      flex: 1;
+      min-width: 0;
+    }
+    .handle {
+      cursor: grab;
+      color: var(--secondary-text-color);
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+    }
+    ha-navigation-picker {
+      display: block;
+      padding-top: var(--ha-space-2);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "home-custom-shortcuts-editor": HomeCustomShortcutsEditor;
+  }
+}

--- a/src/panels/home/components/home-favorite-entity-list-item.ts
+++ b/src/panels/home/components/home-favorite-entity-list-item.ts
@@ -5,6 +5,7 @@ import { computeEntityPickerDisplay } from "../../../common/entity/compute_entit
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/entity/state-badge";
 import "../../../components/ha-icon-button";
+import "../../../components/ha-settings-row";
 import type { HomeAssistant } from "../../../types";
 
 declare global {
@@ -31,18 +32,22 @@ export class HomeFavoriteEntityListItem extends LitElement {
       : { primary: this.entityId, secondary: undefined };
 
     return html`
-      <state-badge .hass=${this.hass} .stateObj=${stateObj}></state-badge>
-      <div class="text">
-        <span class="primary">${primary}</span>
+      <ha-settings-row slim>
+        <state-badge
+          slot="prefix"
+          .hass=${this.hass}
+          .stateObj=${stateObj}
+        ></state-badge>
+        <span slot="heading">${primary}</span>
         ${secondary
-          ? html`<span class="secondary">${secondary}</span>`
+          ? html`<span slot="description">${secondary}</span>`
           : nothing}
-      </div>
-      <ha-icon-button
-        .path=${mdiDelete}
-        .label=${this.hass.localize("ui.common.delete")}
-        @click=${this._delete}
-      ></ha-icon-button>
+        <ha-icon-button
+          .path=${mdiDelete}
+          .label=${this.hass.localize("ui.common.delete")}
+          @click=${this._delete}
+        ></ha-icon-button>
+      </ha-settings-row>
     `;
   }
 
@@ -52,9 +57,16 @@ export class HomeFavoriteEntityListItem extends LitElement {
 
   static styles = css`
     :host {
-      display: flex;
-      align-items: center;
+      display: block;
+    }
+    ha-settings-row {
+      padding: 0;
       gap: var(--ha-space-3);
+      min-height: 40px;
+      --settings-row-prefix-display: contents;
+      --settings-row-content-display: contents;
+      --settings-row-body-padding-top: var(--ha-space-1);
+      --settings-row-body-padding-bottom: var(--ha-space-1);
     }
     state-badge {
       flex-shrink: 0;
@@ -62,25 +74,12 @@ export class HomeFavoriteEntityListItem extends LitElement {
       height: 24px;
       --state-icon-color: var(--secondary-text-color);
     }
-    .text {
-      flex: 1;
-      min-width: 0;
-      display: flex;
-      flex-direction: column;
-    }
-    .primary,
-    .secondary {
+    [slot="heading"],
+    [slot="description"] {
+      display: block;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-    }
-    .primary {
-      font-size: 14px;
-      color: var(--primary-text-color);
-    }
-    .secondary {
-      font-size: 12px;
-      color: var(--secondary-text-color);
     }
     ha-icon-button {
       --ha-icon-button-size: 40px;

--- a/src/panels/home/components/home-favorite-entity-list-item.ts
+++ b/src/panels/home/components/home-favorite-entity-list-item.ts
@@ -1,8 +1,7 @@
 import { mdiDelete } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
-import { computeEntityNameList } from "../../../common/entity/compute_entity_name_display";
-import { computeRTL } from "../../../common/util/compute_rtl";
+import { computeEntityPickerDisplay } from "../../../common/entity/compute_entity_name_display";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/entity/state-badge";
 import "../../../components/ha-icon-button";
@@ -27,28 +26,9 @@ export class HomeFavoriteEntityListItem extends LitElement {
 
   protected render() {
     const stateObj = this.hass.states[this.entityId];
-
-    let primary: string;
-    let secondary: string | undefined;
-
-    if (stateObj) {
-      const [entityName, deviceName, areaName] = computeEntityNameList(
-        stateObj,
-        [{ type: "entity" }, { type: "device" }, { type: "area" }],
-        this.hass.entities,
-        this.hass.devices,
-        this.hass.areas,
-        this.hass.floors
-      );
-      const isRTL = computeRTL(this.hass);
-      primary = entityName || deviceName || this.entityId;
-      secondary =
-        [areaName, entityName ? deviceName : undefined]
-          .filter(Boolean)
-          .join(isRTL ? " ◂ " : " ▸ ") || undefined;
-    } else {
-      primary = this.entityId;
-    }
+    const { primary, secondary } = stateObj
+      ? computeEntityPickerDisplay(this.hass, stateObj)
+      : { primary: this.entityId, secondary: undefined };
 
     return html`
       <state-badge .hass=${this.hass} .stateObj=${stateObj}></state-badge>

--- a/src/panels/home/components/home-favorite-entity-list-item.ts
+++ b/src/panels/home/components/home-favorite-entity-list-item.ts
@@ -1,0 +1,109 @@
+import { mdiDelete } from "@mdi/js";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+import { computeEntityNameList } from "../../../common/entity/compute_entity_name_display";
+import { computeRTL } from "../../../common/util/compute_rtl";
+import { fireEvent } from "../../../common/dom/fire_event";
+import "../../../components/entity/state-badge";
+import "../../../components/ha-icon-button";
+import type { HomeAssistant } from "../../../types";
+
+declare global {
+  interface HASSDomEvents {
+    "delete-favorite-entity": { index: number };
+  }
+  interface HTMLElementTagNameMap {
+    "home-favorite-entity-list-item": HomeFavoriteEntityListItem;
+  }
+}
+
+@customElement("home-favorite-entity-list-item")
+export class HomeFavoriteEntityListItem extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: "entity-id" }) public entityId!: string;
+
+  @property({ type: Number }) public index = 0;
+
+  protected render() {
+    const stateObj = this.hass.states[this.entityId];
+
+    let primary: string;
+    let secondary: string | undefined;
+
+    if (stateObj) {
+      const [entityName, deviceName, areaName] = computeEntityNameList(
+        stateObj,
+        [{ type: "entity" }, { type: "device" }, { type: "area" }],
+        this.hass.entities,
+        this.hass.devices,
+        this.hass.areas,
+        this.hass.floors
+      );
+      const isRTL = computeRTL(this.hass);
+      primary = entityName || deviceName || this.entityId;
+      secondary =
+        [areaName, entityName ? deviceName : undefined]
+          .filter(Boolean)
+          .join(isRTL ? " ◂ " : " ▸ ") || undefined;
+    } else {
+      primary = this.entityId;
+    }
+
+    return html`
+      <state-badge .hass=${this.hass} .stateObj=${stateObj}></state-badge>
+      <div class="text">
+        <span class="primary">${primary}</span>
+        ${secondary
+          ? html`<span class="secondary">${secondary}</span>`
+          : nothing}
+      </div>
+      <ha-icon-button
+        .path=${mdiDelete}
+        .label=${this.hass.localize("ui.common.delete")}
+        @click=${this._delete}
+      ></ha-icon-button>
+    `;
+  }
+
+  private _delete() {
+    fireEvent(this, "delete-favorite-entity", { index: this.index });
+  }
+
+  static styles = css`
+    :host {
+      display: flex;
+      align-items: center;
+      gap: var(--ha-space-3);
+    }
+    state-badge {
+      flex-shrink: 0;
+      width: 24px;
+      height: 24px;
+      --state-icon-color: var(--secondary-text-color);
+    }
+    .text {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+    }
+    .primary,
+    .secondary {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .primary {
+      font-size: 14px;
+      color: var(--primary-text-color);
+    }
+    .secondary {
+      font-size: 12px;
+      color: var(--secondary-text-color);
+    }
+    ha-icon-button {
+      --ha-icon-button-size: 40px;
+    }
+  `;
+}

--- a/src/panels/home/components/home-favorites-editor.ts
+++ b/src/panels/home/components/home-favorites-editor.ts
@@ -1,0 +1,136 @@
+import { mdiDragHorizontalVariant } from "@mdi/js";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+import { repeat } from "lit/directives/repeat";
+import { fireEvent, type HASSDomEvent } from "../../../common/dom/fire_event";
+import "../../../components/entity/ha-entity-picker";
+import "../../../components/ha-sortable";
+import "../../../components/ha-svg-icon";
+import type { HomeAssistant } from "../../../types";
+import "./home-favorite-entity-list-item";
+
+@customElement("home-favorites-editor")
+export class HomeFavoritesEditor extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public favorites: string[] = [];
+
+  @property() public label?: string;
+
+  @property() public helper?: string;
+
+  protected render() {
+    return html`
+      ${this.label ? html`<p class="field-label">${this.label}</p>` : nothing}
+      ${this.helper
+        ? html`<p class="field-helper">${this.helper}</p>`
+        : nothing}
+      <ha-sortable handle-selector=".handle" @item-moved=${this._moved}>
+        <div class="home-list">
+          ${repeat(
+            this.favorites,
+            (entityId) => entityId,
+            (entityId, index) => html`
+              <div class="home-list-item favorite-row">
+                <div class="handle">
+                  <ha-svg-icon .path=${mdiDragHorizontalVariant}></ha-svg-icon>
+                </div>
+                <home-favorite-entity-list-item
+                  class="favorite-content"
+                  .hass=${this.hass}
+                  .entityId=${entityId}
+                  .index=${index}
+                  @delete-favorite-entity=${this._remove}
+                ></home-favorite-entity-list-item>
+              </div>
+            `
+          )}
+        </div>
+      </ha-sortable>
+      <ha-entity-picker
+        add-button
+        .hass=${this.hass}
+        .addButtonLabel=${this.hass.localize(
+          "ui.panel.lovelace.editor.strategy.home.add_favorite_entity"
+        )}
+        .excludeEntities=${this.favorites}
+        @value-changed=${this._add}
+      ></ha-entity-picker>
+    `;
+  }
+
+  private _update(next: string[]): void {
+    fireEvent(this, "value-changed", { value: next });
+  }
+
+  private _add(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const entityId = ev.detail.value as string | undefined;
+    if (!entityId) return;
+
+    (ev.currentTarget as any).value = "";
+
+    if (this.favorites.includes(entityId)) return;
+
+    this._update([...this.favorites, entityId]);
+  }
+
+  private _remove(ev: HASSDomEvent<{ index: number }>): void {
+    const { index } = ev.detail;
+    const next = [...this.favorites];
+    next.splice(index, 1);
+    this._update(next);
+  }
+
+  private _moved(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const { oldIndex, newIndex } = ev.detail;
+    const next = [...this.favorites];
+    const [moved] = next.splice(oldIndex, 1);
+    next.splice(newIndex, 0, moved);
+    this._update(next);
+  }
+
+  static styles = css`
+    .field-label {
+      margin: 0 0 var(--ha-space-1) 0;
+      font-size: 14px;
+      color: var(--primary-text-color);
+    }
+    .field-helper {
+      margin: 0 0 var(--ha-space-2) 0;
+      color: var(--secondary-text-color);
+      font-size: 12px;
+    }
+    .home-list {
+      display: flex;
+      flex-direction: column;
+    }
+    .favorite-row {
+      display: flex;
+      align-items: center;
+      gap: var(--ha-space-2);
+    }
+    .favorite-content {
+      flex: 1;
+      min-width: 0;
+    }
+    .handle {
+      cursor: grab;
+      color: var(--secondary-text-color);
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+    }
+    ha-entity-picker {
+      display: block;
+      padding-top: var(--ha-space-2);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "home-favorites-editor": HomeFavoritesEditor;
+  }
+}

--- a/src/panels/home/components/home-favorites-editor.ts
+++ b/src/panels/home/components/home-favorites-editor.ts
@@ -7,7 +7,7 @@ import type { HaEntityPicker } from "../../../components/entity/ha-entity-picker
 import "../../../components/entity/ha-entity-picker";
 import "../../../components/ha-sortable";
 import "../../../components/ha-svg-icon";
-import type { HomeAssistant } from "../../../types";
+import type { HomeAssistant, ValueChangedEvent } from "../../../types";
 import "./home-favorite-entity-list-item";
 
 @customElement("home-favorites-editor")
@@ -64,9 +64,9 @@ export class HomeFavoritesEditor extends LitElement {
     fireEvent(this, "value-changed", { value: next });
   }
 
-  private _add(ev: CustomEvent): void {
+  private _add(ev: ValueChangedEvent<string | undefined>): void {
     ev.stopPropagation();
-    const entityId = ev.detail.value as string | undefined;
+    const entityId = ev.detail.value;
     if (!entityId) return;
 
     (ev.currentTarget as HaEntityPicker).value = "";
@@ -83,7 +83,7 @@ export class HomeFavoritesEditor extends LitElement {
     this._update(next);
   }
 
-  private _moved(ev: CustomEvent): void {
+  private _moved(ev: HASSDomEvent<HASSDomEvents["item-moved"]>): void {
     ev.stopPropagation();
     const { oldIndex, newIndex } = ev.detail;
     const next = [...this.favorites];

--- a/src/panels/home/components/home-favorites-editor.ts
+++ b/src/panels/home/components/home-favorites-editor.ts
@@ -3,6 +3,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
 import { fireEvent, type HASSDomEvent } from "../../../common/dom/fire_event";
+import type { HaEntityPicker } from "../../../components/entity/ha-entity-picker";
 import "../../../components/entity/ha-entity-picker";
 import "../../../components/ha-sortable";
 import "../../../components/ha-svg-icon";
@@ -68,7 +69,7 @@ export class HomeFavoritesEditor extends LitElement {
     const entityId = ev.detail.value as string | undefined;
     if (!entityId) return;
 
-    (ev.currentTarget as any).value = "";
+    (ev.currentTarget as HaEntityPicker).value = "";
 
     if (this.favorites.includes(entityId)) return;
 

--- a/src/panels/home/components/home-shortcut-list-item.ts
+++ b/src/panels/home/components/home-shortcut-list-item.ts
@@ -6,6 +6,7 @@ import { computeCssColor } from "../../../common/color/compute-color";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-icon";
 import "../../../components/ha-icon-button";
+import "../../../components/ha-settings-row";
 import "../../../components/ha-svg-icon";
 import type { CustomShortcutItem } from "../../../data/frontend";
 import { NavigationPathInfoController } from "../../../data/navigation-path-controller";
@@ -55,14 +56,19 @@ export class HomeShortcutListItem extends LitElement {
     const iconStyle = { "--mdc-icon-size": "24px", color };
 
     return html`
-      ${icon
-        ? html`<ha-icon .icon=${icon} style=${styleMap(iconStyle)}></ha-icon>`
-        : html`<ha-svg-icon
-            .path=${iconPath}
-            style=${styleMap(iconStyle)}
-          ></ha-svg-icon>`}
-      <span class="label">${label}</span>
-      <div class="actions">
+      <ha-settings-row slim>
+        ${icon
+          ? html`<ha-icon
+              slot="prefix"
+              .icon=${icon}
+              style=${styleMap(iconStyle)}
+            ></ha-icon>`
+          : html`<ha-svg-icon
+              slot="prefix"
+              .path=${iconPath}
+              style=${styleMap(iconStyle)}
+            ></ha-svg-icon>`}
+        <span slot="heading">${label}</span>
         <ha-icon-button
           .path=${mdiPencil}
           .label=${this.hass.localize("ui.common.edit")}
@@ -73,7 +79,7 @@ export class HomeShortcutListItem extends LitElement {
           .label=${this.hass.localize("ui.common.delete")}
           @click=${this._delete}
         ></ha-icon-button>
-      </div>
+      </ha-settings-row>
     `;
   }
 
@@ -87,26 +93,26 @@ export class HomeShortcutListItem extends LitElement {
 
   static styles = css`
     :host {
-      display: flex;
-      align-items: center;
+      display: block;
+    }
+    ha-settings-row {
+      padding: 0;
       gap: var(--ha-space-3);
+      min-height: 40px;
+      --settings-row-prefix-display: contents;
+      --settings-row-content-display: contents;
+      --settings-row-body-padding-top: var(--ha-space-1);
+      --settings-row-body-padding-bottom: var(--ha-space-1);
     }
     ha-icon,
     ha-svg-icon {
       --mdc-icon-size: 24px;
       flex-shrink: 0;
     }
-    .label {
-      flex: 1;
-      min-width: 0;
-      font-size: 14px;
+    [slot="heading"] {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-    }
-    .actions {
-      display: flex;
-      align-items: center;
     }
     ha-icon-button {
       --ha-icon-button-size: 40px;

--- a/src/panels/home/components/home-summaries-editor.ts
+++ b/src/panels/home/components/home-summaries-editor.ts
@@ -2,7 +2,10 @@ import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import { computeCssColor } from "../../../common/color/compute-color";
-import { fireEvent } from "../../../common/dom/fire_event";
+import {
+  fireEvent,
+  type HASSDomTargetEvent,
+} from "../../../common/dom/fire_event";
 import "../../../components/ha-icon";
 import "../../../components/ha-switch";
 import {
@@ -78,11 +81,15 @@ export class HomeSummariesEditor extends LitElement {
     return getSummaryLabel(this.hass.localize, key as HomeSummary);
   }
 
-  private _toggleChanged(ev: Event): void {
-    const target = ev.target as HTMLElement & {
-      checked: boolean;
-      summary: string;
-    };
+  private _toggleChanged(
+    ev: HASSDomTargetEvent<
+      HTMLElement & {
+        checked: boolean;
+        summary: string;
+      }
+    >
+  ): void {
+    const target = ev.target;
     const hidden = new Set(this.hiddenSummaries);
     if (target.checked) {
       hidden.delete(target.summary);

--- a/src/panels/home/components/home-summaries-editor.ts
+++ b/src/panels/home/components/home-summaries-editor.ts
@@ -7,6 +7,7 @@ import {
   type HASSDomTargetEvent,
 } from "../../../common/dom/fire_event";
 import "../../../components/ha-icon";
+import "../../../components/ha-settings-row";
 import "../../../components/ha-switch";
 import {
   getSummaryLabel,
@@ -54,18 +55,19 @@ export class HomeSummariesEditor extends LitElement {
           const label = this._getSummaryLabel(item.key);
           const color = computeCssColor(item.color);
           return html`
-            <label class="home-list-item summary-toggle">
+            <ha-settings-row slim>
               <ha-icon
+                slot="prefix"
                 .icon=${item.icon}
                 style=${styleMap({ "--mdc-icon-size": "24px", color })}
               ></ha-icon>
-              <span class="label">${label}</span>
+              <span slot="heading">${label}</span>
               <ha-switch
                 .checked=${!hidden.has(item.key)}
                 .summary=${item.key}
                 @change=${this._toggleChanged}
               ></ha-switch>
-            </label>
+            </ha-settings-row>
           `;
         })}
       </div>
@@ -104,16 +106,19 @@ export class HomeSummariesEditor extends LitElement {
       display: flex;
       flex-direction: column;
     }
-    .summary-toggle {
-      display: flex;
-      align-items: center;
+    ha-settings-row {
+      padding: 0;
       gap: var(--ha-space-3);
-      padding: var(--ha-space-2) 0;
-      cursor: pointer;
+      min-height: 40px;
+      --settings-row-prefix-display: contents;
+      --settings-row-content-display: contents;
+      --settings-row-body-padding-top: var(--ha-space-1);
+      --settings-row-body-padding-bottom: var(--ha-space-1);
     }
-    .summary-toggle .label {
-      flex: 1;
-      font-size: 14px;
+    [slot="heading"] {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   `;
 }

--- a/src/panels/home/components/home-summaries-editor.ts
+++ b/src/panels/home/components/home-summaries-editor.ts
@@ -1,0 +1,118 @@
+import { css, html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
+import { computeCssColor } from "../../../common/color/compute-color";
+import { fireEvent } from "../../../common/dom/fire_event";
+import "../../../components/ha-icon";
+import "../../../components/ha-switch";
+import {
+  getSummaryLabel,
+  HOME_SUMMARIES_ICONS,
+  type HomeSummary,
+} from "../../lovelace/strategies/home/helpers/home-summaries";
+import type { HomeAssistant } from "../../../types";
+
+interface SummaryInfo {
+  key: string;
+  icon: string;
+  color: string;
+}
+
+// Ordered to match dashboard rendering order
+const SUMMARY_ITEMS: SummaryInfo[] = [
+  { key: "light", icon: HOME_SUMMARIES_ICONS.light, color: "amber" },
+  { key: "climate", icon: HOME_SUMMARIES_ICONS.climate, color: "deep-orange" },
+  { key: "security", icon: HOME_SUMMARIES_ICONS.security, color: "blue-grey" },
+  {
+    key: "media_players",
+    icon: HOME_SUMMARIES_ICONS.media_players,
+    color: "blue",
+  },
+  {
+    key: "maintenance",
+    icon: HOME_SUMMARIES_ICONS.maintenance,
+    color: "orange",
+  },
+  { key: "weather", icon: "mdi:weather-partly-cloudy", color: "teal" },
+  { key: "energy", icon: HOME_SUMMARIES_ICONS.energy, color: "amber" },
+];
+
+@customElement("home-summaries-editor")
+export class HomeSummariesEditor extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public hiddenSummaries: string[] = [];
+
+  protected render() {
+    const hidden = new Set(this.hiddenSummaries);
+    return html`
+      <div class="home-list">
+        ${SUMMARY_ITEMS.map((item) => {
+          const label = this._getSummaryLabel(item.key);
+          const color = computeCssColor(item.color);
+          return html`
+            <label class="home-list-item summary-toggle">
+              <ha-icon
+                .icon=${item.icon}
+                style=${styleMap({ "--mdc-icon-size": "24px", color })}
+              ></ha-icon>
+              <span class="label">${label}</span>
+              <ha-switch
+                .checked=${!hidden.has(item.key)}
+                .summary=${item.key}
+                @change=${this._toggleChanged}
+              ></ha-switch>
+            </label>
+          `;
+        })}
+      </div>
+    `;
+  }
+
+  private _getSummaryLabel(key: string): string {
+    if (key === "weather") {
+      return this.hass.localize(
+        "ui.panel.lovelace.strategy.home.summary_list.weather"
+      );
+    }
+    return getSummaryLabel(this.hass.localize, key as HomeSummary);
+  }
+
+  private _toggleChanged(ev: Event): void {
+    const target = ev.target as HTMLElement & {
+      checked: boolean;
+      summary: string;
+    };
+    const hidden = new Set(this.hiddenSummaries);
+    if (target.checked) {
+      hidden.delete(target.summary);
+    } else {
+      hidden.add(target.summary);
+    }
+    fireEvent(this, "value-changed", { value: [...hidden] });
+  }
+
+  static styles = css`
+    .home-list {
+      display: flex;
+      flex-direction: column;
+    }
+    .summary-toggle {
+      display: flex;
+      align-items: center;
+      gap: var(--ha-space-3);
+      padding: var(--ha-space-2) 0;
+      cursor: pointer;
+    }
+    .summary-toggle .label {
+      flex: 1;
+      font-size: 14px;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "home-summaries-editor": HomeSummariesEditor;
+  }
+}

--- a/src/panels/home/dialogs/dialog-edit-home.ts
+++ b/src/panels/home/dialogs/dialog-edit-home.ts
@@ -1,80 +1,40 @@
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { styleMap } from "lit/directives/style-map";
-import { computeCssColor } from "../../../common/color/compute-color";
-import { fireEvent, type HASSDomEvent } from "../../../common/dom/fire_event";
-import "../../../components/entity/ha-entities-picker";
+import memoizeOne from "memoize-one";
+import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-alert";
-import "../../../components/ha-expansion-panel";
 import "../../../components/ha-button";
 import "../../../components/ha-dialog-footer";
 import "../../../components/ha-dialog";
 import "../../../components/ha-form/ha-form";
-import "../../../components/ha-icon";
-import "../../../components/ha-navigation-picker";
-import "../../../components/ha-switch";
 import type { HaFormSchema } from "../../../components/ha-form/types";
 import type {
   CustomShortcutItem,
   HomeFrontendSystemData,
 } from "../../../data/frontend";
 import type { HassDialog } from "../../../dialogs/make-dialog-manager";
-import {
-  getSummaryLabel,
-  HOME_SUMMARIES_ICONS,
-  type HomeSummary,
-} from "../../lovelace/strategies/home/helpers/home-summaries";
 import { haStyleDialog } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
-import "../components/home-shortcut-list-item";
+import "../components/home-custom-shortcuts-editor";
+import "../components/home-favorites-editor";
+import "../components/home-summaries-editor";
 import type { EditHomeDialogParams } from "./show-dialog-edit-home";
-import { showEditShortcutDialog } from "./show-dialog-edit-shortcut";
 
-interface SummaryInfo {
-  key: string;
-  icon: string;
-  color: string;
+interface EditorState {
+  favorite_entities: string[];
+  show_suggested_entities: boolean;
+  show_welcome_message: boolean;
+  hidden_summaries: string[];
+  custom_shortcuts: CustomShortcutItem[];
 }
 
-const SUGGESTED_ENTITIES_SCHEMA: HaFormSchema[] = [
-  { name: "show_suggested", selector: { boolean: {} } },
-];
+// The common-controls strategy caps the section at 8 (or the favorites count,
+// whichever is larger); once favorites reach the cap, predictions never render
+// so the suggested-entities toggle has no effect.
+const SUGGESTED_ENTITIES_CAP = 8;
 
-// Ordered to match dashboard rendering order
-const SUMMARY_ITEMS: SummaryInfo[] = [
-  { key: "light", icon: HOME_SUMMARIES_ICONS.light, color: "amber" },
-  { key: "climate", icon: HOME_SUMMARIES_ICONS.climate, color: "deep-orange" },
-  {
-    key: "security",
-    icon: HOME_SUMMARIES_ICONS.security,
-    color: "blue-grey",
-  },
-  {
-    key: "media_players",
-    icon: HOME_SUMMARIES_ICONS.media_players,
-    color: "blue",
-  },
-  {
-    key: "maintenance",
-    icon: HOME_SUMMARIES_ICONS.maintenance,
-    color: "orange",
-  },
-  { key: "weather", icon: "mdi:weather-partly-cloudy", color: "teal" },
-  { key: "energy", icon: HOME_SUMMARIES_ICONS.energy, color: "amber" },
-];
-
-// Paths already covered by built-in summaries
-const SUMMARY_PANEL_PATHS = [
-  "/home",
-  "/light",
-  "/climate",
-  "/security",
-  "/energy",
-  "/maintenance",
-];
-
-const WELCOME_MESSAGE_SCHEMA = [
-  { name: "welcome_message", selector: { boolean: {} } },
+const WELCOME_SCHEMA: HaFormSchema[] = [
+  { name: "show_welcome_message", selector: { boolean: {} } },
 ];
 
 @customElement("dialog-edit-home")
@@ -86,7 +46,7 @@ export class DialogEditHome
 
   @state() private _params?: EditHomeDialogParams;
 
-  @state() private _config?: HomeFrontendSystemData;
+  @state() private _state?: EditorState;
 
   @state() private _open = false;
 
@@ -94,7 +54,19 @@ export class DialogEditHome
 
   public showDialog(params: EditHomeDialogParams): void {
     this._params = params;
-    this._config = { ...params.config };
+    this._state = {
+      favorite_entities: params.config.favorite_entities
+        ? [...params.config.favorite_entities]
+        : [],
+      show_suggested_entities: !params.config.hide_suggested_entities,
+      show_welcome_message: !params.config.hide_welcome_message,
+      hidden_summaries: params.config.hidden_summaries
+        ? [...params.config.hidden_summaries]
+        : [],
+      custom_shortcuts: params.config.custom_shortcuts
+        ? [...params.config.custom_shortcuts]
+        : [],
+    };
     this._open = true;
   }
 
@@ -105,22 +77,15 @@ export class DialogEditHome
 
   private _dialogClosed(): void {
     this._params = undefined;
-    this._config = undefined;
+    this._state = undefined;
     this._submitting = false;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
   protected render() {
-    if (!this._params) {
+    if (!this._params || !this._state) {
       return nothing;
     }
-
-    const hiddenSummaries = new Set(this._config?.hidden_summaries || []);
-    const customShortcuts = this._config?.custom_shortcuts || [];
-    const excludePaths = [
-      ...SUMMARY_PANEL_PATHS,
-      ...customShortcuts.map((s) => s.path),
-    ];
 
     return html`
       <ha-dialog
@@ -143,118 +108,69 @@ export class DialogEditHome
           })}
         </ha-alert>
 
-        <ha-expansion-panel
-          outlined
-          expanded
-          .header=${this.hass.localize(
-            "ui.panel.lovelace.editor.strategy.home.favorite_entities"
-          )}
-        >
-          <ha-icon slot="leading-icon" icon="mdi:star-outline"></ha-icon>
-          <div class="expansion-content">
-            <p class="section-description">
-              ${this.hass.localize(
-                "ui.panel.home.editor.favorite_entities_description"
-              )}
-            </p>
-            <ha-entities-picker
-              autofocus
-              .hass=${this.hass}
-              .value=${this._config?.favorite_entities || []}
-              .placeholder=${this.hass.localize(
-                "ui.panel.lovelace.editor.strategy.home.add_favorite_entity"
-              )}
-              .helper=${this.hass.localize(
-                "ui.panel.home.editor.favorite_entities_helper"
-              )}
-              reorder
-              @value-changed=${this._favoriteEntitiesChanged}
-            ></ha-entities-picker>
-
-            <ha-form
-              .hass=${this.hass}
-              .data=${{
-                show_suggested: !this._config?.hide_suggested_entities,
-              }}
-              .schema=${SUGGESTED_ENTITIES_SCHEMA}
-              .computeLabel=${this._computeSuggestedLabel}
-              .computeHelper=${this._computeSuggestedHelper}
-              @value-changed=${this._suggestedEntitiesChanged}
-            ></ha-form>
-          </div>
-        </ha-expansion-panel>
-
-        <h3 class="section-header">
-          ${this.hass.localize("ui.panel.home.editor.welcome_message")}
-        </h3>
-        <p class="section-description">
-          ${this.hass.localize("ui.panel.home.editor.welcome_message_helper")}
+        <h2 class="group-header">
+          ${this.hass.localize("ui.panel.home.editor.personalize")}
+        </h2>
+        <p class="group-description">
+          ${this.hass.localize("ui.panel.home.editor.personalize_description")}
         </p>
+
         <ha-form
           .hass=${this.hass}
-          .data=${{ welcome_message: !this._config?.hide_welcome_message }}
-          .schema=${WELCOME_MESSAGE_SCHEMA}
+          .data=${{ show_welcome_message: this._state.show_welcome_message }}
+          .schema=${WELCOME_SCHEMA}
           .computeLabel=${this._computeWelcomeLabel}
-          @value-changed=${this._welcomeMessageToggleChanged}
+          .computeHelper=${this._computeWelcomeHelper}
+          @value-changed=${this._welcomeChanged}
         ></ha-form>
 
-        <h3 class="section-header">
+        <home-favorites-editor
+          .hass=${this.hass}
+          .favorites=${this._state.favorite_entities}
+          .label=${this.hass.localize(
+            "ui.panel.lovelace.editor.strategy.home.favorite_entities"
+          )}
+          @value-changed=${this._favoriteEntitiesChanged}
+        ></home-favorites-editor>
+
+        <ha-form
+          .hass=${this.hass}
+          .data=${{
+            show_suggested_entities: this._state.show_suggested_entities,
+          }}
+          .schema=${this._suggestedSchema(
+            this._state.favorite_entities.length >= SUGGESTED_ENTITIES_CAP
+          )}
+          .computeLabel=${this._computeSuggestedLabel}
+          .computeHelper=${this._computeSuggestedHelper}
+          @value-changed=${this._suggestedChanged}
+        ></ha-form>
+
+        <h2 class="group-header">
           ${this.hass.localize("ui.panel.home.editor.summaries")}
-        </h3>
-        <p class="section-description">
+        </h2>
+        <p class="group-description">
           ${this.hass.localize("ui.panel.home.editor.summaries_description")}
         </p>
-        <div class="home-list">
-          ${SUMMARY_ITEMS.map((item) => {
-            const label = this._getSummaryLabel(item.key);
-            const color = computeCssColor(item.color);
-            return html`
-              <label class="home-list-item summary-toggle">
-                <ha-icon
-                  .icon=${item.icon}
-                  style=${styleMap({ "--mdc-icon-size": "24px", color })}
-                ></ha-icon>
-                <span class="label">${label}</span>
-                <ha-switch
-                  .checked=${!hiddenSummaries.has(item.key)}
-                  .summary=${item.key}
-                  @change=${this._summaryToggleChanged}
-                ></ha-switch>
-              </label>
-            `;
-          })}
-        </div>
+        <home-summaries-editor
+          .hass=${this.hass}
+          .hiddenSummaries=${this._state.hidden_summaries}
+          @value-changed=${this._hiddenSummariesChanged}
+        ></home-summaries-editor>
 
-        <h3 class="section-header">
+        <h2 class="group-header">
           ${this.hass.localize("ui.panel.home.editor.custom_shortcuts")}
-        </h3>
-        <p class="section-description">
+        </h2>
+        <p class="group-description">
           ${this.hass.localize(
             "ui.panel.home.editor.custom_shortcuts_description"
           )}
         </p>
-        <div class="home-list">
-          ${customShortcuts.map(
-            (item, index) => html`
-              <home-shortcut-list-item
-                class="home-list-item"
-                .hass=${this.hass}
-                .item=${item}
-                .index=${index}
-                @edit-shortcut=${this._editShortcut}
-                @delete-shortcut=${this._removeShortcut}
-              ></home-shortcut-list-item>
-            `
-          )}
-        </div>
-        <ha-navigation-picker
+        <home-custom-shortcuts-editor
           .hass=${this.hass}
-          .addButtonLabel=${this.hass.localize(
-            "ui.panel.home.editor.add_custom_shortcut"
-          )}
-          .excludePaths=${excludePaths}
-          @value-changed=${this._addShortcut}
-        ></ha-navigation-picker>
+          .shortcuts=${this._state.custom_shortcuts}
+          @value-changed=${this._shortcutsChanged}
+        ></home-custom-shortcuts-editor>
 
         <ha-dialog-footer slot="footer">
           <ha-button
@@ -277,132 +193,102 @@ export class DialogEditHome
     `;
   }
 
-  private _getSummaryLabel(key: string): string {
-    if (key === "weather") {
-      return this.hass.localize(
-        "ui.panel.lovelace.strategy.home.summary_list.weather"
-      );
-    }
-    return getSummaryLabel(this.hass.localize, key as HomeSummary);
-  }
+  private _suggestedSchema = memoizeOne(
+    (disabled: boolean) =>
+      [
+        {
+          name: "show_suggested_entities",
+          selector: { boolean: {} },
+          disabled,
+        },
+      ] as HaFormSchema[]
+  );
 
-  private _summaryToggleChanged(ev: Event): void {
-    const target = ev.target as HTMLElement & {
-      checked: boolean;
-      summary: string;
-    };
-    const summary = target.summary;
-    const checked = target.checked;
-
-    const hiddenSummaries = new Set(this._config?.hidden_summaries || []);
-
-    if (checked) {
-      hiddenSummaries.delete(summary);
-    } else {
-      hiddenSummaries.add(summary);
-    }
-
-    this._config = {
-      ...this._config,
-      hidden_summaries:
-        hiddenSummaries.size > 0 ? [...hiddenSummaries] : undefined,
-    };
-  }
-
-  private _computeWelcomeLabel = () =>
+  private _computeWelcomeLabel = (): string =>
     this.hass.localize("ui.panel.home.editor.welcome_message");
 
-  private _welcomeMessageToggleChanged(ev: CustomEvent): void {
-    this._config = {
-      ...this._config,
-      hide_welcome_message: ev.detail.value.welcome_message ? undefined : true,
-    };
-  }
+  private _computeWelcomeHelper = (): string =>
+    this.hass.localize("ui.panel.home.editor.welcome_message_helper");
 
   private _computeSuggestedLabel = (): string =>
     this.hass.localize("ui.panel.home.editor.suggested_entities");
 
-  private _computeSuggestedHelper = (): string =>
-    this.hass.localize("ui.panel.home.editor.suggested_entities_description");
-
-  private _suggestedEntitiesChanged(ev: CustomEvent): void {
-    const showSuggested = (ev.detail.value as { show_suggested: boolean })
-      .show_suggested;
-    this._config = {
-      ...this._config,
-      hide_suggested_entities: showSuggested ? undefined : true,
-    };
-  }
-
-  private _updateShortcuts(
-    updater: (shortcuts: CustomShortcutItem[]) => CustomShortcutItem[]
-  ): void {
-    const next = updater([...(this._config?.custom_shortcuts || [])]);
-    this._config = {
-      ...this._config,
-      custom_shortcuts: next.length > 0 ? next : undefined,
-    };
-  }
-
-  private _addShortcut(ev: CustomEvent): void {
-    ev.stopPropagation();
-    const path = ev.detail.value as string;
-    if (!path) return;
-
-    (ev.currentTarget as any).value = "";
-
-    this._updateShortcuts((shortcuts) =>
-      shortcuts.some((item) => item.path === path)
-        ? shortcuts
-        : [...shortcuts, { path }]
+  private _computeSuggestedHelper = (): string => {
+    const favoritesFull =
+      (this._state?.favorite_entities.length ?? 0) >= SUGGESTED_ENTITIES_CAP;
+    return this.hass.localize(
+      favoritesFull
+        ? "ui.panel.home.editor.suggested_entities_disabled_description"
+        : "ui.panel.home.editor.suggested_entities_description"
     );
-  }
-
-  private _editShortcut(ev: HASSDomEvent<{ index: number }>): void {
-    const { index } = ev.detail;
-    const item = this._config?.custom_shortcuts?.[index];
-    if (!item) return;
-
-    showEditShortcutDialog(this, {
-      item,
-      saveCallback: (updated) => {
-        this._updateShortcuts((shortcuts) => {
-          shortcuts[index] = updated;
-          return shortcuts;
-        });
-      },
-    });
-  }
-
-  private _removeShortcut(ev: HASSDomEvent<{ index: number }>): void {
-    const { index } = ev.detail;
-    this._updateShortcuts((shortcuts) => {
-      shortcuts.splice(index, 1);
-      return shortcuts;
-    });
-  }
+  };
 
   private _favoriteEntitiesChanged(ev: CustomEvent): void {
-    const entities = ev.detail.value as string[];
-    this._config = {
-      ...this._config,
-      favorite_entities: entities.length > 0 ? entities : undefined,
+    this._state = {
+      ...this._state!,
+      favorite_entities: ev.detail.value as string[],
+    };
+  }
+
+  private _welcomeChanged(ev: CustomEvent): void {
+    const value = ev.detail.value as { show_welcome_message: boolean };
+    this._state = {
+      ...this._state!,
+      show_welcome_message: value.show_welcome_message,
+    };
+  }
+
+  private _suggestedChanged(ev: CustomEvent): void {
+    const value = ev.detail.value as { show_suggested_entities: boolean };
+    this._state = {
+      ...this._state!,
+      show_suggested_entities: value.show_suggested_entities,
+    };
+  }
+
+  private _hiddenSummariesChanged(ev: CustomEvent): void {
+    this._state = {
+      ...this._state!,
+      hidden_summaries: ev.detail.value as string[],
+    };
+  }
+
+  private _shortcutsChanged(ev: CustomEvent): void {
+    this._state = {
+      ...this._state!,
+      custom_shortcuts: ev.detail.value as CustomShortcutItem[],
     };
   }
 
   private async _save(): Promise<void> {
-    if (!this._params || !this._config) {
-      return;
-    }
+    if (!this._params || !this._state) return;
 
     this._submitting = true;
+    const editor = this._state;
+
+    const config: HomeFrontendSystemData = {
+      ...this._params.config,
+      favorite_entities:
+        editor.favorite_entities.length > 0
+          ? editor.favorite_entities
+          : undefined,
+      hide_suggested_entities: editor.show_suggested_entities
+        ? undefined
+        : true,
+      hide_welcome_message: editor.show_welcome_message ? undefined : true,
+      hidden_summaries:
+        editor.hidden_summaries.length > 0
+          ? editor.hidden_summaries
+          : undefined,
+      custom_shortcuts:
+        editor.custom_shortcuts.length > 0
+          ? editor.custom_shortcuts
+          : undefined,
+    };
 
     try {
-      await this._params.saveConfig(this._config);
+      await this._params.saveConfig(config);
       this.closeDialog();
-    } catch (err: any) {
-      // eslint-disable-next-line no-console
-      console.error("Failed to save home configuration:", err);
     } finally {
       this._submitting = false;
     }
@@ -415,60 +301,32 @@ export class DialogEditHome
         --dialog-content-padding: var(--ha-space-6);
       }
 
-      .section-header {
-        font-size: 16px;
+      .group-header {
+        font-size: 18px;
         font-weight: 500;
         margin: var(--ha-space-6) 0 var(--ha-space-1) 0;
       }
 
-      .section-description {
-        margin: 0 0 var(--ha-space-2) 0;
+      .group-description {
+        margin: 0 0 var(--ha-space-3) 0;
         color: var(--secondary-text-color);
         font-size: 14px;
       }
 
-      .home-list {
-        display: flex;
-        flex-direction: column;
-      }
-
-      .summary-toggle {
-        display: flex;
-        align-items: center;
-        gap: var(--ha-space-3);
-        padding: var(--ha-space-2) 0;
-        cursor: pointer;
-      }
-
-      .summary-toggle .label {
-        flex: 1;
-        font-size: 14px;
-      }
-
-      ha-expansion-panel {
+      ha-form {
         display: block;
-        margin-top: var(--ha-space-4);
-        --expansion-panel-content-padding: 0;
-        border-radius: var(--ha-border-radius-md);
-        --ha-card-border-radius: var(--ha-border-radius-md);
       }
 
-      .expansion-content {
-        padding: var(--ha-space-3);
-      }
-
-      ha-navigation-picker {
+      home-favorites-editor {
         display: block;
-        padding-top: var(--ha-space-2);
-      }
-
-      ha-entities-picker {
-        display: block;
+        margin-top: var(--ha-space-2);
+        margin-bottom: var(--ha-space-4);
       }
 
       ha-alert {
         display: block;
-        margin: 0 calc(-1 * var(--dialog-content-padding));
+        margin: calc(-1 * var(--dialog-content-padding));
+        margin-bottom: 0;
       }
     `,
   ];

--- a/src/panels/home/dialogs/dialog-edit-home.ts
+++ b/src/panels/home/dialogs/dialog-edit-home.ts
@@ -6,7 +6,9 @@ import "../../../components/ha-alert";
 import "../../../components/ha-button";
 import "../../../components/ha-dialog-footer";
 import "../../../components/ha-dialog";
+import "../../../components/ha-expansion-panel";
 import "../../../components/ha-form/ha-form";
+import "../../../components/ha-icon";
 import type { HaFormSchema } from "../../../components/ha-form/types";
 import type {
   CustomShortcutItem,
@@ -108,69 +110,89 @@ export class DialogEditHome
           })}
         </ha-alert>
 
-        <h2 class="group-header">
-          ${this.hass.localize("ui.panel.home.editor.personalize")}
-        </h2>
-        <p class="group-description">
-          ${this.hass.localize("ui.panel.home.editor.personalize_description")}
-        </p>
-
-        <ha-form
-          .hass=${this.hass}
-          .data=${{ show_welcome_message: this._state.show_welcome_message }}
-          .schema=${WELCOME_SCHEMA}
-          .computeLabel=${this._computeWelcomeLabel}
-          .computeHelper=${this._computeWelcomeHelper}
-          @value-changed=${this._welcomeChanged}
-        ></ha-form>
-
-        <home-favorites-editor
-          .hass=${this.hass}
-          .favorites=${this._state.favorite_entities}
-          .label=${this.hass.localize(
-            "ui.panel.lovelace.editor.strategy.home.favorite_entities"
+        <ha-expansion-panel
+          outlined
+          expanded
+          .header=${this.hass.localize("ui.panel.home.editor.personalize")}
+          .secondary=${this.hass.localize(
+            "ui.panel.home.editor.personalize_description"
           )}
-          @value-changed=${this._favoriteEntitiesChanged}
-        ></home-favorites-editor>
+        >
+          <ha-icon slot="leading-icon" icon="mdi:palette-outline"></ha-icon>
+          <div class="expansion-content">
+            <ha-form
+              .hass=${this.hass}
+              .data=${{
+                show_welcome_message: this._state.show_welcome_message,
+              }}
+              .schema=${WELCOME_SCHEMA}
+              .computeLabel=${this._computeWelcomeLabel}
+              .computeHelper=${this._computeWelcomeHelper}
+              @value-changed=${this._welcomeChanged}
+            ></ha-form>
 
-        <ha-form
-          .hass=${this.hass}
-          .data=${{
-            show_suggested_entities: this._state.show_suggested_entities,
-          }}
-          .schema=${this._suggestedSchema(
-            this._state.favorite_entities.length >= SUGGESTED_ENTITIES_CAP
+            <home-favorites-editor
+              .hass=${this.hass}
+              .favorites=${this._state.favorite_entities}
+              .label=${this.hass.localize(
+                "ui.panel.lovelace.editor.strategy.home.favorite_entities"
+              )}
+              @value-changed=${this._favoriteEntitiesChanged}
+            ></home-favorites-editor>
+
+            <ha-form
+              .hass=${this.hass}
+              .data=${{
+                show_suggested_entities: this._state.show_suggested_entities,
+              }}
+              .schema=${this._suggestedSchema(
+                this._state.favorite_entities.length >= SUGGESTED_ENTITIES_CAP
+              )}
+              .computeLabel=${this._computeSuggestedLabel}
+              .computeHelper=${this._computeSuggestedHelper}
+              @value-changed=${this._suggestedChanged}
+            ></ha-form>
+          </div>
+        </ha-expansion-panel>
+
+        <ha-expansion-panel
+          outlined
+          expanded
+          .header=${this.hass.localize("ui.panel.home.editor.summaries")}
+          .secondary=${this.hass.localize(
+            "ui.panel.home.editor.summaries_description"
           )}
-          .computeLabel=${this._computeSuggestedLabel}
-          .computeHelper=${this._computeSuggestedHelper}
-          @value-changed=${this._suggestedChanged}
-        ></ha-form>
+        >
+          <ha-icon
+            slot="leading-icon"
+            icon="mdi:view-dashboard-outline"
+          ></ha-icon>
+          <div class="expansion-content">
+            <home-summaries-editor
+              .hass=${this.hass}
+              .hiddenSummaries=${this._state.hidden_summaries}
+              @value-changed=${this._hiddenSummariesChanged}
+            ></home-summaries-editor>
+          </div>
+        </ha-expansion-panel>
 
-        <h2 class="group-header">
-          ${this.hass.localize("ui.panel.home.editor.summaries")}
-        </h2>
-        <p class="group-description">
-          ${this.hass.localize("ui.panel.home.editor.summaries_description")}
-        </p>
-        <home-summaries-editor
-          .hass=${this.hass}
-          .hiddenSummaries=${this._state.hidden_summaries}
-          @value-changed=${this._hiddenSummariesChanged}
-        ></home-summaries-editor>
-
-        <h2 class="group-header">
-          ${this.hass.localize("ui.panel.home.editor.custom_shortcuts")}
-        </h2>
-        <p class="group-description">
-          ${this.hass.localize(
+        <ha-expansion-panel
+          outlined
+          expanded
+          .header=${this.hass.localize("ui.panel.home.editor.custom_shortcuts")}
+          .secondary=${this.hass.localize(
             "ui.panel.home.editor.custom_shortcuts_description"
           )}
-        </p>
-        <home-custom-shortcuts-editor
-          .hass=${this.hass}
-          .shortcuts=${this._state.custom_shortcuts}
-          @value-changed=${this._shortcutsChanged}
-        ></home-custom-shortcuts-editor>
+        >
+          <ha-icon slot="leading-icon" icon="mdi:link-variant"></ha-icon>
+          <div class="expansion-content">
+            <home-custom-shortcuts-editor
+              .hass=${this.hass}
+              .shortcuts=${this._state.custom_shortcuts}
+              @value-changed=${this._shortcutsChanged}
+            ></home-custom-shortcuts-editor>
+          </div>
+        </ha-expansion-panel>
 
         <ha-dialog-footer slot="footer">
           <ha-button
@@ -301,16 +323,19 @@ export class DialogEditHome
         --dialog-content-padding: var(--ha-space-6);
       }
 
-      .group-header {
-        font-size: 18px;
-        font-weight: 500;
-        margin: var(--ha-space-6) 0 var(--ha-space-1) 0;
+      ha-expansion-panel {
+        display: block;
+        --expansion-panel-content-padding: 0;
+        border-radius: var(--ha-border-radius-md);
+        --ha-card-border-radius: var(--ha-border-radius-md);
       }
 
-      .group-description {
-        margin: 0 0 var(--ha-space-3) 0;
-        color: var(--secondary-text-color);
-        font-size: 14px;
+      ha-expansion-panel + ha-expansion-panel {
+        margin-top: var(--ha-space-2);
+      }
+
+      .expansion-content {
+        padding: var(--ha-space-3);
       }
 
       ha-form {
@@ -326,7 +351,7 @@ export class DialogEditHome
       ha-alert {
         display: block;
         margin: calc(-1 * var(--dialog-content-padding));
-        margin-bottom: 0;
+        margin-bottom: var(--ha-space-4);
       }
     `,
   ];

--- a/src/panels/home/dialogs/dialog-edit-home.ts
+++ b/src/panels/home/dialogs/dialog-edit-home.ts
@@ -16,7 +16,7 @@ import type {
 } from "../../../data/frontend";
 import type { HassDialog } from "../../../dialogs/make-dialog-manager";
 import { haStyleDialog } from "../../../resources/styles";
-import type { HomeAssistant } from "../../../types";
+import type { HomeAssistant, ValueChangedEvent } from "../../../types";
 import "../components/home-custom-shortcuts-editor";
 import "../components/home-favorites-editor";
 import "../components/home-summaries-editor";
@@ -245,40 +245,42 @@ export class DialogEditHome
     );
   };
 
-  private _favoriteEntitiesChanged(ev: CustomEvent): void {
+  private _favoriteEntitiesChanged(ev: ValueChangedEvent<string[]>): void {
     this._state = {
       ...this._state!,
-      favorite_entities: ev.detail.value as string[],
+      favorite_entities: ev.detail.value,
     };
   }
 
-  private _welcomeChanged(ev: CustomEvent): void {
-    const value = ev.detail.value as { show_welcome_message: boolean };
+  private _welcomeChanged(
+    ev: ValueChangedEvent<{ show_welcome_message: boolean }>
+  ): void {
     this._state = {
       ...this._state!,
-      show_welcome_message: value.show_welcome_message,
+      show_welcome_message: ev.detail.value.show_welcome_message,
     };
   }
 
-  private _suggestedChanged(ev: CustomEvent): void {
-    const value = ev.detail.value as { show_suggested_entities: boolean };
+  private _suggestedChanged(
+    ev: ValueChangedEvent<{ show_suggested_entities: boolean }>
+  ): void {
     this._state = {
       ...this._state!,
-      show_suggested_entities: value.show_suggested_entities,
+      show_suggested_entities: ev.detail.value.show_suggested_entities,
     };
   }
 
-  private _hiddenSummariesChanged(ev: CustomEvent): void {
+  private _hiddenSummariesChanged(ev: ValueChangedEvent<string[]>): void {
     this._state = {
       ...this._state!,
-      hidden_summaries: ev.detail.value as string[],
+      hidden_summaries: ev.detail.value,
     };
   }
 
-  private _shortcutsChanged(ev: CustomEvent): void {
+  private _shortcutsChanged(ev: ValueChangedEvent<CustomShortcutItem[]>): void {
     this._state = {
       ...this._state!,
-      custom_shortcuts: ev.detail.value as CustomShortcutItem[],
+      custom_shortcuts: ev.detail.value,
     };
   }
 

--- a/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
@@ -22,6 +22,7 @@ import type {
   AreaCardConfig,
   DiscoveredDevicesCardConfig,
   EmptyStateCardConfig,
+  HeadingCardConfig,
   HomeSummaryCard,
   MarkdownCardConfig,
   RepairsCardConfig,
@@ -33,7 +34,7 @@ import {
   LARGE_SCREEN_CONDITION,
   SMALL_SCREEN_CONDITION,
 } from "../helpers/view-columns-conditions";
-import type { CommonControlSectionStrategyConfig } from "../usage_prediction/common-controls-section-strategy";
+import type { CommonControlsSectionStrategyConfig } from "../usage_prediction/common-controls-section-strategy";
 import { HOME_SUMMARIES_FILTERS } from "./helpers/home-summaries";
 import { OTHER_DEVICES_FILTERS } from "./helpers/other-devices-filters";
 
@@ -193,25 +194,46 @@ export class HomeOverviewViewStrategy extends ReactiveElement {
     );
     const maxCommonControls = Math.max(8, favoriteEntities.length);
 
-    const favoritesSection = {
-      strategy: {
-        type: "common-controls",
-        limit: maxCommonControls,
-        include_entities: favoriteEntities,
-        hide_empty: true,
-        show_predicted: !config.hide_suggested_entities,
-        heading: {
-          type: "heading",
-          heading: hass.localize("ui.panel.lovelace.strategy.home.favorites"),
-          heading_style: "title",
-          visibility: [LARGE_SCREEN_CONDITION],
-          grid_options: {
-            rows: "auto", // Compact style
-          },
-        },
-      } satisfies CommonControlSectionStrategyConfig,
-      column_span: maxColumns,
-    } as LovelaceStrategySectionConfig;
+    const favoritesHeadingCard: HeadingCardConfig = {
+      type: "heading",
+      heading: hass.localize("ui.panel.lovelace.strategy.home.favorites"),
+      heading_style: "title",
+      visibility: [LARGE_SCREEN_CONDITION],
+      grid_options: {
+        rows: "auto",
+      },
+    };
+
+    let favoritesSection: LovelaceSectionRawConfig | undefined;
+    if (!config.hide_suggested_entities) {
+      favoritesSection = {
+        strategy: {
+          type: "common-controls",
+          limit: maxCommonControls,
+          include_entities: favoriteEntities,
+          hide_empty: true,
+          heading: favoritesHeadingCard,
+        } satisfies CommonControlsSectionStrategyConfig,
+        column_span: maxColumns,
+      } satisfies LovelaceStrategySectionConfig;
+    } else if (favoriteEntities.length > 0) {
+      favoritesSection = {
+        type: "grid",
+        column_span: maxColumns,
+        cards: [
+          favoritesHeadingCard,
+          ...favoriteEntities.map(
+            (entityId) =>
+              ({
+                type: "tile",
+                entity: entityId,
+                state_content: ["state", "area_name"],
+                show_entity_picture: true,
+              }) satisfies TileCardConfig
+          ),
+        ],
+      };
+    }
 
     const mediaPlayerFilter = HOME_SUMMARIES_FILTERS.media_players.map(
       (filter) => generateEntityFilter(hass, filter)

--- a/src/panels/lovelace/strategies/usage_prediction/common-controls-section-strategy.ts
+++ b/src/panels/lovelace/strategies/usage_prediction/common-controls-section-strategy.ts
@@ -2,21 +2,20 @@ import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
 import { isComponentLoaded } from "../../../../common/config/is_component_loaded";
 import type { LovelaceSectionConfig } from "../../../../data/lovelace/config/section";
-import { getCommonControlUsagePrediction } from "../../../../data/usage_prediction";
+import { getCommonControlsUsagePrediction } from "../../../../data/usage_prediction";
 import type { HomeAssistant } from "../../../../types";
 import type { HeadingCardConfig, TileCardConfig } from "../../cards/types";
 import type { Condition } from "../../common/validate-condition";
 
 const DEFAULT_LIMIT = 8;
 
-export interface CommonControlSectionStrategyConfig {
+export interface CommonControlsSectionStrategyConfig {
   type: "common-controls";
   limit?: number;
   exclude_entities?: string[];
   include_entities?: string[];
   hide_empty?: boolean;
   heading?: HeadingCardConfig;
-  show_predicted?: boolean;
   /** @deprecated Use `heading` instead */
   icon?: string;
   /** @deprecated Use `heading` instead */
@@ -25,10 +24,17 @@ export interface CommonControlSectionStrategyConfig {
   title_visibilty?: Condition[];
 }
 
+const toTileCard = (entity: string): TileCardConfig => ({
+  type: "tile",
+  entity,
+  state_content: ["state", "area_name"],
+  show_entity_picture: true,
+});
+
 @customElement("common-controls-section-strategy")
 export class CommonControlsSectionStrategy extends ReactiveElement {
   static async generate(
-    config: CommonControlSectionStrategyConfig,
+    config: CommonControlsSectionStrategyConfig,
     hass: HomeAssistant
   ): Promise<LovelaceSectionConfig> {
     const section: LovelaceSectionConfig = {
@@ -47,68 +53,50 @@ export class CommonControlsSectionStrategy extends ReactiveElement {
       } satisfies HeadingCardConfig);
     }
 
-    let predictedEntities: string[] = [];
-
-    if (config.show_predicted !== false) {
-      if (!isComponentLoaded(hass.config, "usage_prediction")) {
-        section.cards!.push({
-          type: "markdown",
-          content: hass.localize(
-            "ui.panel.lovelace.strategy.common_controls.not_loaded"
-          ),
-        });
-        section.disabled = config.hide_empty;
-        return section;
-      }
-
-      const predictedCommonControl =
-        await getCommonControlUsagePrediction(hass);
-      predictedEntities = predictedCommonControl.entities.filter((entity) => {
-        if (!(entity in hass.states)) {
-          return false;
-        }
-        const entityEntry = hass.entities[entity];
-        // Filter out hidden entities (respects user/integration/device hidden_by)
-        if (entityEntry?.hidden) {
-          return false;
-        }
-        return true;
-      });
-
-      if (config.exclude_entities?.length) {
-        predictedEntities = predictedEntities.filter(
-          (entity) => !config.exclude_entities!.includes(entity)
-        );
-      }
-    }
-
-    if (config.include_entities?.length) {
-      // Remove included entities from predicted list to avoid duplicates
-      predictedEntities = predictedEntities.filter(
-        (entity) => !config.include_entities!.includes(entity)
-      );
-      // Add included entities to the start of the list
-      predictedEntities.unshift(
-        ...config.include_entities!.filter((entity) => entity in hass.states)
-      );
-    }
-
     const limit = config.limit ?? DEFAULT_LIMIT;
-    predictedEntities = predictedEntities.slice(0, limit);
+    const includedEntities = (config.include_entities || []).filter(
+      (entity) => entity in hass.states
+    );
 
-    if (predictedEntities.length > 0) {
-      section.cards!.push(
-        ...predictedEntities.map(
-          (entityId) =>
-            ({
-              type: "tile",
-              entity: entityId,
-              state_content: ["state", "area_name"],
-              show_entity_picture: true,
-            }) satisfies TileCardConfig
-        )
-      );
-    } else {
+    // Pinned entities already fill the section, skip the prediction call.
+    if (includedEntities.length >= limit) {
+      section.cards!.push(...includedEntities.slice(0, limit).map(toTileCard));
+      return section;
+    }
+
+    if (!isComponentLoaded(hass.config, "usage_prediction")) {
+      section.cards!.push({
+        type: "markdown",
+        content: hass.localize(
+          "ui.panel.lovelace.strategy.common_controls.not_loaded"
+        ),
+      });
+      section.disabled = config.hide_empty;
+      return section;
+    }
+
+    const predictedCommonControls =
+      await getCommonControlsUsagePrediction(hass);
+    const predictedEntities = predictedCommonControls.entities.filter(
+      (entity) => {
+        // Non-existing entities should not be shown
+        if (!(entity in hass.states)) return false;
+        // Hidden entities should not be shown
+        if (hass.entities[entity]?.hidden) return false;
+        // Entities explicitly excluded by the user should not be shown
+        if (config.exclude_entities?.includes(entity)) return false;
+        // Avoid duplicates with the included entities
+        if (includedEntities.includes(entity)) return false;
+        return true;
+      }
+    );
+
+    const entities = [...includedEntities, ...predictedEntities].slice(
+      0,
+      limit
+    );
+
+    if (entities.length === 0) {
       section.cards!.push({
         type: "markdown",
         content: hass.localize(
@@ -116,8 +104,10 @@ export class CommonControlsSectionStrategy extends ReactiveElement {
         ),
       });
       section.disabled = config.hide_empty;
+      return section;
     }
 
+    section.cards!.push(...entities.map(toTileCard));
     return section;
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2494,10 +2494,11 @@
         "editor": {
           "title": "Edit Overview page",
           "description": "Configure your Overview page display preferences.",
-          "favorite_entities_description": "Pin entities to always show them on your overview page.",
-          "favorite_entities_helper": "Entities in your favorites always appear first.",
+          "personalize": "Personalize",
+          "personalize_description": "Customize the top of your Overview page.",
           "suggested_entities": "Suggested entities",
-          "suggested_entities_description": "Include additional entities based on your most commonly used devices to fill up to 8 slots including your favorites.",
+          "suggested_entities_description": "Show entities you use often alongside your favorites.",
+          "suggested_entities_disabled_description": "Your favorites already fill the section. Remove a favorite to make room for suggestions.",
           "save_failed": "Failed to save Overview page configuration",
           "areas_hint": "You can rearrange your floors and areas in the order that best represents your house on the {areas_page}.",
           "areas_page": "areas page",
@@ -10097,7 +10098,7 @@
             },
             "home": {
               "favorite_entities": "Favorite entities",
-              "add_favorite_entity": "Add favorite entity"
+              "add_favorite_entity": "Add favorite"
             }
           },
           "view": {


### PR DESCRIPTION
## Proposed change

Consistency pass over the Home panel editor dialog from #51407:

- Unified section layout: each section uses the same header + description + dedicated editor component.
- Drag-to-reorder on favorites and custom shortcuts.
- Welcome message now displayed at the top of the Personalize group, matching the dashboard order.
- "Suggested entities" toggle is disabled when favorites fill the section.
- Cleaned up the `common-controls` section strategy: removed the `show_predicted`

## Screenshots

<img width="899" height="1143" alt="CleanShot 2026-04-24 at 11 58 18" src="https://github.com/user-attachments/assets/86057879-5500-4915-be5a-7327bd00f9e5" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #51407
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
