### PR TITLE
Migrate hass.states reads for Group J

### DIFF
--- a/src/components/ha-selector/ha-selector-attribute.ts
+++ b/src/components/ha-selector/ha-selector-attribute.ts
@@ -1,11 +1,15 @@
+import { consume } from "@lit/context";
+import type { HassEntities, HassEntity } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
 import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
+import { transform } from "../../common/decorators/transform";
+import { ensureArray } from "../../common/array/ensure-array";
 import { fireEvent } from "../../common/dom/fire_event";
+import { statesContext } from "../../data/context";
 import type { AttributeSelector } from "../../data/selector";
 import type { HomeAssistant } from "../../types";
 import "../entity/ha-entity-attribute-picker";
-import { ensureArray } from "../../common/array/ensure-array";
 
 @customElement("ha-selector-attribute")
 export class HaSelectorAttribute extends LitElement {
@@ -26,6 +30,29 @@ export class HaSelectorAttribute extends LitElement {
   @property({ attribute: false }) public context?: {
     filter_entity?: string | string[];
   };
+
+  @state()
+  @consume({ context: statesContext, subscribe: true })
+  @transform<HassEntities, HassEntity[] | undefined>({
+    transformer: function (this: HaSelectorAttribute, states) {
+      if (!states) {
+        return undefined;
+      }
+      const entityId =
+        this.selector.attribute?.entity_id || this.context?.filter_entity;
+      if (!entityId) {
+        return undefined;
+      }
+      const ids = ensureArray(entityId);
+      return ids
+        .map((id) => states[id])
+        .filter(
+          (entityState): entityState is HassEntity => entityState !== undefined
+        );
+    },
+    watch: ["selector", "context"],
+  })
+  private _filterEntityStates?: HassEntity[];
 
   protected render() {
     return html`
@@ -73,7 +100,9 @@ export class HaSelectorAttribute extends LitElement {
       const entityIds = ensureArray(this.context.filter_entity);
 
       invalid = !entityIds.some((entityId) => {
-        const stateObj = this.hass.states[entityId];
+        const stateObj = this._filterEntityStates?.find(
+          (entityState) => entityState.entity_id === entityId
+        );
         return (
           stateObj &&
           this.value in stateObj.attributes &&

--- a/src/panels/lovelace/components/hui-buttons-base.ts
+++ b/src/panels/lovelace/components/hui-buttons-base.ts
@@ -1,8 +1,12 @@
+import { consume } from "@lit/context";
+import type { HassEntities, HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, state, property } from "lit/decorators";
+import { transform } from "../../../common/decorators/transform";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import "../../../components/entity/state-badge";
+import { statesContext } from "../../../data/context";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import type { HomeAssistant } from "../../../types";
 import type { EntitiesCardEntityConfig } from "../cards/types";
@@ -17,21 +21,39 @@ import { haStyleScrollbar } from "../../../resources/styles";
 
 @customElement("hui-buttons-base")
 export class HuiButtonsBase extends LitElement {
-  @state() public hass!: HomeAssistant;
+  @property({ attribute: false })
+  public hass!: HomeAssistant;
 
   @property({ attribute: false })
   public configEntities?: EntitiesCardEntityConfig[];
+
+  @state()
+  @consume({ context: statesContext, subscribe: true })
+  @transform<HassEntities, Record<string, HassEntity | undefined>>({
+    transformer: function (this: HuiButtonsBase, states) {
+      if (!states) {
+        return {};
+      }
+      const result: Record<string, HassEntity | undefined> = {};
+      for (const entityConf of this.configEntities || []) {
+        result[entityConf.entity] = states[entityConf.entity];
+      }
+      return result;
+    },
+    watch: ["configEntities"],
+  })
+  private _entityStates: Record<string, HassEntity | undefined> = {};
 
   protected render(): TemplateResult {
     return html`
       <ha-chip-set class="ha-scrollbar">
         ${(this.configEntities || []).map((entityConf) => {
-          const stateObj = this.hass.states[entityConf.entity];
+          const stateObj = this._entityStates[entityConf.entity];
 
           const name =
             (entityConf.show_name && stateObj) ||
             (entityConf.name && entityConf.show_name !== false)
-              ? entityConf.name || computeStateName(stateObj)
+              ? entityConf.name || (stateObj ? computeStateName(stateObj) : "")
               : "";
 
           return html`


### PR DESCRIPTION
## Summary

Partial `hass`-property migration for **Group J** (single `hass.states` touchpoints):

- **`hui-buttons-base`**: Entity states now come from `statesContext` via `@consume` + `@transform` keyed by `configEntities`. `hass` is retained for `handleAction`, `computeTooltip`, and `.hass` on `state-badge`.
- **`ha-selector-attribute`**: Context filter entity states consumed the same way for validation in `updated()`. `hass` is retained for `.hass` on `ha-entity-attribute-picker`.

Tracker: Group J marked done in workspace `HASS_MIGRATION.md` (partial notes).

## Test plan

- [ ] `yarn lint` and `yarn lint:types` in `frontend/`
- [ ] Lovelace buttons header/footer: chips show icons/names and actions work
- [ ] Attribute selector: change `filter_entity` context and confirm invalid attributes clear