### PR TITLE
Fix name for battery entities without device

### DIFF
--- a/src/panels/maintenance/strategies/maintenance-view-strategy.ts
+++ b/src/panels/maintenance/strategies/maintenance-view-strategy.ts
@@ -48,11 +48,18 @@ export const filterUnavailableBatteryEntities = (
     return hass.states[entityId]?.state === "unavailable";
   });
 
-const computeBatteryTileCard = (entityId: string): TileCardConfig => ({
-  type: "tile",
-  entity: entityId,
-  name: { type: "device" },
-});
+const computeBatteryTileCard = (
+  hass: HomeAssistant,
+  entityId: string
+): TileCardConfig => {
+  const entity = hass.entities[entityId];
+  const deviceId = entity?.device_id;
+  return {
+    type: "tile",
+    entity: entityId,
+    name: { type: deviceId ? "device" : "entity" },
+  };
+};
 
 const processAreasForBattery = (
   areaIds: string[],
@@ -72,7 +79,7 @@ const processAreasForBattery = (
     const areaCards: LovelaceCardConfig[] = [];
 
     for (const entityId of areaBatteryEntities) {
-      areaCards.push(computeBatteryTileCard(entityId));
+      areaCards.push(computeBatteryTileCard(hass, entityId));
     }
 
     if (areaCards.length > 0) {
@@ -105,7 +112,7 @@ const processUnassignedEntities = (
   const cards: LovelaceCardConfig[] = [];
 
   for (const entityId of unassignedEntities) {
-    cards.push(computeBatteryTileCard(entityId));
+    cards.push(computeBatteryTileCard(hass, entityId));
   }
 
   return cards;

--- a/src/panels/maintenance/strategies/maintenance-view-strategy.ts
+++ b/src/panels/maintenance/strategies/maintenance-view-strategy.ts
@@ -49,10 +49,10 @@ export const filterUnavailableBatteryEntities = (
   });
 
 const computeBatteryTileCard = (
-  hass: HomeAssistant,
+  entities: HomeAssistant["entities"],
   entityId: string
 ): TileCardConfig => {
-  const entity = hass.entities[entityId];
+  const entity = entities[entityId];
   const deviceId = entity?.device_id;
   return {
     type: "tile",
@@ -79,7 +79,7 @@ const processAreasForBattery = (
     const areaCards: LovelaceCardConfig[] = [];
 
     for (const entityId of areaBatteryEntities) {
-      areaCards.push(computeBatteryTileCard(hass, entityId));
+      areaCards.push(computeBatteryTileCard(hass.entities, entityId));
     }
 
     if (areaCards.length > 0) {
@@ -112,7 +112,7 @@ const processUnassignedEntities = (
   const cards: LovelaceCardConfig[] = [];
 
   for (const entityId of unassignedEntities) {
-    cards.push(computeBatteryTileCard(hass, entityId));
+    cards.push(computeBatteryTileCard(hass.entities, entityId));
   }
 
   return cards;


### PR DESCRIPTION
## Proposed change

Battery tile cards in the maintenance strategy used `name: { type: "device" }` and rendered blank when the entity wasn't tied to a device. Now they fall back to the entity name when no device is present.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
