### PR TITLE
Fix sensor card when visibility changes

### DIFF
--- a/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
@@ -92,7 +92,9 @@ class HuiHistoryChartCardFeature
 
   protected firstUpdated() {
     this._setLoadingCoordinates();
-    this._subscribeHistory();
+    if (this.isConnected) {
+      this._subscribeHistory();
+    }
   }
 
   private _setLoadingCoordinates() {
@@ -163,6 +165,7 @@ class HuiHistoryChartCardFeature
     ) {
       const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
       if (
+        this.isConnected &&
         oldHass &&
         oldHass.config.components !== this.hass!.config.components
       ) {

--- a/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
@@ -157,6 +157,7 @@ class HuiHistoryChartCardFeature
 
   protected updated(changedProps: PropertyValues<this>) {
     if (
+      this.isConnected &&
       !this._subscribed &&
       !this._error &&
       this._config &&
@@ -165,7 +166,6 @@ class HuiHistoryChartCardFeature
     ) {
       const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
       if (
-        this.isConnected &&
         oldHass &&
         oldHass.config.components !== this.hass!.config.components
       ) {

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -317,7 +317,12 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
     ) {
       this._unsubscribeHistory();
       this._subscribeHistory();
-    } else if (!this._subscribed && !this._error && changedProps.has("hass")) {
+    } else if (
+      this.isConnected &&
+      !this._subscribed &&
+      !this._error &&
+      changedProps.has("hass")
+    ) {
       // Retry subscription when components become available after backend restart
       this._subscribeHistory();
     }

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -384,7 +384,10 @@ class HuiMapCard extends LitElement implements LovelaceCard {
 
   protected updated(changedProps: PropertyValues): void {
     if (this._configEntities?.length) {
-      if ((!this._subscribed && !this._error) || changedProps.has("_config")) {
+      if (
+        (this.isConnected && !this._subscribed && !this._error) ||
+        changedProps.has("_config")
+      ) {
         this._unsubscribeHistory();
         this._subscribeHistory();
       }

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -311,7 +311,12 @@ export class HuiGraphHeaderFooter
         this._unsubscribeHistory();
         this._subscribeHistory();
       }
-    } else if (!this._subscribed && !this._error && changedProps.has("hass")) {
+    } else if (
+      this.isConnected &&
+      !this._subscribed &&
+      !this._error &&
+      changedProps.has("hass")
+    ) {
       // Retry subscription when components become available after backend restart
       this._subscribeHistory();
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Looks like this broke in https://github.com/home-assistant/frontend/pull/51531. Card unsubscribes on disconnect, we need to prevent it trying to resubscribe while it's still disconnected, so that it can successfully resub and draw on reconnect.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51951 
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
