### PR TITLE
Modified the chart legend for climate temperature data sets

### DIFF
--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -22,6 +22,7 @@ import { fireEvent } from "../../common/dom/fire_event";
 import { CLIMATE_HVAC_ACTION_TO_MODE } from "../../data/climate";
 import { blankBeforeUnit } from "../../common/translations/blank_before_unit";
 import { filterXSS } from "../../common/util/xss";
+import { computeAttributeValueDisplay } from "../../common/entity/compute_attribute_display";
 
 const safeParseFloat = (value) => {
   const parsed = parseFloat(value);
@@ -322,29 +323,27 @@ export class StateHistoryChartLine extends LitElement {
                   datasetId?.endsWith("-target_temperature_mode") ||
                   datasetId?.endsWith("-target_temperature_mode_low")
                 ) {
-                  const attrs = stateObj.attributes;
-                  let tempValue: number | undefined;
+                  let attribute: string | undefined;
                   if (datasetId.endsWith("-current_temperature")) {
-                    tempValue = attrs?.current_temperature;
+                    attribute = "current_temperature";
                   } else if (
                     datasetId.endsWith("-target_temperature_mode_low")
                   ) {
-                    tempValue = attrs?.target_temp_low;
+                    attribute = "target_temp_low";
                   } else if (datasetId.endsWith("-target_temperature_mode")) {
-                    tempValue = attrs?.target_temp_high;
+                    attribute = "target_temp_high";
                   } else {
-                    tempValue = attrs?.temperature;
+                    attribute = "temperature";
                   }
-                  // Format temperature with unit
-                  if (tempValue !== undefined) {
-                    value = `${formatNumber(
-                      tempValue,
-                      this.hass.locale
-                    )}${blankBeforeUnit(
-                      this.hass.config.unit_system.temperature,
-                      this.hass.locale
-                    )}${this.hass.config.unit_system.temperature}`;
-                  }
+                  // Use the helper to format temperature with proper unit
+                  value = computeAttributeValueDisplay(
+                    this.hass.localize,
+                    stateObj,
+                    this.hass.locale,
+                    this.hass.config,
+                    this.hass.entities,
+                    attribute
+                  );
                 }
 
                 // If not a temperature dataset, use the entity state

--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -311,12 +311,52 @@ export class StateHistoryChartLine extends LitElement {
             .filter((item) => !(item.dataset as LineSeriesOption).areaStyle)
             .map((item) => {
               const stateObj = this.hass.states[item.entityId];
+              let value: string | undefined;
+
+              if (stateObj) {
+                // For climate temperature datasets, show temperature values
+                const datasetId = item.dataset.id as string;
+                if (
+                  datasetId?.endsWith("-current_temperature") ||
+                  datasetId?.endsWith("-target_temperature") ||
+                  datasetId?.endsWith("-target_temperature_mode") ||
+                  datasetId?.endsWith("-target_temperature_mode_low")
+                ) {
+                  const attrs = stateObj.attributes;
+                  let tempValue: number | undefined;
+                  if (datasetId.endsWith("-current_temperature")) {
+                    tempValue = attrs?.current_temperature;
+                  } else if (
+                    datasetId.endsWith("-target_temperature_mode_low")
+                  ) {
+                    tempValue = attrs?.target_temp_low;
+                  } else if (datasetId.endsWith("-target_temperature_mode")) {
+                    tempValue = attrs?.target_temp_high;
+                  } else {
+                    tempValue = attrs?.temperature;
+                  }
+                  // Format temperature with unit
+                  if (tempValue !== undefined) {
+                    value = `${formatNumber(
+                      tempValue,
+                      this.hass.locale
+                    )}${blankBeforeUnit(
+                      this.hass.config.unit_system.temperature,
+                      this.hass.locale
+                    )}${this.hass.config.unit_system.temperature}`;
+                  }
+                }
+
+                // If not a temperature dataset, use the entity state
+                if (value === undefined) {
+                  value = this.hass.formatEntityState(stateObj);
+                }
+              }
+
               return {
                 id: item.dataset.id as string,
                 name: item.dataset.name as string,
-                value: stateObj
-                  ? this.hass.formatEntityState(stateObj)
-                  : undefined,
+                value: value,
               };
             }),
         },

--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -346,7 +346,7 @@ export class StateHistoryChartLine extends LitElement {
                   );
                 }
 
-                // If not a temperature dataset, use the entity state
+                // Default for non-temperature datasets / missing attribute
                 if (value === undefined) {
                   value = this.hass.formatEntityState(stateObj);
                 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The legend for climate entity charts was displaying the overall climate state (e.g., "heat", "cool", "off") instead of the actual temperature values for current and target temperature datasets.

Modified the legend configuration in state-history-chart-line.ts to:
- Check if the dataset is a climate temperature dataset: -target_temperature, -target_temperature_mode, -target_temperature_mode_low) and extract the value from the entity's attributes
For all other datasets, continue using the original entity state behavior

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
**Previous Legend Example that shows hvac_mode**
<img width="1140" height="463" alt="image" src="https://github.com/user-attachments/assets/226bf785-a06e-4d28-8636-f3e10ac1da36" />


**Fixed legend temperature values**
<img width="1186" height="447" alt="image" src="https://github.com/user-attachments/assets/710e9ee1-4c5b-4b73-85df-8fe69c75b5c3" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
