### PR TITLE
Migrate Group H energy total badges (partial hass)

### DIFF
--- a/src/panels/lovelace/badges/energy/hui-gas-total-badge.ts
+++ b/src/panels/lovelace/badges/energy/hui-gas-total-badge.ts
@@ -1,3 +1,5 @@
+import { consume } from "@lit/context";
+import type { ContextType } from "@lit/context";
 import { mdiFire } from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
@@ -5,14 +7,25 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../../components/ha-badge";
 import "../../../../components/ha-svg-icon";
+import { consumeLocalize } from "../../../../common/decorators/consume-context-entry";
+import { transform } from "../../../../common/decorators/transform";
 import { formatNumber } from "../../../../common/number/format_number";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
+import {
+  internationalizationContext,
+  statesContext,
+} from "../../../../data/context";
 import type { EnergyData } from "../../../../data/energy";
 import {
   computeTotalFlowRate,
   getEnergyDataCollection,
 } from "../../../../data/energy";
+import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
-import type { HomeAssistant } from "../../../../types";
+import type {
+  HomeAssistant,
+  HomeAssistantInternationalization,
+} from "../../../../types";
 import type { LovelaceBadge } from "../../types";
 import type { GasTotalBadgeConfig } from "../types";
 
@@ -22,6 +35,21 @@ export class HuiGasTotalBadge
   implements LovelaceBadge
 {
   @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state()
+  @consume({ context: statesContext, subscribe: true })
+  private _states!: ContextType<typeof statesContext>;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale!: FrontendLocaleData;
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
 
   @state() private _config?: GasTotalBadgeConfig;
 
@@ -50,14 +78,16 @@ export class HuiGasTotalBadge
       return true;
     }
 
-    if (changedProps.has("hass")) {
-      const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
-      if (!oldHass || !this._entities.size) {
+    if (changedProps.has("_states")) {
+      const oldStates = changedProps.get("_states") as
+        | ContextType<typeof statesContext>
+        | undefined;
+      if (!oldStates || !this._entities.size) {
         return true;
       }
 
       for (const entityId of this._entities) {
-        if (oldHass.states[entityId] !== this.hass?.states[entityId]) {
+        if (oldStates[entityId] !== this._states?.[entityId]) {
           return true;
         }
       }
@@ -74,14 +104,14 @@ export class HuiGasTotalBadge
     const { value, unit } = computeTotalFlowRate(
       "gas",
       this._data.prefs,
-      this.hass.states,
+      this._states,
       this._entities
     );
-    const displayValue = `${formatNumber(value, this.hass.locale, { maximumFractionDigits: 1 })} ${unit}`;
+    const displayValue = `${formatNumber(value, this._locale, { maximumFractionDigits: 1 })} ${unit}`;
 
     const name =
       this._config.title ||
-      this.hass.localize("ui.panel.lovelace.cards.energy.gas_total_title");
+      this._localize("ui.panel.lovelace.cards.energy.gas_total_title");
 
     return html`
       <ha-badge .label=${name}>

--- a/src/panels/lovelace/badges/energy/hui-power-total-badge.ts
+++ b/src/panels/lovelace/badges/energy/hui-power-total-badge.ts
@@ -1,3 +1,5 @@
+import { consume } from "@lit/context";
+import type { ContextType } from "@lit/context";
 import { mdiHomeLightningBolt } from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
@@ -6,13 +8,24 @@ import { customElement, property, state } from "lit/decorators";
 import { formatNumber } from "../../../../common/number/format_number";
 import "../../../../components/ha-badge";
 import "../../../../components/ha-svg-icon";
+import { consumeLocalize } from "../../../../common/decorators/consume-context-entry";
+import { transform } from "../../../../common/decorators/transform";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
+import {
+  internationalizationContext,
+  statesContext,
+} from "../../../../data/context";
 import type { EnergyData, EnergyPreferences } from "../../../../data/energy";
 import {
   getEnergyDataCollection,
   getPowerFromState,
 } from "../../../../data/energy";
+import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
-import type { HomeAssistant } from "../../../../types";
+import type {
+  HomeAssistant,
+  HomeAssistantInternationalization,
+} from "../../../../types";
 import type { LovelaceBadge } from "../../types";
 import type { PowerTotalBadgeConfig } from "../types";
 
@@ -22,6 +35,21 @@ export class HuiPowerTotalBadge
   implements LovelaceBadge
 {
   @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state()
+  @consume({ context: statesContext, subscribe: true })
+  private _states!: ContextType<typeof statesContext>;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale!: FrontendLocaleData;
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
 
   @state() private _config?: PowerTotalBadgeConfig;
 
@@ -50,14 +78,16 @@ export class HuiPowerTotalBadge
       return true;
     }
 
-    if (changedProps.has("hass")) {
-      const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
-      if (!oldHass || !this._entities.size) {
+    if (changedProps.has("_states")) {
+      const oldStates = changedProps.get("_states") as
+        | ContextType<typeof statesContext>
+        | undefined;
+      if (!oldStates || !this._entities.size) {
         return true;
       }
 
       for (const entityId of this._entities) {
-        if (oldHass.states[entityId] !== this.hass?.states[entityId]) {
+        if (oldStates[entityId] !== this._states?.[entityId]) {
           return true;
         }
       }
@@ -68,7 +98,7 @@ export class HuiPowerTotalBadge
 
   private _getCurrentPower(entityId: string): number {
     this._entities.add(entityId);
-    return getPowerFromState(this.hass.states[entityId]) ?? 0;
+    return getPowerFromState(this._states[entityId]) ?? 0;
   }
 
   private _computeTotalPower(prefs: EnergyPreferences): number {
@@ -108,18 +138,18 @@ export class HuiPowerTotalBadge
 
     let displayValue: string;
     if (power >= 1000) {
-      displayValue = `${formatNumber(power / 1000, this.hass.locale, {
+      displayValue = `${formatNumber(power / 1000, this._locale, {
         maximumFractionDigits: 2,
       })} kW`;
     } else {
-      displayValue = `${formatNumber(power, this.hass.locale, {
+      displayValue = `${formatNumber(power, this._locale, {
         maximumFractionDigits: 0,
       })} W`;
     }
 
     const name =
       this._config.title ||
-      this.hass.localize("ui.panel.lovelace.cards.energy.power_total_title");
+      this._localize("ui.panel.lovelace.cards.energy.power_total_title");
 
     return html`
       <ha-badge .label=${name}>

--- a/src/panels/lovelace/badges/energy/hui-water-total-badge.ts
+++ b/src/panels/lovelace/badges/energy/hui-water-total-badge.ts
@@ -1,3 +1,5 @@
+import { consume } from "@lit/context";
+import type { ContextType } from "@lit/context";
 import { mdiWater } from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
@@ -5,14 +7,25 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../../components/ha-badge";
 import "../../../../components/ha-svg-icon";
+import { consumeLocalize } from "../../../../common/decorators/consume-context-entry";
+import { transform } from "../../../../common/decorators/transform";
 import { formatNumber } from "../../../../common/number/format_number";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
+import {
+  internationalizationContext,
+  statesContext,
+} from "../../../../data/context";
 import type { EnergyData } from "../../../../data/energy";
 import {
   computeTotalFlowRate,
   getEnergyDataCollection,
 } from "../../../../data/energy";
+import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
-import type { HomeAssistant } from "../../../../types";
+import type {
+  HomeAssistant,
+  HomeAssistantInternationalization,
+} from "../../../../types";
 import type { LovelaceBadge } from "../../types";
 import type { WaterTotalBadgeConfig } from "../types";
 
@@ -22,6 +35,21 @@ export class HuiWaterTotalBadge
   implements LovelaceBadge
 {
   @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state()
+  @consume({ context: statesContext, subscribe: true })
+  private _states!: ContextType<typeof statesContext>;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale!: FrontendLocaleData;
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
 
   @state() private _config?: WaterTotalBadgeConfig;
 
@@ -50,14 +78,16 @@ export class HuiWaterTotalBadge
       return true;
     }
 
-    if (changedProps.has("hass")) {
-      const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
-      if (!oldHass || !this._entities.size) {
+    if (changedProps.has("_states")) {
+      const oldStates = changedProps.get("_states") as
+        | ContextType<typeof statesContext>
+        | undefined;
+      if (!oldStates || !this._entities.size) {
         return true;
       }
 
       for (const entityId of this._entities) {
-        if (oldHass.states[entityId] !== this.hass?.states[entityId]) {
+        if (oldStates[entityId] !== this._states?.[entityId]) {
           return true;
         }
       }
@@ -74,14 +104,14 @@ export class HuiWaterTotalBadge
     const { value, unit } = computeTotalFlowRate(
       "water",
       this._data.prefs,
-      this.hass.states,
+      this._states,
       this._entities
     );
-    const displayValue = `${formatNumber(value, this.hass.locale, { maximumFractionDigits: 1 })} ${unit}`;
+    const displayValue = `${formatNumber(value, this._locale, { maximumFractionDigits: 1 })} ${unit}`;
 
     const name =
       this._config.title ||
-      this.hass.localize("ui.panel.lovelace.cards.energy.water_total_title");
+      this._localize("ui.panel.lovelace.cards.energy.water_total_title");
 
     return html`
       <ha-badge .label=${name}>


### PR DESCRIPTION
## Summary

- Partial `@property() hass` migration for gas, water, and power energy total Lovelace badges.
- State reads use `statesContext`; number formatting uses `internationalizationContext` → `locale`; titles use `@consumeLocalize()`.
- **`hass` is intentionally retained** for `getEnergyDataCollection(this.hass, …)` until that helper is migrated off full `HomeAssistant`.

## Test plan

- [ ] Add gas / water / power total badges to a dashboard with energy configured; values and units update when source entity states change.
- [ ] Locale / language change updates formatted numbers and default titles.
- [ ] Energy collection subscription still works (badge shows data after load).

## Notes

- `shouldUpdate` now compares tracked entities against `_states` context updates instead of `hass` changes.
- Workspace `HASS_MIGRATION.md` Group H checklist updated locally (meta repo, not in this PR).