### PR TITLE
Fix vacuum and lawn mower features not showing default buttons

### DIFF
--- a/src/panels/lovelace/card-features/hui-counter-actions-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-counter-actions-card-feature.ts
@@ -86,7 +86,6 @@ class HuiCounterActionsCardFeature
   static getStubConfig(): CounterActionsCardFeatureConfig {
     return {
       type: "counter-actions",
-      actions: COUNTER_ACTIONS.map((action) => action),
     };
   }
 

--- a/src/panels/lovelace/card-features/hui-lawn-mower-commands-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-lawn-mower-commands-card-feature.ts
@@ -110,20 +110,9 @@ class HuiLawnMowerCommandCardFeature
       | undefined;
   }
 
-  static getStubConfig(
-    hass: HomeAssistant,
-    context: LovelaceCardFeatureContext
-  ): LawnMowerCommandsCardFeatureConfig {
-    const stateObj = context.entity_id
-      ? hass.states[context.entity_id]
-      : undefined;
+  static getStubConfig(): LawnMowerCommandsCardFeatureConfig {
     return {
       type: "lawn-mower-commands",
-      commands: stateObj
-        ? LAWN_MOWER_COMMANDS.filter((c) =>
-            supportsLawnMowerCommand(stateObj, c)
-          ).slice(0, 3)
-        : [],
     };
   }
 
@@ -162,28 +151,28 @@ class HuiLawnMowerCommandCardFeature
 
     const stateObj = this._stateObj as LawnMowerEntity;
 
+    const commands = this._config.commands ?? LAWN_MOWER_COMMANDS;
+
     return html`
       <ha-control-button-group>
-        ${LAWN_MOWER_COMMANDS.filter(
-          (command) =>
-            supportsLawnMowerCommand(stateObj, command) &&
-            this._config?.commands?.includes(command)
-        ).map((command) => {
-          const button = LAWN_MOWER_COMMANDS_BUTTONS[command](stateObj);
-          return html`
-            <ha-control-button
-              .entry=${button}
-              .label=${this.hass!.localize(
-                // @ts-ignore
-                `ui.dialogs.more_info_control.lawn_mower.${button.translationKey}`
-              )}
-              @click=${this._onCommandTap}
-              .disabled=${button.disabled || stateObj.state === UNAVAILABLE}
-            >
-              <ha-svg-icon .path=${button.icon}></ha-svg-icon>
-            </ha-control-button>
-          `;
-        })}
+        ${commands
+          .filter((command) => supportsLawnMowerCommand(stateObj, command))
+          .map((command) => {
+            const button = LAWN_MOWER_COMMANDS_BUTTONS[command](stateObj);
+            return html`
+              <ha-control-button
+                .entry=${button}
+                .label=${this.hass!.localize(
+                  // @ts-ignore
+                  `ui.dialogs.more_info_control.lawn_mower.${button.translationKey}`
+                )}
+                @click=${this._onCommandTap}
+                .disabled=${button.disabled || stateObj.state === UNAVAILABLE}
+              >
+                <ha-svg-icon .path=${button.icon}></ha-svg-icon>
+              </ha-control-button>
+            `;
+          })}
       </ha-control-button-group>
     `;
   }

--- a/src/panels/lovelace/card-features/hui-vacuum-commands-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-vacuum-commands-card-feature.ts
@@ -52,6 +52,12 @@ export const VACUUM_COMMANDS_FEATURES: Record<
   return_home: [VacuumEntityFeature.RETURN_HOME],
 };
 
+export const VACUUM_DEFAULT_COMMANDS: VacuumCommand[] = [
+  "start_pause",
+  "stop",
+  "return_home",
+];
+
 export const supportsVacuumCommand = (
   stateObj: HassEntity,
   command: VacuumCommand
@@ -154,20 +160,9 @@ class HuiVacuumCommandCardFeature
       | undefined;
   }
 
-  static getStubConfig(
-    hass: HomeAssistant,
-    context: LovelaceCardFeatureContext
-  ): VacuumCommandsCardFeatureConfig {
-    const stateObj = context.entity_id
-      ? hass.states[context.entity_id]
-      : undefined;
+  static getStubConfig(): VacuumCommandsCardFeatureConfig {
     return {
       type: "vacuum-commands",
-      commands: stateObj
-        ? VACUUM_COMMANDS.filter((c) =>
-            supportsVacuumCommand(stateObj, c)
-          ).slice(0, 3)
-        : [],
     };
   }
 
@@ -204,28 +199,28 @@ class HuiVacuumCommandCardFeature
 
     const stateObj = this._stateObj as VacuumEntity;
 
+    const commands = this._config.commands ?? VACUUM_DEFAULT_COMMANDS;
+
     return html`
       <ha-control-button-group>
-        ${VACUUM_COMMANDS.filter(
-          (command) =>
-            supportsVacuumCommand(stateObj, command) &&
-            this._config?.commands?.includes(command)
-        ).map((command) => {
-          const button = VACUUM_COMMANDS_BUTTONS[command](stateObj);
-          return html`
-            <ha-control-button
-              .entry=${button}
-              .label=${this.hass!.localize(
-                // @ts-ignore
-                `ui.dialogs.more_info_control.vacuum.${button.translationKey}`
-              )}
-              @click=${this._onCommandTap}
-              .disabled=${button.disabled || stateObj.state === UNAVAILABLE}
-            >
-              <ha-svg-icon .path=${button.icon}></ha-svg-icon>
-            </ha-control-button>
-          `;
-        })}
+        ${commands
+          .filter((command) => supportsVacuumCommand(stateObj, command))
+          .map((command) => {
+            const button = VACUUM_COMMANDS_BUTTONS[command](stateObj);
+            return html`
+              <ha-control-button
+                .entry=${button}
+                .label=${this.hass!.localize(
+                  // @ts-ignore
+                  `ui.dialogs.more_info_control.vacuum.${button.translationKey}`
+                )}
+                @click=${this._onCommandTap}
+                .disabled=${button.disabled || stateObj.state === UNAVAILABLE}
+              >
+                <ha-svg-icon .path=${button.icon}></ha-svg-icon>
+              </ha-control-button>
+            `;
+          })}
       </ha-control-button-group>
     `;
   }

--- a/src/panels/lovelace/editor/config-elements/customizable-list-feature.ts
+++ b/src/panels/lovelace/editor/config-elements/customizable-list-feature.ts
@@ -1,0 +1,59 @@
+import type { HaFormSchema } from "../../../../components/ha-form/types";
+
+interface CustomizableListSchemaParams {
+  field: string;
+  customize: boolean;
+  options: { value: string; label: string }[];
+}
+
+export const customizableListSchema = ({
+  field,
+  customize,
+  options,
+}: CustomizableListSchemaParams) =>
+  [
+    {
+      name: "customize",
+      selector: { boolean: {} },
+    },
+    ...(customize
+      ? ([
+          {
+            name: field,
+            selector: {
+              select: {
+                mode: "list",
+                reorder: true,
+                multiple: true,
+                options,
+              },
+            },
+          },
+        ] as const satisfies readonly HaFormSchema[])
+      : []),
+  ] as const satisfies readonly HaFormSchema[];
+
+// `customize` is form-only and never stored in the config.
+export const customizableListData = <T extends object>(
+  config: T,
+  field: string
+): T & { customize: boolean } => ({
+  ...config,
+  customize: (config as Record<string, unknown>)[field] !== undefined,
+});
+
+// Dropping the field lets the feature fall back to its own default.
+export const processCustomizableListValue = <T extends object>(
+  value: T & { customize?: boolean },
+  field: string,
+  defaults: readonly string[]
+): T => {
+  const { customize, ...rest } = value;
+  const config = rest as Record<string, unknown>;
+  if (customize && !config[field]) {
+    config[field] = [...defaults];
+  } else if (!customize) {
+    delete config[field];
+  }
+  return config as unknown as T;
+};

--- a/src/panels/lovelace/editor/config-elements/hui-counter-actions-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-counter-actions-card-feature-editor.ts
@@ -2,16 +2,20 @@ import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import type { LocalizeFunc } from "../../../../common/translations/localize";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import "../../../../components/ha-form/ha-form";
 import type { HomeAssistant } from "../../../../types";
-import {
-  COUNTER_ACTIONS,
-  type LovelaceCardFeatureContext,
-  type CounterActionsCardFeatureConfig,
+import type {
+  CounterActionsCardFeatureConfig,
+  LovelaceCardFeatureContext,
 } from "../../card-features/types";
+import { COUNTER_ACTIONS } from "../../card-features/types";
 import type { LovelaceCardFeatureEditor } from "../../types";
+import {
+  customizableListData,
+  customizableListSchema,
+  processCustomizableListValue,
+} from "./customizable-list-feature";
 
 @customElement("hui-counter-actions-card-feature-editor")
 export class HuiCounterActionsCardFeatureEditor
@@ -28,26 +32,17 @@ export class HuiCounterActionsCardFeatureEditor
     this._config = config;
   }
 
-  private _schema = memoizeOne(
-    (localize: LocalizeFunc) =>
-      [
-        {
-          name: "actions",
-          selector: {
-            select: {
-              multiple: true,
-              mode: "list",
-              reorder: true,
-              options: COUNTER_ACTIONS.map((action) => ({
-                value: action,
-                label: `${localize(
-                  `ui.panel.lovelace.editor.features.types.counter-actions.actions.${action}`
-                )}`,
-              })),
-            },
-          },
-        },
-      ] as const
+  private _schema = memoizeOne((customize: boolean) =>
+    customizableListSchema({
+      field: "actions",
+      customize,
+      options: COUNTER_ACTIONS.map((action) => ({
+        value: action,
+        label: this.hass!.localize(
+          `ui.panel.lovelace.editor.features.types.counter-actions.actions_list.${action}`
+        ),
+      })),
+    })
   );
 
   protected render() {
@@ -55,12 +50,13 @@ export class HuiCounterActionsCardFeatureEditor
       return nothing;
     }
 
-    const schema = this._schema(this.hass.localize);
+    const data = customizableListData(this._config, "actions");
+    const schema = this._schema(data.customize);
 
     return html`
       <ha-form
         .hass=${this.hass}
-        .data=${this._config}
+        .data=${data}
         .schema=${schema}
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
@@ -69,19 +65,21 @@ export class HuiCounterActionsCardFeatureEditor
   }
 
   private _valueChanged(ev: CustomEvent): void {
-    fireEvent(this, "config-changed", { config: ev.detail.value });
+    const config =
+      processCustomizableListValue<CounterActionsCardFeatureConfig>(
+        ev.detail.value,
+        "actions",
+        COUNTER_ACTIONS
+      );
+    fireEvent(this, "config-changed", { config });
   }
 
   private _computeLabelCallback = (
     schema: SchemaUnion<ReturnType<typeof this._schema>>
-  ) => {
-    switch (schema.name) {
-      default:
-        return this.hass!.localize(
-          `ui.panel.lovelace.editor.card.generic.${schema.name}`
-        );
-    }
-  };
+  ) =>
+    this.hass!.localize(
+      `ui.panel.lovelace.editor.features.types.counter-actions.${schema.name}`
+    );
 }
 
 declare global {

--- a/src/panels/lovelace/editor/config-elements/hui-lawn-mower-commands-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-lawn-mower-commands-card-feature-editor.ts
@@ -3,7 +3,6 @@ import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import type { LocalizeFunc } from "../../../../common/translations/localize";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import "../../../../components/ha-form/ha-form";
 import type { HomeAssistant } from "../../../../types";
@@ -14,6 +13,11 @@ import type {
 } from "../../card-features/types";
 import { LAWN_MOWER_COMMANDS } from "../../card-features/types";
 import type { LovelaceCardFeatureEditor } from "../../types";
+import {
+  customizableListData,
+  customizableListSchema,
+  processCustomizableListValue,
+} from "./customizable-list-feature";
 
 @customElement("hui-lawn-mower-commands-card-feature-editor")
 export class HuiLawnMowerCommandsCardFeatureEditor
@@ -31,27 +35,19 @@ export class HuiLawnMowerCommandsCardFeatureEditor
   }
 
   private _schema = memoizeOne(
-    (localize: LocalizeFunc, stateObj?: HassEntity) =>
-      [
-        {
-          name: "commands",
-          selector: {
-            select: {
-              multiple: true,
-              mode: "list",
-              options: LAWN_MOWER_COMMANDS.filter(
-                (command) =>
-                  stateObj && supportsLawnMowerCommand(stateObj, command)
-              ).map((command) => ({
-                value: command,
-                label: `${localize(
-                  `ui.panel.lovelace.editor.features.types.lawn-mower-commands.commands_list.${command}`
-                )}`,
-              })),
-            },
-          },
-        },
-      ] as const
+    (stateObj: HassEntity | undefined, customize: boolean) =>
+      customizableListSchema({
+        field: "commands",
+        customize,
+        options: LAWN_MOWER_COMMANDS.filter(
+          (command) => stateObj && supportsLawnMowerCommand(stateObj, command)
+        ).map((command) => ({
+          value: command,
+          label: this.hass!.localize(
+            `ui.panel.lovelace.editor.features.types.lawn-mower-commands.commands_list.${command}`
+          ),
+        })),
+      })
   );
 
   protected render() {
@@ -60,15 +56,16 @@ export class HuiLawnMowerCommandsCardFeatureEditor
     }
 
     const stateObj = this.context?.entity_id
-      ? this.hass.states[this.context?.entity_id]
+      ? this.hass.states[this.context.entity_id]
       : undefined;
 
-    const schema = this._schema(this.hass.localize, stateObj);
+    const data = customizableListData(this._config, "commands");
+    const schema = this._schema(stateObj, data.customize);
 
     return html`
       <ha-form
         .hass=${this.hass}
-        .data=${this._config}
+        .data=${data}
         .schema=${schema}
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
@@ -77,23 +74,27 @@ export class HuiLawnMowerCommandsCardFeatureEditor
   }
 
   private _valueChanged(ev: CustomEvent): void {
-    fireEvent(this, "config-changed", { config: ev.detail.value });
+    const stateObj = this.context?.entity_id
+      ? this.hass!.states[this.context.entity_id]
+      : undefined;
+    const defaults = LAWN_MOWER_COMMANDS.filter(
+      (command) => stateObj && supportsLawnMowerCommand(stateObj, command)
+    );
+    const config =
+      processCustomizableListValue<LawnMowerCommandsCardFeatureConfig>(
+        ev.detail.value,
+        "commands",
+        defaults
+      );
+    fireEvent(this, "config-changed", { config });
   }
 
   private _computeLabelCallback = (
     schema: SchemaUnion<ReturnType<typeof this._schema>>
-  ) => {
-    switch (schema.name) {
-      case "commands":
-        return this.hass!.localize(
-          `ui.panel.lovelace.editor.features.types.lawn-mower-commands.${schema.name}`
-        );
-      default:
-        return this.hass!.localize(
-          `ui.panel.lovelace.editor.card.generic.${schema.name}`
-        );
-    }
-  };
+  ) =>
+    this.hass!.localize(
+      `ui.panel.lovelace.editor.features.types.lawn-mower-commands.${schema.name}`
+    );
 }
 
 declare global {

--- a/src/panels/lovelace/editor/config-elements/hui-vacuum-commands-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-vacuum-commands-card-feature-editor.ts
@@ -3,17 +3,24 @@ import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import type { LocalizeFunc } from "../../../../common/translations/localize";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import "../../../../components/ha-form/ha-form";
 import type { HomeAssistant } from "../../../../types";
-import { supportsVacuumCommand } from "../../card-features/hui-vacuum-commands-card-feature";
+import {
+  supportsVacuumCommand,
+  VACUUM_DEFAULT_COMMANDS,
+} from "../../card-features/hui-vacuum-commands-card-feature";
 import type {
   LovelaceCardFeatureContext,
   VacuumCommandsCardFeatureConfig,
 } from "../../card-features/types";
 import { VACUUM_COMMANDS } from "../../card-features/types";
 import type { LovelaceCardFeatureEditor } from "../../types";
+import {
+  customizableListData,
+  customizableListSchema,
+  processCustomizableListValue,
+} from "./customizable-list-feature";
 
 @customElement("hui-vacuum-commands-card-feature-editor")
 export class HuiVacuumCommandsCardFeatureEditor
@@ -31,27 +38,19 @@ export class HuiVacuumCommandsCardFeatureEditor
   }
 
   private _schema = memoizeOne(
-    (localize: LocalizeFunc, stateObj?: HassEntity) =>
-      [
-        {
-          name: "commands",
-          selector: {
-            select: {
-              multiple: true,
-              mode: "list",
-              options: VACUUM_COMMANDS.filter(
-                (command) =>
-                  stateObj && supportsVacuumCommand(stateObj, command)
-              ).map((command) => ({
-                value: command,
-                label: `${localize(
-                  `ui.panel.lovelace.editor.features.types.vacuum-commands.commands_list.${command}`
-                )}`,
-              })),
-            },
-          },
-        },
-      ] as const
+    (stateObj: HassEntity | undefined, customize: boolean) =>
+      customizableListSchema({
+        field: "commands",
+        customize,
+        options: VACUUM_COMMANDS.filter(
+          (command) => stateObj && supportsVacuumCommand(stateObj, command)
+        ).map((command) => ({
+          value: command,
+          label: this.hass!.localize(
+            `ui.panel.lovelace.editor.features.types.vacuum-commands.commands_list.${command}`
+          ),
+        })),
+      })
   );
 
   protected render() {
@@ -60,15 +59,16 @@ export class HuiVacuumCommandsCardFeatureEditor
     }
 
     const stateObj = this.context?.entity_id
-      ? this.hass.states[this.context?.entity_id]
+      ? this.hass.states[this.context.entity_id]
       : undefined;
 
-    const schema = this._schema(this.hass.localize, stateObj);
+    const data = customizableListData(this._config, "commands");
+    const schema = this._schema(stateObj, data.customize);
 
     return html`
       <ha-form
         .hass=${this.hass}
-        .data=${this._config}
+        .data=${data}
         .schema=${schema}
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
@@ -77,23 +77,27 @@ export class HuiVacuumCommandsCardFeatureEditor
   }
 
   private _valueChanged(ev: CustomEvent): void {
-    fireEvent(this, "config-changed", { config: ev.detail.value });
+    const stateObj = this.context?.entity_id
+      ? this.hass!.states[this.context.entity_id]
+      : undefined;
+    const defaults = VACUUM_DEFAULT_COMMANDS.filter(
+      (command) => stateObj && supportsVacuumCommand(stateObj, command)
+    );
+    const config =
+      processCustomizableListValue<VacuumCommandsCardFeatureConfig>(
+        ev.detail.value,
+        "commands",
+        defaults
+      );
+    fireEvent(this, "config-changed", { config });
   }
 
   private _computeLabelCallback = (
     schema: SchemaUnion<ReturnType<typeof this._schema>>
-  ) => {
-    switch (schema.name) {
-      case "commands":
-        return this.hass!.localize(
-          `ui.panel.lovelace.editor.features.types.vacuum-commands.${schema.name}`
-        );
-      default:
-        return this.hass!.localize(
-          `ui.panel.lovelace.editor.card.generic.${schema.name}`
-        );
-    }
-  };
+  ) =>
+    this.hass!.localize(
+      `ui.panel.lovelace.editor.features.types.vacuum-commands.${schema.name}`
+    );
 }
 
 declare global {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10151,6 +10151,7 @@
               },
               "vacuum-commands": {
                 "label": "Vacuum commands",
+                "customize": "Customize commands",
                 "commands": "Commands",
                 "commands_list": {
                   "start_pause": "[%key:ui::dialogs::more_info_control::vacuum::start_pause%]",
@@ -10222,7 +10223,9 @@
               },
               "counter-actions": {
                 "label": "Counter actions",
-                "actions": {
+                "customize": "Customize actions",
+                "actions": "Actions",
+                "actions_list": {
                   "increment": "Increment",
                   "decrement": "Decrement",
                   "reset": "Reset"
@@ -10285,6 +10288,7 @@
               },
               "lawn-mower-commands": {
                 "label": "Lawn mower commands",
+                "customize": "Customize commands",
                 "commands": "Commands",
                 "commands_list": {
                   "start_pause": "Start Pause",


### PR DESCRIPTION
## Proposed change

Following https://github.com/home-assistant/frontend/pull/52317.

Vacuum and lawn mower tile features showed no buttons when their `commands` were not explicitly configured, which happens whenever the feature is auto-suggested by the tile card. The render required each command to be present in the config, so an unset `commands` produced an empty button group.

These features now fall back to a sensible default when nothing is configured:
- Vacuum: start/pause, stop, return home
- Lawn mower: start/pause, dock

The editors also gain a "Customize commands" toggle (same pattern as the climate fan modes editor): off shows the defaults, on reveals a reorderable list to pick which commands appear. Counter actions gets the same toggle for consistency.

Under the hood, the shared toggle + list logic is extracted into composable helpers (`customizable-list-feature.ts`) instead of a base class, so editors stay plain `LitElement`s and can add their own fields alongside it. A follow-up will migrate the media player playback feature and unify the existing climate/fan modes editors onto the same helpers.

## Screenshots

<!-- reminder below -->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
