### PR TITLE
Statistics graph card editor: add sub editor

### DIFF
--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -145,7 +145,7 @@ export class HaStatisticPicker extends LitElement {
 
   @query("ha-generic-picker") private _picker?: HaGenericPicker;
 
-  @property({ attribute: "can-edit", type: Boolean }) public canEdit?;
+  @property({ attribute: "can-edit", type: Boolean }) public canEdit?: boolean;
 
   public willUpdate(changedProps: PropertyValues<this>) {
     if (

--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -10,7 +10,7 @@ import { html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { ensureArray } from "../../common/array/ensure-array";
-import { HASSDomEvent, fireEvent } from "../../common/dom/fire_event";
+import { type HASSDomEvent, fireEvent } from "../../common/dom/fire_event";
 import { computeEntityNameList } from "../../common/entity/compute_entity_name_display";
 import { computeStateName } from "../../common/entity/compute_state_name";
 import { computeRTL } from "../../common/util/compute_rtl";

--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -376,7 +376,7 @@ export class HaStatisticPicker extends LitElement {
 
   private _valueRenderer: PickerValueRenderer = this._makeValueRenderer();
 
-  private _editItem(ev) {
+  private _editItem(ev: HASSDomEvent<StatisticElementChangedEvent>) {
     ev.stopPropagation();
     const statisticId = (ev.currentTarget as any).value;
     fireEvent(this, "edit-statistics-element", { statisticId });

--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -1,5 +1,10 @@
 import type { RenderItemFunction } from "@lit-labs/virtualizer/virtualize";
-import { mdiChartLine, mdiHelpCircleOutline, mdiShape } from "@mdi/js";
+import {
+  mdiChartLine,
+  mdiHelpCircleOutline,
+  mdiPencil,
+  mdiShape,
+} from "@mdi/js";
 import type { HassEntity } from "home-assistant-js-websocket";
 import { html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, query } from "lit/decorators";
@@ -52,6 +57,16 @@ const SEARCH_KEYS = [
   { name: "statisticId", weight: 3 },
   { name: "id", weight: 2 },
 ];
+
+export interface StatisticElementChangedEvent {
+  statisticId: string;
+}
+
+declare global {
+  interface HASSDomEvents {
+    "edit-statistics-element": StatisticElementChangedEvent;
+  }
+}
 
 @customElement("ha-statistic-picker")
 export class HaStatisticPicker extends LitElement {
@@ -129,6 +144,8 @@ export class HaStatisticPicker extends LitElement {
   public hideClearIcon = false;
 
   @query("ha-generic-picker") private _picker?: HaGenericPicker;
+
+  @property({ attribute: "can-edit", type: Boolean }) public canEdit?;
 
   public willUpdate(changedProps: PropertyValues<this>) {
     if (
@@ -341,6 +358,15 @@ export class HaStatisticPicker extends LitElement {
       ${item.secondary
         ? html`<span slot="supporting-text">${item.secondary}</span>`
         : nothing}
+      ${this.canEdit
+        ? html`<ha-icon-button
+            slot="end"
+            .value=${statisticId}
+            .label=${this.hass.localize("ui.common.edit")}
+            .path=${mdiPencil}
+            @click=${this._editItem}
+          ></ha-icon-button>`
+        : nothing}
     `;
   }
 
@@ -349,6 +375,12 @@ export class HaStatisticPicker extends LitElement {
   }
 
   private _valueRenderer: PickerValueRenderer = this._makeValueRenderer();
+
+  private _editItem(ev) {
+    ev.stopPropagation();
+    const statisticId = (ev.currentTarget as any).value;
+    fireEvent(this, "edit-statistics-element", { statisticId });
+  }
 
   private _computeItem(statisticId: string): StatisticComboBoxItem {
     const stateObj = this.hass.states[statisticId];

--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -10,7 +10,7 @@ import { html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { ensureArray } from "../../common/array/ensure-array";
-import { fireEvent } from "../../common/dom/fire_event";
+import { HASSDomEvent, fireEvent } from "../../common/dom/fire_event";
 import { computeEntityNameList } from "../../common/entity/compute_entity_name_display";
 import { computeStateName } from "../../common/entity/compute_state_name";
 import { computeRTL } from "../../common/util/compute_rtl";

--- a/src/components/entity/ha-statistics-picker.ts
+++ b/src/components/entity/ha-statistics-picker.ts
@@ -1,9 +1,10 @@
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
-import { fireEvent } from "../../common/dom/fire_event";
+import { type HASSDomEvent, fireEvent } from "../../common/dom/fire_event";
 import type { ValueChangedEvent, HomeAssistant } from "../../types";
 import "./ha-statistic-picker";
+import { type StatisticElementChangedEvent } from "./ha-statistic-picker";
 
 @customElement("ha-statistics-picker")
 class HaStatisticsPicker extends LitElement {
@@ -59,6 +60,8 @@ class HaStatisticsPicker extends LitElement {
   })
   public ignoreRestrictionsOnFirstStatistic = false;
 
+  @property({ attribute: "can-edit", type: Boolean }) public canEdit?;
+
   protected render() {
     if (!this.hass) {
       return nothing;
@@ -99,7 +102,9 @@ class HaStatisticsPicker extends LitElement {
               .statisticIds=${this.statisticIds}
               .excludeStatistics=${this.value}
               .allowCustomEntity=${this.allowCustomEntity}
+              .canEdit=${this.canEdit}
               @value-changed=${this._statisticChanged}
+              @edit-statistics-element=${this._editItem}
             ></ha-statistic-picker>
           </div>
         `
@@ -120,6 +125,17 @@ class HaStatisticsPicker extends LitElement {
         ></ha-statistic-picker>
       </div>
     `;
+  }
+
+  private _editItem(ev: HASSDomEvent<StatisticElementChangedEvent>) {
+    const statisticId = ev.detail.statisticId;
+    const index = this._currentStatistics!.findIndex((e) => e === statisticId);
+    fireEvent(this, "edit-detail-element", {
+      subElementConfig: {
+        index,
+        type: "row",
+      },
+    });
   }
 
   private get _currentStatistics() {

--- a/src/components/entity/ha-statistics-picker.ts
+++ b/src/components/entity/ha-statistics-picker.ts
@@ -4,7 +4,7 @@ import { repeat } from "lit/directives/repeat";
 import { type HASSDomEvent, fireEvent } from "../../common/dom/fire_event";
 import type { ValueChangedEvent, HomeAssistant } from "../../types";
 import "./ha-statistic-picker";
-import { type StatisticElementChangedEvent } from "./ha-statistic-picker";
+import type { StatisticElementChangedEvent } from "./ha-statistic-picker";
 
 @customElement("ha-statistics-picker")
 class HaStatisticsPicker extends LitElement {

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -498,7 +498,7 @@ export class HuiStatisticsGraphCardEditor
     ev.stopPropagation();
 
     // get updated entity config
-    let newEntityConfig = ev.detail.config as GraphEntityConfig;
+    const newEntityConfig = ev.detail.config as GraphEntityConfig;
 
     // update card config with updated entity config
     const index = this._subElementEditorConfig!.index!;

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -35,7 +35,7 @@ import {
   isExternalStatistic,
   statisticsMetaHasType,
 } from "../../../../data/recorder";
-import type { EntityConfig } from "../entity-rows/types";
+import type { EntityConfig } from "../../entity-rows/types";
 import type { HomeAssistant } from "../../../../types";
 import { DEFAULT_DAYS_TO_SHOW } from "../../cards/hui-statistics-graph-card";
 import type {

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -35,7 +35,7 @@ import {
   isExternalStatistic,
   statisticsMetaHasType,
 } from "../../../../data/recorder";
-import type { EntityConfig } from "../../../../panels/lovelace/entity-rows/types";
+import type { EntityConfig } from "../entity-rows/types";
 import type { HomeAssistant } from "../../../../types";
 import { DEFAULT_DAYS_TO_SHOW } from "../../cards/hui-statistics-graph-card";
 import type {

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -15,7 +15,10 @@ import {
   union,
 } from "superstruct";
 import { ensureArray } from "../../../../common/array/ensure-array";
-import { fireEvent } from "../../../../common/dom/fire_event";
+import {
+  type HASSDomEvent,
+  fireEvent,
+} from "../../../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
 import { deepEqual } from "../../../../common/util/deep-equal";
 import { supportedStatTypeMap } from "../../../../components/chart/statistics-chart";
@@ -32,13 +35,19 @@ import {
   isExternalStatistic,
   statisticsMetaHasType,
 } from "../../../../data/recorder";
+import type { EntityConfig } from "../../../../panels/lovelace/entity-rows/types";
 import type { HomeAssistant } from "../../../../types";
 import { DEFAULT_DAYS_TO_SHOW } from "../../cards/hui-statistics-graph-card";
-import type { StatisticsGraphCardConfig } from "../../cards/types";
+import type {
+  GraphEntityConfig,
+  StatisticsGraphCardConfig,
+} from "../../cards/types";
 import { processConfigEntities } from "../../common/process-config-entities";
 import type { LovelaceCardEditor } from "../../types";
+import "../hui-sub-element-editor";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import { graphEntitiesConfigStruct } from "../structs/entities-struct";
+import type { EditDetailElementEvent, SubElementEditorConfig } from "../types";
 import { orderPropertiesGraphCard } from "./order-properties/order-properties-graph";
 
 const statTypeStruct = union([
@@ -113,6 +122,8 @@ export class HuiStatisticsGraphCardEditor
   @state() private _configEntities?: string[];
 
   @state() private _metaDatas?: StatisticsMetaData[];
+
+  @state() private _subElementEditorConfig?: SubElementEditorConfig;
 
   public setConfig(config: StatisticsGraphCardConfig): void {
     assert(config, cardConfigStruct);
@@ -334,9 +345,52 @@ export class HuiStatisticsGraphCardEditor
     }
   );
 
+  private _subForm = memoizeOne((localize: LocalizeFunc) => ({
+    schema: [
+      { name: "entity", required: true, selector: { statistic: {} } },
+      {
+        name: "name",
+        selector: { entity_name: {} },
+        context: {
+          entity: "entity",
+        },
+      },
+      {
+        name: "color",
+        selector: { ui_color: {} },
+      },
+    ] as const,
+    computeLabel: (item: HaFormSchema) => {
+      switch (item.name) {
+        case "entity":
+          return localize(
+            "ui.panel.lovelace.editor.card.statistics-graph.picked_statistic"
+          );
+        case "name":
+        case "color":
+          return localize(`ui.panel.lovelace.editor.card.generic.${item.name}`);
+        default:
+          return undefined;
+      }
+    },
+  }));
+
   protected render() {
     if (!this.hass || !this._config) {
       return nothing;
+    }
+
+    if (this._subElementEditorConfig) {
+      return html`
+        <hui-sub-element-editor
+          .hass=${this.hass}
+          .config=${this._subElementEditorConfig}
+          .form=${this._subForm(this.hass.localize)}
+          @go-back=${this._goBack}
+          @config-changed=${this._handleSubEntityChanged}
+        >
+        </hui-sub-element-editor>
+      `;
     }
 
     const schema = this._schema(
@@ -375,22 +429,41 @@ export class HuiStatisticsGraphCardEditor
         .computeHelper=${this._computeHelperCallback}
         @value-changed=${this._valueChanged}
       ></ha-form>
-      <ha-statistics-picker
-        .hass=${this.hass}
-        .placeholder=${this.hass!.localize(
-          "ui.panel.lovelace.editor.card.statistics-graph.pick_statistic"
-        )}
-        .label=${this.hass!.localize(
-          "ui.panel.lovelace.editor.card.statistics-graph.picked_statistic"
-        )}
-        .includeStatisticsUnitOfMeasurement=${statisticsUnit}
-        .includeUnitClass=${unitClass}
-        .ignoreRestrictionsOnFirstStatistic=${true}
-        .value=${this._configEntities}
-        .configValue=${"entities"}
-        @value-changed=${this._entitiesChanged}
-      ></ha-statistics-picker>
+        <ha-statistics-picker
+          .hass=${this.hass}
+          .placeholder=${this.hass!.localize(
+            "ui.panel.lovelace.editor.card.statistics-graph.pick_statistic"
+          )}
+          .label=${this.hass!.localize(
+            "ui.panel.lovelace.editor.card.statistics-graph.picked_statistic"
+          )}
+          .includeStatisticsUnitOfMeasurement=${statisticsUnit}
+          .includeUnitClass=${unitClass}
+          .ignoreRestrictionsOnFirstStatistic=${true}
+          .value=${this._configEntities}
+          .configValue=${"entities"}
+          can-edit
+          @value-changed=${this._entitiesChanged}
+          @edit-detail-element=${this._editDetailElement}
+        ></ha-statistics-picker>
+      </div>
     `;
+  }
+
+  private _goBack(): void {
+    this._subElementEditorConfig = undefined;
+  }
+
+  private _editDetailElement(ev: HASSDomEvent<EditDetailElementEvent>): void {
+    const index = ev.detail.subElementConfig.index!;
+    let elementConfig = this._config!.entities[index];
+    if (typeof elementConfig === "string") {
+      elementConfig = { entity: elementConfig };
+    }
+    this._subElementEditorConfig = {
+      ...ev.detail.subElementConfig,
+      ...{ elementConfig: elementConfig as EntityConfig },
+    };
   }
 
   private _valueChanged(ev: CustomEvent): void {
@@ -410,15 +483,66 @@ export class HuiStatisticsGraphCardEditor
     });
 
     let config = { ...this._config!, entities: newEntities };
+
+    // remove inappropriate stat options dependently on entities
+    config = await this._cleanConfig(config);
+    // normalize a generated yaml code
+    config = this._orderProperties(config);
+
+    fireEvent(this, "config-changed", {
+      config,
+    });
+  }
+
+  private async _handleSubEntityChanged(ev: CustomEvent): Promise<void> {
+    ev.stopPropagation();
+
+    // get updated entity config
+    let newEntityConfig = ev.detail.config as GraphEntityConfig;
+
+    // update card config with updated entity config
+    const index = this._subElementEditorConfig!.index!;
+    const newEntities = [...this._config!.entities];
+    newEntities[index] = newEntityConfig;
+    let config = this._config!;
+    config = { ...config, entities: newEntities };
+
+    // remove inappropriate stat options dependently on entities
+    config = await this._cleanConfig(config);
+    // normalize a generated yaml code
+    config = this._orderProperties(config);
+    this._config = config;
+
+    // update sub-element editor config
+    this._subElementEditorConfig = {
+      ...this._subElementEditorConfig!,
+      elementConfig: {
+        ...(this._config!.entities[index] as GraphEntityConfig),
+      },
+    };
+
+    fireEvent(this, "config-changed", { config });
+  }
+
+  // remove inappropriate stat options dependently on entities
+  private async _cleanConfig(
+    config: StatisticsGraphCardConfig
+  ): Promise<StatisticsGraphCardConfig> {
+    const entityIds = config.entities.map((entityConf) => {
+      if (typeof entityConf === "string") {
+        return entityConf;
+      }
+      return entityConf.entity ?? undefined;
+    });
     if (
-      newEntityIds?.some((statistic_id) => isExternalStatistic(statistic_id)) &&
+      entityIds.some((statistic_id) => isExternalStatistic(statistic_id)) &&
       config.period === "5minute"
     ) {
       delete config.period;
     }
     const metadata =
       config.stat_types || config.unit
-        ? await getStatisticMetadata(this.hass!, newEntityIds)
+        ? await getStatisticMetadata(this.hass!, entityIds)
         : undefined;
     if (config.stat_types && config.entities.length) {
       config.stat_types = ensureArray(config.stat_types).filter((stat_type) =>
@@ -438,10 +562,8 @@ export class HuiStatisticsGraphCardEditor
     ) {
       delete config.unit;
     }
-    config = this._orderProperties(config);
-    fireEvent(this, "config-changed", {
-      config,
-    });
+
+    return config;
   }
 
   // normalize a generated yaml code by placing lines in a consistent order

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -429,24 +429,23 @@ export class HuiStatisticsGraphCardEditor
         .computeHelper=${this._computeHelperCallback}
         @value-changed=${this._valueChanged}
       ></ha-form>
-        <ha-statistics-picker
-          .hass=${this.hass}
-          .placeholder=${this.hass!.localize(
-            "ui.panel.lovelace.editor.card.statistics-graph.pick_statistic"
-          )}
-          .label=${this.hass!.localize(
-            "ui.panel.lovelace.editor.card.statistics-graph.picked_statistic"
-          )}
-          .includeStatisticsUnitOfMeasurement=${statisticsUnit}
-          .includeUnitClass=${unitClass}
-          .ignoreRestrictionsOnFirstStatistic=${true}
-          .value=${this._configEntities}
-          .configValue=${"entities"}
-          can-edit
-          @value-changed=${this._entitiesChanged}
-          @edit-detail-element=${this._editDetailElement}
-        ></ha-statistics-picker>
-      </div>
+      <ha-statistics-picker
+        .hass=${this.hass}
+        .placeholder=${this.hass!.localize(
+          "ui.panel.lovelace.editor.card.statistics-graph.pick_statistic"
+        )}
+        .label=${this.hass!.localize(
+          "ui.panel.lovelace.editor.card.statistics-graph.picked_statistic"
+        )}
+        .includeStatisticsUnitOfMeasurement=${statisticsUnit}
+        .includeUnitClass=${unitClass}
+        .ignoreRestrictionsOnFirstStatistic=${true}
+        .value=${this._configEntities}
+        .configValue=${"entities"}
+        can-edit
+        @value-changed=${this._entitiesChanged}
+        @edit-detail-element=${this._editDetailElement}
+      ></ha-statistics-picker>
     `;
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

A further development for https://github.com/home-assistant/frontend/pull/51824.
SubEditor added for a statistics entry - allows to select a statistics_id, name, color.

A possible improvement - adding a new type for sub-element-editor, otherwise we have that "Entity row editor" label for Statistics Graph card, History Graph card, Map card....


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

<img width="544" height="594" alt="изображение" src="https://github.com/user-attachments/assets/99f697c0-e32e-46c2-b621-083e6f1178f8" />

<img width="1033" height="569" alt="изображение" src="https://github.com/user-attachments/assets/1996997a-ac4a-4f2c-a210-a96b0b80609c" />




## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
