### PR TITLE
Treat media player unknown state like off instead of unavailable

### DIFF
--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -38,7 +38,7 @@ import { stateActive } from "../common/entity/state_active";
 import { supportsFeature } from "../common/entity/supports-feature";
 import type { MediaPlayerItemId } from "../components/media-player/ha-media-player-browse";
 import type { HomeAssistant, TranslationDict } from "../types";
-import { isUnavailableState } from "./entity/entity";
+import { UNKNOWN, isUnavailableState } from "./entity/entity";
 import { isTTSMediaSource } from "./tts";
 
 interface MediaPlayerEntityAttributes extends HassEntityAttributeBase {
@@ -283,12 +283,11 @@ export const computeMediaControls = (
   }
 
   const state = stateObj.state;
+  const assumedState = stateObj.attributes.assumed_state === true;
 
-  if (isUnavailableState(state)) {
+  if (isUnavailableState(state) && !(assumedState && state === UNKNOWN)) {
     return undefined;
   }
-
-  const assumedState = stateObj.attributes.assumed_state === true;
 
   if (!stateActive(stateObj) && !assumedState) {
     return supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_ON)

--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -38,7 +38,7 @@ import { stateActive } from "../common/entity/state_active";
 import { supportsFeature } from "../common/entity/supports-feature";
 import type { MediaPlayerItemId } from "../components/media-player/ha-media-player-browse";
 import type { HomeAssistant, TranslationDict } from "../types";
-import { UNKNOWN, isUnavailableState } from "./entity/entity";
+import { UNAVAILABLE } from "./entity/entity";
 import { isTTSMediaSource } from "./tts";
 
 interface MediaPlayerEntityAttributes extends HassEntityAttributeBase {
@@ -285,7 +285,8 @@ export const computeMediaControls = (
   const state = stateObj.state;
   const assumedState = stateObj.attributes.assumed_state === true;
 
-  if (isUnavailableState(state) && !(assumedState && state === UNKNOWN)) {
+  // Treat "unknown" like "off" so assumed-state players still expose controls.
+  if (state === UNAVAILABLE) {
     return undefined;
   }
 

--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -283,12 +283,13 @@ export const computeMediaControls = (
   }
 
   const state = stateObj.state;
-  const assumedState = stateObj.attributes.assumed_state === true;
 
-  // Treat "unknown" like "off" so assumed-state players still expose controls.
+  // We only filter out `unavailable`, not `unknown`
   if (state === UNAVAILABLE) {
     return undefined;
   }
+
+  const assumedState = stateObj.attributes.assumed_state === true;
 
   if (!stateActive(stateObj) && !assumedState) {
     return supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_ON)

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -37,7 +37,7 @@ import "../../../components/ha-svg-icon";
 import "../../../components/ha-tooltip";
 import { showJoinMediaPlayersDialog } from "../../../components/media-player/show-join-media-players-dialog";
 import { showMediaBrowserDialog } from "../../../components/media-player/show-media-browser-dialog";
-import { UNKNOWN, isUnavailableState } from "../../../data/entity/entity";
+import { UNAVAILABLE } from "../../../data/entity/entity";
 import type {
   MediaPickedEvent,
   MediaPlayerEntity,
@@ -275,7 +275,7 @@ class MoreInfoMediaPlayer extends LitElement {
   protected _renderGrouping() {
     if (
       !this.stateObj ||
-      isUnavailableState(this.stateObj.state) ||
+      this.stateObj.state === UNAVAILABLE ||
       !supportsFeature(this.stateObj, MediaPlayerEntityFeature.GROUPING)
     ) {
       return nothing;
@@ -315,12 +315,7 @@ class MoreInfoMediaPlayer extends LitElement {
       return nothing;
     }
 
-    const assumedState = this.stateObj.attributes.assumed_state === true;
-
-    if (
-      isUnavailableState(this.stateObj.state) &&
-      !(assumedState && this.stateObj.state === UNKNOWN)
-    ) {
+    if (this.stateObj.state === UNAVAILABLE) {
       return this._renderEmptyCover(this.hass.formatEntityState(this.stateObj));
     }
 
@@ -466,7 +461,7 @@ class MoreInfoMediaPlayer extends LitElement {
           : nothing}
         ${this._renderVolumeControl()}
         <div class="controls-row">
-          ${!isUnavailableState(stateObj.state) &&
+          ${stateObj.state !== UNAVAILABLE &&
           supportsFeature(stateObj, MediaPlayerEntityFeature.BROWSE_MEDIA)
             ? this._renderControlButton(
                 "browse_media",

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -37,7 +37,7 @@ import "../../../components/ha-svg-icon";
 import "../../../components/ha-tooltip";
 import { showJoinMediaPlayersDialog } from "../../../components/media-player/show-join-media-players-dialog";
 import { showMediaBrowserDialog } from "../../../components/media-player/show-media-browser-dialog";
-import { isUnavailableState } from "../../../data/entity/entity";
+import { UNKNOWN, isUnavailableState } from "../../../data/entity/entity";
 import type {
   MediaPickedEvent,
   MediaPlayerEntity,
@@ -315,7 +315,12 @@ class MoreInfoMediaPlayer extends LitElement {
       return nothing;
     }
 
-    if (isUnavailableState(this.stateObj.state)) {
+    const assumedState = this.stateObj.attributes.assumed_state === true;
+
+    if (
+      isUnavailableState(this.stateObj.state) &&
+      !(assumedState && this.stateObj.state === UNKNOWN)
+    ) {
       return this._renderEmptyCover(this.hass.formatEntityState(this.stateObj));
     }
 

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -275,6 +275,7 @@ class MoreInfoMediaPlayer extends LitElement {
   protected _renderGrouping() {
     if (
       !this.stateObj ||
+      // Compare against `unavailable` so we allow `unknown`
       this.stateObj.state === UNAVAILABLE ||
       !supportsFeature(this.stateObj, MediaPlayerEntityFeature.GROUPING)
     ) {

--- a/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
@@ -22,7 +22,7 @@ import { supportsFeature } from "../../../common/entity/supports-feature";
 import { debounce } from "../../../common/util/debounce";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-slider";
-import { isUnavailableState } from "../../../data/entity/entity";
+import { UNKNOWN, isUnavailableState } from "../../../data/entity/entity";
 import type {
   ControlButton,
   MediaPlayerEntity,
@@ -195,7 +195,8 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
         <div class="controls">
           ${supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_ON) &&
           (!stateActive(stateObj) || assumedState) &&
-          !isUnavailableState(entityState)
+          (!isUnavailableState(entityState) ||
+            (assumedState && entityState === UNKNOWN))
             ? html`
                 <ha-icon-button
                   .path=${assumedState ? mdiPowerOn : mdiPower}

--- a/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
@@ -22,7 +22,7 @@ import { supportsFeature } from "../../../common/entity/supports-feature";
 import { debounce } from "../../../common/util/debounce";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-slider";
-import { UNKNOWN, isUnavailableState } from "../../../data/entity/entity";
+import { UNAVAILABLE } from "../../../data/entity/entity";
 import type {
   ControlButton,
   MediaPlayerEntity,
@@ -195,8 +195,7 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
         <div class="controls">
           ${supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_ON) &&
           (!stateActive(stateObj) || assumedState) &&
-          (!isUnavailableState(entityState) ||
-            (assumedState && entityState === UNKNOWN))
+          entityState !== UNAVAILABLE
             ? html`
                 <ha-icon-button
                   .path=${assumedState ? mdiPowerOn : mdiPower}
@@ -210,7 +209,7 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
           (stateActive(stateObj) ||
             assumedState ||
             !supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_ON) ||
-            isUnavailableState(entityState))
+            entityState === UNAVAILABLE)
             ? buttons
             : ""}
           ${supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_OFF) &&


### PR DESCRIPTION
## Breaking change

<!-- Not a breaking change -->

## Proposed change

Media player controls treated the `unknown` state the same as `unavailable` and hid all controls. An `unknown` state is closer to `off`: the device exists but its current power state simply isn't reported.

This is especially important for devices with an **assumed state**. These devices give no state feedback, so they often report `unknown` — yet the user still needs to be able to operate them. Hiding their controls as if they were unavailable left no way to turn them on or off.

With this change, only `unavailable` hides the controls. An `unknown`-state media player now behaves like an `off` one:

- A regular `unknown`-state player shows the turn on button.
- An assumed-state player shows both the turn on and turn off buttons, so it can always be controlled.

This applies consistently to the media player entity row and the more info dialog (including grouping and browse media controls).

## Screenshots

<!-- UI change — screenshots to be added showing an assumed-state media player in the unknown state with both power buttons visible in the entity row and more info dialog. -->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyZojNPCCY65HmRVQaASkG)_