### PR TITLE
Group areas floor vacuum clean

### DIFF
--- a/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-clean-areas.ts
+++ b/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-clean-areas.ts
@@ -2,10 +2,15 @@ import { mdiCogOutline, mdiTextureBox } from "@mdi/js";
 import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import {
+  getAreasFloorHierarchy,
+  type AreasFloorHierarchy,
+} from "../../../../common/areas/areas-floor-hierarchy";
 import { fireEvent } from "../../../../common/dom/fire_event";
 
 import "../../../../components/ha-alert";
 import "../../../../components/ha-button";
+import "../../../../components/ha-floor-icon";
 import "../../../../components/ha-icon";
 import "../../../../components/ha-spinner";
 import "../../../../components/ha-svg-icon";
@@ -17,13 +22,18 @@ import {
 import type { HomeAssistant } from "../../../../types";
 import { showVacuumSegmentMappingView } from "./show-view-vacuum-segment-mapping";
 
+interface MappedSection {
+  floorId: string | null;
+  areaIds: string[];
+}
+
 @customElement("ha-more-info-view-vacuum-clean-areas")
 export class HaMoreInfoViewVacuumCleanAreas extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public params!: { entityId: string };
 
-  @state() private _mappedAreaIds?: string[];
+  @state() private _mappedHierarchy?: AreasFloorHierarchy;
 
   @state() private _selectedAreaIds: string[] = [];
 
@@ -47,8 +57,13 @@ export class HaMoreInfoViewVacuumCleanAreas extends LitElement {
         await getExtendedEntityRegistryEntry(this.hass, this.params.entityId);
 
       const areaMapping = entry?.options?.vacuum?.area_mapping || {};
-      this._mappedAreaIds = Object.keys(areaMapping).filter(
-        (areaId) => this.hass.areas[areaId]
+      const mappedAreaIds = new Set(Object.keys(areaMapping));
+      const mappedAreas = Object.values(this.hass.areas).filter((area) =>
+        mappedAreaIds.has(area.area_id)
+      );
+      this._mappedHierarchy = getAreasFloorHierarchy(
+        Object.values(this.hass.floors),
+        mappedAreas
       );
     } catch (err: any) {
       this._error = err.message || "Failed to load areas";
@@ -95,6 +110,42 @@ export class HaMoreInfoViewVacuumCleanAreas extends LitElement {
     );
   }
 
+  private _getMappedSections(): MappedSection[] {
+    if (!this._mappedHierarchy) return [];
+    const sections: MappedSection[] = this._mappedHierarchy.floors
+      .filter((floor) => floor.areas.length > 0)
+      .map((floor) => ({ floorId: floor.id, areaIds: floor.areas }));
+    if (this._mappedHierarchy.areas.length > 0) {
+      sections.push({ floorId: null, areaIds: this._mappedHierarchy.areas });
+    }
+    return sections;
+  }
+
+  private _renderSection(section: MappedSection, showLabel: boolean) {
+    const floor = section.floorId ? this.hass.floors[section.floorId] : null;
+    const label = showLabel
+      ? floor
+        ? floor.name
+        : this.hass.localize("ui.dialogs.more_info_control.vacuum.other_areas")
+      : null;
+
+    return html`
+      <div class="section">
+        ${label
+          ? html`<div class="section-header">
+              ${floor
+                ? html`<ha-floor-icon .floor=${floor}></ha-floor-icon>`
+                : nothing}
+              <span class="section-name">${label}</span>
+            </div>`
+          : nothing}
+        <div class="area-grid">
+          ${section.areaIds.map((areaId) => this._renderAreaCard(areaId))}
+        </div>
+      </div>
+    `;
+  }
+
   private _renderAreaCard(areaId: string) {
     const area: AreaRegistryEntry | undefined = this.hass.areas[areaId];
     if (!area) return nothing;
@@ -138,7 +189,9 @@ export class HaMoreInfoViewVacuumCleanAreas extends LitElement {
       `;
     }
 
-    if (!this._mappedAreaIds || this._mappedAreaIds.length === 0) {
+    const sections = this._getMappedSections();
+
+    if (sections.length === 0) {
       return html`
         <div class="content empty-content">
           <div class="empty">
@@ -177,11 +230,13 @@ export class HaMoreInfoViewVacuumCleanAreas extends LitElement {
       `;
     }
 
+    const showFloorLabels = sections.length > 1;
+
     return html`
       <div class="content">
-        <div class="area-grid">
-          ${this._mappedAreaIds.map((areaId) => this._renderAreaCard(areaId))}
-        </div>
+        ${sections.map((section) =>
+          this._renderSection(section, showFloorLabels)
+        )}
         <p class="hint">
           ${this.hass.localize(
             "ui.dialogs.more_info_control.vacuum.clean_areas_order_hint"
@@ -223,6 +278,9 @@ export class HaMoreInfoViewVacuumCleanAreas extends LitElement {
       flex: 1;
       overflow-y: auto;
       padding: var(--ha-space-4);
+      display: flex;
+      flex-direction: column;
+      gap: var(--ha-space-4);
     }
 
     .empty-content {
@@ -255,6 +313,20 @@ export class HaMoreInfoViewVacuumCleanAreas extends LitElement {
 
     .empty p {
       margin: 0 0 var(--ha-space-4);
+    }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      gap: var(--ha-space-2);
+      margin-bottom: var(--ha-space-2);
+      color: var(--secondary-text-color);
+      --mdc-icon-size: 20px;
+    }
+
+    .section-name {
+      font-size: var(--ha-font-size-m);
+      font-weight: var(--ha-font-weight-medium);
     }
 
     .area-grid {
@@ -343,7 +415,7 @@ export class HaMoreInfoViewVacuumCleanAreas extends LitElement {
     }
 
     .hint {
-      margin: var(--ha-space-3) 0 0;
+      margin: 0;
       text-align: center;
       font-size: var(--ha-font-size-s);
       color: var(--secondary-text-color);

--- a/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-clean-areas.ts
+++ b/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-clean-areas.ts
@@ -7,6 +7,8 @@ import {
   type AreasFloorHierarchy,
 } from "../../../../common/areas/areas-floor-hierarchy";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import { computeAreaName } from "../../../../common/entity/compute_area_name";
+import { computeFloorName } from "../../../../common/entity/compute_floor_name";
 
 import "../../../../components/ha-alert";
 import "../../../../components/ha-button";
@@ -125,7 +127,7 @@ export class HaMoreInfoViewVacuumCleanAreas extends LitElement {
     const floor = section.floorId ? this.hass.floors[section.floorId] : null;
     const label = showLabel
       ? floor
-        ? floor.name
+        ? computeFloorName(floor)
         : this.hass.localize("ui.dialogs.more_info_control.vacuum.other_areas")
       : null;
 
@@ -167,7 +169,7 @@ export class HaMoreInfoViewVacuumCleanAreas extends LitElement {
             ? html`<ha-icon .icon=${area.icon}></ha-icon>`
             : html`<ha-svg-icon .path=${mdiTextureBox}></ha-svg-icon>`}
         </div>
-        <div class="area-name">${area.name}</div>
+        <div class="area-name">${computeAreaName(area)}</div>
       </div>
     `;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1739,7 +1739,8 @@
           "no_areas_text_non_admin": "Ask an administrator to map your vacuum's segments to areas.",
           "configure_area_mapping": "Configure area mapping",
           "configure": "Configure",
-          "clean_areas_order_hint": "Cleaning order may not be supported by your vacuum."
+          "clean_areas_order_hint": "Cleaning order may not be supported by your vacuum.",
+          "other_areas": "Other areas"
         },
         "person": {
           "create_zone": "Create zone from current location"


### PR DESCRIPTION
## Proposed change

In the vacuum "Clean areas" more info view, areas are now grouped by floor using the standard area/floor hierarchy, in the same order as the rest of the UI. Floor labels (with icon) are shown only when there are multiple sections, so single-floor setups stay unchanged.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
