### PR TITLE
Stabilize more-info group rendering

### DIFF
--- a/src/dialogs/more-info/more-info-content.ts
+++ b/src/dialogs/more-info/more-info-content.ts
@@ -53,7 +53,11 @@ class MoreInfoContent extends LitElement {
 
     if (!moreInfoType) return nothing;
 
-    const memberIds = this._getEntityMemberIds(this.stateObj);
+    const memberIds = this._getEntityMemberIds(
+      this.stateObj,
+      this.entry,
+      this.hass.entities
+    );
 
     return html`
       ${dynamicElement(moreInfoType, {
@@ -75,23 +79,27 @@ class MoreInfoContent extends LitElement {
     `;
   }
 
-  private _getEntityMemberIds(stateObj: HassEntity): string[] | undefined {
-    if (computeStateDomain(stateObj) === "group") {
-      // Don't show entity members for legacy groups as they already show
-      // the members in their more info dialog.
-      return undefined;
+  private _getEntityMemberIds = memoizeOne(
+    (
+      stateObj: HassEntity,
+      entry: ExtEntityRegistryEntry | null | undefined,
+      entities: HomeAssistant["entities"]
+    ): string[] | undefined => {
+      if (computeStateDomain(stateObj) === "group") {
+        // Don't show entity members for legacy groups as they already show
+        // the members in their more info dialog.
+        return undefined;
+      }
+
+      const memberIds =
+        (entry?.capabilities?.group_entities as string[] | undefined) ??
+        (Array.isArray(stateObj.attributes.entity_id)
+          ? (stateObj.attributes.entity_id as string[])
+          : undefined);
+
+      return memberIds?.filter((entityId) => !entities[entityId]?.hidden);
     }
-
-    const memberIds =
-      (this.entry?.capabilities?.group_entities as string[] | undefined) ??
-      (Array.isArray(stateObj.attributes.entity_id)
-        ? (stateObj.attributes.entity_id as string[])
-        : undefined);
-
-    return memberIds?.filter(
-      (entityId) => !this.hass!.entities[entityId]?.hidden
-    );
-  }
+  );
 
   private _entitiesSectionConfig = memoizeOne((entityIds: string[]) => {
     const hass = this.hass!;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When rendering a set of tiles for a more-info group, we were constructing a new configuration object in each render, leading to the destruction and recreation of each tile cards and recreating them on every hass update. 

There was an attempt to mitigate this by memoizing the _entitiesSectionConfig function, but the array passed to the memoization was a brand new array in each render due to use of `filter` function.

If we also memoize the function which generate the array of entities, this stabilizes everything so it doesn't recreate on each hass update. It stiil needs to recreate when hass.entities changes, which I think happens a bit more often than I expect, but at least it's much less than the number of hass.states updates. 

Looks like it regressed due to https://github.com/home-assistant/frontend/pull/30094

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51724
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
