### PR TITLE
Dev tools -> Templates: fix editor height

### DIFF
--- a/src/panels/config/developer-tools/template/developer-tools-template.ts
+++ b/src/panels/config/developer-tools/template/developer-tools-template.ts
@@ -85,18 +85,6 @@ class HaPanelDevTemplate extends LitElement {
     this._inited = true;
   }
 
-  private _getTipHeight(): string | undefined {
-    const tip = this.shadowRoot!.getElementById("editor-tip");
-    if (tip) {
-      const height = tip.scrollHeight;
-      if (!isNaN(height)) {
-        return `${height}px`;
-      }
-      return undefined;
-    }
-    return undefined;
-  }
-
   protected render() {
     const type = typeof this._templateResult?.result;
     const resultType =
@@ -105,7 +93,7 @@ class HaPanelDevTemplate extends LitElement {
           ? "list"
           : "dict"
         : type;
-    const tipHeight = this._getTipHeight();
+    const editorTipHeight = this._getTipHeight();
 
     return html`
       <div class="content">
@@ -159,7 +147,7 @@ class HaPanelDevTemplate extends LitElement {
         })}"
         style=${styleMap({
           "--description-expanded": `${this._descriptionExpanded ? 1 : 0}`,
-          "--tip-height": `${tipHeight}`,
+          "--tip-height": `${editorTipHeight}`,
         })}
       >
         <ha-card
@@ -304,6 +292,18 @@ ${type === "object"
         </ha-card>
       </div>
     `;
+  }
+
+  private _getTipHeight(): string | undefined {
+    const tip = this.shadowRoot?.getElementById("editor-tip");
+    if (tip) {
+      const height = tip.scrollHeight;
+      if (!isNaN(height)) {
+        return `${height}px`;
+      }
+      return undefined;
+    }
+    return undefined;
   }
 
   private _expandedChanged(

--- a/src/panels/config/developer-tools/template/developer-tools-template.ts
+++ b/src/panels/config/developer-tools/template/developer-tools-template.ts
@@ -332,6 +332,10 @@ ${type === "object"
               var(--ha-card-header-font-size, var(--ha-font-size-2xl))
           );
           --card-actions-height: calc(1px + var(--ha-space-2) * 2 + 40px);
+          --tip-height: calc(
+            var(--mdc-icon-size, 24px) + var(--ha-line-height-normal) *
+              var(--ha-font-size-m) + var(--ha-space-4)
+          );
           --edit-pane-height: calc(
             100vh - var(--panel-header-height) - var(
                 --description-pane-height
@@ -341,8 +345,8 @@ ${type === "object"
           --code-mirror-max-height: calc(
             var(--edit-pane-height) - var(--card-header-height) +
               var(--ha-space-2) - var(--card-actions-height) - var(
-                --ha-space-4
-              ) - var(--ha-card-border-width, 1px) *
+                --tip-height
+              ) - var(--ha-space-4) - var(--ha-card-border-width, 1px) *
               2
           );
         }

--- a/src/panels/config/developer-tools/template/developer-tools-template.ts
+++ b/src/panels/config/developer-tools/template/developer-tools-template.ts
@@ -3,6 +3,7 @@ import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import { styleMap } from "lit/directives/style-map";
 import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import { debounce } from "../../../../common/util/debounce";
 import "../../../../components/ha-alert";
@@ -84,6 +85,18 @@ class HaPanelDevTemplate extends LitElement {
     this._inited = true;
   }
 
+  private _getTipHeight(): string | undefined {
+    const tip = this.shadowRoot!.getElementById("editor-tip");
+    if (tip) {
+      const height = tip.scrollHeight;
+      if (!isNaN(height)) {
+        return `${height}px`;
+      }
+      return undefined;
+    }
+    return undefined;
+  }
+
   protected render() {
     const type = typeof this._templateResult?.result;
     const resultType =
@@ -92,6 +105,7 @@ class HaPanelDevTemplate extends LitElement {
           ? "list"
           : "dict"
         : type;
+    const tipHeight = this._getTipHeight();
 
     return html`
       <div class="content">
@@ -143,7 +157,10 @@ class HaPanelDevTemplate extends LitElement {
           layout: !this.narrow,
           horizontal: !this.narrow,
         })}"
-        style="--description-expanded: ${this._descriptionExpanded ? 1 : 0}"
+        style=${styleMap({
+          "--description-expanded": `${this._descriptionExpanded ? 1 : 0}`,
+          "--tip-height": `${tipHeight}`,
+        })}
       >
         <ha-card
           class="edit-pane"
@@ -174,7 +191,7 @@ class HaPanelDevTemplate extends LitElement {
               ${this.hass.localize("ui.common.clear")}
             </ha-button>
           </div>
-          <ha-tip .hass=${this.hass}>
+          <ha-tip id="editor-tip" .hass=${this.hass}>
             ${this.hass.localize(
               "ui.panel.config.developer-tools.tabs.templates.keyboard_tip",
               {
@@ -332,9 +349,8 @@ ${type === "object"
               var(--ha-card-header-font-size, var(--ha-font-size-2xl))
           );
           --card-actions-height: calc(1px + var(--ha-space-2) * 2 + 40px);
-          --tip-height: calc(
-            var(--mdc-icon-size, 24px) + var(--ha-line-height-normal) *
-              var(--ha-font-size-m) + var(--ha-space-4)
+          --tip-height-minimal: calc(
+            var(--mdc-icon-size, 24px) + var(--ha-space-4)
           );
           --edit-pane-height: calc(
             100vh - var(--panel-header-height) - var(
@@ -345,7 +361,8 @@ ${type === "object"
           --code-mirror-max-height: calc(
             var(--edit-pane-height) - var(--card-header-height) +
               var(--ha-space-2) - var(--card-actions-height) - var(
-                --tip-height
+                --tip-height,
+                var(--tip-height-minimal)
               ) - var(--ha-space-4) - var(--ha-card-border-width, 1px) *
               2
           );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

https://github.com/home-assistant/frontend/pull/51792 added a `ha-tip` element which broke an automatic editor height formula.
This PR accounts a height of the added `ha-tip` element (can have 1 or 2 lines of text).
Although, it MAY need a manual refresh (F5) after changing a viewport size - but in a real life scenario it is not critical, the main point that a look is OK for devices with different viewports.


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

<img width="1319" height="1023" alt="image" src="https://github.com/user-attachments/assets/13b8dfe7-249e-4c46-ad40-65983d61d560" />

<img width="849" height="1031" alt="image" src="https://github.com/user-attachments/assets/3c04639b-60fa-4aae-8dfc-224f696c3e18" />




## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
