### PR TITLE
Allow clipboard-write in ingress add-on iframe

### DIFF
--- a/src/panels/app/ha-panel-app.ts
+++ b/src/panels/app/ha-panel-app.ts
@@ -136,6 +136,7 @@ class HaPanelApp extends LitElement {
         })}
         title=${this._addon.name}
         src=${this._addon.ingress_url!}
+        allow="clipboard-write"
         @load=${this._checkLoaded}
         ${ref(this._iframeRef)}
       >


### PR DESCRIPTION
## Proposed change

Add `allow="clipboard-write"` to the ingress add-on iframe. Without it, browsers silently block `navigator.clipboard.writeText()` inside the iframe, breaking OSC52 / clipboard-API copy in terminal-style add-ons (Claude Code add-on, SSH & Web Terminal, etc.). The permission is write-only and still gated on a user gesture in the embedded page.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #30077
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
