### PR TITLE
Fix energy compare bars stacking when compare month has more days

### DIFF
--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -112,11 +112,27 @@ export function getCommonOptions(
   yAxisFractionDigits = 1
 ): ECOption {
   const suggestedPeriod = getSuggestedPeriod(start, end, detailedDailyData);
-  const suggestedMax = getSuggestedMax(suggestedPeriod, end, detailedDailyData);
+  let suggestedMax = getSuggestedMax(suggestedPeriod, end, detailedDailyData);
 
   const compare = compareStart !== undefined && compareEnd !== undefined;
   const showCompareYear =
     compare && start.getFullYear() !== compareStart.getFullYear();
+
+  // Extend suggestedMax so compare bars that land past the main end
+  // (e.g. Feb compared to Jan) stay visible instead of being clipped.
+  if (compare) {
+    const transformedCompareEnd = getCompareTransform(
+      start,
+      compareStart
+    )(compareEnd);
+    if (transformedCompareEnd.getTime() > suggestedMax.getTime()) {
+      suggestedMax = getSuggestedMax(
+        suggestedPeriod,
+        transformedCompareEnd,
+        detailedDailyData
+      );
+    }
+  }
 
   const monthTimeAxis: ECOption = {
     xAxis: {
@@ -351,21 +367,35 @@ export function getCompareTransform(start: Date, compareStart?: Date) {
   if (!compareStart) {
     return (ts: Date) => ts;
   }
+  const compareDayDiff = differenceInDays(start, compareStart);
   const compareYearDiff = differenceInYears(start, compareStart);
   if (
     compareYearDiff !== 0 &&
     start.getTime() === startOfYear(start).getTime()
   ) {
-    return (ts: Date) => addYears(ts, compareYearDiff);
+    // addYears clamps Feb 29 -> Feb 28 across leap-year boundaries; fall back
+    // to a day-shift so each compare day keeps a unique x position.
+    return (ts: Date) => {
+      const shifted = addYears(ts, compareYearDiff);
+      return shifted.getDate() === ts.getDate()
+        ? shifted
+        : addDays(ts, compareDayDiff);
+    };
   }
   const compareMonthDiff = differenceInMonths(start, compareStart);
   if (
     compareMonthDiff !== 0 &&
     start.getTime() === startOfMonth(start).getTime()
   ) {
-    return (ts: Date) => addMonths(ts, compareMonthDiff);
+    // addMonths clamps Jan 31 -> Feb 28 when shifting between unequal-length
+    // months; fall back to a day-shift so each compare day keeps a unique x.
+    return (ts: Date) => {
+      const shifted = addMonths(ts, compareMonthDiff);
+      return shifted.getDate() === ts.getDate()
+        ? shifted
+        : addDays(ts, compareDayDiff);
+    };
   }
-  const compareDayDiff = differenceInDays(start, compareStart);
   if (compareDayDiff !== 0 && start.getTime() === startOfDay(start).getTime()) {
     return (ts: Date) => addDays(ts, compareDayDiff);
   }

--- a/test/panels/lovelace/cards/energy/common/energy-chart-options.test.ts
+++ b/test/panels/lovelace/cards/energy/common/energy-chart-options.test.ts
@@ -532,4 +532,42 @@ describe("getCompareTransform", () => {
     assert.equal(result.getMonth(), 5); // June
     assert.equal(result.getDate(), 20);
   });
+
+  it("falls back to day shift when month shift would clamp end-of-month days", () => {
+    // Comparing Feb 2025 (28d) to Jan 2025 (31d): Jan 29/30/31 don't have a
+    // matching day in Feb, so addMonths would clamp them all to Feb 28 and
+    // stack them on top of the last main-range bar. Day-shift keeps them
+    // unique past the main range.
+    const start = new Date("2025-02-01T00:00:00");
+    const compareStart = new Date("2025-01-01T00:00:00");
+    const transform = getCompareTransform(start, compareStart);
+
+    const jan31 = new Date("2025-01-31T00:00:00");
+    const result = transform(jan31);
+    // Jan 31 + 31 days = Mar 3 (not clamped to Feb 28)
+    assert.equal(result.getMonth(), 2); // March
+    assert.equal(result.getDate(), 3);
+
+    // Jan 28 still maps to Feb 28 via the normal month shift
+    const jan28 = new Date("2025-01-28T00:00:00");
+    const inRange = transform(jan28);
+    assert.equal(inRange.getMonth(), 1); // February
+    assert.equal(inRange.getDate(), 28);
+  });
+
+  it("falls back to day shift when year shift would clamp Feb 29 in a non-leap year", () => {
+    // Comparing 2025 (non-leap) to 2024 (leap): Feb 29 2024 has no match in
+    // 2025, so addYears would clamp it to Feb 28 2025 and stack it on top of
+    // that day's main bar.
+    const start = new Date("2025-01-01T00:00:00");
+    const compareStart = new Date("2024-01-01T00:00:00");
+    const transform = getCompareTransform(start, compareStart);
+
+    const feb29 = new Date("2024-02-29T00:00:00");
+    const result = transform(feb29);
+    // Feb 29 2024 + 366 days = Mar 1 2025 (not clamped to Feb 28 2025)
+    assert.equal(result.getFullYear(), 2025);
+    assert.equal(result.getMonth(), 2); // March
+    assert.equal(result.getDate(), 1);
+  });
 });


### PR DESCRIPTION
## Proposed change

When the Energy Dashboard compares two months of unequal length (e.g. February to January), compare bars for days that don't exist in the shorter destination month (Jan 29/30/31) were collapsing onto the last day of the main range instead of rendering as their own bars.

`getCompareTransform` mapped compare timestamps onto the main range with `addMonths` / `addYears`, which **clamp** out-of-range days (`addMonths(Jan 31, 1)` → `Feb 28`). Three different compare days ended up at the same x coordinate and echarts rendered them stacked.

This change detects the clamp (`shifted.getDate() !== ts.getDate()`) and falls back to a day-based offset for the affected timestamps, so each compare day keeps a unique x position. When that puts a compare bar past the main-range end, `getCommonOptions` extends the chart's x-axis max so the bar stays visible.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #24176
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr