### PR TITLE
Clamp power sources graph usage line to non-negative

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
@@ -315,14 +315,18 @@ export class HuiPowerSourcesGraphCard
         typeof item === "object" && "value" in item!
           ? item.value![0]
           : item![0];
-      usageData[i] = [x, 0];
+      let sum = 0;
       this._chartData.forEach((dataset) => {
         const y =
           typeof dataset.data![i] === "object" && "value" in dataset.data![i]!
             ? dataset.data![i].value![1]
             : dataset.data![i]![1];
-        usageData[i]![1] += y as number;
+        sum += y as number;
       });
+      // Consumption can't be negative; sources unaccounted for in the
+      // configuration (e.g. solar exporting to grid without a configured
+      // solar source) would otherwise drag the usage line below zero.
+      usageData[i] = [x, Math.max(0, sum)];
     });
     this._chartData.push({
       ...commonSeriesOptions,


### PR DESCRIPTION
## Proposed change

In the Power sources chart on the Energy "Now" tab, the dashed "Power usage" (consumption) line could drop below zero when a user exports power without a corresponding configured energy source (e.g. solar panels not connected to Home Assistant). The line is computed by summing all stacked source datasets, so an unaccounted-for export drags it negative.

Clamp the computed usage to `>= 0` since household consumption can't be negative — devices don't generate energy.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51754
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr