### PR TITLE
Refactor events devtools tab layout and events output card

### DIFF
--- a/src/panels/config/developer-tools/event/developer-tools-event.ts
+++ b/src/panels/config/developer-tools/event/developer-tools-event.ts
@@ -18,7 +18,7 @@ import "./events-list";
 class HaPanelDevEvent extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property({ type: Boolean }) public narrow = false;
+  @property({ type: Boolean, reflect: true }) public narrow = false;
 
   @state() private _eventType = "";
 
@@ -94,6 +94,7 @@ class HaPanelDevEvent extends LitElement {
 
           <event-subscribe-card
             .hass=${this.hass}
+            .narrow=${this.narrow}
             .selectedEventType=${this._selectedEventType}
           ></event-subscribe-card>
         </div>
@@ -170,11 +171,23 @@ class HaPanelDevEvent extends LitElement {
           height: 100%;
         }
 
+        :host([narrow]) {
+          height: auto;
+        }
+
+        :host([narrow]) .content {
+          height: auto;
+        }
+
         .flex {
           min-width: 0;
           min-height: 0;
           display: flex;
           flex-direction: column;
+        }
+
+        :host([narrow]) .flex {
+          min-height: auto;
         }
 
         .inputs {
@@ -192,6 +205,11 @@ class HaPanelDevEvent extends LitElement {
           flex: 1;
           margin-top: var(--ha-space-4);
           direction: var(--direction);
+        }
+
+        :host([narrow]) event-subscribe-card {
+          flex: none;
+          min-height: auto;
         }
 
         a {

--- a/src/panels/config/developer-tools/event/developer-tools-event.ts
+++ b/src/panels/config/developer-tools/event/developer-tools-event.ts
@@ -158,6 +158,8 @@ class HaPanelDevEvent extends LitElement {
           padding: var(--ha-space-4);
           max-width: 1200px;
           margin: auto;
+          height: 100%;
+          box-sizing: border-box;
         }
 
         :host {
@@ -165,10 +167,14 @@ class HaPanelDevEvent extends LitElement {
           -webkit-user-select: initial;
           -moz-user-select: initial;
           display: block;
+          height: 100%;
         }
 
         .flex {
           min-width: 0;
+          min-height: 0;
+          display: flex;
+          flex-direction: column;
         }
 
         .inputs {
@@ -180,7 +186,10 @@ class HaPanelDevEvent extends LitElement {
         }
 
         event-subscribe-card {
-          display: block;
+          display: flex;
+          flex-direction: column;
+          min-height: 0;
+          flex: 1;
           margin-top: var(--ha-space-4);
           direction: var(--direction);
         }

--- a/src/panels/config/developer-tools/event/event-subscribe-card.ts
+++ b/src/panels/config/developer-tools/event/event-subscribe-card.ts
@@ -32,6 +32,8 @@ interface SubscribedEvent {
 class EventSubscribeCard extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
+  @property({ type: Boolean, reflect: true }) public narrow = false;
+
   @property({ attribute: false }) public selectedEventType = "";
 
   @state() private _eventType = "";
@@ -398,6 +400,10 @@ class EventSubscribeCard extends LitElement {
       flex-direction: column;
       height: 620px;
       padding: var(--ha-space-2);
+    }
+    :host([narrow]) .events-card {
+      height: auto;
+      min-height: 360px;
     }
     .events-toolbar {
       display: flex;

--- a/src/panels/config/developer-tools/event/event-subscribe-card.ts
+++ b/src/panels/config/developer-tools/event/event-subscribe-card.ts
@@ -44,11 +44,10 @@ class EventSubscribeCard extends LitElement {
 
   @state() private _error?: string;
 
-  @state() private _viewedEventId?: number;
-
   // Tracks which event the user is currently viewing. Stored by id rather
   // than buffer index so the view survives the buffer shifting as new events
   // arrive. New events never auto-advance the view; the user must navigate.
+  @state() private _viewedEventId?: number;
 
   private _eventCount = 0;
 
@@ -152,15 +151,11 @@ class EventSubscribeCard extends LitElement {
       `;
     }
     const bufferTotal = this._events.length;
-    // Find the viewed event. If it has aged out of the buffer (or none is
-    // tracked yet), fall back to the oldest available event so the view
-    // stays close to where the user was rather than jumping around.
     const index = this._resolveViewedIndex();
     const event = this._events[index];
     const position = event.id + 1;
-    // Counter shows the viewed event's slot within the buffer (1 = newest
-    // buffered, bufferTotal = oldest). Stays stable as the buffer fills,
-    // even though the absolute event number in the title keeps growing.
+    // Slot within the buffer (1 = newest buffered, bufferTotal = oldest);
+    // stays stable as the buffer fills.
     const bufferPosition = bufferTotal - index;
     const atNewest = index === 0;
     // Buffer has rolled over once the oldest buffered event isn't event 1.
@@ -247,51 +242,49 @@ class EventSubscribeCard extends LitElement {
       return 0;
     }
     const found = this._events.findIndex((e) => e.id === this._viewedEventId);
-    // Viewed event has aged out of the buffer: fall back to the oldest
-    // available event (closest to where the user was viewing).
+    // Fall back to the oldest available event when the viewed one has aged out.
     return found === -1 ? this._events.length - 1 : found;
   }
 
-  private _showOldest(): void {
+  private _showOldest() {
     if (!this._events.length) {
       return;
     }
     this._viewedEventId = this._events[this._events.length - 1].id;
   }
 
-  private _showOlder(): void {
+  private _showOlder() {
     if (!this._events.length) {
       return;
     }
-    const current = this._resolveViewedIndex();
-    const next = Math.min(current + 1, this._events.length - 1);
+    const next = Math.min(
+      this._resolveViewedIndex() + 1,
+      this._events.length - 1
+    );
     this._viewedEventId = this._events[next].id;
   }
 
-  private _showNewest(): void {
+  private _showNewest() {
     if (!this._events.length) {
       return;
     }
-    // Jump to the current newest event. New events arriving after this will
-    // not auto-advance the view; the user must press this button again.
     this._viewedEventId = this._events[0].id;
   }
 
-  private _showNewer(): void {
+  private _showNewer() {
     if (!this._events.length) {
       return;
     }
-    const current = this._resolveViewedIndex();
-    const next = Math.max(current - 1, 0);
+    const next = Math.max(this._resolveViewedIndex() - 1, 0);
     this._viewedEventId = this._events[next].id;
   }
 
-  private _valueChanged(ev: InputEvent): void {
+  private _valueChanged(ev: InputEvent) {
     this._eventType = (ev.target as HaInput).value ?? "";
     this._error = undefined;
   }
 
-  private _filterChanged(ev: InputEvent): void {
+  private _filterChanged(ev: InputEvent) {
     this._eventFilter = (ev.target as HaInput).value ?? "";
   }
 
@@ -356,28 +349,27 @@ class EventSubscribeCard extends LitElement {
               },
               ...tail,
             ];
-            // Land on the very first event (position 1, id 0) and stay
-            // there until the user navigates.
             if (this._viewedEventId === undefined) {
               this._viewedEventId = id;
             }
           }, this._eventType);
-      } catch (error: any) {
+      } catch (error) {
         this._error = this.hass!.localize(
           "ui.panel.config.developer-tools.tabs.events.subscribe_failed",
           {
             error:
-              error.message ??
-              this.hass!.localize(
-                "ui.panel.config.developer-tools.tabs.events.unknown_error"
-              ),
+              error instanceof Error
+                ? error.message
+                : this.hass!.localize(
+                    "ui.panel.config.developer-tools.tabs.events.unknown_error"
+                  ),
           }
         );
       }
     }
   }
 
-  private _clearEvents(): void {
+  private _clearEvents() {
     this._events = [];
     this._eventCount = 0;
     this._ignoredEventsCount = 0;

--- a/src/panels/config/developer-tools/event/event-subscribe-card.ts
+++ b/src/panels/config/developer-tools/event/event-subscribe-card.ts
@@ -1,12 +1,18 @@
+import {
+  mdiChevronDoubleLeft,
+  mdiChevronDoubleRight,
+  mdiChevronLeft,
+  mdiChevronRight,
+} from "@mdi/js";
 import type { HassEvent } from "home-assistant-js-websocket";
 import type { TemplateResult, PropertyValues } from "lit";
-import { css, html, LitElement, nothing } from "lit";
+import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { repeat } from "lit/directives/repeat";
-import { formatTime } from "../../../../common/datetime/format_time";
+import { formatTimeWithSeconds } from "../../../../common/datetime/format_time";
 import "../../../../components/ha-alert";
 import "../../../../components/ha-button";
 import "../../../../components/ha-card";
+import "../../../../components/ha-icon-button";
 import "../../../../components/ha-yaml-editor";
 import "../../../../components/input/ha-input";
 import type { HaInput } from "../../../../components/input/ha-input";
@@ -32,6 +38,8 @@ class EventSubscribeCard extends LitElement {
   @state() private _events: SubscribedEvent[] = [];
 
   @state() private _error?: string;
+
+  @state() private _viewedEventId?: number;
 
   private _eventCount = 0;
 
@@ -115,36 +123,126 @@ class EventSubscribeCard extends LitElement {
           </ha-button>
         </div>
       </ha-card>
-      ${this._events.length
-        ? html`<ha-card>
-            <div class="card-content">
-              <div class="events">
-                ${repeat(
-                  this._events,
-                  (event: SubscribedEvent) => event.id,
-                  (event: SubscribedEvent) =>
-                    html`<div class="event">
-                      ${this.hass!.localize(
-                        "ui.panel.config.developer-tools.tabs.events.event_fired",
-                        { name: event.id }
-                      )}
-                      ${formatTime(
-                        new Date(event.event.time_fired),
-                        this.hass!.locale,
-                        this.hass!.config
-                      )}:
-                      <ha-yaml-editor
-                        .hass=${this.hass}
-                        .defaultValue=${event.event}
-                        read-only
-                      ></ha-yaml-editor>
-                    </div>`
-                )}
-              </div>
-            </div>
-          </ha-card>`
-        : nothing}
+      ${this._renderEventsCard()}
     `;
+  }
+
+  private _renderEventsCard(): TemplateResult {
+    if (!this._events.length) {
+      const message = this._subscribed
+        ? this.hass!.localize(
+            "ui.panel.config.developer-tools.tabs.events.waiting_for_events"
+          )
+        : this.hass!.localize(
+            "ui.panel.config.developer-tools.tabs.events.subscribe_prompt"
+          );
+      return html`
+        <ha-card class="events-card">
+          <div class="empty-state">${message}</div>
+        </ha-card>
+      `;
+    }
+    const total = this._events.length;
+    // Events are stored newest-first. If the user hasn't navigated, show the
+    // newest (index 0). Once they navigate, pin to the chosen event id.
+    const index =
+      this._viewedEventId === undefined
+        ? 0
+        : Math.max(
+            0,
+            this._events.findIndex((e) => e.id === this._viewedEventId)
+          );
+    const event = this._events[index];
+    return html`
+      <ha-card class="events-card">
+        <div class="events-toolbar">
+          <ha-icon-button
+            .path=${mdiChevronDoubleLeft}
+            .disabled=${index >= total - 1}
+            .label=${this.hass!.localize(
+              "ui.panel.config.developer-tools.tabs.events.oldest_event"
+            )}
+            @click=${this._showOldest}
+          ></ha-icon-button>
+          <ha-icon-button
+            .path=${mdiChevronLeft}
+            .disabled=${index >= total - 1}
+            .label=${this.hass!.localize(
+              "ui.panel.config.developer-tools.tabs.events.older_event"
+            )}
+            @click=${this._showOlder}
+          ></ha-icon-button>
+          <div class="event-info">
+            ${this.hass!.localize(
+              "ui.panel.config.developer-tools.tabs.events.event_fired",
+              { name: event.id + 1 }
+            )}
+            ${formatTimeWithSeconds(
+              new Date(event.event.time_fired),
+              this.hass!.locale,
+              this.hass!.config
+            )}
+            <span class="counter">(${total - index} / ${total})</span>
+          </div>
+          <ha-icon-button
+            .path=${mdiChevronRight}
+            .disabled=${index <= 0}
+            .label=${this.hass!.localize(
+              "ui.panel.config.developer-tools.tabs.events.newer_event"
+            )}
+            @click=${this._showNewer}
+          ></ha-icon-button>
+          <ha-icon-button
+            .path=${mdiChevronDoubleRight}
+            .disabled=${this._viewedEventId === undefined}
+            .label=${this.hass!.localize(
+              "ui.panel.config.developer-tools.tabs.events.newest_event"
+            )}
+            @click=${this._showNewest}
+          ></ha-icon-button>
+        </div>
+        <ha-yaml-editor
+          .hass=${this.hass}
+          .value=${event.event}
+          auto-update
+          read-only
+        ></ha-yaml-editor>
+      </ha-card>
+    `;
+  }
+
+  private _showOldest(): void {
+    if (!this._events.length) {
+      return;
+    }
+    this._viewedEventId = this._events[this._events.length - 1].id;
+  }
+
+  private _showOlder(): void {
+    const total = this._events.length;
+    const current =
+      this._viewedEventId === undefined
+        ? 0
+        : this._events.findIndex((e) => e.id === this._viewedEventId);
+    const next = Math.min(current + 1, total - 1);
+    this._viewedEventId = this._events[next].id;
+  }
+
+  private _showNewest(): void {
+    // Resume auto-follow on incoming events.
+    this._viewedEventId = undefined;
+  }
+
+  private _showNewer(): void {
+    if (this._viewedEventId === undefined) {
+      return;
+    }
+
+    const current = this._events.findIndex((e) => e.id === this._viewedEventId);
+    const next = Math.max(current - 1, 0);
+
+    // Reaching the newest event resumes auto-follow on incoming events.
+    this._viewedEventId = next === 0 ? undefined : this._events[next].id;
   }
 
   private _valueChanged(ev: InputEvent): void {
@@ -220,7 +318,13 @@ class EventSubscribeCard extends LitElement {
       } catch (error: any) {
         this._error = this.hass!.localize(
           "ui.panel.config.developer-tools.tabs.events.subscribe_failed",
-          { error: error.message || "Unknown error" }
+          {
+            error:
+              error.message ??
+              this.hass!.localize(
+                "ui.panel.config.developer-tools.tabs.events.unknown_error"
+              ),
+          }
         );
       }
     }
@@ -231,30 +335,65 @@ class EventSubscribeCard extends LitElement {
     this._eventCount = 0;
     this._ignoredEventsCount = 0;
     this._error = undefined;
+    this._viewedEventId = undefined;
   }
 
   static styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+    }
     ha-input {
       margin-bottom: var(--ha-space-2);
     }
     .error-message {
       margin-top: var(--ha-space-2);
     }
-    .event {
-      border-top: 1px solid var(--divider-color);
-      padding-top: var(--ha-space-2);
-      padding-bottom: var(--ha-space-2);
-      margin: var(--ha-space-4) 0;
-    }
-    .event:last-child {
-      border-bottom: 0;
-      margin-bottom: 0;
-    }
     pre {
       font-family: var(--ha-font-family-code);
     }
     ha-card {
       margin-bottom: var(--ha-space-2);
+    }
+    .events-card {
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      flex: 1;
+      padding: var(--ha-space-2);
+    }
+    .events-toolbar {
+      display: flex;
+      align-items: center;
+      gap: var(--ha-space-2);
+    }
+    .empty-state {
+      display: flex;
+      flex: 1;
+      align-items: center;
+      justify-content: center;
+      padding: var(--ha-space-8);
+      color: var(--primary-text-color);
+      text-align: center;
+      font-size: var(--ha-font-size-xl);
+      line-height: var(--ha-line-height-normal);
+    }
+    .event-info {
+      flex: 1;
+      text-align: center;
+      font-size: var(--ha-font-size-m);
+    }
+    .counter {
+      color: var(--secondary-text-color);
+      margin-left: var(--ha-space-2);
+    }
+    ha-yaml-editor {
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      flex: 1;
+      margin-top: var(--ha-space-2);
     }
   `;
 }

--- a/src/panels/config/developer-tools/event/event-subscribe-card.ts
+++ b/src/panels/config/developer-tools/event/event-subscribe-card.ts
@@ -44,9 +44,6 @@ class EventSubscribeCard extends LitElement {
 
   @state() private _error?: string;
 
-  // Tracks which event the user is currently viewing. Stored by id rather
-  // than buffer index so the view survives the buffer shifting as new events
-  // arrive. New events never auto-advance the view; the user must navigate.
   @state() private _viewedEventId?: number;
 
   private _eventCount = 0;
@@ -154,12 +151,12 @@ class EventSubscribeCard extends LitElement {
     const index = this._resolveViewedIndex();
     const event = this._events[index];
     const position = event.id + 1;
-    // Slot within the buffer (1 = newest buffered, bufferTotal = oldest);
-    // stays stable as the buffer fills.
+
     const bufferPosition = bufferTotal - index;
     const atNewest = index === 0;
-    // Buffer has rolled over once the oldest buffered event isn't event 1.
+
     const hasRolledOver = this._events[bufferTotal - 1].id > 0;
+
     return html`
       <ha-card class="events-card">
         <div class="events-toolbar">
@@ -242,6 +239,7 @@ class EventSubscribeCard extends LitElement {
       return 0;
     }
     const found = this._events.findIndex((e) => e.id === this._viewedEventId);
+
     // Fall back to the oldest available event when the viewed one has aged out.
     return found === -1 ? this._events.length - 1 : found;
   }
@@ -295,7 +293,7 @@ class EventSubscribeCard extends LitElement {
 
     const searchStr = this._eventFilter;
 
-    function visit(node) {
+    function visit(node: unknown) {
       // Handle primitives directly
       if (node === null || typeof node !== "object") {
         return String(node).includes(searchStr);

--- a/src/panels/config/developer-tools/event/event-subscribe-card.ts
+++ b/src/panels/config/developer-tools/event/event-subscribe-card.ts
@@ -406,8 +406,7 @@ class EventSubscribeCard extends LitElement {
     .events-card {
       display: flex;
       flex-direction: column;
-      min-height: 0;
-      flex: 1;
+      height: 620px;
       padding: var(--ha-space-2);
     }
     .events-toolbar {
@@ -452,6 +451,7 @@ class EventSubscribeCard extends LitElement {
       min-height: 0;
       flex: 1;
       margin-top: var(--ha-space-2);
+      --code-mirror-height: 100%;
     }
   `;
 }

--- a/src/panels/config/developer-tools/event/event-subscribe-card.ts
+++ b/src/panels/config/developer-tools/event/event-subscribe-card.ts
@@ -3,6 +3,7 @@ import {
   mdiChevronDoubleRight,
   mdiChevronLeft,
   mdiChevronRight,
+  mdiInformationOutline,
 } from "@mdi/js";
 import type { HassEvent } from "home-assistant-js-websocket";
 import type { TemplateResult, PropertyValues } from "lit";
@@ -13,10 +14,14 @@ import "../../../../components/ha-alert";
 import "../../../../components/ha-button";
 import "../../../../components/ha-card";
 import "../../../../components/ha-icon-button";
+import "../../../../components/ha-svg-icon";
+import "../../../../components/ha-tooltip";
 import "../../../../components/ha-yaml-editor";
 import "../../../../components/input/ha-input";
 import type { HaInput } from "../../../../components/input/ha-input";
 import type { HomeAssistant } from "../../../../types";
+
+const MAX_BUFFERED_EVENTS = 30;
 
 interface SubscribedEvent {
   id: number;
@@ -189,6 +194,17 @@ class EventSubscribeCard extends LitElement {
               }
             )}
             <span class="counter">(${position} / ${totalFired})</span>
+            <ha-svg-icon
+              id="buffer-info"
+              class="buffer-info"
+              .path=${mdiInformationOutline}
+            ></ha-svg-icon>
+            <ha-tooltip for="buffer-info" placement="bottom">
+              ${this.hass!.localize(
+                "ui.panel.config.developer-tools.tabs.events.buffer_disclaimer",
+                { count: MAX_BUFFERED_EVENTS }
+              )}
+            </ha-tooltip>
           </div>
           <ha-icon-button
             .path=${mdiChevronRight}
@@ -320,8 +336,8 @@ class EventSubscribeCard extends LitElement {
               return;
             }
             const tail =
-              this._events.length >= 30
-                ? this._events.slice(0, 29)
+              this._events.length >= MAX_BUFFERED_EVENTS
+                ? this._events.slice(0, MAX_BUFFERED_EVENTS - 1)
                 : this._events;
             const id = this._eventCount++;
             this._events = [
@@ -409,6 +425,12 @@ class EventSubscribeCard extends LitElement {
     .counter {
       color: var(--secondary-text-color);
       margin-left: var(--ha-space-2);
+    }
+    .buffer-info {
+      color: var(--secondary-text-color);
+      margin-left: var(--ha-space-1);
+      vertical-align: middle;
+      --mdc-icon-size: 16px;
     }
     ha-yaml-editor {
       display: flex;

--- a/src/panels/config/developer-tools/event/event-subscribe-card.ts
+++ b/src/panels/config/developer-tools/event/event-subscribe-card.ts
@@ -7,7 +7,7 @@ import {
 } from "@mdi/js";
 import type { HassEvent } from "home-assistant-js-websocket";
 import type { TemplateResult, PropertyValues } from "lit";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { formatTimeWithSeconds } from "../../../../common/datetime/format_time";
 import "../../../../components/ha-alert";
@@ -21,7 +21,7 @@ import "../../../../components/input/ha-input";
 import type { HaInput } from "../../../../components/input/ha-input";
 import type { HomeAssistant } from "../../../../types";
 
-const MAX_BUFFERED_EVENTS = 30;
+const MAX_BUFFERED_EVENTS = 100;
 
 interface SubscribedEvent {
   id: number;
@@ -162,6 +162,8 @@ class EventSubscribeCard extends LitElement {
     // the events array, even if a new event arrives mid-render.
     const totalFired = this._events[0].id + 1;
     const atNewest = index === 0;
+    // Buffer has rolled over once the oldest buffered event isn't event 1.
+    const hasRolledOver = this._events[bufferTotal - 1].id > 0;
     return html`
       <ha-card class="events-card">
         <div class="events-toolbar">
@@ -194,17 +196,23 @@ class EventSubscribeCard extends LitElement {
               }
             )}
             <span class="counter">(${position} / ${totalFired})</span>
-            <ha-svg-icon
-              id="buffer-info"
-              class="buffer-info"
-              .path=${mdiInformationOutline}
-            ></ha-svg-icon>
-            <ha-tooltip for="buffer-info" placement="bottom">
-              ${this.hass!.localize(
-                "ui.panel.config.developer-tools.tabs.events.buffer_disclaimer",
-                { count: MAX_BUFFERED_EVENTS }
-              )}
-            </ha-tooltip>
+            ${hasRolledOver
+              ? html`
+                  <ha-svg-icon
+                    id="buffer-info"
+                    class="buffer-info"
+                    .path=${mdiInformationOutline}
+                  ></ha-svg-icon>
+                  <ha-tooltip for="buffer-info" placement="bottom">
+                    <span class="buffer-tooltip">
+                      ${this.hass!.localize(
+                        "ui.panel.config.developer-tools.tabs.events.buffer_disclaimer",
+                        { count: MAX_BUFFERED_EVENTS }
+                      )}
+                    </span>
+                  </ha-tooltip>
+                `
+              : nothing}
           </div>
           <ha-icon-button
             .path=${mdiChevronRight}
@@ -431,6 +439,11 @@ class EventSubscribeCard extends LitElement {
       margin-left: var(--ha-space-1);
       vertical-align: middle;
       --mdc-icon-size: 16px;
+    }
+    .buffer-tooltip {
+      white-space: pre-line;
+      display: block;
+      max-width: 320px;
     }
     ha-yaml-editor {
       display: flex;

--- a/src/panels/config/developer-tools/event/event-subscribe-card.ts
+++ b/src/panels/config/developer-tools/event/event-subscribe-card.ts
@@ -158,9 +158,10 @@ class EventSubscribeCard extends LitElement {
     const index = this._resolveViewedIndex();
     const event = this._events[index];
     const position = event.id + 1;
-    // Derive total from the newest event's id so all values stay in sync with
-    // the events array, even if a new event arrives mid-render.
-    const totalFired = this._events[0].id + 1;
+    // Counter shows the viewed event's slot within the buffer (1 = newest
+    // buffered, bufferTotal = oldest). Stays stable as the buffer fills,
+    // even though the absolute event number in the title keeps growing.
+    const bufferPosition = bufferTotal - index;
     const atNewest = index === 0;
     // Buffer has rolled over once the oldest buffered event isn't event 1.
     const hasRolledOver = this._events[bufferTotal - 1].id > 0;
@@ -195,7 +196,7 @@ class EventSubscribeCard extends LitElement {
                 ),
               }
             )}
-            <span class="counter">(${position} / ${totalFired})</span>
+            <span class="counter">(${bufferPosition} / ${bufferTotal})</span>
             ${hasRolledOver
               ? html`
                   <ha-svg-icon

--- a/src/panels/config/developer-tools/event/event-subscribe-card.ts
+++ b/src/panels/config/developer-tools/event/event-subscribe-card.ts
@@ -175,12 +175,14 @@ class EventSubscribeCard extends LitElement {
           <div class="event-info">
             ${this.hass!.localize(
               "ui.panel.config.developer-tools.tabs.events.event_fired",
-              { name: event.id + 1 }
-            )}
-            ${formatTimeWithSeconds(
-              new Date(event.event.time_fired),
-              this.hass!.locale,
-              this.hass!.config
+              {
+                name: event.id + 1,
+                time: formatTimeWithSeconds(
+                  new Date(event.event.time_fired),
+                  this.hass!.locale,
+                  this.hass!.config
+                ),
+              }
             )}
             <span class="counter">(${total - index} / ${total})</span>
           </div>

--- a/src/panels/config/developer-tools/event/event-subscribe-card.ts
+++ b/src/panels/config/developer-tools/event/event-subscribe-card.ts
@@ -41,6 +41,10 @@ class EventSubscribeCard extends LitElement {
 
   @state() private _viewedEventId?: number;
 
+  // Tracks which event the user is currently viewing. Stored by id rather
+  // than buffer index so the view survives the buffer shifting as new events
+  // arrive. New events never auto-advance the view; the user must navigate.
+
   private _eventCount = 0;
 
   @state() _ignoredEventsCount = 0;
@@ -142,23 +146,23 @@ class EventSubscribeCard extends LitElement {
         </ha-card>
       `;
     }
-    const total = this._events.length;
-    // Events are stored newest-first. If the user hasn't navigated, show the
-    // newest (index 0). Once they navigate, pin to the chosen event id.
-    const index =
-      this._viewedEventId === undefined
-        ? 0
-        : Math.max(
-            0,
-            this._events.findIndex((e) => e.id === this._viewedEventId)
-          );
+    const bufferTotal = this._events.length;
+    // Find the viewed event. If it has aged out of the buffer (or none is
+    // tracked yet), fall back to the oldest available event so the view
+    // stays close to where the user was rather than jumping around.
+    const index = this._resolveViewedIndex();
     const event = this._events[index];
+    const position = event.id + 1;
+    // Derive total from the newest event's id so all values stay in sync with
+    // the events array, even if a new event arrives mid-render.
+    const totalFired = this._events[0].id + 1;
+    const atNewest = index === 0;
     return html`
       <ha-card class="events-card">
         <div class="events-toolbar">
           <ha-icon-button
             .path=${mdiChevronDoubleLeft}
-            .disabled=${index >= total - 1}
+            .disabled=${index >= bufferTotal - 1}
             .label=${this.hass!.localize(
               "ui.panel.config.developer-tools.tabs.events.oldest_event"
             )}
@@ -166,7 +170,7 @@ class EventSubscribeCard extends LitElement {
           ></ha-icon-button>
           <ha-icon-button
             .path=${mdiChevronLeft}
-            .disabled=${index >= total - 1}
+            .disabled=${index >= bufferTotal - 1}
             .label=${this.hass!.localize(
               "ui.panel.config.developer-tools.tabs.events.older_event"
             )}
@@ -176,7 +180,7 @@ class EventSubscribeCard extends LitElement {
             ${this.hass!.localize(
               "ui.panel.config.developer-tools.tabs.events.event_fired",
               {
-                name: event.id + 1,
+                name: position,
                 time: formatTimeWithSeconds(
                   new Date(event.event.time_fired),
                   this.hass!.locale,
@@ -184,11 +188,11 @@ class EventSubscribeCard extends LitElement {
                 ),
               }
             )}
-            <span class="counter">(${total - index} / ${total})</span>
+            <span class="counter">(${position} / ${totalFired})</span>
           </div>
           <ha-icon-button
             .path=${mdiChevronRight}
-            .disabled=${index <= 0}
+            .disabled=${atNewest}
             .label=${this.hass!.localize(
               "ui.panel.config.developer-tools.tabs.events.newer_event"
             )}
@@ -196,7 +200,7 @@ class EventSubscribeCard extends LitElement {
           ></ha-icon-button>
           <ha-icon-button
             .path=${mdiChevronDoubleRight}
-            .disabled=${this._viewedEventId === undefined}
+            .disabled=${atNewest}
             .label=${this.hass!.localize(
               "ui.panel.config.developer-tools.tabs.events.newest_event"
             )}
@@ -213,6 +217,16 @@ class EventSubscribeCard extends LitElement {
     `;
   }
 
+  private _resolveViewedIndex(): number {
+    if (this._viewedEventId === undefined) {
+      return 0;
+    }
+    const found = this._events.findIndex((e) => e.id === this._viewedEventId);
+    // Viewed event has aged out of the buffer: fall back to the oldest
+    // available event (closest to where the user was viewing).
+    return found === -1 ? this._events.length - 1 : found;
+  }
+
   private _showOldest(): void {
     if (!this._events.length) {
       return;
@@ -221,30 +235,30 @@ class EventSubscribeCard extends LitElement {
   }
 
   private _showOlder(): void {
-    const total = this._events.length;
-    const current =
-      this._viewedEventId === undefined
-        ? 0
-        : this._events.findIndex((e) => e.id === this._viewedEventId);
-    const next = Math.min(current + 1, total - 1);
+    if (!this._events.length) {
+      return;
+    }
+    const current = this._resolveViewedIndex();
+    const next = Math.min(current + 1, this._events.length - 1);
     this._viewedEventId = this._events[next].id;
   }
 
   private _showNewest(): void {
-    // Resume auto-follow on incoming events.
-    this._viewedEventId = undefined;
+    if (!this._events.length) {
+      return;
+    }
+    // Jump to the current newest event. New events arriving after this will
+    // not auto-advance the view; the user must press this button again.
+    this._viewedEventId = this._events[0].id;
   }
 
   private _showNewer(): void {
-    if (this._viewedEventId === undefined) {
+    if (!this._events.length) {
       return;
     }
-
-    const current = this._events.findIndex((e) => e.id === this._viewedEventId);
+    const current = this._resolveViewedIndex();
     const next = Math.max(current - 1, 0);
-
-    // Reaching the newest event resumes auto-follow on incoming events.
-    this._viewedEventId = next === 0 ? undefined : this._events[next].id;
+    this._viewedEventId = this._events[next].id;
   }
 
   private _valueChanged(ev: InputEvent): void {
@@ -306,16 +320,22 @@ class EventSubscribeCard extends LitElement {
               return;
             }
             const tail =
-              this._events.length > 30
+              this._events.length >= 30
                 ? this._events.slice(0, 29)
                 : this._events;
+            const id = this._eventCount++;
             this._events = [
               {
                 event,
-                id: this._eventCount++,
+                id,
               },
               ...tail,
             ];
+            // Land on the very first event (position 1, id 0) and stay
+            // there until the user navigates.
+            if (this._viewedEventId === undefined) {
+              this._viewedEventId = id;
+            }
           }, this._eventType);
       } catch (error: any) {
         this._error = this.hass!.localize(

--- a/src/panels/config/developer-tools/event/event-subscribe-card.ts
+++ b/src/panels/config/developer-tools/event/event-subscribe-card.ts
@@ -1,6 +1,6 @@
 import type { HassEvent } from "home-assistant-js-websocket";
 import type { TemplateResult, PropertyValues } from "lit";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
 import { formatTime } from "../../../../common/datetime/format_time";
@@ -11,6 +11,11 @@ import "../../../../components/ha-yaml-editor";
 import "../../../../components/input/ha-input";
 import type { HaInput } from "../../../../components/input/ha-input";
 import type { HomeAssistant } from "../../../../types";
+
+interface SubscribedEvent {
+  id: number;
+  event: HassEvent;
+}
 
 @customElement("event-subscribe-card")
 class EventSubscribeCard extends LitElement {
@@ -24,10 +29,7 @@ class EventSubscribeCard extends LitElement {
 
   @state() private _eventFilter = "";
 
-  @state() private _events: {
-    id: number;
-    event: HassEvent;
-  }[] = [];
+  @state() private _events: SubscribedEvent[] = [];
 
   @state() private _error?: string;
 
@@ -113,34 +115,35 @@ class EventSubscribeCard extends LitElement {
           </ha-button>
         </div>
       </ha-card>
-      <ha-card>
-        <div class="card-content">
-          <div class="events">
-            ${repeat(
-              this._events,
-              (event) => event.id,
-              (event) => html`
-                <div class="event">
-                  ${this.hass!.localize(
-                    "ui.panel.config.developer-tools.tabs.events.event_fired",
-                    { name: event.id }
-                  )}
-                  ${formatTime(
-                    new Date(event.event.time_fired),
-                    this.hass!.locale,
-                    this.hass!.config
-                  )}:
-                  <ha-yaml-editor
-                    .hass=${this.hass}
-                    .defaultValue=${event.event}
-                    read-only
-                  ></ha-yaml-editor>
-                </div>
-              `
-            )}
-          </div>
-        </div>
-      </ha-card>
+      ${this._events.length
+        ? html`<ha-card>
+            <div class="card-content">
+              <div class="events">
+                ${repeat(
+                  this._events,
+                  (event: SubscribedEvent) => event.id,
+                  (event: SubscribedEvent) =>
+                    html`<div class="event">
+                      ${this.hass!.localize(
+                        "ui.panel.config.developer-tools.tabs.events.event_fired",
+                        { name: event.id }
+                      )}
+                      ${formatTime(
+                        new Date(event.event.time_fired),
+                        this.hass!.locale,
+                        this.hass!.config
+                      )}:
+                      <ha-yaml-editor
+                        .hass=${this.hass}
+                        .defaultValue=${event.event}
+                        read-only
+                      ></ha-yaml-editor>
+                    </div>`
+                )}
+              </div>
+            </div>
+          </ha-card>`
+        : nothing}
     `;
   }
 
@@ -251,7 +254,7 @@ class EventSubscribeCard extends LitElement {
       font-family: var(--ha-font-family-code);
     }
     ha-card {
-      margin-bottom: var(--ha-space-1);
+      margin-bottom: var(--ha-space-2);
     }
   `;
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3781,7 +3781,7 @@
               "type": "Event type",
               "data": "Event data (YAML, optional)",
               "fire_event": "Fire event",
-              "event_fired": "Event {name} fired",
+              "event_fired": "Event {name} fired at {time}",
               "active_listeners": "Active listeners",
               "count_listeners": "({count} {count, plural,\n  one {listener}\n  other {listeners}\n})",
               "listen_to_events": "Listen to events",
@@ -3795,7 +3795,14 @@
               "clear_events": "Clear events",
               "alert_event_type": "Event type is a mandatory field",
               "notification_event_fired": "Event {type} successfully fired!",
-              "subscribe_failed": "Failed to subscribe to event: {error}"
+              "subscribe_failed": "Failed to subscribe to event: {error}",
+              "unknown_error": "Unknown error",
+              "oldest_event": "Oldest event",
+              "older_event": "Older event",
+              "newer_event": "Newer event",
+              "newest_event": "Newest event",
+              "waiting_for_events": "Waiting for events…",
+              "subscribe_prompt": "Subscribe to an event type above to see events here."
             },
             "actions": {
               "title": "Actions",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3802,7 +3802,8 @@
               "newer_event": "Newer event",
               "newest_event": "Newest event",
               "waiting_for_events": "Waiting for events…",
-              "subscribe_prompt": "Subscribe to an event type above to see events here."
+              "subscribe_prompt": "Subscribe to an event type above to see events here.",
+              "buffer_disclaimer": "Only the latest {count} events are kept in memory. Older events are discarded as new ones arrive."
             },
             "actions": {
               "title": "Actions",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3803,7 +3803,7 @@
               "newest_event": "Newest event",
               "waiting_for_events": "Waiting for events…",
               "subscribe_prompt": "Subscribe to an event type above to see events here.",
-              "buffer_disclaimer": "Only the latest {count} events are kept in memory. Older events are discarded as new ones arrive."
+              "buffer_disclaimer": "Only the latest {count} events are kept. Older events are discarded as new ones arrive.\n\nTip: Subscribe to a more specific event type, or use the filter to narrow results."
             },
             "actions": {
               "title": "Actions",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3803,7 +3803,7 @@
               "newest_event": "Newest event",
               "waiting_for_events": "Waiting for events…",
               "subscribe_prompt": "Subscribe to an event type above to see events here.",
-              "buffer_disclaimer": "Only the latest {count} events are kept. Older events are discarded as new ones arrive.\n\nTip: Subscribe to a more specific event type, or use the filter to narrow results."
+              "buffer_disclaimer": "Showing the latest {count} events. Older events are discarded as new ones arrive.\n\nTip: Subscribe to a more specific event type, or use the filter to narrow results."
             },
             "actions": {
               "title": "Actions",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Refactor subscribed event output for output card to fill page, implement pagination for events and scroll in code editor instead of jumping the window bounds. Uses fixed height and makes code editor fill the container.

Also adds tips to keep UI from popping in and explain buffer size.

Increased max buffer to 100 now this does not render everything in the dom at once. Kept this limit not to fill the array to its limits still.

Also fixed narrow (mobile) layouts to show active listeners below

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

https://github.com/user-attachments/assets/dace9267-64bb-4d6a-a0d5-bec3b2654848

<img width="948" height="1248" alt="image" src="https://github.com/user-attachments/assets/b421aa8b-2e05-4bd2-8774-cce74566fce6" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
