### PR TITLE
Add entity context to media browser player picker

### DIFF
--- a/src/panels/media-browser/ha-bar-media-player.ts
+++ b/src/panels/media-browser/ha-bar-media-player.ts
@@ -744,6 +744,14 @@ export class BarMediaPlayer extends SubscribeMixin(LitElement) {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--ha-space-1);
+      max-width: 120px;
+    }
+
+    .player-label > div {
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .player-secondary {

--- a/src/panels/media-browser/ha-bar-media-player.ts
+++ b/src/panels/media-browser/ha-bar-media-player.ts
@@ -14,8 +14,8 @@ import { classMap } from "lit/directives/class-map";
 import { until } from "lit/directives/until";
 import { fireEvent } from "../../common/dom/fire_event";
 import { computeDomain } from "../../common/entity/compute_domain";
+import { computeEntityPickerDisplay } from "../../common/entity/compute_entity_name_display";
 import { computeStateDomain } from "../../common/entity/compute_state_domain";
-import { computeStateName } from "../../common/entity/compute_state_name";
 import { supportsFeature } from "../../common/entity/supports-feature";
 import { debounce } from "../../common/util/debounce";
 import {
@@ -396,15 +396,24 @@ export class BarMediaPlayer extends SubscribeMixin(LitElement) {
                       <span slot="start">
                         ${this._renderIcon(isBrowser, stateObj)}
                       </span>
-                      ${this.narrow
-                        ? nothing
-                        : isBrowser
-                          ? this.hass.localize(
-                              "ui.components.media-browser.web-browser"
-                            )
-                          : stateObj
-                            ? computeStateName(stateObj)
-                            : this.entityId}
+                      ${isBrowser
+                        ? this.hass.localize(
+                            "ui.components.media-browser.web-browser"
+                          )
+                        : stateObj
+                          ? (() => {
+                              const { primary, secondary } =
+                                computeEntityPickerDisplay(this.hass, stateObj);
+                              return html`<div class="player-label">
+                                <div>${primary}</div>
+                                ${secondary
+                                  ? html`<div class="player-secondary">
+                                      ${secondary}
+                                    </div>`
+                                  : nothing}
+                              </div>`;
+                            })()
+                          : this.entityId}
                       <ha-svg-icon
                         slot="end"
                         .path=${mdiChevronDown}
@@ -418,17 +427,26 @@ export class BarMediaPlayer extends SubscribeMixin(LitElement) {
             >
               ${this.hass.localize("ui.components.media-browser.web-browser")}
             </ha-dropdown-item>
-            ${this._mediaPlayerEntities.map(
-              (source) => html`
+            ${this._mediaPlayerEntities.map((source) => {
+              const { primary, secondary } = computeEntityPickerDisplay(
+                this.hass,
+                source
+              );
+              return html`
                 <ha-dropdown-item
                   .selected=${source.entity_id === this.entityId}
                   .disabled=${source.state === UNAVAILABLE}
                   .value=${source.entity_id}
                 >
-                  ${computeStateName(source)}
+                  <div class="content">
+                    ${primary}
+                    ${secondary
+                      ? html`<div class="secondary">${secondary}</div>`
+                      : nothing}
+                  </div>
                 </ha-dropdown-item>
-              `
-            )}
+              `;
+            })}
           </ha-dropdown>
         </div>
       </div>
@@ -708,6 +726,29 @@ export class BarMediaPlayer extends SubscribeMixin(LitElement) {
     .secondary,
     .progress {
       color: var(--secondary-text-color);
+    }
+
+    ha-dropdown-item .content {
+      display: flex;
+      flex-direction: column;
+      gap: var(--ha-space-1);
+    }
+
+    ha-dropdown-item .secondary {
+      font-size: var(--ha-font-size-s);
+      color: var(--ha-color-text-secondary);
+    }
+
+    .player-label {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--ha-space-1);
+    }
+
+    .player-secondary {
+      font-size: var(--ha-font-size-s);
+      color: color-mix(in srgb, currentColor 70%, transparent);
     }
 
     .choose-player {


### PR DESCRIPTION
## Proposed change

The media browser player picker (the dropdown at the bottom of the media browser panel) only showed the entity name for each speaker, making it hard to identify the right one when multiple players share similar names.

This change adds area and device context as a secondary line to both:
- the **active player pill** (the trigger button showing the selected player)
- each **item in the player picker dropdown**

The secondary line follows the same `Area ▸ Device` pattern already used in the Join dialog (`dialog-join-media-players`) and the more-info dialog breadcrumb.

## Screenshots

<!-- Please add before/after screenshots showing the pill and the open dropdown in both light and dark mode -->

### Before
<img width="2672" height="1424" alt="CleanShot 2026-04-27 at 10 21 42" src="https://github.com/user-attachments/assets/95d32d4f-86b7-4b1e-b45b-e89a509882fd" />


### After
<img width="2672" height="1424" alt="CleanShot 2026-04-27 at 10 18 49" src="https://github.com/user-attachments/assets/0672e91d-0cb6-4a55-9d4f-ede4beb66704" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51663
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr