### PR TITLE
Fix quick bar search not focused on first open

### DIFF
--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -150,10 +150,7 @@ export class QuickBar extends LitElement {
   }
 
   protected updated(changedProps: PropertyValues) {
-    // When _loading transitions to false while the dialog is already open,
-    // the combo box is just now rendered for the first time. Use
-    // requestAnimationFrame (like _dialogOpened does) so the combo box's
-    // own shadow DOM has time to render before we attempt to focus it.
+    if (changedProps.has("_loading") && !this._loading && this._opened) {
       requestAnimationFrame(() => {
         this._comboBox?.focus();
       });

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -1,6 +1,6 @@
 import { mdiDevices } from "@mdi/js";
 import Fuse from "fuse.js";
-import type { CSSResultGroup } from "lit";
+import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -147,6 +147,18 @@ export class QuickBar extends LitElement {
     }
 
     this._loading = false;
+  }
+
+  protected updated(changedProps: PropertyValues) {
+    // When _loading transitions to false while the dialog is already open,
+    // the combo box is just now rendered for the first time. Use
+    // requestAnimationFrame (like _dialogOpened does) so the combo box's
+    // own shadow DOM has time to render before we attempt to focus it.
+    if (changedProps.has("_loading") && !this._loading && this._opened) {
+      requestAnimationFrame(() => {
+        this._comboBox?.focus();
+      });
+    }
   }
 
   private _dialogOpened = async () => {

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -154,7 +154,6 @@ export class QuickBar extends LitElement {
     // the combo box is just now rendered for the first time. Use
     // requestAnimationFrame (like _dialogOpened does) so the combo box's
     // own shadow DOM has time to render before we attempt to focus it.
-    if (changedProps.has("_loading") && !this._loading && this._opened) {
       requestAnimationFrame(() => {
         this._comboBox?.focus();
       });


### PR DESCRIPTION
## Proposed change

When pressing `E` (or `C`/`D`) to open the quick bar for the first time, the search field was not focused, preventing the user from typing immediately.

On the first open, `_initialize()` fetches config entries asynchronously, keeping `_loading = true` while the dialog opens. The `ha-picker-combo-box` is only rendered when `!this._loading && this._opened`, so when `_dialogOpened` fires and calls `this._comboBox?.focus()`, the combo box doesn't exist in the DOM yet. By the time `_initialize()` finishes and the combo box renders, the focus call has already passed. On subsequent opens `_loading` is already `false`, so the combo box is present and focus works correctly.

The fix adds an `updated()` lifecycle hook that detects when `_loading` transitions to `false` while the dialog is already open, and calls `requestAnimationFrame(() => this._comboBox?.focus())` — matching the same timing pattern used by `_dialogOpened` — to focus the search field once the combo box's own shadow DOM is ready.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: not found
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to backend pull request: N/A

## Checklist

> [!TIP]
> To be honest, this is AI generated code and I am not familiar enough with frontend dev to properly review it myself. At least I confirmed it works (see video), and I didn't notice any regression. If you prefer I can close this PR and open an issue instead.

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io