### PR TITLE
Migrate ha-relative-time and ha-absolute-time off hass property (Group E)

### DIFF
--- a/src/components/entity/state-info.ts
+++ b/src/components/entity/state-info.ts
@@ -43,7 +43,6 @@ class StateInfo extends LitElement {
                     )}:
                   </span>
                   <ha-relative-time
-                    .hass=${this.hass}
                     .datetime=${this.stateObj.last_changed}
                     capitalize
                   ></ha-relative-time>
@@ -55,7 +54,6 @@ class StateInfo extends LitElement {
                     )}:
                   </span>
                   <ha-relative-time
-                    .hass=${this.hass}
                     .datetime=${this.stateObj.last_updated}
                     capitalize
                   ></ha-relative-time>
@@ -63,7 +61,6 @@ class StateInfo extends LitElement {
               </ha-tooltip>
               <ha-relative-time
                 id="relative-time"
-                .hass=${this.hass}
                 .datetime=${this.stateObj.last_changed}
                 capitalize
               ></ha-relative-time>

--- a/src/components/ha-absolute-time.ts
+++ b/src/components/ha-absolute-time.ts
@@ -1,17 +1,43 @@
+import { consume } from "@lit/context";
 import { addDays, differenceInMilliseconds, startOfDay } from "date-fns";
+import type { HassConfig } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
 import { ReactiveElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import { transform } from "../common/decorators/transform";
 import { absoluteTime } from "../common/datetime/absolute_time";
-import type { HomeAssistant } from "../types";
+import { configContext, internationalizationContext } from "../data/context";
+import type { FrontendLocaleData } from "../data/translation";
+import type { LocalizeFunc } from "../common/translations/localize";
+import type {
+  HomeAssistantConfig,
+  HomeAssistantInternationalization,
+} from "../types";
 
 const SAFE_MARGIN = 5 * 1000;
 
 @customElement("ha-absolute-time")
 class HaAbsoluteTime extends ReactiveElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property({ attribute: false }) public datetime?: string | Date;
+
+  @state()
+  @consumeLocalize()
+  private _localize?: LocalizeFunc;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale?: FrontendLocaleData;
+
+  @state()
+  @consume({ context: configContext, subscribe: true })
+  @transform<HomeAssistantConfig, HassConfig>({
+    transformer: ({ config }) => config,
+  })
+  private _config?: HassConfig;
 
   private _timeout?: number;
 
@@ -62,13 +88,17 @@ class HaAbsoluteTime extends ReactiveElement {
   }
 
   private _updateAbsolute(): void {
+    if (!this._localize || !this._locale || !this._config) {
+      return;
+    }
+
     if (!this.datetime) {
-      this.innerHTML = this.hass.localize("ui.components.absolute_time.never");
+      this.innerHTML = this._localize("ui.components.absolute_time.never");
     } else {
       this.innerHTML = absoluteTime(
         new Date(this.datetime),
-        this.hass.locale,
-        this.hass.config
+        this._locale,
+        this._config
       );
     }
   }

--- a/src/components/ha-relative-time.ts
+++ b/src/components/ha-relative-time.ts
@@ -1,18 +1,33 @@
+import { consume } from "@lit/context";
 import { parseISO } from "date-fns";
 import type { PropertyValues } from "lit";
 import { ReactiveElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import { transform } from "../common/decorators/transform";
 import { relativeTime } from "../common/datetime/relative_time";
 import { capitalizeFirstLetter } from "../common/string/capitalize-first-letter";
-import type { HomeAssistant } from "../types";
+import { internationalizationContext } from "../data/context";
+import type { FrontendLocaleData } from "../data/translation";
+import type { LocalizeFunc } from "../common/translations/localize";
+import type { HomeAssistantInternationalization } from "../types";
 
 @customElement("ha-relative-time")
 class HaRelativeTime extends ReactiveElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property({ attribute: false }) public datetime?: string | Date;
 
   @property({ type: Boolean }) public capitalize = false;
+
+  @state()
+  @consumeLocalize()
+  private _localize?: LocalizeFunc;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale?: FrontendLocaleData;
 
   private _interval?: number;
 
@@ -57,15 +72,19 @@ class HaRelativeTime extends ReactiveElement {
   }
 
   private _updateRelative(): void {
+    if (!this._localize || !this._locale) {
+      return;
+    }
+
     if (!this.datetime) {
-      this.innerHTML = this.hass.localize("ui.components.relative_time.never");
+      this.innerHTML = this._localize("ui.components.relative_time.never");
     } else {
       const date =
         typeof this.datetime === "string"
           ? parseISO(this.datetime)
           : this.datetime;
 
-      const relTime = relativeTime(date, this.hass.locale);
+      const relTime = relativeTime(date, this._locale);
       this.innerHTML = this.capitalize
         ? capitalizeFirstLetter(relTime)
         : relTime;

--- a/src/dialogs/more-info/components/ha-more-info-state-header.ts
+++ b/src/dialogs/more-info/components/ha-more-info-state-header.ts
@@ -54,14 +54,12 @@ export class HaMoreInfoStateHeader extends LitElement {
           ${this._absoluteTime
             ? html`
                 <ha-absolute-time
-                  .hass=${this.hass}
                   .datetime=${this.changedOverride ??
                   this.stateObj.last_changed}
                 ></ha-absolute-time>
               `
             : html`
                 <ha-relative-time
-                  .hass=${this.hass}
                   .datetime=${this.changedOverride ??
                   this.stateObj.last_changed}
                   capitalize

--- a/src/dialogs/more-info/controls/more-info-automation.ts
+++ b/src/dialogs/more-info/controls/more-info-automation.ts
@@ -23,7 +23,6 @@ class MoreInfoAutomation extends LitElement {
       <div class="flex">
         <div>${this.hass.localize("ui.card.automation.last_triggered")}:</div>
         <ha-relative-time
-          .hass=${this.hass}
           .datetime=${this.stateObj.attributes.last_triggered}
           capitalize
         ></ha-relative-time>

--- a/src/dialogs/more-info/controls/more-info-sun.ts
+++ b/src/dialogs/more-info/controls/more-info-sun.ts
@@ -36,7 +36,6 @@ class MoreInfoSun extends LitElement {
                     )}</span
               >
               <ha-relative-time
-                .hass=${this.hass}
                 .datetime=${item === "ris" ? risingDate : settingDate}
               ></ha-relative-time>
             </div>

--- a/src/dialogs/more-info/controls/more-info-weather.ts
+++ b/src/dialogs/more-info/controls/more-info-weather.ts
@@ -201,7 +201,6 @@ class MoreInfoWeather extends LitElement {
             <div class="time-ago">
               <ha-relative-time
                 id="relative-time"
-                .hass=${this.hass}
                 .datetime=${this.stateObj.last_changed}
                 capitalize
               ></ha-relative-time>
@@ -213,7 +212,6 @@ class MoreInfoWeather extends LitElement {
                     )}:
                   </span>
                   <ha-relative-time
-                    .hass=${this.hass}
                     .datetime=${this.stateObj.last_changed}
                     capitalize
                   ></ha-relative-time>
@@ -225,7 +223,6 @@ class MoreInfoWeather extends LitElement {
                     )}:
                   </span>
                   <ha-relative-time
-                    .hass=${this.hass}
                     .datetime=${this.stateObj.last_updated}
                     capitalize
                   ></ha-relative-time>

--- a/src/dialogs/notifications/persistent-notification-item.ts
+++ b/src/dialogs/notifications/persistent-notification-item.ts
@@ -30,7 +30,6 @@ export class HuiPersistentNotificationItem extends LitElement {
           <span>
             <ha-relative-time
               id="relative-time"
-              .hass=${this.hass}
               .datetime=${this.notification.created_at}
               capitalize
             ></ha-relative-time>

--- a/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-advertisement-monitor.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-advertisement-monitor.ts
@@ -173,7 +173,6 @@ export class BluetoothAdvertisementMonitorPanel extends LitElement {
           defaultHidden: false,
           template: (ad) =>
             html`<ha-relative-time
-              .hass=${this.hass}
               .datetime=${ad.datetime}
               capitalize
             ></ha-relative-time>`,

--- a/src/panels/config/tags/ha-config-tags.ts
+++ b/src/panels/config/tags/ha-config-tags.ts
@@ -101,7 +101,6 @@ export class HaConfigTags extends SubscribeMixin(LitElement) {
         template: (tag) => html`
           ${tag.last_scanned_datetime
             ? html`<ha-relative-time
-                .hass=${this.hass}
                 .datetime=${tag.last_scanned_datetime}
                 capitalize
               ></ha-relative-time>`

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -238,7 +238,6 @@ class HaLogbookRenderer extends LitElement {
                 >
                 -
                 <ha-relative-time
-                  .hass=${this.hass}
                   .datetime=${item.when * 1000}
                   capitalize
                 ></ha-relative-time>

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -311,7 +311,6 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
                   : entityConf.show_last_changed
                     ? html`
                         <ha-relative-time
-                          .hass=${this.hass}
                           .datetime=${stateObj.last_changed}
                           capitalize
                         ></ha-relative-time>

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -657,7 +657,6 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
                           )
                         : html`<ha-relative-time
                             capitalize
-                            .hass=${this.hass}
                             .datetime=${due}
                           ></ha-relative-time>`}
                     </div>`

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -115,7 +115,6 @@ export class HuiGenericEntityRow extends LitElement {
                               </ha-tooltip>
                               <ha-relative-time
                                 id="last-changed${this._secondaryInfoElementId}"
-                                .hass=${this.hass}
                                 .datetime=${stateObj.last_changed}
                                 capitalize
                               ></ha-relative-time>
@@ -136,7 +135,6 @@ export class HuiGenericEntityRow extends LitElement {
                                 <ha-relative-time
                                   id="last-updated${this
                                     ._secondaryInfoElementId}"
-                                  .hass=${this.hass}
                                   .datetime=${stateObj.last_updated}
                                   capitalize
                                 ></ha-relative-time>
@@ -160,7 +158,6 @@ export class HuiGenericEntityRow extends LitElement {
                                     <ha-relative-time
                                       id="last-triggered${this
                                         ._secondaryInfoElementId}"
-                                      .hass=${this.hass}
                                       .datetime=${stateObj.attributes
                                         .last_triggered}
                                       capitalize

--- a/src/panels/lovelace/editor/card-editor/hui-entity-picker-table.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-entity-picker-table.ts
@@ -219,7 +219,6 @@ export class HuiEntityPickerTable extends LitElement {
         hidden: narrow,
         template: (entity) => html`
           <ha-relative-time
-            .hass=${this.hass!}
             .datetime=${entity.last_changed}
             capitalize
           ></ha-relative-time>

--- a/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
@@ -164,7 +164,6 @@ class HuiWeatherEntityRow extends LitElement implements LovelaceRow {
                   : this._config.secondary_info === "last-changed"
                     ? html`
                         <ha-relative-time
-                          .hass=${this.hass}
                           .datetime=${stateObj.last_changed}
                           capitalize
                         ></ha-relative-time>
@@ -172,7 +171,6 @@ class HuiWeatherEntityRow extends LitElement implements LovelaceRow {
                     : this._config.secondary_info === "last-updated"
                       ? html`
                           <ha-relative-time
-                            .hass=${this.hass}
                             .datetime=${stateObj.last_updated}
                             capitalize
                           ></ha-relative-time>

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -161,7 +161,6 @@ class StateDisplay extends LitElement {
     if (relativeDateTime) {
       return html`
         <ha-relative-time
-          .hass=${this.hass}
           .datetime=${relativeDateTime}
           capitalize
         ></ha-relative-time>


### PR DESCRIPTION
## Proposed change

Migrate Group E time-display primitives off the `hass` property onto Lit context consumers:

- **`ha-relative-time`** — `@consumeLocalize()` + `internationalizationContext` → `locale` via `@consume` + `@transform`. Both extend `ReactiveElement` with `createRenderRoot()` returning `this`; context fields use `@state()` so `_updateRelative` / `_updateAbsolute` re-run when context arrives.
- **`ha-absolute-time`** — same i18n pattern + `configContext` → `config` via `@transform` (see `ha-domain-icon.ts` / date-picker pattern).

Removed obsolete `.hass=${this.hass}` bindings from all 15 caller sites (logbook, lovelace cards/rows, more-info, state-display, etc.).

Part of the `hass`-property → Lit context migration tracked in [HASS_MIGRATION.md](https://github.com/home-assistant/frontend/blob/dev/HASS_MIGRATION.md). Pattern reference: [HASS_MIGRATION_RECIPE.md](https://github.com/home-assistant/frontend/blob/dev/HASS_MIGRATION_RECIPE.md).

## Screenshots

N/A — no visual change expected.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr