### PR TITLE
Revert global change from tooltip PR

### DIFF
--- a/src/resources/theme/color/color.globals.ts
+++ b/src/resources/theme/color/color.globals.ts
@@ -43,9 +43,9 @@ export const colorStyles = css`
     --info-color: #039be5;
 
     /* backgrounds */
-    --card-background-color: var(--ha-color-surface-default);
-    --primary-background-color: var(--ha-color-surface-low);
-    --secondary-background-color: var(--ha-color-surface-lower);
+    --card-background-color: #ffffff;
+    --primary-background-color: #fafafa;
+    --secondary-background-color: #e5e5e5;
     --clear-background-color: #ffffff;
 
     /* for label-badge */
@@ -263,7 +263,7 @@ export const colorStyles = css`
 
     --state-icon-error-color: var(--error-state-color, var(--error-color));
     --sidebar-text-color: var(--primary-text-color);
-    --sidebar-background-color: var(--ha-color-surface-default);
+    --sidebar-background-color: var(--card-background-color);
     --sidebar-selected-text-color: var(--primary-color);
     --sidebar-selected-icon-color: var(--primary-color);
     --sidebar-icon-color: rgba(var(--rgb-primary-text-color), 0.6);
@@ -341,14 +341,10 @@ export const colorStyles = css`
 
 export const darkColorStyles = css`
   html {
-    --card-background-color: var(--ha-color-surface-default);
-    --primary-background-color: var(--ha-color-surface-lower);
-    --secondary-background-color: var(--ha-color-surface-low);
-    --clear-background-color: #ffffff;
-
-    --sidebar-background-color: var(--ha-color-surface-low);
-    --card-background-color: var(--ha-color-surface-low);
-
+    --primary-background-color: #111111;
+    --card-background-color: #1c1c1c;
+    --secondary-background-color: #282828;
+    --clear-background-color: #111111;
     --primary-text-color: #e1e1e1;
     --secondary-text-color: #9b9b9b;
     --disabled-text-color: #6f6f6f;


### PR DESCRIPTION
## Proposed change

#30386 was scoped to tooltip cleanup but also rewired `--card-background-color`, `--primary-background-color`, `--secondary-background-color`, `--clear-background-color`, and `--sidebar-background-color` to the new `--ha-color-surface-*` tokens in both light and dark themes. 

This brings those variables back to their original hex values.

The `--ha-color-surface-*` tokens stay defined in `semantic.globals.ts` so the tooltip styling that depends on them is unaffected.

Also fixes `--clear-background-color` accidentally being set to `#ffffff` in dark mode.

## Screenshots

<!-- Add a before/after screenshot of a light-theme and dark-theme dashboard. -->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: follow-up to #30386
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
