### PR TITLE
Add created/modified columns to automation, scene, and script tables

### DIFF
--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -116,8 +116,10 @@ import { showCategoryRegistryDetailDialog } from "../category/show-dialog-catego
 import {
   getAreaTableColumn,
   getCategoryTableColumn,
+  getCreatedAtTableColumn,
   getEntityIdHiddenTableColumn,
   getLabelsTableColumn,
+  getModifiedAtTableColumn,
   getTriggeredAtTableColumn,
 } from "../common/data-table-columns";
 import { configSections } from "../ha-panel-config";
@@ -139,6 +141,8 @@ type AutomationItem = AutomationEntity & {
   labels: string[]; // search only
   assistants: string[];
   assistants_sortable_key: string | undefined;
+  created_at: number | undefined;
+  modified_at: number | undefined;
 };
 
 @customElement("ha-automation-picker")
@@ -285,6 +289,8 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
           labels: label_entries.map((lbl) => lbl.name),
           assistants,
           assistants_sortable_key: getAssistantsSortableKey(assistants),
+          created_at: entityRegEntry?.created_at,
+          modified_at: entityRegEntry?.modified_at,
           selectable: entityRegEntry !== undefined,
         };
       });
@@ -335,6 +341,8 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
         category: getCategoryTableColumn(localize),
         labels: getLabelsTableColumn(),
         last_triggered: getTriggeredAtTableColumn(localize, this.hass),
+        created_at: getCreatedAtTableColumn(localize, this.hass),
+        modified_at: getModifiedAtTableColumn(localize, this.hass),
         formatted_state: {
           minWidth: "82px",
           maxWidth: "82px",

--- a/src/panels/config/scene/ha-scene-dashboard.ts
+++ b/src/panels/config/scene/ha-scene-dashboard.ts
@@ -104,8 +104,10 @@ import { showCategoryRegistryDetailDialog } from "../category/show-dialog-catego
 import {
   getAreaTableColumn,
   getCategoryTableColumn,
+  getCreatedAtTableColumn,
   getEditableTableColumn,
   getLabelsTableColumn,
+  getModifiedAtTableColumn,
   renderRelativeTimeColumn,
 } from "../common/data-table-columns";
 import { configSections } from "../ha-panel-config";
@@ -125,6 +127,8 @@ type SceneItem = SceneEntity & {
   labels: string[]; // search only
   assistants: string[];
   assistants_sortable_key: string | undefined;
+  created_at: number | undefined;
+  modified_at: number | undefined;
   editable: boolean;
 };
 
@@ -264,6 +268,8 @@ class HaSceneDashboard extends SubscribeMixin(LitElement) {
           labels: label_entries.map((lbl) => lbl.name),
           assistants,
           assistants_sortable_key: getAssistantsSortableKey(assistants),
+          created_at: entityRegEntry?.created_at,
+          modified_at: entityRegEntry?.modified_at,
           selectable: entityRegEntry !== undefined,
           editable: Boolean(scene.attributes.id),
         };
@@ -323,6 +329,8 @@ class HaSceneDashboard extends SubscribeMixin(LitElement) {
           localize,
           localize("ui.panel.config.scene.picker.only_editable")
         ),
+        created_at: getCreatedAtTableColumn(localize, this.hass),
+        modified_at: getModifiedAtTableColumn(localize, this.hass),
         actions: {
           lastFixed: true,
           title: "",

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -109,8 +109,10 @@ import { showCategoryRegistryDetailDialog } from "../category/show-dialog-catego
 import {
   getAreaTableColumn,
   getCategoryTableColumn,
+  getCreatedAtTableColumn,
   getEntityIdHiddenTableColumn,
   getLabelsTableColumn,
+  getModifiedAtTableColumn,
   getTriggeredAtTableColumn,
 } from "../common/data-table-columns";
 import { configSections } from "../ha-panel-config";
@@ -130,6 +132,8 @@ type ScriptItem = ScriptEntity & {
   labels: string[]; // search only
   assistants: string[];
   assistants_sortable_key: string | undefined;
+  created_at: number | undefined;
+  modified_at: number | undefined;
 };
 
 @customElement("ha-script-picker")
@@ -271,6 +275,8 @@ class HaScriptPicker extends SubscribeMixin(LitElement) {
           labels: label_entries.map((lbl) => lbl.name),
           assistants,
           assistants_sortable_key: getAssistantsSortableKey(assistants),
+          created_at: entityRegEntry?.created_at,
+          modified_at: entityRegEntry?.modified_at,
           selectable: entityRegEntry !== undefined,
         };
       });
@@ -318,6 +324,8 @@ class HaScriptPicker extends SubscribeMixin(LitElement) {
         category: getCategoryTableColumn(localize),
         labels: getLabelsTableColumn(),
         last_triggered: getTriggeredAtTableColumn(localize, this.hass),
+        created_at: getCreatedAtTableColumn(localize, this.hass),
+        modified_at: getModifiedAtTableColumn(localize, this.hass),
         actions: {
           lastFixed: true,
           title: "",


### PR DESCRIPTION
## Proposed change

Adds optional "Created at" and "Modified at" columns to the automation, scene, and script data tables, using values from the entity registry. Both columns are hidden by default and can be enabled from the column visibility menu. Sorting is supported, so users can order their automations (and scenes/scripts) by creation date.

## Screenshots

<!-- Add a screenshot of the column menu and a table sorted by creation date. -->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
