### PR TITLE
Migrate deprecated Web Awesome size values to short form (s/m/l)

### DIFF
--- a/gallery/src/pages/components/ha-alert.ts
+++ b/gallery/src/pages/components/ha-alert.ts
@@ -78,13 +78,13 @@ const alerts: {
     title: "Error with action",
     description: "This is a test error alert with action",
     type: "error",
-    actionSlot: html`<ha-button size="small" slot="action">restart</ha-button>`,
+    actionSlot: html`<ha-button size="s" slot="action">restart</ha-button>`,
   },
   {
     title: "Unsaved data",
     description: "You have unsaved data",
     type: "warning",
-    actionSlot: html`<ha-button size="small" slot="action">save</ha-button>`,
+    actionSlot: html`<ha-button size="s" slot="action">save</ha-button>`,
   },
   {
     title: "Slotted icon",

--- a/gallery/src/pages/components/ha-button.markdown
+++ b/gallery/src/pages/components/ha-button.markdown
@@ -26,7 +26,7 @@ title: Button
     filled button
   </ha-button>
 
-  <ha-button size="small">
+  <ha-button size="s">
     small
   </ha-button>
 </div>
@@ -34,7 +34,7 @@ title: Button
 ```html
 <ha-button> simple button </ha-button>
 
-<ha-button size="small"> small </ha-button>
+<ha-button size="s"> small </ha-button>
 ```
 
 ### API
@@ -57,7 +57,7 @@ Check the [webawesome documentation](https://webawesome.com/docs/components/butt
 | ---------- | ---------------------------------------------- | -------- | --------------------------------------------------------------------------------- |
 | appearance | "accent"/"filled"/"plain"                      | "accent" | Sets the button appearance.                                                       |
 | variants   | "brand"/"danger"/"neutral"/"warning"/"success" | "brand"  | Sets the button color variant. "brand" is default.                                |
-| size       | "small"/"medium"/"large"                       | "medium" | Sets the button size.                                                             |
+| size       | "xs"/"s"/"m"/"l"/"xl"                          | "m"      | Sets the button size.                                                             |
 | loading    | Boolean                                        | false    | Shows a loading indicator instead of the buttons label and disable buttons click. |
 | disabled   | Boolean                                        | false    | Disables the button and prevents user interaction.                                |
 

--- a/gallery/src/pages/components/ha-button.ts
+++ b/gallery/src/pages/components/ha-button.ts
@@ -49,7 +49,7 @@ export class DemoHaButton extends LitElement {
                           <ha-button
                             .appearance=${appearance}
                             .variant=${variant}
-                            size="small"
+                            size="s"
                           >
                             ${titleCase(`${variant} ${appearance}`)}
                           </ha-button>
@@ -100,7 +100,7 @@ export class DemoHaButton extends LitElement {
                           <ha-button
                             .variant=${variant}
                             .appearance=${appearance}
-                            size="small"
+                            size="s"
                             disabled
                           >
                             ${titleCase(`${appearance}`)}

--- a/gallery/src/pages/components/ha-slider.markdown
+++ b/gallery/src/pages/components/ha-slider.markdown
@@ -17,13 +17,13 @@ subtitle: A slider component for selecting a value from a range.
 ### Example Usage
 
 <div class="wrapper">
-  <ha-slider size="small" with-markers min="0" max="8" value="4"></ha-slider>
-  <ha-slider size="medium"></ha-slider>
+  <ha-slider size="s" with-markers min="0" max="8" value="4"></ha-slider>
+  <ha-slider size="m"></ha-slider>
 </div>
 
 ```html
-<ha-slider size="small" with-markers min="0" max="8" value="4"></ha-slider>
-<ha-slider size="medium"></ha-slider>
+<ha-slider size="s" with-markers min="0" max="8" value="4"></ha-slider>
+<ha-slider size="m"></ha-slider>
 ```
 
 ### API

--- a/gallery/src/pages/components/ha-slider.ts
+++ b/gallery/src/pages/components/ha-slider.ts
@@ -29,7 +29,7 @@ export class DemoHaSlider extends LitElement {
                 ></ha-slider>
                 <span>Small</span>
                 <ha-slider
-                  size="small"
+                  size="s"
                   min="0"
                   max="8"
                   value="4"
@@ -37,7 +37,7 @@ export class DemoHaSlider extends LitElement {
                 ></ha-slider>
                 <span>Medium</span>
                 <ha-slider
-                  size="medium"
+                  size="m"
                   min="0"
                   max="8"
                   value="4"

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -167,7 +167,7 @@ export class StateHistoryCharts extends LitElement {
           )}`}
       ${this.syncCharts && this._hasZoomedCharts
         ? html`<ha-button
-            size="large"
+            size="l"
             class="reset-button"
             @click=${this._handleGlobalZoomReset}
           >

--- a/src/components/entity/ha-entity-name-picker.ts
+++ b/src/components/entity/ha-entity-name-picker.ts
@@ -117,7 +117,7 @@ export class HaEntityNamePicker extends LitElement {
         <div class="header">
           ${this.label ? html`<label>${this.label}</label>` : nothing}
           <ha-button-toggle-group
-            size="small"
+            size="s"
             .buttons=${modeButtons}
             .active=${this._mode}
             .disabled=${this.disabled}

--- a/src/components/ha-button-toggle-group.ts
+++ b/src/components/ha-button-toggle-group.ts
@@ -15,7 +15,7 @@ import "./ha-svg-icon";
  *
  * @attr {ToggleButton[]} buttons - the button config
  * @attr {string} active - The value of the currently active button.
- * @attr {("small"|"medium")} size - The size of the buttons in the group.
+ * @attr {("s"|"m")} size - The size of the buttons in the group.
  * @attr {("brand"|"neutral"|"success"|"warning"|"danger")} variant - The variant of the buttons in the group.
  *
  * @fires value-changed - Dispatched when the active button changes.
@@ -26,7 +26,7 @@ export class HaButtonToggleGroup extends LitElement {
 
   @property() public active?: string;
 
-  @property({ reflect: true }) size: "small" | "medium" = "medium";
+  @property({ reflect: true }) size: "s" | "m" = "m";
 
   @property({ type: Boolean, reflect: true, attribute: "no-wrap" })
   public nowrap = false;

--- a/src/components/ha-button.ts
+++ b/src/components/ha-button.ts
@@ -27,7 +27,7 @@ export type Appearance = "accent" | "filled" | "outlined" | "plain";
  * @cssprop --ha-button-height - The height of the button.
  * @cssprop --ha-button-border-radius - The border radius of the button. defaults to `var(--ha-border-radius-pill)`.
  *
- * @attr {("small"|"medium"|"large")} size - Sets the button size.
+ * @attr {("xs"|"s"|"m"|"l"|"xl")} size - Sets the button size.
  * @attr {("brand"|"neutral"|"danger"|"warning"|"success")} variant - Sets the button color variant. "primary" is default.
  * @attr {("accent"|"filled"|"plain")} appearance - Sets the button appearance.
  * @attr {boolean} loading - shows a loading indicator instead of the buttons label and disable buttons click.
@@ -65,7 +65,7 @@ export class HaButton extends Button {
           box-shadow: var(--ha-button-box-shadow);
         }
 
-        :host([size="small"]) .button {
+        :host([size="s"]) .button {
           --wa-form-control-height: var(
             --ha-button-height,
             var(--button-height, 32px)
@@ -74,7 +74,7 @@ export class HaButton extends Button {
           --wa-form-control-padding-inline: var(--ha-space-3);
         }
 
-        :host([size="large"]) .button {
+        :host([size="l"]) .button {
           --wa-form-control-height: var(
             --ha-button-height,
             var(--button-height, 48px)

--- a/src/components/ha-duration-input.ts
+++ b/src/components/ha-duration-input.ts
@@ -61,7 +61,7 @@ export class HaDurationInput extends LitElement {
         ${this.allowNegative
           ? html`
               <ha-button-toggle-group
-                size="small"
+                size="s"
                 .buttons=${[
                   { label: "+", iconPath: mdiPlusThick, value: "+" },
                   { label: "-", iconPath: mdiMinusThick, value: "-" },

--- a/src/components/ha-file-upload.ts
+++ b/src/components/ha-file-upload.ts
@@ -120,7 +120,7 @@ export class HaFileUpload extends LitElement {
             @dragend=${this._handleDragEnd}
             >${!this.value
               ? html`<ha-button
-                    size="small"
+                    size="s"
                     appearance="filled"
                     @click=${this._openFilePicker}
                   >

--- a/src/components/ha-form/ha-form-optional_actions.ts
+++ b/src/components/ha-form/ha-form-optional_actions.ts
@@ -129,7 +129,7 @@ export class HaFormOptionalActions extends LitElement implements HaFormElement {
               @wa-select=${this._handleAddAction}
               @closed=${stopPropagation}
             >
-              <ha-button slot="trigger" appearance="filled" size="small">
+              <ha-button slot="trigger" appearance="filled" size="s">
                 <ha-svg-icon .path=${mdiPlus} slot="start"></ha-svg-icon>
                 ${this.localize?.("ui.components.form-optional-actions.add") ||
                 "Add interaction"}

--- a/src/components/ha-generic-picker.ts
+++ b/src/components/ha-generic-picker.ts
@@ -174,7 +174,7 @@ export class HaGenericPicker extends PickerMixin(LitElement) {
           <slot name="field">
             ${this.addButtonLabel && !this.value
               ? html`<ha-button
-                  size="small"
+                  size="s"
                   appearance="filled"
                   @click=${this.open}
                   .disabled=${this.disabled}

--- a/src/components/ha-labels-picker.ts
+++ b/src/components/ha-labels-picker.ts
@@ -171,7 +171,7 @@ export class HaLabelsPicker extends LitElement {
             : nothing}
           <ha-button
             id="picker"
-            size="small"
+            size="s"
             appearance="filled"
             @click=${this._openPicker}
             .disabled=${this.disabled}

--- a/src/components/ha-lawn_mower-action-button.ts
+++ b/src/components/ha-lawn_mower-action-button.ts
@@ -53,7 +53,7 @@ class HaLawnMowerActionButton extends LitElement {
           appearance="plain"
           @click=${this.callService}
           .service=${action.service}
-          size="small"
+          size="s"
         >
           ${this.hass.localize(`ui.card.lawn_mower.actions.${action.action}`)}
         </ha-button>

--- a/src/components/ha-picture-upload.ts
+++ b/src/components/ha-picture-upload.ts
@@ -102,7 +102,7 @@ export class HaPictureUpload extends LitElement {
         <div>
           <ha-button
             appearance="plain"
-            size="small"
+            size="s"
             variant="danger"
             @click=${this._handleChangeClick}
           >

--- a/src/components/ha-selector/ha-selector-choose.ts
+++ b/src/components/ha-selector/ha-selector-choose.ts
@@ -63,7 +63,7 @@ export class HaChooseSelector extends LitElement {
     return html`<div class="multi-header">
         <span>${this.label}${this.required ? "*" : ""}</span>
         <ha-button-toggle-group
-          size="small"
+          size="s"
           .buttons=${this._toggleButtons(
             this.selector.choose.choices,
             this.selector.choose.translation_key,

--- a/src/components/ha-selector/ha-selector-media.ts
+++ b/src/components/ha-selector/ha-selector-media.ts
@@ -190,7 +190,7 @@ export class HaMediaSelector extends LitElement {
               ? html`<div>
                   <ha-button
                     appearance="plain"
-                    size="small"
+                    size="s"
                     variant="danger"
                     @click=${this._clearValue}
                   >

--- a/src/components/ha-selector/ha-selector-numeric-threshold.ts
+++ b/src/components/ha-selector/ha-selector-numeric-threshold.ts
@@ -307,7 +307,7 @@ export class HaNumericThresholdSelector extends LitElement {
               >`
             : nothing}
           <ha-button-toggle-group
-            size="small"
+            size="s"
             .buttons=${choiceToggleButtons}
             .active=${activeChoice}
             .disabled=${this.disabled}

--- a/src/components/ha-slider.ts
+++ b/src/components/ha-slider.ts
@@ -5,7 +5,7 @@ import { mainWindow } from "../common/dom/get_main_window";
 
 @customElement("ha-slider")
 export class HaSlider extends Slider {
-  @property({ reflect: true }) size: "small" | "medium" = "small";
+  @property({ reflect: true }) size: "s" | "m" = "s";
 
   @property({ type: Boolean, attribute: "with-tooltip" }) withTooltip = true;
 
@@ -110,12 +110,12 @@ export class HaSlider extends Slider {
           );
         }
 
-        :host([size="medium"]) {
+        :host([size="m"]) {
           --thumb-width: 20px;
           --thumb-height: 20px;
         }
 
-        :host([size="small"]) {
+        :host([size="s"]) {
           --thumb-width: 16px;
           --thumb-height: 16px;
         }

--- a/src/components/ha-trace-picker.ts
+++ b/src/components/ha-trace-picker.ts
@@ -43,7 +43,7 @@ class HaTracePicker extends LitElement {
         slot="field"
         appearance="filled"
         variant="neutral"
-        size="small"
+        size="s"
         @click=${this._openPicker}
       >
         ${this._renderTracePickerValue(this.value!)}

--- a/src/components/ha-vacuum-state.ts
+++ b/src/components/ha-vacuum-state.ts
@@ -58,7 +58,7 @@ export class HaVacuumState extends LitElement {
     return html`
       <ha-button
         appearance="plain"
-        size="small"
+        size="s"
         @click=${this._callService}
         .disabled=${!interceptable}
       >

--- a/src/components/input/ha-input-copy.ts
+++ b/src/components/input/ha-input-copy.ts
@@ -99,7 +99,7 @@ export class HaInputCopy extends LitElement {
               : nothing}
           </ha-input>
         </div>
-        <ha-button @click=${this._copy} appearance="plain" size="small">
+        <ha-button @click=${this._copy} appearance="plain" size="s">
           <ha-svg-icon slot="start" .path=${mdiContentCopy}></ha-svg-icon>
           ${this.label || this._i18n.localize("ui.common.copy")}
         </ha-button>

--- a/src/components/input/ha-input-multi.ts
+++ b/src/components/input/ha-input-multi.ts
@@ -130,7 +130,7 @@ class HaInputMulti extends LitElement {
       </ha-sortable>
       <div class="layout horizontal">
         <ha-button
-          size="small"
+          size="s"
           appearance="filled"
           @click=${this._addItem}
           .disabled=${this.disabled ||

--- a/src/components/media-player/ha-media-manage-button.ts
+++ b/src/components/media-player/ha-media-manage-button.ts
@@ -38,7 +38,7 @@ class MediaManageButton extends LitElement {
       return nothing;
     }
     return html`
-      <ha-button appearance="filled" size="small" @click=${this._manage}>
+      <ha-button appearance="filled" size="s" @click=${this._manage}>
         <ha-svg-icon .path=${mdiFolderEdit} slot="start"></ha-svg-icon>
         ${this.hass.localize(
           "ui.components.media-browser.file_management.manage"

--- a/src/dialogs/config-flow/previews/entity-preview-row.ts
+++ b/src/dialogs/config-flow/previews/entity-preview-row.ts
@@ -114,7 +114,7 @@ class EntityPreviewRow extends LitElement {
 
     if (domain === "button") {
       return html`
-        <ha-button appearance="plain" size="small" .disabled=${disabled}>
+        <ha-button appearance="plain" size="s" .disabled=${disabled}>
           ${this.hass.localize("ui.card.button.press")}
         </ha-button>
       `;
@@ -237,7 +237,7 @@ class EntityPreviewRow extends LitElement {
           .disabled=${disabled}
           class="text-content"
           appearance="plain"
-          size="small"
+          size="s"
         >
           ${stateObj.state === "locked"
             ? this.hass!.localize("ui.card.lock.unlock")

--- a/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-clean-areas.ts
+++ b/src/dialogs/more-info/components/vacuum/ha-more-info-view-vacuum-clean-areas.ts
@@ -214,7 +214,7 @@ export class HaMoreInfoViewVacuumCleanAreas extends LitElement {
               ? html`
                   <ha-button
                     appearance="plain"
-                    size="small"
+                    size="s"
                     @click=${this._openSegmentMapping}
                   >
                     <ha-svg-icon

--- a/src/dialogs/more-info/controls/more-info-automation.ts
+++ b/src/dialogs/more-info/controls/more-info-automation.ts
@@ -31,7 +31,7 @@ class MoreInfoAutomation extends LitElement {
       <div class="actions">
         <ha-button
           appearance="plain"
-          size="small"
+          size="s"
           @click=${this._runActions}
           .disabled=${this.stateObj!.state === UNAVAILABLE}
         >

--- a/src/dialogs/more-info/controls/more-info-counter.ts
+++ b/src/dialogs/more-info/controls/more-info-counter.ts
@@ -22,7 +22,7 @@ class MoreInfoCounter extends LitElement {
       <div class="actions">
         <ha-button
           appearance="plain"
-          size="small"
+          size="s"
           .action=${"increment"}
           @click=${this._handleActionClick}
           .disabled=${disabled ||
@@ -32,7 +32,7 @@ class MoreInfoCounter extends LitElement {
         </ha-button>
         <ha-button
           appearance="plain"
-          size="small"
+          size="s"
           .action=${"decrement"}
           @click=${this._handleActionClick}
           .disabled=${disabled ||
@@ -42,7 +42,7 @@ class MoreInfoCounter extends LitElement {
         </ha-button>
         <ha-button
           appearance="plain"
-          size="small"
+          size="s"
           .action=${"reset"}
           @click=${this._handleActionClick}
           .disabled=${disabled}

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -431,7 +431,7 @@ class MoreInfoMediaPlayer extends LitElement {
                   ? html`<ha-button
                       variant="brand"
                       appearance="filled"
-                      size="medium"
+                      size="m"
                       action=${action}
                       @click=${this._handleClick}
                       class="center-control"

--- a/src/dialogs/more-info/controls/more-info-person.ts
+++ b/src/dialogs/more-info/controls/more-info-person.ts
@@ -39,7 +39,7 @@ class MoreInfoPerson extends LitElement {
             <div class="actions">
               <ha-button
                 appearance="plain"
-                size="small"
+                size="s"
                 @click=${this._handleAction}
               >
                 ${this.hass.localize(

--- a/src/dialogs/more-info/controls/more-info-siren.ts
+++ b/src/dialogs/more-info/controls/more-info-siren.ts
@@ -52,7 +52,7 @@ class MoreInfoSiren extends LitElement {
         ${allowAdvanced
           ? html`<ha-button
               appearance="plain"
-              size="small"
+              size="s"
               @click=${this._showAdvancedControlsDialog}
             >
               ${this.hass.localize("ui.components.siren.advanced_controls")}

--- a/src/dialogs/more-info/controls/more-info-timer.ts
+++ b/src/dialogs/more-info/controls/more-info-timer.ts
@@ -21,7 +21,7 @@ class MoreInfoTimer extends LitElement {
           ? html`
               <ha-button
                 appearance="plain"
-                size="small"
+                size="s"
                 .action=${"start"}
                 @click=${this._handleActionClick}
               >
@@ -33,7 +33,7 @@ class MoreInfoTimer extends LitElement {
           ? html`
               <ha-button
                 appearance="plain"
-                size="small"
+                size="s"
                 .action=${"pause"}
                 @click=${this._handleActionClick}
               >
@@ -45,7 +45,7 @@ class MoreInfoTimer extends LitElement {
           ? html`
               <ha-button
                 appearance="plain"
-                size="small"
+                size="s"
                 .action=${"cancel"}
                 @click=${this._handleActionClick}
               >
@@ -53,7 +53,7 @@ class MoreInfoTimer extends LitElement {
               </ha-button>
               <ha-button
                 appearance="plain"
-                size="small"
+                size="s"
                 .action=${"finish"}
                 @click=${this._handleActionClick}
               >

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-local.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-local.ts
@@ -95,10 +95,7 @@ export class HaVoiceAssistantSetupStepLocal extends LitElement {
                   "ui.panel.config.voice_assistants.satellite_wizard.local.failed_secondary"
                 )}
               </p>
-              <ha-button
-                appearance="plain"
-                size="small"
-                @click=${this._prevStep}
+              <ha-button appearance="plain" size="s" @click=${this._prevStep}
                 >${this.hass.localize("ui.common.back")}</ha-button
               >
               <ha-button
@@ -108,7 +105,7 @@ export class HaVoiceAssistantSetupStepLocal extends LitElement {
                 )}
                 target="_blank"
                 rel="noreferrer noopener"
-                size="small"
+                size="s"
                 appearance="plain"
               >
                 <ha-svg-icon .path=${mdiOpenInNew} slot="start"></ha-svg-icon>
@@ -131,10 +128,7 @@ export class HaVoiceAssistantSetupStepLocal extends LitElement {
                     "ui.panel.config.voice_assistants.satellite_wizard.local.not_supported_secondary"
                   )}
                 </p>
-                <ha-button
-                  appearance="plain"
-                  size="small"
-                  @click=${this._prevStep}
+                <ha-button appearance="plain" size="s" @click=${this._prevStep}
                   >${this.hass.localize("ui.common.back")}</ha-button
                 >
                 <ha-button
@@ -145,7 +139,7 @@ export class HaVoiceAssistantSetupStepLocal extends LitElement {
                   target="_blank"
                   rel="noreferrer noopener"
                   appearance="plain"
-                  size="small"
+                  size="s"
                 >
                   <ha-svg-icon .path=${mdiOpenInNew} slot="start"></ha-svg-icon>
                   ${this.hass.localize(

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-success.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-success.ts
@@ -131,7 +131,7 @@ export class HaVoiceAssistantSetupStepSuccess extends LitElement {
                 ></ha-select>
                 <ha-button
                   appearance="plain"
-                  size="small"
+                  size="s"
                   @click=${this._testWakeWord}
                 >
                   <ha-svg-icon
@@ -166,7 +166,7 @@ export class HaVoiceAssistantSetupStepSuccess extends LitElement {
                 </ha-select>
                 <ha-button
                   appearance="plain"
-                  size="small"
+                  size="s"
                   @click=${this._openPipeline}
                 >
                   <ha-svg-icon slot="start" .path=${mdiCog}></ha-svg-icon>
@@ -186,11 +186,7 @@ export class HaVoiceAssistantSetupStepSuccess extends LitElement {
                   @value-changed=${this._voicePicked}
                   @closed=${stopPropagation}
                 ></ha-tts-voice-picker>
-                <ha-button
-                  appearance="plain"
-                  size="small"
-                  @click=${this._testTts}
-                >
+                <ha-button appearance="plain" size="s" @click=${this._testTts}>
                   <ha-svg-icon slot="start" .path=${mdiPlay}></ha-svg-icon>
                   ${this.hass.localize(
                     "ui.panel.config.voice_assistants.satellite_wizard.success.try_tts"

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-wake-word.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-wake-word.ts
@@ -150,7 +150,7 @@ export class HaVoiceAssistantSetupStepWakeWord extends LitElement {
         ? html`<div class="footer centered">
             <ha-button
               appearance="plain"
-              size="small"
+              size="s"
               @click=${this._changeWakeWord}
               >${this.hass.localize(
                 "ui.panel.config.voice_assistants.satellite_wizard.wake_word.change_wake_word"

--- a/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
@@ -117,7 +117,7 @@ export class HaVoiceCommandDialog extends LitElement {
                 slot="trigger"
                 appearance="plain"
                 variant="neutral"
-                size="small"
+                size="s"
                 .loading=${!this._pipelines}
               >
                 ${this._pipeline?.name}

--- a/src/layouts/ha-init-page.ts
+++ b/src/layouts/ha-init-page.ts
@@ -23,7 +23,7 @@ class HaInitPage extends LitElement {
           <p class="retry-text">
             Retrying in ${this._retryInSeconds} seconds...
           </p>
-          <ha-button size="small" appearance="plain" @click=${this._retry}
+          <ha-button size="s" appearance="plain" @click=${this._retry}
             >Retry now</ha-button
           >
           ${location.host.includes("ui.nabu.casa")

--- a/src/layouts/hass-error-screen.ts
+++ b/src/layouts/hass-error-screen.ts
@@ -41,7 +41,7 @@ class HassErrorScreen extends LitElement {
       <div class="content">
         <ha-alert alert-type="error">${this.error}</ha-alert>
         <slot>
-          <ha-button appearance="plain" size="small" @click=${this._handleBack}>
+          <ha-button appearance="plain" size="s" @click=${this._handleBack}>
             ${this.hass?.localize("ui.common.back")}
           </ha-button>
         </slot>

--- a/src/managers/notification-manager.ts
+++ b/src/managers/notification-manager.ts
@@ -97,7 +97,7 @@ class NotificationManager extends LitElement {
           ? html`
               <ha-button
                 appearance="plain"
-                size="small"
+                size="s"
                 slot="action"
                 @click=${this._buttonClicked}
               >

--- a/src/onboarding/restore-backup/onboarding-restore-backup-restore.ts
+++ b/src/onboarding/restore-backup/onboarding-restore-backup-restore.ts
@@ -132,7 +132,7 @@ class OnboardingRestoreBackupRestore extends LitElement {
               href="https://www.home-assistant.io/installation/#advanced-installation-methods"
               target="_blank"
               rel="noreferrer noopener"
-              size="small"
+              size="s"
             >
               ${this.localize(
                 "ui.panel.page-onboarding.restore.ha-cloud.learn_more"

--- a/src/panels/calendar/ha-full-calendar.ts
+++ b/src/panels/calendar/ha-full-calendar.ts
@@ -147,7 +147,7 @@ export class HAFullCalendar extends LitElement {
                     <div class="navigation">
                       <ha-button
                         appearance="filled"
-                        size="small"
+                        size="s"
                         class="today"
                         @click=${this._handleToday}
                         >${this.hass.localize(
@@ -171,7 +171,7 @@ export class HAFullCalendar extends LitElement {
                     <ha-button-toggle-group
                       .buttons=${viewToggleButtons}
                       .active=${this._activeView}
-                      size="small"
+                      size="s"
                       no-wrap
                       @value-changed=${this._handleView}
                     ></ha-button-toggle-group>
@@ -197,7 +197,7 @@ export class HAFullCalendar extends LitElement {
                     <div class="controls buttons">
                       <ha-button
                         appearance="plain"
-                        size="small"
+                        size="s"
                         class="today"
                         @click=${this._handleToday}
                         >${this.hass.localize(
@@ -207,7 +207,7 @@ export class HAFullCalendar extends LitElement {
                       <ha-button-toggle-group
                         .buttons=${viewToggleButtons}
                         .active=${this._activeView}
-                        size="small"
+                        size="s"
                         no-wrap
                         @value-changed=${this._handleView}
                       ></ha-button-toggle-group>
@@ -219,7 +219,7 @@ export class HAFullCalendar extends LitElement {
 
       <div id="calendar"></div>
       ${this.addFab && this._hasMutableCalendars
-        ? html`<ha-button size="large" slot="fab" @click=${this._createEvent}>
+        ? html`<ha-button size="l" slot="fab" @click=${this._createEvent}>
             <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
             ${this.hass.localize("ui.components.calendar.event.add")}
           </ha-button>`

--- a/src/panels/config/application_credentials/ha-config-application-credentials.ts
+++ b/src/panels/config/application_credentials/ha-config-application-credentials.ts
@@ -175,7 +175,7 @@ export class HaConfigApplicationCredentials extends LitElement {
             ? html`
                 <ha-button
                   appearance="plain"
-                  size="small"
+                  size="s"
                   @click=${this._deleteSelected}
                   variant="danger"
                   >${this.hass.localize(
@@ -199,11 +199,7 @@ export class HaConfigApplicationCredentials extends LitElement {
                 </ha-help-tooltip>
               `}
         </div>
-        <ha-button
-          slot="fab"
-          size="large"
-          @click=${this._addApplicationCredential}
-        >
+        <ha-button slot="fab" size="l" @click=${this._addApplicationCredential}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize(
             "ui.panel.config.application_credentials.picker.add_application_credential"

--- a/src/panels/config/apps/ha-config-apps-installed.ts
+++ b/src/panels/config/apps/ha-config-apps-installed.ts
@@ -156,7 +156,7 @@ export class HaConfigAppsInstalled extends LitElement {
               )}
         </div>
 
-        <ha-button size="large" href="/config/apps/available">
+        <ha-button size="l" href="/config/apps/available">
           <ha-svg-icon slot="start" .path=${mdiStorePlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.apps.installed.add_app")}
         </ha-button>
@@ -295,7 +295,7 @@ export class HaConfigAppsInstalled extends LitElement {
         cursor: pointer;
       }
 
-      ha-button[size="large"] {
+      ha-button[size="l"] {
         position: fixed;
         right: calc(var(--ha-space-4) + var(--safe-area-inset-right));
         bottom: calc(var(--ha-space-4) + var(--safe-area-inset-bottom));

--- a/src/panels/config/apps/ha-config-apps-registries.ts
+++ b/src/panels/config/apps/ha-config-apps-registries.ts
@@ -116,7 +116,7 @@ export class HaConfigAppsRegistries extends LitElement {
           id="registry"
           has-fab
         ></ha-data-table>
-        <ha-button size="large" @click=${this._showAddRegistryDialog}>
+        <ha-button size="l" @click=${this._showAddRegistryDialog}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.apps.registries.add")}
         </ha-button>
@@ -184,7 +184,7 @@ export class HaConfigAppsRegistries extends LitElement {
     ha-icon-button.delete {
       color: var(--error-color);
     }
-    ha-button[size="large"] {
+    ha-button[size="l"] {
       position: fixed;
       right: calc(var(--ha-space-4) + var(--safe-area-inset-right));
       bottom: calc(var(--ha-space-4) + var(--safe-area-inset-bottom));

--- a/src/panels/config/apps/ha-config-apps-repositories.ts
+++ b/src/panels/config/apps/ha-config-apps-repositories.ts
@@ -195,7 +195,7 @@ export class HaConfigAppsRepositories extends LitElement {
           id="slug"
           has-fab
         ></ha-data-table>
-        <ha-button size="large" @click=${this._showAddRepositoryDialog}>
+        <ha-button size="l" @click=${this._showAddRepositoryDialog}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.apps.repositories.add")}
         </ha-button>
@@ -292,7 +292,7 @@ export class HaConfigAppsRepositories extends LitElement {
     ha-icon-button.delete {
       color: var(--error-color);
     }
-    ha-button[size="large"] {
+    ha-button[size="l"] {
       position: fixed;
       right: calc(var(--ha-space-4) + var(--safe-area-inset-right));
       bottom: calc(var(--ha-space-4) + var(--safe-area-inset-bottom));

--- a/src/panels/config/areas/ha-config-areas-dashboard.ts
+++ b/src/panels/config/areas/ha-config-areas-dashboard.ts
@@ -318,7 +318,7 @@ export class HaConfigAreasDashboard extends LitElement {
             : nothing}
         </div>
         <ha-dropdown slot="fab" @wa-select=${this._handleCreateAction}>
-          <ha-button slot="trigger" id="fab" size="large">
+          <ha-button slot="trigger" id="fab" size="l">
             <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
             ${this.hass.localize("ui.common.add")}
           </ha-button>

--- a/src/panels/config/automation/action/ha-automation-action.ts
+++ b/src/panels/config/automation/action/ha-automation-action.ts
@@ -120,7 +120,7 @@ export default class HaAutomationAction extends AutomationSortableListMixin<Acti
               .disabled=${this.disabled}
               @click=${this._addActionDialog}
               .appearance=${this.root ? "accent" : "filled"}
-              .size=${this.root ? "medium" : "small"}
+              .size=${this.root ? "m" : "s"}
             >
               <ha-svg-icon .path=${mdiPlus} slot="start"></ha-svg-icon>
               ${this.hass.localize(

--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -728,7 +728,7 @@ class DialogAddAutomationElement
               active-variant="brand"
               .buttons=${tabButtons}
               .active=${this._tab}
-              size="small"
+              size="s"
               full-width
               @value-changed=${this._switchTab}
             ></ha-button-toggle-group>`

--- a/src/panels/config/automation/blueprint-automation-editor.ts
+++ b/src/panels/config/automation/blueprint-automation-editor.ts
@@ -35,7 +35,7 @@ export class HaBlueprintAutomationEditor extends HaBlueprintGenericEditor {
               )}
               <ha-button
                 appearance="plain"
-                size="small"
+                size="s"
                 slot="action"
                 @click=${this._enable}
               >
@@ -57,7 +57,7 @@ export class HaBlueprintAutomationEditor extends HaBlueprintGenericEditor {
 
       <ha-button
         slot="fab"
-        size="large"
+        size="l"
         class=${this.dirty ? "dirty" : ""}
         .disabled=${this.saving}
         @click=${this._saveAutomation}

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -294,7 +294,7 @@ export default class HaAutomationCondition extends AutomationSortableListMixin<C
               .disabled=${this.disabled}
               @click=${this._addConditionDialog}
               .appearance=${this.root ? "accent" : "filled"}
-              .size=${this.root ? "medium" : "small"}
+              .size=${this.root ? "m" : "s"}
             >
               <ha-svg-icon .path=${mdiPlus} slot="start"></ha-svg-icon>
               ${this.hass.localize(

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -237,7 +237,7 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
           ? html`
               <ha-button
                 appearance="plain"
-                size="small"
+                size="s"
                 @click=${this._showTrace}
                 slot="toolbar-icon"
               >
@@ -490,7 +490,7 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
                                     )}
                                     <ha-button
                                       appearance="filled"
-                                      size="small"
+                                      size="s"
                                       variant="warning"
                                       slot="action"
                                       @click=${this._duplicate}
@@ -508,7 +508,7 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
                                       "ui.panel.config.automation.editor.disabled"
                                     )}
                                     <ha-button
-                                      size="small"
+                                      size="s"
                                       slot="action"
                                       @click=${this._toggle}
                                     >
@@ -533,7 +533,7 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
                           )}
                           <ha-button
                             appearance="filled"
-                            size="small"
+                            size="s"
                             slot="action"
                             @click=${this._toggle}
                           >
@@ -553,7 +553,7 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
                   ></ha-yaml-editor>
                   <ha-button
                     slot="fab"
-                    size="large"
+                    size="l"
                     class=${this.dirty ? "dirty" : ""}
                     .disabled=${this.saving}
                     @click=${this._handleSaveAutomation}

--- a/src/panels/config/automation/ha-automation-note.ts
+++ b/src/panels/config/automation/ha-automation-note.ts
@@ -23,11 +23,7 @@ export class HaAutomationNote extends LitElement {
               "ui.panel.config.automation.editor.note.label"
             )}
           </span>
-          <ha-button
-            @click=${this._handleClick}
-            size="small"
-            appearance="plain"
-          >
+          <ha-button @click=${this._handleClick} size="s" appearance="plain">
             ${this._i18n.localize("ui.common.edit")}
           </ha-button>
         </div>

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -695,14 +695,14 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
                 target="_blank"
                 appearance="plain"
                 rel="noreferrer"
-                size="small"
+                size="s"
               >
                 ${this.hass.localize("ui.panel.config.common.learn_more")}
                 <ha-svg-icon slot="end" .path=${mdiOpenInNew}> </ha-svg-icon>
               </ha-button>
             </div>`
           : nothing}
-        <ha-button slot="fab" size="large" @click=${this._createNew}>
+        <ha-button slot="fab" size="l" @click=${this._createNew}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize(
             "ui.panel.config.automation.picker.add_automation"

--- a/src/panels/config/automation/ha-automation-trace.ts
+++ b/src/panels/config/automation/ha-automation-trace.ts
@@ -110,7 +110,7 @@ export class HaAutomationTrace extends LitElement {
           ? html`
               <ha-button
                 appearance="plain"
-                size="small"
+                size="s"
                 class="trace-link"
                 @click=${this._navigateToAutomation}
                 slot="toolbar-icon"

--- a/src/panels/config/automation/ha-manual-editor-mixin.ts
+++ b/src/panels/config/automation/ha-manual-editor-mixin.ts
@@ -114,7 +114,7 @@ export const ManualEditorMixin = <TConfig>(
             <div class="fab-positioner">
               <ha-button
                 slot="fab"
-                size="large"
+                size="l"
                 class=${this.dirty ? "dirty" : ""}
                 .disabled=${this.saving}
                 @click=${this.saveConfig}

--- a/src/panels/config/automation/option/ha-automation-option.ts
+++ b/src/panels/config/automation/option/ha-automation-option.ts
@@ -92,7 +92,7 @@ export default class HaAutomationOption extends AutomationSortableListMixin<Opti
           <div class="buttons">
             <ha-button
               appearance="filled"
-              size="small"
+              size="s"
               .disabled=${this.disabled}
               @click=${this._addOption}
             >
@@ -104,7 +104,7 @@ export default class HaAutomationOption extends AutomationSortableListMixin<Opti
             ${!this.showDefaultActions
               ? html`<ha-button
                   appearance="plain"
-                  size="small"
+                  size="s"
                   .disabled=${this.disabled}
                   @click=${this._showDefaultActions}
                 >

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -179,7 +179,7 @@ export default class HaAutomationTrigger extends AutomationSortableListMixin<Tri
               .disabled=${this.disabled}
               @click=${this._addTriggerDialog}
               .appearance=${this.root ? "accent" : "filled"}
-              .size=${this.root ? "medium" : "small"}
+              .size=${this.root ? "m" : "s"}
             >
               ${this.hass.localize(
                 "ui.panel.config.automation.editor.triggers.add"

--- a/src/panels/config/backup/components/config/ha-backup-config-encryption-key.ts
+++ b/src/panels/config/backup/components/config/ha-backup-config-encryption-key.ts
@@ -40,7 +40,7 @@ class HaBackupConfigEncryptionKey extends LitElement {
               appearance="plain"
               slot="end"
               @click=${this._download}
-              size="small"
+              size="s"
             >
               <ha-svg-icon .path=${mdiDownload} slot="start"></ha-svg-icon>
               ${this.hass.localize(
@@ -63,7 +63,7 @@ class HaBackupConfigEncryptionKey extends LitElement {
               appearance="plain"
               slot="end"
               @click=${this._show}
-              size="small"
+              size="s"
             >
               ${this.hass.localize(
                 "ui.panel.config.backup.encryption_key.show_encryption_key_action"
@@ -84,7 +84,7 @@ class HaBackupConfigEncryptionKey extends LitElement {
             <ha-button
               appearance="plain"
               variant="danger"
-              size="small"
+              size="s"
               slot="end"
               @click=${this._change}
             >
@@ -156,7 +156,7 @@ class HaBackupConfigEncryptionKey extends LitElement {
     ha-list-item-base::part(supporting-text) {
       white-space: wrap;
     }
-    ha-button[size="small"] ha-svg-icon {
+    ha-button[size="s"] ha-svg-icon {
       --mdc-icon-size: 16px;
     }
   `;

--- a/src/panels/config/backup/dialogs/dialog-backup-onboarding.ts
+++ b/src/panels/config/backup/dialogs/dialog-backup-onboarding.ts
@@ -379,7 +379,7 @@ class DialogBackupOnboarding extends LitElement implements HassDialog {
               )}
             </span>
             <ha-button
-              size="small"
+              size="s"
               appearance="plain"
               slot="end"
               @click=${this._downloadKey}

--- a/src/panels/config/backup/dialogs/dialog-set-backup-encryption-key.ts
+++ b/src/panels/config/backup/dialogs/dialog-set-backup-encryption-key.ts
@@ -146,7 +146,7 @@ class DialogSetBackupEncryptionKey extends LitElement implements HassDialog {
               )}
             </span>
             <ha-button
-              size="small"
+              size="s"
               appearance="plain"
               slot="end"
               @click=${this._download}

--- a/src/panels/config/backup/ha-config-backup-backups.ts
+++ b/src/panels/config/backup/ha-config-backup-backups.ts
@@ -533,7 +533,7 @@ class HaConfigBackupBackups extends SubscribeMixin(LitElement) {
           ? html`
               <ha-button
                 slot="fab"
-                size="large"
+                size="l"
                 ?disabled=${backupInProgress}
                 @click=${this._newBackup}
               >

--- a/src/panels/config/backup/ha-config-backup-location.ts
+++ b/src/panels/config/backup/ha-config-backup-location.ts
@@ -161,7 +161,7 @@ class HaConfigBackupDetails extends LitElement {
                                 slot="end"
                                 rel="noreferrer noopener"
                                 appearance="plain"
-                                size="small"
+                                size="s"
                               >
                                 ${this.hass.localize(
                                   "ui.panel.config.backup.location.encryption.location_encrypted_cloud_learn_more"

--- a/src/panels/config/backup/ha-config-backup-overview.ts
+++ b/src/panels/config/backup/ha-config-backup-overview.ts
@@ -323,7 +323,7 @@ class HaConfigBackupOverview extends LitElement {
 
         <ha-button
           slot="fab"
-          size="large"
+          size="l"
           .loading=${backupInProgress}
           @click=${this._newBackup}
         >

--- a/src/panels/config/backup/ha-config-backup-settings.ts
+++ b/src/panels/config/backup/ha-config-backup-settings.ts
@@ -289,7 +289,7 @@ class HaConfigBackupSettings extends LitElement {
               : nothing}
             <div class="card-actions">
               <ha-button
-                size="small"
+                size="s"
                 href=${documentationUrl(this.hass, "/integrations/#backup")}
                 target="_blank"
                 rel="noreferrer"
@@ -302,7 +302,7 @@ class HaConfigBackupSettings extends LitElement {
               </ha-button>
               ${supervisor
                 ? html`<ha-button
-                    size="small"
+                    size="s"
                     appearance="plain"
                     href="/config/storage"
                   >
@@ -478,7 +478,7 @@ class HaConfigBackupSettings extends LitElement {
       justify-content: space-between;
     }
 
-    ha-button[size="small"] ha-svg-icon {
+    ha-button[size="s"] ha-svg-icon {
       --mdc-icon-size: 16px;
     }
   `;

--- a/src/panels/config/blueprint/dialog-import-blueprint.ts
+++ b/src/panels/config/blueprint/dialog-import-blueprint.ts
@@ -174,7 +174,7 @@ class DialogImportBlueprint extends LitElement {
                   )}
                 </p>
                 <ha-button
-                  size="small"
+                  size="s"
                   appearance="plain"
                   href=${documentationUrl(this.hass, "/get-blueprints")}
                   target="_blank"

--- a/src/panels/config/blueprint/ha-blueprint-overview.ts
+++ b/src/panels/config/blueprint/ha-blueprint-overview.ts
@@ -349,7 +349,7 @@ class HaBlueprintOverview extends LitElement {
             href=${documentationUrl(this.hass, "/get-blueprints")}
             target="_blank"
             rel="noreferrer noopener"
-            size="small"
+            size="s"
           >
             ${this.hass.localize(
               "ui.panel.config.blueprint.overview.discover_more"
@@ -375,7 +375,7 @@ class HaBlueprintOverview extends LitElement {
           .path=${mdiHelpCircleOutline}
           @click=${this._showHelp}
         ></ha-icon-button>
-        <ha-button slot="fab" size="large" @click=${this._addBlueprintClicked}>
+        <ha-button slot="fab" size="l" @click=${this._addBlueprintClicked}>
           <ha-svg-icon slot="start" .path=${mdiDownload}></ha-svg-icon>
           ${this.hass.localize(
             "ui.panel.config.blueprint.overview.add_blueprint"

--- a/src/panels/config/cloud/account/cloud-remote-pref.ts
+++ b/src/panels/config/cloud/account/cloud-remote-pref.ts
@@ -187,7 +187,7 @@ export class CloudRemotePref extends LitElement {
               <ha-button
                 slot="end"
                 appearance="plain"
-                size="small"
+                size="s"
                 @click=${this._openCertInfo}
               >
                 ${this.hass.localize(

--- a/src/panels/config/cloud/account/cloud-webhooks.ts
+++ b/src/panels/config/cloud/account/cloud-webhooks.ts
@@ -95,7 +95,7 @@ export class CloudWebhooks extends LitElement {
                               <ha-button
                                 slot="end"
                                 appearance="plain"
-                                size="small"
+                                size="s"
                                 @click=${this._handleManageButton}
                               >
                                 ${this.hass!.localize(

--- a/src/panels/config/core/ha-config-analytics.ts
+++ b/src/panels/config/core/ha-config-analytics.ts
@@ -123,7 +123,7 @@ class ConfigAnalytics extends SubscribeMixin(LitElement) {
             </div>
             <div class="card-actions">
               <ha-button
-                size="small"
+                size="s"
                 appearance="plain"
                 @click=${this._downloadDeviceInfo}
               >

--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -217,7 +217,7 @@ class HaConfigSectionUpdates extends LitElement {
                       ? html`
                           <ha-button
                             appearance="plain"
-                            size="small"
+                            size="s"
                             .group=${group}
                             .disabled=${group.entities.every((entity) =>
                               updateIsInstalling(entity)

--- a/src/panels/config/developer-tools/action/developer-tools-action.ts
+++ b/src/panels/config/developer-tools/action/developer-tools-action.ts
@@ -167,7 +167,7 @@ class HaPanelDevAction extends MatchMinHeightMixin(LitElement) {
                 )}
               </div>
               <ha-button-toggle-group
-                size="small"
+                size="s"
                 class="yaml-mode-toggle"
                 .buttons=${modeButtons}
                 .active=${this._yamlMode ? "yaml" : "ui"}

--- a/src/panels/config/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/config/developer-tools/statistics/developer-tools-statistics.ts
@@ -274,7 +274,7 @@ class HaPanelDevStatistics extends KeyboardShortcutMixin(LitElement) {
                 @click=${this._fixIssue}
                 .data=${statistic.issues}
                 appearance="plain"
-                size="small"
+                size="s"
               >
                 ${localize(
                   statistic.issues.some((issue) =>

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -519,7 +519,7 @@ export class HaConfigDevicePage extends LitElement {
               <div class="card-actions" slot="actions">
                 <ha-button
                   variant="warning"
-                  size="small"
+                  size="s"
                   @click=${this._enableDevice}
                 >
                   ${this.hass.localize("ui.common.enable")}

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -811,7 +811,7 @@ export class HaConfigDeviceDashboard extends LitElement {
           .hass=${this.hass}
           slot="toolbar-icon"
         ></ha-integration-overflow-menu>
-        <ha-button slot="fab" size="large" @click=${this._addDevice}>
+        <ha-button slot="fab" size="l" @click=${this._addDevice}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.devices.add_device")}
         </ha-button>

--- a/src/panels/config/energy/components/ha-energy-battery-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-battery-settings.ts
@@ -140,11 +140,7 @@ export class EnergyBatterySettings extends LitElement {
               `
             : ""}
           <div class="row">
-            <ha-button
-              @click=${this._addSource}
-              appearance="filled"
-              size="small"
-            >
+            <ha-button @click=${this._addSource} appearance="filled" size="s">
               <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
               ${this.hass.localize(
                 "ui.panel.config.energy.battery.add_battery_system"

--- a/src/panels/config/energy/components/ha-energy-device-settings-water.ts
+++ b/src/panels/config/energy/components/ha-energy-device-settings-water.ts
@@ -137,11 +137,7 @@ export class EnergyDeviceSettingsWater extends LitElement {
               `
             : ""}
           <div class="row">
-            <ha-button
-              @click=${this._addDevice}
-              appearance="filled"
-              size="small"
-            >
+            <ha-button @click=${this._addDevice} appearance="filled" size="s">
               <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon
               >${this.hass.localize(
                 "ui.panel.config.energy.device_consumption_water.add_device"

--- a/src/panels/config/energy/components/ha-energy-device-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-device-settings.ts
@@ -135,11 +135,7 @@ export class EnergyDeviceSettings extends LitElement {
               `
             : ""}
           <div class="row">
-            <ha-button
-              @click=${this._addDevice}
-              appearance="filled"
-              size="small"
-            >
+            <ha-button @click=${this._addDevice} appearance="filled" size="s">
               <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon
               >${this.hass.localize(
                 "ui.panel.config.energy.device_consumption.add_device"

--- a/src/panels/config/energy/components/ha-energy-gas-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-gas-settings.ts
@@ -124,11 +124,7 @@ export class EnergyGasSettings extends LitElement {
               `
             : ""}
           <div class="row">
-            <ha-button
-              @click=${this._addSource}
-              appearance="filled"
-              size="small"
-            >
+            <ha-button @click=${this._addSource} appearance="filled" size="s">
               <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon
               >${this.hass.localize(
                 "ui.panel.config.energy.gas.add_gas_source"

--- a/src/panels/config/energy/components/ha-energy-grid-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-grid-settings.ts
@@ -164,11 +164,7 @@ export class EnergyGridSettings extends LitElement {
               `
             : nothing}
           <div class="row">
-            <ha-button
-              @click=${this._addSource}
-              appearance="filled"
-              size="small"
-            >
+            <ha-button @click=${this._addSource} appearance="filled" size="s">
               <ha-svg-icon .path=${mdiPlus} slot="start"></ha-svg-icon>
               ${this.hass.localize(
                 "ui.panel.config.energy.grid.add_connection"
@@ -219,7 +215,7 @@ export class EnergyGridSettings extends LitElement {
                   <ha-button
                     @click=${this._addCO2Sensor}
                     appearance="filled"
-                    size="small"
+                    size="s"
                   >
                     <ha-svg-icon .path=${mdiPlus} slot="start"></ha-svg-icon>
                     ${this.hass.localize(

--- a/src/panels/config/energy/components/ha-energy-solar-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-solar-settings.ts
@@ -138,7 +138,7 @@ export class EnergySolarSettings extends LitElement {
                   <ha-button
                     @click=${this._addSource}
                     appearance="filled"
-                    size="small"
+                    size="s"
                   >
                     <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
                     ${this.hass.localize(

--- a/src/panels/config/energy/components/ha-energy-water-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-water-settings.ts
@@ -123,11 +123,7 @@ export class EnergyWaterSettings extends LitElement {
               `
             : ""}
           <div class="row">
-            <ha-button
-              @click=${this._addSource}
-              appearance="filled"
-              size="small"
-            >
+            <ha-button @click=${this._addSource} appearance="filled" size="s">
               <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon
               >${this.hass.localize(
                 "ui.panel.config.energy.water.add_water_source"

--- a/src/panels/config/energy/dialogs/dialog-energy-solar-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-solar-settings.ts
@@ -227,7 +227,7 @@ export class DialogEnergySolarSettings
               )}
               <ha-button
                 appearance="filled"
-                size="small"
+                size="s"
                 @click=${this._addForecast}
               >
                 <ha-svg-icon .path=${mdiPlus} slot="start"></ha-svg-icon>

--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -92,7 +92,7 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
                 ? html`${this.hass!.localize(
                       "ui.dialogs.entity_registry.editor.device_disabled"
                     )}<ha-button
-                      size="small"
+                      size="s"
                       variant="warning"
                       @click=${this._openDeviceSettings}
                       slot="action"
@@ -108,7 +108,7 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
                       this.entry.disabled_by!
                     )
                       ? html`<ha-button
-                          size="small"
+                          size="s"
                           variant="warning"
                           slot="action"
                           @click=${this._enableEntry}

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -1054,7 +1054,7 @@ export class HaConfigEntities extends LitElement {
           @expanded-changed=${this._filterExpanded}
         ></ha-filter-voice-assistants>
         ${includeAddDeviceFab
-          ? html`<ha-button size="large" @click=${this._addDevice} slot="fab">
+          ? html`<ha-button size="l" @click=${this._addDevice} slot="fab">
               <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
               ${this.hass.localize("ui.panel.config.devices.add_device")}
             </ha-button>`

--- a/src/panels/config/helpers/forms/ha-input_select-form.ts
+++ b/src/panels/config/helpers/forms/ha-input_select-form.ts
@@ -150,7 +150,7 @@ class HaInputSelectForm extends LitElement {
             .disabled=${this.disabled}
           ></ha-input>
           <ha-button
-            size="small"
+            size="s"
             appearance="filled"
             @click=${this._addOption}
             .disabled=${this.disabled}

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -802,7 +802,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
           .hass=${this.hass}
           slot="toolbar-icon"
         ></ha-integration-overflow-menu>
-        <ha-button slot="fab" size="large" @click=${this._createHelper}>
+        <ha-button slot="fab" size="l" @click=${this._createHelper}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.helpers.picker.create_helper")}
         </ha-button>

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -670,7 +670,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                     "ui.panel.config.integrations.config_entry.debug_logging_enabled"
                   )}
                   <ha-button
-                    size="small"
+                    size="s"
                     variant="warning"
                     slot="action"
                     @click=${this._handleDisableDebugLogging}
@@ -696,7 +696,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                           <ha-button
                             slot="end"
                             variant="success"
-                            size="small"
+                            size="s"
                             .flow=${flow}
                             @click=${this._continueFlow}
                           >

--- a/src/panels/config/integrations/ha-config-integrations-dashboard.ts
+++ b/src/panels/config/integrations/ha-config-integrations-dashboard.ts
@@ -557,7 +557,7 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
                         )}
                         <ha-button
                           appearance="plain"
-                          size="small"
+                          size="s"
                           @click=${this._toggleShowDisabled}
                         >
                           ${this.hass.localize(
@@ -677,7 +677,7 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
                     <ha-button
                       @click=${this._createFlow}
                       appearance="filled"
-                      size="small"
+                      size="s"
                     >
                       <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
                       ${this.hass.localize(
@@ -709,7 +709,7 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
                         <ha-button
                           @click=${this._createFlow}
                           appearance="filled"
-                          size="small"
+                          size="s"
                         >
                           <ha-svg-icon
                             slot="start"
@@ -723,7 +723,7 @@ class HaConfigIntegrationsDashboard extends KeyboardShortcutMixin(
                     `
                   : ""}
         </div>
-        <ha-button slot="fab" size="large" @click=${this._createFlow}>
+        <ha-button slot="fab" size="l" @click=${this._createFlow}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.integrations.add_integration")}
         </ha-button>

--- a/src/panels/config/integrations/integration-panels/matter/matter-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/matter/matter-config-dashboard.ts
@@ -91,7 +91,7 @@ export class MatterConfigDashboard extends LitElement {
           ${this._renderNavigationCard()}
         </div>
 
-        <ha-button slot="fab" href="/config/matter/add" size="large">
+        <ha-button slot="fab" href="/config/matter/add" size="l">
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.matter.panel.add_device")}
         </ha-button>

--- a/src/panels/config/integrations/integration-panels/matter/matter-options-page.ts
+++ b/src/panels/config/integrations/integration-panels/matter/matter-options-page.ts
@@ -69,7 +69,7 @@ class MatterOptionsPage extends LitElement {
                     <ha-button
                       appearance="plain"
                       slot="end"
-                      size="small"
+                      size="s"
                       @click=${this._startMobileCommissioning}
                     >
                       ${this.hass.localize(
@@ -92,7 +92,7 @@ class MatterOptionsPage extends LitElement {
                 <ha-button
                   appearance="plain"
                   slot="end"
-                  size="small"
+                  size="s"
                   @click=${this._commission}
                 >
                   ${this.hass.localize(
@@ -114,7 +114,7 @@ class MatterOptionsPage extends LitElement {
                 <ha-button
                   appearance="plain"
                   slot="end"
-                  size="small"
+                  size="s"
                   @click=${this._acceptSharedDevice}
                 >
                   ${this.hass.localize(
@@ -136,7 +136,7 @@ class MatterOptionsPage extends LitElement {
                 <ha-button
                   appearance="plain"
                   slot="end"
-                  size="small"
+                  size="s"
                   @click=${this._setWifi}
                 >
                   ${this.hass.localize(
@@ -158,7 +158,7 @@ class MatterOptionsPage extends LitElement {
                 <ha-button
                   appearance="plain"
                   slot="end"
-                  size="small"
+                  size="s"
                   @click=${this._setThread}
                 >
                   ${this.hass.localize(

--- a/src/panels/config/integrations/integration-panels/mqtt/mqtt-subscribe-card.ts
+++ b/src/panels/config/integrations/integration-panels/mqtt/mqtt-subscribe-card.ts
@@ -101,7 +101,7 @@ class MqttSubscribeCard extends LitElement {
             </ha-select>
             <ha-button
               appearance="plain"
-              size="small"
+              size="s"
               .disabled=${this._topic === ""}
               @click=${this._handleSubmit}
             >

--- a/src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts
@@ -125,7 +125,7 @@ export class ThreadConfigPanel extends SubscribeMixin(LitElement) {
                   <ha-svg-icon .path=${mdiDevices}></ha-svg-icon>
                   <ha-button
                     appearance="plain"
-                    size="small"
+                    size="s"
                     href=${documentationUrl(this.hass, `/integrations/thread`)}
                     target="_blank"
                   >
@@ -157,7 +157,7 @@ export class ThreadConfigPanel extends SubscribeMixin(LitElement) {
                   </div>
                   <div class="card-actions">
                     <ha-button
-                      size="small"
+                      size="s"
                       @click=${this._importExternalThreadCredentials}
                     >
                       ${this.hass.localize(
@@ -322,7 +322,7 @@ export class ThreadConfigPanel extends SubscribeMixin(LitElement) {
                   )}
                   <ha-button
                     appearance="plain"
-                    size="small"
+                    size="s"
                     .otbr=${otbrForNetwork}
                     @click=${this._resetBorderRouterEvent}
                     >${this.hass.localize(
@@ -334,7 +334,7 @@ export class ThreadConfigPanel extends SubscribeMixin(LitElement) {
       ${network.dataset && !network.dataset.preferred
         ? html`<div class="card-actions">
             <ha-button
-              size="small"
+              size="s"
               .datasetId=${network.dataset.dataset_id}
               @click=${this._setPreferred}
               >${this.hass.localize(
@@ -353,7 +353,7 @@ export class ThreadConfigPanel extends SubscribeMixin(LitElement) {
               )}
             </p>
             <ha-button
-              size="small"
+              size="s"
               .networkDataset=${network.dataset}
               @click=${this._sendCredentials}
               >${this.hass.localize(

--- a/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
@@ -80,7 +80,7 @@ class ZHAAddDevicesPage extends LitElement {
       >
         <ha-button
           appearance="plain"
-          size="small"
+          size="s"
           slot="toolbar-icon"
           @click=${this._toggleLogs}
           >${this._showLogs ? "Hide logs" : "Show logs"}</ha-button

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -105,7 +105,7 @@ class ZHAConfigDashboard extends LitElement {
         </div>
 
         <a href="/config/zha/add" slot="fab">
-          <ha-button size="large">
+          <ha-button size="l">
             <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
             ${this.hass.localize("ui.panel.config.zha.add_device")}
           </ha-button>
@@ -319,7 +319,7 @@ class ZHAConfigDashboard extends LitElement {
               <ha-button
                 appearance="plain"
                 slot="end"
-                size="small"
+                size="s"
                 @click=${this._createAndDownloadBackup}
               >
                 <ha-svg-icon .path=${mdiDownload} slot="start"></ha-svg-icon>
@@ -342,7 +342,7 @@ class ZHAConfigDashboard extends LitElement {
               <ha-button
                 appearance="plain"
                 slot="end"
-                size="small"
+                size="s"
                 @click=${this._openOptionFlow}
               >
                 ${this.hass.localize(
@@ -472,7 +472,7 @@ class ZHAConfigDashboard extends LitElement {
           --md-item-overflow: visible;
         }
 
-        ha-button[size="small"] ha-svg-icon {
+        ha-button[size="s"] ha-svg-icon {
           --mdc-icon-size: 16px;
         }
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-groups-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-groups-dashboard.ts
@@ -119,7 +119,7 @@ export class ZHAGroupsDashboard extends LitElement {
         clickable
         has-fab
       >
-        <ha-button href="/config/zha/group-add" slot="fab" size="large">
+        <ha-button href="/config/zha/group-add" slot="fab" size="l">
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass!.localize("ui.panel.config.zha.groups.add_group")}
         </ha-button>

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-rebuild-network-routes/dialog-zwave_js-rebuild-network-routes.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-rebuild-network-routes/dialog-zwave_js-rebuild-network-routes.ts
@@ -145,7 +145,7 @@ class DialogZWaveJSRebuildNetworkRoutes extends DialogMixin<ZWaveJSRebuildNetwor
                           @click=${this._showProgressDetail}
                           appearance="outlined"
                           variant="warning"
-                          size="small"
+                          size="s"
                           .title=${this._i18n.localize(
                             "ui.panel.config.zwave_js.rebuild_network_routes.progress.in_progress",
                             { count: this._progress.pending.length }
@@ -162,7 +162,7 @@ class DialogZWaveJSRebuildNetworkRoutes extends DialogMixin<ZWaveJSRebuildNetwor
                           @click=${this._showProgressDetail}
                           appearance="outlined"
                           variant="success"
-                          size="small"
+                          size="s"
                           .title=${this._i18n.localize(
                             "ui.panel.config.zwave_js.rebuild_network_routes.progress.completed",
                             { count: this._progress.done.length }
@@ -181,7 +181,7 @@ class DialogZWaveJSRebuildNetworkRoutes extends DialogMixin<ZWaveJSRebuildNetwor
                               @click=${this._showProgressDetail}
                               appearance="outlined"
                               variant="danger"
-                              size="small"
+                              size="s"
                               .title=${this._i18n.localize(
                                 "ui.panel.config.zwave_js.rebuild_network_routes.progress.failed",
                                 { count: this._progress.failed.length }
@@ -200,7 +200,7 @@ class DialogZWaveJSRebuildNetworkRoutes extends DialogMixin<ZWaveJSRebuildNetwor
                               @click=${this._showProgressDetail}
                               appearance="outlined"
                               variant="neutral"
-                              size="small"
+                              size="s"
                               .title=${this._i18n.localize(
                                 "ui.panel.config.zwave_js.rebuild_network_routes.progress.skipped",
                                 { count: this._progress.skipped.length }

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -170,7 +170,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
         </div>
         <ha-button
           slot="fab"
-          size="large"
+          size="l"
           @click=${this._addNodeClicked}
           .disabled=${this._status !== "connected" ||
           (this._network?.controller.inclusion_state !== InclusionState.Idle &&
@@ -482,7 +482,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                     <ha-button
                       appearance="plain"
                       slot="end"
-                      size="small"
+                      size="s"
                       @click=${this._downloadBackup}
                     >
                       <ha-svg-icon
@@ -508,7 +508,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                     <ha-button
                       appearance="plain"
                       slot="end"
-                      size="small"
+                      size="s"
                       @click=${this._restoreButtonClick}
                     >
                       ${this.hass.localize(
@@ -537,7 +537,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                     <ha-button
                       appearance="plain"
                       slot="end"
-                      size="small"
+                      size="s"
                       @click=${this._openConfigFlow}
                     >
                       ${this.hass.localize(
@@ -978,7 +978,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
           gap: var(--ha-space-4);
         }
 
-        ha-button[size="small"] ha-svg-icon {
+        ha-button[size="s"] ha-svg-icon {
           --mdc-icon-size: 16px;
         }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-options-page.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-options-page.ts
@@ -74,7 +74,7 @@ class ZWaveJSOptionsPage extends LitElement {
                     <ha-button
                       appearance="plain"
                       slot="end"
-                      size="small"
+                      size="s"
                       @click=${this._rebuildNetworkRoutesClicked}
                       .disabled=${this._status === "disconnected"}
                     >
@@ -97,7 +97,7 @@ class ZWaveJSOptionsPage extends LitElement {
                     <ha-button
                       appearance="plain"
                       slot="end"
-                      size="small"
+                      size="s"
                       @click=${this._removeNodeClicked}
                       .disabled=${this._status !== "connected" ||
                       (this._network?.controller.inclusion_state !==

--- a/src/panels/config/labels/ha-config-labels.ts
+++ b/src/panels/config/labels/ha-config-labels.ts
@@ -275,7 +275,7 @@ export class HaConfigLabels extends LitElement {
           .label=${this.hass.localize("ui.common.help")}
           .path=${mdiHelpCircleOutline}
         ></ha-icon-button>
-        <ha-button slot="fab" size="large" @click=${this._addLabel}>
+        <ha-button slot="fab" size="l" @click=${this._addLabel}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.labels.add_label")}
         </ha-button>

--- a/src/panels/config/logs/error-log-card.ts
+++ b/src/panels/config/logs/error-log-card.ts
@@ -274,7 +274,7 @@ class ErrorLogCard extends LitElement {
                   !this._scrolledToBottomController.value) ||
                 false,
             })}"
-            size="small"
+            size="s"
             appearance="filled"
             @click=${this._scrollToBottom}
           >

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -440,7 +440,7 @@ export class HaConfigLovelaceDashboards extends LitElement {
             </ha-dropdown-item>
           </a>
         </ha-dropdown>
-        <ha-button slot="fab" size="large" @click=${this._addDashboard}>
+        <ha-button slot="fab" size="l" @click=${this._addDashboard}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize(
             "ui.panel.config.lovelace.dashboards.picker.add_dashboard"

--- a/src/panels/config/lovelace/resources/ha-config-lovelace-resources.ts
+++ b/src/panels/config/lovelace/resources/ha-config-lovelace-resources.ts
@@ -202,7 +202,7 @@ export class HaConfigLovelaceResources extends LitElement {
               ></ha-icon-button>
             `
           : ""}
-        <ha-button slot="fab" size="large" @click=${this._addResource}>
+        <ha-button slot="fab" size="l" @click=${this._addResource}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize(
             "ui.panel.config.lovelace.resources.picker.add_resource"

--- a/src/panels/config/network/ha-config-url-form.ts
+++ b/src/panels/config/network/ha-config-url-form.ts
@@ -170,7 +170,7 @@ class ConfigUrlForm extends SubscribeMixin(LitElement) {
                     "ui.panel.config.url.external_get_ha_cloud"
                   )}
                   <ha-button
-                    size="small"
+                    size="s"
                     href="/config/cloud/register"
                     slot="action"
                   >
@@ -201,7 +201,7 @@ class ConfigUrlForm extends SubscribeMixin(LitElement) {
                           "ui.panel.config.url.ha_cloud_remote_not_enabled"
                         )}
                         <ha-button
-                          size="small"
+                          size="s"
                           appearance="plain"
                           href="/config/cloud"
                           slot="action"

--- a/src/panels/config/network/supervisor-network.ts
+++ b/src/panels/config/network/supervisor-network.ts
@@ -400,7 +400,7 @@ export class HassioNetwork extends LitElement {
                       .version=${version}
                       class="add-address"
                       appearance="filled"
-                      size="small"
+                      size="s"
                     >
                       ${this.hass.localize(
                         "ui.panel.config.network.supervisor.add_address"
@@ -458,7 +458,7 @@ export class HassioNetwork extends LitElement {
                 @wa-select=${this._handleDropdownSelect}
                 class="add-nameserver"
               >
-                <ha-button appearance="filled" size="small" slot="trigger">
+                <ha-button appearance="filled" size="s" slot="trigger">
                   ${this.hass.localize(
                     "ui.panel.config.network.supervisor.add_dns_server"
                   )}

--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -116,7 +116,7 @@ export class HaConfigPerson extends LitElement {
                     <ha-button
                       @click=${this._createPerson}
                       appearance="filled"
-                      size="small"
+                      size="s"
                     >
                       <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
                       ${hass.localize(
@@ -147,7 +147,7 @@ export class HaConfigPerson extends LitElement {
               `
             : nothing}
         </ha-config-section>
-        <ha-button slot="fab" size="large" @click=${this._createPerson}>
+        <ha-button slot="fab" size="l" @click=${this._createPerson}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${hass.localize("ui.panel.config.person.add_person")}
         </ha-button>

--- a/src/panels/config/repairs/dialog-system-information.ts
+++ b/src/panels/config/repairs/dialog-system-information.ts
@@ -151,7 +151,7 @@ class DialogSystemInformation extends LitElement {
                     ${this.hass.localize("ui.dialogs.unhealthy.title")}
                     <ha-button
                       appearance="plain"
-                      size="small"
+                      size="s"
                       variant="danger"
                       slot="action"
                       @click=${this._unhealthyDialog}
@@ -165,7 +165,7 @@ class DialogSystemInformation extends LitElement {
                     ${this.hass.localize("ui.dialogs.unsupported.title")}
                     <ha-button
                       appearance="plain"
-                      size="small"
+                      size="s"
                       variant="warning"
                       slot="action"
                       @click=${this._unsupportedDialog}
@@ -368,7 +368,7 @@ class DialogSystemInformation extends LitElement {
                 : html`
                     <ha-button
                       appearance="plain"
-                      size="small"
+                      size="s"
                       class="manage"
                       href=${domainInfo.manage_url}
                     >

--- a/src/panels/config/scene/ha-scene-dashboard.ts
+++ b/src/panels/config/scene/ha-scene-dashboard.ts
@@ -693,14 +693,14 @@ class HaSceneDashboard extends SubscribeMixin(LitElement) {
                 href=${documentationUrl(this.hass, "/docs/scene/editor/")}
                 target="_blank"
                 rel="noreferrer"
-                size="small"
+                size="s"
               >
                 ${this.hass.localize("ui.panel.config.common.learn_more")}
                 <ha-svg-icon slot="end" .path=${mdiOpenInNew}></ha-svg-icon>
               </ha-button>
             </div>`
           : nothing}
-        <ha-button href="/config/scene/edit/new" size="large" slot="fab">
+        <ha-button href="/config/scene/edit/new" size="l" slot="fab">
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.scene.picker.add_scene")}
         </ha-button>

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -308,7 +308,7 @@ export class HaSceneEditor extends PreventUnsavedMixin(
         ${this._mode === "yaml" ? this._renderYamlMode() : this._renderUiMode()}
         <ha-button
           slot="fab"
-          size="large"
+          size="l"
           .disabled=${this._saving}
           @click=${this._saveScene}
           class=${classMap({
@@ -374,7 +374,7 @@ export class HaSceneEditor extends PreventUnsavedMixin(
                   ></ha-svg-icon>
                 </span>
                 <ha-button
-                  size="small"
+                  size="s"
                   slot="action"
                   @click=${this._toggleLiveMode}
                 >

--- a/src/panels/config/script/blueprint-script-editor.ts
+++ b/src/panels/config/script/blueprint-script-editor.ts
@@ -34,7 +34,7 @@ export class HaBlueprintScriptEditor extends HaBlueprintGenericEditor {
 
       <ha-button
         slot="fab"
-        size="large"
+        size="l"
         class=${this.dirty ? "dirty" : ""}
         .disabled=${this.saving}
         @click=${this._saveScript}

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -469,7 +469,7 @@ export class HaScriptEditor extends SubscribeMixin(
                   ></ha-yaml-editor>
                   <ha-button
                     slot="fab"
-                    size="large"
+                    size="l"
                     class=${!this.readOnly && this.dirty ? "dirty" : ""}
                     .disabled=${this.saving}
                     @click=${this._handleSaveScript}

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -676,14 +676,14 @@ class HaScriptPicker extends SubscribeMixin(LitElement) {
                 href=${documentationUrl(this.hass, "/docs/script/editor/")}
                 target="_blank"
                 rel="noreferrer"
-                size="small"
+                size="s"
               >
                 ${this.hass.localize("ui.panel.config.common.learn_more")}
                 <ha-svg-icon slot="end" .path=${mdiOpenInNew}></ha-svg-icon>
               </ha-button>
             </div>`
           : nothing}
-        <ha-button slot="fab" size="large" @click=${this._createNew}>
+        <ha-button slot="fab" size="l" @click=${this._createNew}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.script.picker.add_script")}
         </ha-button>

--- a/src/panels/config/tags/ha-config-tags.ts
+++ b/src/panels/config/tags/ha-config-tags.ts
@@ -208,7 +208,7 @@ export class HaConfigTags extends SubscribeMixin(LitElement) {
           .label=${this.hass.localize("ui.common.help")}
           .path=${mdiHelpCircleOutline}
         ></ha-icon-button>
-        <ha-button slot="fab" size="large" @click=${this._addTag}>
+        <ha-button slot="fab" size="l" @click=${this._addTag}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.tag.add_tag")}
         </ha-button>

--- a/src/panels/config/users/ha-config-users.ts
+++ b/src/panels/config/users/ha-config-users.ts
@@ -195,7 +195,7 @@ export class HaConfigUsers extends LitElement {
         has-fab
         clickable
       >
-        <ha-button slot="fab" size="large" @click=${this._addUser}>
+        <ha-button slot="fab" size="l" @click=${this._addUser}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.users.picker.add_user")}
         </ha-button>

--- a/src/panels/config/voice-assistants/assist-pref.ts
+++ b/src/panels/config/voice-assistants/assist-pref.ts
@@ -208,7 +208,7 @@ export class AssistPref extends LitElement {
           appearance="filled"
           @click=${this._addPipeline}
           class="add"
-          size="small"
+          size="s"
         >
           ${this.hass.localize(
             "ui.panel.config.voice_assistants.assistants.pipeline.add_assistant"

--- a/src/panels/config/voice-assistants/cloud-discover.ts
+++ b/src/panels/config/voice-assistants/cloud-discover.ts
@@ -73,7 +73,7 @@ export class CloudDiscover extends LitElement {
           <div class="more">
             <ha-button
               appearance="plain"
-              size="small"
+              size="s"
               href="https://www.nabucasa.com"
               target="_blank"
               rel="noreferrer"

--- a/src/panels/config/voice-assistants/cloud-google-pref.ts
+++ b/src/panels/config/voice-assistants/cloud-google-pref.ts
@@ -227,7 +227,7 @@ export class CloudGooglePref extends LitElement {
           ? html`<div class="card-actions">
               <ha-button
                 appearance="plain"
-                size="small"
+                size="s"
                 href="/config/voice-assistants/expose?assistants=cloud.google_assistant&historyBack"
               >
                 ${manualConfig

--- a/src/panels/config/voice-assistants/dialog-voice-assistant-pipeline-detail.ts
+++ b/src/panels/config/voice-assistants/dialog-voice-assistant-pipeline-detail.ts
@@ -193,7 +193,7 @@ export class DialogVoiceAssistantPipelineDetail extends LitElement {
                   ${this.hass.localize(
                     "ui.panel.config.voice_assistants.assistants.pipeline.detail.no_cloud_message"
                   )}
-                  <ha-button size="small" href="/config/cloud" slot="action">
+                  <ha-button size="s" href="/config/cloud" slot="action">
                     ${this.hass.localize(
                       "ui.panel.config.voice_assistants.assistants.pipeline.detail.no_cloud_action"
                     )}

--- a/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
+++ b/src/panels/config/voice-assistants/ha-config-voice-assistants-expose.ts
@@ -539,7 +539,7 @@ export class VoiceAssistantsExpose extends LitElement {
                   ? html`
                       <ha-button
                         appearance="plain"
-                        size="small"
+                        size="s"
                         @click=${this._exposeSelected}
                         >${this.hass.localize(
                           "ui.panel.config.voice_assistants.expose.expose"
@@ -547,7 +547,7 @@ export class VoiceAssistantsExpose extends LitElement {
                       >
                       <ha-button
                         appearance="plain"
-                        size="small"
+                        size="s"
                         @click=${this._unexposeSelected}
                         >${this.hass.localize(
                           "ui.panel.config.voice_assistants.expose.unexpose"
@@ -585,7 +585,7 @@ export class VoiceAssistantsExpose extends LitElement {
               </div>
             `
           : ""}
-        <ha-button slot="fab" size="large" @click=${this._addEntry}>
+        <ha-button slot="fab" size="l" @click=${this._addEntry}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.config.voice_assistants.expose.add")}
         </ha-button>

--- a/src/panels/config/zone/ha-config-zone.ts
+++ b/src/panels/config/zone/ha-config-zone.ts
@@ -137,7 +137,7 @@ export class HaConfigZone extends SubscribeMixin(LitElement) {
             <div class="empty">
               ${hass.localize("ui.panel.config.zone.no_zones_created_yet")}
               <br />
-              <ha-button size="small" @click=${this._createZone}>
+              <ha-button size="s" @click=${this._createZone}>
                 ${hass.localize("ui.panel.config.zone.create_zone")}</ha-button
               >
             </div>
@@ -268,7 +268,7 @@ export class HaConfigZone extends SubscribeMixin(LitElement) {
               </div>
             `
           : ""}
-        <ha-button slot="fab" size="large" @click=${this._createZone}>
+        <ha-button slot="fab" size="l" @click=${this._createZone}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${hass.localize("ui.panel.config.zone.create_zone")}
         </ha-button>

--- a/src/panels/home/ha-panel-home.ts
+++ b/src/panels/home/ha-panel-home.ts
@@ -296,7 +296,7 @@ class PanelHome extends LitElement {
           </span>
         </div>
         <div class="banner-actions">
-          <ha-button size="small" appearance="filled" @click=${this._learnMore}>
+          <ha-button size="s" appearance="filled" @click=${this._learnMore}>
             ${this.hass.localize("ui.panel.home.banner.learn_more")}
           </ha-button>
         </div>

--- a/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
@@ -880,7 +880,7 @@ class HuiEnergyDistrubutionCard
               <div class="card-actions">
                 <ha-button
                   appearance="plain"
-                  size="small"
+                  size="s"
                   href=${this._energyDashboardHref}
                 >
                   ${this.hass.localize(

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -260,7 +260,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
                 .action=${stateAction}
                 @click=${this._handleActionClick}
                 appearance="filled"
-                size="small"
+                size="s"
                 variant=${stateAction === "disarm" ? "danger" : "brand"}
               >
                 ${this._actionDisplay(stateAction)}

--- a/src/panels/lovelace/components/hui-energy-period-selector.ts
+++ b/src/panels/lovelace/components/hui-energy-period-selector.ts
@@ -364,7 +364,7 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
               ${!this.narrow
                 ? html`<ha-button
                     appearance="filled"
-                    size="small"
+                    size="s"
                     @click=${this._pickNow}
                   >
                     ${this.hass.localize(

--- a/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-card-features-editor.ts
@@ -441,7 +441,7 @@ export class HuiCardFeaturesEditor extends LitElement {
       ${supportedFeaturesType.length > 0
         ? html`
             <ha-dropdown @wa-select=${this._addFeature}>
-              <ha-button slot="trigger" appearance="filled" size="small">
+              <ha-button slot="trigger" appearance="filled" size="s">
                 <ha-svg-icon .path=${mdiPlus} slot="start"></ha-svg-icon>
                 ${this.hass!.localize(`ui.panel.lovelace.editor.features.add`)}
               </ha-button>

--- a/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
@@ -122,7 +122,7 @@ export class HuiConditionalCardEditor
                       ></ha-icon-button>
                       <ha-button
                         appearance="plain"
-                        size="small"
+                        size="s"
                         @click=${this._handleReplaceCard}
                         >${this.hass!.localize(
                           "ui.panel.lovelace.editor.card.conditional.change_type"

--- a/src/panels/lovelace/editor/config-elements/hui-heading-badges-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-heading-badges-editor.ts
@@ -84,7 +84,7 @@ export class HuiHeadingBadgesEditor extends LitElement {
           `
         : nothing}
       <ha-dropdown @wa-select=${this._addBadge}>
-        <ha-button slot="trigger" appearance="filled" size="small">
+        <ha-button slot="trigger" appearance="filled" size="s">
           <ha-svg-icon .path=${mdiPlus} slot="start"></ha-svg-icon>
           ${this.hass.localize(`ui.panel.lovelace.editor.heading-badges.add`)}
         </ha-button>

--- a/src/panels/lovelace/editor/hui-picture-elements-card-row-editor.ts
+++ b/src/panels/lovelace/editor/hui-picture-elements-card-row-editor.ts
@@ -122,7 +122,7 @@ export class HuiPictureElementsCardRowEditor extends LitElement {
           </div>
         </ha-sortable>
         <ha-dropdown @wa-select=${this._addElement}>
-          <ha-button size="small" slot="trigger" appearance="filled">
+          <ha-button size="s" slot="trigger" appearance="filled">
             <ha-svg-icon slot="start" .path=${mdiPlaylistPlus}></ha-svg-icon>
             ${this.hass.localize(
               "ui.panel.lovelace.editor.card.picture-elements.new_element"

--- a/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
+++ b/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
@@ -86,7 +86,7 @@ export class HuiUnusedEntities extends LitElement {
           selected: this._selectedEntities.length,
         })}"
       >
-        <ha-button size="large" @click=${this._addToLovelaceView}>
+        <ha-button size="l" @click=${this._addToLovelaceView}>
           <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
           ${this.hass.localize("ui.panel.lovelace.editor.edit_card.add")}
         </ha-button>

--- a/src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts
@@ -258,7 +258,7 @@ export class HuiDialogEditView extends LitElement {
                     "ui.panel.lovelace.editor.edit_view.card_to_section_convert"
                   )}
                   <ha-button
-                    size="small"
+                    size="s"
                     slot="action"
                     @click=${this._convertToSection}
                   >

--- a/src/panels/lovelace/entity-rows/hui-button-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-button-entity-row.ts
@@ -46,7 +46,7 @@ class HuiButtonEntityRow extends LitElement implements LovelaceRow {
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         <ha-button
           appearance="plain"
-          size="small"
+          size="s"
           @click=${this._pressButton}
           .disabled=${stateObj.state === UNAVAILABLE}
         >

--- a/src/panels/lovelace/entity-rows/hui-input-button-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-button-entity-row.ts
@@ -46,7 +46,7 @@ class HuiInputButtonEntityRow extends LitElement implements LovelaceRow {
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         <ha-button
           appearance="plain"
-          size="small"
+          size="s"
           @click=${this._pressButton}
           .disabled=${stateObj.state === UNAVAILABLE}
         >

--- a/src/panels/lovelace/entity-rows/hui-lock-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-lock-entity-row.ts
@@ -47,7 +47,7 @@ class HuiLockEntityRow extends LitElement implements LovelaceRow {
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         <ha-button
           appearance="plain"
-          size="small"
+          size="s"
           @click=${this._callService}
           .disabled=${stateObj.state === UNAVAILABLE}
           class="text-content"

--- a/src/panels/lovelace/entity-rows/hui-scene-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-scene-entity-row.ts
@@ -48,7 +48,7 @@ class HuiSceneEntityRow extends LitElement implements LovelaceRow {
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         <ha-button
           appearance="plain"
-          size="small"
+          size="s"
           @click=${this._callService}
           .disabled=${stateObj.state === UNAVAILABLE}
           class="text-content"

--- a/src/panels/lovelace/entity-rows/hui-script-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-script-entity-row.ts
@@ -50,7 +50,7 @@ class HuiScriptEntityRow extends LitElement implements LovelaceRow {
         ${stateObj.state === "on"
           ? html`<ha-button
               appearance="plain"
-              size="small"
+              size="s"
               variant="danger"
               @click=${this._cancelScript}
             >
@@ -66,7 +66,7 @@ class HuiScriptEntityRow extends LitElement implements LovelaceRow {
         ${stateObj.state === "off" || stateObj.attributes.max
           ? html`<ha-button
               appearance="plain"
-              size="small"
+              size="s"
               @click=${this._runScript}
               .disabled=${stateObj.state === UNAVAILABLE || !canRun(stateObj)}
             >

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -203,7 +203,7 @@ class HUIRoot extends LitElement {
           </ha-tooltip>
           <ha-button
             appearance="filled"
-            size="small"
+            size="s"
             class="exit-edit-mode"
             @click=${this._editModeDisable}
           >

--- a/src/panels/lovelace/special-rows/hui-button-row.ts
+++ b/src/panels/lovelace/special-rows/hui-button-row.ts
@@ -76,7 +76,7 @@ export class HuiButtonRow extends LitElement implements LovelaceRow {
         <div .title=${name}>${name}</div>
         <ha-button
           appearance="filled"
-          size="small"
+          size="s"
           @action=${this._handleAction}
           .actionHandler=${actionHandler({
             hasHold: hasAction(this._config!.hold_action),

--- a/src/panels/lovelace/special-rows/hui-cast-row.ts
+++ b/src/panels/lovelace/special-rows/hui-cast-row.ts
@@ -65,7 +65,7 @@ class HuiCastRow extends LitElement implements LovelaceRow {
                         @click=${this._sendLovelace}
                         class=${classMap({ inactive: !active })}
                         appearance="plain"
-                        size="small"
+                        size="s"
                         .disabled=${!this._castManager.status}
                       >
                         SHOW

--- a/src/panels/lovelace/views/hui-masonry-view.ts
+++ b/src/panels/lovelace/views/hui-masonry-view.ts
@@ -89,7 +89,7 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
       ></div>
       ${this.lovelace?.editMode
         ? html`
-            <ha-button size="large" @click=${this._addCard}>
+            <ha-button size="l" @click=${this._addCard}>
               <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
               ${this.hass!.localize("ui.panel.lovelace.editor.edit_card.add")}
             </ha-button>

--- a/src/panels/lovelace/views/hui-panel-view.ts
+++ b/src/panels/lovelace/views/hui-panel-view.ts
@@ -75,7 +75,7 @@ export class PanelView extends LitElement implements LovelaceViewElement {
       ${this.lovelace?.editMode && this.cards.length === 0
         ? html`
             <ha-button
-              size="large"
+              size="l"
               @click=${this._addCard}
               class=${classMap({
                 rtl: computeRTL(

--- a/src/panels/lovelace/views/hui-sidebar-view.ts
+++ b/src/panels/lovelace/views/hui-sidebar-view.ts
@@ -102,7 +102,7 @@ export class SideBarView extends LitElement implements LovelaceViewElement {
       ></div>
       ${this.lovelace?.editMode
         ? html`
-            <ha-button size="large" @click=${this._addCard}>
+            <ha-button size="l" @click=${this._addCard}>
               <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
               ${this.hass!.localize("ui.panel.lovelace.editor.edit_card.add")}
             </ha-button>

--- a/src/panels/media-browser/ha-bar-media-player.ts
+++ b/src/panels/media-browser/ha-bar-media-player.ts
@@ -296,7 +296,7 @@ export class BarMediaPlayer extends SubscribeMixin(LitElement) {
                       step="1"
                       .value=${getCurrentProgress(stateObj)}
                       .withTooltip=${false}
-                      size="small"
+                      size="s"
                       aria-label=${this.hass.localize(
                         "ui.card.media_player.track_position"
                       )}
@@ -314,7 +314,7 @@ export class BarMediaPlayer extends SubscribeMixin(LitElement) {
                           step="1"
                           .value=${getCurrentProgress(stateObj)}
                           .withTooltip=${false}
-                          size="small"
+                          size="s"
                           aria-label=${this.hass.localize(
                             "ui.card.media_player.track_position"
                           )}

--- a/src/panels/profile/ha-mfa-modules-card.ts
+++ b/src/panels/profile/ha-mfa-modules-card.ts
@@ -23,7 +23,7 @@ class HaMfaModulesCard extends LitElement {
               <span slot="heading">${module.name}</span>
               <span slot="description">${module.id}</span>
               <ha-button
-                size="small"
+                size="s"
                 appearance="plain"
                 .module=${module}
                 @click=${module.enabled ? this._disable : this._enable}

--- a/src/panels/profile/ha-pick-theme-row.ts
+++ b/src/panels/profile/ha-pick-theme-row.ts
@@ -152,7 +152,7 @@ export class HaPickThemeRow extends SubscribeMixin(LitElement) {
                   ${themeSettings?.primaryColor || themeSettings?.accentColor
                     ? html` <ha-button
                         appearance="plain"
-                        size="small"
+                        size="s"
                         @click=${this._resetColors}
                       >
                         ${this.hass.localize("ui.panel.profile.themes.reset")}
@@ -175,7 +175,7 @@ export class HaPickThemeRow extends SubscribeMixin(LitElement) {
               </span>
               <ha-button
                 appearance="plain"
-                size="small"
+                size="s"
                 .disabled=${this._migrating}
                 @click=${this._migrateThemePreferences}
               >

--- a/src/panels/profile/ha-profile-section-general.ts
+++ b/src/panels/profile/ha-profile-section-general.ts
@@ -156,7 +156,7 @@ class HaProfileSectionGeneral extends LitElement {
               <ha-button
                 slot="end"
                 appearance="plain"
-                size="small"
+                size="s"
                 @click=${this._customizeSidebar}
               >
                 ${this.hass.localize(

--- a/src/panels/profile/ha-refresh-tokens-card.ts
+++ b/src/panels/profile/ha-refresh-tokens-card.ts
@@ -195,7 +195,7 @@ class HaRefreshTokens extends LitElement {
           <ha-button
             variant="danger"
             appearance="filled"
-            size="small"
+            size="s"
             @click=${this._deleteAllTokens}
           >
             ${this.hass.localize(

--- a/src/panels/todo/ha-panel-todo.ts
+++ b/src/panels/todo/ha-panel-todo.ts
@@ -273,7 +273,7 @@ class PanelTodo extends LitElement {
         </div>
         ${entityState &&
         supportsFeature(entityState, TodoListEntityFeature.CREATE_TODO_ITEM)
-          ? html`<ha-button class="fab" size="large" @click=${this._addItem}>
+          ? html`<ha-button class="fab" size="l" @click=${this._addItem}>
               <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
               ${this.hass.localize("ui.panel.todo.add_item")}
             </ha-button>`

--- a/src/state-summary/state-card-configurator.ts
+++ b/src/state-summary/state-card-configurator.ts
@@ -24,7 +24,7 @@ class StateCardConfigurator extends LitElement {
           .inDialog=${this.inDialog}
         ></state-info>
         ${this.inDialog
-          ? html`<ha-button appearance="plain" size="small"
+          ? html`<ha-button appearance="plain" size="s"
               >${this.hass.formatEntityState(this.stateObj)}</ha-button
             >`
           : nothing}

--- a/src/state-summary/state-card-lock.ts
+++ b/src/state-summary/state-card-lock.ts
@@ -31,7 +31,7 @@ class StateCardLock extends LitElement {
         ${!supportsOpen
           ? html`<ha-button
               appearance="plain"
-              size="small"
+              size="s"
               @click=${this._callService}
               data-service="open"
               >${this.hass.localize("ui.card.lock.open")}</ha-button
@@ -40,7 +40,7 @@ class StateCardLock extends LitElement {
         ${isLocked
           ? html` <ha-button
               appearance="plain"
-              size="small"
+              size="s"
               @click=${this._callService}
               data-service="unlock"
               >${this.hass.localize("ui.card.lock.unlock")}</ha-button
@@ -49,7 +49,7 @@ class StateCardLock extends LitElement {
         ${!isLocked
           ? html`<ha-button
               appearance="plain"
-              size="small"
+              size="s"
               @click=${this._callService}
               data-service="lock"
               >${this.hass.localize("ui.card.lock.lock")}</ha-button

--- a/src/state-summary/state-card-scene.ts
+++ b/src/state-summary/state-card-scene.ts
@@ -24,7 +24,7 @@ class StateCardScene extends LitElement {
           .stateObj=${this.stateObj}
           .inDialog=${this.inDialog}
         ></state-info>
-        <ha-button appearance="plain" size="small" @click=${this._activateScene}
+        <ha-button appearance="plain" size="s" @click=${this._activateScene}
           >${this.hass.localize("ui.card.scene.activate")}</ha-button
         >
       </div>

--- a/src/state-summary/state-card-script.ts
+++ b/src/state-summary/state-card-script.ts
@@ -32,7 +32,7 @@ class StateCardScript extends LitElement {
         ${stateObj.state === "on"
           ? html`<ha-button
               appearance="plain"
-              size="small"
+              size="s"
               @click=${this._cancelScript}
             >
               ${stateObj.attributes.mode !== "single" &&
@@ -46,7 +46,7 @@ class StateCardScript extends LitElement {
         ${stateObj.state === "off" || stateObj.attributes.max
           ? html`<ha-button
               appearance="plain"
-              size="small"
+              size="s"
               @click=${this._runScript}
               .disabled=${stateObj.state === UNAVAILABLE || !canRun(stateObj)}
             >


### PR DESCRIPTION
## Proposed change

Web Awesome 3.6.0 deprecated the long-form `size` values (`small`/`medium`/`large`) in favor of `s`/`m`/`l`. Every affected component now logs a console warning:

> `[ha-button] size="small" is deprecated. Use size="s" instead. The long-form value will be removed in the next major version.`

Changelog entry ([3.6.0](https://webawesome.com/docs/resources/changelog#wa_360)):

> Added `xs` and `xl` sizes for all form controls and sized components.
> Deprecated `small`, `medium`, and `large` in favor of `s`, `m`, and `l` (old values will continue to work in 3.x).

This migrates all usages on the Web Awesome based components that emit the warning to the short form:

- `ha-button`, `ha-slider`, `ha-button-toggle-group`: call sites
- Gallery demo pages and component docs updated to match.

`ha-spinner` and `ha-progress-ring` are intentionally left untouched: they define their own `size` API (`tiny`/`small`/`medium`/`large` mapped to pixel values) and are not part of the Web Awesome deprecation, so they emit no warning. Renaming them would break their sizing.

No visual change: the short-form values map to the same sizes as before.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
