### PR TITLE
Show raw advertisement bytes in Bluetooth device info

### DIFF
--- a/src/data/bluetooth.ts
+++ b/src/data/bluetooth.ts
@@ -17,6 +17,7 @@ export interface BluetoothDeviceData extends DataTableRowData {
   source: string;
   time: number;
   tx_power: number;
+  raw: string | null;
 }
 
 export interface BluetoothConnectionData extends DataTableRowData {

--- a/src/panels/config/integrations/integration-panels/bluetooth/dialog-bluetooth-device-info.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/dialog-bluetooth-device-info.ts
@@ -129,9 +129,9 @@ class DialogBluetoothDeviceInfo extends LitElement {
                   "ui.panel.config.bluetooth.raw_advertisement"
                 )}
               </h4>
-              <pre class="raw">
-${this.showDataAsHex(this._params.entry.raw)}</pre
-              >
+              <div class="raw">
+                ${this.showDataAsHex(this._params.entry.raw)}
+              </div>
             `
           : nothing}
         <ha-dialog-footer slot="footer">
@@ -148,12 +148,10 @@ ${this.showDataAsHex(this._params.entry.raw)}</pre
   }
 
   static readonly styles: CSSResultGroup = css`
-    pre.raw {
-      white-space: pre-wrap;
+    .raw {
       word-break: break-all;
       font-family: var(--ha-font-family-code);
       font-size: var(--ha-font-size-s);
-      margin: 0;
     }
   `;
 }

--- a/src/panels/config/integrations/integration-panels/bluetooth/dialog-bluetooth-device-info.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/dialog-bluetooth-device-info.ts
@@ -1,5 +1,5 @@
-import type { TemplateResult } from "lit";
-import { html, LitElement, nothing } from "lit";
+import type { CSSResultGroup, TemplateResult } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { copyToClipboard } from "../../../../../common/util/copy-clipboard";
@@ -121,6 +121,19 @@ class DialogBluetoothDeviceInfo extends LitElement {
             )}
           </tbody>
         </table>
+
+        ${this._params.entry.raw
+          ? html`
+              <h4>
+                ${this.hass.localize(
+                  "ui.panel.config.bluetooth.raw_advertisement"
+                )}
+              </h4>
+              <pre class="raw">
+${this.showDataAsHex(this._params.entry.raw)}</pre
+              >
+            `
+          : nothing}
         <ha-dialog-footer slot="footer">
           <ha-button
             slot="secondaryAction"
@@ -133,6 +146,16 @@ class DialogBluetoothDeviceInfo extends LitElement {
       </ha-dialog>
     `;
   }
+
+  static readonly styles: CSSResultGroup = css`
+    pre.raw {
+      white-space: pre-wrap;
+      word-break: break-all;
+      font-family: var(--ha-font-family-code);
+      font-size: var(--ha-font-size-s);
+      margin: 0;
+    }
+  `;
 }
 
 declare global {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7149,6 +7149,7 @@
           "manufacturer_data": "Manufacturer data",
           "service_data": "Service data",
           "service_uuids": "Service UUIDs",
+          "raw_advertisement": "Raw advertisement",
           "copy_to_clipboard": "[%key:ui::panel::config::automation::editor::copy_to_clipboard%]",
           "area": "Area",
           "scanners": "Scanners",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Surfaces the raw advertisement hex from BluetoothServiceInfoBleak in the device info dialog; manufacturer_data and service_data are aggregated across packets, so the raw bytes are the only way to see what the latest packet actually contained. The field is already serialized by the backend, this PR just renders it when present.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
<img width="571" height="520" alt="Screenshot 2026-05-24 at 4 09 10 PM" src="https://github.com/user-attachments/assets/566e67d7-d883-481d-8c9d-4f76b561b191" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
