### PR TITLE
Open more-info from energy devices detail graph legend

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -1484,6 +1484,7 @@ export class HaChartBase extends LitElement {
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
+      line-height: 1;
     }
     @media (hover: hover) {
       .chart-legend .label.clickable:hover {

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -53,6 +53,10 @@ export type CustomLegendOption = ECOption["legend"] & {
     name: string;
     value?: string; // Current value to display next to the name in the legend.
     itemStyle?: Record<string, any>;
+    // If true, label click does not fire `legend-label-click` even when the
+    // chart has `clickLabelForMoreInfo`; falls back to toggle. Used for items
+    // without a corresponding entity (e.g. external statistics).
+    noLabelClick?: boolean;
   }[];
 };
 
@@ -361,7 +365,6 @@ export class HaChartBase extends LitElement {
       class=${classMap({
         "chart-legend": true,
         "multiple-items": items.length > 1,
-        "label-clickable": this.clickLabelForMoreInfo,
       })}
     >
       <ul>
@@ -372,6 +375,7 @@ export class HaChartBase extends LitElement {
           let itemStyle: Record<string, any> = {};
           let id = "";
           let value = "";
+          let noLabelClick = false;
           const name = typeof item === "string" ? item : (item.name ?? "");
           if (typeof item === "string") {
             id = item;
@@ -379,7 +383,9 @@ export class HaChartBase extends LitElement {
             id = item.id ?? name;
             value = item.value ?? "";
             itemStyle = item.itemStyle ?? {};
+            noLabelClick = item.noLabelClick ?? false;
           }
+          const labelClickable = this.clickLabelForMoreInfo && !noLabelClick;
           const dataset =
             datasets.find((d) => d.id === id) ??
             datasets.find((d) => d.name === id);
@@ -419,7 +425,7 @@ export class HaChartBase extends LitElement {
             </button>
             <button
               type="button"
-              class="label"
+              class=${classMap({ label: true, clickable: labelClickable })}
               data-id=${id}
               .title=${name}
               @click=${this._labelClick}
@@ -1219,7 +1225,8 @@ export class HaChartBase extends LitElement {
       this._longPressTriggered = false;
       return;
     }
-    const id = (ev.currentTarget as HTMLElement).dataset.id;
+    const target = ev.currentTarget as HTMLElement;
+    const id = target.dataset.id;
     if (!id) {
       return;
     }
@@ -1228,7 +1235,7 @@ export class HaChartBase extends LitElement {
       this._soloLegend(id);
       return;
     }
-    if (this.clickLabelForMoreInfo) {
+    if (target.classList.contains("clickable")) {
       fireEvent(this, "legend-label-click", { id });
     } else {
       this._handleDatasetToggle(id);
@@ -1450,7 +1457,6 @@ export class HaChartBase extends LitElement {
     }
     .chart-legend li {
       height: 24px;
-      cursor: pointer;
       display: inline-flex;
       align-items: center;
       padding: 0 2px;
@@ -1480,7 +1486,7 @@ export class HaChartBase extends LitElement {
       overflow: hidden;
     }
     @media (hover: hover) {
-      .chart-legend.label-clickable .label:hover {
+      .chart-legend .label.clickable:hover {
         text-decoration: underline;
       }
       .chart-legend .legend-toggle:hover {

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -421,11 +421,7 @@ export class HaChartBase extends LitElement {
               type="button"
               class="label"
               data-id=${id}
-              title=${this.clickLabelForMoreInfo
-                ? this.hass.localize(
-                    "ui.components.history_charts.show_more_info"
-                  )
-                : nothing}
+              .title=${name}
               @click=${this._labelClick}
             >
               ${name}
@@ -1483,8 +1479,13 @@ export class HaChartBase extends LitElement {
       white-space: nowrap;
       overflow: hidden;
     }
-    .chart-legend.label-clickable .label:hover {
-      text-decoration: underline;
+    @media (hover: hover) {
+      .chart-legend.label-clickable .label:hover {
+        text-decoration: underline;
+      }
+      .chart-legend .legend-toggle:hover {
+        opacity: 0.5;
+      }
     }
     .chart-legend .value {
       color: var(--secondary-text-color);
@@ -1503,9 +1504,6 @@ export class HaChartBase extends LitElement {
       padding: 4px;
       margin: -4px;
       margin-inline-end: 0;
-    }
-    .chart-legend .legend-toggle:hover {
-      opacity: 0.5;
     }
     .chart-legend .legend-toggle:focus-visible,
     .chart-legend .label:focus-visible {

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -195,7 +195,8 @@ export class StatisticsChart extends LitElement {
         @dataset-hidden=${this._datasetHidden}
         @dataset-unhidden=${this._datasetUnhidden}
         .expandLegend=${this.expandLegend}
-        .clickLabelForMoreInfo=${this.clickForMoreInfo}
+        .clickLabelForMoreInfo=${this.clickForMoreInfo &&
+        !this._statisticIds.every(isExternalStatistic)}
         @legend-label-click=${this._handleLegendLabelClick}
       ></ha-chart-base>
     `;
@@ -433,6 +434,7 @@ export class StatisticsChart extends LitElement {
       name: string;
       color?: ZRColor;
       borderColor?: ZRColor;
+      noLabelClick?: boolean;
     }[] = [];
     const statisticIds: string[] = [];
     let endTime: Date;
@@ -636,6 +638,7 @@ export class StatisticsChart extends LitElement {
                 name,
                 color: series.color as ZRColor,
                 borderColor: series.itemStyle?.borderColor,
+                noLabelClick: isExternalStatistic(statistic_id),
               });
             }
             displayedLegend = displayedLegend || showLegend;
@@ -771,7 +774,11 @@ export class StatisticsChart extends LitElement {
       // only update the legend if it has changed or it will trigger options update
       this._legendData =
         legendData.length > 1
-          ? legendData.map(({ id, name }) => ({ id, name }))
+          ? legendData.map(({ id, name, noLabelClick }) => ({
+              id,
+              name,
+              noLabelClick,
+            }))
           : // if there is only one entity, let the base chart handle the legend
             undefined;
     }

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
@@ -25,7 +25,10 @@ import type { Statistics, StatisticsMetaData } from "../../../../data/recorder";
 import {
   calculateStatisticSumGrowth,
   getStatisticLabel,
+  isExternalStatistic,
 } from "../../../../data/recorder";
+import type { HASSDomEvent } from "../../../../common/dom/fire_event";
+import { fireEvent } from "../../../../common/dom/fire_event";
 import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
 import type { HomeAssistant } from "../../../../types";
@@ -156,8 +159,10 @@ export class HuiEnergyDevicesDetailGraphCard
               this._compareStart,
               this._compareEnd
             )}
+            click-label-for-more-info
             @dataset-hidden=${this._datasetHidden}
             @dataset-unhidden=${this._datasetUnhidden}
+            @legend-label-click=${this._handleLegendLabelClick}
           ></ha-chart-base>
         </div>
       </ha-card>
@@ -183,6 +188,18 @@ export class HuiEnergyDevicesDetailGraphCard
     this._hiddenStats = this._hiddenStats.filter(
       (stat) => stat !== this._getStatIdFromId(ev.detail.id)
     );
+  }
+
+  private _handleLegendLabelClick(
+    ev: HASSDomEvent<HASSDomEvents["legend-label-click"]>
+  ) {
+    const entityId = this._getStatIdFromId(ev.detail.id);
+    if (isExternalStatistic(entityId)) {
+      return;
+    }
+    if (this.hass.states[entityId]) {
+      fireEvent(this, "hass-more-info", { entityId });
+    }
   }
 
   private _createOptions = memoizeOne(
@@ -349,15 +366,19 @@ export class HuiEnergyDevicesDetailGraphCard
     );
 
     datasets.push(...processedData);
-    this._legendData = processedData.map((d) => ({
-      id: d.id as string,
-      secondaryIds: [`compare-${d.id}`],
-      name: d.name as string,
-      itemStyle: {
-        color: d.color as string,
-        borderColor: d.itemStyle?.borderColor as string,
-      },
-    }));
+    this._legendData = processedData.map((d) => {
+      const statId = this._getStatIdFromId(d.id as string);
+      return {
+        id: d.id as string,
+        secondaryIds: [`compare-${d.id}`],
+        name: d.name as string,
+        itemStyle: {
+          color: d.color as string,
+          borderColor: d.itemStyle?.borderColor as string,
+        },
+        noLabelClick: isExternalStatistic(statId) || !this.hass.states[statId],
+      };
+    });
 
     if (showUntracked) {
       const untrackedData = this._processUntracked(
@@ -375,6 +396,7 @@ export class HuiEnergyDevicesDetailGraphCard
           color: untrackedData.color as string,
           borderColor: untrackedData.itemStyle?.borderColor as string,
         },
+        noLabelClick: true,
       });
     }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1104,8 +1104,7 @@
         "zoom_reset": "Reset zoom",
         "expand_legend": "More",
         "collapse_legend": "Less",
-        "toggle_visibility": "Toggle visibility",
-        "show_more_info": "Show more info"
+        "toggle_visibility": "Toggle visibility"
       },
       "map": {
         "error": "Unable to load map"


### PR DESCRIPTION
## Proposed change

Continued from #28517 

Match the legend label-click behavior already in history-graph and statistics-graph cards: clicking a device's label in the energy devices detail graph opens the entity's more-info dialog. The icon click continues to toggle visibility.

To make this safe, the chart-base legend gains a per-item `noLabelClick` flag so individual entries (external statistics, missing entities, the synthetic "untracked consumption" row) keep the legacy toggle-on-label behavior with no underline affordance. Two unrelated chart-legend nits surfaced during testing are also addressed:

- Restore the full series name as the label tooltip on hover (was lost when the `<li>` no longer carried `title`), so truncated legend entries can be revealed again.
- Scope the legend hover effects to `@media (hover: hover)` so taps on touch devices don't leave items stuck underlined or at 50% opacity.
- Drop the redundant `cursor: pointer` from `.chart-legend li`, which was leaking onto the (non-interactive) current-value column and the row's empty padding now that the click targets are `<button>` children with their own cursor.
- For statistics-graph charts where every series is an external statistic, gate the chart-wide `clickLabelForMoreInfo` to false (covers the single-entity fallback case where the per-item flag doesn't reach `ha-chart-base`).

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #28517
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr