### PR TITLE
Add volume up/down to media player playback tile feature

### DIFF
--- a/src/panels/lovelace/card-features/hui-media-player-playback-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-media-player-playback-card-feature.ts
@@ -8,6 +8,8 @@ import {
   mdiSkipNext,
   mdiSkipPrevious,
   mdiStop,
+  mdiVolumeMinus,
+  mdiVolumePlus,
 } from "@mdi/js";
 import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
@@ -52,6 +54,8 @@ const MEDIA_PLAYER_PLAYBACK_CONTROLS_FEATURES: Record<
   media_stop: [MediaPlayerEntityFeature.STOP],
   media_previous_track: [MediaPlayerEntityFeature.PREVIOUS_TRACK],
   media_next_track: [MediaPlayerEntityFeature.NEXT_TRACK],
+  volume_down: [MediaPlayerEntityFeature.VOLUME_STEP],
+  volume_up: [MediaPlayerEntityFeature.VOLUME_STEP],
 };
 
 export const supportsMediaPlayerPlaybackControl = (
@@ -264,6 +268,16 @@ class HuiMediaPlayerPlaybackCardFeature
         case "media_next_track":
           if (supportsFeature(stateObj, MediaPlayerEntityFeature.NEXT_TRACK)) {
             buttons.push({ icon: mdiSkipNext, action: "media_next_track" });
+          }
+          break;
+        case "volume_down":
+          if (supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_STEP)) {
+            buttons.push({ icon: mdiVolumeMinus, action: "volume_down" });
+          }
+          break;
+        case "volume_up":
+          if (supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_STEP)) {
+            buttons.push({ icon: mdiVolumePlus, action: "volume_up" });
           }
           break;
       }

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -63,6 +63,8 @@ export const MEDIA_PLAYER_PLAYBACK_CONTROLS = [
   "media_stop",
   "media_previous_track",
   "media_next_track",
+  "volume_down",
+  "volume_up",
 ] as const;
 
 export type MediaPlayerPlaybackControl =

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -256,6 +256,8 @@
         "media_stop": "Stop",
         "media_next_track": "Next track",
         "media_previous_track": "Previous track",
+        "volume_up": "Volume up",
+        "volume_down": "Volume down",
         "media_volume_up": "Volume up",
         "media_volume_down": "Volume down",
         "media_volume_mute": "Volume mute",


### PR DESCRIPTION
## Proposed change

Adds `volume_up` and `volume_down` to the `controls` options on the **Media player playback** Tile feature (introduced in #30338). Users who previously had to add a separate **Volume buttons** feature for stepwise volume control can now mix volume +/- with transport controls in a single feature, which keeps the row eligible for inline-mode rendering.

The new options appear in the feature editor only when the media player advertises `MediaPlayerEntityFeature.VOLUME_STEP` — the same flag the entity-row volume buttons gate on — so they're hidden for entities that don't support stepwise volume.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/3668
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr