### PR TITLE
Migrate avatar badges off hass property (Group K)

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -539,11 +539,7 @@ class HaSidebar extends SubscribeMixin(ScrollableFadeMixin(LitElement)) {
           rtl: isRTL,
         })}
       >
-        <ha-user-badge
-          slot="start"
-          .user=${this.hass.user}
-          .hass=${this.hass}
-        ></ha-user-badge>
+        <ha-user-badge slot="start" .user=${this.hass.user}></ha-user-badge>
         <span class="item-text" slot="headline"
           >${this.hass.user ? this.hass.user.name : ""}</span
         >

--- a/src/components/user/ha-person-badge.ts
+++ b/src/components/user/ha-person-badge.ts
@@ -1,16 +1,19 @@
+import { consume, type ContextType } from "@lit/context";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { styleMap } from "lit/directives/style-map";
 import type { BasePerson } from "../../data/person";
 import { computeUserInitials } from "../../data/user";
-import type { HomeAssistant } from "../../types";
+import { connectionContext } from "../../data/context";
 
 @customElement("ha-person-badge")
 class PersonBadge extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property({ attribute: false }) public person?: BasePerson;
+
+  @state()
+  @consume({ context: connectionContext, subscribe: true })
+  private _connection?: ContextType<typeof connectionContext>;
 
   protected render() {
     if (!this.person) {
@@ -19,10 +22,10 @@ class PersonBadge extends LitElement {
 
     const picture = this.person.picture;
 
-    if (picture) {
+    if (picture && this._connection) {
       return html`<div
         style=${styleMap({
-          backgroundImage: `url(${this.hass.hassUrl(picture)})`,
+          backgroundImage: `url(${this._connection.hassUrl(picture)})`,
         })}
         class="picture"
       ></div>`;

--- a/src/components/user/ha-user-badge.ts
+++ b/src/components/user/ha-user-badge.ts
@@ -1,57 +1,55 @@
+import type { HassEntities, HassEntity } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
+import { consume, type ContextType } from "@lit/context";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { styleMap } from "lit/directives/style-map";
 import { computeStateDomain } from "../../common/entity/compute_state_domain";
+import { consumeEntityState } from "../../common/decorators/consume-context-entry";
 import type { User } from "../../data/user";
 import { computeUserInitials } from "../../data/user";
-import type { CurrentUser, HomeAssistant } from "../../types";
+import { connectionContext, statesContext } from "../../data/context";
+import type { CurrentUser } from "../../types";
 
 @customElement("ha-user-badge")
 class UserBadge extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property({ attribute: false }) public user?: User | CurrentUser;
 
-  @state() private _personPicture?: string;
+  @state()
+  @consume({ context: connectionContext, subscribe: true })
+  private _connection?: ContextType<typeof connectionContext>;
 
-  private _personEntityId?: string;
+  @state()
+  @consume({ context: statesContext, subscribe: true })
+  private _states?: HassEntities;
+
+  /** Set for {@link consumeEntityState} `entityIdPath`; read by context, not in render. */
+  @state() private _personEntityId?: string;
+
+  @state()
+  @consumeEntityState({ entityIdPath: ["_personEntityId"] })
+  private _personState?: HassEntity;
 
   public willUpdate(changedProps: PropertyValues<this>) {
     super.willUpdate(changedProps);
-    if (changedProps.has("user")) {
-      this._getPersonPicture();
-      return;
-    }
-    const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
-    if (
-      this._personEntityId &&
-      oldHass &&
-      this.hass.states[this._personEntityId] !==
-        oldHass.states[this._personEntityId]
-    ) {
-      const entityState = this.hass.states[this._personEntityId];
-      if (entityState) {
-        this._personPicture = entityState.attributes.entity_picture;
-      } else {
-        this._getPersonPicture();
-      }
-    } else if (!this._personEntityId && oldHass) {
-      this._getPersonPicture();
+    if (changedProps.has("user") || changedProps.has("_states" as keyof this)) {
+      this._updatePersonEntityId();
     }
   }
 
   protected render() {
-    if (!this.hass || !this.user) {
+    if (!this.user) {
       return nothing;
     }
-    const picture = this._personPicture;
+    const picture = this._personState?.attributes.entity_picture as
+      | string
+      | undefined;
 
-    if (picture) {
+    if (picture && this._connection) {
       return html`<div
         style=${styleMap({
-          backgroundImage: `url(${this.hass.hassUrl(picture)})`,
+          backgroundImage: `url(${this._connection.hassUrl(picture)})`,
         })}
         class="picture"
       ></div>`;
@@ -64,20 +62,18 @@ class UserBadge extends LitElement {
     </div>`;
   }
 
-  private _getPersonPicture() {
+  private _updatePersonEntityId() {
     this._personEntityId = undefined;
-    this._personPicture = undefined;
-    if (!this.hass || !this.user) {
+    if (!this.user || !this._states) {
       return;
     }
-    for (const entity of Object.values(this.hass.states)) {
+    for (const entity of Object.values(this._states)) {
       if (
         entity.attributes.user_id === this.user.id &&
         computeStateDomain(entity) === "person"
       ) {
         this._personEntityId = entity.entity_id;
-        this._personPicture = entity.attributes.entity_picture;
-        break;
+        return;
       }
     }
   }

--- a/src/components/user/ha-user-picker.ts
+++ b/src/components/user/ha-user-picker.ts
@@ -64,11 +64,7 @@ class HaUserPicker extends LitElement {
     }
 
     return html`
-      <ha-user-badge
-        slot="start"
-        .hass=${this.hass}
-        .user=${user}
-      ></ha-user-badge>
+      <ha-user-badge slot="start" .user=${user}></ha-user-badge>
       <span slot="headline">${user.name}</span>
     `;
   };
@@ -94,11 +90,7 @@ class HaUserPicker extends LitElement {
 
     return html`
       <ha-combo-box-item type="button" compact>
-        <ha-user-badge
-          slot="start"
-          .hass=${this.hass}
-          .user=${item.user}
-        ></ha-user-badge>
+        <ha-user-badge slot="start" .user=${item.user}></ha-user-badge>
         <span slot="headline">${item.primary}</span>
       </ha-combo-box-item>
     `;
@@ -129,7 +121,6 @@ class HaUserPicker extends LitElement {
 
     return html`
       <ha-generic-picker
-        .hass=${this.hass}
         .autofocus=${this.autofocus}
         .label=${this.label}
         .placeholder=${placeholder}

--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -60,7 +60,6 @@ export class HaConfigPerson extends LitElement {
     const hass = this.hass;
     return html`
       <hass-tabs-subpage
-        .hass=${this.hass}
         .narrow=${this.narrow}
         .route=${this.route}
         back-path="/config"
@@ -102,7 +101,6 @@ export class HaConfigPerson extends LitElement {
                     .entry=${entry}
                   >
                     <ha-person-badge
-                      .hass=${this.hass}
                       .person=${entry}
                       slot="graphic"
                     ></ha-person-badge>
@@ -139,7 +137,6 @@ export class HaConfigPerson extends LitElement {
                       (entry) => html`
                         <ha-list-item graphic="avatar">
                           <ha-person-badge
-                            .hass=${this.hass}
                             .person=${entry}
                             slot="graphic"
                           ></ha-person-badge>

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-user.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-user.ts
@@ -65,11 +65,7 @@ export class HaCardConditionUser extends LitElement {
               hasMeta
               .selected=${selectedUsers.includes(user.id)}
             >
-              <ha-user-badge
-                slot="graphic"
-                .hass=${this.hass}
-                .user=${user}
-              ></ha-user-badge>
+              <ha-user-badge slot="graphic" .user=${user}></ha-user-badge>
               <span>${user.name}</span>
             </ha-check-list-item>
           `

--- a/src/panels/lovelace/editor/view-editor/hui-view-visibility-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-visibility-editor.ts
@@ -70,11 +70,7 @@ export class HuiViewVisibilityEditor extends LitElement {
         ${this._sortedUsers(this._users).map(
           (user) => html`
             <ha-md-list-item>
-              <ha-user-badge
-                slot="start"
-                .hass=${this.hass}
-                .user=${user}
-              ></ha-user-badge>
+              <ha-user-badge slot="start" .user=${user}></ha-user-badge>
               <span slot="headline">${user.name}</span>
               <ha-switch
                 slot="end"


### PR DESCRIPTION
## Summary

- Migrate `ha-person-badge` to `connectionContext` for `hassUrl` (person config picture).
- Migrate `ha-user-badge` to `connectionContext` + `statesContext` / `consumeEntityState` for person entity picture.
- Remove `.hass` bindings from all callers (sidebar, user picker, config person, Lovelace editors).

## Test plan

- [ ] Sidebar profile avatar shows picture or initials
- [ ] Settings → People list shows person badges (storage + configuration.yaml)
- [ ] User picker dropdown shows user badges
- [ ] Lovelace view visibility / card condition user editors show user badges

## Tracker

Group K in `HASS_MIGRATION.md` (ha monorepo) marked complete.