### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/build-scripts/gulp/gallery.js
+++ b/build-scripts/gulp/gallery.js
@@ -57,7 +57,9 @@ gulp.task("gather-gallery-pages", async function gatherPages() {
       if (descriptionContent === "") {
         hasDescription = false;
       } else {
-        descriptionContent = marked(descriptionContent).replace(/`/g, "\\`");
+        descriptionContent = marked(descriptionContent)
+          .replace(/\\/g, "\\\\")
+          .replace(/`/g, "\\`");
         fs.mkdirSync(path.resolve(galleryBuild, category), { recursive: true });
         fs.writeFileSync(
           path.resolve(galleryBuild, `${pageId}-description.ts`),


### PR DESCRIPTION
Potential fix for [https://github.com/home-assistant/frontend/security/code-scanning/3](https://github.com/home-assistant/frontend/security/code-scanning/3)

Use robust escaping for JavaScript template literals before embedding `descriptionContent` into generated `.ts` code.

Best fix here (without changing behavior): escape **backslashes first**, then escape backticks. This preserves intended literal output while preventing escape-sequence ambiguity.

In `build-scripts/gulp/gallery.js`, replace the line:
- `descriptionContent = marked(descriptionContent).replace(/`/g, "\\`");`

with:
- render markdown first,
- then `.replace(/\\/g, "\\\\")` to escape backslashes globally,
- then `.replace(/`/g, "\\`")` to escape backticks globally.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
