### PR TITLE
Fix ha-panel-custom not restoring after suspendWhenHidden disconnect

### DIFF
--- a/src/panels/custom/ha-panel-custom.ts
+++ b/src/panels/custom/ha-panel-custom.ts
@@ -54,6 +54,18 @@ export class HaPanelCustom extends ReactiveElement {
     this.querySelector("iframe")?.classList.add("loaded");
   }
 
+  public connectedCallback() {
+    super.connectedCallback();
+    // The suspendWhenHidden disconnect timer in partial-panel-resolver
+    // removes this element from the DOM after 5 minutes, which triggers
+    // _cleanupPanel() and destroys our child panel. When the user returns,
+    // the same element is re-appended but `update()` won't call _createPanel
+    // again (the `panel` property reference hasn't changed). Rebuild here.
+    if (!this._setProperties && !this.hasChildNodes() && this.panel) {
+      this._createPanel(this.panel);
+    }
+  }
+
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._cleanupPanel();


### PR DESCRIPTION
## Proposed change

### Symptom

Any user with `suspendWhenHidden` enabled (default for every HA user) sees a blank panel when returning to a backgrounded HA tab if the active panel was a non-iframe custom sidebar panel (`component_name: "custom"` without `embed_iframe: true`). Full page reload is the only recovery.

Reproduces in `dev` HEAD with Safari, Chrome, and Firefox. Repro: open any non-iframe custom panel, hide the tab for >5 minutes, return. Panel area is blank/black until manual reload.

This bug has been latent since 2022. Originally reported in #14510 with an accurate mechanism description; that issue was stale-bot closed in 2023 with no fix.

### Root cause

`PartialPanelResolver._onHidden()` (`src/layouts/partial-panel-resolver.ts:145`) starts a 5-minute `setTimeout` (line 146). When it fires, if the panel is not in the exemption set (iframe panel, `app` panel, custom panel with `embed_iframe: true` — lines 158-162), it calls `this.removeChild(this.lastChild)` at line 171, removing `<ha-panel-custom>` from the DOM and saving the reference as `this._disconnectedPanel`.

`<ha-panel-custom>.disconnectedCallback()` (`src/panels/custom/ha-panel-custom.ts:69`) calls `_cleanupPanel()` (line 98), which deletes `window.customPanel`, sets `this._setProperties = undefined` (line 100), and removes all children.

When the user returns, `_onVisible()` (`partial-panel-resolver.ts:177`) re-appends the same `<ha-panel-custom>` element via `appendChild` (line 183). `ReactiveElement`'s base `connectedCallback` schedules an update, but `update()`'s panel-creation branch only fires when `changedProps.has("panel") && !deepEqual(oldPanel, this.panel)` — and `this.panel` is the same reference, so nothing happens. The property-forwarding branch also exits early because `_setProperties` is `undefined`. Result: `<ha-panel-custom>` is in the DOM but empty.

### Fix

Add a `connectedCallback()` override to `HaPanelCustom` (10 lines + a comment, no other file changes). Three guards keep it scoped strictly to the recovery path:

```typescript
public connectedCallback() {
  super.connectedCallback();
  if (!this._setProperties && !this.hasChildNodes() && this.panel) {
    this._createPanel(this.panel);
  }
}
```

- `!this._setProperties` — sentinel for "`_cleanupPanel` ran". `_setProperties` is set inside `_createPanel`'s success paths (`ha-panel-custom.ts:53` for iframe panels, `ha-panel-custom.ts:143` for non-iframe panels) and only nulled in `_cleanupPanel` (`ha-panel-custom.ts:100`). Single reliable sentinel; no new state introduced.
- `!this.hasChildNodes()` — defends against the async window inside `loadCustomPanel(config).then(...)` for non-iframe panels. Without this guard, a rapid detach→attach cycle while the load is in flight could call `_createPanel` a second time and append duplicate elements. The 5-minute timer dominates in practice, but this is cheap insurance.
- `this.panel` — guards first-mount, when the router hasn't assigned a panel yet. The initial `_createPanel` is still handled by the existing `update()` path's `changedProps.has("panel")` branch.

Mirrors the existing `disconnectedCallback` override for symmetry.

### Test plan

The 5-minute timer makes manual repro cumbersome but reliable:

1. Open a non-iframe custom sidebar panel (any of those listed in "Ecosystem impact" below). Verify it renders.
2. Hide the tab for >5 minutes (background, switch app, lock screen).
3. Return.
4. Without patch: panel area is blank/black. With patch: panel rebuilds automatically within ~2 seconds.
5. Verify exemption paths still behave correctly: iframe panels, the `app` panel, and `embed_iframe: true` custom panels. None should be affected (none even hit the new code path).

Manually verified on a real HA instance against `dev` HEAD: baseline reproduces blank-panel after 6 minutes hidden in Safari; patched build rebuilds within ~2 seconds of returning. Iframe panels (Zigbee2MQTT addon), `app` panels (Lovelace dashboard), and `embed_iframe: true` panels (HACS) all unaffected.

`<ha-panel-custom>` has no existing unit-test surface in this repo. Happy to add a test if a reviewer asks (mount → remove → re-append → assert child rendered), but didn't pre-add to keep the diff minimal.

### Ecosystem impact

This is a framework-level bug: every HACS integration registering a non-iframe sidebar panel via `panel_custom.async_register_panel` (or `async_register_built_in_panel(component_name="custom")`) without `embed_iframe=True` is affected. Snapshot of affected integrations above 1k installs (HA opt-in analytics, 2026-04-26):

| Integration | HA installs |
|---|---|
| Alarmo | 23,381 |
| Browser Mod | 22,880 |
| Homematic(IP) Local | 9,299 |
| Custom Icons | 2,405 |
| Smart Irrigation | 1,338 |

Combined ~60k installs across these five plus several smaller ones. Browser Mod and Alarmo together (~46k) are the strongest co-witnesses that this reproduces independently of any single integration.

Verified not affected: HACS itself (uses `embed_iframe: True`), Switch Manager (same), Spook/Frigate/Watchman/etc. (don't register a custom sidebar panel).

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #14510
- This PR is related to issue: #6236 (the same reattach pattern was established for `ha-panel-lovelace` in 2020 — `ha-panel-lovelace` already has its own `connectedCallback` override and is unaffected today)
- Link to documentation pull request: n/a

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the development checklist.
- [x] The code has been formatted using Prettier (yarn run format).
- [ ] Tests have been added to verify that the new code works.
