### PR TITLE
Add customize toggle to media player source and sound mode feature editors

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-media-player-sound-mode-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-media-player-sound-mode-card-feature-editor.ts
@@ -5,7 +5,7 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { MediaPlayerEntity } from "../../../../data/media-player";
-import type { HomeAssistant } from "../../../../types";
+import type { HomeAssistant, ValueChangedEvent } from "../../../../types";
 import type {
   LovelaceCardFeatureContext,
   MediaPlayerSoundModeCardFeatureConfig,
@@ -74,7 +74,9 @@ export class HuiMediaPlayerSoundModeCardFeatureEditor
     `;
   }
 
-  private _valueChanged(ev: CustomEvent): void {
+  private _valueChanged(
+    ev: ValueChangedEvent<MediaPlayerSoundModeCardFeatureConfig>
+  ): void {
     const stateObj = this.context?.entity_id
       ? (this.hass!.states[this.context.entity_id] as
           | MediaPlayerEntity

--- a/src/panels/lovelace/editor/config-elements/hui-media-player-sound-mode-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-media-player-sound-mode-card-feature-editor.ts
@@ -5,12 +5,17 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { MediaPlayerEntity } from "../../../../data/media-player";
-import type { HomeAssistant, ValueChangedEvent } from "../../../../types";
+import type { HomeAssistant } from "../../../../types";
 import type {
   LovelaceCardFeatureContext,
   MediaPlayerSoundModeCardFeatureConfig,
 } from "../../card-features/types";
 import type { LovelaceCardFeatureEditor } from "../../types";
+import {
+  customizableListData,
+  customizableListSchema,
+  processCustomizableListValue,
+} from "./customizable-list-feature";
 
 @customElement("hui-media-player-sound-mode-card-feature-editor")
 export class HuiMediaPlayerSoundModeCardFeatureEditor
@@ -28,28 +33,20 @@ export class HuiMediaPlayerSoundModeCardFeatureEditor
   }
 
   private _schema = memoizeOne(
-    (hass: HomeAssistant, stateObj?: MediaPlayerEntity) =>
-      [
-        {
-          name: "sound_modes",
-          selector: {
-            select: {
-              multiple: true,
-              mode: "list" as const,
-              reorder: true,
-              options:
-                stateObj?.attributes.sound_mode_list?.map((mode) => ({
-                  value: mode,
-                  label: hass.formatEntityAttributeValue(
-                    stateObj,
-                    "sound_mode",
-                    mode
-                  ),
-                })) ?? [],
-            },
-          },
-        },
-      ] as const
+    (stateObj: MediaPlayerEntity | undefined, customize: boolean) =>
+      customizableListSchema({
+        field: "sound_modes",
+        customize,
+        options:
+          stateObj?.attributes.sound_mode_list?.map((mode) => ({
+            value: mode,
+            label: this.hass!.formatEntityAttributeValue(
+              stateObj,
+              "sound_mode",
+              mode
+            ),
+          })) ?? [],
+      })
   );
 
   protected render() {
@@ -63,12 +60,13 @@ export class HuiMediaPlayerSoundModeCardFeatureEditor
           | undefined)
       : undefined;
 
-    const schema = this._schema(this.hass!, stateObj);
+    const data = customizableListData(this._config, "sound_modes");
+    const schema = this._schema(stateObj, data.customize);
 
     return html`
       <ha-form
         .hass=${this.hass}
-        .data=${this._config}
+        .data=${data}
         .schema=${schema}
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
@@ -76,24 +74,28 @@ export class HuiMediaPlayerSoundModeCardFeatureEditor
     `;
   }
 
-  private _valueChanged(
-    ev: ValueChangedEvent<MediaPlayerSoundModeCardFeatureConfig>
-  ): void {
-    fireEvent(this, "config-changed", { config: ev.detail.value });
+  private _valueChanged(ev: CustomEvent): void {
+    const stateObj = this.context?.entity_id
+      ? (this.hass!.states[this.context.entity_id] as
+          | MediaPlayerEntity
+          | undefined)
+      : undefined;
+    const defaults = stateObj?.attributes.sound_mode_list ?? [];
+    const config =
+      processCustomizableListValue<MediaPlayerSoundModeCardFeatureConfig>(
+        ev.detail.value,
+        "sound_modes",
+        defaults
+      );
+    fireEvent(this, "config-changed", { config });
   }
 
   private _computeLabelCallback = (
     schema: SchemaUnion<ReturnType<typeof this._schema>>
-  ) => {
-    switch (schema.name) {
-      case "sound_modes":
-        return this.hass?.localize(
-          `ui.panel.lovelace.editor.features.types.media-player-sound-mode.${schema.name}`
-        );
-      default:
-        return "";
-    }
-  };
+  ) =>
+    this.hass!.localize(
+      `ui.panel.lovelace.editor.features.types.media-player-sound-mode.${schema.name}`
+    );
 }
 
 declare global {

--- a/src/panels/lovelace/editor/config-elements/hui-media-player-source-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-media-player-source-card-feature-editor.ts
@@ -5,7 +5,7 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { MediaPlayerEntity } from "../../../../data/media-player";
-import type { HomeAssistant } from "../../../../types";
+import type { HomeAssistant, ValueChangedEvent } from "../../../../types";
 import type {
   LovelaceCardFeatureContext,
   MediaPlayerSourceCardFeatureConfig,
@@ -74,7 +74,9 @@ export class HuiMediaPlayerSourceCardFeatureEditor
     `;
   }
 
-  private _valueChanged(ev: CustomEvent): void {
+  private _valueChanged(
+    ev: ValueChangedEvent<MediaPlayerSourceCardFeatureConfig>
+  ): void {
     const stateObj = this.context?.entity_id
       ? (this.hass!.states[this.context.entity_id] as
           | MediaPlayerEntity

--- a/src/panels/lovelace/editor/config-elements/hui-media-player-source-card-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-media-player-source-card-feature-editor.ts
@@ -5,12 +5,17 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { MediaPlayerEntity } from "../../../../data/media-player";
-import type { HomeAssistant, ValueChangedEvent } from "../../../../types";
+import type { HomeAssistant } from "../../../../types";
 import type {
   LovelaceCardFeatureContext,
   MediaPlayerSourceCardFeatureConfig,
 } from "../../card-features/types";
 import type { LovelaceCardFeatureEditor } from "../../types";
+import {
+  customizableListData,
+  customizableListSchema,
+  processCustomizableListValue,
+} from "./customizable-list-feature";
 
 @customElement("hui-media-player-source-card-feature-editor")
 export class HuiMediaPlayerSourceCardFeatureEditor
@@ -28,24 +33,20 @@ export class HuiMediaPlayerSourceCardFeatureEditor
   }
 
   private _schema = memoizeOne(
-    (stateObj?: MediaPlayerEntity) =>
-      [
-        {
-          name: "sources",
-          selector: {
-            select: {
-              multiple: true,
-              mode: "list" as const,
-              reorder: true,
-              options:
-                stateObj?.attributes.source_list?.map((source) => ({
-                  value: source,
-                  label: source,
-                })) ?? [],
-            },
-          },
-        },
-      ] as const
+    (stateObj: MediaPlayerEntity | undefined, customize: boolean) =>
+      customizableListSchema({
+        field: "sources",
+        customize,
+        options:
+          stateObj?.attributes.source_list?.map((source) => ({
+            value: source,
+            label: this.hass!.formatEntityAttributeValue(
+              stateObj,
+              "source",
+              source
+            ),
+          })) ?? [],
+      })
   );
 
   protected render() {
@@ -59,12 +60,13 @@ export class HuiMediaPlayerSourceCardFeatureEditor
           | undefined)
       : undefined;
 
-    const schema = this._schema(stateObj);
+    const data = customizableListData(this._config, "sources");
+    const schema = this._schema(stateObj, data.customize);
 
     return html`
       <ha-form
         .hass=${this.hass}
-        .data=${this._config}
+        .data=${data}
         .schema=${schema}
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
@@ -72,24 +74,28 @@ export class HuiMediaPlayerSourceCardFeatureEditor
     `;
   }
 
-  private _valueChanged(
-    ev: ValueChangedEvent<MediaPlayerSourceCardFeatureConfig>
-  ): void {
-    fireEvent(this, "config-changed", { config: ev.detail.value });
+  private _valueChanged(ev: CustomEvent): void {
+    const stateObj = this.context?.entity_id
+      ? (this.hass!.states[this.context.entity_id] as
+          | MediaPlayerEntity
+          | undefined)
+      : undefined;
+    const defaults = stateObj?.attributes.source_list ?? [];
+    const config =
+      processCustomizableListValue<MediaPlayerSourceCardFeatureConfig>(
+        ev.detail.value,
+        "sources",
+        defaults
+      );
+    fireEvent(this, "config-changed", { config });
   }
 
   private _computeLabelCallback = (
     schema: SchemaUnion<ReturnType<typeof this._schema>>
-  ) => {
-    switch (schema.name) {
-      case "sources":
-        return this.hass?.localize(
-          `ui.panel.lovelace.editor.features.types.media-player-source.${schema.name}`
-        );
-      default:
-        return "";
-    }
-  };
+  ) =>
+    this.hass!.localize(
+      `ui.panel.lovelace.editor.features.types.media-player-source.${schema.name}`
+    );
 }
 
 declare global {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10144,11 +10144,13 @@
               },
               "media-player-sound-mode": {
                 "label": "Media player sound mode",
-                "sound_modes": "Sound modes"
+                "sound_modes": "Sound modes",
+                "customize": "Customize sound modes"
               },
               "media-player-source": {
                 "label": "Media player source",
-                "sources": "Sources"
+                "sources": "Sources",
+                "customize": "Customize sources"
               },
               "media-player-volume-buttons": {
                 "label": "Media player volume buttons",


### PR DESCRIPTION
## Proposed change

The media player source and sound mode card feature editors showed the full reorderable list of sources/sound modes directly, with no way to keep the default behavior cleanly. This brings them in line with the other feature editors (alarm modes, vacuum commands, etc.) by adding a "Customize" toggle:

- When off, the feature uses all available sources/sound modes from the entity.
- When on, a reorderable multi-select appears so you can pick and order which ones to show.

Both editors now reuse the shared `customizable-list-feature` helper instead of duplicating the toggle and list logic. Source labels also go through `formatEntityAttributeValue` so they respect entity state translations and customizations, matching the sound mode editor.

## Screenshots
<!-- Reminder: add before/after screenshots or a short video of the two editors. -->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr