### PR TITLE
Consider unknown as stopped for app

### DIFF
--- a/src/panels/config/apps/components/supervisor-apps-state.ts
+++ b/src/panels/config/apps/components/supervisor-apps-state.ts
@@ -1,9 +1,7 @@
 import { consume, type ContextType } from "@lit/context";
-import { mdiHelpCircle } from "@mdi/js";
 import type { TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import "../../../../components/ha-svg-icon";
 import { internationalizationContext } from "../../../../data/context";
 import type { AddonState } from "../../../../data/hassio/addon";
 
@@ -16,13 +14,14 @@ class SupervisorAppsState extends LitElement {
   private _i18n!: ContextType<typeof internationalizationContext>;
 
   protected render(): TemplateResult {
+    // Consider "unknown" state as "stopped" for display purposes
+    // because unknown doesn't add any value to the user
+    const displayState = this.state === "unknown" ? "stopped" : this.state;
     return html`
-      ${this.state === "unknown"
-        ? html`<ha-svg-icon .path=${mdiHelpCircle}></ha-svg-icon>`
-        : html` <div class="dot state-${this.state}"></div> `}
+      <div class="dot state-${displayState}"></div>
       <span
         >${this._i18n.localize(
-          `ui.panel.config.apps.dashboard.capability.state.${this.state}`
+          `ui.panel.config.apps.dashboard.capability.state.${displayState}`
         )}</span
       >
     `;


### PR DESCRIPTION
## Proposed change

Installed addons whose state Supervisor can't determine showed as "Unknown" with a `?` icon. For the user, that's the same thing as "Stopped": it's not running and nothing is wrong. Both are now shown as "Stopped", in the apps list and on the addon detail page. "Error" and "Starting" stay distinct.

## Screenshots

<!-- Add before/after screenshots of an installed addon shown as "Unknown" before and "Stopped" after, in both the apps list and the addon detail page. -->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
