### PR TITLE
Use consumeLocalize instead of hass in localize-only leaf components

### DIFF
--- a/src/components/ha-aliases-editor.ts
+++ b/src/components/ha-aliases-editor.ts
@@ -1,12 +1,15 @@
 import { LitElement, html, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
-import type { HomeAssistant } from "../types";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import type { LocalizeFunc } from "../common/translations/localize";
 import "./input/ha-input-multi";
 
 @customElement("ha-aliases-editor")
 class AliasesEditor extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
 
   @property({ type: Array }) public aliases!: string[];
 
@@ -25,9 +28,9 @@ class AliasesEditor extends LitElement {
         .disabled=${this.disabled}
         .sortable=${this.sortable}
         update-on-blur
-        .label=${this.hass!.localize("ui.dialogs.aliases.label")}
-        .removeLabel=${this.hass!.localize("ui.dialogs.aliases.remove")}
-        .addLabel=${this.hass!.localize("ui.dialogs.aliases.add")}
+        .label=${this._localize("ui.dialogs.aliases.label")}
+        .removeLabel=${this._localize("ui.dialogs.aliases.remove")}
+        .addLabel=${this._localize("ui.dialogs.aliases.add")}
         item-index
         @value-changed=${this._aliasesChanged}
       >

--- a/src/components/ha-grid-size-picker.ts
+++ b/src/components/ha-grid-size-picker.ts
@@ -8,13 +8,12 @@ import { conditionalClamp } from "../common/number/clamp";
 import type { CardGridSize } from "../panels/lovelace/common/compute-card-grid-size";
 import { DEFAULT_GRID_SIZE } from "../panels/lovelace/common/compute-card-grid-size";
 import "../panels/lovelace/editor/card-editor/ha-grid-layout-slider";
-import type { HomeAssistant } from "../types";
 import "./ha-icon-button";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import type { LocalizeFunc } from "../common/translations/localize";
 
 @customElement("ha-grid-size-picker")
 export class HaGridSizeEditor extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property({ attribute: false }) public value?: CardGridSize;
 
   @property({ attribute: false }) public rows = 8;
@@ -34,6 +33,10 @@ export class HaGridSizeEditor extends LitElement {
   @property({ attribute: false }) public step = 1;
 
   @state() public _localValue?: CardGridSize = { rows: 1, columns: 1 };
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
 
   protected willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("value")) {
@@ -62,9 +65,7 @@ export class HaGridSizeEditor extends LitElement {
     return html`
       <div class="grid">
         <ha-grid-layout-slider
-          aria-label=${this.hass.localize(
-            "ui.components.grid-size-picker.columns"
-          )}
+          aria-label=${this._localize("ui.components.grid-size-picker.columns")}
           id="columns"
           .min=${columnMin}
           .max=${columnMax}
@@ -78,9 +79,7 @@ export class HaGridSizeEditor extends LitElement {
         ></ha-grid-layout-slider>
 
         <ha-grid-layout-slider
-          aria-label=${this.hass.localize(
-            "ui.components.grid-size-picker.rows"
-          )}
+          aria-label=${this._localize("ui.components.grid-size-picker.rows")}
           id="rows"
           .min=${rowMin}
           .max=${rowMax}
@@ -98,10 +97,10 @@ export class HaGridSizeEditor extends LitElement {
                 @click=${this._reset}
                 class="reset"
                 .path=${mdiRestore}
-                label=${this.hass.localize(
+                label=${this._localize(
                   "ui.components.grid-size-picker.reset_default"
                 )}
-                title=${this.hass.localize(
+                title=${this._localize(
                   "ui.components.grid-size-picker.reset_default"
                 )}
               >

--- a/src/components/ha-icon-button-arrow-next.ts
+++ b/src/components/ha-icon-button-arrow-next.ts
@@ -3,13 +3,12 @@ import type { TemplateResult } from "lit";
 import { html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { mainWindow } from "../common/dom/get_main_window";
-import type { HomeAssistant } from "../types";
 import "./ha-icon-button";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import type { LocalizeFunc } from "../common/translations/localize";
 
 @customElement("ha-icon-button-arrow-next")
 export class HaIconButtonArrowNext extends LitElement {
-  @property({ attribute: false }) public hass?: HomeAssistant;
-
   @property({ type: Boolean }) public disabled = false;
 
   @property() public label?: string;
@@ -17,11 +16,15 @@ export class HaIconButtonArrowNext extends LitElement {
   @state() private _icon =
     mainWindow.document.dir === "rtl" ? mdiArrowLeft : mdiArrowRight;
 
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
+
   protected render(): TemplateResult {
     return html`
       <ha-icon-button
         .disabled=${this.disabled}
-        .label=${this.label || this.hass?.localize("ui.common.next") || "Next"}
+        .label=${this.label || this._localize("ui.common.next") || "Next"}
         .path=${this._icon}
       ></ha-icon-button>
     `;

--- a/src/components/ha-icon-button-next.ts
+++ b/src/components/ha-icon-button-next.ts
@@ -3,13 +3,12 @@ import type { TemplateResult } from "lit";
 import { html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { mainWindow } from "../common/dom/get_main_window";
-import type { HomeAssistant } from "../types";
 import "./ha-icon-button";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import type { LocalizeFunc } from "../common/translations/localize";
 
 @customElement("ha-icon-button-next")
 export class HaIconButtonNext extends LitElement {
-  @property({ attribute: false }) public hass?: HomeAssistant;
-
   @property({ type: Boolean }) public disabled = false;
 
   @property() public label?: string;
@@ -25,11 +24,15 @@ export class HaIconButtonNext extends LitElement {
   @state() private _icon =
     mainWindow.document.dir === "rtl" ? mdiChevronLeft : mdiChevronRight;
 
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
+
   protected render(): TemplateResult {
     return html`
       <ha-icon-button
         .disabled=${this.disabled}
-        .label=${this.label || this.hass?.localize("ui.common.next") || "Next"}
+        .label=${this.label || this._localize("ui.common.next") || "Next"}
         .path=${this._icon}
         .href=${this.href}
         .target=${this.target}

--- a/src/components/ha-icon-button-prev.ts
+++ b/src/components/ha-icon-button-prev.ts
@@ -3,13 +3,12 @@ import type { TemplateResult } from "lit";
 import { html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { mainWindow } from "../common/dom/get_main_window";
-import type { HomeAssistant } from "../types";
 import "./ha-icon-button";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import type { LocalizeFunc } from "../common/translations/localize";
 
 @customElement("ha-icon-button-prev")
 export class HaIconButtonPrev extends LitElement {
-  @property({ attribute: false }) public hass?: HomeAssistant;
-
   @property({ type: Boolean }) public disabled = false;
 
   @property() public label?: string;
@@ -25,11 +24,15 @@ export class HaIconButtonPrev extends LitElement {
   @state() private _icon =
     mainWindow.document.dir === "rtl" ? mdiChevronRight : mdiChevronLeft;
 
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
+
   protected render(): TemplateResult {
     return html`
       <ha-icon-button
         .disabled=${this.disabled}
-        .label=${this.label || this.hass?.localize("ui.common.back") || "Back"}
+        .label=${this.label || this._localize("ui.common.back") || "Back"}
         .path=${this._icon}
         .href=${this.href}
         .target=${this.target}

--- a/src/components/ha-network.ts
+++ b/src/components/ha-network.ts
@@ -10,8 +10,9 @@ import type {
   NetworkConfig,
 } from "../data/network";
 import { haStyle } from "../resources/styles";
-import type { HomeAssistant } from "../types";
 import "./ha-checkbox";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import type { LocalizeFunc } from "../common/translations/localize";
 import type { HaCheckbox } from "./ha-checkbox";
 import "./ha-settings-row";
 import "./ha-svg-icon";
@@ -41,11 +42,13 @@ declare global {
 }
 @customElement("ha-network")
 export class HaNetwork extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property({ attribute: false }) public networkConfig?: NetworkConfig;
 
   @state() private _expanded?: boolean;
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
 
   protected render() {
     if (this.networkConfig === undefined) {
@@ -57,14 +60,14 @@ export class HaNetwork extends LitElement {
         @change=${this._handleAutoConfigureCheckboxClick}
         .checked=${!configured_adapters.length}
         .hint=${!configured_adapters.length
-          ? this.hass.localize(
+          ? this._localize(
               "ui.panel.config.network.adapter.auto_configure_manual_hint"
             )
           : ""}
       >
-        ${this.hass.localize("ui.panel.config.network.adapter.auto_configure")}
+        ${this._localize("ui.panel.config.network.adapter.auto_configure")}
         <div class="description">
-          ${this.hass.localize("ui.panel.config.network.adapter.detected")}:
+          ${this._localize("ui.panel.config.network.adapter.detected")}:
           ${format_auto_detected_interfaces(this.networkConfig.adapters)}
         </div>
       </ha-checkbox>
@@ -77,13 +80,11 @@ export class HaNetwork extends LitElement {
                 .checked=${configured_adapters.includes(adapter.name)}
                 .adapter=${adapter.name}
               >
-                ${this.hass.localize(
-                  "ui.panel.config.network.adapter.adapter"
-                )}:
+                ${this._localize("ui.panel.config.network.adapter.adapter")}:
                 ${adapter.name}
                 ${adapter.default
                   ? html`<ha-svg-icon .path=${mdiStar}></ha-svg-icon>
-                      (${this.hass.localize("ui.common.default")})`
+                      (${this._localize("ui.common.default")})`
                   : nothing}
                 <div class="description">
                   ${format_addresses([...adapter.ipv4, ...adapter.ipv6])}

--- a/src/dialogs/notifications/notification-drawer.ts
+++ b/src/dialogs/notifications/notification-drawer.ts
@@ -132,7 +132,6 @@ export class HuiNotificationDrawer extends KeyboardShortcutMixin(LitElement) {
           </div>
           <ha-icon-button-prev
             slot="actionItems"
-            .hass=${this.hass}
             @click=${this.closeDialog}
             .label=${this.hass.localize("ui.notification_drawer.close")}
           >

--- a/src/panels/config/areas/dialog-area-registry-detail.ts
+++ b/src/panels/config/areas/dialog-area-registry-detail.ts
@@ -206,7 +206,6 @@ class DialogAreaDetail
             )}
           </p>
           <ha-aliases-editor
-            .hass=${this.hass}
             .aliases=${this._aliases}
             @value-changed=${this._aliasesChanged}
           ></ha-aliases-editor>

--- a/src/panels/config/areas/dialog-floor-registry-detail.ts
+++ b/src/panels/config/areas/dialog-floor-registry-detail.ts
@@ -229,7 +229,6 @@ class DialogFloorDetail extends LitElement {
               )}
             </p>
             <ha-aliases-editor
-              .hass=${this.hass}
               .aliases=${this._aliases}
               @value-changed=${this._aliasesChanged}
             ></ha-aliases-editor>

--- a/src/panels/config/network/ha-config-network.ts
+++ b/src/panels/config/network/ha-config-network.ts
@@ -46,7 +46,6 @@ class ConfigNetwork extends LitElement {
           </p>
           <ha-network
             @network-config-changed=${this._configChanged}
-            .hass=${this.hass}
             .networkConfig=${this._networkConfig}
           ></ha-network>
         </div>

--- a/src/panels/config/voice-assistants/entity-voice-settings.ts
+++ b/src/panels/config/voice-assistants/entity-voice-settings.ts
@@ -304,7 +304,6 @@ export class EntityVoiceSettings extends SubscribeMixin(LitElement) {
               ></ha-switch>
             </ha-md-list-item>
             <ha-aliases-editor
-              .hass=${this.hass}
               .aliases=${(this._aliases ?? this.entry.aliases).filter(
                 (a): a is string => a !== null
               )}

--- a/src/panels/lovelace/editor/card-editor/hui-card-layout-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-layout-editor.ts
@@ -133,7 +133,6 @@ export class HuiCardLayoutEditor extends LitElement {
                 "max-width": `${(this.sectionConfig.column_span ?? 1) * 250 + 40}px`,
               })}
               .columns=${gridTotalColumns}
-              .hass=${this.hass}
               .value=${gridValue}
               .isDefault=${this._isDefault(configOptions)}
               @value-changed=${this._gridSizeChanged}

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -522,7 +522,6 @@ class HUIRoot extends LitElement {
                     @click=${this._editView}
                   ></ha-icon-button>
                   <ha-icon-button-arrow-next
-                    .hass=${this.hass}
                     .label=${this.hass!.localize(
                       "ui.panel.lovelace.editor.edit_view.move_right"
                     )}


### PR DESCRIPTION
## Proposed change

Continues the migration of leaf components away from the full `hass` object toward fine-grained Lit contexts. These six components only ever used `hass` to call `localize`, so they now consume the `localize` slice via the `@consumeLocalize()` decorator instead of taking the whole `hass` property.

Migrated components:

- `ha-icon-button-next`
- `ha-icon-button-prev`
- `ha-icon-button-arrow-next`
- `ha-network`
- `ha-grid-size-picker`
- `ha-aliases-editor`

Each drops its `hass` property (and the `HomeAssistant` import) and replaces `this.hass.localize(...)` with `this._localize(...)`, mirroring the previously merged `ha-icon-button-arrow-prev` migration (#52377). Callers that still bound `.hass` to these elements have had that binding removed; no other bindings were touched.

This is a mechanical refactor with no behavior change.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
