### PR TITLE
Add color and current temperature options to forecast features

### DIFF
--- a/src/panels/lovelace/card-features/hui-daily-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-daily-forecast-card-feature.ts
@@ -228,6 +228,8 @@ class HuiDailyForecastCardFeature
     const drawableHeight = height - padding * 2;
 
     const showTemperature = this._config!.show_temperature ?? true;
+    const showCurrentTemperature =
+      this._config!.show_current_temperature ?? true;
     const showPrecipitation = this._config!.show_precipitation ?? false;
     const precipitationType = this._config!.precipitation_type ?? "amount";
 
@@ -334,7 +336,7 @@ class HuiDailyForecastCardFeature
         : nothing;
 
     const currentTempLine =
-      showTemperature && yFor && hasCurrentTemp
+      showTemperature && showCurrentTemperature && yFor && hasCurrentTemp
         ? svg`<line
             x1="0"
             x2=${width}

--- a/src/panels/lovelace/card-features/hui-daily-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-daily-forecast-card-feature.ts
@@ -7,6 +7,7 @@ import type {
 import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing, svg } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { computeCssColor } from "../../../common/color/compute-color";
 import { consumeEntityState } from "../../../common/decorators/consume-context-entry";
 import { transform } from "../../../common/decorators/transform";
 import { computeDomain } from "../../../common/entity/compute_domain";
@@ -232,6 +233,9 @@ class HuiDailyForecastCardFeature
       this._config!.show_current_temperature ?? true;
     const showPrecipitation = this._config!.show_precipitation ?? false;
     const precipitationType = this._config!.precipitation_type ?? "amount";
+    const customColor = this._config!.color
+      ? computeCssColor(this._config!.color)
+      : undefined;
 
     const currentTemp = Number(this._stateObj?.attributes?.temperature);
     const hasCurrentTemp = Number.isFinite(currentTemp);
@@ -320,9 +324,11 @@ class HuiDailyForecastCardFeature
             const yLow = yFor(entry.templow!);
             const barHeight = Math.max(1, yLow - yHigh);
             const rx = Math.min(barWidth / 2, barHeight / 2);
-            const fill = entry.condition
-              ? `var(--state-weather-${slugify(entry.condition, "_")}-color, var(--feature-color))`
-              : "var(--feature-color)";
+            const fill =
+              customColor ??
+              (entry.condition
+                ? `var(--state-weather-${slugify(entry.condition, "_")}-color, var(--feature-color))`
+                : "var(--feature-color)");
             return svg`<rect
               x=${x}
               y=${yHigh}
@@ -342,7 +348,7 @@ class HuiDailyForecastCardFeature
             x2=${width}
             y1=${yFor(currentTemp)}
             y2=${yFor(currentTemp)}
-            stroke="var(--feature-color)"
+            stroke=${customColor ?? "var(--feature-color)"}
             stroke-width="1"
             stroke-opacity="0.5"
             vector-effect="non-scaling-stroke"

--- a/src/panels/lovelace/card-features/hui-hourly-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-hourly-forecast-card-feature.ts
@@ -2,6 +2,8 @@ import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing, svg } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
+import { computeCssColor } from "../../../common/color/compute-color";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import "../../../components/ha-spinner";
@@ -157,6 +159,13 @@ class HuiHourlyForecastCardFeature
       `;
     }
 
+    const customColor = this._config.color
+      ? computeCssColor(this._config.color)
+      : undefined;
+    const graphStyle = customColor
+      ? styleMap({ "--feature-color": customColor })
+      : nothing;
+
     return html`
       <div class="layers">
         ${layer}
@@ -165,6 +174,7 @@ class HuiHourlyForecastCardFeature
               <hui-graph-base
                 .coordinates=${this._coordinates}
                 .yAxisOrigin=${this._yAxisOrigin}
+                style=${graphStyle}
               ></hui-graph-base>
             `
           : nothing}

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -257,6 +257,7 @@ export interface DailyForecastCardFeatureConfig {
   forecast_type?: "daily" | "twice_daily";
   days_to_show?: number;
   show_temperature?: boolean;
+  show_current_temperature?: boolean;
   show_precipitation?: boolean;
   precipitation_type?: ForecastPrecipitationType;
 }

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -250,6 +250,7 @@ export interface HourlyForecastCardFeatureConfig {
   show_temperature?: boolean;
   show_precipitation?: boolean;
   precipitation_type?: ForecastPrecipitationType;
+  color?: string;
 }
 
 export interface DailyForecastCardFeatureConfig {
@@ -260,6 +261,7 @@ export interface DailyForecastCardFeatureConfig {
   show_current_temperature?: boolean;
   show_precipitation?: boolean;
   precipitation_type?: ForecastPrecipitationType;
+  color?: string;
 }
 
 export const AREA_CONTROL_DOMAINS = [

--- a/src/panels/lovelace/editor/config-elements/hui-daily-forecast-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-daily-forecast-card-feature-editor.ts
@@ -1,3 +1,4 @@
+import { mdiThermometer, mdiWeatherRainy } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -75,41 +76,69 @@ export class HuiDailyForecastCardFeatureEditor
           selector: { number: { min: 1, mode: "box" } },
         },
         {
-          name: "show_temperature",
-          selector: { boolean: {} },
-        },
-        {
-          name: "show_current_temperature",
-          disabled: !showTemperature,
-          selector: { boolean: {} },
-        },
-        {
-          name: "show_precipitation",
-          selector: { boolean: {} },
-        },
-        {
-          name: "precipitation_type",
-          required: true,
-          disabled: !showPrecipitation,
-          selector: {
-            select: {
-              mode: "dropdown",
-              options: [
-                {
-                  value: "amount",
-                  label: localize(
-                    "ui.panel.lovelace.editor.features.types.daily-forecast.precipitation_type_options.amount"
-                  ),
-                },
-                {
-                  value: "probability",
-                  label: localize(
-                    "ui.panel.lovelace.editor.features.types.daily-forecast.precipitation_type_options.probability"
-                  ),
-                },
-              ],
+          name: "temperature",
+          type: "expandable",
+          flatten: true,
+          expanded: true,
+          iconPath: mdiThermometer,
+          schema: [
+            {
+              name: "show_temperature",
+              selector: { boolean: {} },
             },
-          },
+            {
+              name: "show_current_temperature",
+              disabled: !showTemperature,
+              selector: { boolean: {} },
+            },
+            {
+              name: "color",
+              disabled: !showTemperature,
+              selector: {
+                ui_color: {
+                  default_color: "state",
+                  include_state: true,
+                },
+              },
+            },
+          ],
+        },
+        {
+          name: "precipitation",
+          type: "expandable",
+          flatten: true,
+          expanded: true,
+          iconPath: mdiWeatherRainy,
+          schema: [
+            {
+              name: "show_precipitation",
+              selector: { boolean: {} },
+            },
+            {
+              name: "precipitation_type",
+              required: true,
+              disabled: !showPrecipitation,
+              selector: {
+                select: {
+                  mode: "dropdown",
+                  options: [
+                    {
+                      value: "amount",
+                      label: localize(
+                        "ui.panel.lovelace.editor.features.types.daily-forecast.precipitation_type_options.amount"
+                      ),
+                    },
+                    {
+                      value: "probability",
+                      label: localize(
+                        "ui.panel.lovelace.editor.features.types.daily-forecast.precipitation_type_options.probability"
+                      ),
+                    },
+                  ],
+                },
+              },
+            },
+          ],
         },
       ] as const satisfies readonly HaFormSchema[]
   );
@@ -191,6 +220,18 @@ export class HuiDailyForecastCardFeatureEditor
       case "precipitation_type":
         return this.hass!.localize(
           "ui.panel.lovelace.editor.features.types.daily-forecast.precipitation_type"
+        );
+      case "color":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.daily-forecast.color"
+        );
+      case "temperature":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.daily-forecast.temperature"
+        );
+      case "precipitation":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.daily-forecast.precipitation"
         );
       default:
         return "";

--- a/src/panels/lovelace/editor/config-elements/hui-daily-forecast-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-daily-forecast-card-feature-editor.ts
@@ -38,6 +38,7 @@ export class HuiDailyForecastCardFeatureEditor
     (
       supportsDaily: boolean,
       supportsTwiceDaily: boolean,
+      showTemperature: boolean,
       showPrecipitation: boolean,
       localize: HomeAssistant["localize"]
     ) =>
@@ -75,6 +76,11 @@ export class HuiDailyForecastCardFeatureEditor
         },
         {
           name: "show_temperature",
+          selector: { boolean: {} },
+        },
+        {
+          name: "show_current_temperature",
+          disabled: !showTemperature,
           selector: { boolean: {} },
         },
         {
@@ -123,19 +129,22 @@ export class HuiDailyForecastCardFeatureEditor
     const resolvedType =
       resolveDailyForecastType(stateObj, this._config.forecast_type) || "daily";
 
+    const showTemperature = this._config.show_temperature ?? true;
     const showPrecipitation = this._config.show_precipitation ?? false;
 
     const data: DailyForecastCardFeatureConfig = {
       ...this._config,
       forecast_type: resolvedType,
       days_to_show: this._config.days_to_show ?? DEFAULT_DAYS_TO_SHOW,
-      show_temperature: this._config.show_temperature ?? true,
+      show_temperature: showTemperature,
+      show_current_temperature: this._config.show_current_temperature ?? true,
       precipitation_type: this._config.precipitation_type ?? "amount",
     };
 
     const schema = this._schema(
       supportsDaily,
       supportsTwiceDaily,
+      showTemperature,
       showPrecipitation,
       this.hass.localize
     );
@@ -170,6 +179,10 @@ export class HuiDailyForecastCardFeatureEditor
       case "show_temperature":
         return this.hass!.localize(
           "ui.panel.lovelace.editor.features.types.daily-forecast.show_temperature"
+        );
+      case "show_current_temperature":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.daily-forecast.show_current_temperature"
         );
       case "show_precipitation":
         return this.hass!.localize(

--- a/src/panels/lovelace/editor/config-elements/hui-hourly-forecast-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-hourly-forecast-card-feature-editor.ts
@@ -1,3 +1,4 @@
+import { mdiThermometer, mdiWeatherRainy } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -31,7 +32,11 @@ export class HuiHourlyForecastCardFeatureEditor
   }
 
   private _schema = memoizeOne(
-    (showPrecipitation: boolean, localize: HomeAssistant["localize"]) =>
+    (
+      showTemperature: boolean,
+      showPrecipitation: boolean,
+      localize: HomeAssistant["localize"]
+    ) =>
       [
         {
           name: "hours_to_show",
@@ -39,36 +44,64 @@ export class HuiHourlyForecastCardFeatureEditor
           selector: { number: { min: 1, mode: "box" } },
         },
         {
-          name: "show_temperature",
-          selector: { boolean: {} },
-        },
-        {
-          name: "show_precipitation",
-          selector: { boolean: {} },
-        },
-        {
-          name: "precipitation_type",
-          required: true,
-          disabled: !showPrecipitation,
-          selector: {
-            select: {
-              mode: "dropdown",
-              options: [
-                {
-                  value: "amount",
-                  label: localize(
-                    "ui.panel.lovelace.editor.features.types.hourly-forecast.precipitation_type_options.amount"
-                  ),
-                },
-                {
-                  value: "probability",
-                  label: localize(
-                    "ui.panel.lovelace.editor.features.types.hourly-forecast.precipitation_type_options.probability"
-                  ),
-                },
-              ],
+          name: "temperature",
+          type: "expandable",
+          flatten: true,
+          expanded: true,
+          iconPath: mdiThermometer,
+          schema: [
+            {
+              name: "show_temperature",
+              selector: { boolean: {} },
             },
-          },
+            {
+              name: "color",
+              disabled: !showTemperature,
+              selector: {
+                ui_color: {
+                  default_color: "state",
+                  include_state: true,
+                },
+              },
+            },
+          ],
+        },
+        {
+          name: "precipitation",
+          type: "expandable",
+          flatten: true,
+          expanded: true,
+          iconPath: mdiWeatherRainy,
+          schema: [
+            {
+              name: "show_precipitation",
+              selector: { boolean: {} },
+            },
+            {
+              name: "precipitation_type",
+              required: true,
+              disabled: !showPrecipitation,
+              selector: {
+                select: {
+                  mode: "dropdown",
+                  options: [
+                    {
+                      value: "amount",
+                      label: localize(
+                        "ui.panel.lovelace.editor.features.types.hourly-forecast.precipitation_type_options.amount"
+                      ),
+                    },
+                    {
+                      value: "probability",
+                      label: localize(
+                        "ui.panel.lovelace.editor.features.types.hourly-forecast.precipitation_type_options.probability"
+                      ),
+                    },
+                  ],
+                },
+              },
+            },
+          ],
         },
       ] as const satisfies readonly HaFormSchema[]
   );
@@ -78,16 +111,21 @@ export class HuiHourlyForecastCardFeatureEditor
       return nothing;
     }
 
+    const showTemperature = this._config.show_temperature ?? true;
     const showPrecipitation = this._config.show_precipitation ?? false;
 
     const data: HourlyForecastCardFeatureConfig = {
       ...this._config,
       hours_to_show: this._config.hours_to_show ?? DEFAULT_HOURS_TO_SHOW,
-      show_temperature: this._config.show_temperature ?? true,
+      show_temperature: showTemperature,
       precipitation_type: this._config.precipitation_type ?? "amount",
     };
 
-    const schema = this._schema(showPrecipitation, this.hass.localize);
+    const schema = this._schema(
+      showTemperature,
+      showPrecipitation,
+      this.hass.localize
+    );
 
     return html`
       <ha-form
@@ -123,6 +161,18 @@ export class HuiHourlyForecastCardFeatureEditor
       case "precipitation_type":
         return this.hass!.localize(
           "ui.panel.lovelace.editor.features.types.hourly-forecast.precipitation_type"
+        );
+      case "color":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.hourly-forecast.color"
+        );
+      case "temperature":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.hourly-forecast.temperature"
+        );
+      case "precipitation":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.hourly-forecast.precipitation"
         );
       default:
         return "";

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10083,17 +10083,22 @@
               "hourly-forecast": {
                 "label": "Hourly forecast",
                 "no_forecast": "No forecast data available",
+                "temperature": "Temperature",
+                "precipitation": "Precipitation",
                 "show_temperature": "Show temperature",
                 "show_precipitation": "Show precipitation",
                 "precipitation_type": "Precipitation type",
                 "precipitation_type_options": {
                   "amount": "Amount",
                   "probability": "Probability"
-                }
+                },
+                "color": "Color"
               },
               "daily-forecast": {
                 "label": "Daily forecast",
                 "no_forecast": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::no_forecast%]",
+                "temperature": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::temperature%]",
+                "precipitation": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::precipitation%]",
                 "forecast_type": "Forecast type",
                 "forecast_type_options": {
                   "daily": "Daily",
@@ -10106,7 +10111,8 @@
                 "precipitation_type_options": {
                   "amount": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::precipitation_type_options::amount%]",
                   "probability": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::precipitation_type_options::probability%]"
-                }
+                },
+                "color": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::color%]"
               }
             }
           },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10100,6 +10100,7 @@
                   "twice_daily": "Twice daily"
                 },
                 "show_temperature": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::show_temperature%]",
+                "show_current_temperature": "Show current temperature",
                 "show_precipitation": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::show_precipitation%]",
                 "precipitation_type": "[%key:ui::panel::lovelace::editor::features::types::hourly-forecast::precipitation_type%]",
                 "precipitation_type_options": {


### PR DESCRIPTION
## Proposed change

Adds new options to the daily and hourly forecast tile card features and reorganizes their editors:

- New **Color** option — picks a static color for the temperature visualization (bars on daily, line graph on hourly), or defaults to `state` for the existing per-condition / `--feature-color` behavior.
- New **Show current temperature** option for the daily forecast — toggles the horizontal current-temperature line. On by default.
- The editor fields are grouped under two expandable sections (Temperature, Precipitation), expanded by default, to make the growing list of options easier to scan.

The color field is disabled in the editor when `Show temperature` is off.

## Screenshots
<img width="998" height="1514" alt="image" src="https://github.com/user-attachments/assets/c102928f-a095-468e-870b-9423972b5b0a" />


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: #51578
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/1593
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45054
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[perfect-pr]: https://developers.home-assistant.io/docs/development_checklist#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io