### PR TITLE
Add temperature and precipitation forecast card features

### DIFF
--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -116,6 +116,12 @@ export const UNIT_F = "°F";
 
 /** Length units. */
 export const UNIT_IN = "in";
+export const UNIT_KM = "km";
+export const UNIT_MM = "mm";
+
+/** Pressure units. */
+export const UNIT_HPA = "hPa";
+export const UNIT_INHG = "inHg";
 
 /** Entity ID of the default view. */
 export const DEFAULT_VIEW_ENTITY_ID = "group.default_view";

--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -115,7 +115,6 @@ export const UNIT_C = "°C";
 export const UNIT_F = "°F";
 
 /** Length units. */
-export const UNIT_MM = "mm";
 export const UNIT_IN = "in";
 
 /** Entity ID of the default view. */

--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -114,6 +114,10 @@ export const DOMAINS_WITH_DYNAMIC_PICTURE = new Set([
 export const UNIT_C = "°C";
 export const UNIT_F = "°F";
 
+/** Length units. */
+export const UNIT_MM = "mm";
+export const UNIT_IN = "in";
+
 /** Entity ID of the default view. */
 export const DEFAULT_VIEW_ENTITY_ID = "group.default_view";
 

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -29,6 +29,13 @@ import type {
 import type { SVGTemplateResult, TemplateResult } from "lit";
 import { css, html, svg } from "lit";
 import { styleMap } from "lit/directives/style-map";
+import {
+  UNIT_HPA,
+  UNIT_IN,
+  UNIT_INHG,
+  UNIT_KM,
+  UNIT_MM,
+} from "../common/const";
 import { supportsFeature } from "../common/entity/supports-feature";
 import { round } from "../common/number/round";
 import "../components/ha-svg-icon";
@@ -245,12 +252,12 @@ export const getWeatherUnit = (
     case "precipitation":
       return (
         stateObj.attributes.precipitation_unit ||
-        (lengthUnit === "km" ? "mm" : "in")
+        (lengthUnit === UNIT_KM ? UNIT_MM : UNIT_IN)
       );
     case "pressure":
       return (
         stateObj.attributes.pressure_unit ||
-        (lengthUnit === "km" ? "hPa" : "inHg")
+        (lengthUnit === UNIT_KM ? UNIT_HPA : UNIT_INHG)
       );
     case "apparent_temperature":
     case "dew_point":

--- a/src/panels/lovelace/card-features/common/forecast.ts
+++ b/src/panels/lovelace/card-features/common/forecast.ts
@@ -1,0 +1,34 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { computeDomain } from "../../../../common/entity/compute_domain";
+import { supportsFeature } from "../../../../common/entity/supports-feature";
+import {
+  getDefaultForecastType,
+  getSupportedForecastTypes,
+  WeatherEntityFeature,
+} from "../../../../data/weather";
+import type { ForecastResolution } from "../types";
+
+export const DEFAULT_DAYS_TO_SHOW = 7;
+export const DEFAULT_HOURS_TO_SHOW = 24;
+
+export const MS_PER_HOUR = 60 * 60 * 1000;
+
+export const supportsForecast = (stateObj: HassEntity | undefined): boolean => {
+  if (!stateObj) return false;
+  if (computeDomain(stateObj.entity_id) !== "weather") return false;
+  return (
+    supportsFeature(stateObj, WeatherEntityFeature.FORECAST_DAILY) ||
+    supportsFeature(stateObj, WeatherEntityFeature.FORECAST_TWICE_DAILY) ||
+    supportsFeature(stateObj, WeatherEntityFeature.FORECAST_HOURLY)
+  );
+};
+
+export const resolveForecastResolution = (
+  stateObj: HassEntity | undefined,
+  configured?: ForecastResolution
+): ForecastResolution | undefined => {
+  if (!stateObj) return undefined;
+  const supported = getSupportedForecastTypes(stateObj);
+  if (configured && supported.includes(configured)) return configured;
+  return getDefaultForecastType(stateObj);
+};

--- a/src/panels/lovelace/card-features/common/graph-labels.ts
+++ b/src/panels/lovelace/card-features/common/graph-labels.ts
@@ -1,0 +1,81 @@
+import type { CSSResultGroup, TemplateResult } from "lit";
+import { css, html } from "lit";
+import memoizeOne from "memoize-one";
+import { useAmPm } from "../../../../common/datetime/use_am_pm";
+import type { FrontendLocaleData } from "../../../../data/translation";
+import { MS_PER_HOUR } from "./forecast";
+
+export const LABEL_HEIGHT = 10;
+export const LABEL_GAP = 2;
+
+const narrowWeekdayFormatter = memoizeOne(
+  (language: string) => new Intl.DateTimeFormat(language, { weekday: "narrow" })
+);
+
+const hourFormatter = memoizeOne(
+  (language: string, amPm: boolean) =>
+    new Intl.DateTimeFormat(language, {
+      hour: "numeric",
+      hourCycle: amPm ? "h12" : "h23",
+    })
+);
+
+export const renderDayLabels = (
+  entries: { datetime: string }[],
+  step: number,
+  locale: FrontendLocaleData
+): TemplateResult => {
+  const formatter = narrowWeekdayFormatter(locale.language);
+  const labels: string[] = [];
+  for (let i = 0; i < entries.length; i += step) {
+    labels.push(formatter.format(new Date(entries[i].datetime)));
+  }
+  return html`
+    <div class="day-labels">
+      ${labels.map((label) => html`<div class="day-label">${label}</div>`)}
+    </div>
+  `;
+};
+
+export const renderHourLabels = (
+  hoursToShow: number,
+  locale: FrontendLocaleData
+): TemplateResult => {
+  const formatter = hourFormatter(locale.language, useAmPm(locale));
+  const now = Date.now();
+  const maxTime =
+    Math.floor((now + hoursToShow * MS_PER_HOUR) / MS_PER_HOUR) * MS_PER_HOUR;
+  const step = Math.max(1, Math.round(hoursToShow / 4));
+  const labels: string[] = [];
+  for (let h = 0; h <= hoursToShow; h += step) {
+    const t = now + h * MS_PER_HOUR;
+    if (t > maxTime) break;
+    labels.push(formatter.format(new Date(t)));
+  }
+  return html`
+    <div class="hour-labels">
+      ${labels.map((label) => html`<div class="hour-label">${label}</div>`)}
+    </div>
+  `;
+};
+
+export const graphLabelsStyles: CSSResultGroup = css`
+  .day-labels,
+  .hour-labels {
+    display: flex;
+    align-items: center;
+    height: 10px;
+    color: var(--secondary-text-color);
+    font-size: 9px;
+    line-height: 1;
+  }
+
+  .hour-labels {
+    justify-content: space-between;
+  }
+
+  .day-label {
+    flex: 1;
+    text-align: center;
+  }
+`;

--- a/src/panels/lovelace/card-features/common/graph-labels.ts
+++ b/src/panels/lovelace/card-features/common/graph-labels.ts
@@ -1,5 +1,6 @@
 import type { CSSResultGroup, TemplateResult } from "lit";
-import { css, html } from "lit";
+import { css, html, nothing } from "lit";
+import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
 import { useAmPm } from "../../../../common/datetime/use_am_pm";
 import type { FrontendLocaleData } from "../../../../data/translation";
@@ -59,15 +60,50 @@ export const renderHourLabels = (
   `;
 };
 
+export const renderHourSlotLabels = (
+  hoursToShow: number,
+  locale: FrontendLocaleData
+): TemplateResult => {
+  const formatter = hourFormatter(locale.language, useAmPm(locale));
+  const startTime = Math.ceil(Date.now() / MS_PER_HOUR) * MS_PER_HOUR;
+  const step = Math.max(1, Math.round(hoursToShow / 4));
+  return html`
+    <div
+      class="hour-slot-labels"
+      style=${styleMap({
+        "grid-template-columns": `repeat(${hoursToShow}, 1fr)`,
+      })}
+    >
+      ${Array.from({ length: hoursToShow }, (_, i) => {
+        if (i % step !== 0) return nothing;
+        const t = startTime + i * MS_PER_HOUR;
+        return html`
+          <div
+            class="hour-slot-label"
+            style=${styleMap({ "grid-column": String(i + 1) })}
+          >
+            ${formatter.format(new Date(t))}
+          </div>
+        `;
+      })}
+    </div>
+  `;
+};
+
 export const graphLabelsStyles: CSSResultGroup = css`
   .day-labels,
-  .hour-labels {
-    display: flex;
+  .hour-labels,
+  .hour-slot-labels {
     align-items: center;
     height: 10px;
     color: var(--secondary-text-color);
     font-size: 9px;
     line-height: 1;
+  }
+
+  .day-labels,
+  .hour-labels {
+    display: flex;
   }
 
   .hour-labels {
@@ -77,5 +113,15 @@ export const graphLabelsStyles: CSSResultGroup = css`
   .day-label {
     flex: 1;
     text-align: center;
+  }
+
+  .hour-slot-labels {
+    display: grid;
+  }
+
+  .hour-slot-label {
+    text-align: center;
+    min-width: 0;
+    white-space: nowrap;
   }
 `;

--- a/src/panels/lovelace/card-features/common/temperature-palette.ts
+++ b/src/panels/lovelace/card-features/common/temperature-palette.ts
@@ -1,0 +1,119 @@
+import { hex2rgb, rgb2hex } from "../../../../common/color/convert-color";
+import { clamp } from "../../../../common/number/clamp";
+
+type RGB = [number, number, number];
+
+const PALETTE_MIN = -6;
+
+const PALETTE_HEX = [
+  "#249df2", // -6
+  "#239dec", // -5
+  "#239fec", // -4
+  "#23a3eb", // -3
+  "#23a6eb", // -2
+  "#23a9e9", // -1
+  "#22abe6", // 0
+  "#22aee4", // 1
+  "#22b1e0", // 2
+  "#21b1dd", // 3
+  "#23b6da", // 4
+  "#28b8d6", // 5
+  "#2abdd3", // 6
+  "#2fbfcf", // 7
+  "#34c4cc", // 8
+  "#36c6c9", // 9
+  "#43c9c0", // 10
+  "#59c9b3", // 11
+  "#6fc9a3", // 12
+  "#82c992", // 13
+  "#98c985", // 14
+  "#a8c977", // 15
+  "#b9c762", // 16
+  "#c7c74d", // 17
+  "#d1be31", // 18
+  "#dbb921", // 19
+  "#e6ba22", // 20
+  "#ecc123", // 21
+  "#ecba23", // 22
+  "#eeb424", // 23
+  "#ecaa23", // 24
+  "#eca023", // 25
+  "#ec9723", // 26
+  "#ec8f23", // 27
+  "#ec8523", // 28
+  "#ec7c23", // 29
+  "#ee7f24", // 30
+  "#e67122", // 31
+  "#df6321", // 32
+  "#df5b21", // 33
+  "#dd5421", // 34
+  "#db4c21", // 35
+  "#db4121", // 36
+  "#db3721", // 37
+  "#d62f20", // 38
+  "#cc301f", // 39
+  "#c22a1d", // 40
+  "#ca2d1e", // 41
+  "#c82c1d", // 42
+];
+
+const PALETTE_MAX = PALETTE_MIN + PALETTE_HEX.length - 1;
+const PALETTE: RGB[] = PALETTE_HEX.map((hex) => hex2rgb(hex));
+
+const paletteAt = (tempC: number): RGB => {
+  const clamped = Math.max(PALETTE_MIN, Math.min(PALETTE_MAX, tempC));
+  const idx = clamped - PALETTE_MIN;
+  const i0 = Math.floor(idx);
+  const i1 = Math.min(i0 + 1, PALETTE.length - 1);
+  const frac = idx - i0;
+  const a = PALETTE[i0];
+  const b = PALETTE[i1];
+  return [
+    a[0] + (b[0] - a[0]) * frac,
+    a[1] + (b[1] - a[1]) * frac,
+    a[2] + (b[2] - a[2]) * frac,
+  ];
+};
+
+export interface GradientStop {
+  offset: number;
+  color: string;
+}
+
+const buildStops = (
+  min: number,
+  max: number,
+  nStops: number,
+  tEffFor: (temp: number) => number
+): GradientStop[] => {
+  const stops: GradientStop[] = [];
+  for (let i = 0; i < nStops; i++) {
+    const offset = i / (nStops - 1);
+    const temp = max + offset * (min - max);
+    stops.push({ offset, color: rgb2hex(paletteAt(tEffFor(temp))) });
+  }
+  return stops;
+};
+
+export const getAbsoluteGradient = (
+  min: number,
+  max: number,
+  nStops = 5
+): GradientStop[] => buildStops(min, max, nStops, (temp) => temp);
+
+// Compression scales with the midpoint: cool ranges stay near-uniform, warm
+// ranges spread wider across the palette.
+export const getRelativeGradient = (
+  min: number,
+  max: number,
+  nStops = 5
+): GradientStop[] => {
+  const mid = (min + max) / 2;
+  const compression = clamp(-0.15 + 0.025 * mid, 0.05, 1);
+  return buildStops(
+    min,
+    max,
+    nStops,
+    (temp) => mid + compression * (temp - mid)
+  );
+};

--- a/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
@@ -1,4 +1,5 @@
 import { consume } from "@lit/context";
+import { ResizeController } from "@lit-labs/observers/resize-controller";
 import type {
   Connection,
   HassEntity,
@@ -110,6 +111,14 @@ class HuiPrecipitationForecastCardFeature
 
   private _subscribedType?: ForecastResolution;
 
+  private _size = new ResizeController(this, {
+    callback: (entries) => {
+      const rect = entries?.[0]?.contentRect;
+      if (!rect) return undefined;
+      return { width: rect.width, height: rect.height };
+    },
+  });
+
   static getStubConfig(): PrecipitationForecastCardFeatureConfig {
     return {
       type: "precipitation-forecast",
@@ -178,7 +187,12 @@ class HuiPrecipitationForecastCardFeature
     if (this._error) {
       return html`
         <div class="container">
-          <div class="info">${this._error}</div>
+          <div class="info">
+            ${this._localize(
+              "ui.panel.lovelace.editor.features.types.precipitation-forecast.failed_to_load",
+              { error: this._error }
+            )}
+          </div>
         </div>
       `;
     }
@@ -249,8 +263,8 @@ class HuiPrecipitationForecastCardFeature
     precipitationType: "amount" | "probability",
     fill: string
   ): TemplateResult {
-    const width = this.clientWidth || 300;
-    const height = this.clientHeight || 42;
+    const width = this._size.value?.width || this.clientWidth;
+    const height = this._size.value?.height || this.clientHeight;
     const padding = 4;
     const minGap = 4;
     const slotWidth = width / entries.length;
@@ -280,7 +294,7 @@ class HuiPrecipitationForecastCardFeature
           cy=${cy}
           r=${dotRadius}
           fill=${fill}
-          opacity="0.4"
+          class="mark"
         ></circle>`;
       }
       const barHeight = Math.max(
@@ -295,7 +309,7 @@ class HuiPrecipitationForecastCardFeature
         barHeight,
         barWidth / 4
       );
-      return svg`<path d=${d} fill=${fill} opacity="0.4"></path>`;
+      return svg`<path d=${d} fill=${fill} class="mark"></path>`;
     });
 
     return html`
@@ -317,8 +331,8 @@ class HuiPrecipitationForecastCardFeature
     if (!this._forecast?.length) {
       return nothing;
     }
-    const width = this.clientWidth || 300;
-    const height = this.clientHeight || 42;
+    const width = this._size.value?.width || this.clientWidth;
+    const height = this._size.value?.height || this.clientHeight;
     const topPadding = 4;
     const drawableHeight = height - topPadding;
 
@@ -374,7 +388,7 @@ class HuiPrecipitationForecastCardFeature
           cy=${cy}
           r=${dotRadius}
           fill=${fill}
-          opacity="0.4"
+          class="mark"
         ></circle>`;
       }
       const x = xCenter - barWidth / 2;
@@ -384,7 +398,7 @@ class HuiPrecipitationForecastCardFeature
       );
       const y = height - barHeight;
       const d = topRoundedRectPath(x, y, barWidth, barHeight, barWidth / 4);
-      return svg`<path d=${d} fill=${fill} opacity="0.4"></path>`;
+      return svg`<path d=${d} fill=${fill} class="mark"></path>`;
     });
 
     return html`
@@ -452,7 +466,8 @@ class HuiPrecipitationForecastCardFeature
         flex-direction: column;
         justify-content: flex-end;
         align-items: stretch;
-        pointer-events: none !important;
+        pointer-events: none;
+        --feature-precipitation-opacity: 0.4;
       }
 
       .container {
@@ -462,14 +477,7 @@ class HuiPrecipitationForecastCardFeature
         flex-direction: column;
         justify-content: center;
         align-items: stretch;
-        border-bottom-right-radius: 8px;
-        border-bottom-left-radius: 8px;
         overflow: hidden;
-      }
-
-      .container.with-labels {
-        border-bottom-right-radius: 0;
-        border-bottom-left-radius: 0;
       }
 
       .bars {
@@ -490,6 +498,10 @@ class HuiPrecipitationForecastCardFeature
 
       svg {
         display: block;
+      }
+
+      .mark {
+        opacity: var(--feature-precipitation-opacity);
       }
     `,
   ];

--- a/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
@@ -7,10 +7,12 @@ import type {
 import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing, svg } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
 import { computeCssColor } from "../../../common/color/compute-color";
 import { consumeEntityState } from "../../../common/decorators/consume-context-entry";
 import { transform } from "../../../common/decorators/transform";
 import type { LocalizeFunc } from "../../../common/translations/localize";
+import type { FrontendLocaleData } from "../../../data/translation";
 import "../../../components/ha-spinner";
 import {
   connectionContext,
@@ -33,6 +35,11 @@ import {
   resolveForecastResolution,
   supportsForecast,
 } from "./common/forecast";
+import {
+  graphLabelsStyles,
+  renderDayLabels,
+  renderHourLabels,
+} from "./common/graph-labels";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import type {
   ForecastResolution,
@@ -41,6 +48,17 @@ import type {
 } from "./types";
 
 const MAX_BAR_WIDTH = 16;
+
+const topRoundedRectPath = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+): string => {
+  const r = Math.max(0, Math.min(radius, width / 2, height));
+  return `M ${x},${y + r} a ${r},${r} 0 0 1 ${r},${-r} h ${width - 2 * r} a ${r},${r} 0 0 1 ${r},${r} v ${height - r} h ${-width} z`;
+};
 
 export const supportsPrecipitationForecastCardFeature = (
   hass: HomeAssistant,
@@ -67,6 +85,13 @@ class HuiPrecipitationForecastCardFeature
     transformer: ({ localize }) => localize,
   })
   private _localize!: LocalizeFunc;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale?: FrontendLocaleData;
 
   @state()
   @consume({ context: connectionContext, subscribe: true })
@@ -142,6 +167,10 @@ class HuiPrecipitationForecastCardFeature
     );
   }
 
+  private get _showLabels(): boolean {
+    return this._config?.show_labels !== false;
+  }
+
   protected render() {
     if (!this._config || !this.context || !supportsForecast(this._stateObj)) {
       return nothing;
@@ -168,10 +197,21 @@ class HuiPrecipitationForecastCardFeature
       : undefined;
     const fill = customColor ?? "var(--state-weather-rainy-color)";
 
+    const containerClasses = classMap({
+      container: true,
+      "with-labels": this._showLabels,
+    });
+
     if (isHourly) {
+      const hoursToShow = this._config.hours_to_show ?? DEFAULT_HOURS_TO_SHOW;
       return html`
-        <div class="container">
-          ${this._renderHourlyBars(precipitationType, fill)}
+        <div class=${containerClasses}>
+          <div class="bars">
+            ${this._renderHourlyBars(precipitationType, fill)}
+          </div>
+          ${this._showLabels && this._locale
+            ? renderHourLabels(hoursToShow, this._locale)
+            : nothing}
         </div>
       `;
     }
@@ -193,8 +233,13 @@ class HuiPrecipitationForecastCardFeature
     }
 
     return html`
-      <div class="container">
-        ${this._renderDailyBars(entries, precipitationType, fill)}
+      <div class=${containerClasses}>
+        <div class="bars">
+          ${this._renderDailyBars(entries, precipitationType, fill)}
+        </div>
+        ${this._showLabels && this._locale
+          ? renderDayLabels(entries, entriesPerDay, this._locale)
+          : nothing}
       </div>
     `;
   }
@@ -243,14 +288,14 @@ class HuiPrecipitationForecastCardFeature
         (value! / maxPrecipitation) * drawableHeight
       );
       const y = padding + drawableHeight - barHeight;
-      return svg`<rect
-        x=${x - barWidth / 2}
-        y=${y}
-        width=${barWidth}
-        height=${barHeight}
-        fill=${fill}
-        opacity="0.4"
-      ></rect>`;
+      const d = topRoundedRectPath(
+        x - barWidth / 2,
+        y,
+        barWidth,
+        barHeight,
+        barWidth / 4
+      );
+      return svg`<path d=${d} fill=${fill} opacity="0.4"></path>`;
     });
 
     return html`
@@ -338,14 +383,8 @@ class HuiPrecipitationForecastCardFeature
         (value! / maxPrecipitation) * drawableHeight
       );
       const y = height - barHeight;
-      return svg`<rect
-        x=${x}
-        y=${y}
-        width=${barWidth}
-        height=${barHeight}
-        fill=${fill}
-        opacity="0.4"
-      ></rect>`;
+      const d = topRoundedRectPath(x, y, barWidth, barHeight, barWidth / 4);
+      return svg`<path d=${d} fill=${fill} opacity="0.4"></path>`;
     });
 
     return html`
@@ -403,37 +442,57 @@ class HuiPrecipitationForecastCardFeature
     });
   }
 
-  static styles = css`
-    :host {
-      display: flex;
-      width: 100%;
-      height: var(--feature-height);
-      flex-direction: column;
-      justify-content: flex-end;
-      align-items: stretch;
-      pointer-events: none !important;
-    }
+  static styles = [
+    graphLabelsStyles,
+    css`
+      :host {
+        display: flex;
+        width: 100%;
+        height: var(--feature-height);
+        flex-direction: column;
+        justify-content: flex-end;
+        align-items: stretch;
+        pointer-events: none !important;
+      }
 
-    .container {
-      width: 100%;
-      height: 100%;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      border-bottom-right-radius: 8px;
-      border-bottom-left-radius: 8px;
-      overflow: hidden;
-    }
+      .container {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: stretch;
+        border-bottom-right-radius: 8px;
+        border-bottom-left-radius: 8px;
+        overflow: hidden;
+      }
 
-    .info {
-      color: var(--secondary-text-color);
-      font-size: var(--ha-font-size-s);
-    }
+      .container.with-labels {
+        border-bottom-right-radius: 0;
+        border-bottom-left-radius: 0;
+      }
 
-    svg {
-      display: block;
-    }
-  `;
+      .bars {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        align-items: stretch;
+      }
+
+      .container.with-labels .bars {
+        padding-bottom: 2px;
+      }
+
+      .info {
+        color: var(--secondary-text-color);
+        font-size: var(--ha-font-size-s);
+      }
+
+      svg {
+        display: block;
+      }
+    `,
+  ];
 }
 
 declare global {

--- a/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
@@ -1,0 +1,443 @@
+import { consume } from "@lit/context";
+import type {
+  Connection,
+  HassEntity,
+  UnsubscribeFunc,
+} from "home-assistant-js-websocket";
+import type { PropertyValues, TemplateResult } from "lit";
+import { css, html, LitElement, nothing, svg } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { computeCssColor } from "../../../common/color/compute-color";
+import { consumeEntityState } from "../../../common/decorators/consume-context-entry";
+import { transform } from "../../../common/decorators/transform";
+import type { LocalizeFunc } from "../../../common/translations/localize";
+import "../../../components/ha-spinner";
+import {
+  connectionContext,
+  internationalizationContext,
+} from "../../../data/context";
+import type { ForecastAttribute, ForecastEvent } from "../../../data/weather";
+import {
+  getForecastPrecipitation,
+  subscribeForecast,
+} from "../../../data/weather";
+import type {
+  HomeAssistant,
+  HomeAssistantConnection,
+  HomeAssistantInternationalization,
+} from "../../../types";
+import {
+  DEFAULT_DAYS_TO_SHOW,
+  DEFAULT_HOURS_TO_SHOW,
+  MS_PER_HOUR,
+  resolveForecastResolution,
+  supportsForecast,
+} from "./common/forecast";
+import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
+import type {
+  ForecastResolution,
+  LovelaceCardFeatureContext,
+  PrecipitationForecastCardFeatureConfig,
+} from "./types";
+
+const MAX_BAR_WIDTH = 16;
+
+export const supportsPrecipitationForecastCardFeature = (
+  hass: HomeAssistant,
+  context: LovelaceCardFeatureContext
+) =>
+  supportsForecast(
+    context.entity_id ? hass.states[context.entity_id] : undefined
+  );
+
+@customElement("hui-precipitation-forecast-card-feature")
+class HuiPrecipitationForecastCardFeature
+  extends LitElement
+  implements LovelaceCardFeature
+{
+  @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
+
+  @state()
+  @consumeEntityState({ entityIdPath: ["context", "entity_id"] })
+  private _stateObj?: HassEntity;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, LocalizeFunc>({
+    transformer: ({ localize }) => localize,
+  })
+  private _localize!: LocalizeFunc;
+
+  @state()
+  @consume({ context: connectionContext, subscribe: true })
+  @transform<HomeAssistantConnection, Connection>({
+    transformer: ({ connection }) => connection,
+  })
+  private _connection!: Connection;
+
+  @state() private _config?: PrecipitationForecastCardFeatureConfig;
+
+  @state() private _forecast?: ForecastAttribute[];
+
+  @state() private _error?: string;
+
+  private _subscribed?: Promise<UnsubscribeFunc | undefined>;
+
+  private _subscribedType?: ForecastResolution;
+
+  static getStubConfig(): PrecipitationForecastCardFeatureConfig {
+    return {
+      type: "precipitation-forecast",
+    };
+  }
+
+  public static async getConfigElement(): Promise<LovelaceCardFeatureEditor> {
+    await import("../editor/config-elements/hui-precipitation-forecast-card-feature-editor");
+    return document.createElement(
+      "hui-precipitation-forecast-card-feature-editor"
+    ) as LovelaceCardFeatureEditor;
+  }
+
+  public setConfig(config: PrecipitationForecastCardFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  public connectedCallback() {
+    super.connectedCallback();
+    if (this.hasUpdated) {
+      this._subscribeForecast();
+    }
+  }
+
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    this._unsubscribeForecast();
+  }
+
+  protected firstUpdated() {
+    this._subscribeForecast();
+  }
+
+  protected updated(changedProps: PropertyValues) {
+    const resolvedType = this._resolvedForecastType();
+    const contextChanged =
+      changedProps.has("context") &&
+      (changedProps.get("context") as LovelaceCardFeatureContext | undefined)
+        ?.entity_id !== this.context?.entity_id;
+    const configTypeChanged =
+      changedProps.has("_config") && resolvedType !== this._subscribedType;
+    if (contextChanged || configTypeChanged) {
+      this._unsubscribeForecast();
+      this._subscribeForecast();
+    }
+  }
+
+  private _resolvedForecastType(): ForecastResolution | undefined {
+    return resolveForecastResolution(
+      this._stateObj,
+      this._config?.forecast_type
+    );
+  }
+
+  protected render() {
+    if (!this._config || !this.context || !supportsForecast(this._stateObj)) {
+      return nothing;
+    }
+    if (this._error) {
+      return html`
+        <div class="container">
+          <div class="info">${this._error}</div>
+        </div>
+      `;
+    }
+    if (!this._forecast) {
+      return html`
+        <div class="container loading">
+          <ha-spinner size="small"></ha-spinner>
+        </div>
+      `;
+    }
+
+    const isHourly = this._subscribedType === "hourly";
+    const precipitationType = this._config.precipitation_type ?? "amount";
+    const customColor = this._config.color
+      ? computeCssColor(this._config.color)
+      : undefined;
+    const fill = customColor ?? "var(--state-weather-rainy-color)";
+
+    if (isHourly) {
+      return html`
+        <div class="container">
+          ${this._renderHourlyBars(precipitationType, fill)}
+        </div>
+      `;
+    }
+
+    const daysToShow = this._config.days_to_show ?? DEFAULT_DAYS_TO_SHOW;
+    const entriesPerDay = this._subscribedType === "twice_daily" ? 2 : 1;
+    const entries = this._forecast.slice(0, daysToShow * entriesPerDay);
+
+    if (!entries.length) {
+      return html`
+        <div class="container">
+          <div class="info">
+            ${this._localize(
+              "ui.panel.lovelace.editor.features.types.precipitation-forecast.no_forecast"
+            )}
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="container">
+        ${this._renderDailyBars(entries, precipitationType, fill)}
+      </div>
+    `;
+  }
+
+  private _renderDailyBars(
+    entries: ForecastAttribute[],
+    precipitationType: "amount" | "probability",
+    fill: string
+  ): TemplateResult {
+    const width = this.clientWidth || 300;
+    const height = this.clientHeight || 42;
+    const padding = 4;
+    const minGap = 4;
+    const slotWidth = width / entries.length;
+    const barWidth = Math.max(1, Math.min(MAX_BAR_WIDTH, slotWidth - minGap));
+    const drawableHeight = height - padding * 2;
+
+    let maxPrecipitation = 0;
+    if (precipitationType === "probability") {
+      maxPrecipitation = 100;
+    } else {
+      for (const entry of entries) {
+        const value = getForecastPrecipitation(entry, precipitationType);
+        if (Number.isFinite(value)) {
+          maxPrecipitation = Math.max(maxPrecipitation, value!);
+        }
+      }
+    }
+
+    const dotRadius = 1.5;
+    const elements = entries.map((entry, i) => {
+      const value = getForecastPrecipitation(entry, precipitationType);
+      const x = slotWidth * i + slotWidth / 2;
+      if (!Number.isFinite(value) || value! <= 0 || maxPrecipitation <= 0) {
+        const cy = padding + drawableHeight - dotRadius;
+        return svg`<circle
+          cx=${x}
+          cy=${cy}
+          r=${dotRadius}
+          fill=${fill}
+          opacity="0.4"
+        ></circle>`;
+      }
+      const barHeight = Math.max(
+        1,
+        (value! / maxPrecipitation) * drawableHeight
+      );
+      const y = padding + drawableHeight - barHeight;
+      return svg`<rect
+        x=${x - barWidth / 2}
+        y=${y}
+        width=${barWidth}
+        height=${barHeight}
+        fill=${fill}
+        opacity="0.4"
+      ></rect>`;
+    });
+
+    return html`
+      <svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 ${width} ${height}"
+        preserveAspectRatio="none"
+      >
+        ${elements}
+      </svg>
+    `;
+  }
+
+  private _renderHourlyBars(
+    precipitationType: "amount" | "probability",
+    fill: string
+  ): TemplateResult | typeof nothing {
+    if (!this._forecast?.length) {
+      return nothing;
+    }
+    const width = this.clientWidth || 300;
+    const height = this.clientHeight || 42;
+    const topPadding = 4;
+    const drawableHeight = height - topPadding;
+
+    const now = Date.now();
+    const hoursToShow = this._config!.hours_to_show ?? DEFAULT_HOURS_TO_SHOW;
+    const maxTime =
+      Math.floor((now + hoursToShow * MS_PER_HOUR) / MS_PER_HOUR) * MS_PER_HOUR;
+    const timeRange = maxTime - now;
+    if (timeRange <= 0) {
+      return nothing;
+    }
+
+    const inRange: { entry: ForecastAttribute; t: number }[] = [];
+    for (const entry of this._forecast) {
+      const t = new Date(entry.datetime).getTime();
+      if (t >= now && t <= maxTime) {
+        inRange.push({ entry, t });
+      }
+    }
+
+    if (!inRange.length) {
+      return nothing;
+    }
+
+    const entriesWithRain = inRange.filter(({ entry }) => {
+      const value = getForecastPrecipitation(entry, precipitationType);
+      return Number.isFinite(value) && value! > 0;
+    });
+
+    let maxPrecipitation = 0;
+    if (precipitationType === "probability") {
+      maxPrecipitation = 100;
+    } else {
+      for (const { entry } of entriesWithRain) {
+        maxPrecipitation = Math.max(
+          maxPrecipitation,
+          getForecastPrecipitation(entry, precipitationType)!
+        );
+      }
+    }
+
+    const slotWidth = width / hoursToShow;
+    const barWidth = Math.max(1, Math.min(MAX_BAR_WIDTH, slotWidth - 2));
+    const dotRadius = 1.5;
+
+    const elements = inRange.map(({ entry, t }) => {
+      const value = getForecastPrecipitation(entry, precipitationType);
+      const xCenter = ((t - now) / timeRange) * width;
+      if (!Number.isFinite(value) || value! <= 0 || maxPrecipitation <= 0) {
+        const cy = height - dotRadius;
+        return svg`<circle
+          cx=${xCenter}
+          cy=${cy}
+          r=${dotRadius}
+          fill=${fill}
+          opacity="0.4"
+        ></circle>`;
+      }
+      const x = xCenter - barWidth / 2;
+      const barHeight = Math.max(
+        1,
+        (value! / maxPrecipitation) * drawableHeight
+      );
+      const y = height - barHeight;
+      return svg`<rect
+        x=${x}
+        y=${y}
+        width=${barWidth}
+        height=${barHeight}
+        fill=${fill}
+        opacity="0.4"
+      ></rect>`;
+    });
+
+    return html`
+      <svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 ${width} ${height}"
+        preserveAspectRatio="none"
+      >
+        ${elements}
+      </svg>
+    `;
+  }
+
+  private _unsubscribeForecast() {
+    if (this._subscribed) {
+      this._subscribed.then((unsub) => unsub?.()).catch(() => undefined);
+      this._subscribed = undefined;
+    }
+    this._subscribedType = undefined;
+  }
+
+  private async _subscribeForecast() {
+    if (
+      !this.context?.entity_id ||
+      !this._config ||
+      !this._connection ||
+      this._subscribed
+    ) {
+      return;
+    }
+
+    const forecastType = this._resolvedForecastType();
+    if (!forecastType) {
+      return;
+    }
+
+    const entityId = this.context.entity_id;
+    this._forecast = undefined;
+    this._error = undefined;
+    this._subscribedType = forecastType;
+
+    this._subscribed = subscribeForecast(
+      this._connection,
+      entityId,
+      forecastType,
+      (forecastEvent: ForecastEvent) => {
+        this._forecast = forecastEvent.forecast ?? [];
+      }
+    ).catch((err) => {
+      this._subscribed = undefined;
+      this._subscribedType = undefined;
+      this._error = err.message || err.code;
+      return undefined;
+    });
+  }
+
+  static styles = css`
+    :host {
+      display: flex;
+      width: 100%;
+      height: var(--feature-height);
+      flex-direction: column;
+      justify-content: flex-end;
+      align-items: stretch;
+      pointer-events: none !important;
+    }
+
+    .container {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      border-bottom-right-radius: 8px;
+      border-bottom-left-radius: 8px;
+      overflow: hidden;
+    }
+
+    .info {
+      color: var(--secondary-text-color);
+      font-size: var(--ha-font-size-s);
+    }
+
+    svg {
+      display: block;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-precipitation-forecast-card-feature": HuiPrecipitationForecastCardFeature;
+  }
+}

--- a/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
@@ -156,17 +156,23 @@ class HuiPrecipitationForecastCardFeature
   }
 
   protected updated(changedProps: PropertyValues) {
-    const resolvedType = this._resolvedForecastType();
-    const contextChanged =
-      changedProps.has("context") &&
-      (changedProps.get("context") as LovelaceCardFeatureContext | undefined)
-        ?.entity_id !== this.context?.entity_id;
-    const configTypeChanged =
-      changedProps.has("_config") && resolvedType !== this._subscribedType;
-    if (contextChanged || configTypeChanged) {
+    if (this._shouldResubscribe(changedProps)) {
       this._unsubscribeForecast();
       this._subscribeForecast();
     }
+  }
+
+  private _shouldResubscribe(changedProps: PropertyValues): boolean {
+    if (changedProps.has("context")) {
+      const previous = changedProps.get("context") as
+        | LovelaceCardFeatureContext
+        | undefined;
+      if (previous?.entity_id !== this.context?.entity_id) return true;
+    }
+    if (changedProps.has("_config")) {
+      if (this._resolvedForecastType() !== this._subscribedType) return true;
+    }
+    return false;
   }
 
   private _resolvedForecastType(): ForecastResolution | undefined {
@@ -217,12 +223,22 @@ class HuiPrecipitationForecastCardFeature
     });
 
     if (isHourly) {
+      const hourlyBars = this._renderHourlyBars(precipitationType, fill);
+      if (!hourlyBars) {
+        return html`
+          <div class="container">
+            <div class="info">
+              ${this._localize(
+                "ui.panel.lovelace.editor.features.types.precipitation-forecast.no_forecast"
+              )}
+            </div>
+          </div>
+        `;
+      }
       const hoursToShow = this._config.hours_to_show ?? DEFAULT_HOURS_TO_SHOW;
       return html`
         <div class=${containerClasses}>
-          <div class="bars">
-            ${this._renderHourlyBars(precipitationType, fill)}
-          </div>
+          <div class="bars">${hourlyBars}</div>
           ${this._showLabels && this._locale
             ? renderHourLabels(hoursToShow, this._locale)
             : nothing}
@@ -271,12 +287,12 @@ class HuiPrecipitationForecastCardFeature
     const barWidth = Math.max(1, Math.min(MAX_BAR_WIDTH, slotWidth - minGap));
     const drawableHeight = height - padding * 2;
 
-    let maxPrecipitation = 0;
-    if (precipitationType === "probability") {
-      maxPrecipitation = 100;
-    } else {
-      for (const entry of entries) {
-        const value = getForecastPrecipitation(entry, precipitationType);
+    const values = entries.map((entry) =>
+      getForecastPrecipitation(entry, precipitationType)
+    );
+    let maxPrecipitation = precipitationType === "probability" ? 100 : 0;
+    if (precipitationType === "amount") {
+      for (const value of values) {
         if (Number.isFinite(value)) {
           maxPrecipitation = Math.max(maxPrecipitation, value!);
         }
@@ -284,8 +300,7 @@ class HuiPrecipitationForecastCardFeature
     }
 
     const dotRadius = 1.5;
-    const elements = entries.map((entry, i) => {
-      const value = getForecastPrecipitation(entry, precipitationType);
+    const elements = values.map((value, i) => {
       const x = slotWidth * i + slotWidth / 2;
       if (!Number.isFinite(value) || value! <= 0 || maxPrecipitation <= 0) {
         const cy = padding + drawableHeight - dotRadius;
@@ -327,9 +342,9 @@ class HuiPrecipitationForecastCardFeature
   private _renderHourlyBars(
     precipitationType: "amount" | "probability",
     fill: string
-  ): TemplateResult | typeof nothing {
+  ): TemplateResult | undefined {
     if (!this._forecast?.length) {
-      return nothing;
+      return undefined;
     }
     const width = this._size.value?.width || this.clientWidth;
     const height = this._size.value?.height || this.clientHeight;
@@ -342,35 +357,30 @@ class HuiPrecipitationForecastCardFeature
       Math.floor((now + hoursToShow * MS_PER_HOUR) / MS_PER_HOUR) * MS_PER_HOUR;
     const timeRange = maxTime - now;
     if (timeRange <= 0) {
-      return nothing;
+      return undefined;
     }
 
-    const inRange: { entry: ForecastAttribute; t: number }[] = [];
+    const inRange: { value: number | undefined; t: number }[] = [];
     for (const entry of this._forecast) {
       const t = new Date(entry.datetime).getTime();
       if (t >= now && t <= maxTime) {
-        inRange.push({ entry, t });
+        inRange.push({
+          value: getForecastPrecipitation(entry, precipitationType),
+          t,
+        });
       }
     }
 
     if (!inRange.length) {
-      return nothing;
+      return undefined;
     }
 
-    const entriesWithRain = inRange.filter(({ entry }) => {
-      const value = getForecastPrecipitation(entry, precipitationType);
-      return Number.isFinite(value) && value! > 0;
-    });
-
-    let maxPrecipitation = 0;
-    if (precipitationType === "probability") {
-      maxPrecipitation = 100;
-    } else {
-      for (const { entry } of entriesWithRain) {
-        maxPrecipitation = Math.max(
-          maxPrecipitation,
-          getForecastPrecipitation(entry, precipitationType)!
-        );
+    let maxPrecipitation = precipitationType === "probability" ? 100 : 0;
+    if (precipitationType === "amount") {
+      for (const { value } of inRange) {
+        if (Number.isFinite(value)) {
+          maxPrecipitation = Math.max(maxPrecipitation, value!);
+        }
       }
     }
 
@@ -378,9 +388,9 @@ class HuiPrecipitationForecastCardFeature
     const barWidth = Math.max(1, Math.min(MAX_BAR_WIDTH, slotWidth - 2));
     const dotRadius = 1.5;
 
-    const elements = inRange.map(({ entry, t }) => {
-      const value = getForecastPrecipitation(entry, precipitationType);
-      const xCenter = ((t - now) / timeRange) * width;
+    const elements = inRange.map(({ value, t }) => {
+      // Each entry represents an hour-long slot; center the bar in that slot.
+      const xCenter = ((t - now) / timeRange) * width + slotWidth / 2;
       if (!Number.isFinite(value) || value! <= 0 || maxPrecipitation <= 0) {
         const cy = height - dotRadius;
         return svg`<circle
@@ -466,7 +476,7 @@ class HuiPrecipitationForecastCardFeature
         flex-direction: column;
         justify-content: flex-end;
         align-items: stretch;
-        pointer-events: none;
+        pointer-events: none !important;
         --feature-precipitation-opacity: 0.4;
       }
 

--- a/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
@@ -40,7 +40,7 @@ import {
 import {
   graphLabelsStyles,
   renderDayLabels,
-  renderHourLabels,
+  renderHourSlotLabels,
 } from "./common/graph-labels";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import type {
@@ -256,7 +256,7 @@ class HuiPrecipitationForecastCardFeature
         <div class=${containerClasses}>
           <div class="bars">${hourlyBars}</div>
           ${this._showLabels && this._locale
-            ? renderHourLabels(hoursToShow, this._locale)
+            ? renderHourSlotLabels(hoursToShow, this._locale)
             : nothing}
         </div>
       `;
@@ -370,17 +370,14 @@ class HuiPrecipitationForecastCardFeature
 
     const now = Date.now();
     const hoursToShow = this._config!.hours_to_show ?? DEFAULT_HOURS_TO_SHOW;
-    const maxTime =
-      Math.floor((now + hoursToShow * MS_PER_HOUR) / MS_PER_HOUR) * MS_PER_HOUR;
-    const timeRange = maxTime - now;
-    if (timeRange <= 0) {
-      return undefined;
-    }
+    const startTime = Math.ceil(now / MS_PER_HOUR) * MS_PER_HOUR;
+    const timeRange = hoursToShow * MS_PER_HOUR;
+    const maxTime = startTime + timeRange;
 
     const inRange: { value: number | undefined; t: number }[] = [];
     for (const entry of this._forecast) {
       const t = new Date(entry.datetime).getTime();
-      if (t >= now && t <= maxTime) {
+      if (t >= startTime && t < maxTime) {
         inRange.push({
           value: getForecastPrecipitation(entry, precipitationType),
           t,
@@ -408,7 +405,7 @@ class HuiPrecipitationForecastCardFeature
 
     const elements = inRange.map(({ value, t }) => {
       // Each entry represents an hour-long slot; center the bar in that slot.
-      const xCenter = ((t - now) / timeRange) * width + slotWidth / 2;
+      const xCenter = ((t - startTime) / timeRange) * width + slotWidth / 2;
       if (!Number.isFinite(value) || value! <= 0 || maxPrecipitation <= 0) {
         const cy = height - dotRadius;
         return svg`<circle

--- a/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
@@ -2,6 +2,7 @@ import { consume } from "@lit/context";
 import { ResizeController } from "@lit-labs/observers/resize-controller";
 import type {
   Connection,
+  HassConfig,
   HassEntity,
   UnsubscribeFunc,
 } from "home-assistant-js-websocket";
@@ -17,16 +18,23 @@ import type { LocalizeFunc } from "../../../common/translations/localize";
 import type { FrontendLocaleData } from "../../../data/translation";
 import "../../../components/ha-spinner";
 import {
+  configContext,
   connectionContext,
   internationalizationContext,
 } from "../../../data/context";
-import type { ForecastAttribute, ForecastEvent } from "../../../data/weather";
+import type {
+  ForecastAttribute,
+  ForecastEvent,
+  WeatherEntity,
+} from "../../../data/weather";
 import {
   getForecastPrecipitation,
+  getWeatherUnit,
   subscribeForecast,
 } from "../../../data/weather";
 import type {
   HomeAssistant,
+  HomeAssistantConfig,
   HomeAssistantConnection,
   HomeAssistantInternationalization,
 } from "../../../types";
@@ -101,6 +109,13 @@ class HuiPrecipitationForecastCardFeature
     transformer: ({ connection }) => connection,
   })
   private _connection!: Connection;
+
+  @state()
+  @consume({ context: configContext, subscribe: true })
+  @transform<HomeAssistantConfig, HassConfig>({
+    transformer: ({ config }) => config,
+  })
+  private _hassConfig?: HassConfig;
 
   @state() private _config?: PrecipitationForecastCardFeatureConfig;
 
@@ -180,7 +195,13 @@ class HuiPrecipitationForecastCardFeature
   // values above this still drive the scale.
   private _referenceMaxAmount(): number {
     const isImperial =
-      this._stateObj?.attributes?.precipitation_unit === UNIT_IN;
+      this._hassConfig && this._stateObj
+        ? getWeatherUnit(
+            this._hassConfig,
+            this._stateObj as WeatherEntity,
+            "precipitation"
+          ) === UNIT_IN
+        : false;
     switch (this._subscribedType) {
       case "hourly":
         return isImperial ? 0.1 : 2.5;

--- a/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-precipitation-forecast-card-feature.ts
@@ -10,6 +10,7 @@ import { css, html, LitElement, nothing, svg } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { computeCssColor } from "../../../common/color/compute-color";
+import { UNIT_IN } from "../../../common/const";
 import { consumeEntityState } from "../../../common/decorators/consume-context-entry";
 import { transform } from "../../../common/decorators/transform";
 import type { LocalizeFunc } from "../../../common/translations/localize";
@@ -175,6 +176,21 @@ class HuiPrecipitationForecastCardFeature
     return false;
   }
 
+  // Floor for the bar scale so light drizzles don't fill the bar; observed
+  // values above this still drive the scale.
+  private _referenceMaxAmount(): number {
+    const isImperial =
+      this._stateObj?.attributes?.precipitation_unit === UNIT_IN;
+    switch (this._subscribedType) {
+      case "hourly":
+        return isImperial ? 0.1 : 2.5;
+      case "twice_daily":
+        return isImperial ? 0.25 : 6;
+      default:
+        return isImperial ? 0.4 : 10;
+    }
+  }
+
   private _resolvedForecastType(): ForecastResolution | undefined {
     return resolveForecastResolution(
       this._stateObj,
@@ -290,7 +306,8 @@ class HuiPrecipitationForecastCardFeature
     const values = entries.map((entry) =>
       getForecastPrecipitation(entry, precipitationType)
     );
-    let maxPrecipitation = precipitationType === "probability" ? 100 : 0;
+    let maxPrecipitation =
+      precipitationType === "probability" ? 100 : this._referenceMaxAmount();
     if (precipitationType === "amount") {
       for (const value of values) {
         if (Number.isFinite(value)) {
@@ -375,7 +392,8 @@ class HuiPrecipitationForecastCardFeature
       return undefined;
     }
 
-    let maxPrecipitation = precipitationType === "probability" ? 100 : 0;
+    let maxPrecipitation =
+      precipitationType === "probability" ? 100 : this._referenceMaxAmount();
     if (precipitationType === "amount") {
       for (const { value } of inRange) {
         if (Number.isFinite(value)) {

--- a/src/panels/lovelace/card-features/hui-temperature-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-temperature-forecast-card-feature.ts
@@ -1,4 +1,5 @@
 import { consume } from "@lit/context";
+import { ResizeController } from "@lit-labs/observers/resize-controller";
 import type {
   Connection,
   HassEntity,
@@ -116,6 +117,16 @@ class HuiTemperatureForecastCardFeature
 
   private _subscribedType?: ForecastResolution;
 
+  private _size = new ResizeController(this, {
+    callback: (entries) => {
+      const rect = entries?.[0]?.contentRect;
+      if (!rect) return undefined;
+      return { width: rect.width, height: rect.height };
+    },
+  });
+
+  private _lastHourlySize?: { width: number; height: number };
+
   static getStubConfig(): TemperatureForecastCardFeatureConfig {
     return {
       type: "temperature-forecast",
@@ -165,19 +176,24 @@ class HuiTemperatureForecastCardFeature
       this._subscribeForecast();
       return;
     }
+    const size = this._size.value;
+    const sizeChanged =
+      !!size &&
+      (size.width !== this._lastHourlySize?.width ||
+        size.height !== this._lastHourlySize?.height);
+    let showLabelsChanged = false;
     if (changedProps.has("_config")) {
       const prev = changedProps.get("_config") as
         | TemperatureForecastCardFeatureConfig
         | undefined;
-      const showLabelsChanged =
-        (prev?.show_labels !== false) !== this._showLabels;
-      if (
-        showLabelsChanged &&
-        this._subscribedType === "hourly" &&
-        this._forecast
-      ) {
-        this._computeHourly(this._forecast);
-      }
+      showLabelsChanged = (prev?.show_labels !== false) !== this._showLabels;
+    }
+    if (
+      (sizeChanged || showLabelsChanged) &&
+      this._subscribedType === "hourly" &&
+      this._forecast
+    ) {
+      this._computeHourly(this._forecast);
     }
   }
 
@@ -199,7 +215,12 @@ class HuiTemperatureForecastCardFeature
     if (this._error) {
       return html`
         <div class="container">
-          <div class="info">${this._error}</div>
+          <div class="info">
+            ${this._localize(
+              "ui.panel.lovelace.editor.features.types.temperature-forecast.failed_to_load",
+              { error: this._error }
+            )}
+          </div>
         </div>
       `;
     }
@@ -279,11 +300,7 @@ class HuiTemperatureForecastCardFeature
       <div class=${containerClasses}>
         <div class="bars">${this._renderBars(entries, customColor)}</div>
         ${this._showLabels && this._locale
-          ? renderDayLabels(
-              entries,
-              this._subscribedType === "twice_daily" ? 2 : 1,
-              this._locale
-            )
+          ? renderDayLabels(entries, entriesPerDay, this._locale)
           : nothing}
       </div>
     `;
@@ -293,8 +310,8 @@ class HuiTemperatureForecastCardFeature
     entries: ForecastAttribute[],
     customColor: string | undefined
   ): TemplateResult {
-    const width = this.clientWidth || 300;
-    const height = this.clientHeight || 42;
+    const width = this._size.value?.width || this.clientWidth;
+    const height = this._size.value?.height || this.clientHeight;
     const padding = 4;
     const minGap = 4;
     const slotWidth = width / entries.length;
@@ -385,6 +402,7 @@ class HuiTemperatureForecastCardFeature
     }
     this._subscribedType = undefined;
     this._hourly = undefined;
+    this._lastHourlySize = undefined;
   }
 
   private _computeHourly(forecast: ForecastAttribute[]) {
@@ -428,9 +446,14 @@ class HuiTemperatureForecastCardFeature
     const minY = dataMin - range * 0.1;
     const maxY = dataMax + range * 0.1;
 
-    const width = this.clientWidth || 300;
+    const size = this._size.value;
+    const width = size?.width || this.clientWidth;
     const labelSpace = this._showLabels ? LABEL_HEIGHT + LABEL_GAP : 0;
-    const height = Math.max(1, (this.clientHeight || 42) - labelSpace);
+    const height = Math.max(
+      1,
+      (size?.height || this.clientHeight) - labelSpace
+    );
+    this._lastHourlySize = size;
 
     const { points, yAxisOrigin } = coordinates(
       data,
@@ -439,6 +462,7 @@ class HuiTemperatureForecastCardFeature
       data.length,
       { minX: now, maxX: maxTime, minY, maxY }
     );
+    // coordinates() pads with a trailing step-line point at x=width; drop it so the curve ends at the last forecast point.
     points.pop();
 
     const isFahrenheit = this._stateObj.attributes?.temperature_unit === "°F";
@@ -517,7 +541,7 @@ class HuiTemperatureForecastCardFeature
         flex-direction: column;
         justify-content: flex-end;
         align-items: stretch;
-        pointer-events: none !important;
+        pointer-events: none;
         --feature-temperature-freezing-color: #a89bd8;
         --feature-temperature-cold-color: #7dc8dc;
         --feature-temperature-mild-color: #a8dc7c;

--- a/src/panels/lovelace/card-features/hui-temperature-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-temperature-forecast-card-feature.ts
@@ -7,11 +7,13 @@ import type {
 import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing, svg } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
 import { styleMap } from "lit/directives/style-map";
 import { computeCssColor } from "../../../common/color/compute-color";
 import { consumeEntityState } from "../../../common/decorators/consume-context-entry";
 import { transform } from "../../../common/decorators/transform";
 import type { LocalizeFunc } from "../../../common/translations/localize";
+import type { FrontendLocaleData } from "../../../data/translation";
 import "../../../components/ha-spinner";
 import {
   connectionContext,
@@ -31,6 +33,13 @@ import {
   resolveForecastResolution,
   supportsForecast,
 } from "./common/forecast";
+import {
+  graphLabelsStyles,
+  LABEL_GAP,
+  LABEL_HEIGHT,
+  renderDayLabels,
+  renderHourLabels,
+} from "./common/graph-labels";
 import { coordinates } from "../common/graph/coordinates";
 import type { HuiGraphGradient } from "../components/hui-graph-base";
 import "../components/hui-graph-base";
@@ -76,6 +85,13 @@ class HuiTemperatureForecastCardFeature
     transformer: ({ localize }) => localize,
   })
   private _localize!: LocalizeFunc;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale?: FrontendLocaleData;
 
   @state()
   @consume({ context: connectionContext, subscribe: true })
@@ -147,6 +163,21 @@ class HuiTemperatureForecastCardFeature
     if (contextChanged || configTypeChanged) {
       this._unsubscribeForecast();
       this._subscribeForecast();
+      return;
+    }
+    if (changedProps.has("_config")) {
+      const prev = changedProps.get("_config") as
+        | TemperatureForecastCardFeatureConfig
+        | undefined;
+      const showLabelsChanged =
+        (prev?.show_labels !== false) !== this._showLabels;
+      if (
+        showLabelsChanged &&
+        this._subscribedType === "hourly" &&
+        this._forecast
+      ) {
+        this._computeHourly(this._forecast);
+      }
     }
   }
 
@@ -155,6 +186,10 @@ class HuiTemperatureForecastCardFeature
       this._stateObj,
       this._config?.forecast_type
     );
+  }
+
+  private get _showLabels(): boolean {
+    return this._config?.show_labels !== false;
   }
 
   protected render() {
@@ -181,6 +216,11 @@ class HuiTemperatureForecastCardFeature
       ? computeCssColor(this._config.color)
       : undefined;
 
+    const containerClasses = classMap({
+      container: true,
+      "with-labels": this._showLabels,
+    });
+
     if (isHourly) {
       if (!this._hourly?.coordinates.length) {
         return html`
@@ -196,14 +236,20 @@ class HuiTemperatureForecastCardFeature
       const graphStyle = customColor
         ? styleMap({ "--feature-color": customColor })
         : nothing;
+      const hoursToShow = this._config.hours_to_show ?? DEFAULT_HOURS_TO_SHOW;
       return html`
-        <div class="container">
-          <hui-graph-base
-            .coordinates=${this._hourly.coordinates}
-            .yAxisOrigin=${this._hourly.yAxisOrigin}
-            .gradient=${customColor ? undefined : this._hourly.gradient}
-            style=${graphStyle}
-          ></hui-graph-base>
+        <div class=${containerClasses}>
+          <div class="bars">
+            <hui-graph-base
+              .coordinates=${this._hourly.coordinates}
+              .yAxisOrigin=${this._hourly.yAxisOrigin}
+              .gradient=${customColor ? undefined : this._hourly.gradient}
+              style=${graphStyle}
+            ></hui-graph-base>
+          </div>
+          ${this._showLabels && this._locale
+            ? renderHourLabels(hoursToShow, this._locale)
+            : nothing}
         </div>
       `;
     }
@@ -230,7 +276,16 @@ class HuiTemperatureForecastCardFeature
     }
 
     return html`
-      <div class="container">${this._renderBars(entries, customColor)}</div>
+      <div class=${containerClasses}>
+        <div class="bars">${this._renderBars(entries, customColor)}</div>
+        ${this._showLabels && this._locale
+          ? renderDayLabels(
+              entries,
+              this._subscribedType === "twice_daily" ? 2 : 1,
+              this._locale
+            )
+          : nothing}
+      </div>
     `;
   }
 
@@ -374,7 +429,8 @@ class HuiTemperatureForecastCardFeature
     const maxY = dataMax + range * 0.1;
 
     const width = this.clientWidth || 300;
-    const height = this.clientHeight || 42;
+    const labelSpace = this._showLabels ? LABEL_HEIGHT + LABEL_GAP : 0;
+    const height = Math.max(1, (this.clientHeight || 42) - labelSpace);
 
     const { points, yAxisOrigin } = coordinates(
       data,
@@ -451,48 +507,68 @@ class HuiTemperatureForecastCardFeature
     });
   }
 
-  static styles = css`
-    :host {
-      display: flex;
-      width: 100%;
-      height: var(--feature-height);
-      flex-direction: column;
-      justify-content: flex-end;
-      align-items: stretch;
-      pointer-events: none !important;
-      --feature-temperature-freezing-color: #a89bd8;
-      --feature-temperature-cold-color: #7dc8dc;
-      --feature-temperature-mild-color: #a8dc7c;
-      --feature-temperature-warm-color: #e89042;
-      --feature-temperature-hot-color: #d24530;
-    }
+  static styles = [
+    graphLabelsStyles,
+    css`
+      :host {
+        display: flex;
+        width: 100%;
+        height: var(--feature-height);
+        flex-direction: column;
+        justify-content: flex-end;
+        align-items: stretch;
+        pointer-events: none !important;
+        --feature-temperature-freezing-color: #a89bd8;
+        --feature-temperature-cold-color: #7dc8dc;
+        --feature-temperature-mild-color: #a8dc7c;
+        --feature-temperature-warm-color: #e89042;
+        --feature-temperature-hot-color: #d24530;
+      }
 
-    .container {
-      width: 100%;
-      height: 100%;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      border-bottom-right-radius: 8px;
-      border-bottom-left-radius: 8px;
-      overflow: hidden;
-    }
+      .container {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: stretch;
+        border-bottom-right-radius: 8px;
+        border-bottom-left-radius: 8px;
+        overflow: hidden;
+      }
 
-    .info {
-      color: var(--secondary-text-color);
-      font-size: var(--ha-font-size-s);
-    }
+      .container.with-labels {
+        border-bottom-right-radius: 0;
+        border-bottom-left-radius: 0;
+      }
 
-    svg {
-      display: block;
-    }
+      .bars {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        align-items: stretch;
+      }
 
-    hui-graph-base {
-      width: 100%;
-      height: 100%;
-      --accent-color: var(--feature-color);
-    }
-  `;
+      .container.with-labels .bars {
+        padding-bottom: 2px;
+      }
+
+      .info {
+        color: var(--secondary-text-color);
+        font-size: var(--ha-font-size-s);
+      }
+
+      svg {
+        display: block;
+      }
+
+      hui-graph-base {
+        width: 100%;
+        height: 100%;
+        --accent-color: var(--feature-color);
+      }
+    `,
+  ];
 }
 
 declare global {

--- a/src/panels/lovelace/card-features/hui-temperature-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-temperature-forecast-card-feature.ts
@@ -1,0 +1,502 @@
+import { consume } from "@lit/context";
+import type {
+  Connection,
+  HassEntity,
+  UnsubscribeFunc,
+} from "home-assistant-js-websocket";
+import type { PropertyValues, TemplateResult } from "lit";
+import { css, html, LitElement, nothing, svg } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
+import { computeCssColor } from "../../../common/color/compute-color";
+import { consumeEntityState } from "../../../common/decorators/consume-context-entry";
+import { transform } from "../../../common/decorators/transform";
+import type { LocalizeFunc } from "../../../common/translations/localize";
+import "../../../components/ha-spinner";
+import {
+  connectionContext,
+  internationalizationContext,
+} from "../../../data/context";
+import type { ForecastAttribute, ForecastEvent } from "../../../data/weather";
+import { subscribeForecast } from "../../../data/weather";
+import type {
+  HomeAssistant,
+  HomeAssistantConnection,
+  HomeAssistantInternationalization,
+} from "../../../types";
+import {
+  DEFAULT_DAYS_TO_SHOW,
+  DEFAULT_HOURS_TO_SHOW,
+  MS_PER_HOUR,
+  resolveForecastResolution,
+  supportsForecast,
+} from "./common/forecast";
+import { coordinates } from "../common/graph/coordinates";
+import type { HuiGraphGradient } from "../components/hui-graph-base";
+import "../components/hui-graph-base";
+import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
+import type {
+  ForecastResolution,
+  LovelaceCardFeatureContext,
+  TemperatureForecastCardFeatureConfig,
+} from "./types";
+
+const MAX_BAR_WIDTH = 8;
+
+const TEMP_GRADIENT_STOPS: { tempC: number; cssVar: string }[] = [
+  { tempC: -20, cssVar: "--feature-temperature-freezing-color" },
+  { tempC: 0, cssVar: "--feature-temperature-cold-color" },
+  { tempC: 15, cssVar: "--feature-temperature-mild-color" },
+  { tempC: 25, cssVar: "--feature-temperature-warm-color" },
+  { tempC: 40, cssVar: "--feature-temperature-hot-color" },
+];
+
+export const supportsTemperatureForecastCardFeature = (
+  hass: HomeAssistant,
+  context: LovelaceCardFeatureContext
+) =>
+  supportsForecast(
+    context.entity_id ? hass.states[context.entity_id] : undefined
+  );
+
+@customElement("hui-temperature-forecast-card-feature")
+class HuiTemperatureForecastCardFeature
+  extends LitElement
+  implements LovelaceCardFeature
+{
+  @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
+
+  @state()
+  @consumeEntityState({ entityIdPath: ["context", "entity_id"] })
+  private _stateObj?: HassEntity;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, LocalizeFunc>({
+    transformer: ({ localize }) => localize,
+  })
+  private _localize!: LocalizeFunc;
+
+  @state()
+  @consume({ context: connectionContext, subscribe: true })
+  @transform<HomeAssistantConnection, Connection>({
+    transformer: ({ connection }) => connection,
+  })
+  private _connection!: Connection;
+
+  @state() private _config?: TemperatureForecastCardFeatureConfig;
+
+  @state() private _forecast?: ForecastAttribute[];
+
+  @state() private _hourly?: {
+    coordinates: [number, number][];
+    yAxisOrigin: number;
+    gradient?: HuiGraphGradient;
+  };
+
+  @state() private _error?: string;
+
+  private _subscribed?: Promise<UnsubscribeFunc | undefined>;
+
+  private _subscribedType?: ForecastResolution;
+
+  static getStubConfig(): TemperatureForecastCardFeatureConfig {
+    return {
+      type: "temperature-forecast",
+    };
+  }
+
+  public static async getConfigElement(): Promise<LovelaceCardFeatureEditor> {
+    await import("../editor/config-elements/hui-temperature-forecast-card-feature-editor");
+    return document.createElement(
+      "hui-temperature-forecast-card-feature-editor"
+    ) as LovelaceCardFeatureEditor;
+  }
+
+  public setConfig(config: TemperatureForecastCardFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  public connectedCallback() {
+    super.connectedCallback();
+    if (this.hasUpdated) {
+      this._subscribeForecast();
+    }
+  }
+
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    this._unsubscribeForecast();
+  }
+
+  protected firstUpdated() {
+    this._subscribeForecast();
+  }
+
+  protected updated(changedProps: PropertyValues) {
+    const resolvedType = this._resolvedForecastType();
+    const contextChanged =
+      changedProps.has("context") &&
+      (changedProps.get("context") as LovelaceCardFeatureContext | undefined)
+        ?.entity_id !== this.context?.entity_id;
+    const configTypeChanged =
+      changedProps.has("_config") && resolvedType !== this._subscribedType;
+    if (contextChanged || configTypeChanged) {
+      this._unsubscribeForecast();
+      this._subscribeForecast();
+    }
+  }
+
+  private _resolvedForecastType(): ForecastResolution | undefined {
+    return resolveForecastResolution(
+      this._stateObj,
+      this._config?.forecast_type
+    );
+  }
+
+  protected render() {
+    if (!this._config || !this.context || !supportsForecast(this._stateObj)) {
+      return nothing;
+    }
+    if (this._error) {
+      return html`
+        <div class="container">
+          <div class="info">${this._error}</div>
+        </div>
+      `;
+    }
+    if (!this._forecast) {
+      return html`
+        <div class="container loading">
+          <ha-spinner size="small"></ha-spinner>
+        </div>
+      `;
+    }
+
+    const isHourly = this._subscribedType === "hourly";
+    const customColor = this._config.color
+      ? computeCssColor(this._config.color)
+      : undefined;
+
+    if (isHourly) {
+      if (!this._hourly?.coordinates.length) {
+        return html`
+          <div class="container">
+            <div class="info">
+              ${this._localize(
+                "ui.panel.lovelace.editor.features.types.temperature-forecast.no_forecast"
+              )}
+            </div>
+          </div>
+        `;
+      }
+      const graphStyle = customColor
+        ? styleMap({ "--feature-color": customColor })
+        : nothing;
+      return html`
+        <div class="container">
+          <hui-graph-base
+            .coordinates=${this._hourly.coordinates}
+            .yAxisOrigin=${this._hourly.yAxisOrigin}
+            .gradient=${customColor ? undefined : this._hourly.gradient}
+            style=${graphStyle}
+          ></hui-graph-base>
+        </div>
+      `;
+    }
+
+    const daysToShow = this._config.days_to_show ?? DEFAULT_DAYS_TO_SHOW;
+    const entriesPerDay = this._subscribedType === "twice_daily" ? 2 : 1;
+    const entries = this._forecast
+      .filter(
+        (entry) =>
+          Number.isFinite(entry.temperature) && Number.isFinite(entry.templow)
+      )
+      .slice(0, daysToShow * entriesPerDay);
+
+    if (!entries.length) {
+      return html`
+        <div class="container">
+          <div class="info">
+            ${this._localize(
+              "ui.panel.lovelace.editor.features.types.temperature-forecast.no_forecast"
+            )}
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="container">${this._renderBars(entries, customColor)}</div>
+    `;
+  }
+
+  private _renderBars(
+    entries: ForecastAttribute[],
+    customColor: string | undefined
+  ): TemplateResult {
+    const width = this.clientWidth || 300;
+    const height = this.clientHeight || 42;
+    const padding = 4;
+    const minGap = 4;
+    const slotWidth = width / entries.length;
+    const barWidth = Math.max(1, Math.min(MAX_BAR_WIDTH, slotWidth - minGap));
+    const drawableHeight = height - padding * 2;
+
+    let tempMin = Infinity;
+    let tempMax = -Infinity;
+    for (const entry of entries) {
+      tempMin = Math.min(tempMin, entry.templow!);
+      tempMax = Math.max(tempMax, entry.temperature);
+    }
+    if (tempMin === tempMax) {
+      tempMin -= 1;
+      tempMax += 1;
+    }
+    const yFor = (value: number) =>
+      padding +
+      drawableHeight -
+      ((value - tempMin) / (tempMax - tempMin)) * drawableHeight;
+
+    const isFahrenheit = this._stateObj?.attributes?.temperature_unit === "°F";
+    const toDisplayUnit = (tempC: number) =>
+      isFahrenheit ? (tempC * 9) / 5 + 32 : tempC;
+
+    const tempGradient = !customColor
+      ? (() => {
+          const stops = TEMP_GRADIENT_STOPS.map((stop) => ({
+            y: yFor(toDisplayUnit(stop.tempC)),
+            cssVar: stop.cssVar,
+          })).sort((a, b) => a.y - b.y);
+          const y1 = stops[0].y;
+          const y2 = stops[stops.length - 1].y;
+          const range = y2 - y1 || 1;
+          return svg`<defs>
+            <linearGradient
+              id="temp-gradient"
+              gradientUnits="userSpaceOnUse"
+              x1="0" y1=${y1}
+              x2="0" y2=${y2}
+            >
+              ${stops.map(
+                (stop) =>
+                  svg`<stop
+                    offset=${(stop.y - y1) / range}
+                    style="stop-color: var(${stop.cssVar})"
+                  ></stop>`
+              )}
+            </linearGradient>
+          </defs>`;
+        })()
+      : nothing;
+
+    const bars = entries.map((entry, i) => {
+      const x = slotWidth * i + (slotWidth - barWidth) / 2;
+      const yHigh = yFor(entry.temperature);
+      const yLow = yFor(entry.templow!);
+      const barHeight = Math.max(1, yLow - yHigh);
+      const rx = Math.min(barWidth / 2, barHeight / 2);
+      const fill = customColor ?? "url(#temp-gradient)";
+      return svg`<rect
+        x=${x}
+        y=${yHigh}
+        width=${barWidth}
+        height=${barHeight}
+        rx=${rx}
+        ry=${rx}
+        fill=${fill}
+      ></rect>`;
+    });
+
+    return html`
+      <svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 ${width} ${height}"
+        preserveAspectRatio="none"
+      >
+        ${tempGradient}${bars}
+      </svg>
+    `;
+  }
+
+  private _unsubscribeForecast() {
+    if (this._subscribed) {
+      this._subscribed.then((unsub) => unsub?.()).catch(() => undefined);
+      this._subscribed = undefined;
+    }
+    this._subscribedType = undefined;
+    this._hourly = undefined;
+  }
+
+  private _computeHourly(forecast: ForecastAttribute[]) {
+    if (!forecast.length || !this._stateObj) {
+      this._hourly = undefined;
+      return;
+    }
+
+    const data: [number, number][] = [];
+    const now = Date.now();
+    const hoursToShow = this._config!.hours_to_show ?? DEFAULT_HOURS_TO_SHOW;
+    const maxTime =
+      Math.floor((now + hoursToShow * MS_PER_HOUR) / MS_PER_HOUR) * MS_PER_HOUR;
+
+    const currentTemp = this._stateObj.attributes?.temperature;
+    if (currentTemp != null && !Number.isNaN(Number(currentTemp))) {
+      data.push([now, Number(currentTemp)]);
+    }
+
+    for (const entry of forecast) {
+      if (entry.temperature != null && !Number.isNaN(entry.temperature)) {
+        const time = new Date(entry.datetime).getTime();
+        if (time > maxTime) break;
+        if (time < now) continue;
+        data.push([time, entry.temperature]);
+      }
+    }
+
+    if (!data.length) {
+      this._hourly = undefined;
+      return;
+    }
+
+    let dataMin = data[0][1];
+    let dataMax = data[0][1];
+    for (const [, t] of data) {
+      if (t < dataMin) dataMin = t;
+      if (t > dataMax) dataMax = t;
+    }
+    const range = dataMax - dataMin || dataMin * 0.1;
+    const minY = dataMin - range * 0.1;
+    const maxY = dataMax + range * 0.1;
+
+    const width = this.clientWidth || 300;
+    const height = this.clientHeight || 42;
+
+    const { points, yAxisOrigin } = coordinates(
+      data,
+      width,
+      height,
+      data.length,
+      { minX: now, maxX: maxTime, minY, maxY }
+    );
+    points.pop();
+
+    const isFahrenheit = this._stateObj.attributes?.temperature_unit === "°F";
+    const toDisplayUnit = (tempC: number) =>
+      isFahrenheit ? (tempC * 9) / 5 + 32 : tempC;
+    const yFor = (temp: number) =>
+      height - ((temp - minY) / (maxY - minY || 1)) * height;
+
+    const stops = TEMP_GRADIENT_STOPS.map((stop) => ({
+      y: yFor(toDisplayUnit(stop.tempC)),
+      cssVar: stop.cssVar,
+    })).sort((a, b) => a.y - b.y);
+    const y1 = stops[0].y;
+    const y2 = stops[stops.length - 1].y;
+    const gradientRange = y2 - y1 || 1;
+
+    const gradient: HuiGraphGradient = {
+      x1: 0,
+      y1,
+      x2: 0,
+      y2,
+      stops: stops.map((stop) => ({
+        offset: (stop.y - y1) / gradientRange,
+        color: `var(${stop.cssVar})`,
+      })),
+    };
+
+    this._hourly = { coordinates: points, yAxisOrigin, gradient };
+  }
+
+  private async _subscribeForecast() {
+    if (
+      !this.context?.entity_id ||
+      !this._config ||
+      !this._connection ||
+      this._subscribed
+    ) {
+      return;
+    }
+
+    const forecastType = this._resolvedForecastType();
+    if (!forecastType) {
+      return;
+    }
+
+    const entityId = this.context.entity_id;
+    this._forecast = undefined;
+    this._error = undefined;
+    this._subscribedType = forecastType;
+
+    this._subscribed = subscribeForecast(
+      this._connection,
+      entityId,
+      forecastType,
+      (forecastEvent: ForecastEvent) => {
+        this._forecast = forecastEvent.forecast ?? [];
+        if (this._subscribedType === "hourly") {
+          this._computeHourly(this._forecast);
+        }
+      }
+    ).catch((err) => {
+      this._subscribed = undefined;
+      this._subscribedType = undefined;
+      this._error = err.message || err.code;
+      return undefined;
+    });
+  }
+
+  static styles = css`
+    :host {
+      display: flex;
+      width: 100%;
+      height: var(--feature-height);
+      flex-direction: column;
+      justify-content: flex-end;
+      align-items: stretch;
+      pointer-events: none !important;
+      --feature-temperature-freezing-color: #a89bd8;
+      --feature-temperature-cold-color: #7dc8dc;
+      --feature-temperature-mild-color: #a8dc7c;
+      --feature-temperature-warm-color: #e89042;
+      --feature-temperature-hot-color: #d24530;
+    }
+
+    .container {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      border-bottom-right-radius: 8px;
+      border-bottom-left-radius: 8px;
+      overflow: hidden;
+    }
+
+    .info {
+      color: var(--secondary-text-color);
+      font-size: var(--ha-font-size-s);
+    }
+
+    svg {
+      display: block;
+    }
+
+    hui-graph-base {
+      width: 100%;
+      height: 100%;
+      --accent-color: var(--feature-color);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-temperature-forecast-card-feature": HuiTemperatureForecastCardFeature;
+  }
+}

--- a/src/panels/lovelace/card-features/hui-temperature-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-temperature-forecast-card-feature.ts
@@ -105,12 +105,6 @@ class HuiTemperatureForecastCardFeature
 
   @state() private _forecast?: ForecastAttribute[];
 
-  @state() private _hourly?: {
-    coordinates: [number, number][];
-    yAxisOrigin: number;
-    gradient?: HuiGraphGradient;
-  };
-
   @state() private _error?: string;
 
   private _subscribed?: Promise<UnsubscribeFunc | undefined>;
@@ -124,8 +118,6 @@ class HuiTemperatureForecastCardFeature
       return { width: rect.width, height: rect.height };
     },
   });
-
-  private _lastHourlySize?: { width: number; height: number };
 
   static getStubConfig(): TemperatureForecastCardFeatureConfig {
     return {
@@ -164,37 +156,23 @@ class HuiTemperatureForecastCardFeature
   }
 
   protected updated(changedProps: PropertyValues) {
-    const resolvedType = this._resolvedForecastType();
-    const contextChanged =
-      changedProps.has("context") &&
-      (changedProps.get("context") as LovelaceCardFeatureContext | undefined)
-        ?.entity_id !== this.context?.entity_id;
-    const configTypeChanged =
-      changedProps.has("_config") && resolvedType !== this._subscribedType;
-    if (contextChanged || configTypeChanged) {
+    if (this._shouldResubscribe(changedProps)) {
       this._unsubscribeForecast();
       this._subscribeForecast();
-      return;
     }
-    const size = this._size.value;
-    const sizeChanged =
-      !!size &&
-      (size.width !== this._lastHourlySize?.width ||
-        size.height !== this._lastHourlySize?.height);
-    let showLabelsChanged = false;
-    if (changedProps.has("_config")) {
-      const prev = changedProps.get("_config") as
-        | TemperatureForecastCardFeatureConfig
+  }
+
+  private _shouldResubscribe(changedProps: PropertyValues): boolean {
+    if (changedProps.has("context")) {
+      const previous = changedProps.get("context") as
+        | LovelaceCardFeatureContext
         | undefined;
-      showLabelsChanged = (prev?.show_labels !== false) !== this._showLabels;
+      if (previous?.entity_id !== this.context?.entity_id) return true;
     }
-    if (
-      (sizeChanged || showLabelsChanged) &&
-      this._subscribedType === "hourly" &&
-      this._forecast
-    ) {
-      this._computeHourly(this._forecast);
+    if (changedProps.has("_config")) {
+      if (this._resolvedForecastType() !== this._subscribedType) return true;
     }
+    return false;
   }
 
   private _resolvedForecastType(): ForecastResolution | undefined {
@@ -243,7 +221,8 @@ class HuiTemperatureForecastCardFeature
     });
 
     if (isHourly) {
-      if (!this._hourly?.coordinates.length) {
+      const hourly = this._computeHourly();
+      if (!hourly?.coordinates.length) {
         return html`
           <div class="container">
             <div class="info">
@@ -262,9 +241,9 @@ class HuiTemperatureForecastCardFeature
         <div class=${containerClasses}>
           <div class="bars">
             <hui-graph-base
-              .coordinates=${this._hourly.coordinates}
-              .yAxisOrigin=${this._hourly.yAxisOrigin}
-              .gradient=${customColor ? undefined : this._hourly.gradient}
+              .coordinates=${hourly.coordinates}
+              .yAxisOrigin=${hourly.yAxisOrigin}
+              .gradient=${customColor ? undefined : hourly.gradient}
               style=${graphStyle}
             ></hui-graph-base>
           </div>
@@ -401,14 +380,17 @@ class HuiTemperatureForecastCardFeature
       this._subscribed = undefined;
     }
     this._subscribedType = undefined;
-    this._hourly = undefined;
-    this._lastHourlySize = undefined;
   }
 
-  private _computeHourly(forecast: ForecastAttribute[]) {
-    if (!forecast.length || !this._stateObj) {
-      this._hourly = undefined;
-      return;
+  private _computeHourly():
+    | {
+        coordinates: [number, number][];
+        yAxisOrigin: number;
+        gradient: HuiGraphGradient;
+      }
+    | undefined {
+    if (!this._forecast?.length || !this._stateObj) {
+      return undefined;
     }
 
     const data: [number, number][] = [];
@@ -422,7 +404,7 @@ class HuiTemperatureForecastCardFeature
       data.push([now, Number(currentTemp)]);
     }
 
-    for (const entry of forecast) {
+    for (const entry of this._forecast) {
       if (entry.temperature != null && !Number.isNaN(entry.temperature)) {
         const time = new Date(entry.datetime).getTime();
         if (time > maxTime) break;
@@ -432,8 +414,7 @@ class HuiTemperatureForecastCardFeature
     }
 
     if (!data.length) {
-      this._hourly = undefined;
-      return;
+      return undefined;
     }
 
     let dataMin = data[0][1];
@@ -453,7 +434,6 @@ class HuiTemperatureForecastCardFeature
       1,
       (size?.height || this.clientHeight) - labelSpace
     );
-    this._lastHourlySize = size;
 
     const { points, yAxisOrigin } = coordinates(
       data,
@@ -490,7 +470,7 @@ class HuiTemperatureForecastCardFeature
       })),
     };
 
-    this._hourly = { coordinates: points, yAxisOrigin, gradient };
+    return { coordinates: points, yAxisOrigin, gradient };
   }
 
   private async _subscribeForecast() {
@@ -519,9 +499,6 @@ class HuiTemperatureForecastCardFeature
       forecastType,
       (forecastEvent: ForecastEvent) => {
         this._forecast = forecastEvent.forecast ?? [];
-        if (this._subscribedType === "hourly") {
-          this._computeHourly(this._forecast);
-        }
       }
     ).catch((err) => {
       this._subscribed = undefined;
@@ -541,7 +518,7 @@ class HuiTemperatureForecastCardFeature
         flex-direction: column;
         justify-content: flex-end;
         align-items: stretch;
-        pointer-events: none;
+        pointer-events: none !important;
         --feature-temperature-freezing-color: #a89bd8;
         --feature-temperature-cold-color: #7dc8dc;
         --feature-temperature-mild-color: #a8dc7c;

--- a/src/panels/lovelace/card-features/hui-temperature-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-temperature-forecast-card-feature.ts
@@ -11,6 +11,7 @@ import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { styleMap } from "lit/directives/style-map";
 import { computeCssColor } from "../../../common/color/compute-color";
+import { UNIT_F } from "../../../common/const";
 import { consumeEntityState } from "../../../common/decorators/consume-context-entry";
 import { transform } from "../../../common/decorators/transform";
 import type { LocalizeFunc } from "../../../common/translations/localize";
@@ -35,6 +36,10 @@ import {
   supportsForecast,
 } from "./common/forecast";
 import {
+  getAbsoluteGradient,
+  getRelativeGradient,
+} from "./common/temperature-palette";
+import {
   graphLabelsStyles,
   LABEL_GAP,
   LABEL_HEIGHT,
@@ -52,14 +57,6 @@ import type {
 } from "./types";
 
 const MAX_BAR_WIDTH = 8;
-
-const TEMP_GRADIENT_STOPS: { tempC: number; cssVar: string }[] = [
-  { tempC: -20, cssVar: "--feature-temperature-freezing-color" },
-  { tempC: 0, cssVar: "--feature-temperature-cold-color" },
-  { tempC: 15, cssVar: "--feature-temperature-mild-color" },
-  { tempC: 25, cssVar: "--feature-temperature-warm-color" },
-  { tempC: 40, cssVar: "--feature-temperature-hot-color" },
-];
 
 export const supportsTemperatureForecastCardFeature = (
   hass: HomeAssistant,
@@ -312,37 +309,18 @@ class HuiTemperatureForecastCardFeature
       drawableHeight -
       ((value - tempMin) / (tempMax - tempMin)) * drawableHeight;
 
-    const isFahrenheit = this._stateObj?.attributes?.temperature_unit === "°F";
-    const toDisplayUnit = (tempC: number) =>
-      isFahrenheit ? (tempC * 9) / 5 + 32 : tempC;
-
-    const tempGradient = !customColor
-      ? (() => {
-          const stops = TEMP_GRADIENT_STOPS.map((stop) => ({
-            y: yFor(toDisplayUnit(stop.tempC)),
-            cssVar: stop.cssVar,
-          })).sort((a, b) => a.y - b.y);
-          const y1 = stops[0].y;
-          const y2 = stops[stops.length - 1].y;
-          const range = y2 - y1 || 1;
-          return svg`<defs>
-            <linearGradient
-              id="temp-gradient"
-              gradientUnits="userSpaceOnUse"
-              x1="0" y1=${y1}
-              x2="0" y2=${y2}
-            >
-              ${stops.map(
-                (stop) =>
-                  svg`<stop
-                    offset=${(stop.y - y1) / range}
-                    style="stop-color: var(${stop.cssVar})"
-                  ></stop>`
-              )}
-            </linearGradient>
-          </defs>`;
-        })()
-      : nothing;
+    const gradients = customColor
+      ? undefined
+      : entries.map(
+          (entry, i) => svg`<linearGradient
+            id="temp-bar-${i}"
+            x1="0" y1="0" x2="0" y2="1"
+          >
+            ${getRelativeGradient(entry.templow!, entry.temperature, 3).map(
+              (s) => svg`<stop offset=${s.offset} stop-color=${s.color}></stop>`
+            )}
+          </linearGradient>`
+        );
 
     const bars = entries.map((entry, i) => {
       const x = slotWidth * i + (slotWidth - barWidth) / 2;
@@ -350,7 +328,7 @@ class HuiTemperatureForecastCardFeature
       const yLow = yFor(entry.templow!);
       const barHeight = Math.max(1, yLow - yHigh);
       const rx = Math.min(barWidth / 2, barHeight / 2);
-      const fill = customColor ?? "url(#temp-gradient)";
+      const fill = customColor ?? `url(#temp-bar-${i})`;
       return svg`<rect
         x=${x}
         y=${yHigh}
@@ -369,7 +347,7 @@ class HuiTemperatureForecastCardFeature
         viewBox="0 0 ${width} ${height}"
         preserveAspectRatio="none"
       >
-        ${tempGradient}${bars}
+        ${gradients ? svg`<defs>${gradients}</defs>` : nothing}${bars}
       </svg>
     `;
   }
@@ -445,29 +423,20 @@ class HuiTemperatureForecastCardFeature
     // coordinates() pads with a trailing step-line point at x=width; drop it so the curve ends at the last forecast point.
     points.pop();
 
-    const isFahrenheit = this._stateObj.attributes?.temperature_unit === "°F";
-    const toDisplayUnit = (tempC: number) =>
-      isFahrenheit ? (tempC * 9) / 5 + 32 : tempC;
-    const yFor = (temp: number) =>
-      height - ((temp - minY) / (maxY - minY || 1)) * height;
-
-    const stops = TEMP_GRADIENT_STOPS.map((stop) => ({
-      y: yFor(toDisplayUnit(stop.tempC)),
-      cssVar: stop.cssVar,
-    })).sort((a, b) => a.y - b.y);
-    const y1 = stops[0].y;
-    const y2 = stops[stops.length - 1].y;
-    const gradientRange = y2 - y1 || 1;
+    // calcPoints (inside coordinates()) adds an extra 10% padding on top of
+    // what we pass, so the curve actually lives in this expanded range.
+    const padRange = maxY - minY || minY * 0.1;
+    const effMinY = minY - padRange * 0.1;
+    const effMaxY = maxY + padRange * 0.1;
+    const isFahrenheit = this._stateObj.attributes?.temperature_unit === UNIT_F;
+    const toCelsius = (t: number) => (isFahrenheit ? ((t - 32) * 5) / 9 : t);
 
     const gradient: HuiGraphGradient = {
       x1: 0,
-      y1,
+      y1: 0,
       x2: 0,
-      y2,
-      stops: stops.map((stop) => ({
-        offset: (stop.y - y1) / gradientRange,
-        color: `var(${stop.cssVar})`,
-      })),
+      y2: height,
+      stops: getAbsoluteGradient(toCelsius(effMinY), toCelsius(effMaxY)),
     };
 
     return { coordinates: points, yAxisOrigin, gradient };
@@ -519,11 +488,6 @@ class HuiTemperatureForecastCardFeature
         justify-content: flex-end;
         align-items: stretch;
         pointer-events: none !important;
-        --feature-temperature-freezing-color: #a89bd8;
-        --feature-temperature-cold-color: #7dc8dc;
-        --feature-temperature-mild-color: #a8dc7c;
-        --feature-temperature-warm-color: #e89042;
-        --feature-temperature-hot-color: #d24530;
       }
 
       .container {

--- a/src/panels/lovelace/card-features/hui-temperature-forecast-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-temperature-forecast-card-feature.ts
@@ -2,6 +2,7 @@ import { consume } from "@lit/context";
 import { ResizeController } from "@lit-labs/observers/resize-controller";
 import type {
   Connection,
+  HassConfig,
   HassEntity,
   UnsubscribeFunc,
 } from "home-assistant-js-websocket";
@@ -18,13 +19,19 @@ import type { LocalizeFunc } from "../../../common/translations/localize";
 import type { FrontendLocaleData } from "../../../data/translation";
 import "../../../components/ha-spinner";
 import {
+  configContext,
   connectionContext,
   internationalizationContext,
 } from "../../../data/context";
-import type { ForecastAttribute, ForecastEvent } from "../../../data/weather";
-import { subscribeForecast } from "../../../data/weather";
+import type {
+  ForecastAttribute,
+  ForecastEvent,
+  WeatherEntity,
+} from "../../../data/weather";
+import { getWeatherUnit, subscribeForecast } from "../../../data/weather";
 import type {
   HomeAssistant,
+  HomeAssistantConfig,
   HomeAssistantConnection,
   HomeAssistantInternationalization,
 } from "../../../types";
@@ -97,6 +104,13 @@ class HuiTemperatureForecastCardFeature
     transformer: ({ connection }) => connection,
   })
   private _connection!: Connection;
+
+  @state()
+  @consume({ context: configContext, subscribe: true })
+  @transform<HomeAssistantConfig, HassConfig>({
+    transformer: ({ config }) => config,
+  })
+  private _hassConfig?: HassConfig;
 
   @state() private _config?: TemperatureForecastCardFeatureConfig;
 
@@ -181,6 +195,18 @@ class HuiTemperatureForecastCardFeature
 
   private get _showLabels(): boolean {
     return this._config?.show_labels !== false;
+  }
+
+  private _toCelsius(temp: number): number {
+    const isFahrenheit =
+      this._hassConfig && this._stateObj
+        ? getWeatherUnit(
+            this._hassConfig,
+            this._stateObj as WeatherEntity,
+            "temperature"
+          ) === UNIT_F
+        : false;
+    return isFahrenheit ? ((temp - 32) * 5) / 9 : temp;
   }
 
   protected render() {
@@ -316,7 +342,11 @@ class HuiTemperatureForecastCardFeature
             id="temp-bar-${i}"
             x1="0" y1="0" x2="0" y2="1"
           >
-            ${getRelativeGradient(entry.templow!, entry.temperature, 3).map(
+            ${getRelativeGradient(
+              this._toCelsius(entry.templow!),
+              this._toCelsius(entry.temperature),
+              3
+            ).map(
               (s) => svg`<stop offset=${s.offset} stop-color=${s.color}></stop>`
             )}
           </linearGradient>`
@@ -428,15 +458,15 @@ class HuiTemperatureForecastCardFeature
     const padRange = maxY - minY || minY * 0.1;
     const effMinY = minY - padRange * 0.1;
     const effMaxY = maxY + padRange * 0.1;
-    const isFahrenheit = this._stateObj.attributes?.temperature_unit === UNIT_F;
-    const toCelsius = (t: number) => (isFahrenheit ? ((t - 32) * 5) / 9 : t);
-
     const gradient: HuiGraphGradient = {
       x1: 0,
       y1: 0,
       x2: 0,
       y2: height,
-      stops: getAbsoluteGradient(toCelsius(effMinY), toCelsius(effMaxY)),
+      stops: getAbsoluteGradient(
+        this._toCelsius(effMinY),
+        this._toCelsius(effMaxY)
+      ),
     };
 
     return { coordinates: points, yAxisOrigin, gradient };

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -1,6 +1,7 @@
 import type { AlarmMode } from "../../../data/alarm_control_panel";
 import type { HvacMode } from "../../../data/climate";
 import type { OperationMode } from "../../../data/water_heater";
+import type { ForecastPrecipitationType } from "../../../data/weather";
 
 export type ButtonCardData = Record<string, any>;
 
@@ -250,6 +251,25 @@ export interface TrendGraphCardFeatureConfig {
   detail?: boolean;
 }
 
+export type ForecastResolution = "daily" | "twice_daily" | "hourly";
+
+export interface TemperatureForecastCardFeatureConfig {
+  type: "temperature-forecast";
+  forecast_type?: ForecastResolution;
+  days_to_show?: number;
+  hours_to_show?: number;
+  color?: string;
+}
+
+export interface PrecipitationForecastCardFeatureConfig {
+  type: "precipitation-forecast";
+  forecast_type?: ForecastResolution;
+  days_to_show?: number;
+  hours_to_show?: number;
+  precipitation_type?: ForecastPrecipitationType;
+  color?: string;
+}
+
 export const AREA_CONTROL_DOMAINS = [
   "light",
   "fan",
@@ -304,6 +324,8 @@ export type LovelaceCardFeatureConfig =
   | FanPresetModesCardFeatureConfig
   | FanSpeedCardFeatureConfig
   | TrendGraphCardFeatureConfig
+  | TemperatureForecastCardFeatureConfig
+  | PrecipitationForecastCardFeatureConfig
   | HumidifierToggleCardFeatureConfig
   | HumidifierModesCardFeatureConfig
   | LawnMowerCommandsCardFeatureConfig

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -259,6 +259,7 @@ export interface TemperatureForecastCardFeatureConfig {
   days_to_show?: number;
   hours_to_show?: number;
   color?: string;
+  show_labels?: boolean;
 }
 
 export interface PrecipitationForecastCardFeatureConfig {
@@ -268,6 +269,7 @@ export interface PrecipitationForecastCardFeatureConfig {
   hours_to_show?: number;
   precipitation_type?: ForecastPrecipitationType;
   color?: string;
+  show_labels?: boolean;
 }
 
 export const AREA_CONTROL_DOMAINS = [

--- a/src/panels/lovelace/components/hui-graph-base.ts
+++ b/src/panels/lovelace/components/hui-graph-base.ts
@@ -7,6 +7,14 @@ import { parseAnimationDuration } from "../../../common/util/parse-animation-dur
 import { strokeWidth } from "../../../data/graph";
 import { getPath } from "../common/graph/get-path";
 
+export interface HuiGraphGradient {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  stops: { offset: number; color: string }[];
+}
+
 @customElement("hui-graph-base")
 export class HuiGraphBase extends LitElement {
   @property({ attribute: false }) public coordinates?: number[][];
@@ -15,6 +23,8 @@ export class HuiGraphBase extends LitElement {
   public yAxisOrigin?: number;
 
   @property({ type: Boolean, reflect: true }) public loading = false;
+
+  @property({ attribute: false }) public gradient?: HuiGraphGradient;
 
   private _uniqueId = `graph-${Math.random().toString(36).substring(2, 9)}`;
 
@@ -47,7 +57,13 @@ export class HuiGraphBase extends LitElement {
 
     const showShimmer = this.loading && !this._reducedMotion;
     const shimmerId = `${this._uniqueId}-shimmer`;
-    const fillRect = showShimmer ? `url(#${shimmerId})` : "var(--accent-color)";
+    const gradientId = `${this._uniqueId}-gradient`;
+    const gradient = this.gradient;
+    const fillRect = showShimmer
+      ? `url(#${shimmerId})`
+      : gradient
+        ? `url(#${gradientId})`
+        : "var(--accent-color)";
 
     return html`
       ${svg`<svg width="100%" height="100%" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">
@@ -62,7 +78,21 @@ export class HuiGraphBase extends LitElement {
                   <animate attributeName="x2" values="-30%;140%" dur="1.8s" repeatCount="indefinite" />
                 </linearGradient>
               </defs>`
-            : nothing
+            : gradient
+              ? svg`<defs>
+                  <linearGradient
+                    id=${gradientId}
+                    gradientUnits="userSpaceOnUse"
+                    x1=${gradient.x1} y1=${gradient.y1}
+                    x2=${gradient.x2} y2=${gradient.y2}
+                  >
+                    ${gradient.stops.map(
+                      (s) =>
+                        svg`<stop offset=${s.offset} style="stop-color: ${s.color}"></stop>`
+                    )}
+                  </linearGradient>
+                </defs>`
+              : nothing
         }
         <g>
           <mask id="${this._uniqueId}-fill">

--- a/src/panels/lovelace/create-element/create-card-feature-element.ts
+++ b/src/panels/lovelace/create-element/create-card-feature-element.ts
@@ -43,6 +43,8 @@ import "../card-features/hui-valve-position-card-feature";
 import "../card-features/hui-water-heater-operation-modes-card-feature";
 import "../card-features/hui-area-controls-card-feature";
 import "../card-features/hui-bar-gauge-card-feature";
+import "../card-features/hui-precipitation-forecast-card-feature";
+import "../card-features/hui-temperature-forecast-card-feature";
 import "../card-features/hui-trend-graph-card-feature";
 
 import type { LovelaceCardFeatureConfig } from "../card-features/types";
@@ -87,10 +89,12 @@ const TYPES = new Set<LovelaceCardFeatureConfig["type"]>([
   "media-player-volume-buttons",
   "media-player-volume-slider",
   "numeric-input",
+  "precipitation-forecast",
   "select-options",
   "trend-graph",
   "target-humidity",
   "target-temperature",
+  "temperature-forecast",
   "toggle",
   "update-actions",
   "vacuum-commands",

--- a/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
@@ -42,6 +42,8 @@ import { supportsCoverTiltFavoriteCardFeature } from "../../card-features/hui-co
 import { supportsCoverTiltPositionCardFeature } from "../../card-features/hui-cover-tilt-position-card-feature";
 import { supportsDateSetCardFeature } from "../../card-features/hui-date-set-card-feature";
 import { supportsFanDirectionCardFeature } from "../../card-features/hui-fan-direction-card-feature";
+import { supportsPrecipitationForecastCardFeature } from "../../card-features/hui-precipitation-forecast-card-feature";
+import { supportsTemperatureForecastCardFeature } from "../../card-features/hui-temperature-forecast-card-feature";
 import { supportsFanOscilatteCardFeature } from "../../card-features/hui-fan-oscillate-card-feature";
 import { supportsFanPresetModesCardFeature } from "../../card-features/hui-fan-preset-modes-card-feature";
 import { supportsFanSpeedCardFeature } from "../../card-features/hui-fan-speed-card-feature";
@@ -119,10 +121,12 @@ const UI_FEATURE_TYPES = [
   "media-player-volume-buttons",
   "media-player-volume-slider",
   "numeric-input",
+  "precipitation-forecast",
   "select-options",
   "trend-graph",
   "target-humidity",
   "target-temperature",
+  "temperature-forecast",
   "toggle",
   "update-actions",
   "vacuum-commands",
@@ -149,6 +153,8 @@ const EDITABLES_FEATURE_TYPES = new Set<UiFeatureTypes>([
   "cover-tilt-favorite",
   "fan-preset-modes",
   "humidifier-modes",
+  "precipitation-forecast",
+  "temperature-forecast",
   "lawn-mower-commands",
   "media-player-playback",
   "light-color-favorites",
@@ -205,10 +211,12 @@ const SUPPORTS_FEATURE_TYPES: Record<
   "media-player-volume-buttons": supportsMediaPlayerVolumeButtonsCardFeature,
   "media-player-volume-slider": supportsMediaPlayerVolumeSliderCardFeature,
   "numeric-input": supportsNumericInputCardFeature,
+  "precipitation-forecast": supportsPrecipitationForecastCardFeature,
   "select-options": supportsSelectOptionsCardFeature,
   "trend-graph": supportsTrendGraphCardFeature,
   "target-humidity": supportsTargetHumidityCardFeature,
   "target-temperature": supportsTargetTemperatureCardFeature,
+  "temperature-forecast": supportsTemperatureForecastCardFeature,
   toggle: supportsToggleCardFeature,
   "update-actions": supportsUpdateActionsCardFeature,
   "vacuum-commands": supportsVacuumCommandsCardFeature,

--- a/src/panels/lovelace/editor/config-elements/hui-precipitation-forecast-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-precipitation-forecast-card-feature-editor.ts
@@ -1,0 +1,187 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-form/ha-form";
+import type {
+  HaFormSchema,
+  SchemaUnion,
+} from "../../../../components/ha-form/types";
+import { getSupportedForecastTypes } from "../../../../data/weather";
+import type { HomeAssistant } from "../../../../types";
+import {
+  DEFAULT_DAYS_TO_SHOW,
+  DEFAULT_HOURS_TO_SHOW,
+  resolveForecastResolution,
+} from "../../card-features/common/forecast";
+import type {
+  ForecastResolution,
+  LovelaceCardFeatureContext,
+  PrecipitationForecastCardFeatureConfig,
+} from "../../card-features/types";
+import type { LovelaceCardFeatureEditor } from "../../types";
+
+@customElement("hui-precipitation-forecast-card-feature-editor")
+export class HuiPrecipitationForecastCardFeatureEditor
+  extends LitElement
+  implements LovelaceCardFeatureEditor
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
+
+  @state() private _config?: PrecipitationForecastCardFeatureConfig;
+
+  public setConfig(config: PrecipitationForecastCardFeatureConfig): void {
+    this._config = config;
+  }
+
+  private _schema = memoizeOne(
+    (
+      stateObj: HassEntity | undefined,
+      forecastType: ForecastResolution,
+      localize: HomeAssistant["localize"]
+    ) => {
+      const supportedTypes = stateObj
+        ? getSupportedForecastTypes(stateObj)
+        : [];
+      const isHourly = forecastType === "hourly";
+      return [
+        {
+          name: "forecast_type",
+          required: true,
+          disabled: supportedTypes.length <= 1,
+          selector: {
+            select: {
+              mode: "dropdown",
+              options: (
+                ["daily", "twice_daily", "hourly"] as ForecastResolution[]
+              ).map((value) => ({
+                value,
+                label: localize(
+                  `ui.panel.lovelace.editor.features.types.precipitation-forecast.forecast_type_options.${value}`
+                ),
+                disabled: !supportedTypes.includes(value),
+              })),
+            },
+          },
+        },
+        isHourly
+          ? {
+              name: "hours_to_show",
+              default: DEFAULT_HOURS_TO_SHOW,
+              selector: { number: { min: 1, mode: "box" } },
+            }
+          : {
+              name: "days_to_show",
+              default: DEFAULT_DAYS_TO_SHOW,
+              selector: { number: { min: 1, mode: "box" } },
+            },
+        {
+          name: "precipitation_type",
+          required: true,
+          selector: {
+            select: {
+              mode: "dropdown",
+              options: [
+                {
+                  value: "amount",
+                  label: localize(
+                    "ui.panel.lovelace.editor.features.types.precipitation-forecast.precipitation_type_options.amount"
+                  ),
+                },
+                {
+                  value: "probability",
+                  label: localize(
+                    "ui.panel.lovelace.editor.features.types.precipitation-forecast.precipitation_type_options.probability"
+                  ),
+                },
+              ],
+            },
+          },
+        },
+        {
+          name: "color",
+          selector: {
+            ui_color: {
+              default_color: "state",
+              include_state: true,
+            },
+          },
+        },
+      ] as const satisfies readonly HaFormSchema[];
+    }
+  );
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    const stateObj = this.context?.entity_id
+      ? this.hass.states[this.context.entity_id]
+      : undefined;
+    const resolvedType =
+      resolveForecastResolution(stateObj, this._config.forecast_type) ||
+      "daily";
+    const isHourly = resolvedType === "hourly";
+
+    const data: PrecipitationForecastCardFeatureConfig = {
+      ...this._config,
+      forecast_type: resolvedType,
+      precipitation_type: this._config.precipitation_type ?? "amount",
+      ...(isHourly
+        ? { hours_to_show: this._config.hours_to_show ?? DEFAULT_HOURS_TO_SHOW }
+        : { days_to_show: this._config.days_to_show ?? DEFAULT_DAYS_TO_SHOW }),
+    };
+
+    const schema = this._schema(stateObj, resolvedType, this.hass.localize);
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${schema}
+        .computeLabel=${this._computeLabelCallback}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    fireEvent(this, "config-changed", { config: ev.detail.value });
+  }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
+    switch (schema.name) {
+      case "forecast_type":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.temperature-forecast.forecast_type"
+        );
+      case "days_to_show":
+      case "hours_to_show":
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.generic.${schema.name}`
+        );
+      case "precipitation_type":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.precipitation-forecast.precipitation_type"
+        );
+      case "color":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.precipitation-forecast.color"
+        );
+      default:
+        return "";
+    }
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-precipitation-forecast-card-feature-editor": HuiPrecipitationForecastCardFeatureEditor;
+  }
+}

--- a/src/panels/lovelace/editor/config-elements/hui-precipitation-forecast-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-precipitation-forecast-card-feature-editor.ts
@@ -164,7 +164,7 @@ export class HuiPrecipitationForecastCardFeatureEditor
     switch (schema.name) {
       case "forecast_type":
         return this.hass!.localize(
-          "ui.panel.lovelace.editor.features.types.temperature-forecast.forecast_type"
+          "ui.panel.lovelace.editor.features.types.precipitation-forecast.forecast_type"
         );
       case "days_to_show":
       case "hours_to_show":

--- a/src/panels/lovelace/editor/config-elements/hui-precipitation-forecast-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-precipitation-forecast-card-feature-editor.ts
@@ -110,6 +110,11 @@ export class HuiPrecipitationForecastCardFeatureEditor
             },
           },
         },
+        {
+          name: "show_labels",
+          default: true,
+          selector: { boolean: {} },
+        },
       ] as const satisfies readonly HaFormSchema[];
     }
   );
@@ -173,6 +178,10 @@ export class HuiPrecipitationForecastCardFeatureEditor
       case "color":
         return this.hass!.localize(
           "ui.panel.lovelace.editor.features.types.precipitation-forecast.color"
+        );
+      case "show_labels":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.precipitation-forecast.show_labels"
         );
       default:
         return "";

--- a/src/panels/lovelace/editor/config-elements/hui-temperature-forecast-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-temperature-forecast-card-feature-editor.ts
@@ -1,0 +1,159 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-form/ha-form";
+import type {
+  HaFormSchema,
+  SchemaUnion,
+} from "../../../../components/ha-form/types";
+import { getSupportedForecastTypes } from "../../../../data/weather";
+import type { HomeAssistant } from "../../../../types";
+import {
+  DEFAULT_DAYS_TO_SHOW,
+  DEFAULT_HOURS_TO_SHOW,
+  resolveForecastResolution,
+} from "../../card-features/common/forecast";
+import type {
+  ForecastResolution,
+  LovelaceCardFeatureContext,
+  TemperatureForecastCardFeatureConfig,
+} from "../../card-features/types";
+import type { LovelaceCardFeatureEditor } from "../../types";
+
+@customElement("hui-temperature-forecast-card-feature-editor")
+export class HuiTemperatureForecastCardFeatureEditor
+  extends LitElement
+  implements LovelaceCardFeatureEditor
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
+
+  @state() private _config?: TemperatureForecastCardFeatureConfig;
+
+  public setConfig(config: TemperatureForecastCardFeatureConfig): void {
+    this._config = config;
+  }
+
+  private _schema = memoizeOne(
+    (
+      stateObj: HassEntity | undefined,
+      forecastType: ForecastResolution,
+      localize: HomeAssistant["localize"]
+    ) => {
+      const supportedTypes = stateObj
+        ? getSupportedForecastTypes(stateObj)
+        : [];
+      const isHourly = forecastType === "hourly";
+      return [
+        {
+          name: "forecast_type",
+          required: true,
+          disabled: supportedTypes.length <= 1,
+          selector: {
+            select: {
+              mode: "dropdown",
+              options: (
+                ["daily", "twice_daily", "hourly"] as ForecastResolution[]
+              ).map((value) => ({
+                value,
+                label: localize(
+                  `ui.panel.lovelace.editor.features.types.temperature-forecast.forecast_type_options.${value}`
+                ),
+                disabled: !supportedTypes.includes(value),
+              })),
+            },
+          },
+        },
+        isHourly
+          ? {
+              name: "hours_to_show",
+              default: DEFAULT_HOURS_TO_SHOW,
+              selector: { number: { min: 1, mode: "box" } },
+            }
+          : {
+              name: "days_to_show",
+              default: DEFAULT_DAYS_TO_SHOW,
+              selector: { number: { min: 1, mode: "box" } },
+            },
+        {
+          name: "color",
+          selector: {
+            ui_color: {
+              default_color: "state",
+              include_state: true,
+            },
+          },
+        },
+      ] as const satisfies readonly HaFormSchema[];
+    }
+  );
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    const stateObj = this.context?.entity_id
+      ? this.hass.states[this.context.entity_id]
+      : undefined;
+    const resolvedType =
+      resolveForecastResolution(stateObj, this._config.forecast_type) ||
+      "daily";
+    const isHourly = resolvedType === "hourly";
+
+    const data: TemperatureForecastCardFeatureConfig = {
+      ...this._config,
+      forecast_type: resolvedType,
+      ...(isHourly
+        ? { hours_to_show: this._config.hours_to_show ?? DEFAULT_HOURS_TO_SHOW }
+        : { days_to_show: this._config.days_to_show ?? DEFAULT_DAYS_TO_SHOW }),
+    };
+
+    const schema = this._schema(stateObj, resolvedType, this.hass.localize);
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${schema}
+        .computeLabel=${this._computeLabelCallback}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    fireEvent(this, "config-changed", { config: ev.detail.value });
+  }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
+    switch (schema.name) {
+      case "forecast_type":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.temperature-forecast.forecast_type"
+        );
+      case "days_to_show":
+      case "hours_to_show":
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.generic.${schema.name}`
+        );
+      case "color":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.temperature-forecast.color"
+        );
+      default:
+        return "";
+    }
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-temperature-forecast-card-feature-editor": HuiTemperatureForecastCardFeatureEditor;
+  }
+}

--- a/src/panels/lovelace/editor/config-elements/hui-temperature-forecast-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-temperature-forecast-card-feature-editor.ts
@@ -87,6 +87,11 @@ export class HuiTemperatureForecastCardFeatureEditor
             },
           },
         },
+        {
+          name: "show_labels",
+          default: true,
+          selector: { boolean: {} },
+        },
       ] as const satisfies readonly HaFormSchema[];
     }
   );
@@ -145,6 +150,10 @@ export class HuiTemperatureForecastCardFeatureEditor
       case "color":
         return this.hass!.localize(
           "ui.panel.lovelace.editor.features.types.temperature-forecast.color"
+        );
+      case "show_labels":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.features.types.temperature-forecast.show_labels"
         );
       default:
         return "";

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10203,6 +10203,33 @@
               "trend-graph": {
                 "label": "Trend graph",
                 "detail": "Show more detail"
+              },
+              "temperature-forecast": {
+                "label": "Temperature forecast",
+                "no_forecast": "No forecast data available",
+                "forecast_type": "Forecast type",
+                "forecast_type_options": {
+                  "daily": "Daily",
+                  "twice_daily": "Twice daily",
+                  "hourly": "Hourly"
+                },
+                "color": "Color"
+              },
+              "precipitation-forecast": {
+                "label": "Precipitation forecast",
+                "no_forecast": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::no_forecast%]",
+                "forecast_type": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::forecast_type%]",
+                "forecast_type_options": {
+                  "daily": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::forecast_type_options::daily%]",
+                  "twice_daily": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::forecast_type_options::twice_daily%]",
+                  "hourly": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::forecast_type_options::hourly%]"
+                },
+                "precipitation_type": "Precipitation type",
+                "precipitation_type_options": {
+                  "amount": "Amount",
+                  "probability": "Probability"
+                },
+                "color": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::color%]"
               }
             }
           },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10207,6 +10207,7 @@
               "temperature-forecast": {
                 "label": "Temperature forecast",
                 "no_forecast": "No forecast data available",
+                "failed_to_load": "Failed to load forecast: {error}",
                 "forecast_type": "Forecast type",
                 "forecast_type_options": {
                   "daily": "Daily",
@@ -10219,6 +10220,7 @@
               "precipitation-forecast": {
                 "label": "Precipitation forecast",
                 "no_forecast": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::no_forecast%]",
+                "failed_to_load": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::failed_to_load%]",
                 "forecast_type": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::forecast_type%]",
                 "forecast_type_options": {
                   "daily": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::forecast_type_options::daily%]",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10213,7 +10213,8 @@
                   "twice_daily": "Twice daily",
                   "hourly": "Hourly"
                 },
-                "color": "Color"
+                "color": "Color",
+                "show_labels": "Show labels"
               },
               "precipitation-forecast": {
                 "label": "Precipitation forecast",
@@ -10229,7 +10230,8 @@
                   "amount": "Amount",
                   "probability": "Probability"
                 },
-                "color": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::color%]"
+                "color": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::color%]",
+                "show_labels": "[%key:ui::panel::lovelace::editor::features::types::temperature-forecast::show_labels%]"
               }
             }
           },


### PR DESCRIPTION
## Proposed change

Adds two new tile card features for weather entities:

- **Temperature forecast**: bar chart of high/low temperatures across the next days, colored via a calibrated palette (from -6°C cyan to +42°C deep red). In hourly mode, renders a filled curve.
- **Precipitation forecast**: bar chart of precipitation amount or probability per slot, with a small dot for empty slots so the timeline stays readable.

Both features auto-detect the best forecast granularity from the entity (`daily` > `twice_daily` > `hourly`), but the user can pin a specific resolution in the editor. They also accept a custom color override and a `show_labels` toggle for day/hour labels under the bars.

PR #51854 removed the previous daily/hourly forecast features, this PR re-introduces them with a different approach.

### Rendering rules

**Temperature colors** map to actual temperatures via a calibrated palette (cyan → green/yellow → orange → red).
- **Hourly curve**: absolute mapping. Each y-position maps to its real temperature, so 15°C always looks the same regardless of the visible range.
- **Daily/twice-daily bars**: each bar uses a relative gradient anchored on the day's midpoint. Compression scales with that midpoint so cool days stay near-uniform around their mid color, while warm days spread wider across the palette. This keeps inter-day comparison readable instead of every bar showing a full cool→warm rainbow.

**Precipitation bar height** uses a reference floor instead of a pure relative scale, so a 1mm drizzle no longer looks like a thunderstorm just because it's the period max. Observed values above the floor still drive the scale (storms read as full bars).
- **Hourly**: 2.5 mm/h (0.1 in/h)
- **Twice daily**: 6 mm (0.25 in)
- **Daily**: 10 mm (0.4 in)

### YAML configuration

```yaml
type: tile
entity: weather.home
features:
  - type: temperature-forecast
    forecast_type: daily      # optional: daily | twice_daily | hourly. Default: best supported by the entity (daily > twice_daily > hourly)
    days_to_show: 7           # optional, used when forecast_type is daily or twice_daily. Default: 7
    hours_to_show: 24         # optional, used when forecast_type is hourly. Default: 24
    show_labels: true         # optional. Show day or hour labels under the bars. Default: true
    color: accent             # optional. Any HA color token or CSS color. When unset, the temperature palette is used.
```

## Screenshots

<img width="510" height="583" alt="CleanShot 2026-05-19 at 16 14 02" src="https://github.com/user-attachments/assets/c22d6272-5c6f-4ffb-a440-51dd93b2032c" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45451
- Link to developer documentation pull request:
- Link to backend pull request:


## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
