### PR TITLE
Migrate glance and entities state_color to color

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -30,7 +30,7 @@ const colorToStateColor = (
   color: string | undefined,
   stateColor: boolean | undefined
 ): boolean | undefined =>
-  color === undefined ? stateColor : color === "state";
+  color === undefined ? stateColor : color !== "none" && color === "state";
 
 export const computeShowHeaderToggle = <
   T extends EntityConfig | LovelaceRowConfig,
@@ -334,20 +334,26 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
 
   private _renderEntity(entityConf: LovelaceRowConfig): TemplateResult {
     const entityCardConfig = entityConf as EntitiesCardEntityConfig;
-    const stateColor =
-      !("type" in entityConf) || entityConf.type === "conditional"
-        ? colorToStateColor(
-            entityCardConfig.color ?? this._config!.color,
-            entityCardConfig.state_color !== undefined
-              ? entityCardConfig.state_color
-              : this._config!.state_color
-          )
+    const shouldPassStateColor =
+      !("type" in entityConf) || entityConf.type === "conditional";
+    const inheritedColor =
+      entityCardConfig.color === undefined &&
+      entityCardConfig.state_color === undefined
+        ? this._config!.color
         : undefined;
+    const rowColor = entityCardConfig.color ?? inheritedColor;
+    const stateColor = shouldPassStateColor
+      ? entityCardConfig.color !== undefined
+        ? colorToStateColor(entityCardConfig.color, entityCardConfig.state_color)
+        : entityCardConfig.state_color !== undefined
+          ? entityCardConfig.state_color
+          : colorToStateColor(this._config!.color, this._config!.state_color)
+      : undefined;
     const element = createRowElement(
-      (!("type" in entityConf) || entityConf.type === "conditional") &&
-        stateColor !== undefined
+      shouldPassStateColor && (stateColor !== undefined || rowColor !== undefined)
         ? ({
             ...(entityConf as EntityConfig),
+            ...(rowColor !== undefined ? { color: rowColor } : {}),
             state_color: stateColor,
           } as EntityConfig)
         : entityConf.type === "perform-action"

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -23,8 +23,14 @@ import type {
   LovelaceGridOptions,
   LovelaceHeaderFooter,
 } from "../types";
-import type { EntitiesCardConfig } from "./types";
+import type { EntitiesCardConfig, EntitiesCardEntityConfig } from "./types";
 import { haStyleScrollbar } from "../../../resources/styles";
+
+const colorToStateColor = (
+  color: string | undefined,
+  stateColor: boolean | undefined
+): boolean | undefined =>
+  color === undefined ? stateColor : color === "state";
 
 export const computeShowHeaderToggle = <
   T extends EntityConfig | LovelaceRowConfig,
@@ -327,12 +333,22 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   ];
 
   private _renderEntity(entityConf: LovelaceRowConfig): TemplateResult {
+    const entityCardConfig = entityConf as EntitiesCardEntityConfig;
+    const stateColor =
+      !("type" in entityConf) || entityConf.type === "conditional"
+        ? colorToStateColor(
+            entityCardConfig.color ?? this._config!.color,
+            entityCardConfig.state_color !== undefined
+              ? entityCardConfig.state_color
+              : this._config!.state_color
+          )
+        : undefined;
     const element = createRowElement(
       (!("type" in entityConf) || entityConf.type === "conditional") &&
-        "state_color" in this._config!
+        stateColor !== undefined
         ? ({
-            state_color: this._config.state_color,
             ...(entityConf as EntityConfig),
+            state_color: stateColor,
           } as EntityConfig)
         : entityConf.type === "perform-action"
           ? { ...entityConf, type: "call-service" }

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -37,7 +37,12 @@ const colorToStateColor = (
   color: string | undefined,
   stateColor: boolean | undefined
 ): boolean | undefined =>
-  color === undefined ? stateColor : color === "state";
+  color === undefined ? stateColor : color !== "none" && color === "state";
+
+const colorToBadgeColor = (color: string | undefined): string | undefined =>
+  color !== undefined && color !== "state" && color !== "none"
+    ? color
+    : undefined;
 
 @customElement("hui-glance-card")
 export class HuiGlanceCard extends LitElement implements LovelaceCard {
@@ -291,6 +296,9 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
                 .stateColor=${colorToStateColor(
                   entityConf.color ?? this._config!.color,
                   entityConf.state_color ?? this._config!.state_color
+                )}
+                .color=${colorToBadgeColor(
+                  entityConf.color ?? this._config!.color
                 )}
               ></state-badge>
             `

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -3,6 +3,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { ifDefined } from "lit/directives/if-defined";
+import { computeCssColor } from "../../../common/color/compute-color";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import type { HASSDomCurrentTargetEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
@@ -41,7 +42,7 @@ const colorToStateColor = (
 
 const colorToBadgeColor = (color: string | undefined): string | undefined =>
   color !== undefined && color !== "state" && color !== "none"
-    ? color
+    ? computeCssColor(color)
     : undefined;
 
 @customElement("hui-glance-card")
@@ -267,6 +268,15 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
     }
 
     const name = this.hass!.formatEntityName(stateObj, entityConf.name);
+    const color =
+      entityConf.color ??
+      (entityConf.state_color === undefined ? this._config!.color : undefined);
+    const stateColor =
+      entityConf.color !== undefined
+        ? colorToStateColor(entityConf.color, entityConf.state_color)
+        : entityConf.state_color !== undefined
+          ? entityConf.state_color
+          : colorToStateColor(this._config!.color, this._config!.state_color);
 
     return html`
       <div
@@ -293,13 +303,8 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
                 .stateObj=${stateObj}
                 .overrideIcon=${entityConf.icon}
                 .overrideImage=${entityConf.image}
-                .stateColor=${colorToStateColor(
-                  entityConf.color ?? this._config!.color,
-                  entityConf.state_color ?? this._config!.state_color
-                )}
-                .color=${colorToBadgeColor(
-                  entityConf.color ?? this._config!.color
-                )}
+                .stateColor=${stateColor}
+                .color=${colorToBadgeColor(color)}
               ></state-badge>
             `
           : ""}

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -33,6 +33,12 @@ import "../components/hui-warning-element";
 import type { LovelaceCard, LovelaceCardEditor } from "../types";
 import type { GlanceCardConfig, GlanceConfigEntity } from "./types";
 
+const colorToStateColor = (
+  color: string | undefined,
+  stateColor: boolean | undefined
+): boolean | undefined =>
+  color === undefined ? stateColor : color === "state";
+
 @customElement("hui-glance-card")
 export class HuiGlanceCard extends LitElement implements LovelaceCard {
   public static async getConfigElement(): Promise<LovelaceCardEditor> {
@@ -282,8 +288,10 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
                 .stateObj=${stateObj}
                 .overrideIcon=${entityConf.icon}
                 .overrideImage=${entityConf.image}
-                .stateColor=${entityConf.state_color ??
-                this._config!.state_color}
+                .stateColor=${colorToStateColor(
+                  entityConf.color ?? this._config!.color,
+                  entityConf.state_color ?? this._config!.state_color
+                )}
               ></state-badge>
             `
           : ""}

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -116,6 +116,7 @@ export interface EntitiesCardEntityConfig extends EntityConfig {
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
   state_color?: boolean;
+  color?: string;
   show_name?: boolean;
   show_icon?: boolean;
 }
@@ -130,6 +131,7 @@ export interface EntitiesCardConfig extends LovelaceCardConfig {
   header?: LovelaceHeaderFooterConfig;
   footer?: LovelaceHeaderFooterConfig;
   state_color?: boolean;
+  color?: string;
 }
 
 export type AreaCardDisplayType = "compact" | "icon" | "picture" | "camera";
@@ -333,6 +335,7 @@ export interface GlanceConfigEntity extends ConfigEntity {
   image?: string;
   show_state?: boolean;
   state_color?: boolean;
+  color?: string;
   format?: TimestampRenderingFormat;
 }
 
@@ -345,6 +348,7 @@ export interface GlanceCardConfig extends LovelaceCardConfig {
   entities: (string | GlanceConfigEntity)[];
   columns?: number;
   state_color?: boolean;
+  color?: string;
 }
 
 export interface HumidifierCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -3,6 +3,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { ifDefined } from "lit/directives/if-defined";
+import { computeCssColor } from "../../../common/color/compute-color";
 import { DOMAINS_INPUT_ROW } from "../../../common/const";
 import { uid } from "../../../common/util/uid";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
@@ -30,7 +31,7 @@ const colorToStateColor = (
 
 const colorToBadgeColor = (color: string | undefined): string | undefined =>
   color !== undefined && color !== "state" && color !== "none"
-    ? color
+    ? computeCssColor(color)
     : undefined;
 
 @customElement("hui-generic-entity-row")

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -22,6 +22,12 @@ import { handleAction } from "../common/handle-action";
 import { hasAction, hasAnyAction } from "../common/has-action";
 import { createEntityNotFoundWarning } from "./hui-warning";
 
+const colorToStateColor = (
+  color: string | undefined,
+  stateColor: boolean | undefined
+): boolean | undefined =>
+  color === undefined ? stateColor : color === "state";
+
 @customElement("hui-generic-entity-row")
 export class HuiGenericEntityRow extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
@@ -86,7 +92,10 @@ export class HuiGenericEntityRow extends LitElement {
           .stateObj=${stateObj}
           .overrideIcon=${this.config.icon}
           .overrideImage=${this.config.image}
-          .stateColor=${this.config.state_color}
+          .stateColor=${colorToStateColor(
+            this.config.color,
+            this.config.state_color
+          )}
         ></state-badge>
         ${!this.hideName
           ? html`<div

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -26,7 +26,12 @@ const colorToStateColor = (
   color: string | undefined,
   stateColor: boolean | undefined
 ): boolean | undefined =>
-  color === undefined ? stateColor : color === "state";
+  color === undefined ? stateColor : color !== "none" && color === "state";
+
+const colorToBadgeColor = (color: string | undefined): string | undefined =>
+  color !== undefined && color !== "state" && color !== "none"
+    ? color
+    : undefined;
 
 @customElement("hui-generic-entity-row")
 export class HuiGenericEntityRow extends LitElement {
@@ -96,6 +101,7 @@ export class HuiGenericEntityRow extends LitElement {
             this.config.color,
             this.config.state_color
           )}
+          .color=${colorToBadgeColor(this.config.color)}
         ></state-badge>
         ${!this.hideName
           ? html`<div

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -221,11 +221,16 @@ const migrateEntityRowStateColor = (
     return entity;
   }
 
-  let migratedEntity = migrateStateColor(entity);
+  const isGenericEntityRow = (row: LovelaceRowConfig): boolean =>
+    typeof row === "object" && !("type" in row);
+
+  let migratedEntity = isGenericEntityRow(entity)
+    ? migrateStateColor(entity)
+    : entity;
   if (
     migratedEntity.type === "conditional" &&
     "row" in migratedEntity &&
-    typeof migratedEntity.row === "object"
+    isGenericEntityRow(migratedEntity.row)
   ) {
     const migratedRow = migrateStateColor(migratedEntity.row);
     if (migratedRow !== migratedEntity.row) {

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -187,11 +187,76 @@ const cardConfigStruct = assign(
     icon: optional(string()),
     show_header_toggle: optional(boolean()),
     state_color: optional(boolean()),
+    color: optional(string()),
     entities: array(entitiesRowConfigStruct),
     header: optional(headerFooterConfigStructs),
     footer: optional(headerFooterConfigStructs),
   })
 );
+
+const migrateStateColor = <T extends object>(config: T): T => {
+  const stateColorConfig = config as {
+    state_color?: boolean;
+    color?: string;
+  };
+  if (
+    stateColorConfig.state_color === undefined ||
+    stateColorConfig.color !== undefined
+  ) {
+    return config;
+  }
+
+  const migrated = {
+    ...config,
+    color: stateColorConfig.state_color ? "state" : "none",
+  } as T & { state_color?: boolean };
+  delete migrated.state_color;
+  return migrated;
+};
+
+const migrateEntityRowStateColor = (
+  entity: LovelaceRowConfig
+): LovelaceRowConfig => {
+  if (typeof entity !== "object") {
+    return entity;
+  }
+
+  let migratedEntity = migrateStateColor(entity);
+  if (
+    migratedEntity.type === "conditional" &&
+    "row" in migratedEntity &&
+    typeof migratedEntity.row === "object"
+  ) {
+    const migratedRow = migrateStateColor(migratedEntity.row);
+    if (migratedRow !== migratedEntity.row) {
+      migratedEntity = { ...migratedEntity, row: migratedRow };
+    }
+  }
+  return migratedEntity;
+};
+
+const migrateEntitiesStateColor = (
+  config: EntitiesCardConfig
+): EntitiesCardConfig => {
+  let changed = false;
+  let migratedConfig = migrateStateColor(config);
+  changed ||= migratedConfig !== config;
+
+  const entities = migratedConfig.entities.map((entity) => {
+    if (typeof entity === "string") {
+      return entity;
+    }
+    const migratedEntity = migrateEntityRowStateColor(entity);
+    changed ||= migratedEntity !== entity;
+    return migratedEntity;
+  });
+
+  if (entities !== migratedConfig.entities) {
+    migratedConfig = { ...migratedConfig, entities };
+  }
+
+  return changed ? migratedConfig : config;
+};
 
 @customElement("hui-entities-card-editor")
 export class HuiEntitiesCardEditor
@@ -208,6 +273,11 @@ export class HuiEntitiesCardEditor
 
   public setConfig(config: EntitiesCardConfig): void {
     assert(config, cardConfigStruct);
+    const migratedConfig = migrateEntitiesStateColor(config);
+    if (migratedConfig !== config) {
+      fireEvent(this, "config-changed", { config: migratedConfig });
+      return;
+    }
     this._config = config;
     this._configEntities = processEditorEntities(config.entities);
   }
@@ -288,8 +358,10 @@ export class HuiEntitiesCardEditor
             )}
           >
             <ha-switch
-              .checked=${this._config!.state_color}
-              .configValue=${"state_color"}
+              .checked=${this._config!.color === "state" ||
+              (this._config!.color === undefined &&
+                this._config!.state_color === true)}
+              .configValue=${"color"}
               @change=${this._valueChanged}
             ></ha-switch>
           </ha-formfield>
@@ -328,9 +400,13 @@ export class HuiEntitiesCardEditor
     const configValue =
       target.configValue || this._subElementEditorConfig?.type;
     const value =
-      target.checked !== undefined
+      configValue === "color"
         ? target.checked
-        : target.value || ev.detail.config || ev.detail.value;
+          ? "state"
+          : "none"
+        : target.checked !== undefined
+          ? target.checked
+          : target.value || ev.detail.config || ev.detail.value;
 
     if (
       (configValue === "title" && target.value === this._title) ||

--- a/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
@@ -71,7 +71,6 @@ const SUB_FORM = {
           name: "color",
           selector: {
             ui_color: {
-              default_color: "state",
               include_state: true,
               include_none: true,
             },
@@ -129,7 +128,6 @@ const SCHEMA = [
     name: "color",
     selector: {
       ui_color: {
-        default_color: "state",
         include_state: true,
         include_none: true,
       },

--- a/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
@@ -37,6 +37,7 @@ const cardConfigStruct = assign(
     show_state: optional(boolean()),
     show_icon: optional(boolean()),
     state_color: optional(boolean()),
+    color: optional(string()),
     entities: array(entitiesConfigStruct),
   })
 );
@@ -66,6 +67,16 @@ const SUB_FORM = {
         },
         { name: "show_last_changed", selector: { boolean: {} } },
         { name: "show_state", selector: { boolean: {} }, default: true },
+        {
+          name: "color",
+          selector: {
+            ui_color: {
+              default_color: "state",
+              include_state: true,
+              include_none: true,
+            },
+          },
+        },
       ],
     },
     {
@@ -114,8 +125,55 @@ const SCHEMA = [
       { name: "show_state", selector: { boolean: {} } },
     ],
   },
-  { name: "state_color", selector: { boolean: {} } },
+  {
+    name: "color",
+    selector: {
+      ui_color: {
+        default_color: "state",
+        include_state: true,
+        include_none: true,
+      },
+    },
+  },
 ] as const;
+
+const migrateStateColor = <T extends { state_color?: boolean; color?: string }>(
+  config: T
+): T => {
+  if (config.state_color === undefined || config.color !== undefined) {
+    return config;
+  }
+
+  const migrated = {
+    ...config,
+    color: config.state_color ? "state" : "none",
+  };
+  delete migrated.state_color;
+  return migrated;
+};
+
+const migrateGlanceStateColor = (
+  config: GlanceCardConfig
+): GlanceCardConfig => {
+  let changed = false;
+  let migratedConfig = migrateStateColor(config);
+  changed ||= migratedConfig !== config;
+
+  const entities = migratedConfig.entities.map((entity) => {
+    if (typeof entity === "string") {
+      return entity;
+    }
+    const migratedEntity = migrateStateColor(entity);
+    changed ||= migratedEntity !== entity;
+    return migratedEntity;
+  });
+
+  if (entities !== migratedConfig.entities) {
+    migratedConfig = { ...migratedConfig, entities };
+  }
+
+  return changed ? migratedConfig : config;
+};
 
 @customElement("hui-glance-card-editor")
 export class HuiGlanceCardEditor
@@ -132,6 +190,11 @@ export class HuiGlanceCardEditor
 
   public setConfig(config: GlanceCardConfig): void {
     assert(config, cardConfigStruct);
+    const migratedConfig = migrateGlanceStateColor(config);
+    if (migratedConfig !== config) {
+      fireEvent(this, "config-changed", { config: migratedConfig });
+      return;
+    }
     this._config = config;
     this._configEntities = processEditorEntities(config.entities);
   }

--- a/src/panels/lovelace/editor/structs/entities-struct.ts
+++ b/src/panels/lovelace/editor/structs/entities-struct.ts
@@ -15,6 +15,7 @@ export const entitiesConfigStruct = union([
     secondary_info: optional(string()),
     format: optional(enums(TIMESTAMP_RENDERING_FORMATS)),
     state_color: optional(boolean()),
+    color: optional(string()),
     tap_action: optional(actionConfigStruct),
     hold_action: optional(actionConfigStruct),
     double_tap_action: optional(actionConfigStruct),

--- a/src/panels/lovelace/special-rows/hui-conditional-row.ts
+++ b/src/panels/lovelace/special-rows/hui-conditional-row.ts
@@ -1,5 +1,4 @@
 import { customElement } from "lit/decorators";
-import type { EntityCardConfig } from "../cards/types";
 import { HuiConditionalBase } from "../components/hui-conditional-base";
 import { createRowElement } from "../create-element/create-row-element";
 import type {
@@ -8,6 +7,16 @@ import type {
   LovelaceRow,
 } from "../entity-rows/types";
 import { fireEvent } from "../../../common/dom/fire_event";
+
+type ConditionalColorConfig = ConditionalRowConfig & {
+  color?: string;
+  state_color?: boolean;
+};
+
+type EntityColorConfig = EntityConfig & {
+  color?: string;
+  state_color?: boolean;
+};
 
 declare global {
   interface HASSDomEvents {
@@ -23,15 +32,24 @@ class HuiConditionalRow extends HuiConditionalBase implements LovelaceRow {
       throw new Error("No row configured");
     }
 
+    const inheritedConfig = config as ConditionalColorConfig;
+    const rowConfig = config.row as EntityColorConfig;
+    const hasInheritedColorConfig =
+      inheritedConfig.state_color !== undefined ||
+      inheritedConfig.color !== undefined;
+    const hasRowColorConfig =
+      rowConfig.state_color !== undefined || rowConfig.color !== undefined;
+
     this._element = createRowElement(
-      (config as EntityCardConfig).state_color !== undefined ||
-        (config as EntityCardConfig).color !== undefined
+      hasInheritedColorConfig && !hasRowColorConfig
         ? ({
-            ...(config.row as EntityConfig),
-            ...(config as EntityCardConfig).color !== undefined
-              ? { color: (config as EntityCardConfig).color }
-              : {},
-            state_color: (config as EntityCardConfig).state_color,
+            ...rowConfig,
+            ...(inheritedConfig.color !== undefined
+              ? { color: inheritedConfig.color }
+              : {}),
+            ...(inheritedConfig.state_color !== undefined
+              ? { state_color: inheritedConfig.state_color }
+              : {}),
           } as EntityConfig)
         : config.row
     ) as LovelaceRow;

--- a/src/panels/lovelace/special-rows/hui-conditional-row.ts
+++ b/src/panels/lovelace/special-rows/hui-conditional-row.ts
@@ -24,10 +24,14 @@ class HuiConditionalRow extends HuiConditionalBase implements LovelaceRow {
     }
 
     this._element = createRowElement(
-      (config as EntityCardConfig).state_color
+      (config as EntityCardConfig).state_color !== undefined ||
+        (config as EntityCardConfig).color !== undefined
         ? ({
-            state_color: true,
             ...(config.row as EntityConfig),
+            ...(config as EntityCardConfig).color !== undefined
+              ? { color: (config as EntityCardConfig).color }
+              : {},
+            state_color: (config as EntityCardConfig).state_color,
           } as EntityConfig)
         : config.row
     ) as LovelaceRow;


### PR DESCRIPTION
## Proposed change

This PR migrates the existing `state_color` option in `glance` and `entities` card configs toward the newer `color` API.

The goal is to keep the existing runtime behavior for current YAML configs while making the editor normalize saved configs to `color: state` / `color: none` instead of continuing to write `state_color`.

The change is scoped to `glance` and `entities`:
- accepts `color` in the card-level and entity-level config types;
- keeps `state_color` as backward-compatible input for existing configs;
- maps `color: state` / `color: none` to the existing `state-badge.stateColor` boolean internally;
- migrates editor-loaded `state_color: true` to `color: state`;
- migrates editor-loaded `state_color: false` to `color: none`;
- gives explicit `color` values precedence when both options are present.

Heading badges are intentionally left on their existing `color` API only.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr