### PR TITLE
Migrate energy total badges to states/locale/localize context (partial hass)

### DIFF
--- a/src/panels/lovelace/badges/energy/hui-gas-total-badge.ts
+++ b/src/panels/lovelace/badges/energy/hui-gas-total-badge.ts
@@ -7,10 +7,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../../components/ha-badge";
 import "../../../../components/ha-svg-icon";
-import { consumeLocalize } from "../../../../common/decorators/consume-context-entry";
-import { transform } from "../../../../common/decorators/transform";
 import { formatNumber } from "../../../../common/number/format_number";
-import type { LocalizeFunc } from "../../../../common/translations/localize";
 import {
   internationalizationContext,
   statesContext,
@@ -20,7 +17,6 @@ import {
   computeTotalFlowRate,
   getEnergyDataCollection,
 } from "../../../../data/energy";
-import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
 import type {
   HomeAssistant,
@@ -42,14 +38,7 @@ export class HuiGasTotalBadge
 
   @state()
   @consume({ context: internationalizationContext, subscribe: true })
-  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
-    transformer: ({ locale }) => locale,
-  })
-  private _locale!: FrontendLocaleData;
-
-  @state()
-  @consumeLocalize()
-  private _localize!: LocalizeFunc;
+  private _i18n?: HomeAssistantInternationalization;
 
   @state() private _config?: GasTotalBadgeConfig;
 
@@ -97,7 +86,7 @@ export class HuiGasTotalBadge
   }
 
   protected render() {
-    if (!this._config || !this._data) {
+    if (!this._config || !this._data || !this._i18n) {
       return nothing;
     }
 
@@ -107,11 +96,11 @@ export class HuiGasTotalBadge
       this._states,
       this._entities
     );
-    const displayValue = `${formatNumber(value, this._locale, { maximumFractionDigits: 1 })} ${unit}`;
+    const displayValue = `${formatNumber(value, this._i18n.locale, { maximumFractionDigits: 1 })} ${unit}`;
 
     const name =
       this._config.title ||
-      this._localize("ui.panel.lovelace.cards.energy.gas_total_title");
+      this._i18n.localize("ui.panel.lovelace.cards.energy.gas_total_title");
 
     return html`
       <ha-badge .label=${name}>

--- a/src/panels/lovelace/badges/energy/hui-gas-total-badge.ts
+++ b/src/panels/lovelace/badges/energy/hui-gas-total-badge.ts
@@ -1,3 +1,5 @@
+import { consume } from "@lit/context";
+import type { ContextType } from "@lit/context";
 import { mdiFire } from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
@@ -5,14 +7,25 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../../components/ha-badge";
 import "../../../../components/ha-svg-icon";
+import { consumeLocalize } from "../../../../common/decorators/consume-context-entry";
+import { transform } from "../../../../common/decorators/transform";
 import { formatNumber } from "../../../../common/number/format_number";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
+import {
+  internationalizationContext,
+  statesContext,
+} from "../../../../data/context";
 import type { EnergyData } from "../../../../data/energy";
 import {
   computeTotalFlowRate,
   getEnergyDataCollection,
 } from "../../../../data/energy";
+import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
-import type { HomeAssistant } from "../../../../types";
+import type {
+  HomeAssistant,
+  HomeAssistantInternationalization,
+} from "../../../../types";
 import type { LovelaceBadge } from "../../types";
 import type { GasTotalBadgeConfig } from "../types";
 
@@ -22,6 +35,21 @@ export class HuiGasTotalBadge
   implements LovelaceBadge
 {
   @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state()
+  @consume({ context: statesContext, subscribe: true })
+  private _states!: ContextType<typeof statesContext>;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale!: FrontendLocaleData;
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
 
   @state() private _config?: GasTotalBadgeConfig;
 
@@ -50,14 +78,16 @@ export class HuiGasTotalBadge
       return true;
     }
 
-    if (changedProps.has("hass")) {
-      const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
-      if (!oldHass || !this._entities.size) {
+    if (changedProps.has("_states")) {
+      const oldStates = changedProps.get("_states") as
+        | ContextType<typeof statesContext>
+        | undefined;
+      if (!oldStates || !this._entities.size) {
         return true;
       }
 
       for (const entityId of this._entities) {
-        if (oldHass.states[entityId] !== this.hass?.states[entityId]) {
+        if (oldStates[entityId] !== this._states?.[entityId]) {
           return true;
         }
       }
@@ -74,14 +104,14 @@ export class HuiGasTotalBadge
     const { value, unit } = computeTotalFlowRate(
       "gas",
       this._data.prefs,
-      this.hass.states,
+      this._states,
       this._entities
     );
-    const displayValue = `${formatNumber(value, this.hass.locale, { maximumFractionDigits: 1 })} ${unit}`;
+    const displayValue = `${formatNumber(value, this._locale, { maximumFractionDigits: 1 })} ${unit}`;
 
     const name =
       this._config.title ||
-      this.hass.localize("ui.panel.lovelace.cards.energy.gas_total_title");
+      this._localize("ui.panel.lovelace.cards.energy.gas_total_title");
 
     return html`
       <ha-badge .label=${name}>

--- a/src/panels/lovelace/badges/energy/hui-power-total-badge.ts
+++ b/src/panels/lovelace/badges/energy/hui-power-total-badge.ts
@@ -8,9 +8,6 @@ import { customElement, property, state } from "lit/decorators";
 import { formatNumber } from "../../../../common/number/format_number";
 import "../../../../components/ha-badge";
 import "../../../../components/ha-svg-icon";
-import { consumeLocalize } from "../../../../common/decorators/consume-context-entry";
-import { transform } from "../../../../common/decorators/transform";
-import type { LocalizeFunc } from "../../../../common/translations/localize";
 import {
   internationalizationContext,
   statesContext,
@@ -20,7 +17,6 @@ import {
   getEnergyDataCollection,
   getPowerFromState,
 } from "../../../../data/energy";
-import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
 import type {
   HomeAssistant,
@@ -42,14 +38,7 @@ export class HuiPowerTotalBadge
 
   @state()
   @consume({ context: internationalizationContext, subscribe: true })
-  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
-    transformer: ({ locale }) => locale,
-  })
-  private _locale!: FrontendLocaleData;
-
-  @state()
-  @consumeLocalize()
-  private _localize!: LocalizeFunc;
+  private _i18n?: HomeAssistantInternationalization;
 
   @state() private _config?: PowerTotalBadgeConfig;
 
@@ -130,7 +119,7 @@ export class HuiPowerTotalBadge
   }
 
   protected render() {
-    if (!this._config || !this._data) {
+    if (!this._config || !this._data || !this._i18n) {
       return nothing;
     }
 
@@ -138,18 +127,18 @@ export class HuiPowerTotalBadge
 
     let displayValue: string;
     if (power >= 1000) {
-      displayValue = `${formatNumber(power / 1000, this._locale, {
+      displayValue = `${formatNumber(power / 1000, this._i18n.locale, {
         maximumFractionDigits: 2,
       })} kW`;
     } else {
-      displayValue = `${formatNumber(power, this._locale, {
+      displayValue = `${formatNumber(power, this._i18n.locale, {
         maximumFractionDigits: 0,
       })} W`;
     }
 
     const name =
       this._config.title ||
-      this._localize("ui.panel.lovelace.cards.energy.power_total_title");
+      this._i18n.localize("ui.panel.lovelace.cards.energy.power_total_title");
 
     return html`
       <ha-badge .label=${name}>

--- a/src/panels/lovelace/badges/energy/hui-power-total-badge.ts
+++ b/src/panels/lovelace/badges/energy/hui-power-total-badge.ts
@@ -1,3 +1,5 @@
+import { consume } from "@lit/context";
+import type { ContextType } from "@lit/context";
 import { mdiHomeLightningBolt } from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
@@ -6,13 +8,24 @@ import { customElement, property, state } from "lit/decorators";
 import { formatNumber } from "../../../../common/number/format_number";
 import "../../../../components/ha-badge";
 import "../../../../components/ha-svg-icon";
+import { consumeLocalize } from "../../../../common/decorators/consume-context-entry";
+import { transform } from "../../../../common/decorators/transform";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
+import {
+  internationalizationContext,
+  statesContext,
+} from "../../../../data/context";
 import type { EnergyData, EnergyPreferences } from "../../../../data/energy";
 import {
   getEnergyDataCollection,
   getPowerFromState,
 } from "../../../../data/energy";
+import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
-import type { HomeAssistant } from "../../../../types";
+import type {
+  HomeAssistant,
+  HomeAssistantInternationalization,
+} from "../../../../types";
 import type { LovelaceBadge } from "../../types";
 import type { PowerTotalBadgeConfig } from "../types";
 
@@ -22,6 +35,21 @@ export class HuiPowerTotalBadge
   implements LovelaceBadge
 {
   @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state()
+  @consume({ context: statesContext, subscribe: true })
+  private _states!: ContextType<typeof statesContext>;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale!: FrontendLocaleData;
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
 
   @state() private _config?: PowerTotalBadgeConfig;
 
@@ -50,14 +78,16 @@ export class HuiPowerTotalBadge
       return true;
     }
 
-    if (changedProps.has("hass")) {
-      const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
-      if (!oldHass || !this._entities.size) {
+    if (changedProps.has("_states")) {
+      const oldStates = changedProps.get("_states") as
+        | ContextType<typeof statesContext>
+        | undefined;
+      if (!oldStates || !this._entities.size) {
         return true;
       }
 
       for (const entityId of this._entities) {
-        if (oldHass.states[entityId] !== this.hass?.states[entityId]) {
+        if (oldStates[entityId] !== this._states?.[entityId]) {
           return true;
         }
       }
@@ -68,7 +98,7 @@ export class HuiPowerTotalBadge
 
   private _getCurrentPower(entityId: string): number {
     this._entities.add(entityId);
-    return getPowerFromState(this.hass.states[entityId]) ?? 0;
+    return getPowerFromState(this._states[entityId]) ?? 0;
   }
 
   private _computeTotalPower(prefs: EnergyPreferences): number {
@@ -108,18 +138,18 @@ export class HuiPowerTotalBadge
 
     let displayValue: string;
     if (power >= 1000) {
-      displayValue = `${formatNumber(power / 1000, this.hass.locale, {
+      displayValue = `${formatNumber(power / 1000, this._locale, {
         maximumFractionDigits: 2,
       })} kW`;
     } else {
-      displayValue = `${formatNumber(power, this.hass.locale, {
+      displayValue = `${formatNumber(power, this._locale, {
         maximumFractionDigits: 0,
       })} W`;
     }
 
     const name =
       this._config.title ||
-      this.hass.localize("ui.panel.lovelace.cards.energy.power_total_title");
+      this._localize("ui.panel.lovelace.cards.energy.power_total_title");
 
     return html`
       <ha-badge .label=${name}>

--- a/src/panels/lovelace/badges/energy/hui-water-total-badge.ts
+++ b/src/panels/lovelace/badges/energy/hui-water-total-badge.ts
@@ -7,10 +7,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../../components/ha-badge";
 import "../../../../components/ha-svg-icon";
-import { consumeLocalize } from "../../../../common/decorators/consume-context-entry";
-import { transform } from "../../../../common/decorators/transform";
 import { formatNumber } from "../../../../common/number/format_number";
-import type { LocalizeFunc } from "../../../../common/translations/localize";
 import {
   internationalizationContext,
   statesContext,
@@ -20,7 +17,6 @@ import {
   computeTotalFlowRate,
   getEnergyDataCollection,
 } from "../../../../data/energy";
-import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
 import type {
   HomeAssistant,
@@ -42,14 +38,7 @@ export class HuiWaterTotalBadge
 
   @state()
   @consume({ context: internationalizationContext, subscribe: true })
-  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
-    transformer: ({ locale }) => locale,
-  })
-  private _locale!: FrontendLocaleData;
-
-  @state()
-  @consumeLocalize()
-  private _localize!: LocalizeFunc;
+  private _i18n?: HomeAssistantInternationalization;
 
   @state() private _config?: WaterTotalBadgeConfig;
 
@@ -97,7 +86,7 @@ export class HuiWaterTotalBadge
   }
 
   protected render() {
-    if (!this._config || !this._data) {
+    if (!this._config || !this._data || !this._i18n) {
       return nothing;
     }
 
@@ -107,11 +96,11 @@ export class HuiWaterTotalBadge
       this._states,
       this._entities
     );
-    const displayValue = `${formatNumber(value, this._locale, { maximumFractionDigits: 1 })} ${unit}`;
+    const displayValue = `${formatNumber(value, this._i18n.locale, { maximumFractionDigits: 1 })} ${unit}`;
 
     const name =
       this._config.title ||
-      this._localize("ui.panel.lovelace.cards.energy.water_total_title");
+      this._i18n.localize("ui.panel.lovelace.cards.energy.water_total_title");
 
     return html`
       <ha-badge .label=${name}>

--- a/src/panels/lovelace/badges/energy/hui-water-total-badge.ts
+++ b/src/panels/lovelace/badges/energy/hui-water-total-badge.ts
@@ -1,3 +1,5 @@
+import { consume } from "@lit/context";
+import type { ContextType } from "@lit/context";
 import { mdiWater } from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
@@ -5,14 +7,25 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../../components/ha-badge";
 import "../../../../components/ha-svg-icon";
+import { consumeLocalize } from "../../../../common/decorators/consume-context-entry";
+import { transform } from "../../../../common/decorators/transform";
 import { formatNumber } from "../../../../common/number/format_number";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
+import {
+  internationalizationContext,
+  statesContext,
+} from "../../../../data/context";
 import type { EnergyData } from "../../../../data/energy";
 import {
   computeTotalFlowRate,
   getEnergyDataCollection,
 } from "../../../../data/energy";
+import type { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
-import type { HomeAssistant } from "../../../../types";
+import type {
+  HomeAssistant,
+  HomeAssistantInternationalization,
+} from "../../../../types";
 import type { LovelaceBadge } from "../../types";
 import type { WaterTotalBadgeConfig } from "../types";
 
@@ -22,6 +35,21 @@ export class HuiWaterTotalBadge
   implements LovelaceBadge
 {
   @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state()
+  @consume({ context: statesContext, subscribe: true })
+  private _states!: ContextType<typeof statesContext>;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale!: FrontendLocaleData;
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
 
   @state() private _config?: WaterTotalBadgeConfig;
 
@@ -50,14 +78,16 @@ export class HuiWaterTotalBadge
       return true;
     }
 
-    if (changedProps.has("hass")) {
-      const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
-      if (!oldHass || !this._entities.size) {
+    if (changedProps.has("_states")) {
+      const oldStates = changedProps.get("_states") as
+        | ContextType<typeof statesContext>
+        | undefined;
+      if (!oldStates || !this._entities.size) {
         return true;
       }
 
       for (const entityId of this._entities) {
-        if (oldHass.states[entityId] !== this.hass?.states[entityId]) {
+        if (oldStates[entityId] !== this._states?.[entityId]) {
           return true;
         }
       }
@@ -74,14 +104,14 @@ export class HuiWaterTotalBadge
     const { value, unit } = computeTotalFlowRate(
       "water",
       this._data.prefs,
-      this.hass.states,
+      this._states,
       this._entities
     );
-    const displayValue = `${formatNumber(value, this.hass.locale, { maximumFractionDigits: 1 })} ${unit}`;
+    const displayValue = `${formatNumber(value, this._locale, { maximumFractionDigits: 1 })} ${unit}`;
 
     const name =
       this._config.title ||
-      this.hass.localize("ui.panel.lovelace.cards.energy.water_total_title");
+      this._localize("ui.panel.lovelace.cards.energy.water_total_title");
 
     return html`
       <ha-badge .label=${name}>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Partial `@property() hass` migration for gas, water, and power energy total Lovelace badges:

- `hui-gas-total-badge.ts`
- `hui-water-total-badge.ts`
- `hui-power-total-badge.ts`

State reads use `statesContext`. Number formatting and titles use a single `internationalizationContext` consumer (`_i18n`).

`hass` is intentionally retained for `getEnergyDataCollection(this.hass, …)` until that helper is migrated off full `HomeAssistant`.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:
- Contexts: `statesContext`, `internationalizationContext`
- `shouldUpdate` compares tracked entities against `_states` context instead of `hass` changes.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3A%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr