### PR TITLE
Expose Z-Wave exclusion instructions when removing device

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
@@ -197,14 +197,16 @@ class DialogZWaveJSRemoveNode extends LitElement {
               )}</b
             >
             ${this.hass.localize(
-              exclusion
-                ? "ui.panel.config.zwave_js.remove_node.trigger_device_exclusion"
-                : "ui.panel.config.zwave_js.remove_node.follow_device_instructions"
+              "ui.panel.config.zwave_js.remove_node.trigger_device_exclusion"
             )}
           </p>
           ${exclusion
             ? html`<ha-markdown breaks .content=${exclusion}></ha-markdown>`
-            : nothing}
+            : html`<p>
+                ${this.hass.localize(
+                  "ui.panel.config.zwave_js.remove_node.follow_device_instructions"
+                )}
+              </p>`}
         </div>
       `;
     }

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
@@ -8,15 +8,18 @@ import "../../../../../components/ha-alert";
 import "../../../../../components/ha-button";
 import "../../../../../components/ha-icon-next";
 import "../../../../../components/ha-list-item";
+import "../../../../../components/ha-markdown";
 import "../../../../../components/ha-spinner";
 import "../../../../../components/ha-dialog-footer";
 import "../../../../../components/ha-dialog";
 import type { DeviceRegistryEntry } from "../../../../../data/device/device_registry";
 import {
+  fetchZwaveNodeMetadata,
   fetchZwaveNodeStatus,
   NodeStatus,
   removeFailedZwaveNode,
 } from "../../../../../data/zwave_js";
+import type { ZwaveJSNodeMetadata } from "../../../../../data/zwave_js";
 import { haStyleDialog } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import type { ZWaveJSRemoveNodeDialogParams } from "./show-dialog-zwave_js-remove-node";
@@ -51,6 +54,8 @@ class DialogZWaveJSRemoveNode extends LitElement {
 
   @state() private _node?: ZWaveJSRemovedNode;
 
+  @state() private _metadata?: ZwaveJSNodeMetadata;
+
   @state() private _onClose?: () => void;
 
   private _removeNodeTimeoutHandle?: number;
@@ -78,6 +83,16 @@ class DialogZWaveJSRemoveNode extends LitElement {
       this._device = this.hass.devices[this._deviceId];
       this._step =
         nodeStatus.status === NodeStatus.Dead ? "start_removal" : "start";
+      if (nodeStatus.status !== NodeStatus.Dead) {
+        fetchZwaveNodeMetadata(this.hass, this._deviceId!).then(
+          (metadata) => {
+            this._metadata = metadata;
+          },
+          () => {
+            // instructions are supplemental — ignore fetch errors
+          }
+        );
+      }
     } else if (params.skipConfirmation) {
       this._startExclusion();
     } else {
@@ -170,13 +185,37 @@ class DialogZWaveJSRemoveNode extends LitElement {
       `;
     }
 
-    if (["exclusion", "remove"].includes(this._step)) {
+    if (this._step === "exclusion") {
+      const exclusion = this._metadata?.exclusion?.trim();
+      return html`
+        <ha-spinner></ha-spinner>
+        <div>
+          <p>
+            <b
+              >${this.hass.localize(
+                "ui.panel.config.zwave_js.remove_node.ready_to_remove"
+              )}</b
+            >
+            ${this.hass.localize(
+              exclusion
+                ? "ui.panel.config.zwave_js.remove_node.trigger_device_exclusion"
+                : "ui.panel.config.zwave_js.remove_node.follow_device_instructions"
+            )}
+          </p>
+          ${exclusion
+            ? html`<ha-markdown breaks .content=${exclusion}></ha-markdown>`
+            : nothing}
+        </div>
+      `;
+    }
+
+    if (this._step === "remove") {
       return html`
         <ha-spinner></ha-spinner>
         <div>
           <p>
             ${this.hass.localize(
-              `ui.panel.config.zwave_js.remove_node.${this._step === "exclusion" ? "follow_device_instructions" : "removing_device"}`
+              "ui.panel.config.zwave_js.remove_node.removing_device"
             )}
           </p>
         </div>
@@ -343,6 +382,7 @@ class DialogZWaveJSRemoveNode extends LitElement {
   public handleDialogClosed(): void {
     this._unsubscribe();
     this._entryId = undefined;
+    this._metadata = undefined;
     this._step = "start";
     this._open = false;
     if (this._onClose) {
@@ -369,6 +409,11 @@ class DialogZWaveJSRemoveNode extends LitElement {
 
         .content p {
           color: var(--secondary-text-color);
+        }
+
+        .content ha-markdown {
+          color: var(--secondary-text-color);
+          text-align: start;
         }
 
         ha-alert {

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
@@ -77,6 +77,7 @@ class DialogZWaveJSRemoveNode extends LitElement {
     this._entryId = params.entryId;
     this._deviceId = params.deviceId;
     this._onClose = params.onClose;
+    this._metadata = undefined;
     this._open = true;
     if (this._deviceId) {
       const nodeStatus = await fetchZwaveNodeStatus(this.hass, this._deviceId!);
@@ -84,13 +85,14 @@ class DialogZWaveJSRemoveNode extends LitElement {
       this._step =
         nodeStatus.status === NodeStatus.Dead ? "start_removal" : "start";
       if (nodeStatus.status !== NodeStatus.Dead) {
-        fetchZwaveNodeMetadata(this.hass, this._deviceId).then(
+        const requestedDeviceId = this._deviceId;
+        fetchZwaveNodeMetadata(this.hass, requestedDeviceId).then(
           (metadata) => {
-            this._metadata = metadata;
+            if (this._deviceId === requestedDeviceId) {
+              this._metadata = metadata;
+            }
           },
-          () => {
-            // instructions are supplemental — ignore fetch errors
-          }
+          () => {}
         );
       }
     } else if (params.skipConfirmation) {
@@ -415,7 +417,6 @@ class DialogZWaveJSRemoveNode extends LitElement {
 
         .content ha-markdown {
           color: var(--secondary-text-color);
-          text-align: start;
         }
 
         ha-alert {

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
@@ -84,7 +84,7 @@ class DialogZWaveJSRemoveNode extends LitElement {
       this._step =
         nodeStatus.status === NodeStatus.Dead ? "start_removal" : "start";
       if (nodeStatus.status !== NodeStatus.Dead) {
-        fetchZwaveNodeMetadata(this.hass, this._deviceId!).then(
+        fetchZwaveNodeMetadata(this.hass, this._deviceId).then(
           (metadata) => {
             this._metadata = metadata;
           },

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-remove-node.ts
@@ -92,7 +92,9 @@ class DialogZWaveJSRemoveNode extends LitElement {
               this._metadata = metadata;
             }
           },
-          () => {}
+          () => {
+            // instructions are supplemental — ignore fetch errors
+          }
         );
       }
     } else if (params.skipConfirmation) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7673,7 +7673,7 @@
             "start_exclusion": "Start exclusion",
             "cancel_exclusion": "Cancel exclusion",
             "ready_to_remove": "Ready to remove device.",
-            "follow_device_instructions": "Follow the directions that came with your device to trigger exclusion on the device.",
+            "follow_device_instructions": "Follow the directions that came with your device.",
             "trigger_device_exclusion": "To trigger exclusion on the device:",
             "removing_device": "Removing device",
             "exclusion_failed": "An error occurred. Please check the logs for more information.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7672,7 +7672,9 @@
             "menu_remove_device": "Force-remove an unavailable device",
             "start_exclusion": "Start exclusion",
             "cancel_exclusion": "Cancel exclusion",
+            "ready_to_remove": "Ready to remove device.",
             "follow_device_instructions": "Follow the directions that came with your device to trigger exclusion on the device.",
+            "trigger_device_exclusion": "To trigger exclusion on the device:",
             "removing_device": "Removing device",
             "exclusion_failed": "An error occurred. Please check the logs for more information.",
             "exclusion_finished": "Device {id} has been removed from your Z-Wave network."


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Getting a Z-Wave device into exclusion mode can require quite some voodoo, depending on the device. Currently, we only tell the user to follow the instructions that came with the device, which is not very user friendly.

Z-Wave JS has better instructions for a wide range of devices. This PR exposes these in the frontend when removing a specific device.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

**If the instructions are known:**  
<img width="634" height="331" alt="grafik" src="https://github.com/user-attachments/assets/ecf69eb0-ef1e-45d6-b8e1-086247ee3a17" />

**If the instructions are unknown:**  
<img width="634" height="331" alt="grafik" src="https://github.com/user-attachments/assets/92f2e35d-f07d-410b-8814-dbb8e48ca396" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
