### PR TITLE
Simplify and fix target entity count

### DIFF
--- a/src/data/target.ts
+++ b/src/data/target.ts
@@ -1,4 +1,5 @@
 import type { HassServiceTarget } from "home-assistant-js-websocket";
+import { ensureArray } from "../common/array/ensure-array";
 import { computeDomain } from "../common/entity/compute_domain";
 import type { HaDevicePickerDeviceFilterFunc } from "../components/device/ha-device-picker";
 import type { PickerComboBoxItem } from "../components/ha-picker-combo-box";
@@ -58,23 +59,26 @@ export const extractFromTarget = async (
     primary_entities_only: primaryEntitiesOnly,
   });
 
-export const getResolvedTargetEntityCount = async (
-  hass: HomeAssistant,
-  target?: HassServiceTarget
-): Promise<number | undefined> => {
-  if (!target) {
-    return undefined;
+export const getTargetEntityCount = (target?: HassServiceTarget): number => {
+  const tempTarget = {
+    entity_id: target?.entity_id ? ensureArray(target?.entity_id) : [],
+    device_id: target?.device_id ? ensureArray(target?.device_id) : [],
+    area_id: target?.area_id ? ensureArray(target?.area_id) : [],
+    floor_id: target?.floor_id ? ensureArray(target?.floor_id) : [],
+    label_id: target?.label_id ? ensureArray(target?.label_id) : [],
+  };
+
+  if (
+    tempTarget?.device_id?.length > 0 ||
+    tempTarget?.area_id?.length > 0 ||
+    tempTarget?.floor_id?.length > 0 ||
+    tempTarget?.label_id?.length > 0
+  ) {
+    // if targeting non entities the number of entities is dynamic
+    return Infinity;
   }
 
-  try {
-    return (await extractFromTarget(hass, target, true)).referenced_entities
-      .length;
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error("Error resolving target entity count", err);
-  }
-
-  return undefined;
+  return tempTarget?.entity_id?.length;
 };
 
 export const getTriggersForTarget = async (

--- a/src/panels/config/automation/condition/types/ha-automation-condition-platform.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-platform.ts
@@ -432,14 +432,10 @@ export class HaPlatformCondition extends LitElement {
     }
   }
 
-  private _resolveTargetEntityCount = memoizeOne(
-    (target: PlatformCondition["target"]) => getTargetEntityCount(target)
-  );
-
-  private async _updateResolvedTargetEntityCount(
+  private _updateResolvedTargetEntityCount(
     target: PlatformCondition["target"]
   ) {
-    this._resolvedTargetEntityCount = this._resolveTargetEntityCount(target);
+    this._resolvedTargetEntityCount = getTargetEntityCount(target);
 
     if (
       target &&

--- a/src/panels/config/automation/condition/types/ha-automation-condition-platform.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-platform.ts
@@ -16,7 +16,7 @@ import {
 import type { IntegrationManifest } from "../../../../../data/integration";
 import { fetchIntegrationManifest } from "../../../../../data/integration";
 import type { TargetSelector } from "../../../../../data/selector";
-import { getResolvedTargetEntityCount } from "../../../../../data/target";
+import { getTargetEntityCount } from "../../../../../data/target";
 import type { HomeAssistant } from "../../../../../types";
 import { documentationUrl } from "../../../../../util/documentation-url";
 
@@ -433,34 +433,16 @@ export class HaPlatformCondition extends LitElement {
   }
 
   private _resolveTargetEntityCount = memoizeOne(
-    async (target: PlatformCondition["target"]) =>
-      getResolvedTargetEntityCount(this.hass, target)
+    (target: PlatformCondition["target"]) => getTargetEntityCount(target)
   );
 
   private async _updateResolvedTargetEntityCount(
     target: PlatformCondition["target"]
   ) {
-    this._resolvedTargetEntityCount =
-      await this._resolveTargetEntityCount(target);
+    this._resolvedTargetEntityCount = this._resolveTargetEntityCount(target);
 
     if (
-      (!target ||
-        (this._resolvedTargetEntityCount !== undefined &&
-          this._resolvedTargetEntityCount <= 1)) &&
-      this.condition.options?.behavior !== undefined
-    ) {
-      const options = { ...this.condition.options };
-      delete options.behavior;
-
-      fireEvent(this, "value-changed", {
-        value: {
-          ...this.condition,
-          options,
-        },
-      });
-    } else if (
       target &&
-      this._resolvedTargetEntityCount !== undefined &&
       this._resolvedTargetEntityCount > 1 &&
       this.condition.options?.behavior === undefined
     ) {

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
@@ -11,7 +11,7 @@ import type { PlatformTrigger } from "../../../../../data/automation";
 import type { IntegrationManifest } from "../../../../../data/integration";
 import { fetchIntegrationManifest } from "../../../../../data/integration";
 import type { TargetSelector } from "../../../../../data/selector";
-import { getResolvedTargetEntityCount } from "../../../../../data/target";
+import { getTargetEntityCount } from "../../../../../data/target";
 import {
   getTriggerDomain,
   getTriggerObjectId,
@@ -468,34 +468,16 @@ export class HaPlatformTrigger extends LitElement {
   }
 
   private _resolveTargetEntityCount = memoizeOne(
-    async (target: PlatformTrigger["target"]) =>
-      getResolvedTargetEntityCount(this.hass, target)
+    (target: PlatformTrigger["target"]) => getTargetEntityCount(target)
   );
 
   private async _updateResolvedTargetEntityCount(
     target: PlatformTrigger["target"]
   ) {
-    this._resolvedTargetEntityCount =
-      await this._resolveTargetEntityCount(target);
+    this._resolvedTargetEntityCount = this._resolveTargetEntityCount(target);
 
     if (
-      (!target ||
-        (this._resolvedTargetEntityCount !== undefined &&
-          this._resolvedTargetEntityCount <= 1)) &&
-      this.trigger.options?.behavior !== undefined
-    ) {
-      const options = { ...this.trigger.options };
-      delete options.behavior;
-
-      fireEvent(this, "value-changed", {
-        value: {
-          ...this.trigger,
-          options,
-        },
-      });
-    } else if (
       target &&
-      this._resolvedTargetEntityCount !== undefined &&
       this._resolvedTargetEntityCount > 1 &&
       this.trigger.options?.behavior === undefined
     ) {

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
@@ -467,14 +467,8 @@ export class HaPlatformTrigger extends LitElement {
     }
   }
 
-  private _resolveTargetEntityCount = memoizeOne(
-    (target: PlatformTrigger["target"]) => getTargetEntityCount(target)
-  );
-
-  private async _updateResolvedTargetEntityCount(
-    target: PlatformTrigger["target"]
-  ) {
-    this._resolvedTargetEntityCount = this._resolveTargetEntityCount(target);
+  private _updateResolvedTargetEntityCount(target: PlatformTrigger["target"]) {
+    this._resolvedTargetEntityCount = getTargetEntityCount(target);
 
     if (
       target &&


### PR DESCRIPTION
## Proposed change
- simplify `getResolvedTargetEntityCount` 
	- if we have floor, area, device or label we cannot how the entity count will change in the background, so we cannot just remove trigger/condition behavior
	- If we show/hide behavior selector is just if we have more then 1 entity. We don't have to expand groups because groups behave like a single entity, it's not expanded in the trigger or condition too.
	- Stop deleting behavior, why to reset it when you just want to switch out some targets?

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
