### PR TITLE
Resolve service name and icon for shortcut card and badge

### DIFF
--- a/src/components/ha-condition-icon.ts
+++ b/src/components/ha-condition-icon.ts
@@ -55,7 +55,11 @@ export class HaConditionIcon extends LitElement {
       return this._renderFallback();
     }
 
-    const icon = conditionIcon(this.hass, this.condition).then((icn) => {
+    const icon = conditionIcon(
+      this.hass.connection,
+      this.hass.config,
+      this.condition
+    ).then((icn) => {
       if (icn) {
         return html`<ha-icon .icon=${icn}></ha-icon>`;
       }

--- a/src/components/ha-service-icon.ts
+++ b/src/components/ha-service-icon.ts
@@ -32,7 +32,11 @@ export class HaServiceIcon extends LitElement {
       return this._renderFallback();
     }
 
-    const icon = serviceIcon(this.hass, this.service).then((icn) => {
+    const icon = serviceIcon(
+      this.hass.connection,
+      this.hass.config,
+      this.service
+    ).then((icn) => {
       if (icn) {
         return html`<ha-icon .icon=${icn}></ha-icon>`;
       }

--- a/src/components/ha-service-picker.ts
+++ b/src/components/ha-service-picker.ts
@@ -54,7 +54,7 @@ class HaServicePicker extends LitElement {
   protected firstUpdated(props: PropertyValues<this>) {
     super.firstUpdated(props);
     this.hass.loadBackendTranslation("services");
-    getServiceIcons(this.hass);
+    getServiceIcons(this.hass.connection, this.hass.config);
   }
 
   private _rowRenderer: RenderItemFunction<ServiceComboBoxItem> = (

--- a/src/components/ha-service-section-icon.ts
+++ b/src/components/ha-service-section-icon.ts
@@ -29,14 +29,17 @@ export class HaServiceSectionIcon extends LitElement {
       return this._renderFallback();
     }
 
-    const icon = serviceSectionIcon(this.hass, this.service, this.section).then(
-      (icn) => {
-        if (icn) {
-          return html`<ha-icon .icon=${icn}></ha-icon>`;
-        }
-        return this._renderFallback();
+    const icon = serviceSectionIcon(
+      this.hass.connection,
+      this.hass.config,
+      this.service,
+      this.section
+    ).then((icn) => {
+      if (icn) {
+        return html`<ha-icon .icon=${icn}></ha-icon>`;
       }
-    );
+      return this._renderFallback();
+    });
 
     return html`${until(icon)}`;
   }

--- a/src/components/ha-trigger-icon.ts
+++ b/src/components/ha-trigger-icon.ts
@@ -69,7 +69,11 @@ export class HaTriggerIcon extends LitElement {
       return this._renderFallback();
     }
 
-    const icon = triggerIcon(this.hass, this.trigger).then((icn) => {
+    const icon = triggerIcon(
+      this.hass.connection,
+      this.hass.config,
+      this.trigger
+    ).then((icn) => {
       if (icn) {
         return html`<ha-icon .icon=${icn}></ha-icon>`;
       }

--- a/src/data/compute-service-info.ts
+++ b/src/data/compute-service-info.ts
@@ -1,0 +1,34 @@
+import { computeDomain } from "../common/entity/compute_domain";
+import { computeObjectId } from "../common/entity/compute_object_id";
+import type { LocalizeFunc } from "../common/translations/localize";
+import { DEFAULT_SERVICE_ICON } from "./icons";
+import type { HomeAssistant } from "../types";
+
+export interface ServiceInfo {
+  label: string;
+  icon?: string;
+  iconPath: string;
+}
+
+export const DEFAULT_SERVICE_INFO: ServiceInfo = {
+  label: "",
+  iconPath: DEFAULT_SERVICE_ICON,
+};
+
+export const computeServiceLabel = (
+  localize: LocalizeFunc,
+  services: HomeAssistant["services"],
+  service: string
+): string => {
+  const domain = computeDomain(service);
+  const serviceName = computeObjectId(service);
+  const serviceDef = services[domain]?.[serviceName];
+  return (
+    localize(
+      `component.${domain}.services.${serviceName}.name`,
+      serviceDef?.description_placeholders
+    ) ||
+    serviceDef?.name ||
+    service
+  );
+};

--- a/src/data/icons.ts
+++ b/src/data/icons.ts
@@ -323,7 +323,8 @@ export const getComponentIcons = async (
 export const getCategoryIcons = async <
   T extends Exclude<IconCategory, "entity" | "entity_component">,
 >(
-  hass: HomeAssistant,
+  connection: Connection,
+  hassConfig: HomeAssistant["config"],
   category: T,
   domain?: string,
   force = false
@@ -334,12 +335,10 @@ export const getCategoryIcons = async <
         Record<string, CategoryType[T]>
       >;
     }
-    resources[category].all = getHassIcons(hass.connection, category).then(
-      (res) => {
-        resources[category].domains = res.resources as any;
-        return res?.resources as Record<string, CategoryType[T]>;
-      }
-    ) as any;
+    resources[category].all = getHassIcons(connection, category).then((res) => {
+      resources[category].domains = res.resources as any;
+      return res?.resources as Record<string, CategoryType[T]>;
+    }) as any;
     return resources[category].all as Promise<Record<string, CategoryType[T]>>;
   }
   if (!force && domain in resources[category].domains) {
@@ -351,10 +350,10 @@ export const getCategoryIcons = async <
       return resources[category].domains[domain] as Promise<CategoryType[T]>;
     }
   }
-  if (!isComponentLoaded(hass.config, domain)) {
+  if (!isComponentLoaded(hassConfig, domain)) {
     return undefined;
   }
-  const result = getHassIcons(hass.connection, category, domain);
+  const result = getHassIcons(connection, category, domain);
   resources[category].domains[domain] = result.then(
     (res) => res?.resources[domain]
   ) as any;
@@ -362,25 +361,28 @@ export const getCategoryIcons = async <
 };
 
 export const getServiceIcons = async (
-  hass: HomeAssistant,
+  connection: Connection,
+  hassConfig: HomeAssistant["config"],
   domain?: string,
   force = false
 ): Promise<ServiceIcons | Record<string, ServiceIcons> | undefined> =>
-  getCategoryIcons(hass, "services", domain, force);
+  getCategoryIcons(connection, hassConfig, "services", domain, force);
 
 export const getTriggerIcons = async (
-  hass: HomeAssistant,
+  connection: Connection,
+  hassConfig: HomeAssistant["config"],
   domain?: string,
   force = false
 ): Promise<TriggerIcons | Record<string, TriggerIcons> | undefined> =>
-  getCategoryIcons(hass, "triggers", domain, force);
+  getCategoryIcons(connection, hassConfig, "triggers", domain, force);
 
 export const getConditionIcons = async (
-  hass: HomeAssistant,
+  connection: Connection,
+  hassConfig: HomeAssistant["config"],
   domain?: string,
   force = false
 ): Promise<ConditionIcons | Record<string, ConditionIcons> | undefined> =>
-  getCategoryIcons(hass, "conditions", domain, force);
+  getCategoryIcons(connection, hassConfig, "conditions", domain, force);
 
 // Cache for sorted range keys
 const sortedRangeCache = new WeakMap<Record<string, string>, number[]>();
@@ -578,7 +580,8 @@ export const attributeIcon = async (
 };
 
 export const triggerIcon = async (
-  hass: HomeAssistant,
+  connection: Connection,
+  hassConfig: HomeAssistant["config"],
   trigger: string
 ): Promise<string | undefined> => {
   let icon: string | undefined;
@@ -586,62 +589,69 @@ export const triggerIcon = async (
   const domain = getTriggerDomain(trigger);
   const triggerName = getTriggerObjectId(trigger);
 
-  const triggerIcons = await getTriggerIcons(hass, domain);
+  const triggerIcons = await getTriggerIcons(connection, hassConfig, domain);
   if (triggerIcons) {
     const trgrIcon = triggerIcons[triggerName] as TriggerIcons[string];
     icon = trgrIcon?.trigger;
   }
   if (!icon) {
-    icon = await domainIcon(hass.connection, hass.config, domain);
+    icon = await domainIcon(connection, hassConfig, domain);
   }
   return icon;
 };
 
 export const conditionIcon = async (
-  hass: HomeAssistant,
+  connection: Connection,
+  hassConfig: HomeAssistant["config"],
   condition: string
 ): Promise<string | undefined> => {
   let icon: string | undefined;
 
   const domain = getConditionDomain(condition);
-  const conditionIcons = await getConditionIcons(hass, domain);
+  const conditionIcons = await getConditionIcons(
+    connection,
+    hassConfig,
+    domain
+  );
   if (conditionIcons) {
     const conditionName = getConditionObjectId(condition);
     const condIcon = conditionIcons[conditionName] as ConditionIcons[string];
     icon = condIcon?.condition;
   }
   if (!icon) {
-    icon = await domainIcon(hass.connection, hass.config, domain);
+    icon = await domainIcon(connection, hassConfig, domain);
   }
   return icon;
 };
 
 export const serviceIcon = async (
-  hass: HomeAssistant,
+  connection: Connection,
+  hassConfig: HomeAssistant["config"],
   service: string
 ): Promise<string | undefined> => {
   let icon: string | undefined;
   const domain = computeDomain(service);
   const serviceName = computeObjectId(service);
-  const serviceIcons = await getServiceIcons(hass, domain);
+  const serviceIcons = await getServiceIcons(connection, hassConfig, domain);
   if (serviceIcons) {
     const srvceIcon = serviceIcons[serviceName] as ServiceIcons[string];
     icon = srvceIcon?.service;
   }
   if (!icon) {
-    icon = await domainIcon(hass.connection, hass.config, domain);
+    icon = await domainIcon(connection, hassConfig, domain);
   }
   return icon;
 };
 
 export const serviceSectionIcon = async (
-  hass: HomeAssistant,
+  connection: Connection,
+  hassConfig: HomeAssistant["config"],
   service: string,
   section: string
 ): Promise<string | undefined> => {
   const domain = computeDomain(service);
   const serviceName = computeObjectId(service);
-  const serviceIcons = await getServiceIcons(hass, domain);
+  const serviceIcons = await getServiceIcons(connection, hassConfig, domain);
   if (serviceIcons) {
     const srvceIcon = serviceIcons[serviceName] as ServiceIcons[string];
     return srvceIcon?.sections?.[section];

--- a/src/data/service-info-controller.ts
+++ b/src/data/service-info-controller.ts
@@ -1,3 +1,5 @@
+import { ContextConsumer, type Context } from "@lit/context";
+import type { Connection, HassConfig } from "home-assistant-js-websocket";
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { computeDomain } from "../common/entity/compute_domain";
 import {
@@ -6,92 +8,150 @@ import {
   type ServiceInfo,
 } from "./compute-service-info";
 import {
+  configContext,
+  connectionContext,
+  internationalizationContext,
+  servicesContext,
+} from "./context";
+import {
   DEFAULT_SERVICE_ICON,
   FALLBACK_DOMAIN_ICONS,
   serviceIcon,
 } from "./icons";
-import type { HomeAssistant } from "../types";
+import type {
+  HomeAssistant,
+  HomeAssistantInternationalization,
+} from "../types";
+
+type ServiceInfoHost = ReactiveControllerHost & HTMLElement;
 
 /**
  * Reactive controller that prepares display data for a service action
  * (e.g. `light.turn_on`): loads service translations, resolves the localized
  * service name, and resolves the service icon (with a synchronous domain
  * fallback that upgrades once the full icon is loaded).
+ *
+ * Pulls connection, config, services, and i18n from Lit context, so the
+ * caller only needs to feed in the service ID via `updateService()`.
  */
 export class ServiceInfoController implements ReactiveController {
-  private _host: ReactiveControllerHost;
+  private _host: ServiceInfoHost;
 
-  private _hass?: HomeAssistant;
+  private _connection?: Connection;
+
+  private _config?: HassConfig;
+
+  private _services?: HomeAssistant["services"];
+
+  private _i18n?: HomeAssistantInternationalization;
 
   private _service?: string;
 
-  private _language?: string;
+  private _resolvedService?: string;
+
+  private _resolvedLanguage?: string;
 
   private _info: ServiceInfo = DEFAULT_SERVICE_INFO;
 
-  constructor(host: ReactiveControllerHost) {
+  constructor(host: ServiceInfoHost) {
     this._host = host;
     host.addController(this);
+
+    this._consume(connectionContext, (value) => {
+      this._connection = value.connection;
+    });
+    this._consume(configContext, (value) => {
+      this._config = value.config;
+    });
+    this._consume(servicesContext, (value) => {
+      this._services = value;
+    });
+    this._consume(internationalizationContext, (value) => {
+      this._i18n = value;
+    });
+  }
+
+  private _consume<T>(
+    context: Context<unknown, T>,
+    assign: (value: T) => void
+  ): void {
+    new ContextConsumer(this._host, {
+      context,
+      subscribe: true,
+      callback: (value) => {
+        assign(value);
+        this._resolve();
+      },
+    });
   }
 
   get info(): ServiceInfo {
     return this._info;
   }
 
-  update(hass: HomeAssistant, service: string | undefined): void {
-    this._hass = hass;
+  hostConnected(): void {
+    this._resolve();
+  }
 
-    const serviceChanged = service !== this._service;
-    const languageChanged = hass.language !== this._language;
+  updateService(service: string | undefined): void {
+    if (service === this._service) return;
+    this._service = service;
+    this._resolve();
+  }
+
+  private _resolve(): void {
+    if (!this._connection || !this._config || !this._services || !this._i18n) {
+      return;
+    }
+
+    const service = this._service;
+    const language = this._i18n.language;
+
+    const serviceChanged = service !== this._resolvedService;
+    const languageChanged = language !== this._resolvedLanguage;
 
     if (!serviceChanged && !languageChanged) return;
 
-    this._service = service;
-    this._language = hass.language;
+    this._resolvedService = service;
+    this._resolvedLanguage = language;
 
     if (!service) {
       this._info = DEFAULT_SERVICE_INFO;
+      this._host.requestUpdate();
       return;
     }
 
     const domain = computeDomain(service);
     this._info = {
-      label: computeServiceLabel(hass.localize, hass.services, service),
+      label: computeServiceLabel(this._i18n.localize, this._services, service),
       iconPath: serviceChanged
         ? FALLBACK_DOMAIN_ICONS[domain] || DEFAULT_SERVICE_ICON
         : this._info.iconPath,
       icon: serviceChanged ? undefined : this._info.icon,
     };
+    this._host.requestUpdate();
 
-    hass.loadBackendTranslation("services", domain).then((localize) => {
+    this._i18n.loadBackendTranslation("services", domain).then((localize) => {
       if (
-        this._service !== service ||
-        this._language !== hass.language ||
-        !this._hass
+        this._resolvedService !== service ||
+        this._resolvedLanguage !== language ||
+        !this._services
       ) {
         return;
       }
       this._info = {
         ...this._info,
-        label: computeServiceLabel(localize, this._hass.services, service),
+        label: computeServiceLabel(localize, this._services, service),
       };
       this._host.requestUpdate();
     });
 
     if (serviceChanged) {
-      serviceIcon(hass, service).then((icon) => {
-        if (this._service !== service) return;
+      serviceIcon(this._connection, this._config, service).then((icon) => {
+        if (this._resolvedService !== service) return;
         this._info = { ...this._info, icon };
         this._host.requestUpdate();
       });
-    }
-  }
-
-  hostConnected(): void {
-    if (this._hass && this._service && !this._info.icon) {
-      const service = this._service;
-      this._service = undefined;
-      this.update(this._hass, service);
     }
   }
 }

--- a/src/data/service-info-controller.ts
+++ b/src/data/service-info-controller.ts
@@ -1,0 +1,97 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { computeDomain } from "../common/entity/compute_domain";
+import {
+  computeServiceLabel,
+  DEFAULT_SERVICE_INFO,
+  type ServiceInfo,
+} from "./compute-service-info";
+import {
+  DEFAULT_SERVICE_ICON,
+  FALLBACK_DOMAIN_ICONS,
+  serviceIcon,
+} from "./icons";
+import type { HomeAssistant } from "../types";
+
+/**
+ * Reactive controller that prepares display data for a service action
+ * (e.g. `light.turn_on`): loads service translations, resolves the localized
+ * service name, and resolves the service icon (with a synchronous domain
+ * fallback that upgrades once the full icon is loaded).
+ */
+export class ServiceInfoController implements ReactiveController {
+  private _host: ReactiveControllerHost;
+
+  private _hass?: HomeAssistant;
+
+  private _service?: string;
+
+  private _language?: string;
+
+  private _info: ServiceInfo = DEFAULT_SERVICE_INFO;
+
+  constructor(host: ReactiveControllerHost) {
+    this._host = host;
+    host.addController(this);
+  }
+
+  get info(): ServiceInfo {
+    return this._info;
+  }
+
+  update(hass: HomeAssistant, service: string | undefined): void {
+    this._hass = hass;
+
+    const serviceChanged = service !== this._service;
+    const languageChanged = hass.language !== this._language;
+
+    if (!serviceChanged && !languageChanged) return;
+
+    this._service = service;
+    this._language = hass.language;
+
+    if (!service) {
+      this._info = DEFAULT_SERVICE_INFO;
+      return;
+    }
+
+    const domain = computeDomain(service);
+    this._info = {
+      label: computeServiceLabel(hass.localize, hass.services, service),
+      iconPath: serviceChanged
+        ? FALLBACK_DOMAIN_ICONS[domain] || DEFAULT_SERVICE_ICON
+        : this._info.iconPath,
+      icon: serviceChanged ? undefined : this._info.icon,
+    };
+
+    hass.loadBackendTranslation("services", domain).then((localize) => {
+      if (
+        this._service !== service ||
+        this._language !== hass.language ||
+        !this._hass
+      ) {
+        return;
+      }
+      this._info = {
+        ...this._info,
+        label: computeServiceLabel(localize, this._hass.services, service),
+      };
+      this._host.requestUpdate();
+    });
+
+    if (serviceChanged) {
+      serviceIcon(hass, service).then((icon) => {
+        if (this._service !== service) return;
+        this._info = { ...this._info, icon };
+        this._host.requestUpdate();
+      });
+    }
+  }
+
+  hostConnected(): void {
+    if (this._hass && this._service && !this._info.icon) {
+      const service = this._service;
+      this._service = undefined;
+      this.update(this._hass, service);
+    }
+  }
+}

--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -327,14 +327,14 @@ class DialogAddAutomationElement
 
     if (this._params?.type === "action") {
       this.hass.loadBackendTranslation("services");
-      getServiceIcons(this.hass);
+      getServiceIcons(this.hass.connection, this.hass.config);
     } else if (this._params?.type === "trigger") {
       this.hass.loadBackendTranslation("triggers");
-      getTriggerIcons(this.hass);
+      getTriggerIcons(this.hass.connection, this.hass.config);
       this._subscribeDescriptions();
     } else if (this._params?.type === "condition") {
       this.hass.loadBackendTranslation("conditions");
-      getConditionIcons(this.hass);
+      getConditionIcons(this.hass.connection, this.hass.config);
       this._subscribeDescriptions();
     }
 

--- a/src/panels/lovelace/badges/hui-shortcut-badge.ts
+++ b/src/panels/lovelace/badges/hui-shortcut-badge.ts
@@ -60,8 +60,7 @@ export class HuiShortcutBadge extends LitElement implements LovelaceBadge {
         this.hass,
         action?.action === "navigate" ? action.navigation_path : undefined
       );
-      this._serviceInfo.update(
-        this.hass,
+      this._serviceInfo.updateService(
         action?.action === "perform-action" || action?.action === "call-service"
           ? action.perform_action || action.service
           : undefined

--- a/src/panels/lovelace/badges/hui-shortcut-badge.ts
+++ b/src/panels/lovelace/badges/hui-shortcut-badge.ts
@@ -7,6 +7,7 @@ import "../../../components/ha-icon";
 import "../../../components/ha-svg-icon";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import { NavigationPathInfoController } from "../../../data/navigation-path-controller";
+import { ServiceInfoController } from "../../../data/service-info-controller";
 import type { HomeAssistant } from "../../../types";
 import { getShortcutCardDefaults } from "../cards/hui-shortcut-card-defaults";
 import { actionHandler } from "../common/directives/action-handler-directive";
@@ -38,6 +39,8 @@ export class HuiShortcutBadge extends LitElement implements LovelaceBadge {
 
   private _navInfo = new NavigationPathInfoController(this);
 
+  private _serviceInfo = new ServiceInfoController(this);
+
   public setConfig(config: ShortcutBadgeConfig): void {
     this._config = {
       tap_action: {
@@ -56,6 +59,12 @@ export class HuiShortcutBadge extends LitElement implements LovelaceBadge {
       this._navInfo.update(
         this.hass,
         action?.action === "navigate" ? action.navigation_path : undefined
+      );
+      this._serviceInfo.update(
+        this.hass,
+        action?.action === "perform-action" || action?.action === "call-service"
+          ? action.perform_action || action.service
+          : undefined
       );
     }
   }
@@ -80,7 +89,8 @@ export class HuiShortcutBadge extends LitElement implements LovelaceBadge {
     const defaults = getShortcutCardDefaults(
       this.hass,
       this._config.tap_action,
-      this._navInfo.info
+      this._navInfo.info,
+      this._serviceInfo.info
     );
     const text = (this._config.text || defaults.label).trim();
     const icon = this._config.icon || defaults.icon;

--- a/src/panels/lovelace/cards/hui-shortcut-card-defaults.ts
+++ b/src/panels/lovelace/cards/hui-shortcut-card-defaults.ts
@@ -1,6 +1,7 @@
-import { mdiLink, mdiMicrophone, mdiOpenInNew, mdiRoomService } from "@mdi/js";
+import { mdiLink, mdiMicrophone, mdiOpenInNew } from "@mdi/js";
 import type { NavigationPathInfo } from "../../../data/compute-navigation-path-info";
 import type { ActionConfig } from "../../../data/lovelace/config/action";
+import type { ServiceInfo } from "../../../data/compute-service-info";
 import type { HomeAssistant } from "../../../types";
 
 const DEFAULT: NavigationPathInfo = { label: "", iconPath: mdiLink };
@@ -8,7 +9,8 @@ const DEFAULT: NavigationPathInfo = { label: "", iconPath: mdiLink };
 export const getShortcutCardDefaults = (
   hass: HomeAssistant,
   action: ActionConfig | undefined,
-  navInfo: NavigationPathInfo
+  navInfo: NavigationPathInfo,
+  serviceInfo: ServiceInfo
 ): NavigationPathInfo => {
   switch (action?.action) {
     case "navigate":
@@ -22,10 +24,7 @@ export const getShortcutCardDefaults = (
       };
     case "call-service":
     case "perform-action":
-      return {
-        label: action.perform_action || "",
-        iconPath: mdiRoomService,
-      };
+      return serviceInfo;
     case "url":
       return {
         label: action.url_path || "",

--- a/src/panels/lovelace/cards/hui-shortcut-card.ts
+++ b/src/panels/lovelace/cards/hui-shortcut-card.ts
@@ -8,6 +8,7 @@ import "../../../components/tile/ha-tile-icon";
 import "../../../components/tile/ha-tile-info";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import { NavigationPathInfoController } from "../../../data/navigation-path-controller";
+import { ServiceInfoController } from "../../../data/service-info-controller";
 import type { HomeAssistant } from "../../../types";
 import { handleAction } from "../common/handle-action";
 import { hasAction } from "../common/has-action";
@@ -42,6 +43,8 @@ export class HuiShortcutCard extends LitElement implements LovelaceCard {
   @state() private _config?: ShortcutCardConfig;
 
   private _navInfo = new NavigationPathInfoController(this);
+
+  private _serviceInfo = new ServiceInfoController(this);
 
   public setConfig(config: ShortcutCardConfig): void {
     this._config = {
@@ -83,6 +86,12 @@ export class HuiShortcutCard extends LitElement implements LovelaceCard {
         this.hass,
         action?.action === "navigate" ? action.navigation_path : undefined
       );
+      this._serviceInfo.update(
+        this.hass,
+        action?.action === "perform-action" || action?.action === "call-service"
+          ? action.perform_action || action.service
+          : undefined
+      );
     }
   }
 
@@ -106,7 +115,8 @@ export class HuiShortcutCard extends LitElement implements LovelaceCard {
     const defaults = getShortcutCardDefaults(
       this.hass,
       this._config.tap_action,
-      this._navInfo.info
+      this._navInfo.info,
+      this._serviceInfo.info
     );
     const label = this._config.label || defaults.label;
     const description = this._config.description;

--- a/src/panels/lovelace/cards/hui-shortcut-card.ts
+++ b/src/panels/lovelace/cards/hui-shortcut-card.ts
@@ -86,8 +86,7 @@ export class HuiShortcutCard extends LitElement implements LovelaceCard {
         this.hass,
         action?.action === "navigate" ? action.navigation_path : undefined
       );
-      this._serviceInfo.update(
-        this.hass,
+      this._serviceInfo.updateService(
         action?.action === "perform-action" || action?.action === "call-service"
           ? action.perform_action || action.service
           : undefined

--- a/src/panels/lovelace/editor/config-elements/hui-shortcut-badge-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-shortcut-badge-editor.ts
@@ -65,8 +65,7 @@ export class HuiShortcutBadgeEditor
         this.hass,
         action?.action === "navigate" ? action.navigation_path : undefined
       );
-      this._serviceInfo.update(
-        this.hass,
+      this._serviceInfo.updateService(
         action?.action === "perform-action" || action?.action === "call-service"
           ? action.perform_action || action.service
           : undefined

--- a/src/panels/lovelace/editor/config-elements/hui-shortcut-badge-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-shortcut-badge-editor.ts
@@ -7,6 +7,7 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-form/ha-form";
 import type { HaFormSchema } from "../../../../components/ha-form/types";
 import { NavigationPathInfoController } from "../../../../data/navigation-path-controller";
+import { ServiceInfoController } from "../../../../data/service-info-controller";
 import type { HomeAssistant } from "../../../../types";
 import { getShortcutCardDefaults } from "../../cards/hui-shortcut-card-defaults";
 import type { ShortcutBadgeConfig } from "../../badges/types";
@@ -47,6 +48,8 @@ export class HuiShortcutBadgeEditor
 
   private _navInfo = new NavigationPathInfoController(this);
 
+  private _serviceInfo = new ServiceInfoController(this);
+
   public setConfig(config: ShortcutBadgeConfig): void {
     assert(config, badgeConfigStruct);
     this._config = config;
@@ -61,6 +64,12 @@ export class HuiShortcutBadgeEditor
       this._navInfo.update(
         this.hass,
         action?.action === "navigate" ? action.navigation_path : undefined
+      );
+      this._serviceInfo.update(
+        this.hass,
+        action?.action === "perform-action" || action?.action === "call-service"
+          ? action.perform_action || action.service
+          : undefined
       );
     }
   }
@@ -149,7 +158,8 @@ export class HuiShortcutBadgeEditor
     const defaults = getShortcutCardDefaults(
       this.hass,
       this._config.tap_action,
-      this._navInfo.info
+      this._navInfo.info,
+      this._serviceInfo.info
     );
 
     return html`

--- a/src/panels/lovelace/editor/config-elements/hui-shortcut-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-shortcut-card-editor.ts
@@ -8,6 +8,7 @@ import type { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-form/ha-form";
 import type { HaFormSchema } from "../../../../components/ha-form/types";
 import { NavigationPathInfoController } from "../../../../data/navigation-path-controller";
+import { ServiceInfoController } from "../../../../data/service-info-controller";
 import type { HomeAssistant } from "../../../../types";
 import { getShortcutCardDefaults } from "../../cards/hui-shortcut-card-defaults";
 import type { ShortcutCardConfig } from "../../cards/types";
@@ -50,6 +51,8 @@ export class HuiShortcutCardEditor
 
   private _navInfo = new NavigationPathInfoController(this);
 
+  private _serviceInfo = new ServiceInfoController(this);
+
   public setConfig(config: ShortcutCardConfig): void {
     assert(config, cardConfigStruct);
     this._config = config;
@@ -64,6 +67,12 @@ export class HuiShortcutCardEditor
       this._navInfo.update(
         this.hass,
         action?.action === "navigate" ? action.navigation_path : undefined
+      );
+      this._serviceInfo.update(
+        this.hass,
+        action?.action === "perform-action" || action?.action === "call-service"
+          ? action.perform_action || action.service
+          : undefined
       );
     }
   }
@@ -182,7 +191,8 @@ export class HuiShortcutCardEditor
     const defaults = getShortcutCardDefaults(
       this.hass,
       this._config.tap_action,
-      this._navInfo.info
+      this._navInfo.info,
+      this._serviceInfo.info
     );
 
     const data = {

--- a/src/panels/lovelace/editor/config-elements/hui-shortcut-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-shortcut-card-editor.ts
@@ -68,8 +68,7 @@ export class HuiShortcutCardEditor
         this.hass,
         action?.action === "navigate" ? action.navigation_path : undefined
       );
-      this._serviceInfo.update(
-        this.hass,
+      this._serviceInfo.updateService(
         action?.action === "perform-action" || action?.action === "call-service"
           ? action.perform_action || action.service
           : undefined


### PR DESCRIPTION
## Proposed change

For shortcut cards and badges with a `perform-action` tap action, the displayed label and icon now reflect the chosen service instead of falling back to a generic bell icon and the raw service ID.

For example, `frontend.reload_themes` now shows "Reload themes" with the service's icon (or a per-domain fallback while the icon resolves), rather than `frontend.reload_themes` with the generic bell.

## Screenshots

<img width="792" height="548" alt="CleanShot 2026-05-04 at 12 14 24" src="https://github.com/user-attachments/assets/5963c057-7746-4405-8dbe-8e410f4a4055" />

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51823
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
