### PR TITLE
Dev tools -> Templates: observe tip height with ResizeObserver

### DIFF
--- a/src/panels/config/developer-tools/template/developer-tools-template.ts
+++ b/src/panels/config/developer-tools/template/developer-tools-template.ts
@@ -1,9 +1,8 @@
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
-import { styleMap } from "lit/directives/style-map";
 import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import { debounce } from "../../../../common/util/debounce";
 import "../../../../components/ha-alert";
@@ -59,9 +58,13 @@ class HaPanelDevTemplate extends LitElement {
 
   @state() private _descriptionExpanded = false;
 
+  @query("ha-tip") private _editorTip?: HTMLElement;
+
   private _template = "";
 
   private _inited = false;
+
+  private _tipResizeObserver?: ResizeObserver;
 
   public connectedCallback() {
     super.connectedCallback();
@@ -73,6 +76,8 @@ class HaPanelDevTemplate extends LitElement {
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._unsubscribeTemplate();
+    this._tipResizeObserver?.disconnect();
+    this._tipResizeObserver = undefined;
   }
 
   protected firstUpdated() {
@@ -82,6 +87,7 @@ class HaPanelDevTemplate extends LitElement {
       this._template = DEMO_TEMPLATE;
     }
     this._subscribeTemplate();
+    this._observeTipHeight();
     this._inited = true;
   }
 
@@ -93,7 +99,6 @@ class HaPanelDevTemplate extends LitElement {
           ? "list"
           : "dict"
         : type;
-    const editorTipHeight = this._getTipHeight();
 
     return html`
       <div class="content">
@@ -145,10 +150,7 @@ class HaPanelDevTemplate extends LitElement {
           layout: !this.narrow,
           horizontal: !this.narrow,
         })}"
-        style=${styleMap({
-          "--description-expanded": `${this._descriptionExpanded ? 1 : 0}`,
-          "--tip-height": `${editorTipHeight}`,
-        })}
+        style="--description-expanded: ${this._descriptionExpanded ? 1 : 0}"
       >
         <ha-card
           class="edit-pane"
@@ -178,7 +180,7 @@ class HaPanelDevTemplate extends LitElement {
               ${this.hass.localize("ui.common.clear")}
             </ha-button>
           </div>
-          <ha-tip id="editor-tip" .hass=${this.hass}>
+          <ha-tip .hass=${this.hass}>
             ${this.hass.localize(
               "ui.panel.config.developer-tools.tabs.templates.keyboard_tip",
               {
@@ -293,16 +295,19 @@ ${type === "object"
     `;
   }
 
-  private _getTipHeight(): string | undefined {
-    const tip = this.shadowRoot?.getElementById("editor-tip");
-    if (tip) {
-      const height = tip.scrollHeight;
-      if (!isNaN(height)) {
-        return `${height}px`;
-      }
-      return undefined;
+  private _observeTipHeight() {
+    if (!this._editorTip || this._tipResizeObserver) {
+      return;
     }
-    return undefined;
+    this._tipResizeObserver = new ResizeObserver((entries) => {
+      const height =
+        entries[0]?.borderBoxSize?.[0]?.blockSize ??
+        entries[0]?.contentRect.height;
+      if (height) {
+        this.style.setProperty("--tip-height", `${height}px`);
+      }
+    });
+    this._tipResizeObserver.observe(this._editorTip);
   }
 
   private _expandedChanged(


### PR DESCRIPTION
## Proposed change

Follow-up to #52012, which fixed the editor height calc but acknowledged a manual refresh (F5) might be needed after the viewport crosses a tip-wrap threshold. This swaps the per-render `scrollHeight` read for a `ResizeObserver` started in `firstUpdated`, writing `--tip-height` directly onto the host style:

- No per-render forced reflow.
- `--tip-height` updates automatically when the tip rewraps, so the F5 caveat goes away.
- Drops the unreachable `isNaN(scrollHeight)` branch (`scrollHeight` is always a number; `0` now falls through to `--tip-height-minimal` cleanly).
- Uses `@query("ha-tip")` instead of an `id`-based `getElementById` lookup.
- `styleMap` import is no longer needed once `--tip-height` moves off the inline style.

## Screenshots


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: follow-up to #52012
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr