### PR TITLE
Move logs page search bar out of the toolbar

### DIFF
--- a/src/panels/config/logs/error-log-card.ts
+++ b/src/panels/config/logs/error-log-card.ts
@@ -764,17 +764,10 @@ class ErrorLogCard extends LitElement {
       padding-top: 16px;
       padding-bottom: 16px;
       overflow: auto;
-      min-height: var(--error-log-card-height, calc(100vh - 244px));
-      max-height: var(--error-log-card-height, calc(100vh - 244px));
+      min-height: var(--error-log-card-height, calc(100vh - 255px));
+      max-height: var(--error-log-card-height, calc(100vh - 255px));
       border-top: 1px solid var(--divider-color);
       direction: ltr;
-    }
-
-    @media all and (max-width: 870px) {
-      .error-log {
-        min-height: var(--error-log-card-height, calc(100vh - 190px));
-        max-height: var(--error-log-card-height, calc(100vh - 190px));
-      }
     }
 
     .error-log > div {

--- a/src/panels/config/logs/ha-config-logs.ts
+++ b/src/panels/config/logs/ha-config-logs.ts
@@ -100,28 +100,16 @@ export class HaConfigLogs extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const search = this.narrow
-      ? html`
-          <div slot="header">
-            <ha-input-search
-              appearance="outlined"
-              class="header"
-              @input=${this._filterChanged}
-              .value=${this._filter}
-              .placeholder=${this.hass.localize("ui.panel.config.logs.search")}
-            ></ha-input-search>
-          </div>
-        `
-      : html`
-          <div class="search">
-            <ha-input-search
-              appearance="outlined"
-              @input=${this._filterChanged}
-              .value=${this._filter}
-              .placeholder=${this.hass.localize("ui.panel.config.logs.search")}
-            ></ha-input-search>
-          </div>
-        `;
+    const search = html`
+      <div class="search">
+        <ha-input-search
+          appearance="outlined"
+          @input=${this._filterChanged}
+          .value=${this._filter}
+          .placeholder=${this.hass.localize("ui.panel.config.logs.search")}
+        ></ha-input-search>
+      </div>
+    `;
 
     const selectedProvider = this._getActiveProvider(this._selectedLogProvider);
 
@@ -348,22 +336,17 @@ export class HaConfigLogs extends LitElement {
           top: 0;
           z-index: 2;
         }
-        ha-input-search {
+        .search ha-input-search {
           padding: var(--ha-space-3);
           background: var(--sidebar-background-color);
           border-bottom: 1px solid var(--divider-color);
-        }
-        ha-input-search.header {
-          padding-inline-start: 0;
-          background: transparent;
-          border: none;
         }
         .content {
           direction: ltr;
         }
         ha-generic-picker {
           --md-list-item-leading-icon-color: var(--ha-color-primary-50);
-          --mdc-icon-size: 32px;
+          --mdc-icon-size: var(--ha-space-6);
         }
 
         img {
@@ -372,7 +355,7 @@ export class HaConfigLogs extends LitElement {
 
         @media all and (max-width: 870px) {
           ha-generic-picker {
-            max-width: max(30%, 160px);
+            max-width: max(30%, 180px);
           }
           ha-button {
             max-width: 100%;


### PR DESCRIPTION
## Proposed change

In narrow mode the logs search bar was rendered inside `hass-subpage`'s `slot="header"`. iOS Safari renders the input slightly taller than the clamped height, cropping the bottom of the input. 

Search now uses the same sticky-in-content layout as desktop in all viewports.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Screenshot 

<img width="392" height="505" alt="CleanShot 2026-05-06 at 14 45 11" src="https://github.com/user-attachments/assets/46b7294d-42ae-45af-a4d2-bc3319759460" />

## Additional information

- This PR fixes or closes issue: fixes #51861
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
