### PR TITLE
Label HarmonyOS authorize client

### DIFF
--- a/src/auth/app-names.ts
+++ b/src/auth/app-names.ts
@@ -1,0 +1,5 @@
+export const appNames: Record<string, string> = {
+  "https://home-assistant.io/iOS": "iOS",
+  "https://home-assistant.io/android": "Android",
+  "https://home-assistant.io/harmonyos": "HarmonyOS",
+};

--- a/src/auth/ha-authorize.ts
+++ b/src/auth/ha-authorize.ts
@@ -13,14 +13,10 @@ import type { AuthProvider, AuthUrlSearchParams } from "../data/auth";
 import { fetchAuthProviders } from "../data/auth";
 import { litLocalizeLiteMixin } from "../mixins/lit-localize-lite-mixin";
 import { registerServiceWorker } from "../util/register-service-worker";
+import { appNames } from "./app-names";
 import "./ha-auth-flow";
 
 import("./ha-pick-auth-provider");
-
-const appNames = {
-  "https://home-assistant.io/iOS": "iOS",
-  "https://home-assistant.io/android": "Android",
-};
 
 @customElement("ha-authorize")
 export class HaAuthorize extends litLocalizeLiteMixin(LitElement) {

--- a/test/auth/ha-authorize.test.ts
+++ b/test/auth/ha-authorize.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { appNames } from "../../src/auth/app-names";
+
+describe("ha-authorize", () => {
+  it("labels the HarmonyOS companion app", () => {
+    expect(appNames["https://home-assistant.io/harmonyos"]).toBe("HarmonyOS");
+  });
+});


### PR DESCRIPTION
## Summary
- move known authorize app client labels into a small shared map
- label the HarmonyOS client id as HarmonyOS on the authorize page
- add coverage for the HarmonyOS app label

## Validation
- node .yarn/releases/yarn-4.14.1.cjs test test/auth/ha-authorize.test.ts
- node .yarn/releases/yarn-4.14.1.cjs eslint src/auth/app-names.ts src/auth/ha-authorize.ts test/auth/ha-authorize.test.ts --max-warnings=0
- pre-commit hooks during commit

## Related
- Core IndieAuth allowlist support: https://github.com/home-assistant/core/pull/171917