### PR TITLE
Filter out secondary battery entities from Maintenance dashboard, and update summary copy

### DIFF
--- a/src/panels/lovelace/cards/hui-home-summary-card.ts
+++ b/src/panels/lovelace/cards/hui-home-summary-card.ts
@@ -16,6 +16,10 @@ import "../../../components/ha-card";
 import "../../../components/tile/ha-tile-container";
 import "../../../components/tile/ha-tile-icon";
 import "../../../components/tile/ha-tile-info";
+import {
+  getConfigEntries,
+  type ConfigEntry,
+} from "../../../data/config_entries";
 import type { EnergyData } from "../../../data/energy";
 import {
   computeConsumptionData,
@@ -34,7 +38,10 @@ import {
   HOME_SUMMARIES_ICONS,
   type HomeSummary,
 } from "../strategies/home/helpers/home-summaries";
-import { filterNeedsAttentionEntities } from "../../maintenance/strategies/maintenance-view-strategy";
+import {
+  collapseBatteryEntities,
+  filterNeedsAttentionEntities,
+} from "../../maintenance/strategies/maintenance-view-strategy";
 import type { LovelaceCard, LovelaceGridOptions } from "../types";
 import { tileCardStyle } from "./tile/tile-card-style";
 import type { HomeSummaryCard } from "./types";
@@ -60,9 +67,15 @@ export class HuiHomeSummaryCard
 
   @state() private _energyData?: EnergyData;
 
+  @state() private _configEntryLookup?: Record<string, ConfigEntry>;
+
   protected hassSubscribeRequiredHostProps = ["_config"];
 
   public hassSubscribe(): UnsubscribeFunc[] {
+    if (this._config?.summary === "maintenance") {
+      this._loadConfigEntries();
+    }
+
     if (this._config?.summary !== "energy") {
       return [];
     }
@@ -83,6 +96,13 @@ export class HuiHomeSummaryCard
 
   public setConfig(config: HomeSummaryCard): void {
     this._config = config;
+  }
+
+  private async _loadConfigEntries(): Promise<void> {
+    const entries = await getConfigEntries(this.hass!);
+    this._configEntryLookup = Object.fromEntries(
+      entries.map((entry) => [entry.entry_id, entry])
+    );
   }
 
   public getCardSize(): number {
@@ -262,9 +282,10 @@ export class HuiHomeSummaryCard
           (filter) => generateEntityFilter(this.hass!, filter)
         );
 
-        const maintenanceEntities = findEntities(
-          allEntities,
-          maintenanceFilters
+        const maintenanceEntities = collapseBatteryEntities(
+          this.hass!,
+          findEntities(allEntities, maintenanceFilters),
+          this._configEntryLookup
         );
 
         const needsAttentionEntities = filterNeedsAttentionEntities(

--- a/src/panels/maintenance/strategies/maintenance-view-strategy.ts
+++ b/src/panels/maintenance/strategies/maintenance-view-strategy.ts
@@ -7,6 +7,10 @@ import {
   type EntityFilter,
 } from "../../../common/entity/entity_filter";
 import { floorDefaultIcon } from "../../../components/ha-floor-icon";
+import {
+  getConfigEntries,
+  type ConfigEntry,
+} from "../../../data/config_entries";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
 import type { LovelaceSectionRawConfig } from "../../../data/lovelace/config/section";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
@@ -39,6 +43,60 @@ export const filterNeedsAttentionEntities = (
     const stateValue = parseFloat(hass.states[entityId]?.state ?? "");
     return !isNaN(stateValue) && stateValue <= LOW_BATTERY_THRESHOLD;
   });
+
+/**
+ * For devices with battery entities from multiple integrations, keep only
+ * entities from the primary integration. The primary integration is
+ * determined by matching the device's primary config entry to its domain.
+ * Entities without a device pass through.
+ */
+export const collapseBatteryEntities = (
+  hass: HomeAssistant,
+  entityIds: string[],
+  configEntryLookup?: Record<string, ConfigEntry>
+): string[] => {
+  if (!configEntryLookup) {
+    return entityIds;
+  }
+
+  // Group entities by device. Entities without a device pass through.
+  const byDevice: Record<string, string[]> = {};
+  const entitiesWithoutDevice: string[] = [];
+
+  for (const eid of entityIds) {
+    const deviceId = hass.entities[eid]?.device_id;
+    if (!deviceId) {
+      entitiesWithoutDevice.push(eid);
+    } else {
+      if (!byDevice[deviceId]) {
+        byDevice[deviceId] = [];
+      }
+      byDevice[deviceId].push(eid);
+    }
+  }
+
+  // When a device has entities from multiple integrations
+  // (e.g. Battery Notes), keep only the primary integration's entities.
+  const collapsedEntities = Object.entries(byDevice).flatMap(
+    ([deviceId, entities]) => {
+      const primaryConfigEntryId =
+        hass.devices?.[deviceId]?.primary_config_entry;
+      const primaryDomain = primaryConfigEntryId
+        ? configEntryLookup[primaryConfigEntryId]?.domain
+        : undefined;
+
+      if (primaryDomain) {
+        return entities.filter(
+          (eid) => hass.entities[eid]?.platform === primaryDomain
+        );
+      }
+
+      return entities;
+    }
+  );
+
+  return [...entitiesWithoutDevice, ...collapsedEntities];
+};
 
 const computeBatteryTileCard = (entityId: string): TileCardConfig => ({
   type: "tile",
@@ -121,7 +179,16 @@ export class MaintenanceViewStrategy extends ReactiveElement {
       generateEntityFilter(hass, filter)
     );
 
-    const entities = findEntities(allEntities, batteryFilters);
+    const configEntries = await getConfigEntries(hass);
+    const configEntryLookup = Object.fromEntries(
+      configEntries.map((entry) => [entry.entry_id, entry])
+    );
+
+    const entities = collapseBatteryEntities(
+      hass,
+      findEntities(allEntities, batteryFilters),
+      configEntryLookup
+    );
 
     const floorCount =
       hierarchy.floors.length + (hierarchy.areas.length ? 1 : 0);

--- a/src/panels/maintenance/strategies/maintenance-view-strategy.ts
+++ b/src/panels/maintenance/strategies/maintenance-view-strategy.ts
@@ -85,13 +85,18 @@ export const collapseBatteryEntities = (
         ? configEntryLookup[primaryConfigEntryId]?.domain
         : undefined;
 
-      if (primaryDomain) {
-        return entities.filter(
-          (eid) => hass.entities[eid]?.platform === primaryDomain
-        );
+      const primaryDomainEntities = entities.filter(
+        (eid) => hass.entities[eid]?.platform === primaryDomain
+      );
+
+      // if there are no primary entities it might be due to preferring only the
+      // battery entities from the secondary integration (e.g. battery notes)
+      // so we fall back to showing all entities for the device
+      if (primaryDomainEntities.length === 0) {
+        return entities;
       }
 
-      return entities;
+      return primaryDomainEntities;
     }
   );
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -218,7 +218,7 @@
         "all_secure": "All secure",
         "no_media_playing": "No media playing",
         "count_media_playing": "{count} {count, plural,\n one {playing}\n other {playing}\n}",
-        "count_maintenance_issues": "{count} {count, plural,\n one {issue}\n other {issues}\n}",
+        "count_maintenance_issues": "{count} {count, plural,\n one {battery low}\n other {batteries low}\n}",
         "all_maintenance_good": "All good",
         "count_persons_home": "{count} {count, plural,\n one {person}\n other {people}\n} home",
         "nobody_home": "No one home"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -218,7 +218,7 @@
         "all_secure": "All secure",
         "no_media_playing": "No media playing",
         "count_media_playing": "{count} {count, plural,\n one {playing}\n other {playing}\n}",
-        "count_maintenance_issues": "{count} {count, plural,\n one {battery low}\n other {batteries low}\n}",
+        "count_maintenance_issues": "{count} {count, plural,\n one {low battery}\n other {low batteries}\n}",
         "all_maintenance_good": "All good",
         "count_persons_home": "{count} {count, plural,\n one {person}\n other {people}\n} home",
         "nobody_home": "No one home"


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
1. Filters maintenance entities to only include primary ones: Based on discussions in the discord it limits the dashboard to just entities that come from the primary integration. This removes duplicates batteries from things like Battery Notes. Note: it will show battery notes battery+ devices if Battery Notes "hide battery" is enabled 
<img width="662" height="744" alt="image" src="https://github.com/user-attachments/assets/525cb3bf-a408-4e7b-b8ff-0a75d2eb11c7" />

2.  Changed "X issues" / "X issue" to "X low batteries" / "X low battery" for clearer messaging on the home summary card.






## Screenshots


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
