### PR TITLE
Use context instead of hass in domain state display components

### DIFF
--- a/src/components/ha-attribute-value.ts
+++ b/src/components/ha-attribute-value.ts
@@ -1,12 +1,16 @@
+import { consume } from "@lit/context";
+import type { ContextType } from "@lit/context";
 import type { HassEntity } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { until } from "lit/directives/until";
-import type { HomeAssistant } from "../types";
+import { formattersContext } from "../data/context";
 
 @customElement("ha-attribute-value")
 class HaAttributeValue extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state()
+  @consume({ context: formattersContext, subscribe: true })
+  private _formatters?: ContextType<typeof formattersContext>;
 
   @property({ attribute: false }) public stateObj?: HassEntity;
 
@@ -53,7 +57,7 @@ class HaAttributeValue extends LitElement {
     }
 
     if (this.hideUnit) {
-      const parts = this.hass.formatEntityAttributeValueToParts(
+      const parts = this._formatters!.formatEntityAttributeValueToParts(
         this.stateObj!,
         this.attribute
       );
@@ -63,7 +67,10 @@ class HaAttributeValue extends LitElement {
         .join("");
     }
 
-    return this.hass.formatEntityAttributeValue(this.stateObj!, this.attribute);
+    return this._formatters!.formatEntityAttributeValue(
+      this.stateObj!,
+      this.attribute
+    );
   }
 
   static styles = css`

--- a/src/components/ha-attributes.ts
+++ b/src/components/ha-attributes.ts
@@ -80,7 +80,6 @@ class HaAttributes extends LitElement {
                       </div>
                       <div class="value">
                         <ha-attribute-value
-                          .hass=${this.hass}
                           .attribute=${attribute}
                           .stateObj=${this.stateObj}
                         ></ha-attribute-value>

--- a/src/components/ha-climate-state.ts
+++ b/src/components/ha-climate-state.ts
@@ -1,14 +1,22 @@
+import { consume } from "@lit/context";
+import type { ContextType } from "@lit/context";
 import type { TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import type { LocalizeFunc } from "../common/translations/localize";
 import type { ClimateEntity } from "../data/climate";
 import { CLIMATE_PRESET_NONE } from "../data/climate";
+import { formattersContext } from "../data/context";
 import { OFF, UNAVAILABLE, UNKNOWN } from "../data/entity/entity";
-import type { HomeAssistant } from "../types";
 
 @customElement("ha-climate-state")
 class HaClimateState extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state()
+  @consume({ context: formattersContext, subscribe: true })
+  private _formatters?: ContextType<typeof formattersContext>;
+
+  @state() @consumeLocalize() private _localize!: LocalizeFunc;
 
   @property({ attribute: false }) public stateObj!: ClimateEntity;
 
@@ -24,7 +32,7 @@ class HaClimateState extends LitElement {
                 ${this.stateObj.attributes.preset_mode &&
                 this.stateObj.attributes.preset_mode !== CLIMATE_PRESET_NONE
                   ? html`-
-                    ${this.hass.formatEntityAttributeValue(
+                    ${this._formatters!.formatEntityAttributeValue(
                       this.stateObj,
                       "preset_mode"
                     )}`
@@ -37,7 +45,7 @@ class HaClimateState extends LitElement {
       ${currentStatus && !noValue
         ? html`
             <div class="current">
-              ${this.hass.localize("ui.card.climate.currently")}:
+              ${this._localize("ui.card.climate.currently")}:
               <div class="unit">${currentStatus}</div>
             </div>
           `
@@ -45,32 +53,32 @@ class HaClimateState extends LitElement {
   }
 
   private _computeCurrentStatus(): string | undefined {
-    if (!this.hass || !this.stateObj) {
+    if (!this._formatters || !this.stateObj) {
       return undefined;
     }
     if (
       this.stateObj.attributes.current_temperature != null &&
       this.stateObj.attributes.current_humidity != null
     ) {
-      return `${this.hass.formatEntityAttributeValue(
+      return `${this._formatters.formatEntityAttributeValue(
         this.stateObj,
         "current_temperature"
       )}/
-      ${this.hass.formatEntityAttributeValue(
+      ${this._formatters.formatEntityAttributeValue(
         this.stateObj,
         "current_humidity"
       )}`;
     }
 
     if (this.stateObj.attributes.current_temperature != null) {
-      return this.hass.formatEntityAttributeValue(
+      return this._formatters.formatEntityAttributeValue(
         this.stateObj,
         "current_temperature"
       );
     }
 
     if (this.stateObj.attributes.current_humidity != null) {
-      return this.hass.formatEntityAttributeValue(
+      return this._formatters.formatEntityAttributeValue(
         this.stateObj,
         "current_humidity"
       );
@@ -80,7 +88,7 @@ class HaClimateState extends LitElement {
   }
 
   private _computeTarget(): string {
-    if (!this.hass || !this.stateObj) {
+    if (!this._formatters || !this.stateObj) {
       return "";
     }
 
@@ -88,33 +96,39 @@ class HaClimateState extends LitElement {
       this.stateObj.attributes.target_temp_low != null &&
       this.stateObj.attributes.target_temp_high != null
     ) {
-      return `${this.hass.formatEntityAttributeValue(
+      return `${this._formatters.formatEntityAttributeValue(
         this.stateObj,
         "target_temp_low"
-      )}-${this.hass.formatEntityAttributeValue(
+      )}-${this._formatters.formatEntityAttributeValue(
         this.stateObj,
         "target_temp_high"
       )}`;
     }
 
     if (this.stateObj.attributes.temperature != null) {
-      return this.hass.formatEntityAttributeValue(this.stateObj, "temperature");
+      return this._formatters.formatEntityAttributeValue(
+        this.stateObj,
+        "temperature"
+      );
     }
     if (
       this.stateObj.attributes.target_humidity_low != null &&
       this.stateObj.attributes.target_humidity_high != null
     ) {
-      return `${this.hass.formatEntityAttributeValue(
+      return `${this._formatters.formatEntityAttributeValue(
         this.stateObj,
         "target_humidity_low"
-      )}-${this.hass.formatEntityAttributeValue(
+      )}-${this._formatters.formatEntityAttributeValue(
         this.stateObj,
         "target_humidity_high"
       )}`;
     }
 
     if (this.stateObj.attributes.humidity != null) {
-      return this.hass.formatEntityAttributeValue(this.stateObj, "humidity");
+      return this._formatters.formatEntityAttributeValue(
+        this.stateObj,
+        "humidity"
+      );
     }
 
     return "";
@@ -125,13 +139,13 @@ class HaClimateState extends LitElement {
       this.stateObj.state === UNAVAILABLE ||
       this.stateObj.state === UNKNOWN
     ) {
-      return this.hass.localize(`state.default.${this.stateObj.state}`);
+      return this._localize(`state.default.${this.stateObj.state}`);
     }
 
-    const stateString = this.hass.formatEntityState(this.stateObj);
+    const stateString = this._formatters!.formatEntityState(this.stateObj);
 
     if (this.stateObj.attributes.hvac_action && this.stateObj.state !== OFF) {
-      const actionString = this.hass.formatEntityAttributeValue(
+      const actionString = this._formatters!.formatEntityAttributeValue(
         this.stateObj,
         "hvac_action"
       );

--- a/src/components/ha-humidifier-state.ts
+++ b/src/components/ha-humidifier-state.ts
@@ -1,13 +1,21 @@
+import { consume } from "@lit/context";
+import type { ContextType } from "@lit/context";
 import type { TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import type { LocalizeFunc } from "../common/translations/localize";
+import { formattersContext } from "../data/context";
 import { OFF, UNAVAILABLE, UNKNOWN } from "../data/entity/entity";
 import type { HumidifierEntity } from "../data/humidifier";
-import type { HomeAssistant } from "../types";
 
 @customElement("ha-humidifier-state")
 class HaHumidifierState extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state()
+  @consume({ context: formattersContext, subscribe: true })
+  private _formatters?: ContextType<typeof formattersContext>;
+
+  @state() @consumeLocalize() private _localize!: LocalizeFunc;
 
   @property({ attribute: false }) public stateObj!: HumidifierEntity;
 
@@ -22,7 +30,7 @@ class HaHumidifierState extends LitElement {
                 ${this._localizeState()}
                 ${this.stateObj.attributes.mode
                   ? html`-
-                    ${this.hass.formatEntityAttributeValue(
+                    ${this._formatters!.formatEntityAttributeValue(
                       this.stateObj,
                       "mode"
                     )}`
@@ -34,19 +42,19 @@ class HaHumidifierState extends LitElement {
 
       ${currentStatus && !noValue
         ? html`<div class="current">
-            ${this.hass.localize("ui.card.humidifier.currently")}:
+            ${this._localize("ui.card.humidifier.currently")}:
             <div class="unit">${currentStatus}</div>
           </div>`
         : ""}`;
   }
 
   private _computeCurrentStatus(): string | undefined {
-    if (!this.hass || !this.stateObj) {
+    if (!this._formatters || !this.stateObj) {
       return undefined;
     }
 
     if (this.stateObj.attributes.current_humidity != null) {
-      return `${this.hass.formatEntityAttributeValue(
+      return `${this._formatters.formatEntityAttributeValue(
         this.stateObj,
         "current_humidity"
       )}`;
@@ -56,12 +64,12 @@ class HaHumidifierState extends LitElement {
   }
 
   private _computeTarget(): string {
-    if (!this.hass || !this.stateObj) {
+    if (!this._formatters || !this.stateObj) {
       return "";
     }
 
     if (this.stateObj.attributes.humidity != null) {
-      return `${this.hass.formatEntityAttributeValue(
+      return `${this._formatters.formatEntityAttributeValue(
         this.stateObj,
         "humidity"
       )}`;
@@ -75,13 +83,13 @@ class HaHumidifierState extends LitElement {
       this.stateObj.state === UNAVAILABLE ||
       this.stateObj.state === UNKNOWN
     ) {
-      return this.hass.localize(`state.default.${this.stateObj.state}`);
+      return this._localize(`state.default.${this.stateObj.state}`);
     }
 
-    const stateString = this.hass.formatEntityState(this.stateObj);
+    const stateString = this._formatters!.formatEntityState(this.stateObj);
 
     if (this.stateObj.attributes.action && this.stateObj.state !== OFF) {
-      const actionString = this.hass.formatEntityAttributeValue(
+      const actionString = this._formatters!.formatEntityAttributeValue(
         this.stateObj,
         "action"
       );

--- a/src/dialogs/config-flow/previews/entity-preview-row.ts
+++ b/src/dialogs/config-flow/previews/entity-preview-row.ts
@@ -123,8 +123,7 @@ class EntityPreviewRow extends LitElement {
     const climateDomains = ["climate", "water_heater"];
     if (climateDomains.includes(domain)) {
       return html`
-        <ha-climate-state .hass=${this.hass} .stateObj=${stateObj}>
-        </ha-climate-state>
+        <ha-climate-state .stateObj=${stateObj}> </ha-climate-state>
       `;
     }
 
@@ -216,8 +215,7 @@ class EntityPreviewRow extends LitElement {
 
     if (domain === "humidifier") {
       return html`
-        <ha-humidifier-state .hass=${this.hass} .stateObj=${stateObj}>
-        </ha-humidifier-state>
+        <ha-humidifier-state .stateObj=${stateObj}> </ha-humidifier-state>
       `;
     }
 

--- a/src/dialogs/more-info/ha-more-info-details.ts
+++ b/src/dialogs/more-info/ha-more-info-details.ts
@@ -190,7 +190,6 @@ class HaMoreInfoDetails extends LitElement {
           </div>
           <div class="value">
             <ha-attribute-value
-              .hass=${this.hass}
               .attribute=${attribute}
               .stateObj=${this._stateObj}
             ></ha-attribute-value>

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -181,7 +181,6 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
               ? stateObj.attributes[this._config.attribute!] !== undefined
                 ? html`<ha-attribute-value
                     hide-unit
-                    .hass=${this.hass}
                     .stateObj=${stateObj}
                     .attribute=${this._config.attribute!}
                   >

--- a/src/panels/lovelace/entity-rows/hui-climate-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-climate-entity-row.ts
@@ -43,8 +43,7 @@ class HuiClimateEntityRow extends LitElement implements LovelaceRow {
 
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
-        <ha-climate-state .hass=${this.hass} .stateObj=${stateObj}>
-        </ha-climate-state>
+        <ha-climate-state .stateObj=${stateObj}> </ha-climate-state>
       </hui-generic-entity-row>
     `;
   }

--- a/src/panels/lovelace/entity-rows/hui-humidifier-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-humidifier-entity-row.ts
@@ -45,8 +45,7 @@ class HuiHumidifierEntityRow extends LitElement implements LovelaceRow {
 
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
-        <ha-humidifier-state .hass=${this.hass} .stateObj=${stateObj}>
-        </ha-humidifier-state>
+        <ha-humidifier-state .stateObj=${stateObj}> </ha-humidifier-state>
       </hui-generic-entity-row>
     `;
   }

--- a/src/panels/lovelace/special-rows/hui-attribute-row.ts
+++ b/src/panels/lovelace/special-rows/hui-attribute-row.ts
@@ -69,7 +69,6 @@ class HuiAttributeRow extends LitElement implements LovelaceRow {
                 <ha-attribute-value
                   .hideUnit=${this._config.suffix !== undefined &&
                   this._config.suffix !== ""}
-                  .hass=${this.hass}
                   .stateObj=${stateObj}
                   .attribute=${this._config.attribute}
                 >

--- a/src/state-summary/state-card-climate.ts
+++ b/src/state-summary/state-card-climate.ts
@@ -23,10 +23,7 @@ class StateCardClimate extends LitElement {
           .stateObj=${this.stateObj}
           .inDialog=${this.inDialog}
         ></state-info>
-        <ha-climate-state
-          .hass=${this.hass}
-          .stateObj=${this.stateObj}
-        ></ha-climate-state>
+        <ha-climate-state .stateObj=${this.stateObj}></ha-climate-state>
       </div>
     `;
   }

--- a/src/state-summary/state-card-humidifier.ts
+++ b/src/state-summary/state-card-humidifier.ts
@@ -25,10 +25,7 @@ class StateCardHumidifier extends LitElement {
           .inDialog=${this.inDialog}
         >
         </state-info>
-        <ha-humidifier-state
-          .hass=${this.hass}
-          .stateObj=${this.stateObj}
-        ></ha-humidifier-state>
+        <ha-humidifier-state .stateObj=${this.stateObj}></ha-humidifier-state>
       </div>
     `;
   }


### PR DESCRIPTION
## Breaking change

## Proposed change

Migrates three domain state-display leaf components off the whole `hass` object and onto fine-grained Lit context, so they re-render only when the slice they actually read changes:

- `ha-attribute-value` — consumes `formattersContext`.
- `ha-humidifier-state` — consumes `formattersContext` and `consumeLocalize()`.
- `ha-climate-state` — consumes `formattersContext` and `consumeLocalize()`.

The now-dead `.hass=` bindings on these three tags are removed from their callers. This is a mechanical migration with no behavior change.

Note: `ha-water_heater-state` was intentionally left for a follow-up because, beyond `formatEntityState` and `locale`, it also reads `hass.config.unit_system`, which is out of scope for now.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
