### PR TITLE
Add volume mute button to media player playback card feature

### DIFF
--- a/src/panels/lovelace/card-features/hui-media-player-playback-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-media-player-playback-card-feature.ts
@@ -8,7 +8,9 @@ import {
   mdiSkipNext,
   mdiSkipPrevious,
   mdiStop,
+  mdiVolumeHigh,
   mdiVolumeMinus,
+  mdiVolumeOff,
   mdiVolumePlus,
 } from "@mdi/js";
 import type { PropertyValues } from "lit";
@@ -56,6 +58,7 @@ const MEDIA_PLAYER_PLAYBACK_CONTROLS_FEATURES: Record<
   media_next_track: [MediaPlayerEntityFeature.NEXT_TRACK],
   volume_down: [MediaPlayerEntityFeature.VOLUME_STEP],
   volume_up: [MediaPlayerEntityFeature.VOLUME_STEP],
+  volume_mute: [MediaPlayerEntityFeature.VOLUME_MUTE],
 };
 
 export const supportsMediaPlayerPlaybackControl = (
@@ -280,6 +283,16 @@ class HuiMediaPlayerPlaybackCardFeature
             buttons.push({ icon: mdiVolumePlus, action: "volume_up" });
           }
           break;
+        case "volume_mute":
+          if (supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_MUTE)) {
+            buttons.push({
+              icon: stateObj.attributes.is_volume_muted
+                ? mdiVolumeOff
+                : mdiVolumeHigh,
+              action: "volume_mute",
+            });
+          }
+          break;
       }
     }
 
@@ -311,6 +324,14 @@ class HuiMediaPlayerPlaybackCardFeature
             : "media_stop";
       this.hass!.callService("media_player", service, {
         entity_id: this._stateObj.entity_id,
+      });
+      return;
+    }
+
+    if (action === "volume_mute") {
+      this.hass!.callService("media_player", "volume_mute", {
+        entity_id: this._stateObj.entity_id,
+        is_volume_muted: !this._stateObj.attributes.is_volume_muted,
       });
       return;
     }

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -65,6 +65,7 @@ export const MEDIA_PLAYER_PLAYBACK_CONTROLS = [
   "media_next_track",
   "volume_down",
   "volume_up",
+  "volume_mute",
 ] as const;
 
 export type MediaPlayerPlaybackControl =

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -258,6 +258,7 @@
         "media_previous_track": "Previous track",
         "volume_up": "Volume up",
         "volume_down": "Volume down",
+        "volume_mute": "Mute",
         "media_volume_up": "Volume up",
         "media_volume_down": "Volume down",
         "media_volume_mute": "Volume mute",


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

As proposed in discussion [#3747](https://github.com/orgs/home-assistant/discussions/3747) add the capability to have volume mute button to media player playback card feature.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

https://github.com/user-attachments/assets/752f75e5-144e-4fe0-9b57-8e0f3a8dda25


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: [#3747](https://github.com/orgs/home-assistant/discussions/3747)
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45348
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

```yaml
  - type: media-player-playback
    controls:
      - volume_mute
      - turn_off
      - media_play
```

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
