### PR TITLE
Avoid double collection fetch when loading energy dashboard strategy

### DIFF
--- a/src/data/energy.ts
+++ b/src/data/energy.ts
@@ -222,6 +222,12 @@ export interface EnergyPreferences {
   device_consumption_water: DeviceConsumptionEnergyPreference[];
 }
 
+export const EMPTY_PREFERENCES: EnergyPreferences = {
+  energy_sources: [],
+  device_consumption: [],
+  device_consumption_water: [],
+};
+
 export interface EnergyInfo {
   cost_sensors: Record<string, string>;
   solar_forecast_domains: string[];
@@ -802,7 +808,16 @@ export const getEnergyDataCollection = (
       if (!collection.prefs) {
         // This will raise if not found.
         // Detect by checking `e.code === "not_found"
-        collection.prefs = await getEnergyPreferences(hass);
+        try {
+          collection.prefs = await getEnergyPreferences(hass);
+        } catch (err: any) {
+          if (err.code === "not_found") {
+            return {
+              prefs: EMPTY_PREFERENCES,
+            } as EnergyData;
+          }
+          throw err;
+        }
       }
 
       scheduleHourlyRefresh(collection);

--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -14,6 +14,7 @@ import "../lovelace/hui-root";
 import type { Lovelace } from "../lovelace/types";
 import "../lovelace/views/hui-view";
 import "../lovelace/views/hui-view-container";
+import { DEFAULT_POWER_COLLECTION_KEY } from "./constants";
 
 @customElement("ha-panel-energy")
 class PanelEnergy extends LitElement {
@@ -86,7 +87,15 @@ class PanelEnergy extends LitElement {
 
   private async _setLovelace() {
     const config: LovelaceConfig = await generateLovelaceDashboardStrategy(
-      { strategy: { type: "energy" } },
+      {
+        strategy: {
+          type: "energy",
+          default_collection:
+            this.route?.path === "/now"
+              ? DEFAULT_POWER_COLLECTION_KEY
+              : undefined,
+        },
+      },
       this.hass
     );
 

--- a/src/panels/energy/strategies/energy-dashboard-strategy.ts
+++ b/src/panels/energy/strategies/energy-dashboard-strategy.ts
@@ -1,6 +1,9 @@
 import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
-import { getEnergyDataCollection } from "../../../data/energy";
+import {
+  EMPTY_PREFERENCES,
+  getEnergyDataCollection,
+} from "../../../data/energy";
 import type { EnergyPreferences } from "../../../data/energy";
 import type { LovelaceStrategyConfig } from "../../../data/lovelace/config/strategy";
 import type { LovelaceConfig } from "../../../data/lovelace/config/types";
@@ -56,12 +59,6 @@ const WIZARD_VIEW = {
   type: "panel",
   path: "setup",
   cards: [{ type: "custom:energy-setup-wizard-card" }],
-};
-
-const EMPTY_PREFERENCES: EnergyPreferences = {
-  energy_sources: [],
-  device_consumption: [],
-  device_consumption_water: [],
 };
 
 export interface EnergyDashboardStrategyConfig extends LovelaceStrategyConfig {
@@ -152,15 +149,13 @@ async function fetchEnergyPrefs(
   const collection = getEnergyDataCollection(hass, {
     key: DEFAULT_ENERGY_COLLECTION_KEY,
   });
-  try {
-    await collection.refresh();
-  } catch (err: any) {
-    if (err.code === "not_found") {
-      return EMPTY_PREFERENCES;
-    }
-    throw err;
-  }
-  return collection.prefs || EMPTY_PREFERENCES;
+
+  return await new Promise<EnergyPreferences>((resolve) => {
+    const unsub = collection.subscribe((data) => {
+      unsub();
+      resolve(data.prefs || EMPTY_PREFERENCES);
+    });
+  });
 }
 
 declare global {

--- a/src/panels/energy/strategies/energy-dashboard-strategy.ts
+++ b/src/panels/energy/strategies/energy-dashboard-strategy.ts
@@ -63,6 +63,7 @@ const WIZARD_VIEW = {
 
 export interface EnergyDashboardStrategyConfig extends LovelaceStrategyConfig {
   type: "energy";
+  default_collection?: string;
 }
 
 @customElement("energy-dashboard-strategy")
@@ -71,7 +72,7 @@ export class EnergyDashboardStrategy extends ReactiveElement {
     _config: EnergyDashboardStrategyConfig,
     hass: HomeAssistant
   ): Promise<LovelaceConfig> {
-    const prefs = await fetchEnergyPrefs(hass);
+    const prefs = await fetchEnergyPrefs(hass, _config.default_collection);
 
     if (
       !prefs ||
@@ -144,10 +145,11 @@ export class EnergyDashboardStrategy extends ReactiveElement {
 }
 
 async function fetchEnergyPrefs(
-  hass: HomeAssistant
+  hass: HomeAssistant,
+  defaultCollection?: string
 ): Promise<EnergyPreferences> {
   const collection = getEnergyDataCollection(hass, {
-    key: DEFAULT_ENERGY_COLLECTION_KEY,
+    key: defaultCollection || DEFAULT_ENERGY_COLLECTION_KEY,
   });
 
   return await new Promise<EnergyPreferences>((resolve) => {

--- a/src/panels/energy/strategies/power-view-strategy.ts
+++ b/src/panels/energy/strategies/power-view-strategy.ts
@@ -21,7 +21,9 @@ export class PowerViewStrategy extends ReactiveElement {
     const energyCollection = getEnergyDataCollection(hass, {
       key: collectionKey,
     });
-    await energyCollection.refresh();
+    if (!energyCollection.prefs) {
+      await energyCollection.refresh();
+    }
     const prefs = energyCollection.prefs;
 
     const hasPowerSources = prefs?.energy_sources.some((source) => {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
I've noticed that when loading the energy dashboard strategy, we're currently always fetching the entire collection twice.

- First during strategy load, we manually `refresh` the uninitialized collection to get all the preferences. This downloads both the preferences and all statistics data for the collection (which is thrown away unused).

- Then during view rendering, each card subscribes to the same collection. But a collection always refreshes anytime the first subscription is attached, so it immediately must fetch all the same data again. We don't get any credit for having already refreshed the collection just moments prior.

I think that if we change the strategy code from using `refresh` to `subscribe`, that allows us to avoid the double fetch. The strategy can do a trivial one-shot subscribe and unsubscribe which refreshes the collection and gets it ready. Then when the cards all subscirbe moments later, the data is already ready instead of having to refetch it a second time. 


Secondly, this changes the default strategy fetch to use the power collection key when we are routing to the /now tab, so that we get a one-time fetch there as well. The current behavior for /now was to fetch the energy collection for the prefs, and then immediately swtich to the energy_now collection for the view, which again caused a double fetch of all data. 



## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
