### PR TITLE
Use context instead of hass in cover and valve control rows

### DIFF
--- a/src/components/ha-cover-controls.ts
+++ b/src/components/ha-cover-controls.ts
@@ -1,17 +1,23 @@
+import { consume, type ContextType } from "@lit/context";
 import { mdiStop } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
 import { computeCloseIcon, computeOpenIcon } from "../common/entity/cover_icon";
 import { supportsFeature } from "../common/entity/supports-feature";
+import type { LocalizeFunc } from "../common/translations/localize";
+import { apiContext } from "../data/context";
 import type { CoverEntity } from "../data/cover";
 import { canClose, canOpen, canStop, CoverEntityFeature } from "../data/cover";
-import type { HomeAssistant } from "../types";
 import "./ha-icon-button";
 
 @customElement("ha-cover-controls")
 class HaCoverControls extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state() @consumeLocalize() private _localize!: LocalizeFunc;
+
+  @consume({ context: apiContext, subscribe: true })
+  private _api!: ContextType<typeof apiContext>;
 
   @property({ attribute: false }) public stateObj!: CoverEntity;
 
@@ -26,7 +32,7 @@ class HaCoverControls extends LitElement {
           class=${classMap({
             hidden: !supportsFeature(this.stateObj, CoverEntityFeature.OPEN),
           })}
-          .label=${this.hass.localize("ui.card.cover.open_cover")}
+          .label=${this._localize("ui.card.cover.open_cover")}
           @click=${this._onOpenTap}
           .disabled=${!canOpen(this.stateObj)}
           .path=${computeOpenIcon(this.stateObj)}
@@ -36,7 +42,7 @@ class HaCoverControls extends LitElement {
           class=${classMap({
             hidden: !supportsFeature(this.stateObj, CoverEntityFeature.STOP),
           })}
-          .label=${this.hass.localize("ui.card.cover.stop_cover")}
+          .label=${this._localize("ui.card.cover.stop_cover")}
           .path=${mdiStop}
           @click=${this._onStopTap}
           .disabled=${!canStop(this.stateObj)}
@@ -45,7 +51,7 @@ class HaCoverControls extends LitElement {
           class=${classMap({
             hidden: !supportsFeature(this.stateObj, CoverEntityFeature.CLOSE),
           })}
-          .label=${this.hass.localize("ui.card.cover.close_cover")}
+          .label=${this._localize("ui.card.cover.close_cover")}
           @click=${this._onCloseTap}
           .disabled=${!canClose(this.stateObj)}
           .path=${computeCloseIcon(this.stateObj)}
@@ -57,21 +63,21 @@ class HaCoverControls extends LitElement {
 
   private _onOpenTap(ev): void {
     ev.stopPropagation();
-    this.hass.callService("cover", "open_cover", {
+    this._api.callService("cover", "open_cover", {
       entity_id: this.stateObj.entity_id,
     });
   }
 
   private _onCloseTap(ev): void {
     ev.stopPropagation();
-    this.hass.callService("cover", "close_cover", {
+    this._api.callService("cover", "close_cover", {
       entity_id: this.stateObj.entity_id,
     });
   }
 
   private _onStopTap(ev): void {
     ev.stopPropagation();
-    this.hass.callService("cover", "stop_cover", {
+    this._api.callService("cover", "stop_cover", {
       entity_id: this.stateObj.entity_id,
     });
   }

--- a/src/components/ha-cover-tilt-controls.ts
+++ b/src/components/ha-cover-tilt-controls.ts
@@ -1,8 +1,12 @@
+import { consume, type ContextType } from "@lit/context";
 import { mdiArrowBottomLeft, mdiArrowTopRight, mdiStop } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
 import { supportsFeature } from "../common/entity/supports-feature";
+import type { LocalizeFunc } from "../common/translations/localize";
+import { apiContext } from "../data/context";
 import type { CoverEntity } from "../data/cover";
 import {
   canCloseTilt,
@@ -10,12 +14,14 @@ import {
   canStopTilt,
   CoverEntityFeature,
 } from "../data/cover";
-import type { HomeAssistant } from "../types";
 import "./ha-icon-button";
 
 @customElement("ha-cover-tilt-controls")
 class HaCoverTiltControls extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state() @consumeLocalize() private _localize!: LocalizeFunc;
+
+  @consume({ context: apiContext, subscribe: true })
+  private _api!: ContextType<typeof apiContext>;
 
   @property({ attribute: false }) stateObj!: CoverEntity;
 
@@ -31,7 +37,7 @@ class HaCoverTiltControls extends LitElement {
             CoverEntityFeature.OPEN_TILT
           ),
         })}
-        .label=${this.hass.localize("ui.card.cover.open_tilt_cover")}
+        .label=${this._localize("ui.card.cover.open_tilt_cover")}
         .path=${mdiArrowTopRight}
         @click=${this._onOpenTiltTap}
         .disabled=${!canOpenTilt(this.stateObj)}
@@ -43,7 +49,7 @@ class HaCoverTiltControls extends LitElement {
             CoverEntityFeature.STOP_TILT
           ),
         })}
-        .label=${this.hass.localize("ui.card.cover.stop_cover")}
+        .label=${this._localize("ui.card.cover.stop_cover")}
         .path=${mdiStop}
         @click=${this._onStopTiltTap}
         .disabled=${!canStopTilt(this.stateObj)}
@@ -55,7 +61,7 @@ class HaCoverTiltControls extends LitElement {
             CoverEntityFeature.CLOSE_TILT
           ),
         })}
-        .label=${this.hass.localize("ui.card.cover.close_tilt_cover")}
+        .label=${this._localize("ui.card.cover.close_tilt_cover")}
         .path=${mdiArrowBottomLeft}
         @click=${this._onCloseTiltTap}
         .disabled=${!canCloseTilt(this.stateObj)}
@@ -64,21 +70,21 @@ class HaCoverTiltControls extends LitElement {
 
   private _onOpenTiltTap(ev): void {
     ev.stopPropagation();
-    this.hass.callService("cover", "open_cover_tilt", {
+    this._api.callService("cover", "open_cover_tilt", {
       entity_id: this.stateObj.entity_id,
     });
   }
 
   private _onCloseTiltTap(ev): void {
     ev.stopPropagation();
-    this.hass.callService("cover", "close_cover_tilt", {
+    this._api.callService("cover", "close_cover_tilt", {
       entity_id: this.stateObj.entity_id,
     });
   }
 
   private _onStopTiltTap(ev): void {
     ev.stopPropagation();
-    this.hass.callService("cover", "stop_cover_tilt", {
+    this._api.callService("cover", "stop_cover_tilt", {
       entity_id: this.stateObj.entity_id,
     });
   }

--- a/src/components/ha-valve-controls.ts
+++ b/src/components/ha-valve-controls.ts
@@ -1,16 +1,22 @@
+import { consume, type ContextType } from "@lit/context";
 import { mdiStop, mdiValveClosed, mdiValveOpen } from "@mdi/js";
 import { LitElement, html, css, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
 import { supportsFeature } from "../common/entity/supports-feature";
+import type { LocalizeFunc } from "../common/translations/localize";
+import { apiContext } from "../data/context";
 import type { ValveEntity } from "../data/valve";
 import { ValveEntityFeature, canClose, canOpen, canStop } from "../data/valve";
-import type { HomeAssistant } from "../types";
 import "./ha-icon-button";
 
 @customElement("ha-valve-controls")
 class HaValveControls extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state() @consumeLocalize() private _localize!: LocalizeFunc;
+
+  @consume({ context: apiContext, subscribe: true })
+  private _api!: ContextType<typeof apiContext>;
 
   @property({ attribute: false }) public stateObj!: ValveEntity;
 
@@ -25,7 +31,7 @@ class HaValveControls extends LitElement {
           class=${classMap({
             hidden: !supportsFeature(this.stateObj, ValveEntityFeature.OPEN),
           })}
-          .label=${this.hass.localize("ui.card.valve.open_valve")}
+          .label=${this._localize("ui.card.valve.open_valve")}
           @click=${this._onOpenTap}
           .disabled=${!canOpen(this.stateObj)}
           .path=${mdiValveOpen}
@@ -35,7 +41,7 @@ class HaValveControls extends LitElement {
           class=${classMap({
             hidden: !supportsFeature(this.stateObj, ValveEntityFeature.STOP),
           })}
-          .label=${this.hass.localize("ui.card.valve.stop_valve")}
+          .label=${this._localize("ui.card.valve.stop_valve")}
           @click=${this._onStopTap}
           .disabled=${!canStop(this.stateObj)}
           .path=${mdiStop}
@@ -44,7 +50,7 @@ class HaValveControls extends LitElement {
           class=${classMap({
             hidden: !supportsFeature(this.stateObj, ValveEntityFeature.CLOSE),
           })}
-          .label=${this.hass.localize("ui.card.valve.close_valve")}
+          .label=${this._localize("ui.card.valve.close_valve")}
           @click=${this._onCloseTap}
           .disabled=${!canClose(this.stateObj)}
           .path=${mdiValveClosed}
@@ -56,21 +62,21 @@ class HaValveControls extends LitElement {
 
   private _onOpenTap(ev): void {
     ev.stopPropagation();
-    this.hass.callService("valve", "open_valve", {
+    this._api.callService("valve", "open_valve", {
       entity_id: this.stateObj.entity_id,
     });
   }
 
   private _onCloseTap(ev): void {
     ev.stopPropagation();
-    this.hass.callService("valve", "close_valve", {
+    this._api.callService("valve", "close_valve", {
       entity_id: this.stateObj.entity_id,
     });
   }
 
   private _onStopTap(ev): void {
     ev.stopPropagation();
-    this.hass.callService("valve", "stop_valve", {
+    this._api.callService("valve", "stop_valve", {
       entity_id: this.stateObj.entity_id,
     });
   }

--- a/src/dialogs/config-flow/previews/entity-preview-row.ts
+++ b/src/dialogs/config-flow/previews/entity-preview-row.ts
@@ -133,15 +133,11 @@ class EntityPreviewRow extends LitElement {
         ${isTiltOnly(stateObj)
           ? html`
               <ha-cover-tilt-controls
-                .hass=${this.hass}
                 .stateObj=${stateObj}
               ></ha-cover-tilt-controls>
             `
           : html`
-              <ha-cover-controls
-                .hass=${this.hass}
-                .stateObj=${stateObj}
-              ></ha-cover-controls>
+              <ha-cover-controls .stateObj=${stateObj}></ha-cover-controls>
             `}
       `;
     }

--- a/src/panels/lovelace/entity-rows/hui-cover-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-cover-entity-row.ts
@@ -48,15 +48,11 @@ class HuiCoverEntityRow extends LitElement implements LovelaceRow {
         ${isTiltOnly(stateObj)
           ? html`
               <ha-cover-tilt-controls
-                .hass=${this.hass}
                 .stateObj=${stateObj}
               ></ha-cover-tilt-controls>
             `
           : html`
-              <ha-cover-controls
-                .hass=${this.hass}
-                .stateObj=${stateObj}
-              ></ha-cover-controls>
+              <ha-cover-controls .stateObj=${stateObj}></ha-cover-controls>
             `}
       </hui-generic-entity-row>
     `;

--- a/src/state-summary/state-card-cover.ts
+++ b/src/state-summary/state-card-cover.ts
@@ -26,12 +26,10 @@ class StateCardCover extends LitElement {
           .inDialog=${this.inDialog}
         ></state-info>
         <ha-cover-controls
-          .hass=${this.hass}
           .hidden=${isTiltOnly(this.stateObj)}
           .stateObj=${this.stateObj}
         ></ha-cover-controls>
         <ha-cover-tilt-controls
-          .hass=${this.hass}
           .hidden=${!isTiltOnly(this.stateObj)}
           .stateObj=${this.stateObj}
         ></ha-cover-tilt-controls>


### PR DESCRIPTION
## Proposed change

Part of the ongoing migration of leaf components away from the whole `hass` object toward fine-grained Lit context.

`ha-cover-controls`, `ha-cover-tilt-controls`, and `ha-valve-controls` only ever read `hass.localize` (for the icon-button labels) and `hass.callService` (for the open/close/stop actions). This swaps those out:

- labels now use `@consumeLocalize()` (`this._localize(...)`)
- service calls now consume `apiContext` (`this._api.callService(...)`)

The `hass` property is dropped from all three components, and the now-dead `.hass=` bindings are removed from their callers (`hui-cover-entity-row`, `state-card-cover`, `entity-preview-row`).

No behavior change — this is a mechanical context migration.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
