### PR TITLE
Migrate hui-buttons-base and ha-selector-attribute to states context (partial hass)

### DIFF
--- a/src/common/decorators/consume-context-entry.ts
+++ b/src/common/decorators/consume-context-entry.ts
@@ -11,6 +11,7 @@ import {
 } from "../../data/context";
 import type { EntityRegistryDisplayEntry } from "../../data/entity/entity_registry";
 import type { LocalizeFunc } from "../translations/localize";
+import { ensureArray } from "../array/ensure-array";
 import { transform } from "./transform";
 
 interface ConsumeEntryConfig {
@@ -63,18 +64,18 @@ export const consumeEntityState = (config: ConsumeEntryConfig) =>
   );
 
 /**
- * Like {@link consumeEntityState} but for an array of entity IDs at
- * `entityIdPath`. Resolves to a record keyed by entity ID containing the
- * currently-available entities (missing entities and non-string IDs are
- * filtered out).
+ * Like {@link consumeEntityState} but for one or more entity IDs at
+ * `entityIdPath` (a string or string array; wrapped with {@link ensureArray}).
+ * Resolves to a record keyed by entity ID containing the currently-available
+ * entities (missing entities and non-string IDs are filtered out).
  */
 export const consumeEntityStates = (config: ConsumeEntryConfig) =>
   composeDecorator<HassEntities, Record<string, HassEntity>>(
     statesContext,
     config.entityIdPath[0],
     function (states) {
-      const ids = resolveAtPath(this, config.entityIdPath);
-      if (!Array.isArray(ids) || !states) return undefined;
+      const ids = ensureArray(resolveAtPath(this, config.entityIdPath));
+      if (!ids || !states) return undefined;
       const result: Record<string, HassEntity> = {};
       for (const id of ids) {
         if (typeof id !== "string") continue;

--- a/src/common/decorators/consume-context-entry.ts
+++ b/src/common/decorators/consume-context-entry.ts
@@ -27,6 +27,28 @@ const resolveAtPath = (host: unknown, path: readonly string[]) => {
   return cur;
 };
 
+/** Reuse `previous` when every entry still references the same `HassEntity`. */
+export const preserveUnchangedEntityStatesRecord = <
+  T extends Record<string, HassEntity | undefined>,
+>(
+  previous: T | undefined,
+  next: T
+): T => {
+  if (!previous) {
+    return next;
+  }
+  const nextKeys = Object.keys(next);
+  if (Object.keys(previous).length !== nextKeys.length) {
+    return next;
+  }
+  for (const key of nextKeys) {
+    if (previous[key] !== next[key]) {
+      return next;
+    }
+  }
+  return previous;
+};
+
 const composeDecorator = <T, V>(
   context: Parameters<typeof consume>[0]["context"],
   watchKey: string | undefined,
@@ -67,24 +89,49 @@ export const consumeEntityState = (config: ConsumeEntryConfig) =>
  * Like {@link consumeEntityState} but for one or more entity IDs at
  * `entityIdPath` (a string or string array; wrapped with {@link ensureArray}).
  * Resolves to a record keyed by entity ID containing the currently-available
- * entities (missing entities and non-string IDs are filtered out).
+ * entities (missing entities and non-string IDs are filtered out). Returns the
+ * previous record when none of the selected entities changed.
  */
-export const consumeEntityStates = (config: ConsumeEntryConfig) =>
-  composeDecorator<HassEntities, Record<string, HassEntity>>(
-    statesContext,
-    config.entityIdPath[0],
-    function (states) {
-      const ids = ensureArray(resolveAtPath(this, config.entityIdPath));
-      if (!ids || !states) return undefined;
-      const result: Record<string, HassEntity> = {};
-      for (const id of ids) {
-        if (typeof id !== "string") continue;
-        const state = states[id];
-        if (state !== undefined) result[id] = state;
-      }
-      return result;
+export const consumeEntityStates = (config: ConsumeEntryConfig) => {
+  const watchKey = config.entityIdPath[0];
+  const buildRecord = function (this: unknown, states: HassEntities) {
+    const ids = ensureArray(resolveAtPath(this, config.entityIdPath));
+    if (!ids || !states) return undefined;
+    const result: Record<string, HassEntity> = {};
+    for (const id of ids) {
+      if (typeof id !== "string") continue;
+      const state = states[id];
+      if (state !== undefined) result[id] = state;
     }
-  );
+    return result;
+  };
+
+  return (proto: unknown, propertyKey: string) => {
+    const key = String(propertyKey);
+    const transformDec = transform<
+      HassEntities,
+      Record<string, HassEntity> | undefined
+    >({
+      transformer: function (this: unknown, states: HassEntities) {
+        const next = buildRecord.call(this, states);
+        if (next === undefined) {
+          return undefined;
+        }
+        const previous = (this as Record<string, unknown>)[
+          `__transform_${key}`
+        ] as Record<string, HassEntity> | undefined;
+        return preserveUnchangedEntityStatesRecord(previous, next);
+      },
+      watch: watchKey ? [watchKey] : [],
+    });
+    const consumeDec = consume<any>({
+      context: statesContext,
+      subscribe: true,
+    });
+    transformDec(proto as never, propertyKey);
+    consumeDec(proto as never, propertyKey);
+  };
+};
 
 /**
  * Consumes `entitiesContext` and narrows it to the

--- a/src/common/decorators/consume-context-entry.ts
+++ b/src/common/decorators/consume-context-entry.ts
@@ -64,22 +64,22 @@ export const consumeEntityState = (config: ConsumeEntryConfig) =>
 
 /**
  * Like {@link consumeEntityState} but for an array of entity IDs at
- * `entityIdPath`. Resolves to a `HassEntity[]` containing one entry per
- * currently-available entity (missing entities and non-string IDs are
- * filtered out; original order is preserved).
+ * `entityIdPath`. Resolves to a record keyed by entity ID containing the
+ * currently-available entities (missing entities and non-string IDs are
+ * filtered out).
  */
 export const consumeEntityStates = (config: ConsumeEntryConfig) =>
-  composeDecorator<HassEntities, HassEntity[]>(
+  composeDecorator<HassEntities, Record<string, HassEntity>>(
     statesContext,
     config.entityIdPath[0],
     function (states) {
       const ids = resolveAtPath(this, config.entityIdPath);
       if (!Array.isArray(ids) || !states) return undefined;
-      const result: HassEntity[] = [];
+      const result: Record<string, HassEntity> = {};
       for (const id of ids) {
         if (typeof id !== "string") continue;
         const state = states[id];
-        if (state !== undefined) result.push(state);
+        if (state !== undefined) result[id] = state;
       }
       return result;
     }

--- a/src/components/ha-selector/ha-selector-attribute.ts
+++ b/src/components/ha-selector/ha-selector-attribute.ts
@@ -30,24 +30,8 @@ export class HaSelectorAttribute extends LitElement {
   };
 
   @state()
-  private _entityIds?: string[];
-
-  @state()
-  @consumeEntityStates({ entityIdPath: ["_entityIds"] })
+  @consumeEntityStates({ entityIdPath: ["context", "filter_entity"] })
   private _filterEntityStates?: Record<string, HassEntity>;
-
-  protected willUpdate(changedProps: PropertyValues<this>): void {
-    super.willUpdate(changedProps);
-    if (!changedProps.has("selector") && !changedProps.has("context")) {
-      return;
-    }
-
-    const entityId =
-      this.selector.attribute?.entity_id || this.context?.filter_entity;
-    this._entityIds = entityId ? ensureArray(entityId) : undefined;
-    // Used by `@consumeEntityStates` via `entityIdPath`; read to satisfy TS noUnusedLocals.
-    void this._entityIds;
-  }
 
   protected render() {
     return html`

--- a/src/components/ha-selector/ha-selector-attribute.ts
+++ b/src/components/ha-selector/ha-selector-attribute.ts
@@ -1,12 +1,10 @@
-import { consume } from "@lit/context";
-import type { HassEntities, HassEntity } from "home-assistant-js-websocket";
+import type { HassEntity } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
 import { html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { transform } from "../../common/decorators/transform";
 import { ensureArray } from "../../common/array/ensure-array";
+import { consumeEntityStates } from "../../common/decorators/consume-context-entry";
 import { fireEvent } from "../../common/dom/fire_event";
-import { statesContext } from "../../data/context";
 import type { AttributeSelector } from "../../data/selector";
 import type { HomeAssistant } from "../../types";
 import "../entity/ha-entity-attribute-picker";
@@ -32,27 +30,22 @@ export class HaSelectorAttribute extends LitElement {
   };
 
   @state()
-  @consume({ context: statesContext, subscribe: true })
-  @transform<HassEntities, HassEntity[] | undefined>({
-    transformer: function (this: HaSelectorAttribute, states) {
-      if (!states) {
-        return undefined;
-      }
-      const entityId =
-        this.selector.attribute?.entity_id || this.context?.filter_entity;
-      if (!entityId) {
-        return undefined;
-      }
-      const ids = ensureArray(entityId);
-      return ids
-        .map((id) => states[id])
-        .filter(
-          (entityState): entityState is HassEntity => entityState !== undefined
-        );
-    },
-    watch: ["selector", "context"],
-  })
+  private _entityIds?: string[];
+
+  @state()
+  @consumeEntityStates({ entityIdPath: ["_entityIds"] })
   private _filterEntityStates?: HassEntity[];
+
+  protected willUpdate(changedProps: PropertyValues<this>): void {
+    super.willUpdate(changedProps);
+    if (!changedProps.has("selector") && !changedProps.has("context")) {
+      return;
+    }
+
+    const entityId =
+      this.selector.attribute?.entity_id || this.context?.filter_entity;
+    this._entityIds = entityId ? ensureArray(entityId) : undefined;
+  }
 
   protected render() {
     return html`

--- a/src/components/ha-selector/ha-selector-attribute.ts
+++ b/src/components/ha-selector/ha-selector-attribute.ts
@@ -1,11 +1,15 @@
+import { consume } from "@lit/context";
+import type { HassEntities, HassEntity } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
 import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
+import { transform } from "../../common/decorators/transform";
+import { ensureArray } from "../../common/array/ensure-array";
 import { fireEvent } from "../../common/dom/fire_event";
+import { statesContext } from "../../data/context";
 import type { AttributeSelector } from "../../data/selector";
 import type { HomeAssistant } from "../../types";
 import "../entity/ha-entity-attribute-picker";
-import { ensureArray } from "../../common/array/ensure-array";
 
 @customElement("ha-selector-attribute")
 export class HaSelectorAttribute extends LitElement {
@@ -26,6 +30,29 @@ export class HaSelectorAttribute extends LitElement {
   @property({ attribute: false }) public context?: {
     filter_entity?: string | string[];
   };
+
+  @state()
+  @consume({ context: statesContext, subscribe: true })
+  @transform<HassEntities, HassEntity[] | undefined>({
+    transformer: function (this: HaSelectorAttribute, states) {
+      if (!states) {
+        return undefined;
+      }
+      const entityId =
+        this.selector.attribute?.entity_id || this.context?.filter_entity;
+      if (!entityId) {
+        return undefined;
+      }
+      const ids = ensureArray(entityId);
+      return ids
+        .map((id) => states[id])
+        .filter(
+          (entityState): entityState is HassEntity => entityState !== undefined
+        );
+    },
+    watch: ["selector", "context"],
+  })
+  private _filterEntityStates?: HassEntity[];
 
   protected render() {
     return html`
@@ -73,7 +100,9 @@ export class HaSelectorAttribute extends LitElement {
       const entityIds = ensureArray(this.context.filter_entity);
 
       invalid = !entityIds.some((entityId) => {
-        const stateObj = this.hass.states[entityId];
+        const stateObj = this._filterEntityStates?.find(
+          (entityState) => entityState.entity_id === entityId
+        );
         return (
           stateObj &&
           this.value in stateObj.attributes &&

--- a/src/components/ha-selector/ha-selector-attribute.ts
+++ b/src/components/ha-selector/ha-selector-attribute.ts
@@ -34,7 +34,7 @@ export class HaSelectorAttribute extends LitElement {
 
   @state()
   @consumeEntityStates({ entityIdPath: ["_entityIds"] })
-  private _filterEntityStates?: HassEntity[];
+  private _filterEntityStates?: Record<string, HassEntity>;
 
   protected willUpdate(changedProps: PropertyValues<this>): void {
     super.willUpdate(changedProps);
@@ -45,6 +45,8 @@ export class HaSelectorAttribute extends LitElement {
     const entityId =
       this.selector.attribute?.entity_id || this.context?.filter_entity;
     this._entityIds = entityId ? ensureArray(entityId) : undefined;
+    // Used by `@consumeEntityStates` via `entityIdPath`; read to satisfy TS noUnusedLocals.
+    void this._entityIds;
   }
 
   protected render() {
@@ -93,9 +95,7 @@ export class HaSelectorAttribute extends LitElement {
       const entityIds = ensureArray(this.context.filter_entity);
 
       invalid = !entityIds.some((entityId) => {
-        const stateObj = this._filterEntityStates?.find(
-          (entityState) => entityState.entity_id === entityId
-        );
+        const stateObj = this._filterEntityStates?.[entityId];
         return (
           stateObj &&
           this.value in stateObj.attributes &&

--- a/src/panels/lovelace/components/hui-buttons-base.ts
+++ b/src/panels/lovelace/components/hui-buttons-base.ts
@@ -1,8 +1,12 @@
+import { consume } from "@lit/context";
+import type { HassEntities, HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, state, property } from "lit/decorators";
+import { transform } from "../../../common/decorators/transform";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import "../../../components/entity/state-badge";
+import { statesContext } from "../../../data/context";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import type { HomeAssistant } from "../../../types";
 import type { EntitiesCardEntityConfig } from "../cards/types";
@@ -17,21 +21,39 @@ import { haStyleScrollbar } from "../../../resources/styles";
 
 @customElement("hui-buttons-base")
 export class HuiButtonsBase extends LitElement {
-  @state() public hass!: HomeAssistant;
+  @property({ attribute: false })
+  public hass!: HomeAssistant;
 
   @property({ attribute: false })
   public configEntities?: EntitiesCardEntityConfig[];
+
+  @state()
+  @consume({ context: statesContext, subscribe: true })
+  @transform<HassEntities, Record<string, HassEntity | undefined>>({
+    transformer: function (this: HuiButtonsBase, states) {
+      if (!states) {
+        return {};
+      }
+      const result: Record<string, HassEntity | undefined> = {};
+      for (const entityConf of this.configEntities || []) {
+        result[entityConf.entity] = states[entityConf.entity];
+      }
+      return result;
+    },
+    watch: ["configEntities"],
+  })
+  private _entityStates: Record<string, HassEntity | undefined> = {};
 
   protected render(): TemplateResult {
     return html`
       <ha-chip-set class="ha-scrollbar">
         ${(this.configEntities || []).map((entityConf) => {
-          const stateObj = this.hass.states[entityConf.entity];
+          const stateObj = this._entityStates[entityConf.entity];
 
           const name =
             (entityConf.show_name && stateObj) ||
             (entityConf.name && entityConf.show_name !== false)
-              ? entityConf.name || computeStateName(stateObj)
+              ? entityConf.name || (stateObj ? computeStateName(stateObj) : "")
               : "";
 
           return html`

--- a/src/panels/lovelace/components/hui-buttons-base.ts
+++ b/src/panels/lovelace/components/hui-buttons-base.ts
@@ -3,6 +3,7 @@ import type { HassEntities, HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, state, property } from "lit/decorators";
+import { preserveUnchangedEntityStatesRecord } from "../../../common/decorators/consume-context-entry";
 import { transform } from "../../../common/decorators/transform";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import "../../../components/entity/state-badge";
@@ -31,14 +32,13 @@ export class HuiButtonsBase extends LitElement {
   @consume({ context: statesContext, subscribe: true })
   @transform<HassEntities, Record<string, HassEntity | undefined>>({
     transformer: function (this: HuiButtonsBase, states) {
-      if (!states) {
-        return {};
+      const next: Record<string, HassEntity | undefined> = {};
+      if (states) {
+        for (const entityConf of this.configEntities || []) {
+          next[entityConf.entity] = states[entityConf.entity];
+        }
       }
-      const result: Record<string, HassEntity | undefined> = {};
-      for (const entityConf of this.configEntities || []) {
-        result[entityConf.entity] = states[entityConf.entity];
-      }
-      return result;
+      return preserveUnchangedEntityStatesRecord(this._entityStates, next);
     },
     watch: ["configEntities"],
   })


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Partial migration of entity state reads off the `hass` object:

- `hui-buttons-base.ts` — consume the `statesContext` map for button entity states; keep `hass` for `handleAction`, `computeTooltip`, and `state-badge` child binding
- `ha-selector-attribute.ts` — filter entity states using `consumeEntityStates`; keep `hass` for `ha-entity-attribute-picker` child

Also updates `consumeEntityStates` to return a record keyed by entity ID instead of an array, for easier lookups.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:
- Context: `statesContext` (via `@consume`/`@transform` and `consumeEntityStates`)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3A%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr