### PR TITLE
Recover brand icons after Home Assistant restart

### DIFF
--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -361,15 +361,14 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       clearBrandsTokenRefresh();
     }
 
-    private _refreshBrandsAccessToken() {
+    private async _refreshBrandsAccessToken() {
       // The brands WS handler may not be registered yet after a server restart;
       // fetchAndScheduleBrandsAccessToken retries internally. If the token
       // changed, re-render so any brand <img> elements that rendered against a
       // different (or missing) token recompute their src and re-fetch.
-      fetchAndScheduleBrandsAccessToken(this.hass!).then((changed) => {
-        if (changed) {
-          this._updateHass({});
-        }
-      });
+      const changed = await fetchAndScheduleBrandsAccessToken(this.hass!);
+      if (changed) {
+        this._updateHass({});
+      }
     }
   };

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -313,8 +313,7 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       });
       clearInterval(this.__backendPingInterval);
 
-      // Fetch the brands access token on initial connect and schedule refresh
-      fetchAndScheduleBrandsAccessToken(this.hass!);
+      this._refreshBrandsAccessToken();
 
       this.__backendPingInterval = setInterval(() => {
         if (this.hass?.connected) {
@@ -340,8 +339,7 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       this._updateHass({ connected: true });
       broadcastConnectionStatus("connected");
 
-      // Refresh the brands access token on reconnect and restart refresh schedule
-      fetchAndScheduleBrandsAccessToken(this.hass!);
+      this._refreshBrandsAccessToken();
 
       // on reconnect always fetch config as we might miss an update while we were disconnected
       // @ts-ignore
@@ -361,5 +359,17 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       broadcastConnectionStatus("disconnected");
       clearInterval(this.__backendPingInterval);
       clearBrandsTokenRefresh();
+    }
+
+    private _refreshBrandsAccessToken() {
+      // The brands WS handler may not be registered yet after a server restart;
+      // fetchAndScheduleBrandsAccessToken retries internally. If the token
+      // changed, re-render so any brand <img> elements that rendered against a
+      // different (or missing) token recompute their src and re-fetch.
+      fetchAndScheduleBrandsAccessToken(this.hass!).then((changed) => {
+        if (changed) {
+          this._updateHass({});
+        }
+      });
     }
   };

--- a/src/util/brands-url.ts
+++ b/src/util/brands-url.ts
@@ -1,3 +1,4 @@
+import { waitForMs } from "../common/util/wait";
 import type { HomeAssistant } from "../types";
 
 export interface BrandsOptions {
@@ -20,15 +21,35 @@ let _brandsRefreshInterval: ReturnType<typeof setInterval> | undefined;
 // Re-fetch every 30 minutes to always have a valid token.
 const TOKEN_REFRESH_MS = 30 * 60 * 1000;
 
-export const fetchAndScheduleBrandsAccessToken = (
+// Delays before each attempt. The first attempt fires immediately; subsequent
+// ones back off to ride through the window after a Home Assistant restart
+// where the WebSocket server accepts connections but the brands integration
+// hasn't registered its WS handler yet. On older backends without the command,
+// every attempt fails and we give up.
+const FETCH_DELAYS_MS = [0, 500, 1000, 2000, 5000, 10000, 15000];
+
+// Returns true if the cached token changed as a result of this call, so
+// callers can decide whether they need to trigger a re-render.
+export const fetchAndScheduleBrandsAccessToken = async (
   hass: HomeAssistant
-): Promise<void> =>
-  fetchBrandsAccessToken(hass).then(
-    () => scheduleBrandsTokenRefresh(hass),
-    () => {
-      // Ignore failures; older backends may not support this command
+): Promise<boolean> => {
+  const previousToken = _brandsAccessToken;
+  /* eslint-disable no-await-in-loop -- retries are intentionally sequential */
+  for (const delay of FETCH_DELAYS_MS) {
+    if (delay) {
+      await waitForMs(delay);
     }
-  );
+    try {
+      await fetchBrandsAccessToken(hass);
+      scheduleBrandsTokenRefresh(hass);
+      return _brandsAccessToken !== previousToken;
+    } catch {
+      // try next delay
+    }
+  }
+  /* eslint-enable no-await-in-loop */
+  return false;
+};
 
 export const fetchBrandsAccessToken = async (
   hass: HomeAssistant

--- a/test/util/generate-brands-url.test.ts
+++ b/test/util/generate-brands-url.test.ts
@@ -4,6 +4,7 @@ import {
   addBrandsAuth,
   brandsUrl,
   clearBrandsTokenRefresh,
+  fetchAndScheduleBrandsAccessToken,
   fetchBrandsAccessToken,
   scheduleBrandsTokenRefresh,
 } from "../../src/util/brands-url";
@@ -167,5 +168,85 @@ describe("scheduleBrandsTokenRefresh", () => {
     // Advance 30 minutes — should not have refreshed because we cleared
     await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
     assert.strictEqual(callCount, 1);
+  });
+});
+
+describe("fetchAndScheduleBrandsAccessToken", () => {
+  afterEach(() => {
+    clearBrandsTokenRefresh();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("retries with backoff until the WS call succeeds, returns true when the token changed", async () => {
+    vi.useFakeTimers();
+    let callCount = 0;
+    const mockHass = {
+      callWS: async () => {
+        callCount++;
+        if (callCount < 3) {
+          throw new Error("unknown_command");
+        }
+        return { token: `retry-token-${callCount}` };
+      },
+    } as unknown as HomeAssistant;
+
+    const promise = fetchAndScheduleBrandsAccessToken(mockHass);
+
+    // First attempt fires immediately, fails
+    await vi.advanceTimersByTimeAsync(0);
+    assert.strictEqual(callCount, 1);
+
+    // 500ms backoff → second attempt fails
+    await vi.advanceTimersByTimeAsync(500);
+    assert.strictEqual(callCount, 2);
+
+    // 1000ms backoff → third attempt succeeds
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const changed = await promise;
+    assert.strictEqual(changed, true);
+    assert.strictEqual(callCount, 3);
+    assert.strictEqual(
+      brandsUrl(
+        { domain: "test", type: "icon" },
+        "http://homeassistant.local:8123"
+      ),
+      "http://homeassistant.local:8123/api/brands/integration/test/icon.png?token=retry-token-3"
+    );
+  });
+
+  it("returns false when the backend returns the same token (no UI change needed)", async () => {
+    const mockHass = {
+      callWS: async () => ({ token: "stable-token" }),
+    } as unknown as HomeAssistant;
+
+    // Prime the cached token
+    await fetchBrandsAccessToken(mockHass);
+
+    // Same token returned → no change
+    const changed = await fetchAndScheduleBrandsAccessToken(mockHass);
+    assert.strictEqual(changed, false);
+  });
+
+  it("returns false after all retries fail (e.g. older backend)", async () => {
+    vi.useFakeTimers();
+    let callCount = 0;
+    const mockHass = {
+      callWS: async () => {
+        callCount++;
+        throw new Error("unknown_command");
+      },
+    } as unknown as HomeAssistant;
+
+    const promise = fetchAndScheduleBrandsAccessToken(mockHass);
+
+    // Exhaust all retry delays: 500 + 1000 + 2000 + 5000 + 10000 + 15000
+    await vi.advanceTimersByTimeAsync(33500);
+
+    const changed = await promise;
+    assert.strictEqual(changed, false);
+    // 1 immediate attempt + 6 retries = 7 attempts
+    assert.strictEqual(callCount, 7);
   });
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Retry the `brands/access_token` WS call with backoff on (re)connect so brand icons recover after a Home Assistant restart, when the brands integration hasn't yet registered its WS handler. Only force a re-render when the cached token actually changed, so simple network blips stay free of UI churn.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52150
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr