### PR TITLE
Add automation live condition tests

### DIFF
--- a/src/components/automation/ha-automation-row.ts
+++ b/src/components/automation/ha-automation-row.ts
@@ -124,6 +124,7 @@ export class HaAutomationRow extends LitElement {
   static styles = css`
     :host {
       display: block;
+      position: relative;
     }
     .row {
       display: flex;

--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -1,4 +1,5 @@
 import type {
+  Connection,
   HassEntityAttributeBase,
   HassEntityBase,
   HassServiceTarget,
@@ -582,6 +583,19 @@ export const testCondition = (
     type: "test_condition",
     condition,
     variables,
+  });
+
+export const subscribeCondition = (
+  connection: Connection,
+  onChange: (result: {
+    result?: boolean;
+    error?: string | { code: string; message: string };
+  }) => void,
+  condition: Condition
+) =>
+  connection.subscribeMessage(onChange, {
+    type: "subscribe_condition",
+    condition,
   });
 
 export interface AutomationClipboard {

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -591,6 +591,7 @@ export default class HaAutomationConditionRow extends LitElement {
 
   public disconnectedCallback() {
     super.disconnectedCallback();
+    this._debounceSubscribeCondition.cancel();
     if (this._testingTimeout !== undefined) {
       clearTimeout(this._testingTimeout);
     }

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -17,10 +17,13 @@ import {
   mdiStopCircleOutline,
 } from "@mdi/js";
 import deepClone from "deep-clone-simple";
-import type { HassServiceTarget } from "home-assistant-js-websocket";
+import type {
+  HassServiceTarget,
+  UnsubscribeFunc,
+} from "home-assistant-js-websocket";
 import { dump } from "js-yaml";
 import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
-import { LitElement, html, nothing } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import memoizeOne from "memoize-one";
@@ -32,6 +35,7 @@ import { stopPropagation } from "../../../../common/dom/stop_propagation";
 import { capitalizeFirstLetter } from "../../../../common/string/capitalize-first-letter";
 import { handleStructError } from "../../../../common/structs/handle-errors";
 import { copyToClipboard } from "../../../../common/util/copy-clipboard";
+import { debounce } from "../../../../common/util/debounce";
 import "../../../../components/automation/ha-automation-row";
 import type { HaAutomationRow } from "../../../../components/automation/ha-automation-row";
 import "../../../../components/automation/ha-automation-row-event-chip";
@@ -42,13 +46,18 @@ import type { HaDropdownSelectEvent } from "../../../../components/ha-dropdown";
 import "../../../../components/ha-dropdown-item";
 import "../../../../components/ha-expansion-panel";
 import "../../../../components/ha-icon-button";
+import "../../../../components/ha-tooltip";
 import type {
   AutomationClipboard,
   Condition,
   ConditionSidebarConfig,
   PlatformCondition,
 } from "../../../../data/automation";
-import { isCondition, testCondition } from "../../../../data/automation";
+import {
+  isCondition,
+  subscribeCondition,
+  testCondition,
+} from "../../../../data/automation";
 import { describeCondition } from "../../../../data/automation_i18n";
 import type { ConditionDescriptions } from "../../../../data/condition";
 import { CONDITION_BUILDING_BLOCKS } from "../../../../data/condition";
@@ -140,6 +149,11 @@ export default class HaAutomationConditionRow extends LitElement {
 
   @state() private _selected = false;
 
+  @state() private _liveTestResult: {
+    state: "pass" | "fail" | "invalid" | "unknown";
+    message?: string;
+  } = { state: "unknown" };
+
   @state()
   @consume({ context: fullEntitiesContext, subscribe: true })
   _entityReg: EntityRegistryEntry[] = [];
@@ -151,6 +165,8 @@ export default class HaAutomationConditionRow extends LitElement {
   private _automationRowElement?: HaAutomationRow;
 
   private _testingTimeout?: number;
+
+  private _conditionUnsub?: Promise<UnsubscribeFunc>;
 
   get selected() {
     return this._selected;
@@ -481,7 +497,23 @@ export default class HaAutomationConditionRow extends LitElement {
               .dim=${this._testing}
               @click=${this._toggleSidebar}
               @toggle-collapsed=${this._toggleCollapse}
-              >${this._renderRow()}</ha-automation-row
+              >${this._renderRow()}
+              <div
+                slot="icons"
+                id="live-test"
+                class=${this._liveTestResult.state}
+                role="status"
+                tabindex="0"
+                aria-label=${this.hass.localize(
+                  `ui.panel.config.automation.editor.conditions.live_test_state.${this._liveTestResult.state}`
+                )}
+              >
+                ${this._liveTestResult.message
+                  ? html`<ha-tooltip for="live-test">
+                      ${this._liveTestResult.message}
+                    </ha-tooltip>`
+                  : nothing}
+              </div></ha-automation-row
             >`
           : html`
               <ha-expansion-panel
@@ -526,6 +558,11 @@ export default class HaAutomationConditionRow extends LitElement {
       ></ha-automation-row-targets>`
   );
 
+  public connectedCallback(): void {
+    super.connectedCallback();
+    this._subscribeCondition();
+  }
+
   protected firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
 
@@ -541,11 +578,85 @@ export default class HaAutomationConditionRow extends LitElement {
     }
   }
 
+  protected override updated(changedProps: PropertyValues<this>): void {
+    super.updated(changedProps);
+    if (
+      changedProps.has("condition") &&
+      changedProps.get("condition") !== undefined
+    ) {
+      this._resetSubscription();
+      this._debounceSubscribeCondition();
+    }
+  }
+
   public disconnectedCallback() {
     super.disconnectedCallback();
     if (this._testingTimeout !== undefined) {
       clearTimeout(this._testingTimeout);
     }
+    this._resetSubscription();
+  }
+
+  private _resetSubscription() {
+    this._liveTestResult = {
+      state: "unknown",
+      message: this.hass.localize(
+        "ui.panel.config.automation.editor.conditions.live_test_state.unknown"
+      ),
+    };
+    if (this._conditionUnsub) {
+      this._conditionUnsub.then((unsub) => unsub());
+      this._conditionUnsub = undefined;
+    }
+  }
+
+  private _debounceSubscribeCondition = debounce(
+    () => this._subscribeCondition(),
+    500
+  );
+
+  private async _subscribeCondition() {
+    const condition = this.condition;
+
+    this._resetSubscription();
+
+    // Don't do anything if condition changed.
+    if (this.condition !== condition) {
+      return;
+    }
+
+    const conditionUnsub = subscribeCondition(
+      this.hass.connection,
+      (result) => {
+        if (result.error) {
+          this._handleLiveTestError(result.error);
+        } else {
+          this._liveTestResult = {
+            state: result.result ? "pass" : "fail",
+            message: this.hass.localize(
+              `ui.panel.config.automation.editor.conditions.testing_${result.result ? "pass" : "error"}`
+            ),
+          };
+        }
+      },
+      condition
+    );
+    conditionUnsub.catch((err: any) => {
+      this._handleLiveTestError(err);
+      if (this._conditionUnsub === conditionUnsub) {
+        this._conditionUnsub = undefined;
+      }
+    });
+    this._conditionUnsub = conditionUnsub;
+  }
+
+  private _handleLiveTestError(error: any) {
+    const invalid =
+      typeof error !== "string" && error.code === "invalid_format";
+    this._liveTestResult = {
+      state: invalid ? "invalid" : "unknown",
+      message: typeof error === "string" ? error : error.message,
+    };
   }
 
   private _onValueChange(event: CustomEvent) {
@@ -955,7 +1066,52 @@ export default class HaAutomationConditionRow extends LitElement {
   }
 
   static get styles(): CSSResultGroup {
-    return [rowStyles, overflowStyles];
+    return [
+      rowStyles,
+      overflowStyles,
+      css`
+        #live-test {
+          position: absolute;
+          inset-inline-end: -6px;
+          width: 12px;
+          height: 12px;
+          border-radius: var(--ha-border-radius-circle);
+          border: 3px solid;
+          box-sizing: border-box;
+          background-color: var(--card-background-color);
+          transition: all var(--ha-animation-duration-normal) ease-in-out;
+        }
+        #live-test.pass {
+          background-color: var(--ha-color-fill-success-loud-resting);
+          border-color: var(--ha-color-fill-success-loud-resting);
+        }
+        #live-test.pass:hover {
+          background-color: var(--ha-color-fill-success-loud-hover);
+          border-color: var(--ha-color-fill-success-loud-hover);
+        }
+        #live-test.fail {
+          border-color: var(--ha-color-fill-warning-loud-resting);
+        }
+        #live-test.fail:hover {
+          background-color: var(--ha-color-fill-warning-loud-hover);
+          border-color: var(--ha-color-fill-warning-loud-hover);
+        }
+        #live-test.invalid {
+          border-color: var(--ha-color-fill-danger-loud-resting);
+        }
+        #live-test.invalid:hover {
+          background-color: var(--ha-color-fill-danger-loud-hover);
+          border-color: var(--ha-color-fill-danger-loud-hover);
+        }
+        #live-test.unknown {
+          border-color: var(--ha-color-fill-neutral-loud-resting);
+        }
+        #live-test.unknown:hover {
+          background-color: var(--ha-color-fill-neutral-loud-hover);
+          border-color: var(--ha-color-fill-neutral-loud-hover);
+        }
+      `,
+    ];
   }
 }
 

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -616,12 +616,9 @@ export default class HaAutomationConditionRow extends LitElement {
   );
 
   private async _subscribeCondition() {
-    const condition = this.condition;
-
     this._resetSubscription();
 
-    // Don't do anything if condition changed.
-    if (this.condition !== condition) {
+    if (!this.condition) {
       return;
     }
 
@@ -639,7 +636,7 @@ export default class HaAutomationConditionRow extends LitElement {
           };
         }
       },
-      condition
+      this.condition
     );
     conditionUnsub.catch((err: any) => {
       this._handleLiveTestError(err);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5405,6 +5405,12 @@
               "test": "Test",
               "testing_error": "Condition did not pass",
               "testing_pass": "Condition passes",
+              "live_test_state": {
+                "pass": "[%key:ui::panel::config::automation::editor::conditions::testing_pass%]",
+                "fail": "[%key:ui::panel::config::automation::editor::conditions::testing_error%]",
+                "invalid": "Condition is invalid",
+                "unknown": "Condition state unknown"
+              },
               "invalid_condition": "Invalid condition configuration",
               "validation_failed": "Condition validation failed",
               "test_failed": "Error occurred while testing condition",


### PR DESCRIPTION
## Proposed change
- Automation conditions now subscribe their test results and show the live state as a dot at the end of the row.
- fix #51688
- needs home-assistant/core#170385

## Screenshots

https://github.com/user-attachments/assets/156876a0-d095-4f01-9a2a-b23809bb8478


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
