### PR TITLE
Pre-fill entity name field with original name in entity registry editor

### DIFF
--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -217,7 +217,7 @@ export class EntityRegistrySettingsEditor extends LitElement {
       return;
     }
 
-    this._name = this.entry.name || "";
+    this._name = this.entry.name ?? this.entry.original_name ?? "";
     this._icon = this.entry.icon || "";
     this._deviceClass =
       this.entry.device_class || this.entry.original_device_class;
@@ -1065,7 +1065,11 @@ export class EntityRegistrySettingsEditor extends LitElement {
     }
 
     const params: Partial<EntityRegistryEntryUpdateParams> = {
-      name: this._name.trim() || null,
+      name:
+        this.entry.name === null &&
+        this._name.trim() === (this.entry.original_name?.trim() ?? "")
+          ? null
+          : this._name.trim() || null,
       icon: this._icon.trim() || null,
       area_id: this._areaId || null,
       labels: this._labels || [],


### PR DESCRIPTION
## Proposed change

When editing most of my entities, the "Name" field appeared to show the entity's current name in grey (like a placeholder), but clicking into it revealed the field was actually empty — requiring me to retype the name from scratch to make a small edit.

Interestingly, this code was touched in #30349 (migration from `ha-textfield` to `ha-input`), where the `.placeholder=${this.entry.original_name}` attribute was dropped. But I tried to re-add it and it generated the same behavior.
<img width="909" height="309" alt="image" src="https://github.com/user-attachments/assets/9f225da8-99ef-445d-b695-472501aed1d5" />


What I've observed in `core.entity_registry` is that these entities have an `original_name` value, but a `null` value for `name` which creates that behavior. With this change, the field is now pre-filled with the `original_name` value when no `value` override exists. 

A save guard is also added: if the user opens the dialog, does not change the name, and saves, `name: null` is sent instead of setting the original name as an explicit override — avoiding unnecessary value saving.

## Screenshots

**Before:** clicking the name field empties it, requiring a full retype.  Here's an example on an automation, but it also occurs for most of my sensors:
<img width="736" height="226" alt="image" src="https://github.com/user-attachments/assets/d215476e-c7d9-4163-b46c-ad4f9f7eeb61" />

**After:** the field is pre-filled with the entity's current name, ready to edit without having to re-type everything.
<img width="559" height="231" alt="image" src="https://github.com/user-attachments/assets/5f748f00-967c-4f70-899a-0f9393b4b574" />


## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/home-assistant/frontend/issues/7112
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/discussions/11296
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to backend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


