### PR TITLE
Fix Safari 14 legacy bundle require errors

### DIFF
--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -1,3 +1,4 @@
+/* global require, module, __dirname, process */
 const path = require("path");
 const env = require("./env.cjs");
 const paths = require("./paths.cjs");
@@ -176,11 +177,14 @@ module.exports.babelOptions = ({
     {
       // Use unambiguous for dependencies so that require() is correctly injected into CommonJS files
       // Exclusions are needed in some cases where ES modules have no static imports or exports, such as polyfills
+      // (otherwise babel-plugin-polyfill-corejs3 injects bare require("core-js/modules/...") calls
+      // that rspack does not transform, causing ReferenceError in browsers like Safari 14).
       sourceType: "unambiguous",
       include: /\/node_modules\//,
       exclude: [
         "element-internals-polyfill",
         "@?lit(?:-labs|-element|-html)?",
+        "@formatjs/(?:ecma402-abstract|intl-\\w+)",
       ].map((p) => new RegExp(`/node_modules/${p}/`)),
     },
   ],

--- a/build-scripts/get-built-in-node-module-shim.cjs
+++ b/build-scripts/get-built-in-node-module-shim.cjs
@@ -1,0 +1,12 @@
+/* global module */
+// Browser-only replacement for core-js/internals/get-built-in-node-module.
+// The original helper evaluates `Function('return require("...")')()`
+// when it detects a Node environment, which causes a runtime
+// ReferenceError on browsers (notably Safari 14) if environment
+// detection mis-classifies the page. Since browser bundles never need to
+// access Node built-in modules, return undefined unconditionally.
+//
+// Wired up via rspack `NormalModuleReplacementPlugin` in build-scripts/rspack.cjs.
+module.exports = function () {
+  return undefined;
+};

--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -1,3 +1,4 @@
+/* global require, module, __dirname */
 const { existsSync } = require("fs");
 const path = require("path");
 const rspack = require("@rspack/core");
@@ -173,6 +174,16 @@ const createRspackConfig = ({
             path.resolve(paths.root_dir, "src/util/empty.js")
           )
         : false,
+      // core-js ships a Node-only helper that evaluates
+      // `Function('return require("...")')()` when its runtime environment
+      // detection mis-classifies the page as Node. That produces a
+      // ReferenceError on browsers (observed on Safari 14). Since browser
+      // bundles never need to access Node built-in modules, replace it with
+      // a CommonJS no-op stub matching the helper's API (returns undefined).
+      new rspack.NormalModuleReplacementPlugin(
+        /core-js[\\/]internals[\\/]get-built-in-node-module(?:\.js)?$/,
+        path.resolve(__dirname, "get-built-in-node-module-shim.cjs")
+      ),
       !isProdBuild && new LogStartCompilePlugin(),
       isProdBuild &&
         new StatsWriterPlugin({

--- a/src/resources/polyfills/locale-data-polyfill.ts
+++ b/src/resources/polyfills/locale-data-polyfill.ts
@@ -17,14 +17,24 @@ const addData = async (
   addFunc = "__addLocaleData"
 ) => {
   // Add function will only exist if constructor is polyfilled
-  if (typeof (Intl[obj] as any)?.[addFunc] === "function") {
-    const result = await fetch(
-      `${__STATIC_PATH__}locale-data/intl-${obj.toLowerCase()}/${language}.json`
-    );
-    // Ignore if polyfill data does not exist for language
+  if (typeof (Intl[obj] as any)?.[addFunc] !== "function") {
+    return;
+  }
+  const url = `${__STATIC_PATH__}locale-data/intl-${obj.toLowerCase()}/${language}.json`;
+  try {
+    const result = await fetch(url);
+    // 404 means polyfill data does not exist for the language; ignore silently.
     if (result.ok) {
       (Intl[obj] as any)[addFunc](await result.json());
     }
+  } catch (err) {
+    // Network/access-control failures should not block startup, but they
+    // degrade i18n features so surface a warning for diagnostics.
+    // eslint-disable-next-line no-console
+    console.warn(`Failed to load Intl.${obj} locale data for ${language}`, {
+      url,
+      error: err,
+    });
   }
 };
 


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Cursor (opus 4.7 + composer 2) did the work here, I'm not exactly sure what the real fix was, I found the best result from changes made to `build-scripts/bundle.cjs` when testing in browserstack. These fixes allowed login to pass, not gone much further from here. I personally don't think supporting legacy to this degree is good moving forward, I've brought this up before with concerns on security and effort required to test every device that doesn't receive updates from the manufacturer.

There are probably a ton of other issues but at least login and the dashboard shows now

Cursor description of changes:

> Prevent core-js and formatjs polyfill chunks from emitting browser-breaking require() calls, and warn when locale data fetches fail due to network or access-control issues.

Feel free to take this over and rip it apart

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
<img width="1605" height="1080" alt="image" src="https://github.com/user-attachments/assets/c62fc6fe-4913-4d9b-a09b-f9cd12940279" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
