### PR TITLE
Add battery state of charge badges to energy panel

### DIFF
--- a/src/panels/energy/strategies/power-view-strategy.ts
+++ b/src/panels/energy/strategies/power-view-strategy.ts
@@ -98,6 +98,15 @@ export class PowerViewStrategy extends ReactiveElement {
       });
     }
 
+    prefs.energy_sources.forEach((source) => {
+      if (source.type === "battery" && source.stat_soc) {
+        badges.push({
+          type: "entity",
+          entity: source.stat_soc,
+        });
+      }
+    });
+
     if (hasPowerDevices) {
       const showFloorsAndAreas = shouldShowFloorsAndAreas(
         prefs.device_consumption,


### PR DESCRIPTION
## Proposed change

This PR adds support for displaying battery state of charge (SOC) badges in the energy panel's power view strategy. When a battery energy source is configured with a `stat_soc` entity, that entity will now be included in the badges displayed in the energy panel.

The change iterates through configured energy sources and creates entity badges for any battery sources that have a state of charge statistic entity defined.

## Screenshots

<img width="182" height="86" alt="image" src="https://github.com/user-attachments/assets/5d459bbd-e421-4c05-bb3e-81621f2ac3bf" />

## Type of change

- [x] New feature (thank you!)

## Additional information

- This PR adds battery SOC entity badges to the energy panel visualization
- The implementation follows the existing badge pattern used for other energy sources

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]

https://claude.ai/code/session_012E5GLs6fNKaiqg1ps8a2kY