### PR TITLE
Fix water sankey untracked consumption with nested sub-trackers

### DIFF
--- a/src/panels/lovelace/cards/water/hui-water-flow-sankey-card.ts
+++ b/src/panels/lovelace/cards/water/hui-water-flow-sankey-card.ts
@@ -160,10 +160,14 @@ class HuiWaterFlowSankeyCard
     // When there are no source meters, pre-compute total device flow so the
     // home node has the correct value (sum of all device consumption) rather
     // than 0. This avoids a broken sankey where the root node has value=0
-    // while its children have positive values.
+    // while its children have positive values. Skip sub-trackers so the
+    // total only reflects top-level devices and we don't double-count.
     let totalDeviceFlow = 0;
     if (waterSources.length === 0) {
       prefs.device_consumption_water.forEach((device) => {
+        if (device.included_in_stat) {
+          return;
+        }
         if (device.stat_rate) {
           totalDeviceFlow += this._getCurrentFlowRate(device.stat_rate);
         }

--- a/src/panels/lovelace/cards/water/hui-water-sankey-card.ts
+++ b/src/panels/lovelace/cards/water/hui-water-sankey-card.ts
@@ -123,9 +123,14 @@ class HuiWaterSankeyCard
     const nodes: Node[] = [];
     const links: Link[] = [];
 
-    // Calculate total water consumption from all sources or devices
+    // Sum only top-level devices. Devices with `included_in_stat` are already
+    // counted inside their parent stat; adding them again would double-count
+    // and push the home total above the source meter.
     const totalDownstreamConsumption = prefs.device_consumption_water.reduce(
       (total, device) => {
+        if (device.included_in_stat) {
+          return total;
+        }
         const value =
           device.stat_consumption in this._data!.stats
             ? calculateStatisticSumGrowth(


### PR DESCRIPTION
## Proposed change

The water Sankey was summing every device in `device_consumption_water` — including sub-trackers marked with `included_in_stat` — when computing `totalDownstreamConsumption`. Sub-trackers are already counted inside their parent stat, so adding them again double-counts.

Skipping sub-trackers in the totals makes the two computations symmetric around top-level devices.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51967
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr