### PR TITLE
Shared sections proof of concept

### DIFF
--- a/src/data/lovelace/config/section.ts
+++ b/src/data/lovelace/config/section.ts
@@ -31,9 +31,28 @@ export interface LovelaceStrategySectionConfig extends LovelaceBaseSectionConfig
   strategy: LovelaceStrategyConfig;
 }
 
+export interface LovelaceSharedSectionConfig extends LovelaceBaseSectionConfig {
+  id: string;
+  type?: string;
+  cards?: LovelaceCardConfig[];
+}
+
+export interface LovelaceSectionRefConfig {
+  section_ref: string;
+  column_span?: number;
+  row_span?: number;
+}
+
 export type LovelaceSectionRawConfig =
   | LovelaceSectionConfig
-  | LovelaceStrategySectionConfig;
+  | LovelaceStrategySectionConfig
+  | LovelaceSectionRefConfig;
+
+export function isSectionRef(
+  section: LovelaceSectionRawConfig
+): section is LovelaceSectionRefConfig {
+  return "section_ref" in section;
+}
 
 export function resolveSectionBackground(
   background: boolean | LovelaceSectionBackgroundConfig | undefined

--- a/src/data/lovelace/config/types.ts
+++ b/src/data/lovelace/config/types.ts
@@ -1,6 +1,7 @@
 import type { Connection } from "home-assistant-js-websocket";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceResource } from "../resource";
+import type { LovelaceSharedSectionConfig } from "./section";
 import type { LovelaceStrategyConfig } from "./strategy";
 import type { LovelaceViewRawConfig } from "./view";
 
@@ -9,6 +10,7 @@ export interface LovelaceDashboardBaseConfig {}
 export interface LovelaceConfig extends LovelaceDashboardBaseConfig {
   background?: string;
   views: LovelaceViewRawConfig[];
+  shared_sections?: LovelaceSharedSectionConfig[];
 }
 
 export interface LovelaceDashboardStrategyConfig extends LovelaceDashboardBaseConfig {

--- a/src/panels/lovelace/common/check-lovelace-config.ts
+++ b/src/panels/lovelace/common/check-lovelace-config.ts
@@ -1,5 +1,8 @@
 import type { LovelaceSectionRawConfig } from "../../../data/lovelace/config/section";
-import { isStrategySection } from "../../../data/lovelace/config/section";
+import {
+  isSectionRef,
+  isStrategySection,
+} from "../../../data/lovelace/config/section";
 import type { LovelaceRawConfig } from "../../../data/lovelace/config/types";
 import { isStrategyDashboard } from "../../../data/lovelace/config/types";
 import type { LovelaceViewRawConfig } from "../../../data/lovelace/config/view";
@@ -46,6 +49,11 @@ export const checkViewConfig = (
 export const checkSectionConfig = (
   section: LovelaceSectionRawConfig
 ): LovelaceSectionRawConfig => {
+  // Note Erwin: if I understand correctly, ref sections don't need migration, as they defer all content to the shared definition. So we can skip them :)
+  if (isSectionRef(section)) {
+    return section;
+  }
+
   const updatedSection = { ...section };
 
   // Move title to a heading card

--- a/src/panels/lovelace/components/hui-section-edit-mode.ts
+++ b/src/panels/lovelace/components/hui-section-edit-mode.ts
@@ -3,11 +3,15 @@ import {
   mdiDelete,
   mdiDotsVertical,
   mdiDragHorizontalVariant,
+  mdiLinkOff,
+  mdiLinkVariant,
   mdiPencil,
   mdiPlusCircleMultipleOutline,
+  mdiShareVariant,
 } from "@mdi/js";
+import deepClone from "deep-clone-simple";
 import type { CSSResultGroup, TemplateResult } from "lit";
-import { LitElement, css, html } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import "../../../components/ha-dropdown";
 import type { HaDropdownSelectEvent } from "../../../components/ha-dropdown";
@@ -17,8 +21,17 @@ import "../../../components/ha-svg-icon";
 import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
-import { deleteSection, duplicateSection } from "../editor/config-util";
-import { findLovelaceContainer } from "../editor/lovelace-path";
+import {
+  deleteSection,
+  duplicateSection,
+  getSharedSection,
+  promoteToSharedSection,
+} from "../editor/config-util";
+import {
+  findLovelaceContainer,
+  updateLovelaceContainer,
+} from "../editor/lovelace-path";
+import { isSectionRef } from "../../../data/lovelace/config/section";
 import { showEditSectionDialog } from "../editor/section-editor/show-edit-section-dialog";
 import type { Lovelace } from "../types";
 
@@ -33,6 +46,12 @@ export class HuiSectionEditMode extends LitElement {
   @property({ attribute: false }) public viewIndex!: number;
 
   protected render(): TemplateResult {
+    const section = findLovelaceContainer(this.lovelace.config, [
+      this.viewIndex,
+      this.index,
+    ]);
+    const isRef = isSectionRef(section);
+
     return html`
       <div class="section-header">
         <div class="section-actions">
@@ -41,6 +60,15 @@ export class HuiSectionEditMode extends LitElement {
             class="handle"
             .path=${mdiDragHorizontalVariant}
           ></ha-svg-icon>
+          ${isRef
+            ? html`<ha-svg-icon
+                aria-label=${this.hass.localize(
+                  "ui.panel.lovelace.editor.section.shared_indicator"
+                )}
+                class="shared-indicator"
+                .path=${mdiLinkVariant}
+              ></ha-svg-icon>`
+            : nothing}
           <ha-dropdown
             placement="bottom-end"
             @wa-select=${this._handleDropdownSelect}
@@ -50,7 +78,7 @@ export class HuiSectionEditMode extends LitElement {
               .label=${this.hass.localize("ui.common.menu")}
               .path=${mdiDotsVertical}
             ></ha-icon-button>
-            <ha-dropdown-item value="edit">
+            <ha-dropdown-item value=${isRef ? "edit-shared" : "edit"}>
               <ha-svg-icon slot="icon" .path=${mdiPencil}></ha-svg-icon>
               ${this.hass.localize("ui.common.edit")}
             </ha-dropdown-item>
@@ -61,6 +89,26 @@ export class HuiSectionEditMode extends LitElement {
               ></ha-svg-icon>
               ${this.hass.localize("ui.common.duplicate")}
             </ha-dropdown-item>
+            ${isRef
+              ? html`
+                  <ha-dropdown-item value="unlink">
+                    <ha-svg-icon slot="icon" .path=${mdiLinkOff}></ha-svg-icon>
+                    ${this.hass.localize(
+                      "ui.panel.lovelace.editor.section.unlink_section"
+                    )}
+                  </ha-dropdown-item>
+                `
+              : html`
+                  <ha-dropdown-item value="share">
+                    <ha-svg-icon
+                      slot="icon"
+                      .path=${mdiShareVariant}
+                    ></ha-svg-icon>
+                    ${this.hass.localize(
+                      "ui.panel.lovelace.editor.section.share_section"
+                    )}
+                  </ha-dropdown-item>
+                `}
             <wa-divider></wa-divider>
             <ha-dropdown-item value="delete" variant="danger">
               <ha-svg-icon slot="icon" .path=${mdiDelete}></ha-svg-icon>
@@ -82,8 +130,17 @@ export class HuiSectionEditMode extends LitElement {
       case "edit":
         this._editSection();
         break;
+      case "edit-shared":
+        this._editSharedSection();
+        break;
       case "duplicate":
         this._duplicateSection();
+        break;
+      case "share":
+        this._shareSection();
+        break;
+      case "unlink":
+        this._unlinkSection();
         break;
       case "delete":
         this._deleteSection();
@@ -103,6 +160,19 @@ export class HuiSectionEditMode extends LitElement {
     });
   }
 
+  private async _editSharedSection() {
+    showEditSectionDialog(this, {
+      lovelace: this.lovelace!,
+      lovelaceConfig: this.lovelace!.config,
+      saveConfig: (newConfig) => {
+        this.lovelace!.saveConfig(newConfig);
+      },
+      viewIndex: this.viewIndex,
+      sectionIndex: this.index,
+      editSharedDefinition: true,
+    });
+  }
+
   private _duplicateSection(): void {
     const newConfig = duplicateSection(
       this.lovelace!.config,
@@ -112,26 +182,70 @@ export class HuiSectionEditMode extends LitElement {
     this.lovelace!.saveConfig(newConfig);
   }
 
+  private _shareSection(): void {
+    const newConfig = promoteToSharedSection(
+      this.lovelace!.config,
+      this.viewIndex,
+      this.index
+    );
+    this.lovelace!.saveConfig(newConfig);
+  }
+
+  private _unlinkSection(): void {
+    const section = findLovelaceContainer(this.lovelace.config, [
+      this.viewIndex,
+      this.index,
+    ]);
+    if (!isSectionRef(section)) return;
+
+    const sharedDef = getSharedSection(
+      this.lovelace.config,
+      section.section_ref
+    );
+
+    // Deep-clone the shared definition and apply layout overrides from the ref
+    const concreteSection = {
+      ...(sharedDef ? deepClone(sharedDef) : { type: "grid", cards: [] }),
+      ...(section.column_span !== undefined && {
+        column_span: section.column_span,
+      }),
+      ...(section.row_span !== undefined && { row_span: section.row_span }),
+    };
+
+    // Remove the shared-section id field — it belongs only in shared_sections
+    if ("id" in concreteSection) {
+      delete (concreteSection as { id?: string }).id;
+    }
+
+    const newConfig = updateLovelaceContainer(
+      this.lovelace.config,
+      [this.viewIndex, this.index],
+      concreteSection
+    );
+    this.lovelace!.saveConfig(newConfig);
+  }
+
   private async _deleteSection() {
     const path = [this.viewIndex, this.index] as [number, number];
 
     const section = findLovelaceContainer(this.lovelace!.config, path);
 
-    const cardCount = "cards" in section && section.cards?.length;
-
-    if (cardCount) {
-      const confirm = await showConfirmationDialog(this, {
-        title: this.hass.localize(
-          "ui.panel.lovelace.editor.delete_section.title"
-        ),
-        text: this.hass.localize(
-          `ui.panel.lovelace.editor.delete_section.text`
-        ),
-        confirmText: this.hass.localize("ui.common.delete"),
-        destructive: true,
-      });
-
-      if (!confirm) return;
+    // For ref sections just remove the reference — no card-count prompt needed
+    if (!isSectionRef(section)) {
+      const cardCount = "cards" in section && section.cards?.length;
+      if (cardCount) {
+        const confirm = await showConfirmationDialog(this, {
+          title: this.hass.localize(
+            "ui.panel.lovelace.editor.delete_section.title"
+          ),
+          text: this.hass.localize(
+            `ui.panel.lovelace.editor.delete_section.text`
+          ),
+          confirmText: this.hass.localize("ui.common.delete"),
+          destructive: true,
+        });
+        if (!confirm) return;
+      }
     }
 
     const newConfig = deleteSection(
@@ -181,6 +295,12 @@ export class HuiSectionEditMode extends LitElement {
         .handle {
           cursor: grab;
           padding: 8px;
+        }
+
+        .shared-indicator {
+          padding: 8px;
+          color: var(--primary-color);
+          --mdc-icon-size: 16px;
         }
 
         .section-wrapper {

--- a/src/panels/lovelace/editor/config-util.ts
+++ b/src/panels/lovelace/editor/config-util.ts
@@ -1,8 +1,17 @@
 import deepClone from "deep-clone-simple";
+import { generateUuidV4 } from "../../../common/util/uuid";
 import type { LovelaceBadgeConfig } from "../../../data/lovelace/config/badge";
 import { ensureBadgeConfig } from "../../../data/lovelace/config/badge";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
-import type { LovelaceSectionRawConfig } from "../../../data/lovelace/config/section";
+import type {
+  LovelaceSectionRefConfig,
+  LovelaceSectionRawConfig,
+  LovelaceSharedSectionConfig,
+} from "../../../data/lovelace/config/section";
+import {
+  isSectionRef,
+  isStrategySection,
+} from "../../../data/lovelace/config/section";
 import type { LovelaceConfig } from "../../../data/lovelace/config/types";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import { isStrategyView } from "../../../data/lovelace/config/view";
@@ -353,6 +362,123 @@ export const moveSection = (
   newConfig = insertSection(newConfig, toPath[0], toPath[1], section);
 
   return newConfig;
+};
+
+export const getSharedSection = (
+  config: LovelaceConfig,
+  id: string
+): LovelaceSharedSectionConfig | undefined =>
+  config.shared_sections?.find((s) => s.id === id);
+
+// Count how many section refs across all views reference
+export const countSharedSectionRefs = (
+  config: LovelaceConfig,
+  id: string
+): number =>
+  config.views.reduce((total, view) => {
+    if (isStrategyView(view) || !view.sections) return total;
+    return (
+      total +
+      view.sections.filter((s) => isSectionRef(s) && s.section_ref === id)
+        .length
+    );
+  }, 0);
+
+// Create one and update the config with the new shared section definition
+export const createSharedSection = (
+  config: LovelaceConfig,
+  sectionConfig: Omit<LovelaceSharedSectionConfig, "id">
+): { config: LovelaceConfig; id: string } => {
+  const id = generateUuidV4();
+  const newSharedSection: LovelaceSharedSectionConfig = {
+    ...sectionConfig,
+    id,
+  };
+  return {
+    config: {
+      ...config,
+      shared_sections: [...(config.shared_sections ?? []), newSharedSection],
+    },
+    id,
+  };
+};
+
+export const updateSharedSection = (
+  config: LovelaceConfig,
+  id: string,
+  updates: Partial<Omit<LovelaceSharedSectionConfig, "id">>
+): LovelaceConfig => ({
+  ...config,
+  shared_sections: (config.shared_sections ?? []).map((s) =>
+    s.id === id ? { ...s, ...updates } : s
+  ),
+});
+
+export const deleteSharedSection = (
+  config: LovelaceConfig,
+  id: string
+): LovelaceConfig => {
+  const newSharedSections = (config.shared_sections ?? []).filter(
+    (s) => s.id !== id
+  );
+  const newViews = config.views.map((view) => {
+    if (isStrategyView(view) || !view.sections) return view;
+    const filteredSections = view.sections.filter(
+      (s) => !(isSectionRef(s) && s.section_ref === id)
+    );
+    if (filteredSections.length === view.sections.length) return view;
+    return { ...view, sections: filteredSections };
+  });
+  return {
+    ...config,
+    shared_sections: newSharedSections,
+    views: newViews,
+  };
+};
+
+// Promote to shared section and open the shared section editor for the new shared section
+// Note Erwin: if there are better approaches here, please let me know in the review :)
+export const promoteToSharedSection = (
+  config: LovelaceConfig,
+  viewIndex: number,
+  sectionIndex: number
+): LovelaceConfig => {
+  const view = findLovelaceContainer(config, [viewIndex]);
+  if (isStrategyView(view)) {
+    throw new Error("Cannot promote a section in a strategy view");
+  }
+  const section = view.sections?.[sectionIndex];
+  if (!section) {
+    throw new Error("Section does not exist");
+  }
+  if (isSectionRef(section) || isStrategySection(section)) {
+    throw new Error("Section is already a reference or strategy section");
+  }
+
+  const { column_span, row_span, ...sharedDef } = section;
+
+  const { config: newConfig, id } = createSharedSection(config, sharedDef);
+
+  const ref: LovelaceSectionRefConfig = {
+    section_ref: id,
+    ...(column_span !== undefined && { column_span }),
+    ...(row_span !== undefined && { row_span }),
+  };
+
+  const updatedView = {
+    ...view,
+    sections: view.sections!.map((s, idx) => (idx === sectionIndex ? ref : s)),
+  };
+  return updateLovelaceContainer(newConfig, [viewIndex], updatedView);
+};
+
+export const addSectionRef = (
+  config: LovelaceConfig,
+  viewIndex: number,
+  sharedSectionId: string
+): LovelaceConfig => {
+  const ref: LovelaceSectionRefConfig = { section_ref: sharedSectionId };
+  return addSection(config, viewIndex, ref);
 };
 
 export const addBadge = (

--- a/src/panels/lovelace/editor/lovelace-path.ts
+++ b/src/panels/lovelace/editor/lovelace-path.ts
@@ -1,7 +1,10 @@
 import type { LovelaceBadgeConfig } from "../../../data/lovelace/config/badge";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
 import type { LovelaceSectionRawConfig } from "../../../data/lovelace/config/section";
-import { isStrategySection } from "../../../data/lovelace/config/section";
+import {
+  isSectionRef,
+  isStrategySection,
+} from "../../../data/lovelace/config/section";
 import type { LovelaceConfig } from "../../../data/lovelace/config/types";
 import type { LovelaceViewRawConfig } from "../../../data/lovelace/config/view";
 import { isStrategyView } from "../../../data/lovelace/config/view";
@@ -157,6 +160,11 @@ export const updateLovelaceItems = <T extends keyof LovelaceItemKeys>(
       if (isStrategySection(section)) {
         throw new Error(`Can not update ${key} in a strategy section`);
       }
+      if (isSectionRef(section)) {
+        throw new Error(
+          `Can't update ${key} in a shared section ref - edit the shared section definition instead`
+        );
+      }
       updated = true;
       return {
         ...section,
@@ -204,6 +212,11 @@ export const findLovelaceItems = <T extends keyof LovelaceItemKeys>(
   }
   if (isStrategySection(section)) {
     throw new Error("Can not find cards in a strategy section");
+  }
+  if (isSectionRef(section)) {
+    throw new Error(
+      "Can not find cards in a shared section ref — edit the shared section definition instead"
+    );
   }
   if (key === "cards") {
     return section[key as "cards"] as LovelaceItemKeys[T] | undefined;

--- a/src/panels/lovelace/editor/section-editor/hui-dialog-add-section.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-dialog-add-section.ts
@@ -1,0 +1,322 @@
+import { mdiClose, mdiLinkVariant, mdiPlusBox } from "@mdi/js";
+import type { CSSResultGroup, TemplateResult } from "lit";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-button";
+import "../../../../components/ha-dialog";
+import "../../../../components/ha-dialog-header";
+import "../../../../components/ha-icon-button";
+import "../../../../components/ha-svg-icon";
+import type { LovelaceSharedSectionConfig } from "../../../../data/lovelace/config/section";
+import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
+import { haStyleDialog } from "../../../../resources/styles";
+import type { HomeAssistant } from "../../../../types";
+import {
+  addSection,
+  addSectionRef,
+  countSharedSectionRefs,
+} from "../config-util";
+import type { AddSectionDialogParams } from "./show-add-section-dialog";
+import { generateDefaultSection } from "../../views/default-section";
+
+@customElement("hui-dialog-add-section")
+export class HuiDialogAddSection
+  extends LitElement
+  implements HassDialog<AddSectionDialogParams>
+{
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _params?: AddSectionDialogParams;
+
+  @state() private _open = false;
+
+  public async showDialog(params: AddSectionDialogParams): Promise<void> {
+    this._params = params;
+    this._open = true;
+  }
+
+  public closeDialog(): boolean {
+    this._open = false;
+    return true;
+  }
+
+  private _dialogClosed(): void {
+    this._params = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render(): TemplateResult | typeof nothing {
+    if (!this._params) {
+      return nothing;
+    }
+
+    const sharedSections = this._params.lovelaceConfig.shared_sections ?? [];
+
+    return html`
+      <ha-dialog .open=${this._open} @closed=${this._dialogClosed}>
+        <ha-dialog-header show-border slot="header">
+          <ha-icon-button
+            slot="navigationIcon"
+            @click=${this.closeDialog}
+            .label=${this.hass.localize("ui.common.close")}
+            .path=${mdiClose}
+          ></ha-icon-button>
+          <span slot="title">
+            ${this.hass.localize("ui.panel.lovelace.editor.add_section.header")}
+          </span>
+        </ha-dialog-header>
+
+        <div class="options">
+          <!-- New section -->
+          <button class="option-card" @click=${this._createNewSection}>
+            <ha-svg-icon .path=${mdiPlusBox}></ha-svg-icon>
+            <span class="option-label">
+              ${this.hass.localize(
+                "ui.panel.lovelace.editor.add_section.new_section"
+              )}
+            </span>
+          </button>
+        </div>
+
+        ${sharedSections.length > 0
+          ? html`
+              <div class="shared-section">
+                <h3>
+                  ${this.hass.localize(
+                    "ui.panel.lovelace.editor.add_section.use_shared_section"
+                  )}
+                </h3>
+                <div class="shared-list">
+                  ${sharedSections.map((section) =>
+                    this._renderSharedOption(section)
+                  )}
+                </div>
+              </div>
+            `
+          : html`
+              <div class="empty-shared">
+                <ha-svg-icon .path=${mdiLinkVariant}></ha-svg-icon>
+                <p>
+                  ${this.hass.localize(
+                    "ui.panel.lovelace.editor.add_section.no_shared_sections_yet"
+                  )}
+                </p>
+                <span class="hint">
+                  ${this.hass.localize(
+                    "ui.panel.lovelace.editor.add_section.no_shared_sections_hint"
+                  )}
+                </span>
+              </div>
+            `}
+      </ha-dialog>
+    `;
+  }
+
+  private _renderSharedOption(
+    section: LovelaceSharedSectionConfig
+  ): TemplateResult {
+    const label = this._getSectionLabel(section);
+    const cardCount = section.cards?.length ?? 0;
+    const refCount = countSharedSectionRefs(
+      this._params!.lovelaceConfig,
+      section.id
+    );
+
+    return html`
+      <button
+        class="shared-option"
+        data-section-id=${section.id}
+        @click=${this._insertSharedSection}
+      >
+        <ha-svg-icon .path=${mdiLinkVariant}></ha-svg-icon>
+        <div class="shared-option-info">
+          <span class="shared-option-name">${label}</span>
+          <span class="shared-option-meta">
+            ${this.hass.localize(
+              "ui.panel.lovelace.editor.manage_shared_sections.cards_count",
+              { count: cardCount }
+            )}
+            ·
+            ${this.hass.localize(
+              "ui.panel.lovelace.editor.manage_shared_sections.used_in_views",
+              { count: refCount }
+            )}
+          </span>
+        </div>
+      </button>
+    `;
+  }
+
+  private _getSectionLabel(section: LovelaceSharedSectionConfig): string {
+    const headingCard = section.cards?.find((c) => c.type === "heading");
+    if (headingCard && "heading" in headingCard && headingCard.heading) {
+      return String(headingCard.heading);
+    }
+    return this.hass.localize(
+      "ui.panel.lovelace.editor.manage_shared_sections.unnamed_section",
+      { id: section.id.slice(0, 8) }
+    );
+  }
+
+  private _createNewSection(): void {
+    if (!this._params) return;
+    const newConfig = addSection(
+      this._params.lovelaceConfig,
+      this._params.viewIndex,
+      generateDefaultSection(this.hass.localize, true)
+    );
+    this._params.saveConfig(newConfig);
+    this.closeDialog();
+  }
+
+  private _insertSharedSection(ev: Event): void {
+    if (!this._params) return;
+    const sharedSectionId = (ev.currentTarget as HTMLElement).dataset
+      .sectionId!;
+    const newConfig = addSectionRef(
+      this._params.lovelaceConfig,
+      this._params.viewIndex,
+      sharedSectionId
+    );
+    this._params.saveConfig(newConfig);
+    this.closeDialog();
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyleDialog,
+      css`
+        .options {
+          display: flex;
+          gap: var(--ha-space-2);
+          padding: var(--ha-space-2) 0 var(--ha-space-4);
+        }
+
+        .option-card {
+          flex: 1;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: var(--ha-space-2);
+          padding: var(--ha-space-4);
+          background: var(--secondary-background-color);
+          border: 2px solid var(--divider-color);
+          border-radius: var(--ha-border-radius-l);
+          cursor: pointer;
+          transition:
+            border-color 0.15s ease,
+            background 0.15s ease;
+          font-size: 1em;
+          color: var(--primary-text-color);
+        }
+
+        .option-card:hover,
+        .option-card:focus-visible {
+          border-color: var(--primary-color);
+          background: var(--card-background-color);
+        }
+
+        .option-card ha-svg-icon {
+          --mdc-icon-size: 32px;
+          color: var(--primary-color);
+        }
+
+        .option-label {
+          font-weight: 500;
+        }
+
+        .shared-section h3 {
+          margin: 0 0 var(--ha-space-2);
+          font-size: 0.85em;
+          font-weight: 500;
+          color: var(--secondary-text-color);
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+        }
+
+        .shared-list {
+          display: flex;
+          flex-direction: column;
+          gap: var(--ha-space-1);
+        }
+
+        .shared-option {
+          display: flex;
+          align-items: center;
+          gap: var(--ha-space-2);
+          padding: var(--ha-space-2) var(--ha-space-3);
+          background: var(--secondary-background-color);
+          border: 1px solid var(--divider-color);
+          border-radius: var(--ha-border-radius-m);
+          cursor: pointer;
+          width: 100%;
+          text-align: start;
+          color: var(--primary-text-color);
+          font-size: 1em;
+          transition: background 0.15s ease;
+        }
+
+        .shared-option:hover,
+        .shared-option:focus-visible {
+          background: var(--card-background-color);
+        }
+
+        .shared-option ha-svg-icon {
+          color: var(--primary-color);
+          flex-shrink: 0;
+        }
+
+        .shared-option-info {
+          display: flex;
+          flex-direction: column;
+          gap: 2px;
+          min-width: 0;
+        }
+
+        .shared-option-name {
+          font-weight: 500;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .shared-option-meta {
+          font-size: 0.85em;
+          color: var(--secondary-text-color);
+        }
+
+        .empty-shared {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: var(--ha-space-1);
+          padding: var(--ha-space-4);
+          background: var(--secondary-background-color);
+          border-radius: var(--ha-border-radius-l);
+          color: var(--secondary-text-color);
+          text-align: center;
+        }
+
+        .empty-shared ha-svg-icon {
+          --mdc-icon-size: 24px;
+        }
+
+        .empty-shared p {
+          margin: 0;
+          font-weight: 500;
+        }
+
+        .hint {
+          font-size: 0.85em;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-dialog-add-section": HuiDialogAddSection;
+  }
+}

--- a/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-dialog-edit-section.ts
@@ -10,6 +10,7 @@ import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { stopPropagation } from "../../../../common/dom/stop_propagation";
+import "../../../../components/ha-alert";
 import "../../../../components/ha-button";
 import "../../../../components/ha-dialog-header";
 import "../../../../components/ha-dialog-footer";
@@ -21,7 +22,11 @@ import "../../../../components/ha-tab-group";
 import "../../../../components/ha-tab-group-tab";
 import "../../../../components/ha-yaml-editor";
 import type { HaYamlEditor } from "../../../../components/ha-yaml-editor";
-import type { LovelaceSectionRawConfig } from "../../../../data/lovelace/config/section";
+import type {
+  LovelaceSharedSectionConfig,
+  LovelaceSectionRawConfig,
+} from "../../../../data/lovelace/config/section";
+import { isSectionRef } from "../../../../data/lovelace/config/section";
 import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
 import { saveConfig } from "../../../../data/lovelace/config/types";
 import {
@@ -36,7 +41,13 @@ import {
 } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import type { Lovelace } from "../../types";
-import { addSection, deleteSection, moveSection } from "../config-util";
+import {
+  addSection,
+  deleteSection,
+  getSharedSection,
+  moveSection,
+  updateSharedSection,
+} from "../config-util";
 import {
   findLovelaceContainer,
   updateLovelaceContainer,
@@ -72,6 +83,14 @@ export class HuiDialogEditSection
 
   @state() private _open = false;
 
+  @state() private _isRef = false;
+
+  @state() private _sharedSectionId?: string;
+
+  @state() private _editingSharedDef = false;
+
+  @state() private _layoutOnly = false;
+
   @query("ha-yaml-editor") private _editor?: HaYamlEditor;
 
   protected updated(changedProperties: PropertyValues) {
@@ -89,13 +108,36 @@ export class HuiDialogEditSection
 
     this.lovelace = params.lovelace;
 
-    this._config = findLovelaceContainer(this._params.lovelaceConfig, [
+    const rawSection = findLovelaceContainer(this._params.lovelaceConfig, [
       this._params.viewIndex,
       this._params.sectionIndex,
     ]);
+    this._isRef = isSectionRef(rawSection);
     this._viewConfig = findLovelaceContainer(this._params.lovelaceConfig, [
       this._params.viewIndex,
-    ]);
+    ]) as LovelaceViewConfig;
+
+    if (this._isRef && isSectionRef(rawSection)) {
+      this._sharedSectionId = rawSection.section_ref;
+      const editShared = params.editSharedDefinition ?? true;
+      this._editingSharedDef = editShared;
+      this._layoutOnly = !editShared;
+
+      if (editShared) {
+        const sharedDef = getSharedSection(
+          this._params.lovelaceConfig,
+          rawSection.section_ref
+        );
+        this._config = sharedDef ?? rawSection;
+      } else {
+        this._config = rawSection;
+      }
+    } else {
+      this._sharedSectionId = undefined;
+      this._editingSharedDef = false;
+      this._layoutOnly = false;
+      this._config = rawSection;
+    }
   }
 
   public closeDialog() {
@@ -108,6 +150,10 @@ export class HuiDialogEditSection
     this._yamlMode = false;
     this._config = undefined;
     this._currTab = TABS[0];
+    this._isRef = false;
+    this._sharedSectionId = undefined;
+    this._editingSharedDef = false;
+    this._layoutOnly = false;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
@@ -116,14 +162,34 @@ export class HuiDialogEditSection
       return nothing;
     }
 
-    const heading = this.hass!.localize(
-      "ui.panel.lovelace.editor.edit_section.header"
-    );
+    const heading =
+      this._isRef && this._editingSharedDef
+        ? this.hass!.localize(
+            "ui.panel.lovelace.editor.section.edit_shared_section"
+          )
+        : this._isRef && this._layoutOnly
+          ? this.hass!.localize(
+              "ui.panel.lovelace.editor.section.edit_layout_options"
+            )
+          : this.hass!.localize("ui.panel.lovelace.editor.edit_section.header");
+
+    const sharedBanner =
+      this._isRef && this._editingSharedDef
+        ? html`
+            <ha-alert alert-type="info">
+              ${this.hass!.localize(
+                "ui.panel.lovelace.editor.section.shared_section_banner"
+              )}
+            </ha-alert>
+          `
+        : nothing;
 
     let content: TemplateResult<1> | typeof nothing = nothing;
 
     if (this._yamlMode) {
+      // Not pixel perfect, so open to feedback here
       content = html`
+        ${sharedBanner}
         <ha-yaml-editor
           autofocus
           in-dialog
@@ -134,10 +200,12 @@ export class HuiDialogEditSection
       switch (this._currTab) {
         case "tab-settings":
           content = html`
+            ${sharedBanner}
             <hui-section-settings-editor
               .hass=${this.hass}
               .config=${this._config}
               .viewConfig=${this._viewConfig}
+              .layoutOnly=${this._layoutOnly}
               @value-changed=${this._configChanged}
             >
             </hui-section-settings-editor>
@@ -145,6 +213,7 @@ export class HuiDialogEditSection
           break;
         case "tab-visibility":
           content = html`
+            ${sharedBanner}
             <hui-section-visibility-editor
               .hass=${this.hass}
               .config=${this._config}
@@ -416,11 +485,26 @@ export class HuiDialogEditSection
     if (!this._params || !this._config) {
       return;
     }
-    const newConfig = updateLovelaceContainer(
-      this._params.lovelaceConfig,
-      [this._params.viewIndex, this._params.sectionIndex],
-      this._config
-    );
+
+    let newConfig: LovelaceConfig;
+
+    if (this._isRef && this._editingSharedDef && this._sharedSectionId) {
+      // Save changes to the shared section definition (affects all views)
+      const { id: _id, ...updates } = this
+        ._config as LovelaceSharedSectionConfig;
+      newConfig = updateSharedSection(
+        this._params.lovelaceConfig,
+        this._sharedSectionId,
+        updates
+      );
+    } else {
+      // Standard save: update the section (or ref's layout props) in the view
+      newConfig = updateLovelaceContainer(
+        this._params.lovelaceConfig,
+        [this._params.viewIndex, this._params.sectionIndex],
+        this._config
+      );
+    }
 
     this._params.saveConfig(newConfig);
     this.closeDialog();

--- a/src/panels/lovelace/editor/section-editor/hui-dialog-manage-shared-sections.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-dialog-manage-shared-sections.ts
@@ -1,0 +1,305 @@
+import { mdiClose, mdiDelete, mdiPencil } from "@mdi/js";
+import type { CSSResultGroup, TemplateResult } from "lit";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-button";
+import "../../../../components/ha-dialog";
+import "../../../../components/ha-dialog-header";
+import "../../../../components/ha-icon-button";
+import "../../../../components/ha-icon-button-toggle";
+import "../../../../components/ha-list-item";
+import "../../../../components/ha-svg-icon";
+import type { LovelaceSharedSectionConfig } from "../../../../data/lovelace/config/section";
+import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
+import { haStyleDialog } from "../../../../resources/styles";
+import type { HomeAssistant } from "../../../../types";
+import { countSharedSectionRefs, deleteSharedSection } from "../config-util";
+import { showConfirmationDialog } from "../../../../dialogs/generic/show-dialog-box";
+import { showEditSectionDialog } from "./show-edit-section-dialog";
+import type { ManageSharedSectionsDialogParams } from "./show-manage-shared-sections-dialog";
+import type { Lovelace } from "../../types";
+import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
+
+@customElement("hui-dialog-manage-shared-sections")
+export class HuiDialogManageSharedSections
+  extends LitElement
+  implements HassDialog<ManageSharedSectionsDialogParams>
+{
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _params?: ManageSharedSectionsDialogParams;
+
+  @state() private _open = false;
+
+  @state() private _lovelaceConfig?: LovelaceConfig;
+
+  @state() private _lovelace?: Lovelace;
+
+  public async showDialog(
+    params: ManageSharedSectionsDialogParams
+  ): Promise<void> {
+    this._params = params;
+    this._lovelace = params.lovelace;
+    this._lovelaceConfig = params.lovelaceConfig;
+    this._open = true;
+  }
+
+  public closeDialog(): boolean {
+    this._open = false;
+    return true;
+  }
+
+  private _dialogClosed(): void {
+    this._params = undefined;
+    this._lovelaceConfig = undefined;
+    this._lovelace = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render(): TemplateResult | typeof nothing {
+    if (!this._params || !this._lovelaceConfig) {
+      return nothing;
+    }
+
+    const sharedSections = this._lovelaceConfig.shared_sections ?? [];
+
+    return html`
+      <ha-dialog
+        .open=${this._open}
+        @closed=${this._dialogClosed}
+        .heading=${this.hass.localize(
+          "ui.panel.lovelace.editor.manage_shared_sections.header"
+        )}
+      >
+        <ha-dialog-header show-border slot="header">
+          <ha-icon-button
+            slot="navigationIcon"
+            @click=${this.closeDialog}
+            .label=${this.hass.localize("ui.common.close")}
+            .path=${mdiClose}
+          ></ha-icon-button>
+          <span slot="title">
+            ${this.hass.localize(
+              "ui.panel.lovelace.editor.manage_shared_sections.header"
+            )}
+          </span>
+        </ha-dialog-header>
+
+        ${sharedSections.length === 0
+          ? html`
+              <div class="empty-state">
+                <p>
+                  ${this.hass.localize(
+                    "ui.panel.lovelace.editor.manage_shared_sections.no_shared_sections"
+                  )}
+                </p>
+              </div>
+            `
+          : html`
+              <div class="sections-list">
+                ${sharedSections.map((section) =>
+                  this._renderSharedSection(section)
+                )}
+              </div>
+            `}
+
+        <ha-button slot="primaryAction" @click=${this.closeDialog}>
+          ${this.hass.localize("ui.common.close")}
+        </ha-button>
+      </ha-dialog>
+    `;
+  }
+
+  private _renderSharedSection(
+    section: LovelaceSharedSectionConfig
+  ): TemplateResult {
+    const refCount = countSharedSectionRefs(this._lovelaceConfig!, section.id);
+    const cardCount = section.cards?.length ?? 0;
+    const label = this._getSectionLabel(section);
+
+    return html`
+      <div class="section-row">
+        <div class="section-info">
+          <span class="section-name">${label}</span>
+          <span class="section-meta">
+            ${this.hass.localize(
+              "ui.panel.lovelace.editor.manage_shared_sections.cards_count",
+              { count: cardCount }
+            )}
+            ·
+            ${this.hass.localize(
+              "ui.panel.lovelace.editor.manage_shared_sections.used_in_views",
+              { count: refCount }
+            )}
+          </span>
+        </div>
+        <div class="section-actions">
+          <ha-icon-button
+            .label=${this.hass.localize("ui.common.edit")}
+            .path=${mdiPencil}
+            data-section-id=${section.id}
+            @click=${this._editSharedSectionClick}
+          ></ha-icon-button>
+          <ha-icon-button
+            .label=${this.hass.localize("ui.common.delete")}
+            .path=${mdiDelete}
+            class="danger"
+            data-section-id=${section.id}
+            @click=${this._deleteSharedSectionClick}
+          ></ha-icon-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private _getSectionLabel(section: LovelaceSharedSectionConfig): string {
+    const headingCard = section.cards?.find((c) => c.type === "heading");
+    if (headingCard && "heading" in headingCard && headingCard.heading) {
+      return String(headingCard.heading);
+    }
+    return this.hass.localize(
+      "ui.panel.lovelace.editor.manage_shared_sections.unnamed_section",
+      { id: section.id.slice(0, 8) }
+    );
+  }
+
+  private _editSharedSectionClick(ev: Event): void {
+    const id = (ev.currentTarget as HTMLElement).dataset.sectionId!;
+    const section = this._lovelaceConfig?.shared_sections?.find(
+      (s) => s.id === id
+    );
+    if (section) this._editSharedSection(section);
+  }
+
+  private _deleteSharedSectionClick(ev: Event): void {
+    const id = (ev.currentTarget as HTMLElement).dataset.sectionId!;
+    const section = this._lovelaceConfig?.shared_sections?.find(
+      (s) => s.id === id
+    );
+    if (section) this._deleteSharedSection(section);
+  }
+
+  private _editSharedSection(section: LovelaceSharedSectionConfig): void {
+    if (!this._params || !this._lovelace || !this._lovelaceConfig) return;
+
+    // Find the first, at least I think it's good we have the first "master"
+    for (let vi = 0; vi < this._lovelaceConfig.views.length; vi++) {
+      const view = this._lovelaceConfig.views[vi];
+      if ("strategy" in view || !view.sections) continue;
+      for (let si = 0; si < view.sections.length; si++) {
+        const s = view.sections[si];
+        if ("section_ref" in s && s.section_ref === section.id) {
+          showEditSectionDialog(this, {
+            lovelace: this._lovelace,
+            lovelaceConfig: this._lovelaceConfig,
+            saveConfig: (newConfig) => {
+              this._lovelaceConfig = newConfig;
+              this._params!.saveConfig(newConfig);
+            },
+            viewIndex: vi,
+            sectionIndex: si,
+            editSharedDefinition: true,
+          });
+          return;
+        }
+      }
+    }
+
+    this.hass.connection.sendMessagePromise({
+      type: "lovelace/config/save",
+    });
+  }
+
+  private async _deleteSharedSection(
+    section: LovelaceSharedSectionConfig
+  ): Promise<void> {
+    if (!this._params || !this._lovelaceConfig) return;
+
+    const refCount = countSharedSectionRefs(this._lovelaceConfig, section.id);
+
+    if (refCount > 0) {
+      const confirmed = await showConfirmationDialog(this, {
+        title: this.hass.localize(
+          "ui.panel.lovelace.editor.manage_shared_sections.delete_title"
+        ),
+        text: this.hass.localize(
+          "ui.panel.lovelace.editor.manage_shared_sections.delete_warning",
+          { count: refCount }
+        ),
+        confirmText: this.hass.localize("ui.common.delete"),
+        destructive: true,
+      });
+      if (!confirmed) return;
+    }
+
+    const newConfig = deleteSharedSection(this._lovelaceConfig, section.id);
+    this._lovelaceConfig = newConfig;
+    this._params.saveConfig(newConfig);
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyleDialog,
+      css`
+        .sections-list {
+          display: flex;
+          flex-direction: column;
+          gap: var(--ha-space-1);
+          padding: var(--ha-space-2) 0;
+        }
+
+        .section-row {
+          display: flex;
+          align-items: center;
+          gap: var(--ha-space-2);
+          padding: var(--ha-space-2) var(--ha-space-4);
+          border-radius: var(--ha-border-radius-m);
+          background: var(--secondary-background-color);
+        }
+
+        .section-info {
+          flex: 1;
+          min-width: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 2px;
+        }
+
+        .section-name {
+          font-weight: 500;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .section-meta {
+          font-size: 0.85em;
+          color: var(--secondary-text-color);
+        }
+
+        .section-actions {
+          display: flex;
+          align-items: center;
+          gap: var(--ha-space-1);
+        }
+
+        .danger {
+          color: var(--error-color);
+        }
+
+        .empty-state {
+          text-align: center;
+          color: var(--secondary-text-color);
+          padding: var(--ha-space-6) var(--ha-space-4);
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-dialog-manage-shared-sections": HuiDialogManageSharedSections;
+  }
+}

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -12,6 +12,7 @@ import type {
 import {
   DEFAULT_SECTION_BACKGROUND_OPACITY,
   resolveSectionBackground,
+  type LovelaceBaseSectionConfig,
   type LovelaceSectionRawConfig,
 } from "../../../../data/lovelace/config/section";
 import type { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
@@ -33,8 +34,17 @@ export class HuiDialogEditSection extends LitElement {
 
   @property({ attribute: false }) public viewConfig!: LovelaceViewConfig;
 
+  /** When true, only show layout fields (column_span / row_span) — used for shared section refs */
+  @property({ type: Boolean, attribute: "layout-only" }) public layoutOnly =
+    false;
+
   private _schema = memoizeOne(
-    (maxColumns: number, backgroundEnabled: boolean, localize: LocalizeFunc) =>
+    (
+      maxColumns: number,
+      backgroundEnabled: boolean,
+      localize: LocalizeFunc,
+      layoutOnly: boolean
+    ) =>
       [
         {
           name: "column_span",
@@ -46,78 +56,85 @@ export class HuiDialogEditSection extends LitElement {
             },
           },
         },
-        {
-          name: "background_enabled",
-          selector: { boolean: {} },
-        },
-        ...(backgroundEnabled
+        ...(!layoutOnly
           ? ([
               {
-                name: "background",
-                type: "expandable",
-                flatten: true,
-                expanded: true,
-                iconPath: mdiPalette,
-                schema: [
-                  {
-                    name: "background_color",
-                    selector: {
-                      ui_color: {
-                        extra_options: [
-                          {
-                            value: "default",
-                            label: localize(
-                              "ui.panel.lovelace.editor.edit_section.settings.background_color_default"
-                            ),
-                            display_color:
-                              "var(--ha-section-background-color, var(--secondary-background-color))",
+                name: "background_enabled",
+                selector: { boolean: {} },
+              },
+              ...(backgroundEnabled
+                ? ([
+                    {
+                      name: "background",
+                      type: "expandable",
+                      flatten: true,
+                      expanded: true,
+                      iconPath: mdiPalette,
+                      schema: [
+                        {
+                          name: "background_color",
+                          selector: {
+                            ui_color: {
+                              extra_options: [
+                                {
+                                  value: "default",
+                                  label: localize(
+                                    "ui.panel.lovelace.editor.edit_section.settings.background_color_default"
+                                  ),
+                                  display_color:
+                                    "var(--ha-section-background-color, var(--secondary-background-color))",
+                                },
+                              ],
+                            },
                           },
-                        ],
-                      },
+                        },
+                        {
+                          name: "background_opacity",
+                          selector: {
+                            number: {
+                              min: 0,
+                              max: 100,
+                              step: 1,
+                              unit_of_measurement: "%",
+                              mode: "slider",
+                            },
+                          },
+                        },
+                      ],
                     },
-                  },
-                  {
-                    name: "background_opacity",
-                    selector: {
-                      number: {
-                        min: 0,
-                        max: 100,
-                        step: 1,
-                        unit_of_measurement: "%",
-                        mode: "slider",
-                      },
-                    },
-                  },
-                ],
+                  ] as const satisfies readonly HaFormSchema[])
+                : []),
+              {
+                name: "theme",
+                selector: {
+                  theme: {},
+                },
               },
             ] as const satisfies readonly HaFormSchema[])
           : []),
-        {
-          name: "theme",
-          selector: {
-            theme: {},
-          },
-        },
       ] as const satisfies HaFormSchema[]
   );
 
   render() {
-    const backgroundEnabled = this.config.background !== undefined;
-    const background = resolveSectionBackground(this.config.background);
+    const baseConfig = this.config as LovelaceBaseSectionConfig;
+    const backgroundEnabled =
+      !this.layoutOnly && baseConfig.background !== undefined;
+    const background = resolveSectionBackground(baseConfig.background);
 
     const data: SettingsData = {
-      column_span: this.config.column_span || 1,
+      column_span: baseConfig.column_span || 1,
       background_enabled: backgroundEnabled,
       background_color: background?.color ?? "default",
       background_opacity:
         background?.opacity ?? DEFAULT_SECTION_BACKGROUND_OPACITY,
-      theme: this.config.theme,
+      theme: baseConfig.theme,
     };
 
     const schema = this._schema(
       this.viewConfig.max_columns || 4,
       backgroundEnabled,
-      this.hass.localize
+      this.hass.localize,
+      this.layoutOnly
     );
 
     return html`
@@ -150,29 +167,30 @@ export class HuiDialogEditSection extends LitElement {
     ev.stopPropagation();
     const newData = ev.detail.value as SettingsData;
 
-    const newConfig: LovelaceSectionRawConfig = {
+    const newConfig = {
       ...this.config,
       column_span: newData.column_span,
-    };
+    } as LovelaceBaseSectionConfig & { type?: string; cards?: unknown[] };
 
-    if (newData.background_enabled) {
-      const hasCustomColor =
-        newData.background_color !== undefined &&
-        newData.background_color !== "default";
+    if (!this.layoutOnly) {
+      if (newData.background_enabled) {
+        const hasCustomColor =
+          newData.background_color !== undefined &&
+          newData.background_color !== "default";
 
-      newConfig.background = {
-        ...(hasCustomColor ? { color: newData.background_color } : {}),
-        opacity: newData.background_opacity!,
-      };
-    } else {
-      delete newConfig.background;
-    }
+        newConfig.background = {
+          ...(hasCustomColor ? { color: newData.background_color } : {}),
+          opacity: newData.background_opacity!,
+        };
+      } else {
+        delete newConfig.background;
+      }
 
-    // Only include theme if it's set.
-    if (newData.theme) {
-      newConfig.theme = newData.theme;
-    } else {
-      delete newConfig.theme;
+      if (newData.theme) {
+        newConfig.theme = newData.theme;
+      } else {
+        delete newConfig.theme;
+      }
     }
 
     fireEvent(this, "value-changed", { value: newConfig });

--- a/src/panels/lovelace/editor/section-editor/hui-section-visibility-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-visibility-editor.ts
@@ -1,7 +1,10 @@
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import type { LovelaceSectionRawConfig } from "../../../../data/lovelace/config/section";
+import type {
+  LovelaceBaseSectionConfig,
+  LovelaceSectionRawConfig,
+} from "../../../../data/lovelace/config/section";
 import type { HomeAssistant } from "../../../../types";
 import type { Condition } from "../../common/validate-condition";
 import "../conditions/ha-card-conditions-editor";
@@ -14,7 +17,8 @@ export class HuiDialogEditSection extends LitElement {
   @property({ attribute: false }) public config!: LovelaceSectionRawConfig;
 
   render() {
-    const conditions = this.config.visibility ?? [];
+    const conditions =
+      (this.config as LovelaceBaseSectionConfig).visibility ?? [];
     return html`
       <ha-visibility-status
         .hass=${this.hass}
@@ -38,10 +42,10 @@ export class HuiDialogEditSection extends LitElement {
   private _valueChanged(ev: CustomEvent): void {
     ev.stopPropagation();
     const conditions = ev.detail.value as Condition[];
-    const newConfig: LovelaceSectionRawConfig = {
+    const newConfig = {
       ...this.config,
       visibility: conditions,
-    };
+    } as LovelaceBaseSectionConfig;
     if (newConfig.visibility?.length === 0) {
       delete newConfig.visibility;
     }

--- a/src/panels/lovelace/editor/section-editor/show-add-section-dialog.ts
+++ b/src/panels/lovelace/editor/section-editor/show-add-section-dialog.ts
@@ -1,0 +1,23 @@
+import { fireEvent } from "../../../../common/dom/fire_event";
+import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
+import type { Lovelace } from "../../types";
+
+export interface AddSectionDialogParams {
+  lovelace: Lovelace;
+  lovelaceConfig: LovelaceConfig;
+  viewIndex: number;
+  saveConfig: (config: LovelaceConfig) => void;
+}
+
+const importAddSectionDialog = () => import("./hui-dialog-add-section");
+
+export const showAddSectionDialog = (
+  element: HTMLElement,
+  params: AddSectionDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "hui-dialog-add-section",
+    dialogImport: importAddSectionDialog,
+    dialogParams: params,
+  });
+};

--- a/src/panels/lovelace/editor/section-editor/show-edit-section-dialog.ts
+++ b/src/panels/lovelace/editor/section-editor/show-edit-section-dialog.ts
@@ -8,6 +8,7 @@ export interface EditSectionDialogParams {
   saveConfig: (config: LovelaceConfig) => void;
   viewIndex: number;
   sectionIndex: number;
+  editSharedDefinition?: boolean;
 }
 
 const importEditSectionDialog = () => import("./hui-dialog-edit-section");

--- a/src/panels/lovelace/editor/section-editor/show-manage-shared-sections-dialog.ts
+++ b/src/panels/lovelace/editor/section-editor/show-manage-shared-sections-dialog.ts
@@ -1,0 +1,23 @@
+import { fireEvent } from "../../../../common/dom/fire_event";
+import type { LovelaceConfig } from "../../../../data/lovelace/config/types";
+import type { Lovelace } from "../../types";
+
+export interface ManageSharedSectionsDialogParams {
+  lovelace: Lovelace;
+  lovelaceConfig: LovelaceConfig;
+  saveConfig: (config: LovelaceConfig) => void;
+}
+
+const importManageSharedSectionsDialog = () =>
+  import("./hui-dialog-manage-shared-sections");
+
+export const showManageSharedSectionsDialog = (
+  element: HTMLElement,
+  params: ManageSharedSectionsDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "hui-dialog-manage-shared-sections",
+    dialogImport: importManageSharedSectionsDialog,
+    dialogParams: params,
+  });
+};

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -14,6 +14,7 @@ import {
   mdiRefresh,
   mdiRobot,
   mdiShape,
+  mdiShareVariant,
   mdiSofa,
   mdiUndo,
   mdiViewDashboard,
@@ -86,6 +87,7 @@ import { showDashboardDetailDialog } from "../config/lovelace/dashboards/show-di
 import { showPersonDetailDialog } from "../config/person/show-dialog-person-detail";
 import { swapView } from "./editor/config-util";
 import { showDashboardStrategyEditorDialog } from "./editor/dashboard-strategy-editor/dialogs/show-dialog-dashboard-strategy-editor";
+import { showManageSharedSectionsDialog } from "./editor/section-editor/show-manage-shared-sections-dialog";
 import { showSaveDialog } from "./editor/show-save-config-dialog";
 import { showEditViewDialog } from "./editor/view-editor/show-edit-view-dialog";
 import { getLovelaceStrategy } from "./strategies/get-strategy";
@@ -248,6 +250,14 @@ class HUIRoot extends LitElement {
         key: "ui.panel.lovelace.editor.menu.manage_resources",
         overflowAction: this._handleManageResources,
         visible: this._editMode,
+        overflow: true,
+      },
+      {
+        icon: mdiShareVariant,
+        key: "ui.panel.lovelace.editor.menu.manage_shared_sections",
+        overflowAction: this._handleManageSharedSections,
+        visible:
+          this._editMode && !!this.lovelace?.config?.shared_sections?.length,
         overflow: true,
       },
       {
@@ -955,6 +965,15 @@ class HUIRoot extends LitElement {
 
   private _handleManageResources = () => {
     navigate("/config/lovelace/resources");
+  };
+
+  private _handleManageSharedSections = () => {
+    if (!this.lovelace) return;
+    showManageSharedSectionsDialog(this, {
+      lovelace: this.lovelace,
+      lovelaceConfig: this.lovelace.config,
+      saveConfig: this.lovelace.saveConfig,
+    });
   };
 
   private _handleUnusedEntities = () => {

--- a/src/panels/lovelace/sections/hui-section.ts
+++ b/src/panels/lovelace/sections/hui-section.ts
@@ -12,8 +12,15 @@ import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
 import type {
   LovelaceSectionConfig,
   LovelaceSectionRawConfig,
+  LovelaceSectionRefConfig,
 } from "../../../data/lovelace/config/section";
-import { isStrategySection } from "../../../data/lovelace/config/section";
+import {
+  isSectionRef,
+  isStrategySection,
+} from "../../../data/lovelace/config/section";
+import type { LovelaceConfig } from "../../../data/lovelace/config/types";
+import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
+import { isStrategyView } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
 import { ConditionalListenerMixin } from "../../../mixins/conditional-listener-mixin";
 import "../cards/hui-card";
@@ -22,7 +29,12 @@ import { checkConditionsMet } from "../common/validate-condition";
 import { createSectionElement } from "../create-element/create-section-element";
 import { showCreateCardDialog } from "../editor/card-editor/show-create-card-dialog";
 import { showEditCardDialog } from "../editor/card-editor/show-edit-card-dialog";
-import { addCard, replaceCard } from "../editor/config-util";
+import {
+  addCard,
+  getSharedSection,
+  replaceCard,
+  updateSharedSection,
+} from "../editor/config-util";
 import { performDeleteCard } from "../editor/delete-card";
 import { parseLovelaceCardPath } from "../editor/lovelace-path";
 import { generateLovelaceSectionStrategy } from "../strategies/get-strategy";
@@ -100,10 +112,12 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
 
     const oldConfig = changedProperties.get("config");
 
-    // If config has changed, create element if necessary and set all values.
+    // Re-initialize when config changes, or when the lovelace context changes
+    // for a ref section (shared_sections update won't change this.config itself).
     if (
-      changedProperties.has("config") &&
-      (!oldConfig || this.config !== oldConfig)
+      (changedProperties.has("config") &&
+        (!oldConfig || this.config !== oldConfig)) ||
+      (changedProperties.has("lovelace") && isSectionRef(this.config))
     ) {
       this._initializeConfig();
     }
@@ -180,7 +194,28 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
     let sectionConfig = { ...this.config };
     let isStrategy = false;
 
-    if (isStrategySection(sectionConfig)) {
+    if (isSectionRef(sectionConfig)) {
+      // Resolve the ref to its shared definition from the dashboard config
+      const sharedDef = getSharedSection(
+        this.lovelace!.config,
+        sectionConfig.section_ref
+      );
+      if (sharedDef) {
+        sectionConfig = {
+          ...sharedDef,
+          // Layout overrides on the ref take precedence over the shared definition
+          ...(sectionConfig.column_span !== undefined && {
+            column_span: sectionConfig.column_span,
+          }),
+          ...(sectionConfig.row_span !== undefined && {
+            row_span: sectionConfig.row_span,
+          }),
+        } as LovelaceSectionConfig;
+      } else {
+        // Broken ref — render an empty grid section so the view doesn't crash
+        sectionConfig = { type: "grid", cards: [] } as LovelaceSectionConfig;
+      }
+    } else if (isStrategySection(sectionConfig)) {
       isStrategy = true;
       sectionConfig = await generateLovelaceSectionStrategy(
         sectionConfig,
@@ -286,6 +321,50 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
     }
   }
 
+  /**
+   * For a ref section, return a "virtual" lovelace config where the ref at
+   * [viewIndex, sectionIndex] is temporarily replaced by the resolved concrete
+   * section. Card dialogs can operate on the virtual config, then we extract
+   * the modified cards array and persist via updateSharedSection.
+   */
+  private _virtualConfigForRef(): LovelaceConfig | null {
+    if (!isSectionRef(this.config) || !this._config || !this.lovelace) {
+      return null;
+    }
+    const views = this.lovelace.config.views.map((v, vi) => {
+      if (vi !== this.viewIndex || isStrategyView(v)) return v;
+      const view = v as LovelaceViewConfig;
+      return {
+        ...view,
+        sections: view.sections!.map((s, si) =>
+          si === this.index ? this._config! : s
+        ),
+      };
+    });
+    return { ...this.lovelace.config, views };
+  }
+
+  /**
+   * Save a virtual config (produced by _virtualConfigForRef) by extracting
+   * the modified section cards and persisting them in shared_sections.
+   */
+  private _saveVirtualRefConfig = async (
+    virtualConfig: LovelaceConfig
+  ): Promise<void> => {
+    if (!isSectionRef(this.config) || !this.lovelace) return;
+    const refId = (this.config as LovelaceSectionRefConfig).section_ref;
+    const virtualView = virtualConfig.views[
+      this.viewIndex
+    ] as LovelaceViewConfig;
+    const updatedSection = virtualView.sections?.[
+      this.index
+    ] as LovelaceSectionConfig;
+    const newRealConfig = updateSharedSection(this.lovelace.config, refId, {
+      cards: updatedSection?.cards ?? [],
+    });
+    await this.lovelace.saveConfig(newRealConfig);
+  };
+
   private _createLayoutElement(config: LovelaceSectionConfig): void {
     this._layoutElement = createSectionElement(
       config
@@ -294,9 +373,15 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
     this._layoutElement.addEventListener("ll-create-card", (ev) => {
       ev.stopPropagation();
       if (!this.lovelace) return;
+      const isRef = isSectionRef(this.config);
+      const lovelaceConfig = isRef
+        ? (this._virtualConfigForRef() ?? this.lovelace.config)
+        : this.lovelace.config;
       showCreateCardDialog(this, {
-        lovelaceConfig: this.lovelace.config,
-        saveConfig: this.lovelace.saveConfig,
+        lovelaceConfig,
+        saveConfig: isRef
+          ? this._saveVirtualRefConfig
+          : this.lovelace.saveConfig,
         path: [this.viewIndex, this.index],
         suggestedCards: ev.detail?.suggested,
       });
@@ -306,27 +391,66 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
       if (!this.lovelace) return;
       const { cardIndex } = parseLovelaceCardPath(ev.detail.path);
       const sectionConfig = this.config;
-      if (isStrategySection(sectionConfig)) {
-        return;
+      if (isStrategySection(sectionConfig)) return;
+
+      // For ref sections use the resolved _config for card data
+      const resolvedConfig = isSectionRef(sectionConfig)
+        ? this._config
+        : sectionConfig;
+      if (!resolvedConfig) return;
+      const cardConfig = resolvedConfig.cards?.[cardIndex];
+      if (!cardConfig) return;
+
+      if (isSectionRef(sectionConfig)) {
+        showEditCardDialog(this, {
+          lovelaceConfig: this._virtualConfigForRef() ?? this.lovelace.config,
+          saveCardConfig: async (newCardConfig) => {
+            const refId = (sectionConfig as LovelaceSectionRefConfig)
+              .section_ref;
+            const currentCards = [...(this._config?.cards ?? [])];
+            currentCards[cardIndex] = newCardConfig;
+            const newRealConfig = updateSharedSection(
+              this.lovelace!.config,
+              refId,
+              { cards: currentCards }
+            );
+            await this.lovelace!.saveConfig(newRealConfig);
+          },
+          sectionConfig: resolvedConfig,
+          cardConfig,
+        });
+      } else {
+        showEditCardDialog(this, {
+          lovelaceConfig: this.lovelace.config,
+          saveCardConfig: async (newCardConfig) => {
+            const newConfig = replaceCard(
+              this.lovelace!.config,
+              [this.viewIndex, this.index, cardIndex],
+              newCardConfig
+            );
+            await this.lovelace!.saveConfig(newConfig);
+          },
+          sectionConfig,
+          cardConfig,
+        });
       }
-      const cardConfig = sectionConfig.cards![cardIndex];
-      showEditCardDialog(this, {
-        lovelaceConfig: this.lovelace.config,
-        saveCardConfig: async (newCardConfig) => {
-          const newConfig = replaceCard(
-            this.lovelace!.config,
-            [this.viewIndex, this.index, cardIndex],
-            newCardConfig
-          );
-          await this.lovelace!.saveConfig(newConfig);
-        },
-        sectionConfig,
-        cardConfig,
-      });
     });
     this._layoutElement.addEventListener("ll-delete-card", (ev) => {
       ev.stopPropagation();
       if (!this.lovelace) return;
+      if (isSectionRef(this.config)) {
+        // For ref sections, delete from the shared definition cards array
+        const { cardIndex } = parseLovelaceCardPath(ev.detail.path);
+        const refId = (this.config as LovelaceSectionRefConfig).section_ref;
+        const newCards = (this._config?.cards ?? []).filter(
+          (_, i) => i !== cardIndex
+        );
+        const newConfig = updateSharedSection(this.lovelace.config, refId, {
+          cards: newCards,
+        });
+        this.lovelace.saveConfig(newConfig);
+        return;
+      }
       performDeleteCard(this.hass, this.lovelace, ev.detail);
     });
     this._layoutElement.addEventListener("ll-duplicate-card", (ev) => {
@@ -334,25 +458,49 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
       if (!this.lovelace) return;
       const { cardIndex } = parseLovelaceCardPath(ev.detail.path);
       const sectionConfig = this.config;
-      if (isStrategySection(sectionConfig)) {
-        return;
-      }
-      const cardConfig = sectionConfig.cards![cardIndex];
+      if (isStrategySection(sectionConfig)) return;
 
-      showEditCardDialog(this, {
-        lovelaceConfig: this.lovelace!.config,
-        saveCardConfig: async (newCardConfig) => {
-          const newConfig = addCard(
-            this.lovelace!.config,
-            [this.viewIndex, this.index],
-            newCardConfig
-          );
-          await this.lovelace!.saveConfig(newConfig);
-        },
-        cardConfig,
-        sectionConfig,
-        isNew: true,
-      });
+      const resolvedConfig = isSectionRef(sectionConfig)
+        ? this._config
+        : sectionConfig;
+      if (!resolvedConfig) return;
+      const cardConfig = resolvedConfig.cards?.[cardIndex];
+      if (!cardConfig) return;
+
+      if (isSectionRef(sectionConfig)) {
+        showEditCardDialog(this, {
+          lovelaceConfig: this._virtualConfigForRef() ?? this.lovelace.config,
+          saveCardConfig: async (newCardConfig) => {
+            const refId = (sectionConfig as LovelaceSectionRefConfig)
+              .section_ref;
+            const newCards = [...(this._config?.cards ?? []), newCardConfig];
+            const newRealConfig = updateSharedSection(
+              this.lovelace!.config,
+              refId,
+              { cards: newCards }
+            );
+            await this.lovelace!.saveConfig(newRealConfig);
+          },
+          cardConfig,
+          sectionConfig: resolvedConfig,
+          isNew: true,
+        });
+      } else {
+        showEditCardDialog(this, {
+          lovelaceConfig: this.lovelace!.config,
+          saveCardConfig: async (newCardConfig) => {
+            const newConfig = addCard(
+              this.lovelace!.config,
+              [this.viewIndex, this.index],
+              newCardConfig
+            );
+            await this.lovelace!.saveConfig(newConfig);
+          },
+          cardConfig,
+          sectionConfig,
+          isNew: true,
+        });
+      }
     });
     this._layoutElement.addEventListener("ll-copy-card", (ev) => {
       ev.stopPropagation();
@@ -360,10 +508,15 @@ export class HuiSection extends ConditionalListenerMixin<LovelaceSectionConfig>(
       const { cardIndex } = parseLovelaceCardPath(ev.detail.path);
       const sectionConfig = this.config;
 
-      if (isStrategySection(sectionConfig)) {
-        return;
-      }
-      const cardConfig = sectionConfig.cards![cardIndex];
+      if (isStrategySection(sectionConfig)) return;
+
+      // For ref sections use the resolved _config for card data
+      const resolvedConfig = isSectionRef(sectionConfig)
+        ? this._config
+        : sectionConfig;
+      if (!resolvedConfig) return;
+      const cardConfig = resolvedConfig.cards?.[cardIndex];
+      if (!cardConfig) return;
       this._clipboard = deepClone(cardConfig);
     });
   }

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -16,6 +16,7 @@ import "../../../components/ha-svg-icon";
 import { maxColumnsContext } from "../common/context";
 import type { LovelaceViewElement } from "../../../data/lovelace";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
+import { isSectionRef } from "../../../data/lovelace/config/section";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
 import type { HuiBadge } from "../badges/hui-badge";
@@ -23,6 +24,7 @@ import type { HuiCard } from "../cards/hui-card";
 import "../components/hui-badge-edit-mode";
 import "../components/hui-section-edit-mode";
 import { addSection, moveCard, moveSection } from "../editor/config-util";
+import { showAddSectionDialog } from "../editor/section-editor/show-add-section-dialog";
 import type { LovelaceCardPath } from "../editor/lovelace-path";
 import {
   findLovelaceItems,
@@ -414,7 +416,12 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
   );
 
   private _renderSection(section: HuiSection, alignBackground: boolean) {
-    const hasBackground = section.config.background !== undefined;
+    // Ref sections defer background/theme to the resolved shared definition;
+    // access only the base section props that are present on all config types.
+    // Again, i thought this would be the best, open to feedback here
+    const sectionConfig = section.config;
+    const hasBackground =
+      !isSectionRef(sectionConfig) && sectionConfig.background !== undefined;
 
     return html`
       <div
@@ -423,11 +430,11 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
           "align-background": alignBackground,
         })}"
       >
-        ${hasBackground
+        ${hasBackground && !isSectionRef(sectionConfig)
           ? html`<hui-section-background
               .hass=${this.hass}
-              .background=${section.config.background}
-              .theme=${section.config.theme}
+              .background=${sectionConfig.background}
+              .theme=${sectionConfig.theme}
             ></hui-section-background>`
           : nothing}
         ${section}
@@ -436,12 +443,14 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
   }
 
   private _createSection(): void {
-    const newConfig = addSection(
-      this.lovelace!.config,
-      this.index!,
-      generateDefaultSection(this.hass.localize, true)
-    );
-    this.lovelace!.saveConfig(newConfig);
+    showAddSectionDialog(this, {
+      lovelace: this.lovelace!,
+      lovelaceConfig: this.lovelace!.config,
+      viewIndex: this.index!,
+      saveConfig: (newConfig) => {
+        this.lovelace!.saveConfig(newConfig);
+      },
+    });
   }
 
   private _sectionMoved(ev: CustomEvent) {

--- a/src/panels/lovelace/views/sections-background-alignment.ts
+++ b/src/panels/lovelace/views/sections-background-alignment.ts
@@ -1,3 +1,4 @@
+import { isSectionRef } from "../../../data/lovelace/config/section";
 import type { HuiSection } from "../sections/hui-section";
 
 /**
@@ -39,7 +40,8 @@ export function computeSectionsBackgroundAlignment(
     columnsUsed += span;
     currentRow.indices.push(idx);
 
-    if (section.config.background !== undefined) {
+    const sectionCfg = section.config;
+    if (!isSectionRef(sectionCfg) && sectionCfg.background !== undefined) {
       currentRow.hasBackground = true;
     }
   }
@@ -49,7 +51,8 @@ export function computeSectionsBackgroundAlignment(
   for (const row of rows) {
     if (!row.hasBackground) continue;
     for (const idx of row.indices) {
-      if (sections[idx].config.background === undefined) {
+      const cfg = sections[idx].config;
+      if (isSectionRef(cfg) || cfg.background === undefined) {
         sectionsNeedingMargin.add(idx);
       }
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8865,7 +8865,8 @@
             "open": "Open dashboard menu",
             "raw_editor": "Raw configuration editor",
             "manage_dashboards": "Manage dashboards",
-            "manage_resources": "Manage resources"
+            "manage_resources": "Manage resources",
+            "manage_shared_sections": "Manage shared sections"
           },
           "common": {
             "edit": "Edit",
@@ -9135,7 +9136,29 @@
             "create_section": "Create section",
             "default_section_title": "New section",
             "imported_cards_title": "Imported cards",
-            "imported_cards_description": "These cards are imported from another view. They will only be displayed in edit mode. Move them into sections to display them in your view."
+            "imported_cards_description": "These cards are imported from another view. They will only be displayed in edit mode. Move them into sections to display them in your view.",
+            "share_section": "Share section",
+            "unlink_section": "Unlink from shared",
+            "edit_shared_section": "Edit shared section",
+            "edit_layout_options": "Edit layout options",
+            "shared_indicator": "Shared section",
+            "shared_section_banner": "This section is shared. Changes will apply to all views using it."
+          },
+          "add_section": {
+            "header": "Add section",
+            "new_section": "New section",
+            "use_shared_section": "Use a shared section",
+            "no_shared_sections_yet": "No shared sections yet",
+            "no_shared_sections_hint": "Share an existing section using the three dotted menu on any section."
+          },
+          "manage_shared_sections": {
+            "header": "Shared sections",
+            "no_shared_sections": "No shared sections yet. Share a section from the edit mode menu.",
+            "cards_count": "{count} {count, plural, one {card} other {cards}}",
+            "used_in_views": "{count} {count, plural, one {view} other {views}}",
+            "delete_title": "Delete shared section",
+            "delete_warning": "This shared section is used in {count} {count, plural, one {view} other {views}}. All references will be removed.",
+            "unnamed_section": "Section {id}"
           },
           "delete_section": {
             "title": "Delete section",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Basically scratching my own itch, so I decided to make a proof of concept. It's not pixel perfect and I am very open to any further feedback to polish it out. So far it works and the main workflow is capable of sharing and editing/deleting sections. :)
Adds shared sections to Lovelace dashboards; define a section once and reference it from multiple views. Any edit to the shared section propagates to every view that uses it.

A shared_sections array lives at the dashboard level, that's the best I could come up with. The ref is resolved at render time, so the YAML stays lightweight and existing dashboards with no shared_sections key are unaffected.

It now has: 
- Add section dialog: create a new section or insert an existing shared section.
- Share section: any existing section can be promoted to a shared section via the menu. It's replaced in-place with a reference, and the original content moves to shared_sections.
- Edit shared section:  ya, just that.
- Unlink from shared: detaches the current view's copy from the shared definition; the section becomes a fully independent deep clone. So you're good to go with changes again.
- Manage shared sections: the dashboard overflow menu lists all shared sections. Deleting a shared section removes all references from all views (with a confirmation when it's still in use).

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
1. Make a section sharable
<img width="653" height="898" alt="image" src="https://github.com/user-attachments/assets/bb6f717e-82d6-4d2b-9ee6-1d0d570dff79" />

2. Once it's shared, it shows this via the shared icon
<img width="681" height="905" alt="image" src="https://github.com/user-attachments/assets/595ade50-f3d4-4807-8556-dc91e6aa4773" />

3. When pressing new section, this dialog now shows up (not pixel perfect with rounded corners, but it works)
<img width="788" height="410" alt="image" src="https://github.com/user-attachments/assets/ef391ffb-c76c-4ece-b1cf-64ea929870f0" />

4. Now both of them exist
<img width="1125" height="910" alt="image" src="https://github.com/user-attachments/assets/00c4475b-9c22-48d5-a92f-98fbe822f511" />

5. When making changes, it will affect both sections
<img width="1133" height="958" alt="image" src="https://github.com/user-attachments/assets/06025d75-50e7-43b2-a1ce-a6d8194d9fd5" />

6. Sections can also be decoupled and then then will clone in (I thought this was the best UX way)
<img width="554" height="914" alt="image" src="https://github.com/user-attachments/assets/4d7fb171-c3d1-41b6-b9ff-18676c8789e0" />

7. Updates no longer are shared
<img width="1171" height="994" alt="image" src="https://github.com/user-attachments/assets/06d6aa28-55b1-44d8-b5ed-2b4b08df7d1c" />

8. Shared sections are managable via the dashboard menu (it will be hidden if no sections are created before)
<img width="367" height="401" alt="image" src="https://github.com/user-attachments/assets/dee818cb-44a4-47a6-9679-103190c180b0" />

9. Menu
<img width="799" height="316" alt="image" src="https://github.com/user-attachments/assets/096e6c18-6edb-48ea-a268-7df325b1c796" />

10. When editing a shared section, you now get the alert (again, not pixel perfect, so feel free to help me here)
<img width="730" height="708" alt="image" src="https://github.com/user-attachments/assets/53f28fca-2376-431a-8c2a-1cbb22c09363" />

11. And once they're all deleted, this is the final dialog
<img width="748" height="251" alt="image" src="https://github.com/user-attachments/assets/80f20b09-5564-4b32-9e69-cefb2f66f581" />

Live demo:

[demo-shared-sections-poc.webm](https://github.com/user-attachments/assets/8e4dfe57-9513-48ce-a4d5-2516ac6d04e2)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
