### PR TITLE
Position bars on statistics charts at centre of data point time range

### DIFF
--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -506,13 +506,21 @@ export class StatisticsChart extends LitElement {
       const statDataSets: (LineSeriesOption | BarSeriesOption)[] = [];
       const statLegendData: typeof legendData = [];
 
+      // Place bars at centre of their specified time range if this is a bar chart
+      // and the period is 5minute or hour.
+      const centerBars =
+        chartType === "bar" &&
+        (this.period === "5minute" || this.period === "hour");
+
       const pushData = (
-        start: Date,
-        end: Date,
+        start: Date, // Data point start time
+        end: Date, // Data point end time
+        limit: Date, // Limited end time if bar extends beyond now
         dataValues: (number | null)[][]
       ) => {
         if (!dataValues.length) return;
-        if (start > end) {
+
+        if (start > limit) {
           // Drop data points that are after the requested endTime. This could happen if
           // endTime is "now" and client time is not in sync with server time.
           return;
@@ -529,10 +537,19 @@ export class StatisticsChart extends LitElement {
             d.data!.push([prevEndTime, ...prevValues[i]!]);
             d.data!.push([prevEndTime, null]);
           }
-          d.data!.push([start, ...dataValues[i]!]);
+          if (centerBars) {
+            // If centering bars, set the time to the midpoint between start and end instead
+            // of the start time.
+            d.data!.push([
+              new Date((start.getTime() + end.getTime()) / 2),
+              ...dataValues[i]!,
+            ]);
+          } else {
+            d.data!.push([start, ...dataValues[i]!]);
+          }
         });
         prevValues = dataValues;
-        prevEndTime = end;
+        prevEndTime = limit;
       };
 
       let color = colors[statistic_id];
@@ -694,6 +711,7 @@ export class StatisticsChart extends LitElement {
         if (!this._hiddenStats.has(statistic_id)) {
           pushData(
             startDate,
+            endDate,
             endDate.getTime() < endTime.getTime() ? endDate : endTime,
             dataValues
           );

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -8,12 +8,12 @@ import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
-import { addHours, addMinutes } from "date-fns";
 import { getGraphColorByIndex } from "../../common/color/colors";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import type { HASSDomEvent } from "../../common/dom/fire_event";
 import { fireEvent } from "../../common/dom/fire_event";
 
+import { formatDate } from "../../common/datetime/format_date";
 import { formatDateTimeWithSeconds } from "../../common/datetime/format_date_time";
 import { formatTimeWithSeconds } from "../../common/datetime/format_time";
 import {
@@ -257,27 +257,65 @@ export class StatisticsChart extends LitElement {
         const stateObj = this.hass.states[statisticId];
         const entry = this.hass.entities[statisticId];
         let rawValue: string;
-        let startTime: Date;
-        let endTime: Date | undefined;
+        let rawTime: string;
         if (chartIsBar) {
           // For bar charts value is always second value.
           rawValue = String(param.value[1]);
           // Time value is third value (un-shifted date) if given, otherwise first value
+          let startTime: Date;
+          let endTime: Date | undefined;
           if (param.value[2]) {
             startTime = new Date(param.value[2]);
-            if (period === "hour") {
-              endTime = addHours(startTime, 1);
-            } else if (period === "5minute") {
-              endTime = addMinutes(startTime, 5);
+            if (param.value[3]) {
+              endTime = new Date(param.value[3]);
             }
           } else {
             startTime = new Date(param.value[0]);
+          }
+          if (
+            period === "year" ||
+            period === "month" ||
+            period === "week" ||
+            period === "day"
+          ) {
+            // For year/month/day periods, show only the date
+            rawTime =
+              formatDate(startTime, this.hass.locale, this.hass.config) +
+              (endTime && period !== "day"
+                ? ` – ${formatDate(
+                    endTime,
+                    this.hass.locale,
+                    this.hass.config
+                  )}`
+                : "") +
+              "<br>";
+          } else {
+            // For other time periods, include time in render, and optionally show range
+            // if we have an end time.
+            rawTime =
+              formatDateTimeWithSeconds(
+                startTime,
+                this.hass.locale,
+                this.hass.config
+              ) +
+              (endTime
+                ? ` – ${formatTimeWithSeconds(
+                    endTime,
+                    this.hass.locale,
+                    this.hass.config
+                  )}`
+                : "") +
+              "<br>";
           }
         } else {
           // For lines max series can have 3 values, as the second value is the max-min to form a band
           rawValue = String(param.value[2] ?? param.value[1]);
           // Time value is always first value
-          startTime = new Date(param.value[0]);
+          rawTime = `${formatDateTimeWithSeconds(
+            new Date(param.value[0]),
+            this.hass.locale,
+            this.hass.config
+          )} <br>`;
         }
 
         const options = getNumberFormatOptions(stateObj, entry) ?? {
@@ -290,22 +328,7 @@ export class StatisticsChart extends LitElement {
           options
         )}${unit}`;
 
-        const time =
-          index === 0
-            ? formatDateTimeWithSeconds(
-                startTime,
-                this.hass.locale,
-                this.hass.config
-              ) +
-              (endTime
-                ? ` – ${formatTimeWithSeconds(
-                    endTime,
-                    this.hass.locale,
-                    this.hass.config
-                  )}`
-                : "") +
-              "<br>"
-            : "";
+        const time = index === 0 ? rawTime : "";
         return `${time}${param.marker} ${param.seriesName}: ${value}`;
       })
       .filter(Boolean)
@@ -560,28 +583,28 @@ export class StatisticsChart extends LitElement {
           return;
         }
         statDataSets.forEach((d, i) => {
-          if (
-            chartType === "line" &&
-            prevEndTime &&
-            prevValues &&
-            prevEndTime.getTime() !== start.getTime()
-          ) {
-            // if the end of the previous data doesn't match the start of the current data,
-            // we have to draw a gap so add a value at the end time, and then an empty value.
-            d.data!.push([prevEndTime, ...prevValues[i]!]);
-            d.data!.push([prevEndTime, null]);
-          }
-          if (centerBars) {
-            // If centering bars, set the time to the midpoint between start and end instead
-            // of the start time. Data value should always be a scalar for bar charts. Pass in
-            // real start time as extra value to allow formatting tooltip.
-            d.data!.push([
-              new Date((start.getTime() + end.getTime()) / 2),
-              dataValues[i][0]!,
-              start,
-            ]);
-          } else {
+          if (chartType === "line") {
+            if (
+              prevEndTime &&
+              prevValues &&
+              prevEndTime.getTime() !== start.getTime()
+            ) {
+              // if the end of the previous data doesn't match the start of the current data,
+              // we have to draw a gap so add a value at the end time, and then an empty value.
+              d.data!.push([prevEndTime, ...prevValues[i]!]);
+              d.data!.push([prevEndTime, null]);
+            }
             d.data!.push([start, ...dataValues[i]!]);
+          } else {
+            let time = start;
+            if (centerBars) {
+              // If centering bars, set the time to the midpoint between start and end instead
+              // of the start time.
+              time = new Date((start.getTime() + end.getTime()) / 2);
+            }
+            // Data value should always be a scalar for bar charts. Pass in
+            // real start time as extra value to allow formatting tooltip.
+            d.data!.push([time, dataValues[i][0]!, start, end]);
           }
         });
         prevValues = dataValues;

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -8,12 +8,14 @@ import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
+import { addHours, addMinutes } from "date-fns";
 import { getGraphColorByIndex } from "../../common/color/colors";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import type { HASSDomEvent } from "../../common/dom/fire_event";
 import { fireEvent } from "../../common/dom/fire_event";
 
 import { formatDateTimeWithSeconds } from "../../common/datetime/format_date_time";
+import { formatTimeWithSeconds } from "../../common/datetime/format_time";
 import {
   formatNumber,
   getNumberFormatOptions,
@@ -241,6 +243,8 @@ export class StatisticsChart extends LitElement {
 
   private _renderTooltip = (params: any) => {
     const rendered: Record<string, boolean> = {};
+    const chartIsBar = this.chartType.startsWith("bar");
+    const period = this.period;
     const unit = this.unit
       ? `${blankBeforeUnit(this.unit, this.hass.locale)}${this.unit}`
       : "";
@@ -252,8 +256,29 @@ export class StatisticsChart extends LitElement {
         const statisticId = this._statisticIds[param.seriesIndex];
         const stateObj = this.hass.states[statisticId];
         const entry = this.hass.entities[statisticId];
-        // max series can have 3 values, as the second value is the max-min to form a band
-        const rawValue = String(param.value[2] ?? param.value[1]);
+        let rawValue: string;
+        let startTime: Date;
+        let endTime: Date | undefined;
+        if (chartIsBar) {
+          // For bar charts value is always second value.
+          rawValue = String(param.value[1]);
+          // Time value is third value (un-shifted date) if given, otherwise first value
+          if (param.value[2]) {
+            startTime = new Date(param.value[2]);
+            if (period === "hour") {
+              endTime = addHours(startTime, 1);
+            } else if (period === "5minute") {
+              endTime = addMinutes(startTime, 5);
+            }
+          } else {
+            startTime = new Date(param.value[0]);
+          }
+        } else {
+          // For lines max series can have 3 values, as the second value is the max-min to form a band
+          rawValue = String(param.value[2] ?? param.value[1]);
+          // Time value is always first value
+          startTime = new Date(param.value[0]);
+        }
 
         const options = getNumberFormatOptions(stateObj, entry) ?? {
           maximumFractionDigits: 2,
@@ -268,10 +293,18 @@ export class StatisticsChart extends LitElement {
         const time =
           index === 0
             ? formatDateTimeWithSeconds(
-                new Date(param.value[0]),
+                startTime,
                 this.hass.locale,
                 this.hass.config
-              ) + "<br>"
+              ) +
+              (endTime
+                ? ` – ${formatTimeWithSeconds(
+                    endTime,
+                    this.hass.locale,
+                    this.hass.config
+                  )}`
+                : "") +
+              "<br>"
             : "";
         return `${time}${param.marker} ${param.seriesName}: ${value}`;
       })
@@ -540,10 +573,12 @@ export class StatisticsChart extends LitElement {
           }
           if (centerBars) {
             // If centering bars, set the time to the midpoint between start and end instead
-            // of the start time.
+            // of the start time. Data value should always be a scalar for bar charts. Pass in
+            // real start time as extra value to allow formatting tooltip.
             d.data!.push([
               new Date((start.getTime() + end.getTime()) / 2),
-              ...dataValues[i]!,
+              dataValues[i][0]!,
+              start,
             ]);
           } else {
             d.data!.push([start, ...dataValues[i]!]);

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -515,12 +515,13 @@ export class StatisticsChart extends LitElement {
       const pushData = (
         start: Date, // Data point start time
         end: Date, // Data point end time
-        limit: Date, // Limited end time if bar extends beyond now
+        limit: Date, // Limit for end time (e.g. now)
         dataValues: (number | null)[][]
       ) => {
         if (!dataValues.length) return;
-
-        if (start > limit) {
+        // Limit for time range is lesser of overall limit and data point end
+        limit = end.getTime() < limit.getTime() ? end : limit;
+        if (start.getTime() > limit.getTime()) {
           // Drop data points that are after the requested endTime. This could happen if
           // endTime is "now" and client time is not in sync with server time.
           return;
@@ -709,12 +710,7 @@ export class StatisticsChart extends LitElement {
           dataValues.push(val);
         });
         if (!this._hiddenStats.has(statistic_id)) {
-          pushData(
-            startDate,
-            endDate,
-            endDate.getTime() < endTime.getTime() ? endDate : endTime,
-            dataValues
-          );
+          pushData(startDate, endDate, endTime, dataValues);
         }
       });
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When displaying bar charts with either `5minute` or `hour` periods, change the statistics card to position each bar at the midpoint of its start/end time.

For consistency, this mimics the recent change in behaviour of the various energy cards which now do the same.

It is only applied to 5min/hour data because for longer time scales the axis ticks represent whole days anyway.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

### Before ###

Statistics chart above, energy solar card below. Behaviours are inconsistent in positioning of the data bars.

<img width="500" height="610" alt="image" src="https://github.com/user-attachments/assets/e8512785-7ddd-4f73-a6a4-b3888df314c5" />

### After ###

Behaviours are now consistent, with data bars centred in time range.

<img width="498" height="609" alt="image" src="https://github.com/user-attachments/assets/f891ed16-27d2-4b31-b0e3-299a3327ad7b" />

Tooltips have been updated to render with a time range for hour/5minute bars to show the time range they cover.

<img width="502" height="338" alt="image" src="https://github.com/user-attachments/assets/4b48c9f9-d935-48a4-8ae6-d503051e75cb" />

We also now render just the date on the tooltip for bars with period of "day", and the date ranges for bars with periods of "week", "month" and "year":

<img width="497" height="334" alt="image" src="https://github.com/user-attachments/assets/ee45dbfd-9471-480c-9c65-1edc7261d40c" />

<img width="495" height="340" alt="image" src="https://github.com/user-attachments/assets/29f7371e-d948-472a-8520-0c3312061af6" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/51916#issuecomment-4401845616
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
