### PR TITLE
Show all the power buttons when media player is in assumed state

### DIFF
--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -16,6 +16,8 @@ import {
   mdiPlayPause,
   mdiPodcast,
   mdiPower,
+  mdiPowerOff,
+  mdiPowerOn,
   mdiRepeat,
   mdiRepeatOff,
   mdiRepeatOnce,
@@ -286,7 +288,9 @@ export const computeMediaControls = (
     return undefined;
   }
 
-  if (!stateActive(stateObj)) {
+  const assumedState = stateObj.attributes.assumed_state === true;
+
+  if (!stateActive(stateObj) && !assumedState) {
     return supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_ON)
       ? [
           {
@@ -299,14 +303,23 @@ export const computeMediaControls = (
 
   const buttons: ControlButton[] = [];
 
+  if (
+    assumedState &&
+    supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_ON)
+  ) {
+    buttons.push({
+      icon: mdiPowerOn,
+      action: "turn_on",
+    });
+  }
+
   if (supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_OFF)) {
     buttons.push({
-      icon: mdiPower,
+      icon: assumedState ? mdiPowerOff : mdiPower,
       action: "turn_off",
     });
   }
 
-  const assumedState = stateObj.attributes.assumed_state === true;
   const stateAttr = stateObj.attributes;
 
   if (

--- a/src/panels/lovelace/card-features/hui-media-player-playback-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-media-player-playback-card-feature.ts
@@ -3,6 +3,8 @@ import {
   mdiPlay,
   mdiPlayPause,
   mdiPower,
+  mdiPowerOff,
+  mdiPowerOn,
   mdiSkipNext,
   mdiSkipPrevious,
   mdiStop,
@@ -198,25 +200,32 @@ class HuiMediaPlayerPlaybackCardFeature
     stateObj: MediaPlayerEntity
   ): ControlButton[] {
     const active = stateActive(stateObj);
+    const assumedState = stateObj.attributes.assumed_state === true;
     const buttons: ControlButton[] = [];
 
     for (const control of this._controls) {
       switch (control) {
         case "turn_off":
           if (
-            active &&
+            (active || assumedState) &&
             supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_OFF)
           ) {
-            buttons.push({ icon: mdiPower, action: "turn_off" });
+            buttons.push({
+              icon: assumedState ? mdiPowerOff : mdiPower,
+              action: "turn_off",
+            });
           }
           break;
         case "turn_on":
           if (
-            !active &&
+            (!active || assumedState) &&
             !isUnavailableState(stateObj.state) &&
             supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_ON)
           ) {
-            buttons.push({ icon: mdiPower, action: "turn_on" });
+            buttons.push({
+              icon: assumedState ? mdiPowerOn : mdiPower,
+              action: "turn_on",
+            });
           }
           break;
         case "media_play":

--- a/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
@@ -3,6 +3,8 @@ import {
   mdiPlay,
   mdiPlayPause,
   mdiPower,
+  mdiPowerOff,
+  mdiPowerOn,
   mdiSkipNext,
   mdiSkipPrevious,
   mdiStop,
@@ -192,26 +194,31 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
       >
         <div class="controls">
           ${supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_ON) &&
-          !stateActive(stateObj) &&
+          (!stateActive(stateObj) || assumedState) &&
           !isUnavailableState(entityState)
             ? html`
                 <ha-icon-button
-                  .path=${mdiPower}
+                  .path=${assumedState ? mdiPowerOn : mdiPower}
                   .label=${this.hass.localize("ui.card.media_player.turn_on")}
-                  @click=${this._togglePower}
+                  @click=${this._turnOn}
                 ></ha-icon-button>
               `
-            : !supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_SET) &&
-                !supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_STEP)
-              ? buttons
-              : ""}
+            : ""}
+          ${!supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_SET) &&
+          !supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_STEP) &&
+          (stateActive(stateObj) ||
+            assumedState ||
+            !supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_ON) ||
+            isUnavailableState(entityState))
+            ? buttons
+            : ""}
           ${supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_OFF) &&
-          stateActive(stateObj)
+          (stateActive(stateObj) || assumedState)
             ? html`
                 <ha-icon-button
-                  .path=${mdiPower}
+                  .path=${assumedState ? mdiPowerOff : mdiPower}
                   .label=${this.hass.localize("ui.card.media_player.turn_off")}
-                  @click=${this._togglePower}
+                  @click=${this._turnOff}
                 ></ha-icon-button>
               `
             : ""}
@@ -311,16 +318,16 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
           : { icon: mdiStop, action: "media_stop" };
   }
 
-  private _togglePower(): void {
-    const stateObj = this.hass!.states[this._config!.entity];
+  private _turnOn(): void {
+    this.hass!.callService("media_player", "turn_on", {
+      entity_id: this._config!.entity,
+    });
+  }
 
-    this.hass!.callService(
-      "media_player",
-      stateActive(stateObj) ? "turn_off" : "turn_on",
-      {
-        entity_id: this._config!.entity,
-      }
-    );
+  private _turnOff(): void {
+    this.hass!.callService("media_player", "turn_off", {
+      entity_id: this._config!.entity,
+    });
   }
 
   private _playPauseStop(): void {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Media players with an assumed state should show both power on and power off buttons.



## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

<img width="666" height="522" alt="CleanShot 2026-04-27 at 11 11 52@2x" src="https://github.com/user-attachments/assets/d61a162f-433a-41b0-9da4-6a12f1a72386" />

<img width="1218" height="1126" alt="CleanShot 2026-04-27 at 11 12 15@2x" src="https://github.com/user-attachments/assets/077e3798-955a-4a7e-bb28-b2f3e297445d" />

<img width="388" height="262" alt="CleanShot 2026-04-27 at 11 12 58@2x" src="https://github.com/user-attachments/assets/34209a24-732b-40b5-891a-061ea9b62138" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
