### PR TITLE
Avoid regex look-behind in obfuscateUrl (Safari <16.4 compatibility)

### DIFF
--- a/src/util/url.ts
+++ b/src/util/url.ts
@@ -3,7 +3,7 @@ export function obfuscateUrl(url: string) {
     return "https://•••••••••••••••••.ui.nabu.casa";
   }
   // hide any words that look like they might be a hostname or IP address
-  return url.replace(/(?<=:\/\/)[\w-]+|(?<=\.)[\w-]+/g, (match) =>
-    "•".repeat(match.length)
+  return url.replace(/(:\/\/|\.)([\w-]+)/g, (_m, prefix, word) =>
+    prefix + "•".repeat(word.length)
   );
 }


### PR DESCRIPTION
Part of #52440.

`obfuscateUrl()` uses a regex **look-behind** (`/(?<=:\/\/)[\w-]+|(?<=\.)[\w-]+/g`). A look-behind in a regex *literal* is a **parse-time `SyntaxError` on Safari < 16.4**, so any chunk containing it fails to load on those browsers — which are within the supported range (back to Safari 14, #51365).

This replaces it with a behaviour-identical capture-group form:

```js
url.replace(/(:\/\/|\.)([\w-]+)/g, (_m, prefix, word) => prefix + "•".repeat(word.length))
```
(keeps the `://`/`.` prefix and obfuscates the following host word — same output as before).
