### PR TITLE
Remove unused hass property (Group L pass batch)

### DIFF
--- a/src/components/chart/ha-sunburst-chart.ts
+++ b/src/components/chart/ha-sunburst-chart.ts
@@ -7,7 +7,6 @@ import memoizeOne from "memoize-one";
 import { getGraphColorByIndex } from "../../common/color/colors";
 import { filterXSS } from "../../common/util/xss";
 import type { ECOption } from "../../resources/echarts/echarts";
-import type { HomeAssistant } from "../../types";
 import "./ha-chart-base";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/consistent-type-imports
@@ -25,8 +24,6 @@ export interface SunburstNode {
 
 @customElement("ha-sunburst-chart")
 export class HaSunburstChart extends LitElement {
-  public hass!: HomeAssistant;
-
   @property({ attribute: false }) public data?: SunburstNode;
 
   @property({ attribute: false }) public valueFormatter?: (

--- a/src/components/ha-selector/ha-selector-boolean.ts
+++ b/src/components/ha-selector/ha-selector-boolean.ts
@@ -1,15 +1,12 @@
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
-import type { HomeAssistant } from "../../types";
 import "../ha-formfield";
 import "../ha-switch";
 import "../ha-input-helper-text";
 
 @customElement("ha-selector-boolean")
 export class HaBooleanSelector extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property({ type: Boolean }) public value = false;
 
   @property() public placeholder?: any;

--- a/src/components/ha-selector/ha-selector-duration.ts
+++ b/src/components/ha-selector/ha-selector-duration.ts
@@ -2,14 +2,11 @@ import { html, LitElement } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import type { DurationSelector } from "../../data/selector";
-import type { HomeAssistant } from "../../types";
 import "../ha-duration-input";
 import type { HaDurationData, HaDurationInput } from "../ha-duration-input";
 
 @customElement("ha-selector-duration")
 export class HaTimeDuration extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property({ attribute: false }) public selector!: DurationSelector;
 
   @property({ attribute: false }) public value?:

--- a/src/panels/config/storage/storage-breakdown-chart.ts
+++ b/src/panels/config/storage/storage-breakdown-chart.ts
@@ -78,7 +78,6 @@ export class StorageBreakdownChart extends LitElement {
               )}
             ></ha-segmented-bar>`
           : html`<ha-sunburst-chart
-              .hass=${this.hass}
               .data=${this._transformToSunburstData(this.storageInfo!)}
               .valueFormatter=${this._formatBytes}
             ></ha-sunburst-chart>`}


### PR DESCRIPTION
## Summary
- Verification sweep classified three Group L candidates as PASS (no `this.hass` usage and no `.hass=` bindings in-component).
- Removes unused `hass` from `ha-selector-boolean`, `ha-selector-duration`, and `ha-sunburst-chart`.
- Drops `.hass` binding on `ha-sunburst-chart` in `storage-breakdown-chart`.

## Verification (pre-PR)
| File | `this.hass` | `.hass=${` | Class |
|------|-------------|-----------|-------|
| ha-selector-boolean | none | none | PASS |
| ha-selector-duration | none | none | PASS |
| ha-sunburst-chart | none | none | PASS |

Other Group L files in this batch remain PARTIAL/FAIL (see HASS_MIGRATION.md).

## Test plan
- [ ] Open Settings → System → Storage breakdown chart (sunburst) and confirm chart renders.
- [ ] Exercise a boolean selector and duration selector via any flow using `ha-selector` (e.g. automation editor).