### PR TITLE
Preserve PNG transparency on area pictures

### DIFF
--- a/src/panels/config/areas/dialog-area-registry-detail.ts
+++ b/src/panels/config/areas/dialog-area-registry-detail.ts
@@ -48,8 +48,6 @@ import type { AreaRegistryDetailDialogParams } from "./show-dialog-area-registry
 
 const cropOptions: CropOptions = {
   round: false,
-  type: "image/jpeg",
-  quality: 0.75,
 };
 
 const SENSOR_DOMAINS = ["sensor"];


### PR DESCRIPTION
## Proposed change

Drop `type: "image/jpeg"` (and the now-meaningless `quality: 0.75`) from the area-registry dialog's `cropOptions`. The cropper was re-encoding PNG uploads to JPEG and discarding their alpha channel. Same fix as #14689 in another path.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52269
- This PR is related to issue or discussion: #14689
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
