### PR TITLE
Add device availability status filtering support

### DIFF
--- a/src/data/device/device_registry.ts
+++ b/src/data/device/device_registry.ts
@@ -2,6 +2,7 @@ import { computeStateName } from "../../common/entity/compute_state_name";
 import { caseInsensitiveStringCompare } from "../../common/string/compare";
 import type { HomeAssistant } from "../../types";
 import type { ConfigEntry } from "../config_entries";
+import { UNAVAILABLE } from "../entity/entity";
 import type {
   EntityRegistryDisplayEntry,
   EntityRegistryEntry,
@@ -47,6 +48,19 @@ export type DeviceEntityLookup<
     | EntityRegistryEntry
     | EntityRegistryDisplayEntry,
 > = Record<string, T[]>;
+
+export type DeviceAvailabilityStatus =
+  | "available"
+  | "unavailable"
+  | "unknown"
+  | "disabled";
+
+export const DEVICE_AVAILABILITY_STATUSES = [
+  "available",
+  "unavailable",
+  "unknown",
+  "disabled",
+] as const satisfies readonly DeviceAvailabilityStatus[];
 
 export interface DeviceRegistryEntryMutableParams {
   area_id?: string | null;
@@ -132,6 +146,37 @@ export const getDeviceEntityDisplayLookup = (
     deviceEntityLookup[entity.device_id].push(entity);
   }
   return deviceEntityLookup;
+};
+
+export const computeDeviceAvailabilityStatus = (
+  hass: Pick<HomeAssistant, "states">,
+  device: DeviceRegistryEntry,
+  entities: EntityRegistryEntry[]
+): DeviceAvailabilityStatus => {
+  if (device.disabled_by) {
+    return "disabled";
+  }
+
+  const enabledEntities = entities.filter((entity) => !entity.disabled_by);
+  if (!enabledEntities.length) {
+    return "unknown";
+  }
+
+  const entityStates = enabledEntities
+    .map((entity) => hass.states[entity.entity_id])
+    .filter(Boolean);
+
+  if (!entityStates.length) {
+    return "unknown";
+  }
+
+  for (const stateObj of entityStates) {
+    if (stateObj.state !== UNAVAILABLE) {
+      return "available";
+    }
+  }
+
+  return "unavailable";
 };
 
 export const getDeviceIntegrationLookup = (

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -104,7 +104,8 @@ interface DeviceRowData extends DeviceRegistryEntry {
   device?: DeviceRowData;
   area?: string;
   integration?: string;
-  status?: DeviceAvailabilityStatus;
+  availability?: DeviceAvailabilityStatus;
+  status?: string;
   battery_entity?: [string | undefined, string | undefined];
   label_entries: LabelRegistryEntry[];
 }
@@ -526,7 +527,10 @@ export class HaConfigDeviceDashboard extends LitElement {
                 "ui.panel.config.devices.data_table.no_integration"
               ),
           domains: deviceEntries.map((entry) => entry.domain),
-          status: availabilityStatus,
+          availability: availabilityStatus,
+          status: localize(
+            `ui.panel.config.devices.picker.status.${availabilityStatus}`
+          ),
           firmware_version: device.sw_version || undefined,
           battery_entity: [
             this._batteryEntity(device.id, deviceEntityLookup),
@@ -675,7 +679,7 @@ export class HaConfigDeviceDashboard extends LitElement {
         minWidth: "80px",
         maxWidth: "80px",
         template: (device) => {
-          const unavailable = device.status === "unavailable";
+          const unavailable = device.availability === "unavailable";
           return device.disabled_by || unavailable
             ? html`
                 <div
@@ -688,9 +692,7 @@ export class HaConfigDeviceDashboard extends LitElement {
                     .path=${unavailable ? mdiAlertCircle : mdiCancel}
                   ></ha-svg-icon>
                   <ha-tooltip .for="svg-icon-${device.id}" placement="left">
-                    ${localize(
-                      `ui.panel.config.devices.picker.status.${device.status}`
-                    )}
+                    ${device.status}
                   </ha-tooltip>
                 </div>
               `

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -2,6 +2,7 @@ import "@home-assistant/webawesome/dist/components/divider/divider";
 import { ResizeController } from "@lit-labs/observers/resize-controller";
 import { consume } from "@lit/context";
 import {
+  mdiAlertCircle,
   mdiCancel,
   mdiDelete,
   mdiDotsVertical,
@@ -59,10 +60,13 @@ import {
   serializeFilters,
 } from "../../../data/data_table_filters";
 import type {
+  DeviceAvailabilityStatus,
   DeviceEntityLookup,
   DeviceRegistryEntry,
 } from "../../../data/device/device_registry";
 import {
+  DEVICE_AVAILABILITY_STATUSES,
+  computeDeviceAvailabilityStatus,
   removeConfigEntryFromDevice,
   updateDeviceRegistryEntry,
 } from "../../../data/device/device_registry";
@@ -100,6 +104,7 @@ interface DeviceRowData extends DeviceRegistryEntry {
   device?: DeviceRowData;
   area?: string;
   integration?: string;
+  status?: DeviceAvailabilityStatus;
   battery_entity?: [string | undefined, string | undefined];
   label_entries: LabelRegistryEntry[];
 }
@@ -224,8 +229,20 @@ export class HaConfigDeviceDashboard extends LitElement {
 
   private _states = memoizeOne((localize: LocalizeFunc) => [
     {
+      value: "available",
+      label: localize("ui.panel.config.devices.picker.status.available"),
+    },
+    {
+      value: "unavailable",
+      label: localize("ui.panel.config.devices.picker.status.unavailable"),
+    },
+    {
+      value: "unknown",
+      label: localize("ui.panel.config.devices.picker.status.unknown"),
+    },
+    {
       value: "disabled",
-      label: localize("ui.panel.config.devices.data_table.disabled_by"),
+      label: localize("ui.panel.config.devices.picker.status.disabled"),
     },
   ]);
 
@@ -262,13 +279,6 @@ export class HaConfigDeviceDashboard extends LitElement {
     this._filter = history.state?.filter || "";
 
     this._filters = {
-      "ha-filter-states": {
-        value: [
-          ...((this._filters["ha-filter-states"]?.value as string[]) || []),
-          "disabled",
-        ],
-        items: undefined,
-      },
       "ha-filter-integrations": {
         value: domain ? [domain] : [],
         items: undefined,
@@ -438,11 +448,21 @@ export class HaConfigDeviceDashboard extends LitElement {
         | string[]
         | undefined;
 
-      const showDisabled =
-        stateFilters?.length && stateFilters.includes("disabled");
+      const availabilityFilters = stateFilters?.filter(
+        (status): status is DeviceAvailabilityStatus =>
+          (DEVICE_AVAILABILITY_STATUSES as readonly string[]).includes(status)
+      );
 
-      if (!showDisabled) {
-        outputDevices = outputDevices.filter((device) => !device.disabled_by);
+      if (availabilityFilters?.length) {
+        outputDevices = outputDevices.filter((device) =>
+          availabilityFilters.includes(
+            computeDeviceAvailabilityStatus(
+              this.hass,
+              device,
+              deviceEntityLookup[device.id] || []
+            )
+          )
+        );
       }
 
       const formattedOutputDevices = outputDevices.map((device) => {
@@ -469,6 +489,12 @@ export class HaConfigDeviceDashboard extends LitElement {
             floorName = computeFloorName(this.hass.floors[floorId!]);
           }
         }
+
+        const availabilityStatus = computeDeviceAvailabilityStatus(
+          this.hass,
+          device,
+          deviceEntityLookup[device.id] || []
+        );
 
         return {
           ...device,
@@ -500,6 +526,7 @@ export class HaConfigDeviceDashboard extends LitElement {
                 "ui.panel.config.devices.data_table.no_integration"
               ),
           domains: deviceEntries.map((entry) => entry.domain),
+          status: availabilityStatus,
           firmware_version: device.sw_version || undefined,
           battery_entity: [
             this._batteryEntity(device.id, deviceEntityLookup),
@@ -637,16 +664,19 @@ export class HaConfigDeviceDashboard extends LitElement {
       },
       created_at: getCreatedAtTableColumn(localize, this.hass),
       modified_at: getModifiedAtTableColumn(localize, this.hass),
-      disabled_by: {
+      status: {
         title: localize("ui.panel.config.devices.picker.state"),
         type: "icon",
         defaultHidden: true,
         sortable: true,
         filterable: true,
+        groupable: true,
+        valueColumn: "status",
         minWidth: "80px",
         maxWidth: "80px",
-        template: (device) =>
-          device.disabled_by
+        template: (device) => {
+          const unavailable = device.status === "unavailable";
+          return device.disabled_by || unavailable
             ? html`
                 <div
                   tabindex="0"
@@ -654,16 +684,18 @@ export class HaConfigDeviceDashboard extends LitElement {
                 >
                   <ha-svg-icon
                     .id="svg-icon-${device.id}"
-                    .path=${mdiCancel}
+                    style=${unavailable ? "color: var(--error-color)" : ""}
+                    .path=${unavailable ? mdiAlertCircle : mdiCancel}
                   ></ha-svg-icon>
                   <ha-tooltip .for="svg-icon-${device.id}" placement="left">
-                    ${this.hass.localize(
-                      "ui.panel.config.entities.picker.status.disabled"
+                    ${localize(
+                      `ui.panel.config.devices.picker.status.${device.status}`
                     )}
                   </ha-tooltip>
                 </div>
               `
-            : "—",
+            : "—";
+        },
       },
       labels: getLabelsTableColumn(),
     } as DataTableColumnContainer<DeviceItem>;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6571,7 +6571,6 @@
             "integration": "Integration",
             "firmware_version": "Firmware",
             "battery": "Battery",
-            "disabled_by": "Disabled",
             "no_devices": "No devices",
             "no_integration": "No integration",
             "unknown": "unknown"
@@ -6583,6 +6582,12 @@
           "picker": {
             "search": "Search {number} {number, plural,\n  one {device}\n  other {devices}\n}",
             "state": "Status",
+            "status": {
+              "available": "Available",
+              "unavailable": "Unavailable",
+              "unknown": "Unknown",
+              "disabled": "Disabled"
+            },
             "bulk_actions": {
               "move_area": "Move to area",
               "no_area": "No area",


### PR DESCRIPTION
## Proposed change

Adds device availability status filtering to the devices data table.
Devices now have a computed status based on their enabled entities:

- Available
- Unavailable
- Unknown
- Disabled

The existing status column is reused for sorting, grouping, and filtering. This lets users filter unavailable devices without adding a separate availability column.

Use case could be filtering for unavailable Zigbee devices or linking from the Zigbee page to show unavailable devices.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr