### PR TITLE
Fix automation sidebar top padding

### DIFF
--- a/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
+++ b/src/panels/config/automation/sidebar/ha-automation-sidebar-card.ts
@@ -142,6 +142,7 @@ export default class HaAutomationSidebarCard extends ScrollableFadeMixin(
           min-height: 0;
           overflow: auto;
           margin-top: 0;
+          padding-top: 0;
           padding-bottom: max(var(--safe-area-inset-bottom, 0px), 32px);
         }
 

--- a/src/panels/config/automation/styles.ts
+++ b/src/panels/config/automation/styles.ts
@@ -241,7 +241,6 @@ export const automationRowsStyles = css`
 export const sidebarEditorStyles = css`
   .sidebar-editor {
     display: block;
-    padding-top: 8px;
   }
   .description {
     padding-top: 16px;


### PR DESCRIPTION
## Proposed change

Remove extra top padding from the automation sidebar editor. The `.sidebar-editor` class had a hardcoded `padding-top: 8px` that caused unwanted spacing at the top of the trigger/condition/action editor panel. The scrollable content area in `ha-automation-sidebar-card` also now explicitly sets `padding-top: 0` to prevent inherited spacing.

## Screenshots

Before / After:

> See attached screenshots showing the trigger editor panel ("Battery level changed") — the top padding gap above the description text is removed.

<img width="1024" height="900" alt="before" src="https://github.com/user-attachments/assets/3de93f2e-143f-4569-acbe-5a9751318843" />
<img width="1024" height="900" alt="after" src="https://github.com/user-attachments/assets/7e298311-47a3-4ff8-a5a3-e8a587ac411d" />


<!-- Screenshots provided by contributor -->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr