### PR TITLE
Show verify-email flash after cloud signup

### DIFF
--- a/src/components/ha-alert.ts
+++ b/src/components/ha-alert.ts
@@ -6,8 +6,9 @@ import {
   mdiInformationOutline,
 } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
 import type { LocalizeFunc } from "../common/translations/localize";
 import { fireEvent } from "../common/dom/fire_event";
 import "./ha-icon-button";
@@ -39,7 +40,9 @@ class HaAlert extends LitElement {
 
   @property({ type: Boolean }) public dismissable = false;
 
-  @property({ attribute: false }) public localize?: LocalizeFunc;
+  @state()
+  @consumeLocalize()
+  private _localize?: LocalizeFunc;
 
   @property({ type: Boolean }) public narrow = false;
 
@@ -68,7 +71,7 @@ class HaAlert extends LitElement {
               ${this.dismissable
                 ? html`<ha-icon-button
                     @click=${this._dismissClicked}
-                    .label=${this.localize!("ui.common.dismiss_alert")}
+                    .label=${this._localize?.("ui.common.dismiss_alert")}
                     .path=${mdiClose}
                   ></ha-icon-button>`
                 : nothing}

--- a/src/panels/lovelace/cards/energy/hui-energy-compare-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-compare-card.ts
@@ -143,11 +143,7 @@ export class HuiEnergyCompareCard
     );
 
     return html`
-      <ha-alert
-        dismissable
-        .localize=${this.hass.localize}
-        @alert-dismissed-clicked=${this._stopCompare}
-      >
+      <ha-alert dismissable @alert-dismissed-clicked=${this._stopCompare}>
         ${this.hass.localize(
           "ui.panel.lovelace.cards.energy.energy_compare.info",
           {


### PR DESCRIPTION
## Proposed change

After signing up for Home Assistant Cloud, the user is redirected to the sign-in page but the "Account created! Check your email for instructions on how to activate your account." flash message never appeared.

Root cause: the login panel renders the flash as a dismissable `ha-alert` without passing `localize`. `ha-alert`'s dismiss button called `this.localize!("ui.common.dismiss_alert")` — with the non-null assertion stripped at runtime that's `undefined(...)`, which throws and the entire alert template fails to render.

Fix: migrate `ha-alert` to consume `localize` from the i18n context via `@consumeLocalize()` (matching the `ha-tip` migration in #52177), so callers don't need to pass it. Drop the now-redundant `.localize=${this.hass.localize}` on the two existing callers (`cloud-login-panel`, `hui-energy-compare-card`).

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
