### PR TITLE
Add precipitation visualization to forecast tile features

### DIFF
--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -57,9 +57,11 @@ export interface ForecastAttribute {
   wind_speed?: string;
 }
 
+export type ForecastPrecipitationType = "amount" | "probability";
+
 export const getForecastPrecipitation = (
   entry: ForecastAttribute,
-  type: "amount" | "probability"
+  type: ForecastPrecipitationType
 ) =>
   type === "probability"
     ? entry.precipitation_probability

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -57,6 +57,14 @@ export interface ForecastAttribute {
   wind_speed?: string;
 }
 
+export const getForecastPrecipitation = (
+  entry: ForecastAttribute,
+  type: "amount" | "probability"
+) =>
+  type === "probability"
+    ? entry.precipitation_probability
+    : entry.precipitation;
+
 interface WeatherEntityAttributes extends HassEntityAttributeBase {
   attribution?: string;
   humidity?: number;

--- a/src/panels/lovelace/card-features/hui-daily-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-daily-forecast-card-feature.ts
@@ -19,7 +19,11 @@ import {
   internationalizationContext,
 } from "../../../data/context";
 import type { ForecastAttribute, ForecastEvent } from "../../../data/weather";
-import { subscribeForecast, WeatherEntityFeature } from "../../../data/weather";
+import {
+  getForecastPrecipitation,
+  subscribeForecast,
+  WeatherEntityFeature,
+} from "../../../data/weather";
 import type {
   HomeAssistantConnection,
   HomeAssistantInternationalization,
@@ -32,7 +36,7 @@ import type {
 
 export const DEFAULT_DAYS_TO_SHOW = 7;
 
-const MAX_BAR_WIDTH = 12;
+const MAX_BAR_WIDTH = 8;
 
 export type DailyForecastType = "daily" | "twice_daily";
 
@@ -183,16 +187,20 @@ class HuiDailyForecastCardFeature
       `;
     }
 
+    const showTemperature = this._config.show_temperature ?? true;
+    const showPrecipitation = this._config.show_precipitation ?? false;
+
     const daysToShow = this._config.days_to_show ?? DEFAULT_DAYS_TO_SHOW;
     const entriesPerDay = this._subscribedType === "twice_daily" ? 2 : 1;
     const entries = this._forecast
-      .filter(
-        (entry) =>
-          entry.temperature != null &&
-          !Number.isNaN(entry.temperature) &&
-          entry.templow != null &&
-          !Number.isNaN(entry.templow)
-      )
+      .filter((entry) => {
+        if (showTemperature) {
+          return (
+            Number.isFinite(entry.temperature) && Number.isFinite(entry.templow)
+          );
+        }
+        return showPrecipitation;
+      })
       .slice(0, daysToShow * entriesPerDay);
 
     if (!entries.length) {
@@ -217,62 +225,145 @@ class HuiDailyForecastCardFeature
     const minGap = 4;
     const slotWidth = width / entries.length;
     const barWidth = Math.max(1, Math.min(MAX_BAR_WIDTH, slotWidth - minGap));
+    const drawableHeight = height - padding * 2;
+
+    const showTemperature = this._config!.show_temperature ?? true;
+    const showPrecipitation = this._config!.show_precipitation ?? false;
+    const precipitationType = this._config!.precipitation_type ?? "amount";
 
     const currentTemp = Number(this._stateObj?.attributes?.temperature);
-    const hasCurrentTemp = currentTemp != null && !Number.isNaN(currentTemp);
+    const hasCurrentTemp = Number.isFinite(currentTemp);
 
-    let tempMin = Infinity;
-    let tempMax = -Infinity;
-    for (const entry of entries) {
-      tempMin = Math.min(tempMin, entry.templow!);
-      tempMax = Math.max(tempMax, entry.temperature);
+    let yFor: ((value: number) => number) | undefined;
+    if (showTemperature) {
+      let tempMin = Infinity;
+      let tempMax = -Infinity;
+      for (const entry of entries) {
+        if (
+          Number.isFinite(entry.templow) &&
+          Number.isFinite(entry.temperature)
+        ) {
+          tempMin = Math.min(tempMin, entry.templow!);
+          tempMax = Math.max(tempMax, entry.temperature);
+        }
+      }
+      if (hasCurrentTemp) {
+        tempMin = Math.min(tempMin, currentTemp);
+        tempMax = Math.max(tempMax, currentTemp);
+      }
+      if (tempMin === tempMax) {
+        tempMin -= 1;
+        tempMax += 1;
+      }
+      yFor = (value: number) =>
+        padding +
+        drawableHeight -
+        ((value - tempMin) / (tempMax - tempMin)) * drawableHeight;
     }
-    if (hasCurrentTemp) {
-      tempMin = Math.min(tempMin, currentTemp);
-      tempMax = Math.max(tempMax, currentTemp);
+
+    let maxPrecipitation = 0;
+    if (showPrecipitation) {
+      if (precipitationType === "probability") {
+        maxPrecipitation = 100;
+      } else {
+        for (const entry of entries) {
+          const value = getForecastPrecipitation(entry, precipitationType);
+          if (Number.isFinite(value)) {
+            maxPrecipitation = Math.max(maxPrecipitation, value!);
+          }
+        }
+      }
     }
-    if (tempMin === tempMax) {
-      tempMin -= 1;
-      tempMax += 1;
-    }
 
-    const drawableHeight = height - padding * 2;
-    const yFor = (value: number) =>
-      padding +
-      drawableHeight -
-      ((value - tempMin) / (tempMax - tempMin)) * drawableHeight;
+    const rainBarWidth = Math.max(
+      barWidth,
+      Math.min(barWidth + 8, slotWidth - 2)
+    );
 
-    const bars = entries.map((entry, i) => {
-      const x = slotWidth * i + (slotWidth - barWidth) / 2;
-      const yHigh = yFor(entry.temperature);
-      const yLow = yFor(entry.templow!);
-      const barHeight = Math.max(1, yLow - yHigh);
-      const rx = Math.min(barWidth / 2, barHeight / 2);
-      const fill = entry.condition
-        ? `var(--state-weather-${slugify(entry.condition, "_")}-color, var(--feature-color))`
-        : "var(--feature-color)";
-      return svg`<rect
-        x=${x}
-        y=${yHigh}
-        width=${barWidth}
-        height=${barHeight}
-        rx=${rx}
-        ry=${rx}
-        fill=${fill}
-      ></rect>`;
-    });
+    const precipitationBars =
+      showPrecipitation && maxPrecipitation > 0
+        ? entries.map((entry, i) => {
+            const value = getForecastPrecipitation(entry, precipitationType);
+            if (!Number.isFinite(value) || value! <= 0) {
+              return nothing;
+            }
+            const x = slotWidth * i + (slotWidth - rainBarWidth) / 2;
+            const barHeight = Math.max(
+              1,
+              (value! / maxPrecipitation) * drawableHeight
+            );
+            const y = padding + drawableHeight - barHeight;
+            return svg`<rect
+              x=${x}
+              y=${y}
+              width=${rainBarWidth}
+              height=${barHeight}
+              fill="var(--state-weather-rainy-color)"
+              opacity="0.4"
+            ></rect>`;
+          })
+        : nothing;
 
-    const currentTempLine = hasCurrentTemp
-      ? svg`<line
-          x1="0"
-          x2=${width}
-          y1=${yFor(currentTemp)}
-          y2=${yFor(currentTemp)}
-          stroke="var(--feature-color)"
-          stroke-width="1"
-          stroke-opacity="0.5"
-          vector-effect="non-scaling-stroke"
-        ></line>`
+    const bars =
+      showTemperature && yFor
+        ? entries.map((entry, i) => {
+            if (
+              !Number.isFinite(entry.temperature) ||
+              !Number.isFinite(entry.templow)
+            ) {
+              return nothing;
+            }
+            const x = slotWidth * i + (slotWidth - barWidth) / 2;
+            const yHigh = yFor(entry.temperature);
+            const yLow = yFor(entry.templow!);
+            const barHeight = Math.max(1, yLow - yHigh);
+            const rx = Math.min(barWidth / 2, barHeight / 2);
+            const fill = entry.condition
+              ? `var(--state-weather-${slugify(entry.condition, "_")}-color, var(--feature-color))`
+              : "var(--feature-color)";
+            return svg`<rect
+              x=${x}
+              y=${yHigh}
+              width=${barWidth}
+              height=${barHeight}
+              rx=${rx}
+              ry=${rx}
+              fill=${fill}
+            ></rect>`;
+          })
+        : nothing;
+
+    const currentTempLine =
+      showTemperature && yFor && hasCurrentTemp
+        ? svg`<line
+            x1="0"
+            x2=${width}
+            y1=${yFor(currentTemp)}
+            y2=${yFor(currentTemp)}
+            stroke="var(--feature-color)"
+            stroke-width="1"
+            stroke-opacity="0.5"
+            vector-effect="non-scaling-stroke"
+          ></line>`
+        : nothing;
+
+    const dotRadius = 1.5;
+    const dots = !showTemperature
+      ? entries.map((entry, i) => {
+          const value = getForecastPrecipitation(entry, precipitationType);
+          if (Number.isFinite(value) && value! > 0) {
+            return nothing;
+          }
+          const cx = slotWidth * i + slotWidth / 2;
+          const cy = padding + drawableHeight - dotRadius;
+          return svg`<circle
+            cx=${cx}
+            cy=${cy}
+            r=${dotRadius}
+            fill="var(--state-weather-rainy-color)"
+            opacity="0.4"
+          ></circle>`;
+        })
       : nothing;
 
     return html`
@@ -282,7 +373,7 @@ class HuiDailyForecastCardFeature
         viewBox="0 0 ${width} ${height}"
         preserveAspectRatio="none"
       >
-        ${bars}${currentTempLine}
+        ${dots}${precipitationBars}${bars}${currentTempLine}
       </svg>
     `;
   }

--- a/src/panels/lovelace/card-features/hui-hourly-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-hourly-forecast-card-feature.ts
@@ -1,12 +1,16 @@
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
-import type { PropertyValues } from "lit";
-import { css, html, LitElement, nothing } from "lit";
+import type { PropertyValues, TemplateResult } from "lit";
+import { css, html, LitElement, nothing, svg } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import "../../../components/ha-spinner";
-import type { ForecastEvent } from "../../../data/weather";
-import { subscribeForecast, WeatherEntityFeature } from "../../../data/weather";
+import type { ForecastAttribute, ForecastEvent } from "../../../data/weather";
+import {
+  getForecastPrecipitation,
+  subscribeForecast,
+  WeatherEntityFeature,
+} from "../../../data/weather";
 import type { HomeAssistant } from "../../../types";
 import { coordinates } from "../common/graph/coordinates";
 import "../components/hui-graph-base";
@@ -17,6 +21,9 @@ import type {
 } from "./types";
 
 export const DEFAULT_HOURS_TO_SHOW = 24;
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+const MAX_RAIN_BAR_WIDTH = 16;
 
 export const supportsHourlyForecastCardFeature = (
   hass: HomeAssistant,
@@ -44,6 +51,8 @@ class HuiHourlyForecastCardFeature
   @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
 
   @state() private _config?: HourlyForecastCardFeatureConfig;
+
+  @state() private _forecast?: ForecastAttribute[];
 
   @state() private _coordinates?: [number, number][];
 
@@ -117,14 +126,26 @@ class HuiHourlyForecastCardFeature
         </div>
       `;
     }
-    if (!this._coordinates) {
+    if (!this._forecast || !this._coordinates) {
       return html`
         <div class="container loading">
           <ha-spinner size="small"></ha-spinner>
         </div>
       `;
     }
-    if (!this._coordinates.length) {
+
+    const showTemperature = this._config.show_temperature ?? true;
+    const showPrecipitation = this._config.show_precipitation ?? false;
+
+    const showDots = !showTemperature && showPrecipitation;
+    const layer =
+      showPrecipitation || showDots
+        ? this._renderForecastLayer(showPrecipitation, showDots)
+        : nothing;
+    const hasGraphData = this._coordinates.length > 0;
+    const showGraph = showTemperature && hasGraphData;
+
+    if (!showGraph && layer === nothing) {
       return html`
         <div class="container">
           <div class="info">
@@ -135,11 +156,132 @@ class HuiHourlyForecastCardFeature
         </div>
       `;
     }
+
     return html`
-      <hui-graph-base
-        .coordinates=${this._coordinates}
-        .yAxisOrigin=${this._yAxisOrigin}
-      ></hui-graph-base>
+      <div class="layers">
+        ${layer}
+        ${showGraph
+          ? html`
+              <hui-graph-base
+                .coordinates=${this._coordinates}
+                .yAxisOrigin=${this._yAxisOrigin}
+              ></hui-graph-base>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private _renderForecastLayer(showRain: boolean, showDots: boolean) {
+    if (!this._forecast?.length) {
+      return nothing;
+    }
+    const width = this.clientWidth || 300;
+    const height = this.clientHeight || 42;
+    const padding = 4;
+    const drawableHeight = height - padding * 2;
+
+    const now = Date.now();
+    const hoursToShow = this._config!.hours_to_show ?? DEFAULT_HOURS_TO_SHOW;
+    const maxTime =
+      Math.floor((now + hoursToShow * MS_PER_HOUR) / MS_PER_HOUR) * MS_PER_HOUR;
+    const timeRange = maxTime - now;
+    if (timeRange <= 0) {
+      return nothing;
+    }
+
+    const precipitationType = this._config!.precipitation_type ?? "amount";
+
+    const inRange: { entry: ForecastAttribute; t: number }[] = [];
+    for (const entry of this._forecast) {
+      const t = new Date(entry.datetime).getTime();
+      if (t >= now && t <= maxTime) {
+        inRange.push({ entry, t });
+      }
+    }
+
+    if (!inRange.length) {
+      return nothing;
+    }
+
+    const rainRects: TemplateResult[] = [];
+    if (showRain) {
+      const rainEntries = inRange.filter(({ entry }) => {
+        const value = getForecastPrecipitation(entry, precipitationType);
+        return Number.isFinite(value) && value! > 0;
+      });
+      let maxPrecipitation = 0;
+      if (precipitationType === "probability") {
+        maxPrecipitation = 100;
+      } else {
+        for (const { entry } of rainEntries) {
+          maxPrecipitation = Math.max(
+            maxPrecipitation,
+            getForecastPrecipitation(entry, precipitationType)!
+          );
+        }
+      }
+      if (maxPrecipitation > 0 && rainEntries.length) {
+        const slotWidth = width / hoursToShow;
+        const barWidth = Math.max(
+          1,
+          Math.min(MAX_RAIN_BAR_WIDTH, slotWidth - 2)
+        );
+        for (const { entry, t } of rainEntries) {
+          const value = getForecastPrecipitation(entry, precipitationType)!;
+          const xCenter = ((t - now) / timeRange) * width;
+          const x = xCenter - barWidth / 2;
+          const barHeight = Math.max(
+            1,
+            (value / maxPrecipitation) * drawableHeight
+          );
+          const y = padding + drawableHeight - barHeight;
+          rainRects.push(svg`<rect
+            x=${x}
+            y=${y}
+            width=${barWidth}
+            height=${barHeight}
+            fill="var(--state-weather-rainy-color)"
+            opacity="0.4"
+          ></rect>`);
+        }
+      }
+    }
+
+    const dots: TemplateResult[] = [];
+    if (showDots) {
+      const dotRadius = 1.5;
+      const cy = padding + drawableHeight - dotRadius;
+      for (const { entry, t } of inRange) {
+        const value = getForecastPrecipitation(entry, precipitationType);
+        if (Number.isFinite(value) && value! > 0) {
+          continue;
+        }
+        const cx = ((t - now) / timeRange) * width;
+        dots.push(svg`<circle
+          cx=${cx}
+          cy=${cy}
+          r=${dotRadius}
+          fill="var(--state-weather-rainy-color)"
+          opacity="0.4"
+        ></circle>`);
+      }
+    }
+
+    if (!rainRects.length && !dots.length) {
+      return nothing;
+    }
+
+    return html`
+      <svg
+        class="rain"
+        width="100%"
+        height="100%"
+        viewBox="0 0 ${width} ${height}"
+        preserveAspectRatio="none"
+      >
+        ${dots}${rainRects}
+      </svg>
     `;
   }
 
@@ -162,10 +304,9 @@ class HuiHourlyForecastCardFeature
     const data: [number, number][] = [];
     const now = Date.now();
     const hoursToShow = this._config!.hours_to_show ?? DEFAULT_HOURS_TO_SHOW;
-    const msPerHour = 60 * 60 * 1000;
     // Round down to the nearest hour so the axis aligns with forecast data points
     const maxTime =
-      Math.floor((now + hoursToShow * msPerHour) / msPerHour) * msPerHour;
+      Math.floor((now + hoursToShow * MS_PER_HOUR) / MS_PER_HOUR) * MS_PER_HOUR;
 
     // Start with current temperature
     const currentTemp = stateObj?.attributes?.temperature;
@@ -218,6 +359,7 @@ class HuiHourlyForecastCardFeature
       entityId,
       "hourly",
       (forecastEvent) => {
+        this._forecast = forecastEvent.forecast ?? [];
         this._computeCoordinates(forecastEvent);
       }
     ).catch((err) => {
@@ -234,23 +376,44 @@ class HuiHourlyForecastCardFeature
       height: var(--feature-height);
       flex-direction: column;
       justify-content: flex-end;
-      align-items: flex-end;
+      align-items: stretch;
       pointer-events: none !important;
     }
 
-    .container.loading {
+    .container {
       width: 100%;
+      height: 100%;
       display: flex;
       justify-content: center;
       align-items: center;
     }
 
-    hui-graph-base {
+    .info {
+      color: var(--secondary-text-color);
+      font-size: var(--ha-font-size-s);
+    }
+
+    .layers {
+      position: relative;
       width: 100%;
-      --accent-color: var(--feature-color);
+      height: 100%;
       border-bottom-right-radius: 8px;
       border-bottom-left-radius: 8px;
       overflow: hidden;
+    }
+
+    .rain {
+      position: absolute;
+      inset: 0;
+      display: block;
+    }
+
+    hui-graph-base {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      --accent-color: var(--feature-color);
     }
   `;
 }

--- a/src/panels/lovelace/card-features/hui-hourly-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-hourly-forecast-card-feature.ts
@@ -178,8 +178,9 @@ class HuiHourlyForecastCardFeature
     }
     const width = this.clientWidth || 300;
     const height = this.clientHeight || 42;
-    const padding = 4;
-    const drawableHeight = height - padding * 2;
+    // No bottom padding so bars and dots line up with the line graph baseline.
+    const topPadding = 4;
+    const drawableHeight = height - topPadding;
 
     const now = Date.now();
     const hoursToShow = this._config!.hours_to_show ?? DEFAULT_HOURS_TO_SHOW;
@@ -235,7 +236,7 @@ class HuiHourlyForecastCardFeature
             1,
             (value / maxPrecipitation) * drawableHeight
           );
-          const y = padding + drawableHeight - barHeight;
+          const y = height - barHeight;
           rainRects.push(svg`<rect
             x=${x}
             y=${y}
@@ -251,7 +252,7 @@ class HuiHourlyForecastCardFeature
     const dots: TemplateResult[] = [];
     if (showDots) {
       const dotRadius = 1.5;
-      const cy = padding + drawableHeight - dotRadius;
+      const cy = height - dotRadius;
       for (const { entry, t } of inRange) {
         const value = getForecastPrecipitation(entry, precipitationType);
         if (Number.isFinite(value) && value! > 0) {

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -241,15 +241,23 @@ export interface TrendGraphCardFeatureConfig {
   detail?: boolean;
 }
 
+export type ForecastPrecipitationType = "amount" | "probability";
+
 export interface HourlyForecastCardFeatureConfig {
   type: "hourly-forecast";
   hours_to_show?: number;
+  show_temperature?: boolean;
+  show_precipitation?: boolean;
+  precipitation_type?: ForecastPrecipitationType;
 }
 
 export interface DailyForecastCardFeatureConfig {
   type: "daily-forecast";
   forecast_type?: "daily" | "twice_daily";
   days_to_show?: number;
+  show_temperature?: boolean;
+  show_precipitation?: boolean;
+  precipitation_type?: ForecastPrecipitationType;
 }
 
 export const AREA_CONTROL_DOMAINS = [

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -1,6 +1,9 @@
 import type { AlarmMode } from "../../../data/alarm_control_panel";
 import type { HvacMode } from "../../../data/climate";
 import type { OperationMode } from "../../../data/water_heater";
+import type { ForecastPrecipitationType } from "../../../data/weather";
+
+export type { ForecastPrecipitationType };
 
 export type ButtonCardData = Record<string, any>;
 
@@ -240,8 +243,6 @@ export interface TrendGraphCardFeatureConfig {
   hours_to_show?: number;
   detail?: boolean;
 }
-
-export type ForecastPrecipitationType = "amount" | "probability";
 
 export interface HourlyForecastCardFeatureConfig {
   type: "hourly-forecast";

--- a/src/panels/lovelace/editor/config-elements/hui-daily-forecast-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-daily-forecast-card-feature-editor.ts
@@ -38,6 +38,7 @@ export class HuiDailyForecastCardFeatureEditor
     (
       supportsDaily: boolean,
       supportsTwiceDaily: boolean,
+      showPrecipitation: boolean,
       localize: HomeAssistant["localize"]
     ) =>
       [
@@ -72,6 +73,38 @@ export class HuiDailyForecastCardFeatureEditor
           default: DEFAULT_DAYS_TO_SHOW,
           selector: { number: { min: 1, mode: "box" } },
         },
+        {
+          name: "show_temperature",
+          selector: { boolean: {} },
+        },
+        {
+          name: "show_precipitation",
+          selector: { boolean: {} },
+        },
+        {
+          name: "precipitation_type",
+          required: true,
+          disabled: !showPrecipitation,
+          selector: {
+            select: {
+              mode: "dropdown",
+              options: [
+                {
+                  value: "amount",
+                  label: localize(
+                    "ui.panel.lovelace.editor.features.types.daily-forecast.precipitation_type_options.amount"
+                  ),
+                },
+                {
+                  value: "probability",
+                  label: localize(
+                    "ui.panel.lovelace.editor.features.types.daily-forecast.precipitation_type_options.probability"
+                  ),
+                },
+              ],
+            },
+          },
+        },
       ] as const satisfies readonly HaFormSchema[]
   );
 
@@ -90,15 +123,20 @@ export class HuiDailyForecastCardFeatureEditor
     const resolvedType =
       resolveDailyForecastType(stateObj, this._config.forecast_type) || "daily";
 
+    const showPrecipitation = this._config.show_precipitation ?? false;
+
     const data: DailyForecastCardFeatureConfig = {
       ...this._config,
       forecast_type: resolvedType,
       days_to_show: this._config.days_to_show ?? DEFAULT_DAYS_TO_SHOW,
+      show_temperature: this._config.show_temperature ?? true,
+      precipitation_type: this._config.precipitation_type ?? "amount",
     };
 
     const schema = this._schema(
       supportsDaily,
       supportsTwiceDaily,
+      showPrecipitation,
       this.hass.localize
     );
 
@@ -128,6 +166,18 @@ export class HuiDailyForecastCardFeatureEditor
       case "days_to_show":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.generic.${schema.name}`
+        );
+      case "show_temperature":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.daily-forecast.show_temperature"
+        );
+      case "show_precipitation":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.daily-forecast.show_precipitation"
+        );
+      case "precipitation_type":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.daily-forecast.precipitation_type"
         );
       default:
         return "";

--- a/src/panels/lovelace/editor/config-elements/hui-hourly-forecast-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-hourly-forecast-card-feature-editor.ts
@@ -1,5 +1,6 @@
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-form/ha-form";
 import type {
@@ -13,14 +14,6 @@ import type {
   LovelaceCardFeatureContext,
 } from "../../card-features/types";
 import type { LovelaceCardFeatureEditor } from "../../types";
-
-const SCHEMA = [
-  {
-    name: "hours_to_show",
-    default: DEFAULT_HOURS_TO_SHOW,
-    selector: { number: { min: 1, mode: "box" } },
-  },
-] as const satisfies HaFormSchema[];
 
 @customElement("hui-hourly-forecast-card-feature-editor")
 export class HuiHourlyForecastCardFeatureEditor
@@ -37,22 +30,70 @@ export class HuiHourlyForecastCardFeatureEditor
     this._config = config;
   }
 
+  private _schema = memoizeOne(
+    (showPrecipitation: boolean, localize: HomeAssistant["localize"]) =>
+      [
+        {
+          name: "hours_to_show",
+          default: DEFAULT_HOURS_TO_SHOW,
+          selector: { number: { min: 1, mode: "box" } },
+        },
+        {
+          name: "show_temperature",
+          selector: { boolean: {} },
+        },
+        {
+          name: "show_precipitation",
+          selector: { boolean: {} },
+        },
+        {
+          name: "precipitation_type",
+          required: true,
+          disabled: !showPrecipitation,
+          selector: {
+            select: {
+              mode: "dropdown",
+              options: [
+                {
+                  value: "amount",
+                  label: localize(
+                    "ui.panel.lovelace.editor.features.types.hourly-forecast.precipitation_type_options.amount"
+                  ),
+                },
+                {
+                  value: "probability",
+                  label: localize(
+                    "ui.panel.lovelace.editor.features.types.hourly-forecast.precipitation_type_options.probability"
+                  ),
+                },
+              ],
+            },
+          },
+        },
+      ] as const satisfies readonly HaFormSchema[]
+  );
+
   protected render() {
     if (!this.hass || !this._config) {
       return nothing;
     }
 
-    const data = { ...this._config };
+    const showPrecipitation = this._config.show_precipitation ?? false;
 
-    if (!this._config.hours_to_show) {
-      data.hours_to_show = DEFAULT_HOURS_TO_SHOW;
-    }
+    const data: HourlyForecastCardFeatureConfig = {
+      ...this._config,
+      hours_to_show: this._config.hours_to_show ?? DEFAULT_HOURS_TO_SHOW,
+      show_temperature: this._config.show_temperature ?? true,
+      precipitation_type: this._config.precipitation_type ?? "amount",
+    };
+
+    const schema = this._schema(showPrecipitation, this.hass.localize);
 
     return html`
       <ha-form
         .hass=${this.hass}
         .data=${data}
-        .schema=${SCHEMA}
+        .schema=${schema}
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
       ></ha-form>
@@ -63,11 +104,25 @@ export class HuiHourlyForecastCardFeatureEditor
     fireEvent(this, "config-changed", { config: ev.detail.value });
   }
 
-  private _computeLabelCallback = (schema: SchemaUnion<typeof SCHEMA>) => {
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
     switch (schema.name) {
       case "hours_to_show":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.generic.${schema.name}`
+        );
+      case "show_temperature":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.hourly-forecast.show_temperature"
+        );
+      case "show_precipitation":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.hourly-forecast.show_precipitation"
+        );
+      case "precipitation_type":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.hourly-forecast.precipitation_type"
         );
       default:
         return "";

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10066,7 +10066,14 @@
               },
               "hourly-forecast": {
                 "label": "Hourly forecast",
-                "no_forecast": "No forecast data available"
+                "no_forecast": "No forecast data available",
+                "show_temperature": "Show temperature",
+                "show_precipitation": "Show precipitation",
+                "precipitation_type": "Precipitation type",
+                "precipitation_type_options": {
+                  "amount": "Amount",
+                  "probability": "Probability"
+                }
               },
               "daily-forecast": {
                 "label": "Daily forecast",
@@ -10075,6 +10082,13 @@
                 "forecast_type_options": {
                   "daily": "Daily",
                   "twice_daily": "Twice daily"
+                },
+                "show_temperature": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::show_temperature%]",
+                "show_precipitation": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::show_precipitation%]",
+                "precipitation_type": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::precipitation_type%]",
+                "precipitation_type_options": {
+                  "amount": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::precipitation_type_options::amount%]",
+                  "probability": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::precipitation_type_options::probability%]"
                 }
               }
             }


### PR DESCRIPTION
## Proposed change

Adds rain forecast visualization to the daily and hourly weather forecast tile card features.

New config options on both features:
- `show_temperature` (default `true`) — toggles the temperature line/range bars and current-temp line.
- `show_precipitation` (default `false`) — overlays rain forecast as translucent bars in the rainy condition color.
- `precipitation_type` — `amount` (default) plots forecasted precipitation volume, scaled relative to the period's max; `probability` plots `precipitation_probability` on a fixed 0–100% scale.

When the temperature layer is hidden, periods that have no rain bar get a small dot at the bottom of the bar area in the same rain color, so the cadence of days/hours stays readable.

Daily temp bars are also slimmer (`MAX_BAR_WIDTH` 12 → 8) so rain bars can sit on either side without crowding.

Users can still have temps and rain as separate features by adding the feature twice and configuring temps on one and rain on the other.

## Screenshots
<img width="928" height="764" alt="image" src="https://github.com/user-attachments/assets/4aa4de6c-fd8a-4858-8796-29ac73b1e27f" />
<img width="454" height="250" alt="image" src="https://github.com/user-attachments/assets/24533d95-a032-43fe-a5fb-12c11023b08e" />


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51578
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/1593
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45035
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr