### PR TITLE
Add attribute support for numeric state and state

### DIFF
--- a/src/data/entity/entity_attributes.ts
+++ b/src/data/entity/entity_attributes.ts
@@ -187,6 +187,30 @@ export const NON_NUMERIC_ATTRIBUTES = [
   "xy_color",
 ];
 
+export const STATE_CONDITION_HIDDEN_ATTRIBUTES = [
+  "access_token",
+  "available_modes",
+  "color_modes",
+  "editable",
+  "effect_list",
+  "entity_picture",
+  "event_types",
+  "fan_modes",
+  "fan_speed_list",
+  "forecast",
+  "friendly_name",
+  "hvac_modes",
+  "icon",
+  "operation_list",
+  "options",
+  "preset_modes",
+  "sound_mode_list",
+  "source_list",
+  "state_class",
+  "swing_modes",
+  "token",
+];
+
 export const computeShownAttributes = (stateObj: HassEntity) => {
   const domain = computeStateDomain(stateObj);
   const filtersArray = STATE_ATTRIBUTES.concat(

--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -18,6 +18,7 @@ import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../../components/ha-form/types";
 import type { StateCondition } from "../../../../../data/automation";
+import { STATE_CONDITION_HIDDEN_ATTRIBUTES } from "../../../../../data/entity/entity_attributes";
 import type { HomeAssistant } from "../../../../../types";
 import { forDictStruct } from "../../structs";
 import type { ConditionElement } from "../ha-automation-condition-row";
@@ -38,29 +39,7 @@ const SCHEMA = [
     name: "attribute",
     selector: {
       attribute: {
-        hide_attributes: [
-          "access_token",
-          "available_modes",
-          "color_modes",
-          "editable",
-          "effect_list",
-          "entity_picture",
-          "event_types",
-          "fan_modes",
-          "fan_speed_list",
-          "forecast",
-          "friendly_name",
-          "hvac_modes",
-          "icon",
-          "operation_list",
-          "options",
-          "preset_modes",
-          "sound_mode_list",
-          "source_list",
-          "state_class",
-          "swing_modes",
-          "token",
-        ],
+        hide_attributes: STATE_CONDITION_HIDDEN_ATTRIBUTES,
       },
     },
     context: {

--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -53,6 +53,7 @@ export interface LocationCondition extends BaseCondition {
 export interface NumericStateCondition extends BaseCondition {
   condition: "numeric_state";
   entity?: string;
+  attribute?: string;
   below?: string | number;
   above?: string | number;
 }
@@ -60,6 +61,7 @@ export interface NumericStateCondition extends BaseCondition {
 export interface StateCondition extends BaseCondition {
   condition: "state";
   entity?: string;
+  attribute?: string;
   state?: string | string[];
   state_not?: string | string[];
 }
@@ -110,10 +112,17 @@ function checkStateCondition(
   condition: StateCondition | LegacyCondition,
   hass: HomeAssistant
 ) {
-  const state =
-    condition.entity && hass.states[condition.entity]
-      ? hass.states[condition.entity].state
-      : UNKNOWN;
+  const stateObj = condition.entity ? hass.states[condition.entity] : undefined;
+  const attribute = "attribute" in condition ? condition.attribute : undefined;
+  let state: string;
+  if (!stateObj) {
+    state = UNKNOWN;
+  } else if (attribute) {
+    const attrValue = stateObj.attributes[attribute];
+    state = attrValue == null ? UNKNOWN : String(attrValue);
+  } else {
+    state = stateObj.state;
+  }
   let value = condition.state ?? condition.state_not;
 
   // Guard against invalid/incomplete condition configuration
@@ -144,8 +153,10 @@ function checkStateNumericCondition(
   condition: NumericStateCondition,
   hass: HomeAssistant
 ) {
-  const state = (condition.entity ? hass.states[condition.entity] : undefined)
-    ?.state;
+  const stateObj = condition.entity ? hass.states[condition.entity] : undefined;
+  const state = condition.attribute
+    ? stateObj?.attributes[condition.attribute]
+    : stateObj?.state;
   let above = condition.above;
   let below = condition.below;
 

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-numeric_state.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-numeric_state.ts
@@ -1,4 +1,3 @@
-import type { HassEntity } from "home-assistant-js-websocket";
 import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -9,6 +8,7 @@ import type {
   SchemaUnion,
   HaFormSchema,
 } from "../../../../../components/ha-form/types";
+import { NON_NUMERIC_ATTRIBUTES } from "../../../../../data/entity/entity_attributes";
 import type { HomeAssistant } from "../../../../../types";
 import type {
   NumericStateCondition,
@@ -18,6 +18,7 @@ import type {
 const numericStateConditionStruct = object({
   condition: literal("numeric_state"),
   entity: optional(string()),
+  attribute: optional(string()),
   above: optional(number()),
   below: optional(number()),
 });
@@ -41,9 +42,24 @@ export class HaCardConditionNumericState extends LitElement {
   }
 
   private _schema = memoizeOne(
-    (noEntity: boolean, stateObj?: HassEntity) =>
+    (noEntity: boolean, unit?: string) =>
       [
-        ...(noEntity ? [] : [{ name: "entity", selector: { entity: {} } }]),
+        ...(noEntity
+          ? []
+          : [
+              { name: "entity", selector: { entity: {} } },
+              {
+                name: "attribute",
+                selector: {
+                  attribute: {
+                    hide_attributes: NON_NUMERIC_ATTRIBUTES,
+                  },
+                },
+                context: {
+                  filter_entity: "entity",
+                },
+              },
+            ]),
         {
           name: "",
           type: "grid",
@@ -54,7 +70,7 @@ export class HaCardConditionNumericState extends LitElement {
                 number: {
                   step: "any",
                   mode: "box",
-                  unit_of_measurement: stateObj?.attributes.unit_of_measurement,
+                  unit_of_measurement: unit,
                 },
               },
             },
@@ -64,7 +80,7 @@ export class HaCardConditionNumericState extends LitElement {
                 number: {
                   step: "any",
                   mode: "box",
-                  unit_of_measurement: stateObj?.attributes.unit_of_measurement,
+                  unit_of_measurement: unit,
                 },
               },
             },
@@ -78,11 +94,15 @@ export class HaCardConditionNumericState extends LitElement {
       ? this.hass.states[this.condition.entity]
       : undefined;
 
+    const unit = this.condition.attribute
+      ? undefined
+      : stateObj?.attributes.unit_of_measurement;
+
     return html`
       <ha-form
         .hass=${this.hass}
         .data=${this.condition}
-        .schema=${this._schema(this.noEntity, stateObj)}
+        .schema=${this._schema(this.noEntity, unit)}
         .disabled=${this.disabled}
         @value-changed=${this._valueChanged}
         .computeLabel=${this._computeLabelCallback}
@@ -92,7 +112,10 @@ export class HaCardConditionNumericState extends LitElement {
 
   private _valueChanged(ev: CustomEvent): void {
     ev.stopPropagation();
-    const condition = ev.detail.value as NumericStateCondition;
+    const condition = { ...ev.detail.value } as NumericStateCondition;
+    if (!condition.attribute) {
+      delete condition.attribute;
+    }
     fireEvent(this, "value-changed", { value: condition });
   }
 
@@ -102,6 +125,10 @@ export class HaCardConditionNumericState extends LitElement {
     switch (schema.name) {
       case "entity":
         return this.hass.localize("ui.components.entity.entity-picker.entity");
+      case "attribute":
+        return this.hass.localize(
+          "ui.panel.lovelace.editor.condition-editor.condition.numeric_state.attribute"
+        );
       case "below":
       case "above":
         return this.hass.localize(

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-state.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-state.ts
@@ -10,12 +10,14 @@ import type {
   SchemaUnion,
   HaFormSchema,
 } from "../../../../../components/ha-form/types";
+import { STATE_CONDITION_HIDDEN_ATTRIBUTES } from "../../../../../data/entity/entity_attributes";
 import type { HomeAssistant } from "../../../../../types";
 import type { StateCondition } from "../../../common/validate-condition";
 
 const stateConditionStruct = object({
   condition: literal("state"),
   entity: optional(string()),
+  attribute: optional(string()),
   state: optional(string()),
   state_not: optional(string()),
 });
@@ -23,6 +25,7 @@ const stateConditionStruct = object({
 interface StateConditionData {
   condition: "state";
   entity?: string;
+  attribute?: string;
   invert: "true" | "false";
   state?: string | string[];
 }
@@ -66,7 +69,22 @@ export class HaCardConditionState extends LitElement {
   private _schema = memoizeOne(
     (noEntity: boolean, localize: LocalizeFunc, presetStates: PresetState[]) =>
       [
-        ...(noEntity ? [] : [{ name: "entity", selector: { entity: {} } }]),
+        ...(noEntity
+          ? []
+          : [
+              { name: "entity", selector: { entity: {} } },
+              {
+                name: "attribute",
+                selector: {
+                  attribute: {
+                    hide_attributes: STATE_CONDITION_HIDDEN_ATTRIBUTES,
+                  },
+                },
+                context: {
+                  filter_entity: "entity",
+                },
+              },
+            ]),
         {
           name: "",
           type: "grid",
@@ -112,6 +130,7 @@ export class HaCardConditionState extends LitElement {
                     },
                     context: {
                       filter_entity: "entity",
+                      filter_attribute: "attribute",
                     },
                   }),
             },
@@ -159,6 +178,10 @@ export class HaCardConditionState extends LitElement {
       state_not: invert === "true" ? (state ?? "") : undefined,
     };
 
+    if (!condition.attribute) {
+      delete condition.attribute;
+    }
+
     fireEvent(this, "value-changed", { value: condition });
   }
 
@@ -168,6 +191,10 @@ export class HaCardConditionState extends LitElement {
     switch (schema.name) {
       case "entity":
         return this.hass.localize("ui.components.entity.entity-picker.entity");
+      case "attribute":
+        return this.hass.localize(
+          "ui.panel.lovelace.editor.condition-editor.condition.state.attribute"
+        );
       case "state":
         return this.hass.localize(
           "ui.components.entity.entity-state-picker.state"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8969,6 +8969,7 @@
               },
               "numeric_state": {
                 "label": "Entity numeric state",
+                "attribute": "[%key:ui::panel::lovelace::editor::condition-editor::condition::state::attribute%]",
                 "above": "Above",
                 "below": "Below"
               },
@@ -8985,6 +8986,7 @@
               },
               "state": {
                 "label": "Entity state",
+                "attribute": "Attribute (optional)",
                 "state_equal": "State is equal to",
                 "state_not_equal": "State is not equal to"
               },


### PR DESCRIPTION
## Proposed change

Extends the `state` and `numeric_state` card visibility conditions to match automation conditions.
Users can now check against an entity **attribute** in addition to the entity state.

Example:

```yaml
type: tile
entity: sun.sun
visibility:
  - condition: state
    entity: sun.sun
    attribute: rising
    state: "true"
```

Both editors add an optional "Attribute" picker after the entity field. When an attribute is selected, the state preset list (for `state`)

## Screenshots

<!-- Add before/after screenshots of the condition editor here. -->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/668, https://github.com/home-assistant/frontend/pull/24721
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
