### PR TITLE
Add to for area page

### DIFF
--- a/src/dialogs/more-info/add-to.ts
+++ b/src/dialogs/more-info/add-to.ts
@@ -3,6 +3,7 @@ import type { LocalizeFunc } from "../../common/translations/localize";
 import { createSearchParam } from "../../common/url/search-params";
 import type { SingleHassServiceTarget } from "../../data/target";
 import {
+  ADD_AUTOMATION_ELEMENT_AREA_TARGET_PARAM,
   ADD_AUTOMATION_ELEMENT_DEVICE_TARGET_PARAM,
   ADD_AUTOMATION_ELEMENT_QUERY_PARAM,
   ADD_AUTOMATION_ELEMENT_ENTITY_TARGET_PARAM,
@@ -105,6 +106,8 @@ export function addToActionHandler(
     searchParams[ADD_AUTOMATION_ELEMENT_ENTITY_TARGET_PARAM] = target.entity_id;
   } else if (target.device_id) {
     searchParams[ADD_AUTOMATION_ELEMENT_DEVICE_TARGET_PARAM] = target.device_id;
+  } else if (target.area_id) {
+    searchParams[ADD_AUTOMATION_ELEMENT_AREA_TARGET_PARAM] = target.area_id;
   }
 
   const params = (addElement: string) =>

--- a/src/panels/config/areas/dialog-area-add-to.ts
+++ b/src/panels/config/areas/dialog-area-add-to.ts
@@ -1,0 +1,230 @@
+import { consume, type ContextType } from "@lit/context";
+import {
+  mdiPalette,
+  mdiPlayCircleOutline,
+  mdiPlaylistCheck,
+  mdiRobotOutline,
+  mdiScriptTextOutline,
+} from "@mdi/js";
+import type { CSSResultGroup } from "lit";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, state } from "lit/decorators";
+import { computeAreaName } from "../../../common/entity/compute_area_name";
+import { fireEvent } from "../../../common/dom/fire_event";
+import "../../../components/ha-adaptive-dialog";
+import "../../../components/ha-list";
+import "../../../components/ha-list-item";
+import "../../../components/ha-svg-icon";
+import {
+  areasContext,
+  internationalizationContext,
+} from "../../../data/context";
+import type { SceneEntities } from "../../../data/scene";
+import { showSceneEditor } from "../../../data/scene";
+import {
+  addToActionHandler,
+  type AddToActionKey,
+} from "../../../dialogs/more-info/add-to";
+import { haStyle, haStyleDialog } from "../../../resources/styles";
+import type { AreaAddToDialogParams } from "./show-dialog-area-add-to";
+
+@customElement("dialog-area-add-to")
+class DialogAreaAddTo extends LitElement {
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  private _i18n!: ContextType<typeof internationalizationContext>;
+
+  @state()
+  @consume({ context: areasContext, subscribe: true })
+  private _areas!: ContextType<typeof areasContext>;
+
+  @state() private _params?: AreaAddToDialogParams;
+
+  @state() private _open = false;
+
+  public showDialog(params: AreaAddToDialogParams): void {
+    this._params = params;
+    this._open = true;
+  }
+
+  public closeDialog(): void {
+    this._open = false;
+  }
+
+  private _dialogClosed(): void {
+    this._params = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render() {
+    if (!this._params) {
+      return nothing;
+    }
+
+    return html`
+      <ha-adaptive-dialog
+        .open=${this._open}
+        header-title=${this._i18n.localize(
+          "ui.dialogs.more_info_control.add_to.title"
+        )}
+        @closed=${this._dialogClosed}
+      >
+        ${this._renderOptions()}
+      </ha-adaptive-dialog>
+    `;
+  }
+
+  private _renderOptions() {
+    if (!this._params) {
+      return nothing;
+    }
+
+    const area = this._areas[this._params.areaId];
+    const areaName = computeAreaName(area) || this._params.areaId;
+
+    switch (this._params.mode) {
+      case "automation":
+        return html`
+          <h3 class="section-header">
+            ${this._i18n.localize(
+              "ui.panel.config.devices.automation.automations_heading"
+            )}
+          </h3>
+          <ha-list>
+            ${this._renderActionItem(
+              "automation_trigger",
+              mdiRobotOutline,
+              "ui.dialogs.more_info_control.add_to.actions.automation_trigger",
+              areaName
+            )}
+            ${this._renderActionItem(
+              "automation_condition",
+              mdiPlaylistCheck,
+              "ui.dialogs.more_info_control.add_to.actions.automation_condition",
+              areaName
+            )}
+            ${this._renderActionItem(
+              "automation_action",
+              mdiPlayCircleOutline,
+              "ui.dialogs.more_info_control.add_to.actions.automation_action",
+              areaName
+            )}
+          </ha-list>
+        `;
+      case "script":
+        return html`
+          <h3 class="section-header">
+            ${this._i18n.localize(
+              "ui.panel.config.devices.script.scripts_heading"
+            )}
+          </h3>
+          <ha-list>
+            ${this._renderActionItem(
+              "script_action",
+              mdiScriptTextOutline,
+              "ui.dialogs.more_info_control.add_to.actions.script_action",
+              areaName
+            )}
+          </ha-list>
+        `;
+      case "scene":
+        return html`
+          <h3 class="section-header">
+            ${this._i18n.localize(
+              "ui.panel.config.devices.scene.scenes_heading"
+            )}
+          </h3>
+          <ha-list>
+            <ha-list-item
+              graphic="icon"
+              @click=${this._handleCreateScene}
+              data-dialog="close"
+            >
+              <ha-svg-icon slot="graphic" .path=${mdiPalette}></ha-svg-icon>
+              ${this._i18n.localize(
+                "ui.dialogs.more_info_control.add_to.actions.scene",
+                { target: areaName }
+              )}
+            </ha-list-item>
+          </ha-list>
+        `;
+      default:
+        return nothing;
+    }
+  }
+
+  private _renderActionItem(
+    key: AddToActionKey,
+    path: string,
+    translationKey:
+      | "ui.dialogs.more_info_control.add_to.actions.automation_trigger"
+      | "ui.dialogs.more_info_control.add_to.actions.automation_condition"
+      | "ui.dialogs.more_info_control.add_to.actions.automation_action"
+      | "ui.dialogs.more_info_control.add_to.actions.script_action",
+    areaName: string
+  ) {
+    return html`
+      <ha-list-item
+        graphic="icon"
+        data-type=${key}
+        @click=${this._handleAction}
+        data-dialog="close"
+      >
+        <ha-svg-icon slot="graphic" .path=${path}></ha-svg-icon>
+        ${this._i18n.localize(translationKey, { target: areaName })}
+      </ha-list-item>
+    `;
+  }
+
+  private _handleAction(ev: Event) {
+    if (!this._params) {
+      return;
+    }
+
+    const key = (ev.currentTarget as HTMLElement).dataset
+      .type as AddToActionKey;
+
+    this.closeDialog();
+    addToActionHandler(key, { area_id: this._params.areaId });
+  }
+
+  private _handleCreateScene() {
+    if (!this._params) {
+      return;
+    }
+
+    const entities: SceneEntities = {};
+    for (const entityId of this._params.entityIds) {
+      entities[entityId] = "";
+    }
+
+    this.closeDialog();
+    showSceneEditor({ entities }, this._params.areaId);
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      haStyleDialog,
+      css`
+        ha-adaptive-dialog {
+          --dialog-content-padding: 0;
+        }
+
+        .section-header {
+          padding: var(--ha-space-2) var(--ha-space-4) 0;
+          margin: 0;
+          font-size: var(--ha-font-size-m);
+          font-weight: var(--ha-font-weight-medium);
+          color: var(--secondary-text-color);
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-area-add-to": DialogAreaAddTo;
+  }
+}

--- a/src/panels/config/areas/dialog-area-add-to.ts
+++ b/src/panels/config/areas/dialog-area-add-to.ts
@@ -1,4 +1,7 @@
+import type { CSSResultGroup } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { consume, type ContextType } from "@lit/context";
+import { customElement, state } from "lit/decorators";
 import {
   mdiPalette,
   mdiPlayCircleOutline,
@@ -6,9 +9,6 @@ import {
   mdiRobotOutline,
   mdiScriptTextOutline,
 } from "@mdi/js";
-import type { CSSResultGroup } from "lit";
-import { LitElement, css, html, nothing } from "lit";
-import { customElement, state } from "lit/decorators";
 import { computeAreaName } from "../../../common/entity/compute_area_name";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-adaptive-dialog";
@@ -82,75 +82,70 @@ class DialogAreaAddTo extends LitElement {
     const area = this._areas[this._params.areaId];
     const areaName = computeAreaName(area) || this._params.areaId;
 
-    switch (this._params.mode) {
-      case "automation":
-        return html`
-          <h3 class="section-header">
-            ${this._i18n.localize(
-              "ui.panel.config.devices.automation.automations_heading"
-            )}
-          </h3>
-          <ha-list>
-            ${this._renderActionItem(
-              "automation_trigger",
-              mdiRobotOutline,
-              "ui.dialogs.more_info_control.add_to.actions.automation_trigger",
-              areaName
-            )}
-            ${this._renderActionItem(
-              "automation_condition",
-              mdiPlaylistCheck,
-              "ui.dialogs.more_info_control.add_to.actions.automation_condition",
-              areaName
-            )}
-            ${this._renderActionItem(
-              "automation_action",
-              mdiPlayCircleOutline,
-              "ui.dialogs.more_info_control.add_to.actions.automation_action",
-              areaName
-            )}
-          </ha-list>
-        `;
-      case "script":
-        return html`
-          <h3 class="section-header">
-            ${this._i18n.localize(
-              "ui.panel.config.devices.script.scripts_heading"
-            )}
-          </h3>
-          <ha-list>
-            ${this._renderActionItem(
-              "script_action",
-              mdiScriptTextOutline,
-              "ui.dialogs.more_info_control.add_to.actions.script_action",
-              areaName
-            )}
-          </ha-list>
-        `;
-      case "scene":
-        return html`
-          <h3 class="section-header">
-            ${this._i18n.localize(
-              "ui.panel.config.devices.scene.scenes_heading"
-            )}
-          </h3>
-          <ha-list>
-            <ha-list-item
-              graphic="icon"
-              @click=${this._handleCreateScene}
-              data-dialog="close"
-            >
-              <ha-svg-icon slot="graphic" .path=${mdiPalette}></ha-svg-icon>
-              ${this._i18n.localize(
-                "ui.dialogs.more_info_control.add_to.actions.scene",
-                { target: areaName }
-              )}
-            </ha-list-item>
-          </ha-list>
-        `;
-      default:
-        return nothing;
+    return html`
+      <h3 class="section-header">
+        ${this._i18n.localize(
+          "ui.panel.config.devices.automation.automations_heading"
+        )}
+      </h3>
+      <ha-list>
+        ${this._renderActionItem(
+          "automation_trigger",
+          mdiRobotOutline,
+          "ui.dialogs.more_info_control.add_to.actions.automation_trigger",
+          areaName
+        )}
+        ${this._renderActionItem(
+          "automation_condition",
+          mdiPlaylistCheck,
+          "ui.dialogs.more_info_control.add_to.actions.automation_condition",
+          areaName
+        )}
+        ${this._renderActionItem(
+          "automation_action",
+          mdiPlayCircleOutline,
+          "ui.dialogs.more_info_control.add_to.actions.automation_action",
+          areaName
+        )}
+      </ha-list>
+      <h3 class="section-header">
+        ${this._i18n.localize("ui.panel.config.devices.script.scripts_heading")}
+      </h3>
+      <ha-list>
+        ${this._renderActionItem(
+          "script_action",
+          mdiScriptTextOutline,
+          "ui.dialogs.more_info_control.add_to.actions.script_action",
+          areaName
+        )}
+      </ha-list>
+      ${this._renderSceneSection(areaName)}
+    `;
+  }
+
+  private _renderSceneSection(areaName: string) {
+    if (!this._params?.entityIds.length) {
+      return nothing;
     }
+
+    return html`
+      <h3 class="section-header">
+        ${this._i18n.localize("ui.panel.config.devices.scene.scenes_heading")}
+      </h3>
+      <ha-list>
+        <ha-list-item
+          graphic="icon"
+          @click=${this._handleCreateScene}
+          data-dialog="close"
+        >
+          <ha-svg-icon slot="graphic" .path=${mdiPalette}></ha-svg-icon>
+          ${this._i18n.localize(
+            "ui.dialogs.more_info_control.add_to.actions.scene",
+            { target: areaName }
+          )}
+        </ha-list-item>
+      </ha-list>
+    `;
   }
 
   private _renderActionItem(

--- a/src/panels/config/areas/ha-config-area-page.ts
+++ b/src/panels/config/areas/ha-config-area-page.ts
@@ -345,7 +345,6 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
           <ha-button
             appearance="filled"
             variant="brand"
-            size="small"
             @click=${this._showAddToDialog}
           >
             <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
@@ -417,7 +416,6 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
                   <div class="action-buttons">
                     <ha-button
                       appearance="filled"
-                      size="small"
                       .entry=${area}
                       @click=${this._showSettings}
                     >
@@ -434,7 +432,6 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
                   <div class="action-buttons">
                     <ha-button
                       appearance="filled"
-                      size="small"
                       .entry=${area}
                       @click=${this._showSettings}
                     >

--- a/src/panels/config/areas/ha-config-area-page.ts
+++ b/src/panels/config/areas/ha-config-area-page.ts
@@ -400,33 +400,40 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
                   ></ha-icon-button>
                 </div>`
               : nothing}
-            <div class="action-buttons">
-              ${area.picture
-                ? nothing
-                : html`<ha-button
-                    appearance="filled"
-                    .entry=${area}
-                    @click=${this._showSettings}
-                  >
-                    <ha-svg-icon
-                      .path=${mdiImagePlus}
-                      slot="start"
-                    ></ha-svg-icon>
-                    ${this.hass.localize("ui.panel.config.areas.add_picture")}
-                  </ha-button>`}
-              ${this._newTriggersConditions
-                ? html`<ha-button
-                    appearance="filled"
-                    variant="brand"
-                    @click=${this._showAddToDialog}
-                  >
-                    <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
-                    ${this.hass.localize(
-                      "ui.dialogs.more_info_control.add_to.title"
-                    )}
-                  </ha-button>`
-                : nothing}
-            </div>
+            ${area.picture && !this._newTriggersConditions
+              ? nothing
+              : html`<div class="action-buttons">
+                  ${area.picture
+                    ? nothing
+                    : html`<ha-button
+                        appearance="filled"
+                        .entry=${area}
+                        @click=${this._showSettings}
+                      >
+                        <ha-svg-icon
+                          .path=${mdiImagePlus}
+                          slot="start"
+                        ></ha-svg-icon>
+                        ${this.hass.localize(
+                          "ui.panel.config.areas.add_picture"
+                        )}
+                      </ha-button>`}
+                  ${this._newTriggersConditions
+                    ? html`<ha-button
+                        appearance="filled"
+                        variant="brand"
+                        @click=${this._showAddToDialog}
+                      >
+                        <ha-svg-icon
+                          slot="start"
+                          .path=${mdiPlus}
+                        ></ha-svg-icon>
+                        ${this.hass.localize(
+                          "ui.dialogs.more_info_control.add_to.title"
+                        )}
+                      </ha-button>`
+                    : nothing}
+                </div>`}
             <ha-card
               outlined
               .header=${this.hass.localize("ui.panel.config.devices.caption")}

--- a/src/panels/config/areas/ha-config-area-page.ts
+++ b/src/panels/config/areas/ha-config-area-page.ts
@@ -340,19 +340,6 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
         )
     );
 
-    const addToButton = this._newTriggersConditions
-      ? html`
-          <ha-button
-            appearance="filled"
-            variant="brand"
-            @click=${this._showAddToDialog}
-          >
-            <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
-            ${this.hass.localize("ui.dialogs.more_info_control.add_to.title")}
-          </ha-button>
-        `
-      : nothing;
-
     return html`
       <hass-subpage
         .hass=${this.hass}
@@ -400,50 +387,46 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
         <div class="container">
           <div class="column">
             ${area.picture
-              ? html`
-                  <div class="img-container">
-                    <img alt=${area.name} src=${area.picture} />
-                    <ha-icon-button
-                      .path=${mdiPencil}
-                      .entry=${area}
-                      @click=${this._showSettings}
-                      .label=${this.hass.localize(
-                        "ui.panel.config.areas.edit_settings"
-                      )}
-                      class="img-edit-btn"
-                    ></ha-icon-button>
-                  </div>
-                  <div class="action-buttons">
-                    <ha-button
-                      appearance="filled"
-                      .entry=${area}
-                      @click=${this._showSettings}
-                    >
-                      <ha-svg-icon
-                        .path=${mdiImagePlus}
-                        slot="start"
-                      ></ha-svg-icon>
-                      ${this.hass.localize("ui.panel.config.areas.add_picture")}
-                    </ha-button>
-                    ${addToButton}
-                  </div>
-                `
-              : html`
-                  <div class="action-buttons">
-                    <ha-button
-                      appearance="filled"
-                      .entry=${area}
-                      @click=${this._showSettings}
-                    >
-                      <ha-svg-icon
-                        .path=${mdiImagePlus}
-                        slot="start"
-                      ></ha-svg-icon>
-                      ${this.hass.localize("ui.panel.config.areas.add_picture")}
-                    </ha-button>
-                    ${addToButton}
-                  </div>
-                `}
+              ? html`<div class="img-container">
+                  <img alt=${area.name} src=${area.picture} />
+                  <ha-icon-button
+                    .path=${mdiPencil}
+                    .entry=${area}
+                    @click=${this._showSettings}
+                    .label=${this.hass.localize(
+                      "ui.panel.config.areas.edit_settings"
+                    )}
+                    class="img-edit-btn"
+                  ></ha-icon-button>
+                </div>`
+              : nothing}
+            <div class="action-buttons">
+              ${area.picture
+                ? nothing
+                : html`<ha-button
+                    appearance="filled"
+                    .entry=${area}
+                    @click=${this._showSettings}
+                  >
+                    <ha-svg-icon
+                      .path=${mdiImagePlus}
+                      slot="start"
+                    ></ha-svg-icon>
+                    ${this.hass.localize("ui.panel.config.areas.add_picture")}
+                  </ha-button>`}
+              ${this._newTriggersConditions
+                ? html`<ha-button
+                    appearance="filled"
+                    variant="brand"
+                    @click=${this._showAddToDialog}
+                  >
+                    <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
+                    ${this.hass.localize(
+                      "ui.dialogs.more_info_control.add_to.title"
+                    )}
+                  </ha-button>`
+                : nothing}
+            </div>
             <ha-card
               outlined
               .header=${this.hass.localize("ui.panel.config.devices.caption")}
@@ -879,6 +862,7 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
           display: flex;
           gap: var(--ha-space-2);
           flex-wrap: wrap;
+          justify-content: space-around;
         }
 
         img {

--- a/src/panels/config/areas/ha-config-area-page.ts
+++ b/src/panels/config/areas/ha-config-area-page.ts
@@ -1,5 +1,11 @@
 import { consume } from "@lit/context";
-import { mdiPlus } from "@mdi/js";
+import {
+  mdiDelete,
+  mdiDotsVertical,
+  mdiImagePlus,
+  mdiPencil,
+  mdiPlus,
+} from "@mdi/js";
 import type {
   HassEntity,
   UnsubscribeFunc,
@@ -765,7 +771,6 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
   private async _findRelated() {
     this._related = await findRelated(this.hass, "area", this.areaId);
   }
-
 
   private _showAddToDialog() {
     const area = this.hass.areas[this.areaId];

--- a/src/panels/config/areas/ha-config-area-page.ts
+++ b/src/panels/config/areas/ha-config-area-page.ts
@@ -1,10 +1,16 @@
 import { consume } from "@lit/context";
 import {
   mdiDelete,
+  mdiDevices,
   mdiDotsVertical,
   mdiImagePlus,
+  mdiPalette,
   mdiPencil,
   mdiPlus,
+  mdiRobot,
+  mdiScriptText,
+  mdiShape,
+  mdiTools,
 } from "@mdi/js";
 import type {
   HassEntity,

--- a/src/panels/config/areas/ha-config-area-page.ts
+++ b/src/panels/config/areas/ha-config-area-page.ts
@@ -1,17 +1,9 @@
 import { consume } from "@lit/context";
-import {
-  mdiDelete,
-  mdiDevices,
-  mdiDotsVertical,
-  mdiImagePlus,
-  mdiPalette,
-  mdiPencil,
-  mdiRobot,
-  mdiScriptText,
-  mdiShape,
-  mdiTools,
-} from "@mdi/js";
-import type { HassEntity } from "home-assistant-js-websocket/dist/types";
+import { mdiPlus } from "@mdi/js";
+import type {
+  HassEntity,
+  UnsubscribeFunc,
+} from "home-assistant-js-websocket/dist/types";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
@@ -35,6 +27,7 @@ import "../../../components/ha-dropdown-item";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-icon-next";
 import "../../../components/ha-list";
+import "../../../components/ha-svg-icon";
 import "../../../components/ha-tooltip";
 import type { AreaRegistryEntry } from "../../../data/area/area_registry";
 import {
@@ -50,6 +43,7 @@ import {
   computeEntityRegistryName,
   sortEntityRegistryByName,
 } from "../../../data/entity/entity_registry";
+import { subscribeLabFeature } from "../../../data/labs";
 import type { SceneEntity } from "../../../data/scene";
 import type { ScriptEntity } from "../../../data/script";
 import type { RelatedResult } from "../../../data/search";
@@ -58,10 +52,15 @@ import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box
 import { showMoreInfoDialog } from "../../../dialogs/more-info/show-ha-more-info-dialog";
 import "../../../layouts/hass-error-screen";
 import "../../../layouts/hass-subpage";
+import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 import { isHelperDomain } from "../helpers/const";
 import "../../logbook/ha-logbook";
+import {
+  loadAreaAddToDialog,
+  showAreaAddToDialog,
+} from "./show-dialog-area-add-to";
 import {
   loadAreaRegistryDetailDialog,
   showAreaRegistryDetailDialog,
@@ -125,7 +124,7 @@ const NAVIGATION_ACTIONS: {
 ] as const;
 
 @customElement("ha-config-area-page")
-class HaConfigAreaPage extends LitElement {
+class HaConfigAreaPage extends SubscribeMixin(LitElement) {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public areaId!: string;
@@ -141,6 +140,8 @@ class HaConfigAreaPage extends LitElement {
   _entityReg: EntityRegistryEntry[] = [];
 
   @state() private _related?: RelatedResult;
+
+  @state() private _newTriggersConditions = false;
 
   private _logbookTime = { recent: 86400 };
 
@@ -221,6 +222,7 @@ class HaConfigAreaPage extends LitElement {
   protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     loadAreaRegistryDetailDialog();
+    loadAreaAddToDialog();
   }
 
   protected updated(changedProps: PropertyValues<this>) {
@@ -228,6 +230,23 @@ class HaConfigAreaPage extends LitElement {
     if (changedProps.has("areaId")) {
       this._findRelated();
     }
+  }
+
+  // When new_triggers_conditions labs feature is promoted, this whole method can be removed.
+  protected hassSubscribe(): (UnsubscribeFunc | Promise<UnsubscribeFunc>)[] {
+    if (!isComponentLoaded(this.hass!.config, "automation")) {
+      return [];
+    }
+    return [
+      subscribeLabFeature(
+        this.hass!.connection,
+        "automation",
+        "new_triggers_conditions",
+        (feature) => {
+          this._newTriggersConditions = feature.enabled;
+        }
+      ),
+    ];
   }
 
   protected render() {
@@ -446,12 +465,29 @@ class HaConfigAreaPage extends LitElement {
           <div class="column">
             ${isComponentLoaded(this.hass.config, "automation")
               ? html`
-                  <ha-card
-                    outlined
-                    .header=${this.hass.localize(
-                      "ui.panel.config.devices.automation.automations_heading"
-                    )}
-                  >
+                  <ha-card outlined>
+                    <h1 class="card-header">
+                      ${this.hass.localize(
+                        "ui.panel.config.devices.automation.automations_heading"
+                      )}
+                      ${this._newTriggersConditions
+                        ? html`
+                            <ha-button
+                              appearance="filled"
+                              variant="brand"
+                              @click=${this._showAutomationAddToDialog}
+                            >
+                              <ha-svg-icon
+                                slot="start"
+                                .path=${mdiPlus}
+                              ></ha-svg-icon>
+                              ${this.hass.localize(
+                                "ui.dialogs.more_info_control.add_to.title"
+                              )}
+                            </ha-button>
+                          `
+                        : nothing}
+                    </h1>
                     ${groupedAutomations?.length
                       ? html`<h3>
                             ${this.hass.localize(
@@ -496,12 +532,30 @@ class HaConfigAreaPage extends LitElement {
               : ""}
             ${isComponentLoaded(this.hass.config, "scene")
               ? html`
-                  <ha-card
-                    outlined
-                    .header=${this.hass.localize(
-                      "ui.panel.config.devices.scene.scenes_heading"
-                    )}
-                  >
+                  <ha-card outlined>
+                    <h1 class="card-header">
+                      ${this.hass.localize(
+                        "ui.panel.config.devices.scene.scenes_heading"
+                      )}
+                      ${this._newTriggersConditions &&
+                      this._areaEntityIds.length
+                        ? html`
+                            <ha-button
+                              appearance="filled"
+                              variant="brand"
+                              @click=${this._showSceneAddToDialog}
+                            >
+                              <ha-svg-icon
+                                slot="start"
+                                .path=${mdiPlus}
+                              ></ha-svg-icon>
+                              ${this.hass.localize(
+                                "ui.dialogs.more_info_control.add_to.title"
+                              )}
+                            </ha-button>
+                          `
+                        : nothing}
+                    </h1>
                     ${groupedScenes?.length
                       ? html`<h3>
                             ${this.hass.localize(
@@ -540,12 +594,29 @@ class HaConfigAreaPage extends LitElement {
               : ""}
             ${isComponentLoaded(this.hass.config, "script")
               ? html`
-                  <ha-card
-                    outlined
-                    .header=${this.hass.localize(
-                      "ui.panel.config.devices.script.scripts_heading"
-                    )}
-                  >
+                  <ha-card outlined>
+                    <h1 class="card-header">
+                      ${this.hass.localize(
+                        "ui.panel.config.devices.script.scripts_heading"
+                      )}
+                      ${this._newTriggersConditions
+                        ? html`
+                            <ha-button
+                              appearance="filled"
+                              variant="brand"
+                              @click=${this._showScriptAddToDialog}
+                            >
+                              <ha-svg-icon
+                                slot="start"
+                                .path=${mdiPlus}
+                              ></ha-svg-icon>
+                              ${this.hass.localize(
+                                "ui.dialogs.more_info_control.add_to.title"
+                              )}
+                            </ha-button>
+                          `
+                        : nothing}
+                    </h1>
                     ${groupedScripts?.length
                       ? html`<h3>
                             ${this.hass.localize(
@@ -721,6 +792,53 @@ class HaConfigAreaPage extends LitElement {
     this._related = await findRelated(this.hass, "area", this.areaId);
   }
 
+
+  private _showAutomationAddToDialog() {
+    const area = this.hass.areas[this.areaId];
+    if (!area) {
+      return;
+    }
+    showAreaAddToDialog(this, {
+      areaId: area.area_id,
+      mode: "automation",
+      entityIds: this._areaEntityIds,
+    });
+  }
+
+  private _showScriptAddToDialog() {
+    const area = this.hass.areas[this.areaId];
+    if (!area) {
+      return;
+    }
+    showAreaAddToDialog(this, {
+      areaId: area.area_id,
+      mode: "script",
+      entityIds: this._areaEntityIds,
+    });
+  }
+
+  private _showSceneAddToDialog() {
+    const area = this.hass.areas[this.areaId];
+    if (!area) {
+      return;
+    }
+    showAreaAddToDialog(this, {
+      areaId: area.area_id,
+      mode: "scene",
+      entityIds: this._areaEntityIds,
+    });
+  }
+
+  private get _areaEntityIds(): string[] {
+    const memberships = this._memberships(
+      this.areaId,
+      Object.values(this.hass.devices),
+      this._entityReg
+    );
+
+    return this._allEntities(memberships);
+  }
+
   private _handleMenuAction(
     ev: HaDropdownSelectEvent<string, AreaRegistryEntry>
   ) {
@@ -797,6 +915,29 @@ class HaConfigAreaPage extends LitElement {
           font-weight: var(--ha-font-weight-medium);
           color: var(--secondary-text-color);
         }
+
+        .card-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding-bottom: var(--ha-space-3);
+          margin: 0;
+          font-family: var(--ha-font-family-body);
+          -webkit-font-smoothing: var(--ha-font-smoothing);
+          -moz-osx-font-smoothing: var(--ha-moz-osx-font-smoothing);
+          font-size: var(--ha-font-size-2xl);
+          font-weight: var(--ha-font-weight-normal);
+          line-height: var(--ha-line-height-condensed);
+          opacity: var(--dark-primary-opacity);
+        }
+
+        .card-header ha-button {
+          margin-right: calc(var(--ha-space-2) * -1);
+          margin-inline-end: calc(var(--ha-space-2) * -1);
+          margin-inline-start: initial;
+          direction: var(--direction);
+        }
+
         img {
           border-radius: var(
             --ha-card-border-radius,

--- a/src/panels/config/areas/ha-config-area-page.ts
+++ b/src/panels/config/areas/ha-config-area-page.ts
@@ -340,6 +340,20 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
         )
     );
 
+    const addToButton = this._newTriggersConditions
+      ? html`
+          <ha-button
+            appearance="filled"
+            variant="brand"
+            size="small"
+            @click=${this._showAddToDialog}
+          >
+            <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
+            ${this.hass.localize("ui.dialogs.more_info_control.add_to.title")}
+          </ha-button>
+        `
+      : nothing;
+
     return html`
       <hass-subpage
         .hass=${this.hass}
@@ -387,27 +401,52 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
         <div class="container">
           <div class="column">
             ${area.picture
-              ? html`<div class="img-container">
-                  <img alt=${area.name} src=${area.picture} />
-                  <ha-icon-button
-                    .path=${mdiPencil}
-                    .entry=${area}
-                    @click=${this._showSettings}
-                    .label=${this.hass.localize(
-                      "ui.panel.config.areas.edit_settings"
-                    )}
-                    class="img-edit-btn"
-                  ></ha-icon-button>
-                </div>`
-              : html`<ha-button
-                  appearance="filled"
-                  size="small"
-                  .entry=${area}
-                  @click=${this._showSettings}
-                >
-                  <ha-svg-icon .path=${mdiImagePlus} slot="start"></ha-svg-icon>
-                  ${this.hass.localize("ui.panel.config.areas.add_picture")}
-                </ha-button>`}
+              ? html`
+                  <div class="img-container">
+                    <img alt=${area.name} src=${area.picture} />
+                    <ha-icon-button
+                      .path=${mdiPencil}
+                      .entry=${area}
+                      @click=${this._showSettings}
+                      .label=${this.hass.localize(
+                        "ui.panel.config.areas.edit_settings"
+                      )}
+                      class="img-edit-btn"
+                    ></ha-icon-button>
+                  </div>
+                  <div class="action-buttons">
+                    <ha-button
+                      appearance="filled"
+                      size="small"
+                      .entry=${area}
+                      @click=${this._showSettings}
+                    >
+                      <ha-svg-icon
+                        .path=${mdiImagePlus}
+                        slot="start"
+                      ></ha-svg-icon>
+                      ${this.hass.localize("ui.panel.config.areas.add_picture")}
+                    </ha-button>
+                    ${addToButton}
+                  </div>
+                `
+              : html`
+                  <div class="action-buttons">
+                    <ha-button
+                      appearance="filled"
+                      size="small"
+                      .entry=${area}
+                      @click=${this._showSettings}
+                    >
+                      <ha-svg-icon
+                        .path=${mdiImagePlus}
+                        slot="start"
+                      ></ha-svg-icon>
+                      ${this.hass.localize("ui.panel.config.areas.add_picture")}
+                    </ha-button>
+                    ${addToButton}
+                  </div>
+                `}
             <ha-card
               outlined
               .header=${this.hass.localize("ui.panel.config.devices.caption")}
@@ -465,29 +504,12 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
           <div class="column">
             ${isComponentLoaded(this.hass.config, "automation")
               ? html`
-                  <ha-card outlined>
-                    <h1 class="card-header">
-                      ${this.hass.localize(
-                        "ui.panel.config.devices.automation.automations_heading"
-                      )}
-                      ${this._newTriggersConditions
-                        ? html`
-                            <ha-button
-                              appearance="filled"
-                              variant="brand"
-                              @click=${this._showAutomationAddToDialog}
-                            >
-                              <ha-svg-icon
-                                slot="start"
-                                .path=${mdiPlus}
-                              ></ha-svg-icon>
-                              ${this.hass.localize(
-                                "ui.dialogs.more_info_control.add_to.title"
-                              )}
-                            </ha-button>
-                          `
-                        : nothing}
-                    </h1>
+                  <ha-card
+                    outlined
+                    .header=${this.hass.localize(
+                      "ui.panel.config.devices.automation.automations_heading"
+                    )}
+                  >
                     ${groupedAutomations?.length
                       ? html`<h3>
                             ${this.hass.localize(
@@ -532,30 +554,12 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
               : ""}
             ${isComponentLoaded(this.hass.config, "scene")
               ? html`
-                  <ha-card outlined>
-                    <h1 class="card-header">
-                      ${this.hass.localize(
-                        "ui.panel.config.devices.scene.scenes_heading"
-                      )}
-                      ${this._newTriggersConditions &&
-                      this._areaEntityIds.length
-                        ? html`
-                            <ha-button
-                              appearance="filled"
-                              variant="brand"
-                              @click=${this._showSceneAddToDialog}
-                            >
-                              <ha-svg-icon
-                                slot="start"
-                                .path=${mdiPlus}
-                              ></ha-svg-icon>
-                              ${this.hass.localize(
-                                "ui.dialogs.more_info_control.add_to.title"
-                              )}
-                            </ha-button>
-                          `
-                        : nothing}
-                    </h1>
+                  <ha-card
+                    outlined
+                    .header=${this.hass.localize(
+                      "ui.panel.config.devices.scene.scenes_heading"
+                    )}
+                  >
                     ${groupedScenes?.length
                       ? html`<h3>
                             ${this.hass.localize(
@@ -594,29 +598,12 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
               : ""}
             ${isComponentLoaded(this.hass.config, "script")
               ? html`
-                  <ha-card outlined>
-                    <h1 class="card-header">
-                      ${this.hass.localize(
-                        "ui.panel.config.devices.script.scripts_heading"
-                      )}
-                      ${this._newTriggersConditions
-                        ? html`
-                            <ha-button
-                              appearance="filled"
-                              variant="brand"
-                              @click=${this._showScriptAddToDialog}
-                            >
-                              <ha-svg-icon
-                                slot="start"
-                                .path=${mdiPlus}
-                              ></ha-svg-icon>
-                              ${this.hass.localize(
-                                "ui.dialogs.more_info_control.add_to.title"
-                              )}
-                            </ha-button>
-                          `
-                        : nothing}
-                    </h1>
+                  <ha-card
+                    outlined
+                    .header=${this.hass.localize(
+                      "ui.panel.config.devices.script.scripts_heading"
+                    )}
+                  >
                     ${groupedScripts?.length
                       ? html`<h3>
                             ${this.hass.localize(
@@ -793,38 +780,13 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
   }
 
 
-  private _showAutomationAddToDialog() {
+  private _showAddToDialog() {
     const area = this.hass.areas[this.areaId];
     if (!area) {
       return;
     }
     showAreaAddToDialog(this, {
       areaId: area.area_id,
-      mode: "automation",
-      entityIds: this._areaEntityIds,
-    });
-  }
-
-  private _showScriptAddToDialog() {
-    const area = this.hass.areas[this.areaId];
-    if (!area) {
-      return;
-    }
-    showAreaAddToDialog(this, {
-      areaId: area.area_id,
-      mode: "script",
-      entityIds: this._areaEntityIds,
-    });
-  }
-
-  private _showSceneAddToDialog() {
-    const area = this.hass.areas[this.areaId];
-    if (!area) {
-      return;
-    }
-    showAreaAddToDialog(this, {
-      areaId: area.area_id,
-      mode: "scene",
       entityIds: this._areaEntityIds,
     });
   }
@@ -916,26 +878,10 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
           color: var(--secondary-text-color);
         }
 
-        .card-header {
+        .action-buttons {
           display: flex;
-          align-items: center;
-          justify-content: space-between;
-          padding-bottom: var(--ha-space-3);
-          margin: 0;
-          font-family: var(--ha-font-family-body);
-          -webkit-font-smoothing: var(--ha-font-smoothing);
-          -moz-osx-font-smoothing: var(--ha-moz-osx-font-smoothing);
-          font-size: var(--ha-font-size-2xl);
-          font-weight: var(--ha-font-weight-normal);
-          line-height: var(--ha-line-height-condensed);
-          opacity: var(--dark-primary-opacity);
-        }
-
-        .card-header ha-button {
-          margin-right: calc(var(--ha-space-2) * -1);
-          margin-inline-end: calc(var(--ha-space-2) * -1);
-          margin-inline-start: initial;
-          direction: var(--direction);
+          gap: var(--ha-space-2);
+          flex-wrap: wrap;
         }
 
         img {

--- a/src/panels/config/areas/show-dialog-area-add-to.ts
+++ b/src/panels/config/areas/show-dialog-area-add-to.ts
@@ -2,7 +2,6 @@ import { fireEvent } from "../../../common/dom/fire_event";
 
 export interface AreaAddToDialogParams {
   areaId: string;
-  mode: "automation" | "script" | "scene";
   entityIds: string[];
 }
 

--- a/src/panels/config/areas/show-dialog-area-add-to.ts
+++ b/src/panels/config/areas/show-dialog-area-add-to.ts
@@ -1,0 +1,20 @@
+import { fireEvent } from "../../../common/dom/fire_event";
+
+export interface AreaAddToDialogParams {
+  areaId: string;
+  mode: "automation" | "script" | "scene";
+  entityIds: string[];
+}
+
+export const loadAreaAddToDialog = () => import("./dialog-area-add-to");
+
+export const showAreaAddToDialog = (
+  element: HTMLElement,
+  params: AreaAddToDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-area-add-to",
+    dialogImport: loadAreaAddToDialog,
+    dialogParams: params,
+  });
+};

--- a/src/panels/config/automation/action/ha-automation-action.ts
+++ b/src/panels/config/automation/action/ha-automation-action.ts
@@ -143,6 +143,7 @@ export default class HaAutomationAction extends AutomationSortableListMixin<Acti
     const addActionTargetFromQuery = getAddAutomationElementTargetFromQuery(
       this.hass.states,
       this.hass.devices,
+      this.hass.areas,
       "action"
     );
 

--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -130,6 +130,7 @@ import "./add-automation-element/ha-automation-add-items";
 import "./add-automation-element/ha-automation-add-search";
 import type { AddAutomationElementDialogParams } from "./show-add-automation-element-dialog";
 import {
+  ADD_AUTOMATION_ELEMENT_AREA_TARGET_PARAM,
   ADD_AUTOMATION_ELEMENT_DEVICE_TARGET_PARAM,
   ADD_AUTOMATION_ELEMENT_ENTITY_TARGET_PARAM,
   ADD_AUTOMATION_ELEMENT_QUERY_PARAM,
@@ -311,6 +312,7 @@ class DialogAddAutomationElement
     const queryTarget = getAddAutomationElementTargetFromQuery(
       this.hass.states,
       this.hass.devices,
+      this.hass.areas,
       params.type
     );
     this._openedFromQuery = !!queryTarget;
@@ -320,6 +322,7 @@ class DialogAddAutomationElement
       searchParams.delete(ADD_AUTOMATION_ELEMENT_QUERY_PARAM);
       searchParams.delete(ADD_AUTOMATION_ELEMENT_ENTITY_TARGET_PARAM);
       searchParams.delete(ADD_AUTOMATION_ELEMENT_DEVICE_TARGET_PARAM);
+      searchParams.delete(ADD_AUTOMATION_ELEMENT_AREA_TARGET_PARAM);
       mainWindow.history.replaceState(
         mainWindow.history.state,
         "",

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -128,6 +128,7 @@ export default class HaAutomationCondition extends AutomationSortableListMixin<C
     const addConditionTargetFromQuery = getAddAutomationElementTargetFromQuery(
       this.hass.states,
       this.hass.devices,
+      this.hass.areas,
       "condition"
     );
 

--- a/src/panels/config/automation/show-add-automation-element-dialog.ts
+++ b/src/panels/config/automation/show-add-automation-element-dialog.ts
@@ -8,6 +8,7 @@ export const PASTE_VALUE = "__paste__";
 export const ADD_AUTOMATION_ELEMENT_QUERY_PARAM = "add_automation_element";
 export const ADD_AUTOMATION_ELEMENT_ENTITY_TARGET_PARAM = "target_entity_id";
 export const ADD_AUTOMATION_ELEMENT_DEVICE_TARGET_PARAM = "target_device_id";
+export const ADD_AUTOMATION_ELEMENT_AREA_TARGET_PARAM = "target_area_id";
 
 /** Parameters for the add automation element dialog. */
 export interface AddAutomationElementDialogParams {
@@ -21,6 +22,7 @@ export interface AddAutomationElementDialogParams {
 export const getAddAutomationElementTargetFromQuery = (
   states: HomeAssistant["states"],
   devices: HomeAssistant["devices"],
+  areas: HomeAssistant["areas"],
   type: AddAutomationElementDialogParams["type"]
 ): SingleHassServiceTarget | undefined => {
   const params = new URLSearchParams(window.location.search);
@@ -37,6 +39,11 @@ export const getAddAutomationElementTargetFromQuery = (
   const deviceId = params.get(ADD_AUTOMATION_ELEMENT_DEVICE_TARGET_PARAM);
   if (deviceId && devices[deviceId]) {
     return { device_id: deviceId };
+  }
+
+  const areaId = params.get(ADD_AUTOMATION_ELEMENT_AREA_TARGET_PARAM);
+  if (areaId && areas[areaId]) {
+    return { area_id: areaId };
   }
 
   return undefined;

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -311,6 +311,7 @@ export default class HaAutomationTrigger extends AutomationSortableListMixin<Tri
     const addTriggerTargetFromQuery = getAddAutomationElementTargetFromQuery(
       this.hass.states,
       this.hass.devices,
+      this.hass.areas,
       "trigger"
     );
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
#52121

- Add to button and adaptive dialog for areas page.
- Query param support for area targets.
- Only shows with labs feature, will need checks removed once promoted.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

### Add to button:

<img width="816" height="736" alt="image" src="https://github.com/user-attachments/assets/f91b3995-c776-4733-8643-13f2aa3e5d55" />
<img width="653" height="541" alt="image" src="https://github.com/user-attachments/assets/a1ceff96-5cd3-4b80-bdea-e54000954429" />

### Prompt:

<img width="1153" height="941" alt="image" src="https://github.com/user-attachments/assets/dc739f17-7931-436b-a80b-6217e55185fc" />

### Add prompt after navigation:

<img width="1643" height="1631" alt="image" src="https://github.com/user-attachments/assets/5ff088d3-436d-4a3f-af85-b76e15ac0c54" />
<img width="1626" height="1615" alt="image" src="https://github.com/user-attachments/assets/2170a543-0628-4cc2-bcb9-f01dc1335598" />

### Labs disabled:

<img width="1101" height="583" alt="image" src="https://github.com/user-attachments/assets/8e0a56f2-7fb3-49c5-b13d-941041d09cbd" />
<img width="790" height="576" alt="image" src="https://github.com/user-attachments/assets/bbe2c756-bba9-40d3-8062-73aa67f2cd27" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #52121
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
