### PR TITLE
Fixes tile card misalignment (#25745)

### DIFF
--- a/src/components/tile/ha-tile-container.ts
+++ b/src/components/tile/ha-tile-container.ts
@@ -99,7 +99,7 @@ export class HaTileContainer extends LitElement {
       display: flex;
       flex-direction: row;
       align-items: center;
-      padding: 10px;
+      padding: 0 10px;
       flex: 1;
       min-width: 0;
       box-sizing: border-box;

--- a/src/components/tile/ha-tile-container.ts
+++ b/src/components/tile/ha-tile-container.ts
@@ -100,6 +100,7 @@ export class HaTileContainer extends LitElement {
       flex-direction: row;
       align-items: center;
       padding: 0 10px;
+      min-height: var(--row-height, 56px);
       flex: 1;
       min-width: 0;
       box-sizing: border-box;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

n/a
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Very small change that fixes an misalignment on tile cards as reported in #25745.

The misalignemtn happens in a very specific situations where a (larger) system font is used for rendering items, such as the Android Companion app. Because the font is larger than expected the `10px` top padding pushes the content down, while the `10px` bottom padding isn't rendered because it falls outside the bounding box. Thus rendering the content misaligned.

The padding isn't needed because the content is already vertically centered using flexbox in an inner div anyway.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Screenshots

I've added a card-mod with my change to the tile on the bottom right to show the difference.

### Android Companion App

<img width="851" height="563" alt="image" src="https://github.com/user-attachments/assets/286c2fdb-d4cf-45ba-ac9f-d1f2d841afe0" />

### Windows

<img width="648" height="236" alt="image" src="https://github.com/user-attachments/assets/c1876a68-2b04-4f34-a356-32e8d5065e5f" />

### Workaround with card-mod

<details>
<summary>YAML</summary>

```yaml
type: tile
entity: switch.was_droogcombinatie_was_droogcombinatie
name: Wasmachine
vertical: false
card_mod:
  style:
    ha-tile-container$: |
      .content {
        padding: 0 10px!important;
      }
```
</details>

### Side-effects

> [!NOTE]
> I've added a light blue background to show the card which I've applied the changes to, while the other one is 'stock'

There is no (visible) difference on multi-line tile cards in Windows (Edge):

<img width="636" height="215" alt="image" src="https://github.com/user-attachments/assets/b9b589d5-3c0a-46c4-9c11-a5b2be54f18d" />

But there is within the Android companion app:

<img width="773" height="412" alt="image" src="https://github.com/user-attachments/assets/b29f80b1-d3ad-4100-a1ba-949c9c6eec45" />

This is expected because of the removed padding. IMHO even this is a 'fix', cause now the layout is more vertically centered within the bounding box of the tile card:

<img width="773" height="412" alt="Untitled-1" src="https://github.com/user-attachments/assets/9f909987-444b-4a82-97ee-1aa93d9a7134" />

While the content doesn't overflow in any unexpected or broken way.

It's still a little off, but that's probably something for another issue.

<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #25745
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
