### PR TITLE
Fix duplicate ha-panel-custom on first mount

### DIFF
--- a/src/panels/custom/ha-panel-custom.ts
+++ b/src/panels/custom/ha-panel-custom.ts
@@ -34,6 +34,8 @@ export class HaPanelCustom extends ReactiveElement {
 
   private _setProperties?: (props: Record<string, unknown>) => void;
 
+  private _wasDisconnected = false;
+
   protected createRenderRoot() {
     return this;
   }
@@ -56,18 +58,19 @@ export class HaPanelCustom extends ReactiveElement {
 
   public connectedCallback() {
     super.connectedCallback();
-    // The suspendWhenHidden disconnect timer in partial-panel-resolver
-    // removes this element from the DOM after 5 minutes, which triggers
-    // _cleanupPanel() and destroys our child panel. When the user returns,
-    // the same element is re-appended but `update()` won't call _createPanel
-    // again (the `panel` property reference hasn't changed). Rebuild here.
-    if (!this._setProperties && !this.hasChildNodes() && this.panel) {
+    // Only rebuild when reattached after a real disconnect (the 5-minute
+    // suspendWhenHidden timer in partial-panel-resolver). On first mount,
+    // update() handles creation via the panel-changed branch, so calling
+    // _createPanel here too would start a duplicate loadCustomPanel().
+    if (this._wasDisconnected && this.panel) {
+      this._wasDisconnected = false;
       this._createPanel(this.panel);
     }
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
+    this._wasDisconnected = true;
     this._cleanupPanel();
   }
 
@@ -139,6 +142,12 @@ export class HaPanelCustom extends ReactiveElement {
     if (!config.embed_iframe) {
       loadCustomPanel(config).then(
         () => {
+          // loadCustomPanel caches its Promise, so a detach/reattach cycle
+          // during load can fan out multiple .then callbacks onto it. Skip
+          // any that arrive after we've already populated or been removed.
+          if (!this.isConnected || this._setProperties) {
+            return;
+          }
           const element = createCustomPanelElement(config);
           this._setProperties = (props) =>
             setCustomPanelProperties(element, props);


### PR DESCRIPTION
## Proposed change

Follow-up to #51727. After that merged, every non-iframe custom sidebar panel renders **twice** on first mount.

Root cause: `hass-router-page` assigns `el.panel` (queueing a Lit update) before `appendChild`. The new `connectedCallback` guard from #51727 fires `_createPanel` synchronously, then the queued `update()` fires `_createPanel` again. Both `loadCustomPanel(...).then` callbacks fan out onto the same cached promise and append a child each.

Fix: track `_wasDisconnected` so `connectedCallback` only rebuilds on reattach (not first mount, where `update()` already handles it). Plus a defensive bail in the `.then` callback if `_setProperties` is already set or the element is detached, covering the in-flight-load case raised in [the comment thread](https://github.com/home-assistant/frontend/pull/51727#issuecomment-4340365943) by @dcapslock .

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes regression in #51727
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr