### PR TITLE
Don't show charging devices as low battery in Maintenance chip

### DIFF
--- a/src/panels/maintenance/strategies/maintenance-view-strategy.ts
+++ b/src/panels/maintenance/strategies/maintenance-view-strategy.ts
@@ -48,19 +48,6 @@ const _deviceEntities = memoizeOne(
   }
 );
 
-const _mobileAppBatteryChargingEntity = memoizeOne(
-  (
-    hass: HomeAssistant,
-    entities: EntityRegistryDisplayEntry[]
-  ): EntityRegistryDisplayEntry | undefined =>
-    entities.find(
-      (entity) =>
-        hass.states[entity.entity_id] &&
-        entity.platform === "mobile_app" &&
-        entity.name === "Battery state"
-    )
-);
-
 export const filterLowBatteryEntities = (
   hass: HomeAssistant,
   entityIds: string[]
@@ -74,14 +61,12 @@ export const filterLowBatteryEntities = (
     const deviceId = hass.entities[entityId]?.device_id;
     const entities = deviceId ? _deviceEntities(deviceId, hass.entities) : [];
 
-    const batteryChargingEntity =
-      findBatteryChargingEntity(hass, entities) ??
-      _mobileAppBatteryChargingEntity(hass, entities);
+    const batteryChargingEntity = findBatteryChargingEntity(hass, entities);
     const batteryCharging = batteryChargingEntity
       ? hass.states[batteryChargingEntity?.entity_id]
       : undefined;
 
-    if (batteryCharging && ["on", "charging"].includes(batteryCharging.state)) {
+    if (batteryCharging && batteryCharging.state === "on") {
       return false;
     }
 

--- a/src/panels/maintenance/strategies/maintenance-view-strategy.ts
+++ b/src/panels/maintenance/strategies/maintenance-view-strategy.ts
@@ -1,5 +1,6 @@
 import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
+import memoizeOne from "memoize-one";
 import { getAreasFloorHierarchy } from "../../../common/areas/areas-floor-hierarchy";
 import {
   findEntities,
@@ -14,6 +15,10 @@ import type { HomeAssistant } from "../../../types";
 import type { TileCardConfig } from "../../lovelace/cards/types";
 import { BINARY_STATE_ON } from "../../../common/const";
 import { computeDomain } from "../../../common/entity/compute_domain";
+import {
+  type EntityRegistryDisplayEntry,
+  findBatteryChargingEntity,
+} from "../../../data/entity/entity_registry";
 
 export interface MaintenanceViewStrategyConfig {
   type: "maintenance";
@@ -33,6 +38,29 @@ export const maintenanceEntityFilters: EntityFilter[] = [
 
 const LOW_BATTERY_THRESHOLD = 20;
 
+const _deviceEntities = memoizeOne(
+  (
+    deviceId: string,
+    entities: HomeAssistant["entities"]
+  ): EntityRegistryDisplayEntry[] => {
+    const entries = Object.values(entities);
+    return entries.filter((entity) => entity.device_id === deviceId);
+  }
+);
+
+const _mobileAppBatteryChargingEntity = memoizeOne(
+  (
+    hass: HomeAssistant,
+    entities: EntityRegistryDisplayEntry[]
+  ): EntityRegistryDisplayEntry | undefined =>
+    entities.find(
+      (entity) =>
+        hass.states[entity.entity_id] &&
+        entity.platform === "mobile_app" &&
+        entity.name === "Battery state"
+    )
+);
+
 export const filterLowBatteryEntities = (
   hass: HomeAssistant,
   entityIds: string[]
@@ -42,6 +70,21 @@ export const filterLowBatteryEntities = (
     if (computeDomain(entityId) === "binary_sensor") {
       return state === BINARY_STATE_ON;
     }
+
+    const deviceId = hass.entities[entityId]?.device_id;
+    const entities = deviceId ? _deviceEntities(deviceId, hass.entities) : [];
+
+    const batteryChargingEntity =
+      findBatteryChargingEntity(hass, entities) ??
+      _mobileAppBatteryChargingEntity(hass, entities);
+    const batteryCharging = batteryChargingEntity
+      ? hass.states[batteryChargingEntity?.entity_id]
+      : undefined;
+
+    if (batteryCharging && ["on", "charging"].includes(batteryCharging.state)) {
+      return false;
+    }
+
     const stateValue = parseFloat(state);
     return !isNaN(stateValue) && stateValue <= LOW_BATTERY_THRESHOLD;
   });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Currently, since the introduction of the Maintenance dashboard, the Maintenance chip on the Overview dashboard will show the number of devices with low batteries.
However, this doesn't take into account charging state.

It doesn't seem very useful to get prompted to fix an issue with a low battery if the device is already charging, so this PR adds a condition to the filter to not include charging devices.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

This is my first code contribution to the project, so I'm very open to feedback, especially if there's ways to achieve the same thing that fit the project code style better.

## Checklist
- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] I have followed the perfect PR recommendations
- [X] No code has been generated

To help with the load of incoming pull requests:

- [x] I have reviewed two other prs in this repository.
