### PR TITLE
Group pending updates by category on the updates page

### DIFF
--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -133,6 +133,11 @@ export const filterUpdateEntitiesParameterized = (
     return updateCanInstall(entity, showSkipped);
   });
 
+export const installUpdates = (hass: HomeAssistant, entityIds: string[]) =>
+  hass.callService("update", "install", {
+    entity_id: entityIds,
+  });
+
 export const checkForEntityUpdates = async (
   element: HTMLElement,
   hass: HomeAssistant

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -87,6 +87,19 @@ const HOME_ASSISTANT_CORE_TITLE = "Home Assistant Core";
 const HOME_ASSISTANT_SUPERVISOR_TITLE = "Home Assistant Supervisor";
 const HOME_ASSISTANT_OS_TITLE = "Home Assistant Operating System";
 
+// The hassio integration sets these as hard-coded `_attr_title` on the Core,
+// Operating System, and Supervisor update entities. They are not translated,
+// so a title comparison is the reliable way to identify them without depending
+// on the (lazily-fetched) entity sources.
+export const isSystemUpdate = (entity: UpdateEntity): boolean => {
+  const title = entity.attributes.title || "";
+  return (
+    title === HOME_ASSISTANT_CORE_TITLE ||
+    title === HOME_ASSISTANT_OS_TITLE ||
+    title === HOME_ASSISTANT_SUPERVISOR_TITLE
+  );
+};
+
 export const filterUpdateEntities = (
   entities: HassEntities,
   language?: string

--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -35,6 +35,8 @@ import {
   checkForEntityUpdates,
   filterUpdateEntitiesParameterized,
   getUpdateType,
+  installUpdates,
+  updateIsInstalling,
 } from "../../../data/update";
 import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-subpage";
@@ -69,6 +71,8 @@ class HaConfigSectionUpdates extends LitElement {
 
   @state() private _loadedIntegrationTitles = new Set<string>();
 
+  @state() private _loadingGroups = new Set<string>();
+
   protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
 
@@ -76,9 +80,15 @@ class HaConfigSectionUpdates extends LitElement {
       this._refreshSupervisorInfo();
     }
 
-    fetchEntitySourcesWithCache(this.hass).then((sources) => {
-      this._entitySources = sources;
-    });
+    this._loadEntitySources();
+  }
+
+  private async _loadEntitySources() {
+    try {
+      this._entitySources = await fetchEntitySourcesWithCache(this.hass);
+    } catch (_err) {
+      // Non-fatal: grouping falls back to entity registry platform lookup.
+    }
   }
 
   protected updated(changedProps: PropertyValues<this>) {
@@ -180,6 +190,7 @@ class HaConfigSectionUpdates extends LitElement {
                           <ha-button
                             appearance="plain"
                             size="small"
+                            ?loading=${this._isGroupLoading(group)}
                             .group=${group}
                             @click=${this._updateAll}
                           >
@@ -276,18 +287,31 @@ class HaConfigSectionUpdates extends LitElement {
     checkForEntityUpdates(this, this.hass);
   }
 
+  private _isGroupLoading(group: UpdateGroup): boolean {
+    return (
+      this._loadingGroups.has(group.key) ||
+      group.entities.every(updateIsInstalling)
+    );
+  }
+
   private async _updateAll(ev: Event) {
     const group = (ev.currentTarget as any).group as UpdateGroup;
+    this._loadingGroups = new Set(this._loadingGroups).add(group.key);
     try {
-      await this.hass.callService("update", "install", {
-        entity_id: group.entities.map((entity) => entity.entity_id),
-      });
+      await installUpdates(
+        this.hass,
+        group.entities.map((entity) => entity.entity_id)
+      );
     } catch (err: any) {
       showAlertDialog(this, {
         title: this.hass.localize("ui.panel.config.updates.update_all_failed"),
         text: err.message,
         warning: true,
       });
+    } finally {
+      const next = new Set(this._loadingGroups);
+      next.delete(group.key);
+      this._loadingGroups = next;
     }
   }
 

--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -143,7 +143,13 @@ class HaConfigSectionUpdates extends LitElement {
       this._showSkipped
     );
 
-    const groups = this._groupUpdates(installableUpdates, this._entitySources);
+    const groups = this._groupUpdates(
+      installableUpdates,
+      this._entitySources,
+      this.hass.localize,
+      this.hass.entities,
+      this.hass.locale.language
+    );
 
     return html`
       <hass-subpage
@@ -373,13 +379,14 @@ class HaConfigSectionUpdates extends LitElement {
   private _groupUpdates = memoizeOne(
     (
       entities: UpdateEntity[],
-      entitySources: EntitySources | undefined
+      entitySources: EntitySources | undefined,
+      localize: HomeAssistant["localize"],
+      entityRegistry: HomeAssistant["entities"],
+      language: string
     ): UpdateGroup[] => {
       if (!entities.length) {
         return [];
       }
-
-      const localize = this.hass.localize;
 
       const systemEntities: UpdateEntity[] = [];
       const appEntities: UpdateEntity[] = [];
@@ -393,7 +400,7 @@ class HaConfigSectionUpdates extends LitElement {
         }
         const domain =
           entitySources?.[entity.entity_id]?.domain ??
-          this.hass.entities[entity.entity_id]?.platform;
+          entityRegistry[entity.entity_id]?.platform;
         if (domain === "hassio") {
           appEntities.push(entity);
           continue;
@@ -423,11 +430,7 @@ class HaConfigSectionUpdates extends LitElement {
       });
 
       multiInstanceGroups.sort((a, b) =>
-        caseInsensitiveStringCompare(
-          a.title,
-          b.title,
-          this.hass.locale.language
-        )
+        caseInsensitiveStringCompare(a.title, b.title, language)
       );
 
       const groups: UpdateGroup[] = [];

--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -11,10 +11,13 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
+import { caseInsensitiveStringCompare } from "../../../common/string/compare";
 import "../../../components/ha-card";
 import "../../../components/ha-dropdown";
 import type { HaDropdownSelectEvent } from "../../../components/ha-dropdown";
 import "../../../components/ha-dropdown-item";
+import type { EntitySources } from "../../../data/entity/entity_sources";
+import { fetchEntitySourcesWithCache } from "../../../data/entity/entity_sources";
 import { extractApiErrorMessage } from "../../../data/hassio/common";
 import type {
   HassioSupervisorInfo,
@@ -25,6 +28,8 @@ import {
   reloadSupervisor,
   setSupervisorOption,
 } from "../../../data/hassio/supervisor";
+import { domainToName } from "../../../data/integration";
+import type { UpdateEntity } from "../../../data/update";
 import {
   checkForEntityUpdates,
   filterUpdateEntitiesParameterized,
@@ -34,6 +39,17 @@ import "../../../layouts/hass-subpage";
 import type { HomeAssistant } from "../../../types";
 import "../dashboard/ha-config-updates";
 import { showJoinBetaDialog } from "./updates/show-dialog-join-beta";
+
+interface UpdateGroup {
+  key: string;
+  title: string;
+  entities: UpdateEntity[];
+  showUpdateAll: boolean;
+}
+
+const SYSTEM_KEY = "__system__";
+const APPS_KEY = "__apps__";
+const INTEGRATIONS_KEY = "__integrations__";
 
 @customElement("ha-config-section-updates")
 class HaConfigSectionUpdates extends LitElement {
@@ -47,16 +63,22 @@ class HaConfigSectionUpdates extends LitElement {
 
   @state() private _supervisorInfo?: HassioSupervisorInfo;
 
+  @state() private _entitySources?: EntitySources;
+
   protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
 
     if (isComponentLoaded(this.hass.config, "hassio")) {
       this._refreshSupervisorInfo();
     }
+
+    fetchEntitySourcesWithCache(this.hass).then((sources) => {
+      this._entitySources = sources;
+    });
   }
 
   protected render(): TemplateResult {
-    const canInstallUpdates = this._filterInstallableUpdateEntities(
+    const installableUpdates = this._filterInstallableUpdateEntities(
       this.hass.states,
       this._showSkipped
     );
@@ -64,6 +86,8 @@ class HaConfigSectionUpdates extends LitElement {
       this.hass.states,
       this._showSkipped
     );
+
+    const groups = this._groupUpdates(installableUpdates, this._entitySources);
 
     return html`
       <hass-subpage
@@ -118,36 +142,51 @@ class HaConfigSectionUpdates extends LitElement {
           </ha-dropdown>
         </div>
         <div class="content">
-          ${canInstallUpdates.length
-            ? html`
-                <ha-card outlined>
-                  <div class="card-content">
+          ${groups.map(
+            (group) => html`
+              <ha-card outlined>
+                <div class="card-content">
+                  <div class="card-header">
                     <div class="title" role="heading" aria-level="2">
-                      ${this.hass.localize("ui.panel.config.updates.title", {
-                        count: canInstallUpdates.length,
-                      })}
+                      ${group.title}
                     </div>
-                    <ha-config-updates
-                      .hass=${this.hass}
-                      .narrow=${this.narrow}
-                      .updateEntities=${canInstallUpdates}
-                      showAll
-                    ></ha-config-updates>
+                    ${group.showUpdateAll
+                      ? html`
+                          <button
+                            class="update-all"
+                            .group=${group}
+                            @click=${this._updateAll}
+                          >
+                            ${this.hass.localize(
+                              "ui.panel.config.updates.update_all"
+                            )}
+                          </button>
+                        `
+                      : nothing}
                   </div>
-                </ha-card>
-              `
-            : nothing}
+                  <ha-config-updates
+                    .hass=${this.hass}
+                    .narrow=${this.narrow}
+                    .updateEntities=${group.entities}
+                    showAll
+                  ></ha-config-updates>
+                </div>
+              </ha-card>
+            `
+          )}
           ${notInstallableUpdates.length
             ? html`
                 <ha-card outlined>
                   <div class="card-content">
-                    <div class="title" role="heading" aria-level="2">
-                      ${this.hass.localize(
-                        "ui.panel.config.updates.title_not_installable",
-                        {
-                          count: notInstallableUpdates.length,
-                        }
-                      )}
+                    <div class="card-header">
+                      <div class="title" role="heading" aria-level="2">
+                        ${this.hass.localize(
+                          "ui.panel.config.updates.title_not_installable",
+                          {
+                            count: notInstallableUpdates.length,
+                          }
+                        )}
+                      </div>
                     </div>
                     <ha-config-updates
                       .hass=${this.hass}
@@ -159,7 +198,7 @@ class HaConfigSectionUpdates extends LitElement {
                 </ha-card>
               `
             : nothing}
-          ${canInstallUpdates.length + notInstallableUpdates.length
+          ${groups.length + notInstallableUpdates.length
             ? nothing
             : html`
                 <ha-card outlined>
@@ -211,6 +250,13 @@ class HaConfigSectionUpdates extends LitElement {
     checkForEntityUpdates(this, this.hass);
   }
 
+  private _updateAll(ev: Event) {
+    const group = (ev.currentTarget as any).group as UpdateGroup;
+    this.hass.callService("update", "install", {
+      entity_id: group.entities.map((entity) => entity.entity_id),
+    });
+  }
+
   private _filterInstallableUpdateEntities = memoizeOne(
     (entities: HassEntities, showSkipped: boolean) =>
       filterUpdateEntitiesParameterized(entities, showSkipped, false)
@@ -219,6 +265,106 @@ class HaConfigSectionUpdates extends LitElement {
   private _filterNotInstallableUpdateEntities = memoizeOne(
     (entities: HassEntities, showSkipped: boolean) =>
       filterUpdateEntitiesParameterized(entities, showSkipped, true)
+  );
+
+  private _groupUpdates = memoizeOne(
+    (
+      entities: UpdateEntity[],
+      entitySources: EntitySources | undefined
+    ): UpdateGroup[] => {
+      if (!entities.length) {
+        return [];
+      }
+
+      const localize = this.hass.localize;
+
+      const systemEntities: UpdateEntity[] = [];
+      const appEntities: UpdateEntity[] = [];
+      const byDomain = new Map<string, UpdateEntity[]>();
+      const otherIntegrationEntities: UpdateEntity[] = [];
+
+      for (const entity of entities) {
+        const title = entity.attributes.title || "";
+        if (
+          title === "Home Assistant Core" ||
+          title === "Home Assistant Operating System" ||
+          title === "Home Assistant Supervisor"
+        ) {
+          systemEntities.push(entity);
+          continue;
+        }
+        const sourceDomain = entitySources?.[entity.entity_id]?.domain;
+        const domain =
+          sourceDomain ?? this.hass.entities[entity.entity_id]?.platform;
+        if (domain === "hassio") {
+          appEntities.push(entity);
+          continue;
+        }
+        if (!domain) {
+          otherIntegrationEntities.push(entity);
+          continue;
+        }
+        if (!byDomain.has(domain)) {
+          byDomain.set(domain, []);
+        }
+        byDomain.get(domain)!.push(entity);
+      }
+
+      const multiInstanceGroups: UpdateGroup[] = [];
+      byDomain.forEach((entries, domain) => {
+        if (entries.length >= 2) {
+          multiInstanceGroups.push({
+            key: domain,
+            title: domainToName(localize, domain),
+            entities: entries,
+            showUpdateAll: true,
+          });
+        } else {
+          otherIntegrationEntities.push(...entries);
+        }
+      });
+
+      multiInstanceGroups.sort((a, b) =>
+        caseInsensitiveStringCompare(
+          a.title,
+          b.title,
+          this.hass.locale.language
+        )
+      );
+
+      const groups: UpdateGroup[] = [];
+
+      if (systemEntities.length) {
+        groups.push({
+          key: SYSTEM_KEY,
+          title: localize("ui.panel.config.updates.group_system"),
+          entities: systemEntities,
+          showUpdateAll: false,
+        });
+      }
+
+      groups.push(...multiInstanceGroups);
+
+      if (otherIntegrationEntities.length) {
+        groups.push({
+          key: INTEGRATIONS_KEY,
+          title: localize("ui.panel.config.updates.group_integrations"),
+          entities: otherIntegrationEntities,
+          showUpdateAll: true,
+        });
+      }
+
+      if (appEntities.length) {
+        groups.push({
+          key: APPS_KEY,
+          title: localize("ui.panel.config.updates.group_apps"),
+          entities: appEntities,
+          showUpdateAll: true,
+        });
+      }
+
+      return groups;
+    }
   );
 
   static styles = css`
@@ -247,9 +393,31 @@ class HaConfigSectionUpdates extends LitElement {
       padding: 0;
     }
 
-    .title {
+    .card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--ha-space-2);
       padding: var(--ha-space-4) var(--ha-space-4) 0;
+    }
+
+    .title {
       font-size: var(--ha-font-size-l);
+    }
+
+    .update-all {
+      background: none;
+      border: none;
+      color: var(--primary-color);
+      cursor: pointer;
+      font: inherit;
+      font-size: var(--ha-font-size-m);
+      padding: var(--ha-space-1) var(--ha-space-2);
+    }
+    .update-all:focus-visible {
+      outline: 2px solid var(--primary-color);
+      outline-offset: 2px;
+      border-radius: 4px;
     }
 
     .no-updates {

--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -275,11 +275,19 @@ class HaConfigSectionUpdates extends LitElement {
     checkForEntityUpdates(this, this.hass);
   }
 
-  private _updateAll(ev: Event) {
+  private async _updateAll(ev: Event) {
     const group = (ev.currentTarget as any).group as UpdateGroup;
-    this.hass.callService("update", "install", {
-      entity_id: group.entities.map((entity) => entity.entity_id),
-    });
+    try {
+      await this.hass.callService("update", "install", {
+        entity_id: group.entities.map((entity) => entity.entity_id),
+      });
+    } catch (err: any) {
+      showAlertDialog(this, {
+        title: this.hass.localize("ui.panel.config.updates.update_all_failed"),
+        text: err.message,
+        warning: true,
+      });
+    }
   }
 
   private _filterInstallableUpdateEntities = memoizeOne(

--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -293,7 +293,7 @@ class HaConfigSectionUpdates extends LitElement {
     } catch (err: any) {
       showAlertDialog(this, {
         title: this.hass.localize("ui.panel.config.updates.update_all_failed"),
-        text: err.message,
+        text: extractApiErrorMessage(err),
         warning: true,
       });
     }

--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -94,20 +94,37 @@ class HaConfigSectionUpdates extends LitElement {
 
   protected updated(changedProps: PropertyValues<this>) {
     super.updated(changedProps);
-    this._loadIntegrationTitles();
+    if (changedProps.has("hass")) {
+      this._loadIntegrationTitles();
+    }
   }
 
+  private _collectUpdateDomains = memoizeOne(
+    (states: HassEntities, entities: HomeAssistant["entities"]) => {
+      const domains = new Set<string>();
+      for (const entity of Object.values(states)) {
+        if (!entity.entity_id.startsWith("update.")) continue;
+        const platform = entities[entity.entity_id]?.platform;
+        if (platform) {
+          domains.add(platform);
+        }
+      }
+      return domains;
+    }
+  );
+
   private async _loadIntegrationTitles() {
-    const domains = new Set<string>();
-    for (const entity of Object.values(this.hass.states)) {
-      if (!entity.entity_id.startsWith("update.")) continue;
-      const platform = this.hass.entities[entity.entity_id]?.platform;
-      if (platform && !this._loadedIntegrationTitles.has(platform)) {
-        domains.add(platform);
+    const domains = this._collectUpdateDomains(
+      this.hass.states,
+      this.hass.entities
+    );
+    const toLoad: string[] = [];
+    for (const domain of domains) {
+      if (!this._loadedIntegrationTitles.has(domain)) {
+        toLoad.push(domain);
       }
     }
-    if (!domains.size) return;
-    const toLoad = Array.from(domains);
+    if (!toLoad.length) return;
     toLoad.forEach((d) => this._loadedIntegrationTitles.add(d));
     await this.hass.loadBackendTranslation("title", toLoad);
     this.requestUpdate();

--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -12,6 +12,7 @@ import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { caseInsensitiveStringCompare } from "../../../common/string/compare";
+import "../../../components/ha-button";
 import "../../../components/ha-card";
 import "../../../components/ha-dropdown";
 import type { HaDropdownSelectEvent } from "../../../components/ha-dropdown";
@@ -65,6 +66,8 @@ class HaConfigSectionUpdates extends LitElement {
 
   @state() private _entitySources?: EntitySources;
 
+  @state() private _loadedIntegrationTitles = new Set<string>();
+
   protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
 
@@ -75,6 +78,27 @@ class HaConfigSectionUpdates extends LitElement {
     fetchEntitySourcesWithCache(this.hass).then((sources) => {
       this._entitySources = sources;
     });
+  }
+
+  protected updated(changedProps: PropertyValues<this>) {
+    super.updated(changedProps);
+    this._loadIntegrationTitles();
+  }
+
+  private async _loadIntegrationTitles() {
+    const domains = new Set<string>();
+    for (const entity of Object.values(this.hass.states)) {
+      if (!entity.entity_id.startsWith("update.")) continue;
+      const platform = this.hass.entities[entity.entity_id]?.platform;
+      if (platform && !this._loadedIntegrationTitles.has(platform)) {
+        domains.add(platform);
+      }
+    }
+    if (!domains.size) return;
+    const toLoad = Array.from(domains);
+    toLoad.forEach((d) => this._loadedIntegrationTitles.add(d));
+    await this.hass.loadBackendTranslation("title", toLoad);
+    this.requestUpdate();
   }
 
   protected render(): TemplateResult {
@@ -152,15 +176,16 @@ class HaConfigSectionUpdates extends LitElement {
                     </div>
                     ${group.showUpdateAll
                       ? html`
-                          <button
-                            class="update-all"
+                          <ha-button
+                            appearance="plain"
+                            size="small"
                             .group=${group}
                             @click=${this._updateAll}
                           >
                             ${this.hass.localize(
                               "ui.panel.config.updates.update_all"
                             )}
-                          </button>
+                          </ha-button>
                         `
                       : nothing}
                   </div>
@@ -398,26 +423,11 @@ class HaConfigSectionUpdates extends LitElement {
       align-items: center;
       justify-content: space-between;
       gap: var(--ha-space-2);
-      padding: var(--ha-space-4) var(--ha-space-4) 0;
+      padding: var(--ha-space-4) var(--ha-space-2) 0 var(--ha-space-4);
     }
 
     .title {
       font-size: var(--ha-font-size-l);
-    }
-
-    .update-all {
-      background: none;
-      border: none;
-      color: var(--primary-color);
-      cursor: pointer;
-      font: inherit;
-      font-size: var(--ha-font-size-m);
-      padding: var(--ha-space-1) var(--ha-space-2);
-    }
-    .update-all:focus-visible {
-      outline: 2px solid var(--primary-color);
-      outline-offset: 2px;
-      border-radius: 4px;
     }
 
     .no-updates {

--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -34,8 +34,8 @@ import type { UpdateEntity } from "../../../data/update";
 import {
   checkForEntityUpdates,
   filterUpdateEntitiesParameterized,
-  getUpdateType,
   installUpdates,
+  isSystemUpdate,
 } from "../../../data/update";
 import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-subpage";
@@ -326,18 +326,17 @@ class HaConfigSectionUpdates extends LitElement {
       const otherIntegrationEntities: UpdateEntity[] = [];
 
       for (const entity of entities) {
-        if (entitySources) {
-          const type = getUpdateType(entity, entitySources);
-          if (type === "home_assistant" || type === "home_assistant_os") {
-            systemEntities.push(entity);
-            continue;
-          }
-          if (type === "addon") {
-            appEntities.push(entity);
-            continue;
-          }
+        if (isSystemUpdate(entity)) {
+          systemEntities.push(entity);
+          continue;
         }
-        const domain = this.hass.entities[entity.entity_id]?.platform;
+        const domain =
+          entitySources?.[entity.entity_id]?.domain ??
+          this.hass.entities[entity.entity_id]?.platform;
+        if (domain === "hassio") {
+          appEntities.push(entity);
+          continue;
+        }
         if (!domain) {
           otherIntegrationEntities.push(entity);
           continue;

--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -34,6 +34,7 @@ import type { UpdateEntity } from "../../../data/update";
 import {
   checkForEntityUpdates,
   filterUpdateEntitiesParameterized,
+  getUpdateType,
 } from "../../../data/update";
 import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-subpage";
@@ -317,22 +318,18 @@ class HaConfigSectionUpdates extends LitElement {
       const otherIntegrationEntities: UpdateEntity[] = [];
 
       for (const entity of entities) {
-        const title = entity.attributes.title || "";
-        if (
-          title === "Home Assistant Core" ||
-          title === "Home Assistant Operating System" ||
-          title === "Home Assistant Supervisor"
-        ) {
-          systemEntities.push(entity);
-          continue;
+        if (entitySources) {
+          const type = getUpdateType(entity, entitySources);
+          if (type === "home_assistant" || type === "home_assistant_os") {
+            systemEntities.push(entity);
+            continue;
+          }
+          if (type === "addon") {
+            appEntities.push(entity);
+            continue;
+          }
         }
-        const sourceDomain = entitySources?.[entity.entity_id]?.domain;
-        const domain =
-          sourceDomain ?? this.hass.entities[entity.entity_id]?.platform;
-        if (domain === "hassio") {
-          appEntities.push(entity);
-          continue;
-        }
+        const domain = this.hass.entities[entity.entity_id]?.platform;
         if (!domain) {
           otherIntegrationEntities.push(entity);
           continue;

--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -11,6 +11,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
+import { supportsFeature } from "../../../common/entity/supports-feature";
 import { caseInsensitiveStringCompare } from "../../../common/string/compare";
 import "../../../components/ha-button";
 import "../../../components/ha-card";
@@ -33,9 +34,12 @@ import { domainToName } from "../../../data/integration";
 import type { UpdateEntity } from "../../../data/update";
 import {
   checkForEntityUpdates,
+  filterUpdateEntities,
   filterUpdateEntitiesParameterized,
   installUpdates,
   isSystemUpdate,
+  latestVersionIsSkipped,
+  UpdateEntityFeature,
 } from "../../../data/update";
 import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-subpage";
@@ -111,10 +115,13 @@ class HaConfigSectionUpdates extends LitElement {
 
   protected render(): TemplateResult {
     const installableUpdates = this._filterInstallableUpdateEntities(
+      this.hass.states
+    );
+    const notInstallableUpdates = this._filterNotInstallableUpdateEntities(
       this.hass.states,
       this._showSkipped
     );
-    const notInstallableUpdates = this._filterNotInstallableUpdateEntities(
+    const skippedUpdates = this._filterSkippedUpdateEntities(
       this.hass.states,
       this._showSkipped
     );
@@ -207,6 +214,30 @@ class HaConfigSectionUpdates extends LitElement {
               </ha-card>
             `
           )}
+          ${skippedUpdates.length
+            ? html`
+                <ha-card outlined>
+                  <div class="card-content">
+                    <div class="card-header">
+                      <div class="title" role="heading" aria-level="2">
+                        ${this.hass.localize(
+                          "ui.panel.config.updates.title_skipped",
+                          {
+                            count: skippedUpdates.length,
+                          }
+                        )}
+                      </div>
+                    </div>
+                    <ha-config-updates
+                      .hass=${this.hass}
+                      .narrow=${this.narrow}
+                      .updateEntities=${skippedUpdates}
+                      showAll
+                    ></ha-config-updates>
+                  </div>
+                </ha-card>
+              `
+            : nothing}
           ${notInstallableUpdates.length
             ? html`
                 <ha-card outlined>
@@ -231,7 +262,7 @@ class HaConfigSectionUpdates extends LitElement {
                 </ha-card>
               `
             : nothing}
-          ${groups.length + notInstallableUpdates.length
+          ${groups.length + notInstallableUpdates.length + skippedUpdates.length
             ? nothing
             : html`
                 <ha-card outlined>
@@ -300,13 +331,26 @@ class HaConfigSectionUpdates extends LitElement {
   }
 
   private _filterInstallableUpdateEntities = memoizeOne(
-    (entities: HassEntities, showSkipped: boolean) =>
-      filterUpdateEntitiesParameterized(entities, showSkipped, false)
+    (entities: HassEntities) =>
+      filterUpdateEntitiesParameterized(entities, false, false)
   );
 
   private _filterNotInstallableUpdateEntities = memoizeOne(
     (entities: HassEntities, showSkipped: boolean) =>
       filterUpdateEntitiesParameterized(entities, showSkipped, true)
+  );
+
+  private _filterSkippedUpdateEntities = memoizeOne(
+    (entities: HassEntities, showSkipped: boolean): UpdateEntity[] => {
+      if (!showSkipped) {
+        return [];
+      }
+      return filterUpdateEntities(entities).filter(
+        (entity) =>
+          latestVersionIsSkipped(entity) &&
+          supportsFeature(entity, UpdateEntityFeature.INSTALL)
+      );
+    }
   );
 
   private _groupUpdates = memoizeOne(

--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -36,7 +36,6 @@ import {
   filterUpdateEntitiesParameterized,
   getUpdateType,
   installUpdates,
-  updateIsInstalling,
 } from "../../../data/update";
 import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-subpage";
@@ -70,8 +69,6 @@ class HaConfigSectionUpdates extends LitElement {
   @state() private _entitySources?: EntitySources;
 
   @state() private _loadedIntegrationTitles = new Set<string>();
-
-  @state() private _loadingGroups = new Set<string>();
 
   protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
@@ -190,7 +187,6 @@ class HaConfigSectionUpdates extends LitElement {
                           <ha-button
                             appearance="plain"
                             size="small"
-                            ?loading=${this._isGroupLoading(group)}
                             .group=${group}
                             @click=${this._updateAll}
                           >
@@ -287,16 +283,8 @@ class HaConfigSectionUpdates extends LitElement {
     checkForEntityUpdates(this, this.hass);
   }
 
-  private _isGroupLoading(group: UpdateGroup): boolean {
-    return (
-      this._loadingGroups.has(group.key) ||
-      group.entities.every(updateIsInstalling)
-    );
-  }
-
   private async _updateAll(ev: Event) {
     const group = (ev.currentTarget as any).group as UpdateGroup;
-    this._loadingGroups = new Set(this._loadingGroups).add(group.key);
     try {
       await installUpdates(
         this.hass,
@@ -308,10 +296,6 @@ class HaConfigSectionUpdates extends LitElement {
         text: err.message,
         warning: true,
       });
-    } finally {
-      const next = new Set(this._loadingGroups);
-      next.delete(group.key);
-      this._loadingGroups = next;
     }
   }
 

--- a/src/panels/config/dashboard/ha-config-updates.ts
+++ b/src/panels/config/dashboard/ha-config-updates.ts
@@ -104,9 +104,6 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
 
           return html`
             <ha-list-item-button
-              class=${ifDefined(
-                entity.attributes.skipped_version ? "skipped" : undefined
-              )}
               .entity_id=${entity.entity_id}
               .hasMeta=${!this.narrow}
               @click=${this._openMoreInfo}
@@ -166,9 +163,6 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
   static get styles(): CSSResultGroup[] {
     return [
       css`
-        .skipped {
-          background: var(--secondary-background-color);
-        }
         ha-list-item-button {
           --md-list-item-leading-icon-size: 40px;
         }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2748,6 +2748,7 @@
           "group_integrations": "Integrations",
           "group_apps": "Apps",
           "update_all": "Update all",
+          "update_all_failed": "Failed to start updates",
           "no_updates": "No updates available",
           "no_update_entities": {
             "title": "Unable to check for updates",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2744,6 +2744,10 @@
         "updates": {
           "caption": "Updates",
           "description": "Manage updates of Home Assistant, apps, and devices",
+          "group_system": "Home Assistant",
+          "group_integrations": "Integrations",
+          "group_apps": "Apps",
+          "update_all": "Update all",
           "no_updates": "No updates available",
           "no_update_entities": {
             "title": "Unable to check for updates",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2760,6 +2760,7 @@
           "checking_updates": "Checking for updates...",
           "title": "{count} {count, plural,\n  one {update}\n  other {updates}\n}",
           "title_not_installable": "{count} not installable {count, plural,\n  one {update}\n  other {updates}\n}",
+          "title_skipped": "{count} skipped {count, plural,\n  one {update}\n  other {updates}\n}",
           "unable_to_fetch": "Unable to load updates",
           "more_updates": "Show all updates",
           "show": "show",


### PR DESCRIPTION
## Breaking change

## Proposed change

Restructures the **Settings → Updates** page (`/config/updates`) to group pending updates into categorized cards, replacing the single flat "Installable" card:

1. **Home Assistant** card at the top — Home Assistant Core / Operating System / Supervisor. No "Update all" (these need to be prioritized).
2. **One card per integration** that has 2 or more pending updates (e.g., "ESPHome" if multiple ESPHome devices have updates). Each has an "Update all" button.
3. **Integrations** card bundling single-instance integration updates. Has "Update all".
4. **Apps** card bundling add-on updates. Has "Update all".
5. **Skipped** card (only when "Show skipped updates" is toggled on) — separated so they don't get pulled in by an "Update all" click.
6. The existing **Not installable** card stays unchanged at the bottom.

"Update all" makes one `update.install` service call with the group's entity IDs — no confirmation dialog, no backup flag.

Implements the design from the last comment of #29910.

cc @marcinbauer-ohf 

## Screenshots

These are mocked updates

<img width="1230" height="1344" alt="image" src="https://github.com/user-attachments/assets/e68fd6f3-b723-4a04-a544-e249a526ff7d" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #29910
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr