### PR TITLE
Add source filtering to media-player-source card feature

### DIFF
--- a/src/panels/lovelace/card-features/hui-media-player-source-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-media-player-source-card-feature.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../data/media-player";
 import type { HomeAssistant } from "../../../types";
 import { hasConfigChanged } from "../common/has-changed";
-import type { LovelaceCardFeature } from "../types";
+import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import { HuiModeSelectCardFeatureBase } from "./hui-mode-select-card-feature-base";
 import type {
   LovelaceCardFeatureContext,
@@ -43,6 +43,11 @@ class HuiMediaPlayerSourceCardFeature
 
   protected readonly _modesAttribute = "source_list";
 
+  protected get _configuredModes() {
+    const sources = this._config?.sources;
+    return sources?.length ? sources : undefined;
+  }
+
   protected readonly _serviceDomain = "media_player";
 
   protected readonly _serviceAction = "select_source";
@@ -61,6 +66,13 @@ class HuiMediaPlayerSourceCardFeature
     return {
       type: "media-player-source",
     };
+  }
+
+  public static async getConfigElement(): Promise<LovelaceCardFeatureEditor> {
+    await import("../editor/config-elements/hui-media-player-source-card-feature-editor");
+    return document.createElement(
+      "hui-media-player-source-card-feature-editor"
+    );
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {

--- a/src/panels/lovelace/card-features/types.ts
+++ b/src/panels/lovelace/card-features/types.ts
@@ -78,6 +78,7 @@ export interface MediaPlayerPlaybackCardFeatureConfig {
 
 export interface MediaPlayerSourceCardFeatureConfig {
   type: "media-player-source";
+  sources?: string[];
 }
 
 export interface MediaPlayerVolumeSliderCardFeatureConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
@@ -152,6 +152,7 @@ const EDITABLES_FEATURE_TYPES = new Set<UiFeatureTypes>([
   "lawn-mower-commands",
   "media-player-playback",
   "light-color-favorites",
+  "media-player-source",
   "media-player-volume-buttons",
   "numeric-input",
   "select-options",

--- a/src/panels/lovelace/editor/config-elements/hui-media-player-source-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-media-player-source-card-feature-editor.ts
@@ -1,0 +1,97 @@
+import { html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-form/ha-form";
+import type { SchemaUnion } from "../../../../components/ha-form/types";
+import type { MediaPlayerEntity } from "../../../../data/media-player";
+import type { HomeAssistant } from "../../../../types";
+import type {
+  LovelaceCardFeatureContext,
+  MediaPlayerSourceCardFeatureConfig,
+} from "../../card-features/types";
+import type { LovelaceCardFeatureEditor } from "../../types";
+
+@customElement("hui-media-player-source-card-feature-editor")
+export class HuiMediaPlayerSourceCardFeatureEditor
+  extends LitElement
+  implements LovelaceCardFeatureEditor
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public context?: LovelaceCardFeatureContext;
+
+  @state() private _config?: MediaPlayerSourceCardFeatureConfig;
+
+  public setConfig(config: MediaPlayerSourceCardFeatureConfig): void {
+    this._config = config;
+  }
+
+  private _schema = memoizeOne(
+    (stateObj?: MediaPlayerEntity) =>
+      [
+        {
+          name: "sources",
+          selector: {
+            select: {
+              multiple: true,
+              mode: "list" as const,
+              reorder: true,
+              options:
+                stateObj?.attributes.source_list?.map((source) => ({
+                  value: source,
+                  label: source,
+                })) ?? [],
+            },
+          },
+        },
+      ] as const
+  );
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    const stateObj = this.context?.entity_id
+      ? (this.hass.states[this.context.entity_id] as
+          | MediaPlayerEntity
+          | undefined)
+      : undefined;
+
+    const schema = this._schema(stateObj);
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${this._config}
+        .schema=${schema}
+        .computeLabel=${this._computeLabelCallback}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    fireEvent(this, "config-changed", { config: ev.detail.value });
+  }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
+    switch (schema.name) {
+      case "sources":
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.features.types.media-player-source.${schema.name}`
+        );
+      default:
+        return "";
+    }
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-media-player-source-card-feature-editor": HuiMediaPlayerSourceCardFeatureEditor;
+  }
+}

--- a/src/panels/lovelace/editor/config-elements/hui-media-player-source-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-media-player-source-card-feature-editor.ts
@@ -5,7 +5,7 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { MediaPlayerEntity } from "../../../../data/media-player";
-import type { HomeAssistant } from "../../../../types";
+import type { HomeAssistant, ValueChangedEvent } from "../../../../types";
 import type {
   LovelaceCardFeatureContext,
   MediaPlayerSourceCardFeatureConfig,
@@ -72,7 +72,9 @@ export class HuiMediaPlayerSourceCardFeatureEditor
     `;
   }
 
-  private _valueChanged(ev: CustomEvent): void {
+  private _valueChanged(
+    ev: ValueChangedEvent<MediaPlayerSourceCardFeatureConfig>
+  ): void {
     fireEvent(this, "config-changed", { config: ev.detail.value });
   }
 
@@ -81,7 +83,7 @@ export class HuiMediaPlayerSourceCardFeatureEditor
   ) => {
     switch (schema.name) {
       case "sources":
-        return this.hass!.localize(
+        return this.hass?.localize(
           `ui.panel.lovelace.editor.features.types.media-player-source.${schema.name}`
         );
       default:

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9992,7 +9992,8 @@
                 "label": "Media player sound mode"
               },
               "media-player-source": {
-                "label": "Media player source"
+                "label": "Media player source",
+                "sources": "Sources"
               },
               "media-player-volume-buttons": {
                 "label": "Media player volume buttons",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add an editor for `hui-media-player-source-card-feature` to select/filter source to fill the dropdown in of the feature.

Use same selector as `hui-media-player-playback-card-feature`

Some A(V)R have lots of sources, but this is common to only use a few of them.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

https://github.com/user-attachments/assets/d6850f4d-1c3c-4999-90fa-999abf3b6503

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: [this comment](https://github.com/home-assistant/frontend/pull/52028#issuecomment-4444219557) 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45367
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

```yaml
type: tile
grid_options:
  rows: 2
  columns: full
entity: media_player.salon
vertical: false
features:
  - type: media-player-volume-buttons
    step: 5
  - type: media-player-source
    sources:
      - AirPlay
      - SHIELD
      - NET RADIO
features_position: bottom
```

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
