### PR TITLE
Add Ctrl/Cmd+Click legend solo shortcut to shortcuts dialog

### DIFF
--- a/src/dialogs/shortcuts/dialog-shortcuts.ts
+++ b/src/dialogs/shortcuts/dialog-shortcuts.ts
@@ -148,6 +148,16 @@ const _SHORTCUTS: Section[] = [
         ],
         descriptionTranslationKey: "ui.dialogs.shortcuts.charts.double_click",
       },
+      {
+        shortcut: [
+          CTRL_CMD,
+          {
+            shortcutTranslationKey: "ui.dialogs.shortcuts.shortcuts.click",
+          },
+        ],
+        descriptionTranslationKey:
+          "ui.dialogs.shortcuts.charts.click_legend_solo",
+      },
     ],
   },
   {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2372,6 +2372,7 @@
         },
         "shortcuts": {
           "double_click": "Double-click",
+          "click": "Click",
           "scroll_wheel": "Scroll",
           "drag": "Drag"
         },
@@ -2403,7 +2404,8 @@
           "title": "Charts",
           "drag_to_zoom": "to zoom in part of a chart",
           "scroll_to_zoom": "to zoom in or out",
-          "double_click": "to zoom in on part of the chart"
+          "double_click": "to zoom in on part of the chart",
+          "click_legend_solo": "on a chart legend item to show only that series"
         },
         "other": {
           "title": "Other",


### PR DESCRIPTION
## Proposed change

Documents the chart legend solo/isolate interaction in the keyboard shortcuts dialog (accessible via Shift+?).

When viewing a chart, pressing Ctrl (or Cmd on Mac) and clicking a legend item isolates that series — hiding all others. Clicking again restores all series. This behavior was introduced in #28517 but was not listed in the shortcuts dialog.

This PR adds a new entry to the **Charts** section of the shortcuts dialog:
> **Ctrl/Cmd + Click** — on a chart legend item to show only that series

## Screenshots

_Please add a screenshot of the updated shortcuts dialog after review._

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #28517
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr