### PR TITLE
Allow to set refresh url while dialog is open, use for matter device

### DIFF
--- a/src/common/navigate.ts
+++ b/src/common/navigate.ts
@@ -18,6 +18,19 @@ export interface NavigateOptions {
 const DIALOG_WAIT_TIMEOUT = 500;
 
 /**
+ * Stash a destination URL in the current history entry's state. If the page
+ * is refreshed while a dialog is open, urlSyncMixin will navigate to this URL
+ * on load instead of cleaning up the stale dialog state by going back.
+ * The current URL is not changed.
+ */
+export const setRefreshUrl = (path: string) => {
+  mainWindow.history.replaceState(
+    { ...mainWindow.history.state, refreshUrl: path },
+    ""
+  );
+};
+
+/**
  * Ensures all dialogs are closed before navigation.
  * Returns true if navigation can proceed, false if a dialog refused to close.
  */

--- a/src/panels/config/integrations/integration-panels/matter/dialog-matter-add-device.ts
+++ b/src/panels/config/integrations/integration-panels/matter/dialog-matter-add-device.ts
@@ -5,7 +5,7 @@ import { dynamicElement } from "../../../../../common/dom/dynamic-element-direct
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { computeDomain } from "../../../../../common/entity/compute_domain";
 import { computeDeviceName } from "../../../../../common/entity/compute_device_name";
-import { navigate } from "../../../../../common/navigate";
+import { navigate, setRefreshUrl } from "../../../../../common/navigate";
 import "../../../../../components/ha-dialog-footer";
 import "../../../../../components/ha-icon-button-arrow-prev";
 import "../../../../../components/ha-button";
@@ -100,6 +100,8 @@ class DialogMatterAddDevice extends LitElement {
   public showDialog(): void {
     this._open = true;
     this._unsub = watchForNewMatterDevice(this.hass, (device) => {
+      // make sure a refresh of the page will navigate to the device page, old iOS apps will refresh the webview when commissioning is done
+      setRefreshUrl(`/config/devices/device/${device.id}`);
       this._newDevice = device;
       this._step = "device_added";
       this._fetchMainEntity();

--- a/src/state/url-sync-mixin.ts
+++ b/src/state/url-sync-mixin.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import type { ReactiveElement, PropertyValues } from "lit";
+import { fireEvent } from "../common/dom/fire_event";
 import { mainWindow } from "../common/dom/get_main_window";
 import { closeLastDialog } from "../dialogs/make-dialog-manager";
 import type { ProvideHassElement } from "../mixins/provide-hass-lit-mixin";
@@ -38,6 +39,21 @@ export const urlSyncMixin = <
         protected firstUpdated(changedProperties: PropertyValues<this>): void {
           super.firstUpdated(changedProperties);
           if (mainWindow.history.state?.dialog) {
+            const refreshUrl = mainWindow.history.state.refreshUrl;
+            if (typeof refreshUrl === "string") {
+              // Page was refreshed while a dialog had stashed an intended
+              // destination URL. Clean up the stale dialog state and route
+              // to the intended URL. We bypass navigate() because its
+              // ensureDialogsClosed loop would spin until timeout on the
+              // dangling state.dialog with no actual dialog open.
+              mainWindow.history.replaceState(null, "", refreshUrl);
+              // Defer: the host element's firstUpdated registers the
+              // location-changed listener after super.firstUpdated() returns.
+              setTimeout(() => {
+                fireEvent(mainWindow, "location-changed", { replace: true });
+              });
+              return;
+            }
             // this is a page refresh with a dialog open
             // the dialog stack must be empty in this case so this state should be cleaned up
             mainWindow.history.back();


### PR DESCRIPTION


## Proposed change

The iOS app does a refresh when matter commissioning is done, since we navigate to the device page after the dialog is closed by the user, the iOS app would no longer go to the device page like it did before.

This PR set a url that will be used to navigate to when the page is refreshed while the dialog is open, so the old behavior is intact while the iOS app is not updated yet to no longer refresh the webview.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
