### PR TITLE
Treat unregistered entities as having no entity_category

### DIFF
--- a/src/common/entity/entity_filter.ts
+++ b/src/common/entity/entity_filter.ts
@@ -117,9 +117,6 @@ export const generateEntityFilter = (
       }
     }
     if (entityCategories) {
-      if (!entity) {
-        return false;
-      }
       const category = entity?.entity_category || "none";
       if (!entityCategories.has(category)) {
         return false;

--- a/test/common/entity/entity_filter.test.ts
+++ b/test/common/entity/entity_filter.test.ts
@@ -55,6 +55,11 @@ const mockHass: HomeAssistant = {
       state: "off",
       attributes: { device_class: "light" },
     },
+    "binary_sensor.unregistered_battery": {
+      entity_id: "binary_sensor.unregistered_battery",
+      state: "off",
+      attributes: { device_class: "battery" },
+    },
   } as any,
   entities: {
     "light.living_room": {
@@ -301,6 +306,20 @@ describe("generateEntityFilter", () => {
 
       expect(filter("light.living_room")).toBe(true);
       expect(filter("sensor.humidity")).toBe(false);
+    });
+
+    it("should treat entities without a registry entry as having no category", () => {
+      const noneFilter = generateEntityFilter(mockHass, {
+        entity_category: "none",
+      });
+      const diagnosticFilter = generateEntityFilter(mockHass, {
+        entity_category: "diagnostic",
+      });
+
+      expect(noneFilter("binary_sensor.unregistered_battery")).toBe(true);
+      expect(diagnosticFilter("binary_sensor.unregistered_battery")).toBe(
+        false
+      );
     });
   });
 


### PR DESCRIPTION
## Proposed change

Several home strategies (Maintenance, Security, etc.) filter on `entity_category: "none"`. Today, [`generateEntityFilter`](src/common/entity/entity_filter.ts) silently rejects any entity that is in `hass.states` but missing from `hass.entities` whenever an `entity_category` filter is set, regardless of which categories were requested.

That means an entity that is genuinely uncategorized — but for some reason isn't yet present in the entity registry display data — gets dropped from views like the Maintenance dashboard, even though semantically it has no category and should match `entity_category: "none"`.

This treats a missing registry entry as "no category set" and runs the normal `entity_category` comparison. If the filter accepts `"none"`, the entity passes; otherwise it's rejected on category mismatch as before. Hidden, label, and platform checks remain strict (they require a registry entry).

Adds a unit test covering the unregistered-entity case.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51921
- This PR is related to issue or discussion: #51905
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr