### PR TITLE
Dirty state context provider, update more info settings and categories to prevent scrim closure

### DIFF
--- a/src/data/context/dirty-state.ts
+++ b/src/data/context/dirty-state.ts
@@ -1,13 +1,22 @@
 import { createContext } from "@lit/context";
 
-export interface DirtyStateContext<State = unknown> {
-  /** Whether current state differs from the initial snapshot */
+export const DEFAULT_DIRTY_STATE_KEY = "__default__";
+
+export type DefaultDirtyStateKey = typeof DEFAULT_DIRTY_STATE_KEY;
+
+export interface DirtyStateContext<
+  State = unknown,
+  Key extends string = DefaultDirtyStateKey,
+> {
+  /** Whether any contributor's current slice differs from its initial snapshot */
   isDirty: boolean;
-  /** Current tracked state */
-  state: State;
-  /** Update the tracked state — triggers dirty comparison */
-  setState: (state: State) => void;
-  /** Reset initial snapshot to current state (marks clean) */
+  /**
+   * Push a state slice. The first push for a slice sets its baseline.
+   * Subsequent pushes are compared against that baseline using the provider's
+   * compare strategy.
+   */
+  setState: (state: State, key: Key) => void;
+  /** Reset every slice baseline to its current value (marks clean). */
   markClean: () => void;
 }
 
@@ -15,7 +24,8 @@ export interface DirtyStateContext<State = unknown> {
  * Singleton context key for dirty-state tracking.
  *
  * Because Lit context keys are singletons, the value type is
- * `DirtyStateContext<unknown>`. The provider mixin and consumer controller
- * supply type-safe APIs on top of this boundary.
+ * `DirtyStateContext<unknown, DefaultDirtyStateKey>`. Providers and consumers
+ * can use narrower `DirtyStateContext<State, Key>` annotations at the type
+ * boundary.
  */
 export const dirtyStateContext = createContext<DirtyStateContext>("dirtyState");

--- a/src/data/context/dirty-state.ts
+++ b/src/data/context/dirty-state.ts
@@ -1,0 +1,21 @@
+import { createContext } from "@lit/context";
+
+export interface DirtyStateContext<State = unknown> {
+  /** Whether current state differs from the initial snapshot */
+  isDirty: boolean;
+  /** Current tracked state */
+  state: State;
+  /** Update the tracked state — triggers dirty comparison */
+  setState: (state: State) => void;
+  /** Reset initial snapshot to current state (marks clean) */
+  markClean: () => void;
+}
+
+/**
+ * Singleton context key for dirty-state tracking.
+ *
+ * Because Lit context keys are singletons, the value type is
+ * `DirtyStateContext<unknown>`. The provider mixin and consumer controller
+ * supply type-safe APIs on top of this boundary.
+ */
+export const dirtyStateContext = createContext<DirtyStateContext>("dirtyState");

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -856,7 +856,7 @@ export class MoreInfoDialog extends DirtyStateProviderMixin()(
           })}
         >
           ${keyed(
-            `${this._entityId}-${this._currView}`,
+            this._entityId,
             html`
               <div
                 class="content ha-scrollbar"
@@ -865,70 +865,70 @@ export class MoreInfoDialog extends DirtyStateProviderMixin()(
                 @toggle-edit-mode=${this._handleToggleInfoEditModeEvent}
                 @hass-more-info=${this._handleMoreInfoEvent}
               >
-                ${cache(
-                  this._childView
-                    ? html`
-                        <div class="child-view">
-                          ${dynamicElement(this._childView.viewTag, {
-                            hass: this.hass,
-                            entry: this._entry,
-                            params: this._childView.viewParams,
-                          })}
-                        </div>
-                      `
-                    : this._currView === "info"
-                      ? html`
-                          <ha-more-info-info
-                            .hass=${this.hass}
-                            .entityId=${this._entityId}
-                            .entry=${this._entry}
-                            .editMode=${this._infoEditMode}
-                            .data=${this._data}
-                          ></ha-more-info-info>
-                        `
-                      : this._currView === "history"
+                ${this._currView === "settings"
+                  ? html`
+                      <ha-more-info-settings
+                        .hass=${this.hass}
+                        .entityId=${this._entityId}
+                        .entry=${this._entry}
+                      ></ha-more-info-settings>
+                    `
+                  : cache(
+                      this._childView
                         ? html`
-                            <ha-more-info-history-and-logbook
-                              .hass=${this.hass}
-                              .entityId=${this._entityId}
-                            ></ha-more-info-history-and-logbook>
+                            <div class="child-view">
+                              ${dynamicElement(this._childView.viewTag, {
+                                hass: this.hass,
+                                entry: this._entry,
+                                params: this._childView.viewParams,
+                              })}
+                            </div>
                           `
-                        : this._currView === "settings"
+                        : this._currView === "info"
                           ? html`
-                              <ha-more-info-settings
+                              <ha-more-info-info
                                 .hass=${this.hass}
                                 .entityId=${this._entityId}
                                 .entry=${this._entry}
-                              ></ha-more-info-settings>
+                                .editMode=${this._infoEditMode}
+                                .data=${this._data}
+                              ></ha-more-info-info>
                             `
-                          : this._currView === "related"
+                          : this._currView === "history"
                             ? html`
-                                <ha-related-items
+                                <ha-more-info-history-and-logbook
                                   .hass=${this.hass}
-                                  .itemId=${entityId}
-                                  .itemType=${SearchableDomains.has(domain)
-                                    ? (domain as ItemType)
-                                    : "entity"}
-                                ></ha-related-items>
+                                  .entityId=${this._entityId}
+                                ></ha-more-info-history-and-logbook>
                               `
-                            : this._currView === "add_to"
+                            : this._currView === "related"
                               ? html`
-                                  <ha-more-info-add-to
-                                    .entityId=${entityId}
-                                    @add-to-action-selected=${this._goBack}
-                                  ></ha-more-info-add-to>
+                                  <ha-related-items
+                                    .hass=${this.hass}
+                                    .itemId=${entityId}
+                                    .itemType=${SearchableDomains.has(domain)
+                                      ? (domain as ItemType)
+                                      : "entity"}
+                                  ></ha-related-items>
                                 `
-                              : this._currView === "details"
+                              : this._currView === "add_to"
                                 ? html`
-                                    <ha-more-info-details
-                                      .hass=${this.hass}
-                                      .entry=${this._entry}
-                                      .params=${{ entityId }}
-                                      .yamlMode=${this._detailsYamlMode}
-                                    ></ha-more-info-details>
+                                    <ha-more-info-add-to
+                                      .entityId=${entityId}
+                                      @add-to-action-selected=${this._goBack}
+                                    ></ha-more-info-add-to>
                                   `
-                                : nothing
-                )}
+                                : this._currView === "details"
+                                  ? html`
+                                      <ha-more-info-details
+                                        .hass=${this.hass}
+                                        .entry=${this._entry}
+                                        .params=${{ entityId }}
+                                        .yamlMode=${this._detailsYamlMode}
+                                      ></ha-more-info-details>
+                                    `
+                                  : nothing
+                    )}
               </div>
             `
           )}

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -856,7 +856,7 @@ export class MoreInfoDialog extends DirtyStateProviderMixin()(
           })}
         >
           ${keyed(
-            this._entityId,
+            `${this._entityId}-${this._currView}`,
             html`
               <div
                 class="content ha-scrollbar"
@@ -950,6 +950,10 @@ export class MoreInfoDialog extends DirtyStateProviderMixin()(
     const previousView = changedProps.get("_currView") as
       | MoreInfoView
       | undefined;
+
+    if (previousView === "settings" && this._currView !== "settings") {
+      this._discardDirtyStateChanges();
+    }
 
     if (previousView === "details" && this._currView !== "details") {
       const dialog =

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -63,6 +63,7 @@ import { subscribeLabFeature } from "../../data/labs";
 import type { ItemType } from "../../data/search";
 import { SearchableDomains } from "../../data/search";
 import { getSensorNumericDeviceClasses } from "../../data/sensor";
+import { DirtyStateProviderMixin } from "../../mixins/dirty-state-provider-mixin";
 import { ScrollableFadeMixin } from "../../mixins/scrollable-fade-mixin";
 import { SubscribeMixin } from "../../mixins/subscribe-mixin";
 import {
@@ -121,8 +122,8 @@ declare global {
 const DEFAULT_VIEW: MoreInfoView = "info";
 
 @customElement("ha-more-info-dialog")
-export class MoreInfoDialog extends SubscribeMixin(
-  ScrollableFadeMixin(LitElement)
+export class MoreInfoDialog extends DirtyStateProviderMixin()(
+  SubscribeMixin(ScrollableFadeMixin(LitElement))
 ) {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
@@ -640,7 +641,8 @@ export class MoreInfoDialog extends SubscribeMixin(
         @closed=${this._dialogClosed}
         @opened=${this._handleOpened}
         @show-child-view=${this._showChildView}
-        .preventScrimClose=${this._currView === "settings" ||
+        .preventScrimClose=${(this._currView === "settings" &&
+          this.isDirtyState) ||
         !this._isEscapeEnabled}
         flexcontent
       >
@@ -954,6 +956,12 @@ export class MoreInfoDialog extends SubscribeMixin(
         this._dialogElement?.shadowRoot?.querySelector("ha-dialog");
       if (dialog) {
         fireEvent(dialog as HTMLElement, "dialog-set-fullscreen", false);
+      }
+    }
+
+    if (changedProps.has("_currView") || changedProps.has("_entry")) {
+      if (this._currView === "settings" && this._entry) {
+        this._initDirtyTracking({ type: "deep" });
       }
     }
 

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -64,6 +64,8 @@ import type { ItemType } from "../../data/search";
 import { SearchableDomains } from "../../data/search";
 import { getSensorNumericDeviceClasses } from "../../data/sensor";
 import { DirtyStateProviderMixin } from "../../mixins/dirty-state-provider-mixin";
+import type { EntitySettingsState } from "../../panels/config/entities/entity-registry-settings-editor";
+import type { Helper } from "../../panels/config/helpers/const";
 import { ScrollableFadeMixin } from "../../mixins/scrollable-fade-mixin";
 import { SubscribeMixin } from "../../mixins/subscribe-mixin";
 import {
@@ -122,9 +124,10 @@ declare global {
 const DEFAULT_VIEW: MoreInfoView = "info";
 
 @customElement("ha-more-info-dialog")
-export class MoreInfoDialog extends DirtyStateProviderMixin()(
-  SubscribeMixin(ScrollableFadeMixin(LitElement))
-) {
+export class MoreInfoDialog extends DirtyStateProviderMixin<
+  EntitySettingsState | Helper | null,
+  "entity-registry" | "helper"
+>()(SubscribeMixin(ScrollableFadeMixin(LitElement))) {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ type: Boolean, reflect: true }) public large = false;

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -637,6 +637,18 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
       this.hass.translationMetadata.translations
     );
 
+    const childViewContent = this._childView
+      ? html`
+          <div class="child-view">
+            ${dynamicElement(this._childView.viewTag, {
+              hass: this.hass,
+              entry: this._entry,
+              params: this._childView.viewParams,
+            })}
+          </div>
+        `
+      : nothing;
+
     return html`
       <ha-adaptive-dialog
         .open=${this._open}
@@ -870,23 +882,18 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
               >
                 ${this._currView === "settings"
                   ? html`
-                      <ha-more-info-settings
-                        .hass=${this.hass}
-                        .entityId=${this._entityId}
-                        .entry=${this._entry}
-                      ></ha-more-info-settings>
+                      <div ?hidden=${!!this._childView}>
+                        <ha-more-info-settings
+                          .hass=${this.hass}
+                          .entityId=${this._entityId}
+                          .entry=${this._entry}
+                        ></ha-more-info-settings>
+                      </div>
+                      ${childViewContent}
                     `
                   : cache(
                       this._childView
-                        ? html`
-                            <div class="child-view">
-                              ${dynamicElement(this._childView.viewTag, {
-                                hass: this.hass,
-                                entry: this._entry,
-                                params: this._childView.viewParams,
-                              })}
-                            </div>
-                          `
+                        ? childViewContent
                         : this._currView === "info"
                           ? html`
                               <ha-more-info-info

--- a/src/mixins/dirty-state-provider-mixin.ts
+++ b/src/mixins/dirty-state-provider-mixin.ts
@@ -1,0 +1,201 @@
+import { provide } from "@lit/context";
+import type { LitElement } from "lit";
+import { state } from "lit/decorators";
+import { deepEqual } from "../common/util/deep-equal";
+import { shallowEqual } from "../common/util/shallow-equal";
+import {
+  dirtyStateContext,
+  type DirtyStateContext,
+} from "../data/context/dirty-state";
+import type { Constructor } from "../types";
+
+export type CompareStrategy<State> =
+  | { type: "deep" }
+  | { type: "shallow" }
+  | { type: "custom"; compare: (a: State, b: State) => boolean };
+
+function resolveCompare<State>(
+  strategy: CompareStrategy<State>
+): (a: State, b: State) => boolean {
+  switch (strategy.type) {
+    case "deep":
+      return (a, b) => deepEqual(a, b);
+    case "shallow":
+      return (a, b) => shallowEqual(a, b);
+    default:
+      return strategy.compare;
+  }
+}
+
+/**
+ * Mixin that provides dirty-state tracking via Lit context.
+ *
+ * Uses the `@provide` decorator so any descendant component can consume
+ * dirty-state with `@consume({ context: dirtyStateContext, subscribe: true })`.
+ *
+ * Curried generic pattern: `State` is explicitly provided while `Base` is
+ * inferred from the superclass argument.
+ *
+ * @example Eager init (state known upfront, e.g. dialog open):
+ * ```ts
+ * interface MyDialogState { name: string; icon: string }
+ *
+ * class MyDialog extends DirtyStateProviderMixin<MyDialogState>()(LitElement) {
+ *   open() {
+ *     this._initDirtyTracking({ type: "shallow" }, { name: "", icon: "" });
+ *   }
+ * }
+ * ```
+ *
+ * @example Deferred init (child consumer reports initial state):
+ * ```ts
+ * class MyPage extends DirtyStateProviderMixin<FormState>()(LitElement) {
+ *   connectedCallback() {
+ *     super.connectedCallback();
+ *     this._initDirtyTracking({ type: "deep" });
+ *     // First setState from a child consumer sets the baseline
+ *   }
+ * }
+ * ```
+ *
+ * Child consumers:
+ * ```ts
+ * @consume({ context: dirtyStateContext, subscribe: true })
+ * @state()
+ * private _dirtyState?: DirtyStateContext;
+ *
+ * // Read: this._dirtyState?.isDirty
+ * // Write: this._dirtyState?.setState(newState)
+ * ```
+ */
+export const DirtyStateProviderMixin =
+  <State = unknown>() =>
+  <Base extends Constructor<LitElement>>(superClass: Base) => {
+    class DirtyStateProviderMixinClass extends superClass {
+      private _dirtyInitialState: State | undefined;
+
+      private _dirtyCurrentState: State | undefined;
+
+      private _dirtyCompareFn: (a: State, b: State) => boolean = deepEqual;
+
+      @provide({ context: dirtyStateContext })
+      @state()
+      private _dirtyStateContext: DirtyStateContext = this._buildContextValue(
+        undefined,
+        false
+      );
+
+      /**
+       * Build the context value object for the provider.
+       *
+       * The returned type is `DirtyStateContext` (i.e. `DirtyStateContext<unknown>`)
+       * because the singleton context key is typed at `unknown`. The single
+       * `unknown → State` narrowing cast in `setState` is the only unsafe boundary
+       * and is confined here.
+       */
+      private _buildContextValue(
+        currentState: State | undefined,
+        isDirty: boolean
+      ): DirtyStateContext {
+        return {
+          isDirty,
+          state: currentState,
+          setState: (incoming: unknown) => {
+            this._updateDirtyState(incoming as State);
+          },
+          markClean: () => {
+            this._markDirtyStateClean();
+          },
+        };
+      }
+
+      /**
+       * Initialize dirty state tracking.
+       *
+       * When `initialState` is provided, tracking starts immediately.
+       * When omitted (deferred mode), the first `_updateDirtyState` /
+       * `setState` call from a consumer becomes the baseline snapshot.
+       *
+       * Call again to reset (e.g. when the underlying entity changes).
+       */
+      protected _initDirtyTracking(
+        strategy: CompareStrategy<State>,
+        initialState?: State
+      ): void {
+        this._dirtyCompareFn = resolveCompare(strategy);
+        if (initialState !== undefined) {
+          this._dirtyInitialState = initialState;
+          this._dirtyCurrentState = initialState;
+          this._dirtyStateContext = this._buildContextValue(
+            initialState,
+            false
+          );
+        } else {
+          this._dirtyInitialState = undefined;
+          this._dirtyCurrentState = undefined;
+          this._dirtyStateContext = this._buildContextValue(undefined, false);
+        }
+      }
+
+      /**
+       * Update the tracked state. Triggers dirty comparison against initial snapshot.
+       *
+       * If called before `_initDirtyTracking` provided an initial state (deferred
+       * mode), the first call sets the baseline and reports clean.
+       *
+       * Guarded: no-ops if the computed dirty status and state reference are
+       * unchanged, preventing render loops when called from `updated()`.
+       */
+      protected _updateDirtyState(newState: State): void {
+        // Deferred init: first state becomes the baseline
+        if (this._dirtyInitialState === undefined) {
+          this._dirtyInitialState = newState;
+          this._dirtyCurrentState = newState;
+          this._dirtyStateContext = this._buildContextValue(newState, false);
+          return;
+        }
+
+        const isDirty = !this._dirtyCompareFn(
+          this._dirtyInitialState,
+          newState
+        );
+        if (
+          this._dirtyCurrentState === newState &&
+          this._dirtyStateContext.isDirty === isDirty
+        ) {
+          return;
+        }
+        this._dirtyCurrentState = newState;
+        this._dirtyStateContext = this._buildContextValue(newState, isDirty);
+      }
+
+      /**
+       * Reset the initial snapshot to the current state, marking the state as clean.
+       * Call this after a successful save.
+       */
+      protected _markDirtyStateClean(): void {
+        this._dirtyInitialState = this._dirtyCurrentState;
+        this._dirtyStateContext = this._buildContextValue(
+          this._dirtyCurrentState,
+          false
+        );
+      }
+
+      /**
+       * Whether the current state differs from the initial snapshot.
+       */
+      public get isDirtyState(): boolean {
+        if (
+          this._dirtyInitialState === undefined ||
+          this._dirtyCurrentState === undefined
+        ) {
+          return false;
+        }
+        return !this._dirtyCompareFn(
+          this._dirtyInitialState,
+          this._dirtyCurrentState
+        );
+      }
+    }
+    return DirtyStateProviderMixinClass;
+  };

--- a/src/mixins/dirty-state-provider-mixin.ts
+++ b/src/mixins/dirty-state-provider-mixin.ts
@@ -1,4 +1,5 @@
 import { provide } from "@lit/context";
+import deepClone from "deep-clone-simple";
 import type { LitElement } from "lit";
 import { state } from "lit/decorators";
 import { deepEqual } from "../common/util/deep-equal";
@@ -67,6 +68,8 @@ export const DirtyStateProviderMixin =
 
       private _dirtyCompareFn: (a: State, b: State) => boolean = deepEqual;
 
+      private _dirtyCloneFn: (value: State) => State = (value) => value;
+
       @provide({ context: dirtyStateContext })
       @state()
       private _dirtyStateContext: DirtyStateContext<State, Key> =
@@ -94,7 +97,10 @@ export const DirtyStateProviderMixin =
         const slice = this._dirtySlices.get(key);
         if (!slice) {
           // First push for this key becomes the baseline.
-          this._dirtySlices.set(key, { initial: value, current: value });
+          this._dirtySlices.set(key, {
+            initial: this._dirtyCloneFn(value),
+            current: value,
+          });
           this._publishContext();
           return;
         }
@@ -122,17 +128,20 @@ export const DirtyStateProviderMixin =
         switch (strategy.type) {
           case "deep":
             this._dirtyCompareFn = (a, b) => deepEqual(a, b);
+            this._dirtyCloneFn = (value) => deepClone(value);
             break;
           case "shallow":
             this._dirtyCompareFn = (a, b) => shallowEqual(a, b);
+            this._dirtyCloneFn = (value) => value;
             break;
           default:
             this._dirtyCompareFn = strategy.compare;
+            this._dirtyCloneFn = (value) => value;
         }
         this._dirtySlices.clear();
         if (initialState !== undefined) {
           this._dirtySlices.set(DEFAULT_DIRTY_STATE_KEY, {
-            initial: initialState,
+            initial: this._dirtyCloneFn(initialState),
             current: initialState,
           });
         }
@@ -154,7 +163,7 @@ export const DirtyStateProviderMixin =
        */
       protected _markDirtyStateClean(): void {
         for (const slice of this._dirtySlices.values()) {
-          slice.initial = slice.current;
+          slice.initial = this._dirtyCloneFn(slice.current);
         }
         this._publishContext();
       }
@@ -165,7 +174,7 @@ export const DirtyStateProviderMixin =
        */
       protected _discardDirtyStateChanges(): void {
         for (const slice of this._dirtySlices.values()) {
-          slice.current = slice.initial;
+          slice.current = this._dirtyCloneFn(slice.initial);
         }
         this._publishContext();
       }

--- a/src/mixins/dirty-state-provider-mixin.ts
+++ b/src/mixins/dirty-state-provider-mixin.ts
@@ -160,7 +160,8 @@ export const DirtyStateProviderMixin =
           newState
         );
         if (
-          this._dirtyCurrentState === newState &&
+          this._dirtyCurrentState !== undefined &&
+          this._dirtyCompareFn(this._dirtyCurrentState, newState) &&
           this._dirtyStateContext.isDirty === isDirty
         ) {
           return;
@@ -185,16 +186,7 @@ export const DirtyStateProviderMixin =
        * Whether the current state differs from the initial snapshot.
        */
       public get isDirtyState(): boolean {
-        if (
-          this._dirtyInitialState === undefined ||
-          this._dirtyCurrentState === undefined
-        ) {
-          return false;
-        }
-        return !this._dirtyCompareFn(
-          this._dirtyInitialState,
-          this._dirtyCurrentState
-        );
+        return this._dirtyStateContext.isDirty;
       }
     }
     return DirtyStateProviderMixinClass;

--- a/src/mixins/dirty-state-provider-mixin.ts
+++ b/src/mixins/dirty-state-provider-mixin.ts
@@ -183,6 +183,17 @@ export const DirtyStateProviderMixin =
       }
 
       /**
+       * Discard current changes and restore the last clean snapshot.
+       */
+      protected _discardDirtyStateChanges(): void {
+        this._dirtyCurrentState = this._dirtyInitialState;
+        this._dirtyStateContext = this._buildContextValue(
+          this._dirtyInitialState,
+          false
+        );
+      }
+
+      /**
        * Whether the current state differs from the initial snapshot.
        */
       public get isDirtyState(): boolean {

--- a/src/mixins/dirty-state-provider-mixin.ts
+++ b/src/mixins/dirty-state-provider-mixin.ts
@@ -4,7 +4,9 @@ import { state } from "lit/decorators";
 import { deepEqual } from "../common/util/deep-equal";
 import { shallowEqual } from "../common/util/shallow-equal";
 import {
+  DEFAULT_DIRTY_STATE_KEY,
   dirtyStateContext,
+  type DefaultDirtyStateKey,
   type DirtyStateContext,
 } from "../data/context/dirty-state";
 import type { Constructor } from "../types";
@@ -14,46 +16,32 @@ export type CompareStrategy<State> =
   | { type: "shallow" }
   | { type: "custom"; compare: (a: State, b: State) => boolean };
 
-function resolveCompare<State>(
-  strategy: CompareStrategy<State>
-): (a: State, b: State) => boolean {
-  switch (strategy.type) {
-    case "deep":
-      return (a, b) => deepEqual(a, b);
-    case "shallow":
-      return (a, b) => shallowEqual(a, b);
-    default:
-      return strategy.compare;
-  }
-}
-
 /**
  * Mixin that provides dirty-state tracking via Lit context.
  *
- * Uses the `@provide` decorator so any descendant component can consume
- * dirty-state with `@consume({ context: dirtyStateContext, subscribe: true })`.
+ * The provider holds a map of named slices. Each slice has its own initial
+ * snapshot and current value, and is compared with the configured compare
+ * strategy. `isDirty` is true when any slice differs from its initial value,
+ * so independent contributors (e.g. a helper form alongside the entity
+ * registry editor) can coexist without overwriting each other.
  *
- * Curried generic pattern: `State` is explicitly provided while `Base` is
- * inferred from the superclass argument.
- *
- * @example Eager init (state known upfront, e.g. dialog open):
+ * @example Eager init for the provider's own slice:
  * ```ts
- * interface MyDialogState { name: string; icon: string }
- *
  * class MyDialog extends DirtyStateProviderMixin<MyDialogState>()(LitElement) {
  *   open() {
  *     this._initDirtyTracking({ type: "shallow" }, { name: "", icon: "" });
+ *     // Update later with `this._updateDirtyState({ name, icon })`.
  *   }
  * }
  * ```
  *
- * @example Deferred init (child consumer reports initial state):
+ * @example Deferred init with child consumers:
  * ```ts
- * class MyPage extends DirtyStateProviderMixin<FormState>()(LitElement) {
+ * class MyPage extends DirtyStateProviderMixin<MyState, "their-key">()(LitElement) {
  *   connectedCallback() {
  *     super.connectedCallback();
  *     this._initDirtyTracking({ type: "deep" });
- *     // First setState from a child consumer sets the baseline
+ *     // Child consumers push slices via `setState(value, "their-key")`.
  *   }
  * }
  * ```
@@ -62,46 +50,35 @@ function resolveCompare<State>(
  * ```ts
  * @consume({ context: dirtyStateContext, subscribe: true })
  * @state()
- * private _dirtyState?: DirtyStateContext;
+ * private _dirtyState?: DirtyStateContext<MyState, "my-section">;
  *
  * // Read: this._dirtyState?.isDirty
- * // Write: this._dirtyState?.setState(newState)
+ * // Write: this._dirtyState?.setState(value, "my-section")
  * ```
  */
 export const DirtyStateProviderMixin =
-  <State = unknown>() =>
+  <State = unknown, Key extends string = DefaultDirtyStateKey>() =>
   <Base extends Constructor<LitElement>>(superClass: Base) => {
     class DirtyStateProviderMixinClass extends superClass {
-      private _dirtyInitialState: State | undefined;
-
-      private _dirtyCurrentState: State | undefined;
+      private _dirtySlices = new Map<
+        Key | DefaultDirtyStateKey,
+        { initial: State; current: State }
+      >();
 
       private _dirtyCompareFn: (a: State, b: State) => boolean = deepEqual;
 
       @provide({ context: dirtyStateContext })
       @state()
-      private _dirtyStateContext: DirtyStateContext = this._buildContextValue(
-        undefined,
-        false
-      );
+      private _dirtyStateContext: DirtyStateContext<State, Key> =
+        this._buildContextValue();
 
-      /**
-       * Build the context value object for the provider.
-       *
-       * The returned type is `DirtyStateContext` (i.e. `DirtyStateContext<unknown>`)
-       * because the singleton context key is typed at `unknown`. The single
-       * `unknown → State` narrowing cast in `setState` is the only unsafe boundary
-       * and is confined here.
-       */
-      private _buildContextValue(
-        currentState: State | undefined,
-        isDirty: boolean
-      ): DirtyStateContext {
+      private _buildContextValue(): DirtyStateContext<State, Key> {
         return {
-          isDirty,
-          state: currentState,
-          setState: (incoming: unknown) => {
-            this._updateDirtyState(incoming as State);
+          isDirty: Array.from(this._dirtySlices.values()).some(
+            ({ initial, current }) => !this._dirtyCompareFn(initial, current)
+          ),
+          setState: (value: State, key: Key) => {
+            this._writeSlice(key, value);
           },
           markClean: () => {
             this._markDirtyStateClean();
@@ -109,12 +86,32 @@ export const DirtyStateProviderMixin =
         };
       }
 
+      private _publishContext(): void {
+        this._dirtyStateContext = this._buildContextValue();
+      }
+
+      private _writeSlice(key: Key | DefaultDirtyStateKey, value: State): void {
+        const slice = this._dirtySlices.get(key);
+        if (!slice) {
+          // First push for this key becomes the baseline.
+          this._dirtySlices.set(key, { initial: value, current: value });
+          this._publishContext();
+          return;
+        }
+        if (this._dirtyCompareFn(slice.current, value)) {
+          return;
+        }
+        slice.current = value;
+        this._publishContext();
+      }
+
       /**
        * Initialize dirty state tracking.
        *
-       * When `initialState` is provided, tracking starts immediately.
-       * When omitted (deferred mode), the first `_updateDirtyState` /
-       * `setState` call from a consumer becomes the baseline snapshot.
+       * When `initialState` is provided, it seeds the provider's own slice so
+       * `_updateDirtyState` can be used immediately. When omitted, the first
+       * push for any key (via the provider helper or a consumer's `setState`)
+       * becomes that key's baseline.
        *
        * Call again to reset (e.g. when the underlying entity changes).
        */
@@ -122,79 +119,59 @@ export const DirtyStateProviderMixin =
         strategy: CompareStrategy<State>,
         initialState?: State
       ): void {
-        this._dirtyCompareFn = resolveCompare(strategy);
-        if (initialState !== undefined) {
-          this._dirtyInitialState = initialState;
-          this._dirtyCurrentState = initialState;
-          this._dirtyStateContext = this._buildContextValue(
-            initialState,
-            false
-          );
-        } else {
-          this._dirtyInitialState = undefined;
-          this._dirtyCurrentState = undefined;
-          this._dirtyStateContext = this._buildContextValue(undefined, false);
+        switch (strategy.type) {
+          case "deep":
+            this._dirtyCompareFn = (a, b) => deepEqual(a, b);
+            break;
+          case "shallow":
+            this._dirtyCompareFn = (a, b) => shallowEqual(a, b);
+            break;
+          default:
+            this._dirtyCompareFn = strategy.compare;
         }
+        this._dirtySlices.clear();
+        if (initialState !== undefined) {
+          this._dirtySlices.set(DEFAULT_DIRTY_STATE_KEY, {
+            initial: initialState,
+            current: initialState,
+          });
+        }
+        this._publishContext();
       }
 
       /**
-       * Update the tracked state. Triggers dirty comparison against initial snapshot.
-       *
-       * If called before `_initDirtyTracking` provided an initial state (deferred
-       * mode), the first call sets the baseline and reports clean.
-       *
-       * Guarded: no-ops if the computed dirty status and state reference are
-       * unchanged, preventing render loops when called from `updated()`.
+       * Update the provider's own state slice. Triggers dirty comparison
+       * against the provider's baseline (or sets the baseline if this is the
+       * first push after a deferred init).
        */
       protected _updateDirtyState(newState: State): void {
-        // Deferred init: first state becomes the baseline
-        if (this._dirtyInitialState === undefined) {
-          this._dirtyInitialState = newState;
-          this._dirtyCurrentState = newState;
-          this._dirtyStateContext = this._buildContextValue(newState, false);
-          return;
-        }
-
-        const isDirty = !this._dirtyCompareFn(
-          this._dirtyInitialState,
-          newState
-        );
-        if (
-          this._dirtyCurrentState !== undefined &&
-          this._dirtyCompareFn(this._dirtyCurrentState, newState) &&
-          this._dirtyStateContext.isDirty === isDirty
-        ) {
-          return;
-        }
-        this._dirtyCurrentState = newState;
-        this._dirtyStateContext = this._buildContextValue(newState, isDirty);
+        this._writeSlice(DEFAULT_DIRTY_STATE_KEY, newState);
       }
 
       /**
-       * Reset the initial snapshot to the current state, marking the state as clean.
-       * Call this after a successful save.
+       * Reset every slice's baseline to its current value. Call this after a
+       * successful save.
        */
       protected _markDirtyStateClean(): void {
-        this._dirtyInitialState = this._dirtyCurrentState;
-        this._dirtyStateContext = this._buildContextValue(
-          this._dirtyCurrentState,
-          false
-        );
+        for (const slice of this._dirtySlices.values()) {
+          slice.initial = slice.current;
+        }
+        this._publishContext();
       }
 
       /**
-       * Discard current changes and restore the last clean snapshot.
+       * Discard pending changes by restoring each slice's current value back
+       * to its baseline.
        */
       protected _discardDirtyStateChanges(): void {
-        this._dirtyCurrentState = this._dirtyInitialState;
-        this._dirtyStateContext = this._buildContextValue(
-          this._dirtyInitialState,
-          false
-        );
+        for (const slice of this._dirtySlices.values()) {
+          slice.current = slice.initial;
+        }
+        this._publishContext();
       }
 
       /**
-       * Whether the current state differs from the initial snapshot.
+       * Whether any slice's current value differs from its baseline.
        */
       public get isDirtyState(): boolean {
         return this._dirtyStateContext.isDirty;

--- a/src/panels/config/category/dialog-category-registry-detail.ts
+++ b/src/panels/config/category/dialog-category-registry-detail.ts
@@ -15,13 +15,19 @@ import type {
 } from "../../../data/category_registry";
 import { internationalizationContext } from "../../../data/context";
 import { DialogMixin } from "../../../dialogs/dialog-mixin";
+import { DirtyStateProviderMixin } from "../../../mixins/dirty-state-provider-mixin";
 import { haStyleDialog } from "../../../resources/styles";
 import type { ValueChangedEvent } from "../../../types";
 import type { CategoryRegistryDetailDialogParams } from "./show-dialog-category-registry-detail";
 
+interface CategoryFormState {
+  name: string;
+  icon: string | null;
+}
+
 @customElement("dialog-category-registry-detail")
-class DialogCategoryDetail extends DialogMixin<CategoryRegistryDetailDialogParams>(
-  LitElement
+class DialogCategoryDetail extends DirtyStateProviderMixin<CategoryFormState>()(
+  DialogMixin<CategoryRegistryDetailDialogParams>(LitElement)
 ) {
   @state()
   @consume({ context: internationalizationContext, subscribe: true })
@@ -44,6 +50,10 @@ class DialogCategoryDetail extends DialogMixin<CategoryRegistryDetailDialogParam
       this._name = this.params?.suggestedName || "";
       this._icon = null;
     }
+    this._initDirtyTracking(
+      { type: "shallow" },
+      { name: this._name, icon: this._icon }
+    );
   }
 
   protected render() {
@@ -52,6 +62,7 @@ class DialogCategoryDetail extends DialogMixin<CategoryRegistryDetailDialogParam
     }
     const entry = this.params.entry;
     const nameInvalid = !this._isNameValid();
+    const isCreate = !entry;
     return html`
       <ha-dialog
         open
@@ -96,7 +107,9 @@ class DialogCategoryDetail extends DialogMixin<CategoryRegistryDetailDialogParam
           <ha-button
             slot="primaryAction"
             @click=${this._updateEntry}
-            .disabled=${nameInvalid || !!this._submitting}
+            .disabled=${nameInvalid ||
+            !!this._submitting ||
+            (!isCreate && !this.isDirtyState)}
           >
             ${entry
               ? this._i18n.localize("ui.common.save")
@@ -114,15 +127,17 @@ class DialogCategoryDetail extends DialogMixin<CategoryRegistryDetailDialogParam
   private _nameChanged(ev: InputEvent) {
     this._error = undefined;
     this._name = (ev.target as HaInput).value ?? "";
+    this._updateDirtyState({ name: this._name, icon: this._icon });
   }
 
   private _iconChanged(ev: ValueChangedEvent<string>) {
     this._error = undefined;
     this._icon = ev.detail.value;
+    this._updateDirtyState({ name: this._name, icon: this._icon });
   }
 
   private async _updateEntry() {
-    const create = !this.params!.entry;
+    const create = !this.params?.entry;
     this._submitting = true;
     let newValue: CategoryRegistryEntry | undefined;
     try {
@@ -131,10 +146,11 @@ class DialogCategoryDetail extends DialogMixin<CategoryRegistryDetailDialogParam
         icon: this._icon || (create ? undefined : null),
       };
       if (create) {
-        newValue = await this.params!.createEntry!(values);
+        newValue = await this.params?.createEntry?.(values);
       } else {
-        newValue = await this.params!.updateEntry!(values);
+        newValue = await this.params?.updateEntry?.(values);
       }
+      this._markDirtyStateClean();
       this.closeDialog();
     } catch (err: any) {
       this._error =

--- a/src/panels/config/category/dialog-category-registry-detail.ts
+++ b/src/panels/config/category/dialog-category-registry-detail.ts
@@ -69,7 +69,7 @@ class DialogCategoryDetail extends DirtyStateProviderMixin<CategoryFormState>()(
         header-title=${entry
           ? this._i18n.localize("ui.panel.config.category.editor.edit")
           : this._i18n.localize("ui.panel.config.category.editor.create")}
-        prevent-scrim-close
+        .preventScrimClose=${this.isDirtyState}
       >
         ${this._error
           ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`

--- a/src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts
+++ b/src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts
@@ -61,10 +61,7 @@ export class EntitySettingsHelperTab extends DirtyStateProviderMixin()(
     super.updated(changedProperties);
     if (changedProperties.has("entry")) {
       this._error = undefined;
-      if (
-        this.entry.unique_id !==
-        (changedProperties.get("entry") as ExtEntityRegistryEntry)?.unique_id
-      ) {
+      if (this.entry.unique_id !== changedProperties.get("entry")?.unique_id) {
         this._item = undefined;
       }
       this._initDirtyTracking({ type: "deep" });

--- a/src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts
+++ b/src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts
@@ -10,6 +10,7 @@ import type { ExtEntityRegistryEntry } from "../../../../../data/entity/entity_r
 import { removeEntityRegistryEntry } from "../../../../../data/entity/entity_registry";
 import { HELPERS_CRUD } from "../../../../../data/helpers_crud";
 import { showConfirmationDialog } from "../../../../../dialogs/generic/show-dialog-box";
+import { DirtyStateProviderMixin } from "../../../../../mixins/dirty-state-provider-mixin";
 import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import type { Helper } from "../../../helpers/const";
@@ -28,7 +29,9 @@ import type { EntityRegistrySettingsEditor } from "../../entity-registry-setting
 import { getDeleteConfirmationText } from "../../get-delete-confirmation-text";
 
 @customElement("entity-settings-helper-tab")
-export class EntitySettingsHelperTab extends LitElement {
+export class EntitySettingsHelperTab extends DirtyStateProviderMixin()(
+  LitElement
+) {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public entry!: ExtEntityRegistryEntry;
@@ -38,8 +41,6 @@ export class EntitySettingsHelperTab extends LitElement {
   @state() private _item?: Helper | null;
 
   @state() private _submitting = false;
-
-  @state() private _dirty = false;
 
   @state() private _componentLoaded?: boolean;
 
@@ -66,7 +67,7 @@ export class EntitySettingsHelperTab extends LitElement {
       ) {
         this._item = undefined;
       }
-
+      this._initDirtyTracking({ type: "deep" });
       this._getItem();
     }
   }
@@ -107,7 +108,6 @@ export class EntitySettingsHelperTab extends LitElement {
           .hass=${this.hass}
           .entry=${this.entry}
           .disabled=${!!this._submitting}
-          @change=${this._entityRegistryChanged}
           hide-name
           hide-icon
         ></entity-registry-settings-editor>
@@ -124,7 +124,7 @@ export class EntitySettingsHelperTab extends LitElement {
         </ha-button>
         <ha-button
           @click=${this._updateItem}
-          .disabled=${!this._dirty ||
+          .disabled=${!(this.isDirtyState || this._isHelperDirty) ||
           !!this._submitting ||
           !!(this._item && !this._item.name)}
         >
@@ -139,22 +139,12 @@ export class EntitySettingsHelperTab extends LitElement {
     return JSON.stringify(this._item) !== this._originalItemJson;
   }
 
-  private _updateDirty() {
-    this._dirty = (this._registryEditor?.dirty ?? false) || this._isHelperDirty;
-  }
-
-  private _entityRegistryChanged() {
-    this._error = undefined;
-    this._updateDirty();
-  }
-
   private _valueChanged(ev: CustomEvent): void {
     if (this._item === null) {
       return;
     }
     this._error = undefined;
     this._item = ev.detail.value;
-    this._updateDirty();
   }
 
   private async _getItem() {
@@ -167,15 +157,20 @@ export class EntitySettingsHelperTab extends LitElement {
 
   private async _updateItem(): Promise<void> {
     this._submitting = true;
+    this._error = undefined;
     try {
       if (this._componentLoaded && this._item) {
         await HELPERS_CRUD[this.entry.platform].update(
-          this.hass!,
+          this.hass,
           this._item.id,
           this._item
         );
       }
       const result = await this._registryEditor!.updateEntry();
+      this._markDirtyStateClean();
+      this._originalItemJson = this._item
+        ? JSON.stringify(this._item)
+        : undefined;
       if (result.close) {
         fireEvent(this, "close-dialog");
       }

--- a/src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts
+++ b/src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts
@@ -1,16 +1,17 @@
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
+import { consume, type ContextType } from "@lit/context";
 import { isComponentLoaded } from "../../../../../common/config/is_component_loaded";
 import { dynamicElement } from "../../../../../common/dom/dynamic-element-directive";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { computeEntityEntryName } from "../../../../../common/entity/compute_entity_name";
 import "../../../../../components/ha-button";
+import { dirtyStateContext } from "../../../../../data/context/dirty-state";
 import type { ExtEntityRegistryEntry } from "../../../../../data/entity/entity_registry";
 import { removeEntityRegistryEntry } from "../../../../../data/entity/entity_registry";
 import { HELPERS_CRUD } from "../../../../../data/helpers_crud";
 import { showConfirmationDialog } from "../../../../../dialogs/generic/show-dialog-box";
-import { DirtyStateProviderMixin } from "../../../../../mixins/dirty-state-provider-mixin";
 import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import type { Helper } from "../../../helpers/const";
@@ -29,12 +30,14 @@ import type { EntityRegistrySettingsEditor } from "../../entity-registry-setting
 import { getDeleteConfirmationText } from "../../get-delete-confirmation-text";
 
 @customElement("entity-settings-helper-tab")
-export class EntitySettingsHelperTab extends DirtyStateProviderMixin()(
-  LitElement
-) {
+export class EntitySettingsHelperTab extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public entry!: ExtEntityRegistryEntry;
+
+  @consume({ context: dirtyStateContext, subscribe: true })
+  @state()
+  private _dirtyState?: ContextType<typeof dirtyStateContext>;
 
   @state() private _error?: string;
 
@@ -64,7 +67,6 @@ export class EntitySettingsHelperTab extends DirtyStateProviderMixin()(
       if (this.entry.unique_id !== changedProperties.get("entry")?.unique_id) {
         this._item = undefined;
       }
-      this._initDirtyTracking({ type: "deep" });
       this._getItem();
     }
   }
@@ -121,7 +123,7 @@ export class EntitySettingsHelperTab extends DirtyStateProviderMixin()(
         </ha-button>
         <ha-button
           @click=${this._updateItem}
-          .disabled=${!(this.isDirtyState || this._isHelperDirty) ||
+          .disabled=${!(this._dirtyState?.isDirty || this._isHelperDirty) ||
           !!this._submitting ||
           !!(this._item && !this._item.name)}
         >
@@ -164,7 +166,7 @@ export class EntitySettingsHelperTab extends DirtyStateProviderMixin()(
         );
       }
       const result = await this._registryEditor!.updateEntry();
-      this._markDirtyStateClean();
+      this._dirtyState?.markClean();
       this._originalItemJson = this._item
         ? JSON.stringify(this._item)
         : undefined;

--- a/src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts
+++ b/src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts
@@ -1,19 +1,22 @@
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
-import { consume, type ContextType } from "@lit/context";
+import { consume } from "@lit/context";
 import { isComponentLoaded } from "../../../../../common/config/is_component_loaded";
 import { dynamicElement } from "../../../../../common/dom/dynamic-element-directive";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { computeEntityEntryName } from "../../../../../common/entity/compute_entity_name";
 import "../../../../../components/ha-button";
-import { dirtyStateContext } from "../../../../../data/context/dirty-state";
+import {
+  dirtyStateContext,
+  type DirtyStateContext,
+} from "../../../../../data/context/dirty-state";
 import type { ExtEntityRegistryEntry } from "../../../../../data/entity/entity_registry";
 import { removeEntityRegistryEntry } from "../../../../../data/entity/entity_registry";
 import { HELPERS_CRUD } from "../../../../../data/helpers_crud";
 import { showConfirmationDialog } from "../../../../../dialogs/generic/show-dialog-box";
 import { haStyle } from "../../../../../resources/styles";
-import type { HomeAssistant } from "../../../../../types";
+import type { HomeAssistant, ValueChangedEvent } from "../../../../../types";
 import type { Helper } from "../../../helpers/const";
 import "../../../helpers/forms/ha-counter-form";
 import "../../../helpers/forms/ha-input_boolean-form";
@@ -37,7 +40,7 @@ export class EntitySettingsHelperTab extends LitElement {
 
   @consume({ context: dirtyStateContext, subscribe: true })
   @state()
-  private _dirtyState?: ContextType<typeof dirtyStateContext>;
+  private _dirtyState?: DirtyStateContext<Helper | null, "helper">;
 
   @state() private _error?: string;
 
@@ -49,8 +52,6 @@ export class EntitySettingsHelperTab extends LitElement {
 
   @query("entity-registry-settings-editor")
   private _registryEditor?: EntityRegistrySettingsEditor;
-
-  private _originalItemJson?: string;
 
   protected firstUpdated(changedProperties: PropertyValues<this>) {
     super.firstUpdated(changedProperties);
@@ -123,7 +124,7 @@ export class EntitySettingsHelperTab extends LitElement {
         </ha-button>
         <ha-button
           @click=${this._updateItem}
-          .disabled=${!(this._dirtyState?.isDirty || this._isHelperDirty) ||
+          .disabled=${!this._dirtyState?.isDirty ||
           !!this._submitting ||
           !!(this._item && !this._item.name)}
         >
@@ -133,25 +134,21 @@ export class EntitySettingsHelperTab extends LitElement {
     `;
   }
 
-  private get _isHelperDirty(): boolean {
-    if (!this._item || !this._originalItemJson) return false;
-    return JSON.stringify(this._item) !== this._originalItemJson;
-  }
-
-  private _valueChanged(ev: CustomEvent): void {
+  private _valueChanged(ev: ValueChangedEvent<Helper>): void {
     if (this._item === null) {
       return;
     }
     this._error = undefined;
     this._item = ev.detail.value;
+    this._dirtyState?.setState(this._item, "helper");
   }
 
   private async _getItem() {
     const items = await HELPERS_CRUD[this.entry.platform].fetch(this.hass!);
-    this._item = items.find((item) => item.id === this.entry.unique_id) || null;
-    this._originalItemJson = this._item
-      ? JSON.stringify(this._item)
-      : undefined;
+    const item =
+      items.find((helper) => helper.id === this.entry.unique_id) || null;
+    this._item = item;
+    this._dirtyState?.setState(item, "helper");
   }
 
   private async _updateItem(): Promise<void> {
@@ -167,9 +164,6 @@ export class EntitySettingsHelperTab extends LitElement {
       }
       const result = await this._registryEditor!.updateEntry();
       this._dirtyState?.markClean();
-      this._originalItemJson = this._item
-        ? JSON.stringify(this._item)
-        : undefined;
       if (result.close) {
         fireEvent(this, "close-dialog");
       }

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -372,6 +372,45 @@ export class EntityRegistrySettingsEditor extends LitElement {
   }
 
   protected async updated(changedProps: PropertyValues): Promise<void> {
+    if (changedProps.has("helperConfigEntry")) {
+      if (this.helperConfigEntry?.domain === "switch_as_x") {
+        this._switchAsDomain = computeDomain(this.entry.entity_id);
+        this.hass.loadBackendTranslation("title", SWITCH_AS_DOMAINS, false);
+      } else {
+        this._switchAsDomain = "switch";
+        this._switchAsInvert = false;
+      }
+    }
+
+    if (this._name === undefined || this._entityId === undefined) {
+      return;
+    }
+
+    this._dirtyState?.setState(
+      {
+        name: this._name.trim() || null,
+        icon: this._icon.trim() || null,
+        entityId: this._entityId.trim(),
+        areaId: this._areaId ?? null,
+        labels: this._labels ?? [],
+        deviceClass: this._deviceClass,
+        disabledBy: this._disabledBy,
+        hiddenBy: this._hiddenBy,
+        unitOfMeasurement: this._unit_of_measurement,
+        precision: this._precision,
+        defaultCode: this._defaultCode,
+        calendarColor: this._calendarColor ?? null,
+        precipitationUnit: this._precipitation_unit,
+        pressureUnit: this._pressure_unit,
+        temperatureUnit: this._temperature_unit,
+        visibilityUnit: this._visibility_unit,
+        windSpeedUnit: this._wind_speed_unit,
+        switchAsDomain: this._switchAsDomain,
+        switchAsInvert: this._switchAsInvert,
+      },
+      "entity-registry"
+    );
+
     if (changedProps.has("_deviceClass")) {
       const domain = computeDomain(this.entry.entity_id);
 
@@ -415,40 +454,6 @@ export class EntityRegistrySettingsEditor extends LitElement {
         this._weatherConvertibleUnits = undefined;
       }
     }
-    if (changedProps.has("helperConfigEntry")) {
-      if (this.helperConfigEntry?.domain === "switch_as_x") {
-        this._switchAsDomain = computeDomain(this.entry.entity_id);
-        this.hass.loadBackendTranslation("title", SWITCH_AS_DOMAINS, false);
-      } else {
-        this._switchAsDomain = "switch";
-        this._switchAsInvert = false;
-      }
-    }
-
-    this._dirtyState?.setState(
-      {
-        name: this._name.trim() || null,
-        icon: this._icon.trim() || null,
-        entityId: this._entityId.trim(),
-        areaId: this._areaId ?? null,
-        labels: this._labels ?? [],
-        deviceClass: this._deviceClass,
-        disabledBy: this._disabledBy,
-        hiddenBy: this._hiddenBy,
-        unitOfMeasurement: this._unit_of_measurement,
-        precision: this._precision,
-        defaultCode: this._defaultCode,
-        calendarColor: this._calendarColor ?? null,
-        precipitationUnit: this._precipitation_unit,
-        pressureUnit: this._pressure_unit,
-        temperatureUnit: this._temperature_unit,
-        visibilityUnit: this._visibility_unit,
-        windSpeedUnit: this._wind_speed_unit,
-        switchAsDomain: this._switchAsDomain,
-        switchAsInvert: this._switchAsInvert,
-      },
-      "entity-registry"
-    );
   }
 
   protected render() {

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -6,7 +6,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { until } from "lit/directives/until";
 import memoizeOne from "memoize-one";
-import { consume, type ContextType } from "@lit/context";
+import { consume } from "@lit/context";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { computeObjectId } from "../../../common/entity/compute_object_id";
@@ -45,7 +45,10 @@ import {
   STREAM_TYPE_HLS,
   updateCameraPrefs,
 } from "../../../data/camera";
-import { dirtyStateContext } from "../../../data/context/dirty-state";
+import {
+  dirtyStateContext,
+  type DirtyStateContext,
+} from "../../../data/context/dirty-state";
 import type { ConfigEntry } from "../../../data/config_entries";
 import { deleteConfigEntry } from "../../../data/config_entries";
 import {
@@ -145,7 +148,7 @@ const SCANNER_SOURCE_TYPES = ["router", "bluetooth", "bluetooth_le"];
 
 const ZONE_DOMAINS = ["zone"];
 
-interface EntitySettingsState {
+export interface EntitySettingsState {
   name: string | null;
   icon: string | null;
   entityId: string;
@@ -183,7 +186,10 @@ export class EntityRegistrySettingsEditor extends LitElement {
 
   @consume({ context: dirtyStateContext, subscribe: true })
   @state()
-  private _dirtyState?: ContextType<typeof dirtyStateContext>;
+  private _dirtyState?: DirtyStateContext<
+    EntitySettingsState,
+    "entity-registry"
+  >;
 
   @state() private _name!: string;
 
@@ -247,30 +253,6 @@ export class EntityRegistrySettingsEditor extends LitElement {
   private _origEntityId!: string;
 
   private _deviceClassOptions?: string[][];
-
-  private _currentState(): EntitySettingsState {
-    return {
-      name: this._name.trim() || null,
-      icon: this._icon.trim() || null,
-      entityId: this._entityId.trim(),
-      areaId: this._areaId ?? null,
-      labels: this._labels ?? [],
-      deviceClass: this._deviceClass,
-      disabledBy: this._disabledBy,
-      hiddenBy: this._hiddenBy,
-      unitOfMeasurement: this._unit_of_measurement,
-      precision: this._precision,
-      defaultCode: this._defaultCode,
-      calendarColor: this._calendarColor ?? null,
-      precipitationUnit: this._precipitation_unit,
-      pressureUnit: this._pressure_unit,
-      temperatureUnit: this._temperature_unit,
-      visibilityUnit: this._visibility_unit,
-      windSpeedUnit: this._wind_speed_unit,
-      switchAsDomain: this._switchAsDomain,
-      switchAsInvert: this._switchAsInvert,
-    };
-  }
 
   protected willUpdate(changedProperties: PropertyValues<this>) {
     super.willUpdate(changedProperties);
@@ -443,7 +425,30 @@ export class EntityRegistrySettingsEditor extends LitElement {
       }
     }
 
-    this._dirtyState?.setState(this._currentState());
+    this._dirtyState?.setState(
+      {
+        name: this._name.trim() || null,
+        icon: this._icon.trim() || null,
+        entityId: this._entityId.trim(),
+        areaId: this._areaId ?? null,
+        labels: this._labels ?? [],
+        deviceClass: this._deviceClass,
+        disabledBy: this._disabledBy,
+        hiddenBy: this._hiddenBy,
+        unitOfMeasurement: this._unit_of_measurement,
+        precision: this._precision,
+        defaultCode: this._defaultCode,
+        calendarColor: this._calendarColor ?? null,
+        precipitationUnit: this._precipitation_unit,
+        pressureUnit: this._pressure_unit,
+        temperatureUnit: this._temperature_unit,
+        visibilityUnit: this._visibility_unit,
+        windSpeedUnit: this._wind_speed_unit,
+        switchAsDomain: this._switchAsDomain,
+        switchAsInvert: this._switchAsInvert,
+      },
+      "entity-registry"
+    );
   }
 
   protected render() {

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -6,8 +6,8 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { until } from "lit/directives/until";
 import memoizeOne from "memoize-one";
+import { consume, type ContextType } from "@lit/context";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
-import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { computeObjectId } from "../../../common/entity/compute_object_id";
 import { supportsFeature } from "../../../common/entity/supports-feature";
@@ -45,6 +45,7 @@ import {
   STREAM_TYPE_HLS,
   updateCameraPrefs,
 } from "../../../data/camera";
+import { dirtyStateContext } from "../../../data/context/dirty-state";
 import type { ConfigEntry } from "../../../data/config_entries";
 import { deleteConfigEntry } from "../../../data/config_entries";
 import {
@@ -144,6 +145,28 @@ const SCANNER_SOURCE_TYPES = ["router", "bluetooth", "bluetooth_le"];
 
 const ZONE_DOMAINS = ["zone"];
 
+interface EntitySettingsState {
+  name: string | null;
+  icon: string | null;
+  entityId: string;
+  areaId: string | null;
+  labels: string[];
+  deviceClass: string | undefined;
+  disabledBy: EntityRegistryEntry["disabled_by"];
+  hiddenBy: EntityRegistryEntry["hidden_by"];
+  unitOfMeasurement: string | null | undefined;
+  precision: number | null | undefined;
+  defaultCode: string | null | undefined;
+  calendarColor: string | null;
+  precipitationUnit: string | null | undefined;
+  pressureUnit: string | null | undefined;
+  temperatureUnit: string | null | undefined;
+  visibilityUnit: string | null | undefined;
+  windSpeedUnit: string | null | undefined;
+  switchAsDomain: string;
+  switchAsInvert: boolean;
+}
+
 @customElement("entity-registry-settings-editor")
 export class EntityRegistrySettingsEditor extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -158,41 +181,50 @@ export class EntityRegistrySettingsEditor extends LitElement {
 
   @property({ attribute: false }) public helperConfigEntry?: ConfigEntry;
 
+  @consume({ context: dirtyStateContext, subscribe: true })
+  @state()
+  private _dirtyState?: ContextType<typeof dirtyStateContext>;
+
   @state() private _name!: string;
 
   @state() private _icon!: string;
 
-  @state() private _entityId!: string;
+  @state() private _entityId!: EntitySettingsState["entityId"];
 
-  @state() private _deviceClass?: string;
+  @state() private _deviceClass?: EntitySettingsState["deviceClass"];
 
-  @state() private _switchAsDomain = "switch";
+  @state() private _switchAsDomain: EntitySettingsState["switchAsDomain"] =
+    "switch";
 
-  @state() private _switchAsInvert = false;
+  @state() private _switchAsInvert: EntitySettingsState["switchAsInvert"] =
+    false;
 
   @state() private _areaId?: string | null;
 
   @state() private _labels?: string[] | null;
 
-  @state() private _disabledBy!: EntityRegistryEntry["disabled_by"];
+  @state() private _disabledBy!: EntitySettingsState["disabledBy"];
 
-  @state() private _hiddenBy!: EntityRegistryEntry["hidden_by"];
+  @state() private _hiddenBy!: EntitySettingsState["hiddenBy"];
 
   @state() private _device?: DeviceRegistryEntry;
 
-  @state() private _unit_of_measurement?: string | null;
+  @state()
+  private _unit_of_measurement?: EntitySettingsState["unitOfMeasurement"];
 
-  @state() private _precision?: number | null;
+  @state() private _precision?: EntitySettingsState["precision"];
 
-  @state() private _precipitation_unit?: string | null;
+  @state()
+  private _precipitation_unit?: EntitySettingsState["precipitationUnit"];
 
-  @state() private _pressure_unit?: string | null;
+  @state() private _pressure_unit?: EntitySettingsState["pressureUnit"];
 
-  @state() private _temperature_unit?: string | null;
+  @state()
+  private _temperature_unit?: EntitySettingsState["temperatureUnit"];
 
-  @state() private _visibility_unit?: string | null;
+  @state() private _visibility_unit?: EntitySettingsState["visibilityUnit"];
 
-  @state() private _wind_speed_unit?: string | null;
+  @state() private _wind_speed_unit?: EntitySettingsState["windSpeedUnit"];
 
   @state() private _cameraPrefs?: CameraPreferences;
 
@@ -204,9 +236,9 @@ export class EntityRegistrySettingsEditor extends LitElement {
 
   @state() private _weatherConvertibleUnits?: WeatherUnits;
 
-  @state() private _defaultCode?: string | null;
+  @state() private _defaultCode?: EntitySettingsState["defaultCode"];
 
-  @state() private _calendarColor?: string | null;
+  @state() private _calendarColor?: EntitySettingsState["calendarColor"];
 
   @state() private _associatedZone?: string;
 
@@ -216,11 +248,7 @@ export class EntityRegistrySettingsEditor extends LitElement {
 
   private _deviceClassOptions?: string[][];
 
-  private _initialStateJson!: string;
-
-  private _lastDirty = false;
-
-  private _currentState() {
+  private _currentState(): EntitySettingsState {
     return {
       name: this._name.trim() || null,
       icon: this._icon.trim() || null,
@@ -314,9 +342,6 @@ export class EntityRegistrySettingsEditor extends LitElement {
       this._visibility_unit = stateObj?.attributes?.visibility_unit;
       this._wind_speed_unit = stateObj?.attributes?.wind_speed_unit;
     }
-
-    this._initialStateJson = JSON.stringify(this._currentState());
-    this._lastDirty = false;
 
     const deviceClasses: string[][] = OVERRIDE_DEVICE_CLASSES[domain];
 
@@ -416,17 +441,9 @@ export class EntityRegistrySettingsEditor extends LitElement {
         this._switchAsDomain = "switch";
         this._switchAsInvert = false;
       }
-      this._initialStateJson = JSON.stringify(this._currentState());
-      this._lastDirty = false;
     }
 
-    if (this._initialStateJson) {
-      const dirty = this.dirty;
-      if (dirty !== this._lastDirty) {
-        this._lastDirty = dirty;
-        fireEvent(this, "change");
-      }
-    }
+    this._dirtyState?.setState(this._currentState());
   }
 
   protected render() {
@@ -1144,10 +1161,6 @@ export class EntityRegistrySettingsEditor extends LitElement {
     `;
   }
 
-  public get dirty(): boolean {
-    return JSON.stringify(this._currentState()) !== this._initialStateJson;
-  }
-
   public async updateEntry(): Promise<{
     close: boolean;
     entry: ExtEntityRegistryEntry;
@@ -1433,12 +1446,10 @@ export class EntityRegistrySettingsEditor extends LitElement {
   }
 
   private _nameChanged(ev: InputEvent): void {
-    fireEvent(this, "change");
     this._name = (ev.target as HTMLInputElement).value;
   }
 
   private _iconChanged(ev: CustomEvent): void {
-    fireEvent(this, "change");
     this._icon = ev.detail.value;
   }
 
@@ -1457,22 +1468,18 @@ export class EntityRegistrySettingsEditor extends LitElement {
   }
 
   private _entityIdChanged(ev: InputEvent): void {
-    fireEvent(this, "change");
     this._entityId = `${computeDomain(this._origEntityId)}.${(ev.target as HTMLInputElement).value}`;
   }
 
   private _deviceClassChanged(ev: HaSelectSelectEvent<string, true>): void {
-    fireEvent(this, "change");
     this._deviceClass = ev.detail.value;
   }
 
   private _unitChanged(ev: HaSelectSelectEvent): void {
-    fireEvent(this, "change");
     this._unit_of_measurement = ev.detail.value;
   }
 
   private _defaultcodeChanged(ev: InputEvent): void {
-    fireEvent(this, "change");
     this._defaultCode =
       (ev.target as HTMLInputElement).value === ""
         ? null
@@ -1480,43 +1487,35 @@ export class EntityRegistrySettingsEditor extends LitElement {
   }
 
   private _calendarColorChanged(ev: CustomEvent): void {
-    fireEvent(this, "change");
     this._calendarColor = ev.detail.value || null;
   }
 
   private _associatedZoneChanged(ev: CustomEvent): void {
-    fireEvent(this, "change");
     this._associatedZone = ev.detail.value || "zone.home";
   }
 
   private _precipitationUnitChanged(ev: HaSelectSelectEvent): void {
-    fireEvent(this, "change");
     this._precipitation_unit = ev.detail.value;
   }
 
   private _precisionChanged(ev: HaSelectSelectEvent): void {
-    fireEvent(this, "change");
     this._precision =
       ev.detail.value === "default" ? null : Number(ev.detail.value);
   }
 
   private _pressureUnitChanged(ev: HaSelectSelectEvent): void {
-    fireEvent(this, "change");
     this._pressure_unit = ev.detail.value;
   }
 
   private _temperatureUnitChanged(ev: HaSelectSelectEvent): void {
-    fireEvent(this, "change");
     this._temperature_unit = ev.detail.value;
   }
 
   private _visibilityUnitChanged(ev: HaSelectSelectEvent): void {
-    fireEvent(this, "change");
     this._visibility_unit = ev.detail.value;
   }
 
   private _windSpeedUnitChanged(ev: HaSelectSelectEvent): void {
-    fireEvent(this, "change");
     this._wind_speed_unit = ev.detail.value;
   }
 
@@ -1551,7 +1550,6 @@ export class EntityRegistrySettingsEditor extends LitElement {
   }
 
   private _areaPicked(ev: CustomEvent) {
-    fireEvent(this, "change");
     this._areaId = ev.detail.value;
   }
 
@@ -1624,8 +1622,6 @@ export class EntityRegistrySettingsEditor extends LitElement {
 
   private _resetNameAndOpenDeviceSettings() {
     this._name = this.entry.name || "";
-    fireEvent(this, "change");
-
     this._openDeviceSettings();
   }
 

--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -2,7 +2,7 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
-import { consume, type ContextType } from "@lit/context";
+import { consume } from "@lit/context";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDeviceName } from "../../../common/entity/compute_device_name";
 import { computeEntityEntryName } from "../../../common/entity/compute_entity_name";
@@ -14,7 +14,10 @@ import {
   deleteConfigEntry,
   getConfigEntry,
 } from "../../../data/config_entries";
-import { dirtyStateContext } from "../../../data/context/dirty-state";
+import {
+  dirtyStateContext,
+  type DirtyStateContext,
+} from "../../../data/context/dirty-state";
 import { updateDeviceRegistryEntry } from "../../../data/device/device_registry";
 import type { ExtEntityRegistryEntry } from "../../../data/entity/entity_registry";
 import {
@@ -42,7 +45,7 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
 
   @consume({ context: dirtyStateContext, subscribe: true })
   @state()
-  private _dirtyState?: ContextType<typeof dirtyStateContext>;
+  private _dirtyState?: DirtyStateContext;
 
   @state() private _helperConfigEntry?: ConfigEntry;
 

--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -24,6 +24,7 @@ import {
   showAlertDialog,
   showConfirmationDialog,
 } from "../../../dialogs/generic/show-dialog-box";
+import { DirtyStateProviderMixin } from "../../../mixins/dirty-state-provider-mixin";
 import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
@@ -33,7 +34,9 @@ import type { EntityRegistrySettingsEditor } from "./entity-registry-settings-ed
 import { getDeleteConfirmationText } from "./get-delete-confirmation-text";
 
 @customElement("entity-registry-settings")
-export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
+export class EntityRegistrySettings extends DirtyStateProviderMixin()(
+  SubscribeMixin(LitElement)
+) {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ type: Object }) public entry!: ExtEntityRegistryEntry;
@@ -44,14 +47,13 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
 
   @state() private _submitting?: boolean;
 
-  @state() private _dirty = false;
-
   @query("entity-registry-settings-editor")
   private _registryEditor?: EntityRegistrySettingsEditor;
 
   protected willUpdate(changedProps: PropertyValues<this>): void {
     super.willUpdate(changedProps);
     if (changedProps.has("entry")) {
+      this._initDirtyTracking({ type: "deep" });
       this._fetchHelperConfigEntry();
     }
   }
@@ -133,7 +135,6 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
           .entry=${this.entry}
           .helperConfigEntry=${this._helperConfigEntry}
           .disabled=${!!this._submitting}
-          @change=${this._entityRegistryChanged}
         ></entity-registry-settings-editor>
       </div>
       <div class="buttons">
@@ -148,18 +149,13 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
         </ha-button>
         <ha-button
           @click=${this._updateEntry}
-          .disabled=${!this._dirty || !!this._submitting}
+          .disabled=${!this.isDirtyState || !!this._submitting}
           .loading=${!!this._submitting}
         >
           ${this.hass.localize("ui.dialogs.entity_registry.editor.update")}
         </ha-button>
       </div>
     `;
-  }
-
-  private _entityRegistryChanged() {
-    this._error = undefined;
-    this._dirty = this._registryEditor?.dirty ?? false;
   }
 
   private _openDeviceSettings() {
@@ -207,8 +203,10 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
 
   private async _updateEntry(): Promise<void> {
     this._submitting = true;
+    this._error = undefined;
     try {
       const result = await this._registryEditor!.updateEntry();
+      this._markDirtyStateClean();
       if (result.close) {
         fireEvent(this, "close-dialog");
       }

--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -2,6 +2,7 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
+import { consume, type ContextType } from "@lit/context";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDeviceName } from "../../../common/entity/compute_device_name";
 import { computeEntityEntryName } from "../../../common/entity/compute_entity_name";
@@ -13,6 +14,7 @@ import {
   deleteConfigEntry,
   getConfigEntry,
 } from "../../../data/config_entries";
+import { dirtyStateContext } from "../../../data/context/dirty-state";
 import { updateDeviceRegistryEntry } from "../../../data/device/device_registry";
 import type { ExtEntityRegistryEntry } from "../../../data/entity/entity_registry";
 import {
@@ -24,7 +26,6 @@ import {
   showAlertDialog,
   showConfirmationDialog,
 } from "../../../dialogs/generic/show-dialog-box";
-import { DirtyStateProviderMixin } from "../../../mixins/dirty-state-provider-mixin";
 import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
@@ -34,12 +35,14 @@ import type { EntityRegistrySettingsEditor } from "./entity-registry-settings-ed
 import { getDeleteConfirmationText } from "./get-delete-confirmation-text";
 
 @customElement("entity-registry-settings")
-export class EntityRegistrySettings extends DirtyStateProviderMixin()(
-  SubscribeMixin(LitElement)
-) {
+export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ type: Object }) public entry!: ExtEntityRegistryEntry;
+
+  @consume({ context: dirtyStateContext, subscribe: true })
+  @state()
+  private _dirtyState?: ContextType<typeof dirtyStateContext>;
 
   @state() private _helperConfigEntry?: ConfigEntry;
 
@@ -53,7 +56,6 @@ export class EntityRegistrySettings extends DirtyStateProviderMixin()(
   protected willUpdate(changedProps: PropertyValues<this>): void {
     super.willUpdate(changedProps);
     if (changedProps.has("entry")) {
-      this._initDirtyTracking({ type: "deep" });
       this._fetchHelperConfigEntry();
     }
   }
@@ -149,7 +151,7 @@ export class EntityRegistrySettings extends DirtyStateProviderMixin()(
         </ha-button>
         <ha-button
           @click=${this._updateEntry}
-          .disabled=${!this.isDirtyState || !!this._submitting}
+          .disabled=${!this._dirtyState?.isDirty || !!this._submitting}
           .loading=${!!this._submitting}
         >
           ${this.hass.localize("ui.dialogs.entity_registry.editor.update")}
@@ -206,7 +208,7 @@ export class EntityRegistrySettings extends DirtyStateProviderMixin()(
     this._error = undefined;
     try {
       const result = await this._registryEditor!.updateEntry();
-      this._markDirtyStateClean();
+      this._dirtyState?.markClean();
       if (result.close) {
         fireEvent(this, "close-dialog");
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Starter for #52334 

Introduce a reusable context provider mixin for handling dirty state. This could be in a dialog/sheet/popover or other provider set at highest level, then consumed in child components. Generally used for forms but could be used in other contexts.

Potential uses for this:

- Controlling scrim closure for forms when edited ([new guideline](https://github.com/home-assistant/frontend/pull/52333/changes#diff-557ce3a988748b1c6c53501f3185dc3af2a815c249dd9bfa5feea641f7652347))
- Control save/update actions (disable/hide etc.)
- Show/hide/disable other content based on changes.

Added to:

- More info settings editor.
  - This was already using an internal dirty state, migrates this to the provider + consumer model.
  - Uses `deep` stable comparator to compare A-B of full dialog as before with JSON.stringify comparison. This is set in the more info dialog, which is deferred to when the settings editor sets it.
- Category editor
  - This is new, it would always allow save before (first learning that editing categories exists, accessed via the filters panel and the 3 dot menu)
  - Uses `shallow` comparator for the 2 items that can be changed

Scrim closure is now prevented in more info (settings view only) and category editor dialogs when the state is dirty. The changes from here on should be smoother, the category dialog is the simple example of how future changes should work. More info was more complex in general. 

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

https://github.com/user-attachments/assets/9c55a7fe-5608-4767-98c1-01dfe1cec6eb

https://github.com/user-attachments/assets/6dd53c25-3b46-44ac-92d1-d3fce1bbbbd6

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
