### PR TITLE
Improve continue on error tooltip in automation editor

### DIFF
--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -331,7 +331,7 @@ export default class HaAutomationActionRow extends LitElement {
               ></ha-svg-icon>
               <ha-tooltip for="svg-icon">
                 ${this.hass.localize(
-                  "ui.panel.config.automation.editor.actions.continue_on_error"
+                  "ui.panel.config.automation.editor.actions.continue_on_error_description"
                 )}
               </ha-tooltip>`
           : nothing}
@@ -1148,7 +1148,7 @@ export default class HaAutomationActionRow extends LitElement {
     overflowStyles,
     css`
       ha-svg-icon.arrow-right {
-        --icon-primary-color: var(--ha-color-fill-neutral-normal-resting);
+        --icon-primary-color: var(--ha-color-fill-neutral-loud-resting);
       }
       ha-svg-icon#svg-icon {
         --icon-primary-color: var(--ha-color-fill-neutral-loud-active);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5584,6 +5584,7 @@
               "unsupported_action": "No visual editor support for this action",
               "type_select": "Action type",
               "continue_on_error": "Continue on error",
+              "continue_on_error_description": "If this action fails, the next action will still run.",
               "action": "Action",
               "copied_to_clipboard": "Action copied to clipboard",
               "cut_to_clipboard": "Action cut to clipboard",


### PR DESCRIPTION
## Proposed change
The tooltip on the "continue on error" icon in the automation action row previously
showed "Continue on error" — identical to the menu item label, adding no information.

This adds a dedicated description string that clearly communicates the behavior:
"If this action fails, the next action will still run."

This is especially relevant since 2026.05, where the flag was expanded to catch more
error types, making it more likely users will encounter and want to understand this option.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to backend pull request: N/A

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr