### PR TITLE
Add mute button to media player volume buttons card f…

### DIFF
--- a/src/panels/lovelace/card-features/hui-media-player-volume-buttons-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-media-player-volume-buttons-card-feature.ts
@@ -1,9 +1,13 @@
-import { html, LitElement, nothing } from "lit";
+import { mdiVolumeHigh, mdiVolumeOff } from "@mdi/js";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import { clamp } from "../../../common/number/clamp";
+import "../../../components/ha-control-button";
 import "../../../components/ha-control-number-buttons";
+import "../../../components/ha-svg-icon";
+import { forwardHaptic } from "../../../data/haptics";
 import { isUnavailableState } from "../../../data/entity/entity";
 import {
   MediaPlayerEntityFeature,
@@ -84,14 +88,22 @@ class HuiMediaPlayerVolumeButtonsCardFeature
       return nothing;
     }
 
+    const stateObj = this._stateObj;
+    const disabled = isUnavailableState(stateObj.state);
+    const supportsMute = supportsFeature(
+      stateObj,
+      MediaPlayerEntityFeature.VOLUME_MUTE
+    );
+    const isMuted = stateObj.attributes.is_volume_muted;
+
     const position =
-      this._stateObj.attributes.volume_level != null
-        ? Math.round(this._stateObj.attributes.volume_level * 100)
+      stateObj.attributes.volume_level != null
+        ? Math.round(stateObj.attributes.volume_level * 100)
         : undefined;
 
     return html`
       <ha-control-number-buttons
-        .disabled=${!this._stateObj || isUnavailableState(this._stateObj.state)}
+        .disabled=${disabled}
         .locale=${this.hass.locale}
         min="0"
         max="100"
@@ -100,6 +112,22 @@ class HuiMediaPlayerVolumeButtonsCardFeature
         unit="%"
         @value-changed=${this._valueChanged}
       ></ha-control-number-buttons>
+      ${supportsMute
+        ? html`
+            <ha-control-button
+              class="mute"
+              .label=${this.hass.localize(
+                `ui.card.media_player.${isMuted ? "media_volume_unmute" : "media_volume_mute"}`
+              )}
+              .disabled=${disabled}
+              @click=${this._toggleMute}
+            >
+              <ha-svg-icon
+                .path=${isMuted ? mdiVolumeOff : mdiVolumeHigh}
+              ></ha-svg-icon>
+            </ha-control-button>
+          `
+        : nothing}
     `;
   }
 
@@ -112,8 +140,34 @@ class HuiMediaPlayerVolumeButtonsCardFeature
     });
   }
 
+  private _toggleMute(ev: Event) {
+    ev.stopPropagation();
+    forwardHaptic(this, "light");
+    this.hass!.callService("media_player", "volume_mute", {
+      entity_id: this._stateObj!.entity_id,
+      is_volume_muted: !this._stateObj!.attributes.is_volume_muted,
+    });
+  }
+
   static get styles() {
-    return cardFeatureStyles;
+    return [
+      cardFeatureStyles,
+      css`
+        :host {
+          display: flex;
+          flex-direction: row;
+          gap: var(--feature-button-spacing);
+        }
+        ha-control-number-buttons {
+          flex: 1;
+          min-width: 0;
+        }
+        .mute {
+          width: var(--feature-height);
+          height: var(--feature-height);
+        }
+      `,
+    ];
   }
 }
 

--- a/src/panels/lovelace/card-features/hui-media-player-volume-buttons-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-media-player-volume-buttons-card-feature.ts
@@ -90,10 +90,9 @@ class HuiMediaPlayerVolumeButtonsCardFeature
 
     const stateObj = this._stateObj;
     const disabled = isUnavailableState(stateObj.state);
-    const supportsMute = supportsFeature(
-      stateObj,
-      MediaPlayerEntityFeature.VOLUME_MUTE
-    );
+    const supportsMute =
+      (this._config.show_mute_button ?? true) &&
+      supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_MUTE);
     const isMuted = stateObj.attributes.is_volume_muted;
 
     const position =

--- a/src/panels/lovelace/card-features/hui-media-player-volume-buttons-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-media-player-volume-buttons-card-feature.ts
@@ -90,7 +90,7 @@ class HuiMediaPlayerVolumeButtonsCardFeature
 
     const stateObj = this._stateObj;
     const disabled = isUnavailableState(stateObj.state);
-    const supportsMute =
+    const showMute =
       (this._config.show_mute_button ?? true) &&
       supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_MUTE);
     const isMuted = stateObj.attributes.is_volume_muted;
@@ -111,7 +111,7 @@ class HuiMediaPlayerVolumeButtonsCardFeature
         unit="%"
         @value-changed=${this._valueChanged}
       ></ha-control-number-buttons>
-      ${supportsMute
+      ${showMute
         ? html`
             <ha-control-button
               class="mute"

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -86,6 +86,7 @@ export interface MediaPlayerVolumeSliderCardFeatureConfig {
 export interface MediaPlayerVolumeButtonsCardFeatureConfig {
   type: "media-player-volume-buttons";
   step?: number;
+  show_mute_button?: boolean;
 }
 
 export interface MediaPlayerSoundModeCardFeatureConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-media-player-volume-buttons-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-media-player-volume-buttons-card-feature-editor.ts
@@ -4,6 +4,8 @@ import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
+import { supportsFeature } from "../../../../common/entity/supports-feature";
+import { MediaPlayerEntityFeature } from "../../../../data/media-player";
 import type { HomeAssistant } from "../../../../types";
 import type {
   LovelaceCardFeatureContext,
@@ -27,7 +29,7 @@ export class HuiMediaPlayerVolumeButtonsCardFeatureEditor
   }
 
   private _schema = memoizeOne(
-    () =>
+    (supportsMute: boolean) =>
       [
         {
           name: "step",
@@ -43,6 +45,7 @@ export class HuiMediaPlayerVolumeButtonsCardFeatureEditor
         },
         {
           name: "show_mute_button",
+          disabled: !supportsMute,
           selector: { boolean: {} },
         },
       ] as const
@@ -53,13 +56,20 @@ export class HuiMediaPlayerVolumeButtonsCardFeatureEditor
       return nothing;
     }
 
+    const stateObj = this.context?.entity_id
+      ? this.hass.states[this.context.entity_id]
+      : undefined;
+    const supportsMute =
+      !!stateObj &&
+      supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_MUTE);
+
     const data: MediaPlayerVolumeButtonsCardFeatureConfig = {
       type: "media-player-volume-buttons",
       step: this._config.step ?? 5,
       show_mute_button: this._config.show_mute_button ?? true,
     };
 
-    const schema = this._schema();
+    const schema = this._schema(supportsMute);
 
     return html`
       <ha-form

--- a/src/panels/lovelace/editor/config-elements/hui-media-player-volume-buttons-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-media-player-volume-buttons-card-feature-editor.ts
@@ -41,6 +41,10 @@ export class HuiMediaPlayerVolumeButtonsCardFeatureEditor
             },
           },
         },
+        {
+          name: "show_mute_button",
+          selector: { boolean: {} },
+        },
       ] as const
   );
 
@@ -52,6 +56,7 @@ export class HuiMediaPlayerVolumeButtonsCardFeatureEditor
     const data: MediaPlayerVolumeButtonsCardFeatureConfig = {
       type: "media-player-volume-buttons",
       step: this._config.step ?? 5,
+      show_mute_button: this._config.show_mute_button ?? true,
     };
 
     const schema = this._schema();

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9978,7 +9978,8 @@
               },
               "media-player-volume-buttons": {
                 "label": "Media player volume buttons",
-                "step": "Step size"
+                "step": "Step size",
+                "show_mute_button": "Show mute button"
               },
               "media-player-volume-slider": {
                 "label": "Media player volume slider"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

As proposed in https://github.com/orgs/home-assistant/discussions/3747, add optional mute button to Media player volume buttons feature for Tile card.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

<img width="368" height="326" alt="image" src="https://github.com/user-attachments/assets/4cc360c2-c408-4e3c-b144-735e80479671" />


https://github.com/user-attachments/assets/70aa2758-746e-4475-83eb-4005f9edd367


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/3747
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45347
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

```yaml
type: tile
grid_options:
  rows: 2
  columns: 6
entity: media_player.salon
vertical: false
features:
  - type: media-player-volume-buttons
    step: 5
    show_mute_button: true
features_position: bottom
```

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
