### PR TITLE
Add custom card suggestions in the entity card picker

### DIFF
--- a/src/data/lovelace_custom_cards.ts
+++ b/src/data/lovelace_custom_cards.ts
@@ -1,6 +1,14 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import type { HomeAssistant } from "../types";
 import type { LovelaceCardFeatureContext } from "../panels/lovelace/card-features/types";
+import type { LovelaceCardConfig } from "./lovelace/config/card";
+
+export interface CustomCardSuggestion<
+  T extends LovelaceCardConfig = LovelaceCardConfig,
+> {
+  label?: string;
+  config: T;
+}
 
 export interface CustomCardEntry {
   type: string;
@@ -8,6 +16,10 @@ export interface CustomCardEntry {
   description?: string;
   preview?: boolean;
   documentationURL?: string;
+  getSuggestion?: (
+    hass: HomeAssistant,
+    entityId: string
+  ) => CustomCardSuggestion | CustomCardSuggestion[] | null;
 }
 
 export interface CustomBadgeEntry {

--- a/src/data/lovelace_custom_cards.ts
+++ b/src/data/lovelace_custom_cards.ts
@@ -16,7 +16,7 @@ export interface CustomCardEntry {
   description?: string;
   preview?: boolean;
   documentationURL?: string;
-  getSuggestion?: (
+  getEntitySuggestion?: (
     hass: HomeAssistant,
     entityId: string
   ) => CustomCardSuggestion | CustomCardSuggestion[] | null;

--- a/src/panels/lovelace/card-suggestions/index.ts
+++ b/src/panels/lovelace/card-suggestions/index.ts
@@ -1,3 +1,4 @@
+import { customCards } from "../../../data/lovelace_custom_cards";
 import type { HomeAssistant } from "../../../types";
 import { CARD_SUGGESTION_PROVIDERS } from "./registry";
 import type { CardSuggestion } from "./types";
@@ -5,18 +6,43 @@ import type { CardSuggestion } from "./types";
 export type { CardSuggestion, CardSuggestionProvider } from "./types";
 export { CARD_SUGGESTION_PROVIDERS } from "./registry";
 
+export interface CardSuggestions {
+  core: CardSuggestion[];
+  custom: CardSuggestion[];
+}
+
+const collect = (
+  result: CardSuggestion | CardSuggestion[] | null | undefined
+): CardSuggestion[] => {
+  if (!result) return [];
+  return Array.isArray(result) ? result : [result];
+};
+
 export const generateCardSuggestions = (
   hass: HomeAssistant,
   entityId: string | undefined
-): CardSuggestion[] => {
-  if (!entityId || hass.states[entityId] === undefined) return [];
-  return Object.values(CARD_SUGGESTION_PROVIDERS).flatMap((provider) => {
+): CardSuggestions => {
+  if (!entityId || hass.states[entityId] === undefined) {
+    return { core: [], custom: [] };
+  }
+  const core = Object.values(CARD_SUGGESTION_PROVIDERS).flatMap((provider) => {
     try {
-      const result = provider.getEntitySuggestion(hass, entityId);
-      if (!result) return [];
-      return Array.isArray(result) ? result : [result];
-    } catch {
+      return collect(provider.getEntitySuggestion(hass, entityId));
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("Card suggestion provider threw:", err);
       return [];
     }
   });
+  const custom = customCards.flatMap((card) => {
+    if (!card.getSuggestion) return [];
+    try {
+      return collect(card.getSuggestion(hass, entityId));
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`Custom card "${card.type}" getSuggestion threw:`, err);
+      return [];
+    }
+  });
+  return { core, custom };
 };

--- a/src/panels/lovelace/card-suggestions/index.ts
+++ b/src/panels/lovelace/card-suggestions/index.ts
@@ -35,12 +35,15 @@ export const generateCardSuggestions = (
     }
   });
   const custom = customCards.flatMap((card) => {
-    if (!card.getSuggestion) return [];
+    if (!card.getEntitySuggestion) return [];
     try {
-      return collect(card.getSuggestion(hass, entityId));
+      return collect(card.getEntitySuggestion(hass, entityId));
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.error(`Custom card "${card.type}" getSuggestion threw:`, err);
+      console.error(
+        `Custom card "${card.type}" getEntitySuggestion threw:`,
+        err
+      );
       return [];
     }
   });

--- a/src/panels/lovelace/card-suggestions/index.ts
+++ b/src/panels/lovelace/card-suggestions/index.ts
@@ -1,3 +1,4 @@
+import { ensureArray } from "../../../common/array/ensure-array";
 import { customCards } from "../../../data/lovelace_custom_cards";
 import type { HomeAssistant } from "../../../types";
 import { CARD_SUGGESTION_PROVIDERS } from "./registry";
@@ -11,13 +12,6 @@ export interface CardSuggestions {
   custom: CardSuggestion[];
 }
 
-const collect = (
-  result: CardSuggestion | CardSuggestion[] | null | undefined
-): CardSuggestion[] => {
-  if (!result) return [];
-  return Array.isArray(result) ? result : [result];
-};
-
 export const generateCardSuggestions = (
   hass: HomeAssistant,
   entityId: string | undefined
@@ -27,7 +21,7 @@ export const generateCardSuggestions = (
   }
   const core = Object.values(CARD_SUGGESTION_PROVIDERS).flatMap((provider) => {
     try {
-      return collect(provider.getEntitySuggestion(hass, entityId));
+      return ensureArray(provider.getEntitySuggestion(hass, entityId)) ?? [];
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error("Card suggestion provider threw:", err);
@@ -37,7 +31,7 @@ export const generateCardSuggestions = (
   const custom = customCards.flatMap((card) => {
     if (!card.getEntitySuggestion) return [];
     try {
-      return collect(card.getEntitySuggestion(hass, entityId));
+      return ensureArray(card.getEntitySuggestion(hass, entityId)) ?? [];
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error(

--- a/src/panels/lovelace/editor/card-editor/hui-suggestion-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-suggestion-card.ts
@@ -3,6 +3,11 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-ripple";
+import {
+  getCustomCardEntry,
+  isCustomType,
+  stripCustomPrefix,
+} from "../../../../data/lovelace_custom_cards";
 import type { LovelaceCardConfig } from "../../../../data/lovelace/config/card";
 import type { HomeAssistant } from "../../../../types";
 import "../../cards/hui-card";
@@ -52,9 +57,16 @@ export class HuiSuggestionCard extends LitElement {
   protected render(): TemplateResult {
     const { suggestion } = this;
     const hiddenCount = this._preview?.hiddenCount ?? 0;
-    const cardName = this.hass.localize(
-      `ui.panel.lovelace.editor.card.${suggestion.config.type}.name` as any
-    );
+    const type = suggestion.config.type;
+    let cardName: string;
+    if (isCustomType(type)) {
+      const customType = stripCustomPrefix(type);
+      cardName = getCustomCardEntry(customType)?.name ?? customType;
+    } else {
+      cardName = this.hass.localize(
+        `ui.panel.lovelace.editor.card.${type}.name` as any
+      );
+    }
     const label = suggestion.label
       ? `${cardName} - ${suggestion.label}`
       : cardName;

--- a/src/panels/lovelace/editor/card-editor/hui-suggestion-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-suggestion-picker.ts
@@ -134,9 +134,7 @@ export class HuiSuggestionPicker extends LitElement {
     return html`
       <div class="browse-card">
         <p>
-          ${this.hass.localize(
-            "ui.panel.lovelace.editor.cardpicker.not_found"
-          )}
+          ${this.hass.localize("ui.panel.lovelace.editor.cardpicker.not_found")}
         </p>
         <ha-button appearance="plain" @click=${this._browseCards}>
           <ha-svg-icon slot="start" .path=${mdiViewGridPlus}></ha-svg-icon>

--- a/src/panels/lovelace/editor/card-editor/hui-suggestion-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-suggestion-picker.ts
@@ -17,7 +17,10 @@ import "../../../../components/ha-svg-icon";
 import type { LovelaceCardConfig } from "../../../../data/lovelace/config/card";
 import { haStyleScrollbar } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
-import { generateCardSuggestions } from "../../card-suggestions";
+import {
+  generateCardSuggestions,
+  type CardSuggestions,
+} from "../../card-suggestions";
 import type { CardSuggestion } from "../../card-suggestions/types";
 import "./hui-suggestion-card";
 import "./hui-suggestion-entity-tree";
@@ -58,18 +61,21 @@ export class HuiSuggestionPicker extends LitElement {
     (
       entityId: string | undefined,
       priorityTypesKey: string
-    ): CardSuggestion[] => {
-      const suggestions = generateCardSuggestions(this.hass, entityId);
+    ): CardSuggestions => {
+      const { core, custom } = generateCardSuggestions(this.hass, entityId);
       const priorityTypes = priorityTypesKey
         ? priorityTypesKey.split("|")
         : undefined;
-      if (!priorityTypes?.length) return suggestions;
+      if (!priorityTypes?.length) return { core, custom };
       const isPrioritized = (s: CardSuggestion) =>
         priorityTypes.includes(s.config.type);
-      return [
-        ...suggestions.filter(isPrioritized),
-        ...suggestions.filter((s) => !isPrioritized(s)),
-      ];
+      return {
+        core: [
+          ...core.filter(isPrioritized),
+          ...core.filter((s) => !isPrioritized(s)),
+        ],
+        custom,
+      };
     }
   );
 
@@ -101,18 +107,45 @@ export class HuiSuggestionPicker extends LitElement {
     hasEntity: boolean
   ): TemplateResult | typeof nothing {
     if (!hasEntity) return this._renderEmptyState();
-    if (this._narrow) {
-      return html`
-        ${this._renderSelectedEntity()}
-        <ha-section-title>
+    const { core, custom } = this._suggestions();
+    return html`
+      ${this._narrow ? this._renderSelectedEntity() : nothing}
+      <ha-section-title>
+        ${this.hass.localize(
+          "ui.panel.lovelace.editor.cardpicker.suggestions_title"
+        )}
+      </ha-section-title>
+      ${this._renderSuggestionsGrid(core)}
+      ${custom.length
+        ? html`
+            <ha-section-title>
+              ${this.hass.localize(
+                "ui.panel.lovelace.editor.cardpicker.community_title"
+              )}
+            </ha-section-title>
+            ${this._renderSuggestionsGrid(custom)}
+          `
+        : nothing}
+      ${this._renderBrowseCard()}
+    `;
+  }
+
+  private _renderBrowseCard(): TemplateResult {
+    return html`
+      <div class="browse-card">
+        <p>
           ${this.hass.localize(
-            "ui.panel.lovelace.editor.cardpicker.suggestions_title"
+            "ui.panel.lovelace.editor.cardpicker.not_found"
           )}
-        </ha-section-title>
-        ${this._renderSuggestionsGrid(this._suggestions())}
-      `;
-    }
-    return this._renderSuggestionsGrid(this._suggestions());
+        </p>
+        <ha-button appearance="plain" @click=${this._browseCards}>
+          <ha-svg-icon slot="start" .path=${mdiViewGridPlus}></ha-svg-icon>
+          ${this.hass.localize(
+            "ui.panel.lovelace.editor.cardpicker.browse_cards"
+          )}
+        </ha-button>
+      </div>
+    `;
   }
 
   private _renderSelectedEntity(): TemplateResult {
@@ -171,6 +204,17 @@ export class HuiSuggestionPicker extends LitElement {
     `;
   }
 
+  private _suggestionKeys = new WeakMap<CardSuggestion, string>();
+
+  private _suggestionKey = (s: CardSuggestion): string => {
+    let key = this._suggestionKeys.get(s);
+    if (key === undefined) {
+      key = JSON.stringify(s.config);
+      this._suggestionKeys.set(s, key);
+    }
+    return key;
+  };
+
   private _renderSuggestionsGrid(
     suggestions: CardSuggestion[]
   ): TemplateResult {
@@ -178,7 +222,7 @@ export class HuiSuggestionPicker extends LitElement {
       <div class="suggestions" @pick-suggestion=${this._pickSuggestion}>
         ${repeat(
           suggestions,
-          (s: CardSuggestion) => JSON.stringify(s.config),
+          this._suggestionKey,
           (s: CardSuggestion) => html`
             <hui-suggestion-card
               .hass=${this.hass}
@@ -186,34 +230,11 @@ export class HuiSuggestionPicker extends LitElement {
             ></hui-suggestion-card>
           `
         )}
-        <div
-          class="browse-card"
-          tabindex="0"
-          role="button"
-          aria-label=${this.hass.localize(
-            "ui.panel.lovelace.editor.cardpicker.browse_cards"
-          )}
-          @click=${this._browseCards}
-          @keydown=${this._browseCardsKeydown}
-        >
-          <ha-svg-icon .path=${mdiViewGridPlus}></ha-svg-icon>
-          <span class="browse-card-title">
-            ${this.hass.localize(
-              "ui.panel.lovelace.editor.cardpicker.browse_cards"
-            )}
-          </span>
-          <p>
-            ${this.hass.localize(
-              "ui.panel.lovelace.editor.cardpicker.not_found"
-            )}
-          </p>
-          <ha-ripple></ha-ripple>
-        </div>
       </div>
     `;
   }
 
-  private _suggestions(): CardSuggestion[] {
+  private _suggestions(): CardSuggestions {
     return this._computeSuggestions(
       this._entityId,
       (this.prioritizedCardTypes ?? []).join("|")
@@ -222,13 +243,6 @@ export class HuiSuggestionPicker extends LitElement {
 
   private _browseCards(): void {
     fireEvent(this, "browse-cards", undefined);
-  }
-
-  private _browseCardsKeydown(ev: KeyboardEvent): void {
-    if (ev.key === "Enter" || ev.key === " ") {
-      ev.preventDefault();
-      this._browseCards();
-    }
   }
 
   private _handleEntityPicked(ev: CustomEvent<{ entityId: string }>): void {
@@ -313,37 +327,11 @@ export class HuiSuggestionPicker extends LitElement {
           line-height: var(--ha-line-height-expanded);
         }
         .browse-card {
-          position: relative;
-          box-sizing: border-box;
-          height: 100%;
           display: flex;
           flex-direction: column;
           align-items: center;
-          justify-content: center;
           gap: var(--ha-space-2);
-          padding: var(--ha-space-6);
-          text-align: center;
-          cursor: pointer;
-          overflow: hidden;
-          border-radius: var(
-            --ha-card-border-radius,
-            var(--ha-border-radius-lg)
-          );
-          border: var(--ha-card-border-width, 1px) dashed
-            var(--ha-card-border-color, var(--divider-color));
-          background: var(--primary-background-color, #fafafa);
-          color: var(--primary-text-color);
-        }
-        .browse-card:focus-visible {
-          outline: 2px solid var(--primary-color);
-          outline-offset: 2px;
-        }
-        .browse-card ha-svg-icon {
-          color: var(--ha-color-text-secondary);
-        }
-        .browse-card-title {
-          font-size: var(--ha-font-size-m);
-          font-weight: var(--ha-font-weight-medium);
+          padding: var(--ha-space-6) var(--ha-space-4);
         }
         .browse-card p {
           margin: 0;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10425,6 +10425,7 @@
             "no_search_results_description": "Try a different keyword.",
             "selected_entity": "Selected entity",
             "suggestions_title": "Suggestions",
+            "community_title": "Community",
             "not_found": "Can't find the card you want?",
             "suggestions": {
               "periods": {

--- a/test/panels/lovelace/card-suggestions/generate-card-suggestions.test.ts
+++ b/test/panels/lovelace/card-suggestions/generate-card-suggestions.test.ts
@@ -139,7 +139,7 @@ describe("generateCardSuggestions", () => {
       {
         type: "my-custom-card",
         name: "My Custom Card",
-        getSuggestion: (_hass, entityId) => ({
+        getEntitySuggestion: (_hass, entityId) => ({
           config: { type: "custom:my-custom-card", entity: entityId },
         }),
       },
@@ -158,7 +158,7 @@ describe("generateCardSuggestions", () => {
     cleanupCustom = registerCustomCards([
       {
         type: "broken-card",
-        getSuggestion: () => {
+        getEntitySuggestion: () => {
           throw new Error("boom");
         },
       },

--- a/test/panels/lovelace/card-suggestions/generate-card-suggestions.test.ts
+++ b/test/panels/lovelace/card-suggestions/generate-card-suggestions.test.ts
@@ -1,5 +1,7 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import { afterEach, describe, expect, it } from "vitest";
+import { customCards } from "../../../../src/data/lovelace_custom_cards";
+import type { CustomCardEntry } from "../../../../src/data/lovelace_custom_cards";
 import {
   CARD_SUGGESTION_PROVIDERS,
   generateCardSuggestions,
@@ -40,20 +42,39 @@ const registerTestProviders = (
   };
 };
 
+const registerCustomCards = (entries: CustomCardEntry[]): (() => void) => {
+  customCards.push(...entries);
+  return () => {
+    const types = new Set(entries.map((e) => e.type));
+    for (let i = customCards.length - 1; i >= 0; i--) {
+      if (types.has(customCards[i].type)) customCards.splice(i, 1);
+    }
+  };
+};
+
 describe("generateCardSuggestions", () => {
   let cleanupProviders: (() => void) | undefined;
+  let cleanupCustom: (() => void) | undefined;
 
   afterEach(() => {
     cleanupProviders?.();
     cleanupProviders = undefined;
+    cleanupCustom?.();
+    cleanupCustom = undefined;
   });
 
   it("suggests nothing when no entity is picked", () => {
-    expect(generateCardSuggestions(makeHass([]), undefined)).toEqual([]);
+    expect(generateCardSuggestions(makeHass([]), undefined)).toEqual({
+      core: [],
+      custom: [],
+    });
   });
 
   it("suggests nothing when the picked entity doesn't exist", () => {
-    expect(generateCardSuggestions(makeHass([]), "light.ghost")).toEqual([]);
+    expect(generateCardSuggestions(makeHass([]), "light.ghost")).toEqual({
+      core: [],
+      custom: [],
+    });
   });
 
   it("returns the entity-specific suggestions for a known entity", () => {
@@ -61,7 +82,9 @@ describe("generateCardSuggestions", () => {
       makeState("light.a", "on", { supported_color_modes: ["onoff"] }),
     ]);
     const suggestions = generateCardSuggestions(hass, "light.a");
-    expect(suggestions.some((s) => s.config.type === "tile")).toBe(true);
+    expect(suggestions.core.some((s) => s.config.type === "tile")).toBe(
+      true
+    );
   });
 
   it("accepts null, a single suggestion, or a list from each provider", () => {
@@ -88,7 +111,7 @@ describe("generateCardSuggestions", () => {
     });
 
     const hass = makeHass([makeState("sensor.a", "1")]);
-    const types = generateCardSuggestions(hass, "sensor.a").map(
+    const types = generateCardSuggestions(hass, "sensor.a").core.map(
       (s) => s.config.type
     );
 
@@ -107,9 +130,44 @@ describe("generateCardSuggestions", () => {
     });
 
     const hass = makeHass([makeState("sensor.a", "1")]);
-    const types = generateCardSuggestions(hass, "sensor.a").map(
+    const types = generateCardSuggestions(hass, "sensor.a").core.map(
       (s) => s.config.type
     );
     expect(types).toContain("tile");
+  });
+
+  it("collects suggestions from custom cards into the custom bucket", () => {
+    cleanupCustom = registerCustomCards([
+      {
+        type: "my-custom-card",
+        name: "My Custom Card",
+        getSuggestion: (_hass, entityId) => ({
+          config: { type: "custom:my-custom-card", entity: entityId },
+        }),
+      },
+    ]);
+    const hass = makeHass([makeState("light.a")]);
+    const result = generateCardSuggestions(hass, "light.a");
+    expect(result.custom.map((s) => s.config.type)).toContain(
+      "custom:my-custom-card"
+    );
+    expect(result.core.every((s) => s.config.type !== "custom:my-custom-card"))
+      .toBe(true);
+  });
+
+  it("keeps working when a custom card throws", () => {
+    cleanupCustom = registerCustomCards([
+      {
+        type: "broken-card",
+        getSuggestion: () => {
+          throw new Error("boom");
+        },
+      },
+    ]);
+    const hass = makeHass([makeState("light.a")]);
+    const result = generateCardSuggestions(hass, "light.a");
+    expect(result.custom).toEqual([]);
+    // core path still produces tile suggestions
+    expect(result.core.some((s) => s.config.type === "tile")).toBe(true);
   });
 });

--- a/test/panels/lovelace/card-suggestions/generate-card-suggestions.test.ts
+++ b/test/panels/lovelace/card-suggestions/generate-card-suggestions.test.ts
@@ -82,9 +82,7 @@ describe("generateCardSuggestions", () => {
       makeState("light.a", "on", { supported_color_modes: ["onoff"] }),
     ]);
     const suggestions = generateCardSuggestions(hass, "light.a");
-    expect(suggestions.core.some((s) => s.config.type === "tile")).toBe(
-      true
-    );
+    expect(suggestions.core.some((s) => s.config.type === "tile")).toBe(true);
   });
 
   it("accepts null, a single suggestion, or a list from each provider", () => {
@@ -151,8 +149,9 @@ describe("generateCardSuggestions", () => {
     expect(result.custom.map((s) => s.config.type)).toContain(
       "custom:my-custom-card"
     );
-    expect(result.core.every((s) => s.config.type !== "custom:my-custom-card"))
-      .toBe(true);
+    expect(
+      result.core.every((s) => s.config.type !== "custom:my-custom-card")
+    ).toBe(true);
   });
 
   it("keeps working when a custom card throws", () => {


### PR DESCRIPTION
## Proposed change

The entity card picker now supports custom cards in addition to built-in cards.

When an entity is selected, custom cards that opt in display below the built-in suggestions, under a "Community" section. Each custom card decides which entities it supports and what configuration to suggest.

Custom card authors opt in by setting `getEntitySuggestion(hass, entityId)` on their `window.customCards` entry. The method returns one or several suggestions, or `null` if the entity is not supported.

```js
window.customCards.push({
  type: "my-card",
  name: "My Card",
  getEntitySuggestion: (hass, entityId) => {
    if (computeDomain(entityId) !== "light") return null;
    return { config: { type: "custom:my-card", entity: entityId } };
  },
});
```

Each suggestion shows the card name, optionally followed by a variant label. The card name comes from the `name` field of the `customCards` entry, falling back to the card type. The variant label comes from the optional `label` field returned by `getEntitySuggestion`, allowing a single card to suggest multiple presets.

## Screenshots

<!-- Reminder: add a screenshot of the picker showing the new "Community" section with a few custom card suggestions. -->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3122
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr