### PR TITLE
Migrate automation icon components to context consumption (Group G)

### DIFF
--- a/src/components/ha-condition-icon.ts
+++ b/src/components/ha-condition-icon.ts
@@ -11,12 +11,13 @@ import {
   mdiStateMachine,
   mdiWeatherSunny,
 } from "@mdi/js";
+import { consume, type ContextType } from "@lit/context";
 import { html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { until } from "lit/directives/until";
 import { computeDomain } from "../common/entity/compute_domain";
+import { configContext, connectionContext } from "../data/context";
 import { conditionIcon, FALLBACK_DOMAIN_ICONS } from "../data/icons";
-import type { HomeAssistant } from "../types";
 import "./ha-icon";
 import "./ha-svg-icon";
 
@@ -36,11 +37,17 @@ export const CONDITION_ICONS = {
 
 @customElement("ha-condition-icon")
 export class HaConditionIcon extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property() public condition?: string;
 
   @property() public icon?: string;
+
+  @state()
+  @consume({ context: configContext, subscribe: true })
+  private _hassConfig?: ContextType<typeof configContext>;
+
+  @state()
+  @consume({ context: connectionContext, subscribe: true })
+  private _connection?: ContextType<typeof connectionContext>;
 
   protected render() {
     if (this.icon) {
@@ -51,13 +58,13 @@ export class HaConditionIcon extends LitElement {
       return nothing;
     }
 
-    if (!this.hass) {
+    if (!this._connection || !this._hassConfig) {
       return this._renderFallback();
     }
 
     const icon = conditionIcon(
-      this.hass.connection,
-      this.hass.config,
+      this._connection.connection,
+      this._hassConfig.config,
       this.condition
     ).then((icn) => {
       if (icn) {

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -478,7 +478,6 @@ export class HaServiceControl extends LitElement {
     return html`${this.hidePicker
       ? nothing
       : html`<ha-service-picker
-          .hass=${this.hass}
           .value=${this._value?.action}
           .disabled=${this.disabled}
           @value-changed=${this._serviceChanged}
@@ -517,7 +516,6 @@ export class HaServiceControl extends LitElement {
             >${this.hass.localize("ui.components.service-control.target")}</span
           >
           <ha-selector
-            .hass=${this.hass}
             .selector=${this._targetSelector(
               serviceData.target as TargetSelector,
               this._value?.target
@@ -529,7 +527,6 @@ export class HaServiceControl extends LitElement {
         ></ha-settings-row>`
       : entityId
         ? html`<ha-entity-picker
-            .hass=${this.hass}
             .disabled=${this.disabled}
             .value=${this._value?.data?.entity_id}
             .label=${this.hass.localize(
@@ -584,7 +581,6 @@ export class HaServiceControl extends LitElement {
               >
                 <ha-service-section-icon
                   slot="icons"
-                  .hass=${this.hass}
                   .service=${this._value!.action}
                   .section=${dataField.key}
                 ></ha-service-section-icon>
@@ -709,7 +705,6 @@ export class HaServiceControl extends LitElement {
               !this._checkedKeys.has(dataField.key) &&
               (!this._value?.data ||
                 this._value.data[dataField.key] === undefined))}
-            .hass=${this.hass}
             .selector=${selector}
             .key=${dataField.key}
             @value-changed=${this._serviceDataChanged}

--- a/src/components/ha-service-icon.ts
+++ b/src/components/ha-service-icon.ts
@@ -1,23 +1,30 @@
+import { consume, type ContextType } from "@lit/context";
 import { html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { until } from "lit/directives/until";
 import { computeDomain } from "../common/entity/compute_domain";
+import { configContext, connectionContext } from "../data/context";
 import {
   DEFAULT_SERVICE_ICON,
   FALLBACK_DOMAIN_ICONS,
   serviceIcon,
 } from "../data/icons";
-import type { HomeAssistant } from "../types";
 import "./ha-icon";
 import "./ha-svg-icon";
 
 @customElement("ha-service-icon")
 export class HaServiceIcon extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property() public service?: string;
 
   @property() public icon?: string;
+
+  @state()
+  @consume({ context: configContext, subscribe: true })
+  private _hassConfig?: ContextType<typeof configContext>;
+
+  @state()
+  @consume({ context: connectionContext, subscribe: true })
+  private _connection?: ContextType<typeof connectionContext>;
 
   protected render() {
     if (this.icon) {
@@ -28,13 +35,13 @@ export class HaServiceIcon extends LitElement {
       return nothing;
     }
 
-    if (!this.hass) {
+    if (!this._connection || !this._hassConfig) {
       return this._renderFallback();
     }
 
     const icon = serviceIcon(
-      this.hass.connection,
-      this.hass.config,
+      this._connection.connection,
+      this._hassConfig.config,
       this.service
     ).then((icn) => {
       if (icn) {

--- a/src/components/ha-service-picker.ts
+++ b/src/components/ha-service-picker.ts
@@ -62,11 +62,7 @@ class HaServicePicker extends LitElement {
     index
   ) => html`
     <ha-combo-box-item type="button" .borderTop=${index !== 0}>
-      <ha-service-icon
-        slot="start"
-        .hass=${this.hass}
-        .service=${item.id}
-      ></ha-service-icon>
+      <ha-service-icon slot="start" .service=${item.id}></ha-service-icon>
       <span slot="headline">${item.primary}</span>
       <span slot="supporting-text">${item.secondary}</span>
       ${item.service_id && this.showServiceId
@@ -112,11 +108,7 @@ class HaServicePicker extends LitElement {
           service;
 
         return html`
-          <ha-service-icon
-            slot="start"
-            .hass=${this.hass}
-            .service=${serviceId}
-          ></ha-service-icon>
+          <ha-service-icon slot="start" .service=${serviceId}></ha-service-icon>
           <span slot="headline">${serviceName}</span>
           ${this.showServiceId
             ? html`<span slot="supporting-text" class="code"
@@ -134,7 +126,6 @@ class HaServicePicker extends LitElement {
 
     return html`
       <ha-generic-picker
-        .hass=${this.hass}
         .autofocus=${this.autofocus}
         .notFoundLabel=${this.hass.localize(
           "ui.components.service-picker.no_match"

--- a/src/components/ha-service-section-icon.ts
+++ b/src/components/ha-service-section-icon.ts
@@ -1,20 +1,27 @@
+import { consume, type ContextType } from "@lit/context";
 import { html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { until } from "lit/directives/until";
-import type { HomeAssistant } from "../types";
+import { configContext, connectionContext } from "../data/context";
+import { serviceSectionIcon } from "../data/icons";
 import "./ha-icon";
 import "./ha-svg-icon";
-import { serviceSectionIcon } from "../data/icons";
 
 @customElement("ha-service-section-icon")
 export class HaServiceSectionIcon extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property() public service?: string;
 
   @property() public section?: string;
 
   @property() public icon?: string;
+
+  @state()
+  @consume({ context: configContext, subscribe: true })
+  private _hassConfig?: ContextType<typeof configContext>;
+
+  @state()
+  @consume({ context: connectionContext, subscribe: true })
+  private _connection?: ContextType<typeof connectionContext>;
 
   protected render() {
     if (this.icon) {
@@ -25,13 +32,13 @@ export class HaServiceSectionIcon extends LitElement {
       return nothing;
     }
 
-    if (!this.hass) {
+    if (!this._connection || !this._hassConfig) {
       return this._renderFallback();
     }
 
     const icon = serviceSectionIcon(
-      this.hass.connection,
-      this.hass.config,
+      this._connection.connection,
+      this._hassConfig.config,
       this.service,
       this.section
     ).then((icn) => {

--- a/src/components/ha-trigger-icon.ts
+++ b/src/components/ha-trigger-icon.ts
@@ -17,13 +17,14 @@ import {
   mdiWeatherSunny,
   mdiWebhook,
 } from "@mdi/js";
+import { consume, type ContextType } from "@lit/context";
 import { html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { until } from "lit/directives/until";
 import { computeDomain } from "../common/entity/compute_domain";
+import { configContext, connectionContext } from "../data/context";
 import { FALLBACK_DOMAIN_ICONS, triggerIcon } from "../data/icons";
 import { mdiHomeAssistant } from "../resources/home-assistant-logo-svg";
-import type { HomeAssistant } from "../types";
 import "./ha-icon";
 import "./ha-svg-icon";
 
@@ -50,11 +51,17 @@ export const TRIGGER_ICONS = {
 
 @customElement("ha-trigger-icon")
 export class HaTriggerIcon extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property() public trigger?: string;
 
   @property() public icon?: string;
+
+  @state()
+  @consume({ context: configContext, subscribe: true })
+  private _hassConfig?: ContextType<typeof configContext>;
+
+  @state()
+  @consume({ context: connectionContext, subscribe: true })
+  private _connection?: ContextType<typeof connectionContext>;
 
   protected render() {
     if (this.icon) {
@@ -65,13 +72,13 @@ export class HaTriggerIcon extends LitElement {
       return nothing;
     }
 
-    if (!this.hass) {
+    if (!this._connection || !this._hassConfig) {
       return this._renderFallback();
     }
 
     const icon = triggerIcon(
-      this.hass.connection,
-      this.hass.config,
+      this._connection.connection,
+      this._hassConfig.config,
       this.trigger
     ).then((icn) => {
       if (icn) {

--- a/src/components/trace/hat-script-graph.ts
+++ b/src/components/trace/hat-script-graph.ts
@@ -451,7 +451,6 @@ export class HatScriptGraph extends LitElement {
         ${node.action
           ? html`<ha-service-icon
               slot="icon"
-              .hass=${this.hass}
               .service=${node.action}
             ></ha-service-icon>`
           : nothing}

--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -308,7 +308,6 @@ export default class HaAutomationActionRow extends LitElement {
             <ha-service-icon
               slot="leading-icon"
               class="action-icon"
-              .hass=${this.hass}
               .service=${this.action.action}
             ></ha-service-icon>
           `
@@ -615,7 +614,6 @@ export default class HaAutomationActionRow extends LitElement {
                 </ha-automation-editor-warning>`
               : nothing}
             <ha-automation-action-editor
-              .hass=${this.hass}
               .action=${this.action}
               .disabled=${this.disabled}
               .yamlMode=${this._yamlMode}
@@ -692,7 +690,6 @@ export default class HaAutomationActionRow extends LitElement {
           )))
         ? html`<ha-automation-action-editor
             class=${this._collapsed ? "hidden" : ""}
-            .hass=${this.hass}
             .action=${this.action}
             .narrow=${this.narrow}
             .disabled=${this.disabled}
@@ -724,7 +721,6 @@ export default class HaAutomationActionRow extends LitElement {
       targetSpec?: TargetSelector["target"]
     ) =>
       html`<ha-automation-row-targets
-        .hass=${this.hass}
         .target=${target}
         .targetRequired=${targetRequired}
         .selector=${targetSpec ? { target: targetSpec } : undefined}

--- a/src/panels/config/automation/action/types/ha-automation-action-condition.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-condition.ts
@@ -96,7 +96,6 @@ export class HaConditionAction
       ${this.inSidebar || (!this.inSidebar && !this.indent)
         ? html`
             <ha-generic-picker
-              .hass=${this.hass}
               .label=${this.hass.localize(
                 "ui.panel.config.automation.editor.conditions.type_select"
               )}
@@ -120,7 +119,6 @@ export class HaConditionAction
               .condition=${this.action}
               .description=${this._conditionDescriptions[this.action.condition]}
               .disabled=${this.disabled}
-              .hass=${this.hass}
               @value-changed=${this._conditionChanged}
               .narrow=${this.narrow}
               .uiSupported=${this._uiSupported(
@@ -156,7 +154,6 @@ export class HaConditionAction
 
     return html`<ha-condition-icon
         slot="start"
-        .hass=${this.hass}
         .condition=${condition}
       ></ha-condition-icon
       ><span slot="headline">${label}</span>`;
@@ -166,7 +163,6 @@ export class HaConditionAction
     <ha-combo-box-item type="button">
       <ha-condition-icon
         slot="start"
-        .hass=${this.hass}
         .condition=${item.search_labels!.condition || undefined}
       ></ha-condition-icon>
       <span slot="headline">${item.primary}</span>

--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -750,7 +750,6 @@ class DialogAddAutomationElement
       >
         ${this._filter
           ? html`<ha-automation-add-search
-              .hass=${this.hass}
               .filter=${this._filter}
               .configEntryLookup=${this._configEntryLookup}
               .manifests=${this._manifests}
@@ -769,7 +768,6 @@ class DialogAddAutomationElement
             </ha-automation-add-search>`
           : this._tab === "targets"
             ? html`<ha-automation-add-from-target
-                .hass=${this.hass}
                 .value=${this._selectedTarget}
                 @value-changed=${this._handleTargetSelected}
                 .narrow=${this._narrow}
@@ -879,7 +877,6 @@ class DialogAddAutomationElement
         ${!this._filter
           ? html`
               <ha-automation-add-items
-                .hass=${this.hass}
                 .items=${this._getItems()}
                 .scrollable=${!this._narrow}
                 .error=${this._tab === "targets" && this._loadItemsError
@@ -1638,7 +1635,6 @@ class DialogAddAutomationElement
           result.push({
             icon: html`
               <ha-service-icon
-                .hass=${this.hass}
                 .service=${`${dmn}.${service}`}
               ></ha-service-icon>
             `,
@@ -1897,12 +1893,7 @@ class DialogAddAutomationElement
   ): AddAutomationElementListItem {
     const triggerName = getTriggerObjectId(trigger);
     return {
-      icon: html`
-        <ha-trigger-icon
-          .hass=${this.hass}
-          .trigger=${trigger}
-        ></ha-trigger-icon>
-      `,
+      icon: html` <ha-trigger-icon .trigger=${trigger}></ha-trigger-icon> `,
       key: `${DYNAMIC_PREFIX}${trigger}`,
       name:
         localize(`component.${domain}.triggers.${triggerName}.name`) || trigger,
@@ -1920,10 +1911,7 @@ class DialogAddAutomationElement
     const conditionName = getConditionObjectId(condition);
     return {
       icon: html`
-        <ha-condition-icon
-          .hass=${this.hass}
-          .condition=${condition}
-        ></ha-condition-icon>
+        <ha-condition-icon .condition=${condition}></ha-condition-icon>
       `,
       key: `${DYNAMIC_PREFIX}${condition}`,
       name:
@@ -1957,7 +1945,6 @@ class DialogAddAutomationElement
       items[domain].items.push({
         icon: html`
           <ha-service-icon
-            .hass=${this.hass}
             .service=${`${domain}.${serviceName}`}
           ></ha-service-icon>
         `,

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -213,7 +213,6 @@ export default class HaAutomationConditionRow extends LitElement {
     return html`
       <ha-condition-icon
         slot="leading-icon"
-        .hass=${this.hass}
         .condition=${this.condition.condition}
       ></ha-condition-icon>
       <h3 slot="header">
@@ -470,7 +469,6 @@ export default class HaAutomationConditionRow extends LitElement {
                 </ha-automation-editor-warning>`
               : nothing}
             <ha-automation-condition-editor
-              .hass=${this.hass}
               .condition=${this.condition}
               .description=${this.conditionDescriptions[
                 this.condition.condition
@@ -554,7 +552,6 @@ export default class HaAutomationConditionRow extends LitElement {
       CONDITION_BUILDING_BLOCKS.includes(this.condition.condition)
         ? html`<ha-automation-condition-editor
             class=${this._collapsed ? "hidden" : ""}
-            .hass=${this.hass}
             .condition=${this.condition}
             .disabled=${this.disabled}
             .uiSupported=${this._uiSupported(
@@ -576,7 +573,6 @@ export default class HaAutomationConditionRow extends LitElement {
       targetSpec?: TargetSelector["target"]
     ) =>
       html`<ha-automation-row-targets
-        .hass=${this.hass}
         .target=${target}
         .targetRequired=${targetRequired}
         .selector=${targetSpec ? { target: targetSpec } : undefined}

--- a/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
@@ -240,7 +240,6 @@ export default class HaAutomationTriggerRow extends LitElement {
           ></ha-svg-icon>`
         : html`<ha-trigger-icon
             slot="leading-icon"
-            .hass=${this.hass}
             .trigger=${(this.trigger as Exclude<Trigger, TriggerList>).trigger}
           ></ha-trigger-icon>`}
       <h3 slot="header">
@@ -500,7 +499,6 @@ export default class HaAutomationTriggerRow extends LitElement {
                 </ha-automation-editor-warning>`
               : nothing}
             <ha-automation-trigger-editor
-              .hass=${this.hass}
               .trigger=${this.trigger}
               .description=${"trigger" in this.trigger
                 ? this.triggerDescriptions[this.trigger.trigger]
@@ -560,7 +558,6 @@ export default class HaAutomationTriggerRow extends LitElement {
       targetSpec?: TargetSelector["target"]
     ) =>
       html`<ha-automation-row-targets
-        .hass=${this.hass}
         .target=${target}
         .targetRequired=${targetRequired}
         .selector=${targetSpec ? { target: targetSpec } : undefined}


### PR DESCRIPTION
## Summary
- Migrate `ha-condition-icon`, `ha-trigger-icon`, `ha-service-icon`, and `ha-service-section-icon` from `hass` prop to `configContext` + `connectionContext` (same pattern as `ha-domain-icon`).
- Remove redundant `.hass=${this.hass}` bindings from automation UI and service picker/control callers.

## Test plan
- [ ] Open automation editor; verify condition, trigger, and action icons render in rows and add-element dialog
- [ ] Open service picker; verify service icons render in dropdown items
- [ ] Open service control with sectioned fields; verify section icons render
- [ ] Open script trace graph; verify service icons still render on action nodes