### PR TITLE
Fix automation row right padding and soften chip highlight animation

### DIFF
--- a/src/components/automation/ha-automation-row-event-chip.ts
+++ b/src/components/automation/ha-automation-row-event-chip.ts
@@ -53,12 +53,7 @@ export class HaAutomationRowEventChip extends LitElement {
       return keyed(
         this._highlight,
         html`
-          <wa-animation
-            fill="both"
-            .iterations=${1}
-            playbackRate="1"
-            name="headShake"
-            play
+          <wa-animation fill="both" .iterations=${1} name="headShake" play
             >${base}</wa-animation
           >
         `

--- a/src/components/automation/ha-automation-row-event-chip.ts
+++ b/src/components/automation/ha-automation-row-event-chip.ts
@@ -53,7 +53,12 @@ export class HaAutomationRowEventChip extends LitElement {
       return keyed(
         this._highlight,
         html`
-          <wa-animation fill="both" .iterations=${1} name="tada" play
+          <wa-animation
+            fill="both"
+            .iterations=${1}
+            playbackRate="1"
+            name="headShake"
+            play
             >${base}</wa-animation
           >
         `

--- a/src/components/automation/ha-automation-row.ts
+++ b/src/components/automation/ha-automation-row.ts
@@ -127,7 +127,7 @@ export class HaAutomationRow extends LitElement {
     }
     .row {
       display: flex;
-      padding: 0 var(--ha-space-3);
+      padding: 0 0 0 var(--ha-space-3);
       min-height: 48px;
       align-items: flex-start;
       cursor: pointer;


### PR DESCRIPTION
## Breaking change

<!-- Not a breaking change — remove section per template instructions -->

## Proposed change

Two small polish fixes to the automation row:

1. **Right padding removed** — the `.row` element had `padding: 0 var(--ha-space-3)` applying equal padding to both sides. This created extra visual space to the right of the three-dot menu. Changed to `padding: 0 0 0 var(--ha-space-3)` to keep only the left padding.

2. **Chip highlight animation softened** — the `heartBeat` animation used when the status chip is already visible and `highlight()` is called had a pronounced zoom effect (scales up to 1.3×). Replaced with `headShake`, which is a horizontal shake with no scale change.

## Screenshots

<!-- Please add before/after screenshots or a short video showing the visual changes. -->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr