### PR TITLE
Add action confirmation editor

### DIFF
--- a/src/panels/lovelace/common/confirmation-default-text.ts
+++ b/src/panels/lovelace/common/confirmation-default-text.ts
@@ -1,0 +1,45 @@
+import { domainToName } from "../../../data/integration";
+import type { ActionConfig } from "../../../data/lovelace/config/action";
+import type { HomeAssistant } from "../../../types";
+
+export const getConfirmationDefaultText = async (
+  hass: HomeAssistant,
+  actionConfig: Pick<ActionConfig, "action"> & {
+    perform_action?: string;
+    service?: string;
+  }
+): Promise<string> => {
+  let actionLabel: string | undefined;
+
+  if (
+    actionConfig.action === "call-service" ||
+    actionConfig.action === "perform-action"
+  ) {
+    const performAction = actionConfig.perform_action || actionConfig.service;
+    if (performAction) {
+      const [domain, service] = performAction.split(".", 2);
+      const serviceDomains = hass.services;
+      if (domain in serviceDomains && service in serviceDomains[domain]) {
+        await hass.loadBackendTranslation("title");
+        const localize = await hass.loadBackendTranslation("services");
+        actionLabel = `${domainToName(localize, domain)}: ${
+          localize(
+            `component.${domain}.services.${service}.name`,
+            hass.services[domain][service].description_placeholders
+          ) ||
+          serviceDomains[domain][service].name ||
+          service
+        }`;
+      }
+    }
+  }
+
+  return hass.localize("ui.panel.lovelace.cards.actions.action_confirmation", {
+    action:
+      actionLabel ||
+      hass.localize(
+        `ui.panel.lovelace.editor.action-editor.actions.${actionConfig.action}` as any
+      ) ||
+      actionConfig.action,
+  });
+};

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -1,12 +1,12 @@
 import { fireEvent } from "../../../common/dom/fire_event";
 import { navigate } from "../../../common/navigate";
 import { forwardHaptic } from "../../../data/haptics";
-import { domainToName } from "../../../data/integration";
 import type { ActionConfig } from "../../../data/lovelace/config/action";
 import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
 import { showVoiceCommandDialog } from "../../../dialogs/voice-command-dialog/show-ha-voice-command-dialog";
 import type { HomeAssistant } from "../../../types";
 import { showToast } from "../../../util/toast";
+import { getConfirmationDefaultText } from "./confirmation-default-text";
 import { toggleEntity } from "./entity/toggle-entity";
 
 declare global {
@@ -55,40 +55,11 @@ export const handleAction = async (
   ) {
     forwardHaptic(node, "warning");
 
-    let serviceName;
-    if (
-      actionConfig.action === "call-service" ||
-      actionConfig.action === "perform-action"
-    ) {
-      const [domain, service] = (actionConfig.perform_action ||
-        actionConfig.service)!.split(".", 2);
-      const serviceDomains = hass.services;
-      if (domain in serviceDomains && service in serviceDomains[domain]) {
-        await hass.loadBackendTranslation("title");
-        const localize = await hass.loadBackendTranslation("services");
-        serviceName = `${domainToName(localize, domain)}: ${
-          localize(
-            `component.${domain}.services.${service}.name`,
-            hass.services[domain][service].description_placeholders
-          ) ||
-          serviceDomains[domain][service].name ||
-          service
-        }`;
-      }
-    }
-
     if (
       !(await showConfirmationDialog(node, {
         text:
           actionConfig.confirmation.text ||
-          hass.localize("ui.panel.lovelace.cards.actions.action_confirmation", {
-            action:
-              serviceName ||
-              hass.localize(
-                `ui.panel.lovelace.editor.action-editor.actions.${actionConfig.action}`
-              ) ||
-              actionConfig.action,
-          }),
+          (await getConfirmationDefaultText(hass, actionConfig)),
         title: actionConfig.confirmation.title,
         dismissText: actionConfig.confirmation.dismiss_text,
         confirmText: actionConfig.confirmation.confirm_text,

--- a/src/panels/lovelace/components/hui-action-editor.ts
+++ b/src/panels/lovelace/components/hui-action-editor.ts
@@ -448,6 +448,9 @@ export class HuiActionEditor extends LitElement {
     .confirmation-row ha-formfield {
       flex-grow: 1;
     }
+    .confirmation-row ha-icon-button {
+      color: var(--secondary-text-color);
+    }
   `;
 }
 

--- a/src/panels/lovelace/components/hui-action-editor.ts
+++ b/src/panels/lovelace/components/hui-action-editor.ts
@@ -1,12 +1,9 @@
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
-import { mdiPencil } from "@mdi/js";
 import { refine } from "superstruct";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-assist-pipeline-picker";
-import "../../../components/ha-formfield";
-import "../../../components/ha-icon-button";
 import type {
   HaFormSchema,
   SchemaUnion,
@@ -15,16 +12,15 @@ import "../../../components/ha-help-tooltip";
 import "../../../components/ha-navigation-picker";
 import type { HaSelectSelectEvent } from "../../../components/ha-select";
 import "../../../components/ha-service-control";
-import "../../../components/ha-switch";
 import "../../../components/input/ha-input";
 import type { HaInput } from "../../../components/input/ha-input";
 import type {
   ActionConfig,
   CallServiceActionConfig,
-  ConfirmationRestrictionConfig,
   NavigateActionConfig,
   UrlActionConfig,
 } from "../../../data/lovelace/config/action";
+import "../editor/confirmation-editor/hui-action-confirmation-toggle";
 import type { ServiceAction } from "../../../data/script";
 import type { HomeAssistant } from "../../../types";
 
@@ -239,30 +235,11 @@ export class HuiActionEditor extends LitElement {
             </ha-form>
           `
         : nothing}
-      ${this.config?.action && this.config.action !== "none"
-        ? html`
-            <div class="confirmation-row">
-              <ha-formfield
-                .label=${this.hass!.localize(
-                  "ui.panel.lovelace.editor.action-editor.confirmation.enable"
-                )}
-              >
-                <ha-switch
-                  .checked=${!!this.config.confirmation}
-                  @change=${this._toggleConfirmation}
-                ></ha-switch>
-              </ha-formfield>
-              <ha-icon-button
-                .path=${mdiPencil}
-                .disabled=${!this.config.confirmation}
-                .label=${this.hass!.localize(
-                  "ui.panel.lovelace.editor.action-editor.confirmation.edit"
-                )}
-                @click=${this._editConfirmation}
-              ></ha-icon-button>
-            </div>
-          `
-        : nothing}
+      <hui-action-confirmation-toggle
+        .hass=${this.hass}
+        .config=${this.config}
+        .label=${this.label}
+      ></hui-action-confirmation-toggle>
     `;
   }
 
@@ -309,47 +286,6 @@ export class HuiActionEditor extends LitElement {
 
     fireEvent(this, "value-changed", {
       value: { action: value, ...preservedConfirmation, ...data },
-    });
-  }
-
-  private _toggleConfirmation(ev: Event): void {
-    ev.stopPropagation();
-    const enabled = (ev.target as HTMLInputElement).checked;
-    if (enabled) {
-      const existing = this.config!.confirmation;
-      fireEvent(this, "value-changed", {
-        value: {
-          ...this.config!,
-          confirmation:
-            existing && typeof existing === "object" ? existing : {},
-        },
-      });
-    } else {
-      const { confirmation: _removed, ...rest } = this
-        .config as ActionConfig & {
-        confirmation?: ConfirmationRestrictionConfig | boolean;
-      };
-      fireEvent(this, "value-changed", { value: rest });
-    }
-  }
-
-  private _editConfirmation(): void {
-    if (!this.config?.confirmation) {
-      return;
-    }
-    const confirmation =
-      typeof this.config.confirmation === "object"
-        ? this.config.confirmation
-        : {};
-    fireEvent(this, "edit-sub-element", {
-      type: "confirmation",
-      config: confirmation,
-      context: { label: this.label },
-      saveConfig: (newConfirmation: ConfirmationRestrictionConfig) => {
-        fireEvent(this, "value-changed", {
-          value: { ...this.config!, confirmation: newConfirmation },
-        });
-      },
     });
   }
 
@@ -439,17 +375,6 @@ export class HuiActionEditor extends LitElement {
     }
     ha-service-control {
       --service-control-padding: 0;
-    }
-    .confirmation-row {
-      display: flex;
-      align-items: center;
-      margin-top: 8px;
-    }
-    .confirmation-row ha-formfield {
-      flex-grow: 1;
-    }
-    .confirmation-row ha-icon-button {
-      color: var(--secondary-text-color);
     }
   `;
 }

--- a/src/panels/lovelace/components/hui-action-editor.ts
+++ b/src/panels/lovelace/components/hui-action-editor.ts
@@ -1,9 +1,12 @@
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
+import { mdiPencil } from "@mdi/js";
 import { refine } from "superstruct";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-assist-pipeline-picker";
+import "../../../components/ha-formfield";
+import "../../../components/ha-icon-button";
 import type {
   HaFormSchema,
   SchemaUnion,
@@ -12,11 +15,13 @@ import "../../../components/ha-help-tooltip";
 import "../../../components/ha-navigation-picker";
 import type { HaSelectSelectEvent } from "../../../components/ha-select";
 import "../../../components/ha-service-control";
+import "../../../components/ha-switch";
 import "../../../components/input/ha-input";
 import type { HaInput } from "../../../components/input/ha-input";
 import type {
   ActionConfig,
   CallServiceActionConfig,
+  ConfirmationRestrictionConfig,
   NavigateActionConfig,
   UrlActionConfig,
 } from "../../../data/lovelace/config/action";
@@ -234,6 +239,30 @@ export class HuiActionEditor extends LitElement {
             </ha-form>
           `
         : nothing}
+      ${this.config?.action && this.config.action !== "none"
+        ? html`
+            <div class="confirmation-row">
+              <ha-formfield
+                .label=${this.hass!.localize(
+                  "ui.panel.lovelace.editor.action-editor.confirmation.enable"
+                )}
+              >
+                <ha-switch
+                  .checked=${!!this.config.confirmation}
+                  @change=${this._toggleConfirmation}
+                ></ha-switch>
+              </ha-formfield>
+              <ha-icon-button
+                .path=${mdiPencil}
+                .disabled=${!this.config.confirmation}
+                .label=${this.hass!.localize(
+                  "ui.panel.lovelace.editor.action-editor.confirmation.edit"
+                )}
+                @click=${this._editConfirmation}
+              ></ha-icon-button>
+            </div>
+          `
+        : nothing}
     `;
   }
 
@@ -274,8 +303,53 @@ export class HuiActionEditor extends LitElement {
       }
     }
 
+    const preservedConfirmation = this.config?.confirmation
+      ? { confirmation: this.config.confirmation }
+      : {};
+
     fireEvent(this, "value-changed", {
-      value: { action: value, ...data },
+      value: { action: value, ...preservedConfirmation, ...data },
+    });
+  }
+
+  private _toggleConfirmation(ev: Event): void {
+    ev.stopPropagation();
+    const enabled = (ev.target as HTMLInputElement).checked;
+    if (enabled) {
+      const existing = this.config!.confirmation;
+      fireEvent(this, "value-changed", {
+        value: {
+          ...this.config!,
+          confirmation:
+            existing && typeof existing === "object" ? existing : {},
+        },
+      });
+    } else {
+      const { confirmation: _removed, ...rest } = this
+        .config as ActionConfig & {
+        confirmation?: ConfirmationRestrictionConfig | boolean;
+      };
+      fireEvent(this, "value-changed", { value: rest });
+    }
+  }
+
+  private _editConfirmation(): void {
+    if (!this.config?.confirmation) {
+      return;
+    }
+    const confirmation =
+      typeof this.config.confirmation === "object"
+        ? this.config.confirmation
+        : {};
+    fireEvent(this, "edit-sub-element", {
+      type: "confirmation",
+      config: confirmation,
+      context: { label: this.label },
+      saveConfig: (newConfirmation: ConfirmationRestrictionConfig) => {
+        fireEvent(this, "value-changed", {
+          value: { ...this.config!, confirmation: newConfirmation },
+        });
+      },
     });
   }
 
@@ -365,6 +439,14 @@ export class HuiActionEditor extends LitElement {
     }
     ha-service-control {
       --service-control-padding: 0;
+    }
+    .confirmation-row {
+      display: flex;
+      align-items: center;
+      margin-top: 8px;
+    }
+    .confirmation-row ha-formfield {
+      flex-grow: 1;
     }
   `;
 }

--- a/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-editor.ts
+++ b/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-editor.ts
@@ -15,7 +15,13 @@ export class HuiActionConfirmationEditor extends HuiElementEditor<ConfirmationRe
       schema: [
         {
           name: "title",
-          selector: { text: {} },
+          selector: {
+            text: {
+              placeholder: localize(
+                "ui.dialogs.generic.default_confirmation_title"
+              ),
+            },
+          },
         },
         {
           name: "text",

--- a/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-editor.ts
+++ b/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-editor.ts
@@ -2,14 +2,31 @@ import { css, html } from "lit";
 import { customElement } from "lit/decorators";
 import "../../../../components/ha-alert";
 import type { HaFormSchema } from "../../../../components/ha-form/types";
-import type { ConfirmationRestrictionConfig } from "../../../../data/lovelace/config/action";
+import type {
+  ActionConfig,
+  ConfirmationRestrictionConfig,
+} from "../../../../data/lovelace/config/action";
+import { getConfirmationDefaultText } from "../../common/confirmation-default-text";
 import type { LovelaceConfigForm } from "../../types";
 import { HuiElementEditor } from "../hui-element-editor";
 
+interface ConfirmationEditorContext {
+  label?: string;
+  actionConfig?: ActionConfig;
+}
+
 @customElement("hui-action-confirmation-editor")
-export class HuiActionConfirmationEditor extends HuiElementEditor<ConfirmationRestrictionConfig> {
+export class HuiActionConfirmationEditor extends HuiElementEditor<
+  ConfirmationRestrictionConfig,
+  ConfirmationEditorContext
+> {
   protected async getConfigForm(): Promise<LovelaceConfigForm | undefined> {
     const localize = this.hass.localize.bind(this.hass);
+    const actionConfig = this.context?.actionConfig;
+
+    const textPlaceholder = actionConfig
+      ? await getConfirmationDefaultText(this.hass, actionConfig)
+      : undefined;
 
     return {
       schema: [
@@ -25,7 +42,11 @@ export class HuiActionConfirmationEditor extends HuiElementEditor<ConfirmationRe
         },
         {
           name: "text",
-          selector: { text: {} },
+          selector: {
+            text: {
+              ...(textPlaceholder ? { placeholder: textPlaceholder } : {}),
+            },
+          },
         },
         {
           name: "confirm_text",

--- a/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-editor.ts
+++ b/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-editor.ts
@@ -1,0 +1,71 @@
+import { css, html } from "lit";
+import { customElement } from "lit/decorators";
+import "../../../../components/ha-alert";
+import type { HaFormSchema } from "../../../../components/ha-form/types";
+import type { ConfirmationRestrictionConfig } from "../../../../data/lovelace/config/action";
+import type { LovelaceConfigForm } from "../../types";
+import { HuiElementEditor } from "../hui-element-editor";
+
+const CONFIRMATION_SCHEMA = [
+  {
+    name: "title",
+    selector: { text: {} },
+  },
+  {
+    name: "text",
+    selector: { text: {} },
+  },
+  {
+    name: "confirm_text",
+    selector: { text: {} },
+  },
+  {
+    name: "dismiss_text",
+    selector: { text: {} },
+  },
+] as const satisfies readonly HaFormSchema[];
+
+@customElement("hui-action-confirmation-editor")
+export class HuiActionConfirmationEditor extends HuiElementEditor<ConfirmationRestrictionConfig> {
+  protected async getConfigForm(): Promise<LovelaceConfigForm | undefined> {
+    return {
+      schema: CONFIRMATION_SCHEMA as unknown as HaFormSchema[],
+      computeLabel: (schema, localize) =>
+        localize(
+          `ui.panel.lovelace.editor.action-editor.confirmation.${schema.name}` as any
+        ),
+      computeHelper: (schema, localize) => {
+        const key = `ui.panel.lovelace.editor.action-editor.confirmation.${schema.name}_placeholder`;
+        const translated = localize(key as any);
+        return translated !== key ? translated : undefined;
+      },
+    };
+  }
+
+  protected override renderConfigElement() {
+    return html`
+      ${super.renderConfigElement()}
+      <ha-alert alert-type="info">
+        ${this.hass?.localize(
+          "ui.panel.lovelace.editor.action-editor.confirmation.exemptions_hint"
+        )}
+      </ha-alert>
+    `;
+  }
+
+  static override styles = [
+    HuiElementEditor.styles,
+    css`
+      ha-alert {
+        display: block;
+        margin-top: var(--ha-space-2);
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-action-confirmation-editor": HuiActionConfirmationEditor;
+  }
+}

--- a/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-editor.ts
+++ b/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-editor.ts
@@ -24,47 +24,40 @@ export class HuiActionConfirmationEditor extends HuiElementEditor<
     const localize = this.hass.localize.bind(this.hass);
     const actionConfig = this.context?.actionConfig;
 
-    const textPlaceholder = actionConfig
+    const defaultText = actionConfig
       ? await getConfirmationDefaultText(this.hass, actionConfig)
       : undefined;
 
+    const defaultTitle = localize(
+      "ui.dialogs.generic.default_confirmation_title"
+    );
+
+    const helpers: Record<string, string | undefined> = {
+      title: defaultTitle,
+      text: defaultText,
+      confirm_text: localize("ui.common.ok"),
+      dismiss_text: localize("ui.common.cancel"),
+    };
+
     return {
       schema: [
-        {
-          name: "title",
-          selector: {
-            text: {
-              placeholder: localize(
-                "ui.dialogs.generic.default_confirmation_title"
-              ),
-            },
-          },
-        },
-        {
-          name: "text",
-          selector: {
-            text: {
-              ...(textPlaceholder ? { placeholder: textPlaceholder } : {}),
-            },
-          },
-        },
-        {
-          name: "confirm_text",
-          selector: {
-            text: { placeholder: localize("ui.common.ok") },
-          },
-        },
-        {
-          name: "dismiss_text",
-          selector: {
-            text: { placeholder: localize("ui.common.cancel") },
-          },
-        },
+        { name: "title", selector: { text: {} } },
+        { name: "text", selector: { text: {} } },
+        { name: "confirm_text", selector: { text: {} } },
+        { name: "dismiss_text", selector: { text: {} } },
       ] as HaFormSchema[],
       computeLabel: (schema) =>
         localize(
           `ui.panel.lovelace.editor.action-editor.confirmation.${schema.name}` as any
         ),
+      computeHelper: (schema) => {
+        const value = helpers[schema.name];
+        if (!value) return undefined;
+        return localize(
+          "ui.panel.lovelace.editor.action-editor.confirmation.default_value" as any,
+          { value }
+        );
+      },
     };
   }
 

--- a/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-editor.ts
+++ b/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-editor.ts
@@ -6,39 +6,38 @@ import type { ConfirmationRestrictionConfig } from "../../../../data/lovelace/co
 import type { LovelaceConfigForm } from "../../types";
 import { HuiElementEditor } from "../hui-element-editor";
 
-const CONFIRMATION_SCHEMA = [
-  {
-    name: "title",
-    selector: { text: {} },
-  },
-  {
-    name: "text",
-    selector: { text: {} },
-  },
-  {
-    name: "confirm_text",
-    selector: { text: {} },
-  },
-  {
-    name: "dismiss_text",
-    selector: { text: {} },
-  },
-] as const satisfies readonly HaFormSchema[];
-
 @customElement("hui-action-confirmation-editor")
 export class HuiActionConfirmationEditor extends HuiElementEditor<ConfirmationRestrictionConfig> {
   protected async getConfigForm(): Promise<LovelaceConfigForm | undefined> {
+    const localize = this.hass.localize.bind(this.hass);
+
     return {
-      schema: CONFIRMATION_SCHEMA as unknown as HaFormSchema[],
-      computeLabel: (schema, localize) =>
+      schema: [
+        {
+          name: "title",
+          selector: { text: {} },
+        },
+        {
+          name: "text",
+          selector: { text: {} },
+        },
+        {
+          name: "confirm_text",
+          selector: {
+            text: { placeholder: localize("ui.common.ok") },
+          },
+        },
+        {
+          name: "dismiss_text",
+          selector: {
+            text: { placeholder: localize("ui.common.cancel") },
+          },
+        },
+      ] as HaFormSchema[],
+      computeLabel: (schema) =>
         localize(
           `ui.panel.lovelace.editor.action-editor.confirmation.${schema.name}` as any
         ),
-      computeHelper: (schema, localize) => {
-        const key = `ui.panel.lovelace.editor.action-editor.confirmation.${schema.name}_placeholder`;
-        const translated = localize(key as any);
-        return translated !== key ? translated : undefined;
-      },
     };
   }
 

--- a/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-editor.ts
+++ b/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-editor.ts
@@ -2,6 +2,7 @@ import { css, html } from "lit";
 import { customElement } from "lit/decorators";
 import "../../../../components/ha-alert";
 import type { HaFormSchema } from "../../../../components/ha-form/types";
+import "../../../../components/user/ha-users-picker";
 import type {
   ActionConfig,
   ConfirmationRestrictionConfig,
@@ -62,22 +63,35 @@ export class HuiActionConfirmationEditor extends HuiElementEditor<
   }
 
   protected override renderConfigElement() {
+    const exemptionIds = this.value?.exemptions?.map((e) => e.user) ?? [];
+
     return html`
       ${super.renderConfigElement()}
-      <ha-alert alert-type="info">
-        ${this.hass?.localize(
-          "ui.panel.lovelace.editor.action-editor.confirmation.exemptions_hint"
-        )}
-      </ha-alert>
+      <div class="exemptions">
+        <ha-users-picker
+          .hass=${this.hass}
+          .label=${this.hass.localize(
+            "ui.panel.lovelace.editor.action-editor.confirmation.exemptions"
+          )}
+          .value=${exemptionIds}
+          @value-changed=${this._exemptionsChanged}
+        ></ha-users-picker>
+      </div>
     `;
+  }
+
+  private _exemptionsChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const ids: string[] = ev.detail.value;
+    const exemptions = ids.length ? ids.map((id) => ({ user: id })) : undefined;
+    this.value = { ...this.value, exemptions } as ConfirmationRestrictionConfig;
   }
 
   static override styles = [
     HuiElementEditor.styles,
     css`
-      ha-alert {
-        display: block;
-        margin-top: var(--ha-space-2);
+      .exemptions {
+        margin-top: var(--ha-space-4);
       }
     `,
   ];

--- a/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-toggle.ts
+++ b/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-toggle.ts
@@ -1,0 +1,111 @@
+import { mdiPencil } from "@mdi/js";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-formfield";
+import "../../../../components/ha-icon-button";
+import "../../../../components/ha-switch";
+import type {
+  ActionConfig,
+  ConfirmationRestrictionConfig,
+} from "../../../../data/lovelace/config/action";
+import type { HomeAssistant } from "../../../../types";
+
+@customElement("hui-action-confirmation-toggle")
+export class HuiActionConfirmationToggle extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public config?: ActionConfig;
+
+  @property() public label?: string;
+
+  protected render() {
+    if (!this.hass || !this.config?.action || this.config.action === "none") {
+      return nothing;
+    }
+
+    return html`
+      <div class="confirmation-row">
+        <ha-formfield
+          .label=${this.hass.localize(
+            "ui.panel.lovelace.editor.action-editor.confirmation.enable"
+          )}
+        >
+          <ha-switch
+            .checked=${!!this.config.confirmation}
+            @change=${this._toggleConfirmation}
+          ></ha-switch>
+        </ha-formfield>
+        <ha-icon-button
+          .path=${mdiPencil}
+          .disabled=${!this.config.confirmation}
+          .label=${this.hass.localize(
+            "ui.panel.lovelace.editor.action-editor.confirmation.edit"
+          )}
+          @click=${this._editConfirmation}
+        ></ha-icon-button>
+      </div>
+    `;
+  }
+
+  private _toggleConfirmation(ev: Event): void {
+    ev.stopPropagation();
+    const enabled = (ev.target as HTMLInputElement).checked;
+    if (enabled) {
+      const existing = this.config!.confirmation;
+      fireEvent(this, "value-changed", {
+        value: {
+          ...this.config!,
+          confirmation:
+            existing && typeof existing === "object" ? existing : {},
+        },
+      });
+    } else {
+      const { confirmation: _removed, ...rest } = this
+        .config as ActionConfig & {
+        confirmation?: ConfirmationRestrictionConfig | boolean;
+      };
+      fireEvent(this, "value-changed", { value: rest });
+    }
+  }
+
+  private _editConfirmation(): void {
+    if (!this.config?.confirmation) {
+      return;
+    }
+    const confirmation =
+      typeof this.config.confirmation === "object"
+        ? this.config.confirmation
+        : {};
+    fireEvent(this, "edit-sub-element", {
+      type: "confirmation",
+      config: confirmation,
+      context: { label: this.label },
+      saveConfig: (newConfirmation: ConfirmationRestrictionConfig) => {
+        fireEvent(this, "value-changed", {
+          value: { ...this.config!, confirmation: newConfirmation },
+        });
+      },
+    });
+  }
+
+  static styles = css`
+    .confirmation-row {
+      display: flex;
+      align-items: center;
+      margin-top: 8px;
+    }
+    ha-formfield {
+      flex-grow: 1;
+    }
+    ha-icon-button {
+      color: var(--secondary-text-color);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-action-confirmation-toggle": HuiActionConfirmationToggle;
+  }
+}

--- a/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-toggle.ts
+++ b/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-toggle.ts
@@ -76,7 +76,7 @@ export class HuiActionConfirmationToggle extends LitElement {
     fireEvent(this, "edit-sub-element", {
       type: "confirmation",
       config: confirmation,
-      context: { label: this.label },
+      context: { label: this.label, actionConfig: this.config },
       saveConfig: (newConfirmation: ConfirmationRestrictionConfig) => {
         fireEvent(this, "value-changed", {
           value: { ...this.config!, confirmation: newConfirmation },

--- a/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-toggle.ts
+++ b/src/panels/lovelace/editor/confirmation-editor/hui-action-confirmation-toggle.ts
@@ -2,9 +2,8 @@ import { mdiPencil } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import "../../../../components/ha-formfield";
 import "../../../../components/ha-icon-button";
-import "../../../../components/ha-switch";
+import "../../../../components/ha-selector/ha-selector-boolean";
 import type {
   ActionConfig,
   ConfirmationRestrictionConfig,
@@ -26,16 +25,13 @@ export class HuiActionConfirmationToggle extends LitElement {
 
     return html`
       <div class="confirmation-row">
-        <ha-formfield
+        <ha-selector-boolean
           .label=${this.hass.localize(
             "ui.panel.lovelace.editor.action-editor.confirmation.enable"
           )}
-        >
-          <ha-switch
-            .checked=${!!this.config.confirmation}
-            @change=${this._toggleConfirmation}
-          ></ha-switch>
-        </ha-formfield>
+          .value=${!!this.config.confirmation}
+          @value-changed=${this._toggleConfirmation}
+        ></ha-selector-boolean>
         <ha-icon-button
           .path=${mdiPencil}
           .disabled=${!this.config.confirmation}
@@ -48,9 +44,9 @@ export class HuiActionConfirmationToggle extends LitElement {
     `;
   }
 
-  private _toggleConfirmation(ev: Event): void {
+  private _toggleConfirmation(ev: CustomEvent): void {
     ev.stopPropagation();
-    const enabled = (ev.target as HTMLInputElement).checked;
+    const enabled = ev.detail.value as boolean;
     if (enabled) {
       const existing = this.config!.confirmation;
       fireEvent(this, "value-changed", {
@@ -95,10 +91,11 @@ export class HuiActionConfirmationToggle extends LitElement {
       align-items: center;
       margin-top: 8px;
     }
-    ha-formfield {
+    ha-selector-boolean {
       flex-grow: 1;
     }
     ha-icon-button {
+      --ha-icon-button-size: var(--ha-space-9);
       color: var(--secondary-text-color);
     }
   `;

--- a/src/panels/lovelace/editor/hui-sub-element-editor.ts
+++ b/src/panels/lovelace/editor/hui-sub-element-editor.ts
@@ -166,6 +166,7 @@ export class HuiSubElementEditor extends LitElement {
             class="editor"
             .hass=${this.hass}
             .value=${this.config.elementConfig}
+            .context=${this.config.context}
             @config-changed=${this._handleConfigChanged}
             @GUImode-changed=${this._handleGUIModeChanged}
           ></hui-action-confirmation-editor>

--- a/src/panels/lovelace/editor/hui-sub-element-editor.ts
+++ b/src/panels/lovelace/editor/hui-sub-element-editor.ts
@@ -7,6 +7,7 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-icon-button-prev";
 import type { HomeAssistant } from "../../../types";
+import "./confirmation-editor/hui-action-confirmation-editor";
 import "./entity-row-editor/hui-row-element-editor";
 import "./feature-editor/hui-card-feature-element-editor";
 import "./header-footer-editor/hui-header-footer-element-editor";
@@ -61,9 +62,14 @@ export class HuiSubElementEditor extends LitElement {
                       ) || elementType,
                   }
                 )
-              : this.hass.localize(
-                  `ui.panel.lovelace.editor.sub-element-editor.types.${this.config?.type}`
-                )}
+              : this.config?.type === "confirmation" &&
+                  this.config.context?.label
+                ? `${this.config.context.label} - ${this.hass.localize(
+                    "ui.panel.lovelace.editor.sub-element-editor.types.confirmation"
+                  )}`
+                : this.hass.localize(
+                    `ui.panel.lovelace.editor.sub-element-editor.types.${this.config?.type}`
+                  )}
           </span>
         </div>
         <ha-icon-button
@@ -153,6 +159,16 @@ export class HuiSubElementEditor extends LitElement {
             @config-changed=${this._handleConfigChanged}
             @GUImode-changed=${this._handleGUIModeChanged}
           ></hui-heading-badge-element-editor>
+        `;
+      case "confirmation":
+        return html`
+          <hui-action-confirmation-editor
+            class="editor"
+            .hass=${this.hass}
+            .value=${this.config.elementConfig}
+            @config-changed=${this._handleConfigChanged}
+            @GUImode-changed=${this._handleGUIModeChanged}
+          ></hui-action-confirmation-editor>
         `;
       default:
         return nothing;

--- a/src/panels/lovelace/editor/structs/action-struct.ts
+++ b/src/panels/lovelace/editor/structs/action-struct.ts
@@ -19,8 +19,11 @@ const actionConfigStructUser = object({
 export const actionConfigStructConfirmation = union([
   boolean(),
   object({
+    title: optional(string()),
     text: optional(string()),
-    excemptions: optional(array(actionConfigStructUser)),
+    confirm_text: optional(string()),
+    dismiss_text: optional(string()),
+    exemptions: optional(array(actionConfigStructUser)),
   }),
 ]);
 

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -104,7 +104,14 @@ export interface SubElementEditorConfig {
     | LovelaceHeadingBadgeConfig;
   saveElementConfig?: (elementConfig: any) => void;
   context?: any;
-  type: "header" | "footer" | "row" | "feature" | "element" | "heading-badge";
+  type:
+    | "header"
+    | "footer"
+    | "row"
+    | "feature"
+    | "element"
+    | "heading-badge"
+    | "confirmation";
 }
 
 export interface EditSubElementEvent<T = any, C = any> {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9220,6 +9220,17 @@
               "assist": "Assist",
               "url": "URL",
               "none": "Nothing"
+            },
+            "confirmation": {
+              "enable": "Require confirmation",
+              "edit": "Edit confirmation",
+              "title": "Dialog title",
+              "text": "Message",
+              "confirm_text": "Confirm button label",
+              "dismiss_text": "Cancel button label",
+              "confirm_text_placeholder": "OK",
+              "dismiss_text_placeholder": "Cancel",
+              "exemptions_hint": "To configure exempt users, switch to YAML mode."
             }
           },
           "condition-editor": {
@@ -10501,7 +10512,8 @@
               "feature": "Feature editor",
               "element": "Element editor",
               "heading-badge": "Heading badge editor",
-              "element_type": "{type} element editor"
+              "element_type": "{type} element editor",
+              "confirmation": "Confirmation"
             }
           }
         },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9228,8 +9228,7 @@
               "text": "Message",
               "confirm_text": "Confirm button label",
               "dismiss_text": "Cancel button label",
-              "confirm_text_placeholder": "OK",
-              "dismiss_text_placeholder": "Cancel",
+              "default_value": "Default: {value}",
               "exemptions_hint": "To configure exempt users, switch to YAML mode."
             }
           },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9229,7 +9229,7 @@
               "confirm_text": "Confirm button label",
               "dismiss_text": "Cancel button label",
               "default_value": "Default: {value}",
-              "exemptions_hint": "To configure exempt users, switch to YAML mode."
+              "exemptions": "Exempt users"
             }
           },
           "condition-editor": {


### PR DESCRIPTION
## Proposed change

Adds a visual editor for the `confirmation` option on Lovelace card interactions (`tap_action`, `hold_action`, `double_tap_action`, etc.).

Each interaction that has an eligible action (anything except `none` / unset) shows an inline toggle + edit button
Click on the edit button navigates to the confirmation dialog editor

~~**For now, exemptions is not implemented. I can add it in this PR or in a follow-up PR. let me know**~~

## Screenshots

<img width="1028" height="868" alt="image" src="https://github.com/user-attachments/assets/1ec3bac6-66ba-4f3e-a562-b1792653c7e5" />

<img width="1026" height="725" alt="image" src="https://github.com/user-attachments/assets/8925c119-813b-4bc2-94cb-27e72b8ce109" />

<!-- Please add screenshots or a short video showing the before/after. -->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/3805
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
