### PR TITLE
Show diagnostic moisture binary sensors on security dashboard

### DIFF
--- a/src/panels/security/strategies/security-view-strategy.ts
+++ b/src/panels/security/strategies/security-view-strategy.ts
@@ -61,10 +61,11 @@ export const securityEntityFilters: EntityFilter[] = [
     ],
     entity_category: "none",
   },
-  // We also want the tamper sensors when they are diagnostic
+  // We also want the tamper and moisture sensors when they are diagnostic
+  // (some integrations, e.g. homee, mark water leak alarms as diagnostic)
   {
     domain: "binary_sensor",
-    device_class: ["tamper"],
+    device_class: ["moisture", "tamper"],
     entity_category: "diagnostic",
   },
 ];


### PR DESCRIPTION
## Proposed change

Extend the security dashboard's diagnostic `binary_sensor` filter to include `moisture` in addition to `tamper`. Some integrations (e.g. [`homee`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/homee/binary_sensor.py)) register water leak alarms with `device_class=moisture` but `entity_category=diagnostic`, which the existing filter only accepting `entity_category=none` was dropping.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52064
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr