### PR TITLE
Change display for `uptime` sensors

### DIFF
--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -17,6 +17,7 @@ import {
 import { blankBeforeUnit } from "../translations/blank_before_unit";
 import type { LocalizeFunc } from "../translations/localize";
 import { computeDomain } from "./compute_domain";
+import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../data/sensor";
 
 export const computeStateDisplay = (
   localize: LocalizeFunc,
@@ -267,8 +268,7 @@ const computeStateToPartsFromEntityAttributes = (
       "datetime",
     ].includes(domain) ||
     (domain === "sensor" &&
-      (attributes.device_class === "timestamp" ||
-        attributes.device_class === "uptime"))
+      SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(attributes.device_class))
   ) {
     try {
       return [

--- a/src/data/sensor.ts
+++ b/src/data/sensor.ts
@@ -3,6 +3,7 @@ import type { HomeAssistant } from "../types";
 export const SENSOR_DEVICE_CLASS_BATTERY = "battery";
 export const SENSOR_DEVICE_CLASS_TEMPERATURE = "temperature";
 export const SENSOR_DEVICE_CLASS_HUMIDITY = "humidity";
+export const SENSOR_DEVICE_CLASS_UPTIME = "uptime";
 
 export const SENSOR_TIMESTAMP_DEVICE_CLASSES: (string | undefined)[] = [
   "timestamp",

--- a/src/data/sensor.ts
+++ b/src/data/sensor.ts
@@ -1,6 +1,7 @@
 import type { HomeAssistant } from "../types";
 
 export const SENSOR_DEVICE_CLASS_BATTERY = "battery";
+export const SENSOR_DEVICE_CLASS_TIMESTAMP = "timestamp";
 export const SENSOR_DEVICE_CLASS_TEMPERATURE = "temperature";
 export const SENSOR_DEVICE_CLASS_HUMIDITY = "humidity";
 export const SENSOR_DEVICE_CLASS_UPTIME = "uptime";

--- a/src/data/sensor.ts
+++ b/src/data/sensor.ts
@@ -1,9 +1,13 @@
 import type { HomeAssistant } from "../types";
 
 export const SENSOR_DEVICE_CLASS_BATTERY = "battery";
-export const SENSOR_DEVICE_CLASS_TIMESTAMP = "timestamp";
 export const SENSOR_DEVICE_CLASS_TEMPERATURE = "temperature";
 export const SENSOR_DEVICE_CLASS_HUMIDITY = "humidity";
+
+export const SENSOR_TIMESTAMP_DEVICE_CLASSES: (string | undefined)[] = [
+  "timestamp",
+  "uptime",
+];
 
 export interface SensorDeviceClassUnits {
   units: string[];

--- a/src/dialogs/config-flow/previews/entity-preview-row.ts
+++ b/src/dialogs/config-flow/previews/entity-preview-row.ts
@@ -23,7 +23,10 @@ import type { ImageEntity } from "../../../data/image";
 import { computeImageUrl } from "../../../data/image";
 import "../../../panels/lovelace/components/hui-timestamp-display";
 import type { HomeAssistant } from "../../../types";
-import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../../data/sensor";
+import {
+  SENSOR_DEVICE_CLASS_UPTIME,
+  SENSOR_TIMESTAMP_DEVICE_CLASSES,
+} from "../../../data/sensor";
 
 @customElement("entity-preview-row")
 class EntityPreviewRow extends LitElement {
@@ -321,6 +324,10 @@ class EntityPreviewRow extends LitElement {
               <hui-timestamp-display
                 .hass=${this.hass}
                 .ts=${new Date(stateObj.state)}
+                .format=${stateObj.attributes.device_class ===
+                SENSOR_DEVICE_CLASS_UPTIME
+                  ? "total"
+                  : undefined}
                 capitalize
               ></hui-timestamp-display>
             `

--- a/src/dialogs/config-flow/previews/entity-preview-row.ts
+++ b/src/dialogs/config-flow/previews/entity-preview-row.ts
@@ -21,9 +21,9 @@ import { isTiltOnly } from "../../../data/cover";
 import { isUnavailableState } from "../../../data/entity/entity";
 import type { ImageEntity } from "../../../data/image";
 import { computeImageUrl } from "../../../data/image";
-import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../../../data/sensor";
 import "../../../panels/lovelace/components/hui-timestamp-display";
 import type { HomeAssistant } from "../../../types";
+import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../../data/sensor";
 
 @customElement("entity-preview-row")
 class EntityPreviewRow extends LitElement {
@@ -312,8 +312,9 @@ class EntityPreviewRow extends LitElement {
 
     if (domain === "sensor") {
       const showSensor =
-        stateObj.attributes.device_class === SENSOR_DEVICE_CLASS_TIMESTAMP &&
-        !isUnavailableState(stateObj.state);
+        SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
+          stateObj.attributes.device_class
+        ) && !isUnavailableState(stateObj.state);
       return html`
         ${showSensor
           ? html`

--- a/src/dialogs/more-info/components/ha-more-info-state-header.ts
+++ b/src/dialogs/more-info/components/ha-more-info-state-header.ts
@@ -3,9 +3,7 @@ import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../components/ha-absolute-time";
 import "../../../components/ha-relative-time";
-import { isUnavailableState } from "../../../data/entity/entity";
 import type { LightEntity } from "../../../data/light";
-import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../../data/sensor";
 import "../../../panels/lovelace/components/hui-timestamp-display";
 import type { HomeAssistant } from "../../../types";
 
@@ -22,22 +20,6 @@ export class HaMoreInfoStateHeader extends LitElement {
   @state() private _absoluteTime = false;
 
   private _localizeState(): TemplateResult | string {
-    if (
-      SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
-        this.stateObj.attributes.device_class
-      ) &&
-      !isUnavailableState(this.stateObj.state)
-    ) {
-      return html`
-        <hui-timestamp-display
-          .hass=${this.hass}
-          .ts=${new Date(this.stateObj.state)}
-          format="relative"
-          capitalize
-        ></hui-timestamp-display>
-      `;
-    }
-
     return this.hass.formatEntityState(this.stateObj);
   }
 

--- a/src/dialogs/more-info/components/ha-more-info-state-header.ts
+++ b/src/dialogs/more-info/components/ha-more-info-state-header.ts
@@ -5,7 +5,7 @@ import "../../../components/ha-absolute-time";
 import "../../../components/ha-relative-time";
 import { isUnavailableState } from "../../../data/entity/entity";
 import type { LightEntity } from "../../../data/light";
-import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../../../data/sensor";
+import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../../data/sensor";
 import "../../../panels/lovelace/components/hui-timestamp-display";
 import type { HomeAssistant } from "../../../types";
 
@@ -23,7 +23,9 @@ export class HaMoreInfoStateHeader extends LitElement {
 
   private _localizeState(): TemplateResult | string {
     if (
-      this.stateObj.attributes.device_class === SENSOR_DEVICE_CLASS_TIMESTAMP &&
+      SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
+        this.stateObj.attributes.device_class
+      ) &&
       !isUnavailableState(this.stateObj.state)
     ) {
       return html`

--- a/src/dialogs/more-info/components/ha-more-info-state-header.ts
+++ b/src/dialogs/more-info/components/ha-more-info-state-header.ts
@@ -3,7 +3,9 @@ import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../components/ha-absolute-time";
 import "../../../components/ha-relative-time";
+import { isUnavailableState } from "../../../data/entity/entity";
 import type { LightEntity } from "../../../data/light";
+import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../../../data/sensor";
 import "../../../panels/lovelace/components/hui-timestamp-display";
 import type { HomeAssistant } from "../../../types";
 
@@ -20,6 +22,20 @@ export class HaMoreInfoStateHeader extends LitElement {
   @state() private _absoluteTime = false;
 
   private _localizeState(): TemplateResult | string {
+    if (
+      this.stateObj.attributes.device_class === SENSOR_DEVICE_CLASS_TIMESTAMP &&
+      !isUnavailableState(this.stateObj.state)
+    ) {
+      return html`
+        <hui-timestamp-display
+          .hass=${this.hass}
+          .ts=${new Date(this.stateObj.state)}
+          format="relative"
+          capitalize
+        ></hui-timestamp-display>
+      `;
+    }
+
     return this.hass.formatEntityState(this.stateObj);
   }
 

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -15,7 +15,10 @@ import type {
   CallServiceActionConfig,
   MoreInfoActionConfig,
 } from "../../../data/lovelace/config/action";
-import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../../data/sensor";
+import {
+  SENSOR_DEVICE_CLASS_UPTIME,
+  SENSOR_TIMESTAMP_DEVICE_CLASSES,
+} from "../../../data/sensor";
 import type { HomeAssistant } from "../../../types";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { findEntities } from "../common/find-entities";
@@ -295,7 +298,11 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
                       <hui-timestamp-display
                         .hass=${this.hass}
                         .ts=${new Date(stateObj.state)}
-                        .format=${entityConf.format}
+                        .format=${entityConf.format ??
+                        (stateObj.attributes.device_class ===
+                        SENSOR_DEVICE_CLASS_UPTIME
+                          ? "total"
+                          : undefined)}
                         capitalize
                       ></hui-timestamp-display>
                     `

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -15,7 +15,7 @@ import type {
   CallServiceActionConfig,
   MoreInfoActionConfig,
 } from "../../../data/lovelace/config/action";
-import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../../../data/sensor";
+import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../../data/sensor";
 import type { HomeAssistant } from "../../../types";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { findEntities } from "../common/find-entities";
@@ -287,8 +287,9 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
           ? html`
               <div>
                 ${computeDomain(entityConf.entity) === "sensor" &&
-                stateObj.attributes.device_class ===
-                  SENSOR_DEVICE_CLASS_TIMESTAMP &&
+                SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
+                  stateObj.attributes.device_class
+                ) &&
                 !isUnavailableState(stateObj.state)
                   ? html`
                       <hui-timestamp-display

--- a/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
@@ -2,7 +2,7 @@ import type { PropertyValues } from "lit";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isUnavailableState } from "../../../data/entity/entity";
-import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../../../data/sensor";
+import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../../data/sensor";
 import type { HomeAssistant } from "../../../types";
 import type { EntitiesCardEntityConfig } from "../cards/types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
@@ -50,8 +50,9 @@ class HuiSensorEntityRow extends LitElement implements LovelaceRow {
 
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
-        ${stateObj.attributes.device_class === SENSOR_DEVICE_CLASS_TIMESTAMP &&
-        !isUnavailableState(stateObj.state)
+        ${SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
+          stateObj.attributes.device_class
+        ) && !isUnavailableState(stateObj.state)
           ? html`
               <hui-timestamp-display
                 .hass=${this.hass}

--- a/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
@@ -2,7 +2,10 @@ import type { PropertyValues } from "lit";
 import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isUnavailableState } from "../../../data/entity/entity";
-import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../../data/sensor";
+import {
+  SENSOR_DEVICE_CLASS_UPTIME,
+  SENSOR_TIMESTAMP_DEVICE_CLASSES,
+} from "../../../data/sensor";
 import type { HomeAssistant } from "../../../types";
 import type { EntitiesCardEntityConfig } from "../cards/types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
@@ -57,7 +60,10 @@ class HuiSensorEntityRow extends LitElement implements LovelaceRow {
               <hui-timestamp-display
                 .hass=${this.hass}
                 .ts=${new Date(stateObj.state)}
-                .format=${this._config.format}
+                .format=${this._config.format ??
+                (stateObj.attributes.device_class === SENSOR_DEVICE_CLASS_UPTIME
+                  ? "total"
+                  : undefined)}
                 capitalize
               ></hui-timestamp-display>
             `

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -8,7 +8,10 @@ import { computeStateDomain } from "../common/entity/compute_state_domain";
 import { STRINGS_SEPARATOR_DOT } from "../common/const";
 import "../components/ha-relative-time";
 import { isUnavailableState } from "../data/entity/entity";
-import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../data/sensor";
+import {
+  SENSOR_TIMESTAMP_DEVICE_CLASSES,
+  SENSOR_DEVICE_CLASS_UPTIME,
+} from "../data/sensor";
 import type { UpdateEntity } from "../data/update";
 import { computeUpdateStateDisplay } from "../data/update";
 import "../panels/lovelace/components/hui-timestamp-display";
@@ -100,7 +103,10 @@ class StateDisplay extends LitElement {
           <hui-timestamp-display
             .hass=${this.hass}
             .ts=${new Date(stateObj.state)}
-            format="relative"
+            .format=${this.stateObj.attributes.device_class ===
+            SENSOR_DEVICE_CLASS_UPTIME
+              ? "total"
+              : "relative"}
             capitalize
           ></hui-timestamp-display>
         `;

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -8,7 +8,7 @@ import { computeStateDomain } from "../common/entity/compute_state_domain";
 import { STRINGS_SEPARATOR_DOT } from "../common/const";
 import "../components/ha-relative-time";
 import { isUnavailableState } from "../data/entity/entity";
-import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../data/sensor";
+import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../data/sensor";
 import type { UpdateEntity } from "../data/update";
 import { computeUpdateStateDisplay } from "../data/update";
 import "../panels/lovelace/components/hui-timestamp-display";
@@ -90,7 +90,9 @@ class StateDisplay extends LitElement {
         return "—";
       }
       if (
-        (stateObj.attributes.device_class === SENSOR_DEVICE_CLASS_TIMESTAMP ||
+        (SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
+          this.stateObj.attributes.device_class
+        ) ||
           TIMESTAMP_STATE_DOMAINS.includes(domain)) &&
         !isUnavailableState(stateObj.state)
       ) {

--- a/src/state-summary/state-card-display.ts
+++ b/src/state-summary/state-card-display.ts
@@ -6,7 +6,7 @@ import { classMap } from "lit/directives/class-map";
 import { computeDomain } from "../common/entity/compute_domain";
 import "../components/entity/state-info";
 import { isUnavailableState } from "../data/entity/entity";
-import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../data/sensor";
+import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../data/sensor";
 import "../panels/lovelace/components/hui-timestamp-display";
 import { haStyle } from "../resources/styles";
 import type { HomeAssistant } from "../types";
@@ -38,8 +38,9 @@ class StateCardDisplay extends LitElement {
           })}"
         >
           ${computeDomain(this.stateObj.entity_id) === "sensor" &&
-          this.stateObj.attributes.device_class ===
-            SENSOR_DEVICE_CLASS_TIMESTAMP &&
+          SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
+            this.stateObj.attributes.device_class
+          ) &&
           !isUnavailableState(this.stateObj.state)
             ? html`<hui-timestamp-display
                 .hass=${this.hass}

--- a/src/state-summary/state-card-display.ts
+++ b/src/state-summary/state-card-display.ts
@@ -6,7 +6,10 @@ import { classMap } from "lit/directives/class-map";
 import { computeDomain } from "../common/entity/compute_domain";
 import "../components/entity/state-info";
 import { isUnavailableState } from "../data/entity/entity";
-import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../data/sensor";
+import {
+  SENSOR_TIMESTAMP_DEVICE_CLASSES,
+  SENSOR_DEVICE_CLASS_UPTIME,
+} from "../data/sensor";
 import "../panels/lovelace/components/hui-timestamp-display";
 import { haStyle } from "../resources/styles";
 import type { HomeAssistant } from "../types";
@@ -45,7 +48,10 @@ class StateCardDisplay extends LitElement {
             ? html`<hui-timestamp-display
                 .hass=${this.hass}
                 .ts=${new Date(this.stateObj.state)}
-                format="datetime"
+                .format=${this.stateObj.attributes.device_class ===
+                SENSOR_DEVICE_CLASS_UPTIME
+                  ? "total"
+                  : "datetime"}
                 capitalize
               ></hui-timestamp-display>`
             : this.hass.formatEntityState(this.stateObj)}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
<details>
<summary>Original revision (updated to new behavior)</summary>
When uptime class was added, it seems the intention was to treat it like timestamp, but we missed a lot of spots where timestamp is rendered differently. This PR makes uptime same as timestamp everywhere, (showing relative time).

After writing this I'm now not 100% sure this is what is wanted for uptime, since that might benefit from a different rendering, e.g. something like "15 days, 7 hours" instead of "last month"?

Also the more info display still shows the exact time & date, since that's what timestamp currently does. 

Put this up for debate, and we can take this or reject and try for something else. 

But right now it just displays the date & time everywhere, which I think is not what was wanted. 
</details>

Updated the display rules for uptime sensor. Mostly showing it as a `total` format everywhere the timestamp-display element was used ("`5 minutes`, or `3 hours`, or `1 day`, etc"). Could probably benefit from an additional precision level but we don't have that now. 

Some more detailed comments inline review. 


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
