### PR TITLE
Highlight problematic devices in Energy Dashboard list

### DIFF
--- a/src/panels/config/energy/components/ha-energy-device-settings-water.ts
+++ b/src/panels/config/energy/components/ha-energy-device-settings-water.ts
@@ -1,4 +1,5 @@
 import {
+  mdiAlertCircle,
   mdiDelete,
   mdiWater,
   mdiDragHorizontalVariant,
@@ -6,7 +7,7 @@ import {
   mdiPlus,
 } from "@mdi/js";
 import type { CSSResultGroup, TemplateResult } from "lit";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { repeat } from "lit/directives/repeat";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
@@ -15,10 +16,12 @@ import "../../../../components/ha-button";
 import "../../../../components/ha-icon-button";
 import "../../../../components/ha-sortable";
 import "../../../../components/ha-svg-icon";
+import "../../../../components/ha-tooltip";
 import type {
   DeviceConsumptionEnergyPreference,
   EnergyPreferences,
   EnergyPreferencesValidation,
+  EnergyValidationIssue,
 } from "../../../../data/energy";
 import { saveEnergyPreferences } from "../../../../data/energy";
 import type { StatisticsMetaData } from "../../../../data/recorder";
@@ -93,7 +96,7 @@ export class EnergyDeviceSettingsWater extends LitElement {
                       ${repeat(
                         this.preferences.device_consumption_water,
                         (device) => device.stat_consumption,
-                        (device) => html`
+                        (device, index) => html`
                           <div class="row" .device=${device}>
                             <div class="handle">
                               <ha-svg-icon
@@ -108,6 +111,12 @@ export class EnergyDeviceSettingsWater extends LitElement {
                                 this.statsMetadata?.[device.stat_consumption]
                               )}</span
                             >
+                            ${this._renderIssueIndicator(
+                              this.validationResult?.device_consumption_water[
+                                index
+                              ],
+                              index
+                            )}
                             <ha-icon-button
                               .label=${this.hass.localize("ui.common.edit")}
                               @click=${this._editDevice}
@@ -141,6 +150,31 @@ export class EnergyDeviceSettingsWater extends LitElement {
           </div>
         </div>
       </ha-card>
+    `;
+  }
+
+  private _renderIssueIndicator(
+    issues: EnergyValidationIssue[] | undefined,
+    index: number
+  ) {
+    if (!issues?.length) {
+      return nothing;
+    }
+    const titles = issues.map(
+      (issue) =>
+        this.hass.localize(`component.energy.issues.${issue.type}.title`) ||
+        issue.type
+    );
+    const label = titles.join("\n");
+    const id = `issue-icon-${index}`;
+    return html`
+      <ha-svg-icon
+        id=${id}
+        class="issue-icon"
+        .path=${mdiAlertCircle}
+        aria-label=${label}
+      ></ha-svg-icon>
+      <ha-tooltip .for=${id} placement="top">${label}</ha-tooltip>
     `;
   }
 
@@ -247,6 +281,9 @@ export class EnergyDeviceSettingsWater extends LitElement {
         .handle {
           cursor: move; /* fallback if grab cursor is unsupported */
           cursor: grab;
+        }
+        .issue-icon {
+          color: var(--warning-color);
         }
       `,
     ];

--- a/src/panels/config/energy/components/ha-energy-device-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-device-settings.ts
@@ -1,4 +1,5 @@
 import {
+  mdiAlertCircle,
   mdiDelete,
   mdiDevices,
   mdiDragHorizontalVariant,
@@ -6,7 +7,7 @@ import {
   mdiPlus,
 } from "@mdi/js";
 import type { CSSResultGroup, TemplateResult } from "lit";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { repeat } from "lit/directives/repeat";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
@@ -15,10 +16,12 @@ import "../../../../components/ha-button";
 import "../../../../components/ha-icon-button";
 import "../../../../components/ha-sortable";
 import "../../../../components/ha-svg-icon";
+import "../../../../components/ha-tooltip";
 import type {
   DeviceConsumptionEnergyPreference,
   EnergyPreferences,
   EnergyPreferencesValidation,
+  EnergyValidationIssue,
 } from "../../../../data/energy";
 import { saveEnergyPreferences } from "../../../../data/energy";
 import type { StatisticsMetaData } from "../../../../data/recorder";
@@ -93,7 +96,7 @@ export class EnergyDeviceSettings extends LitElement {
                       ${repeat(
                         this.preferences.device_consumption,
                         (device) => device.stat_consumption,
-                        (device) => html`
+                        (device, index) => html`
                           <div class="row" .device=${device}>
                             <div class="handle">
                               <ha-svg-icon
@@ -108,6 +111,10 @@ export class EnergyDeviceSettings extends LitElement {
                                 this.statsMetadata?.[device.stat_consumption]
                               )}</span
                             >
+                            ${this._renderIssueIndicator(
+                              this.validationResult?.device_consumption[index],
+                              index
+                            )}
                             <ha-icon-button
                               .label=${this.hass.localize("ui.common.edit")}
                               @click=${this._editDevice}
@@ -141,6 +148,31 @@ export class EnergyDeviceSettings extends LitElement {
           </div>
         </div>
       </ha-card>
+    `;
+  }
+
+  private _renderIssueIndicator(
+    issues: EnergyValidationIssue[] | undefined,
+    index: number
+  ) {
+    if (!issues?.length) {
+      return nothing;
+    }
+    const titles = issues.map(
+      (issue) =>
+        this.hass.localize(`component.energy.issues.${issue.type}.title`) ||
+        issue.type
+    );
+    const label = titles.join("\n");
+    const id = `issue-icon-${index}`;
+    return html`
+      <ha-svg-icon
+        id=${id}
+        class="issue-icon"
+        .path=${mdiAlertCircle}
+        aria-label=${label}
+      ></ha-svg-icon>
+      <ha-tooltip .for=${id} placement="top">${label}</ha-tooltip>
     `;
   }
 
@@ -243,6 +275,9 @@ export class EnergyDeviceSettings extends LitElement {
         .handle {
           cursor: move; /* fallback if grab cursor is unsupported */
           cursor: grab;
+        }
+        .issue-icon {
+          color: var(--warning-color);
         }
       `,
     ];


### PR DESCRIPTION
## Proposed change

Add a warning icon with tooltip to rows in the Energy Dashboard's *Individual electrical devices* and *Individual water devices* lists whenever the backend validation reports an issue for that device (e.g. the underlying entity or statistic has been deleted). The tooltip uses the localized issue title from the existing `component.energy.issues.{type}.title` translation keys, joined with newlines if a device has multiple issues. Global validation alerts above the list are unchanged.

This makes "ghost" rows easy to locate so users can remove them with the existing trashcan button — previously the row showed only the device name (or a raw `statistic_id` fallback) with no visual hint of which entry was broken, forcing users to cross-reference the diagnostic JSON.

## Screenshots

<img width="450" height="64" alt="image" src="https://github.com/user-attachments/assets/cba26721-b848-4376-a4ea-a5c776341a29" />

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #28326
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr