### PR TITLE
Add time_format to tile card

### DIFF
--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -110,6 +110,15 @@ export const DOMAINS_WITH_DYNAMIC_PICTURE = new Set([
   "media_player",
 ]);
 
+/** Domains that use a timestamp for state. */
+export const TIMESTAMP_STATE_DOMAINS = [
+  "button",
+  "infrared",
+  "input_button",
+  "radio_frequency",
+  "scene",
+];
+
 /** Temperature units. */
 export const UNIT_C = "°C";
 export const UNIT_F = "°F";

--- a/src/components/ha-selector/ha-selector-ui-time-format.ts
+++ b/src/components/ha-selector/ha-selector-ui-time-format.ts
@@ -4,7 +4,7 @@ import "../ha-time-format-picker";
 
 @customElement("ha-selector-ui_time_format")
 export class HaSelectorUiTimeFormat extends LitElement {
-  @property() public value?: string | string[];
+  @property() public value?: string;
 
   @property() public label?: string;
 

--- a/src/components/ha-selector/ha-selector-ui-time-format.ts
+++ b/src/components/ha-selector/ha-selector-ui-time-format.ts
@@ -1,0 +1,32 @@
+import { html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import "../ha-time-format-picker";
+
+@customElement("ha-selector-ui_time_format")
+export class HaSelectorUiTimeFormat extends LitElement {
+  @property() public value?: string | string[];
+
+  @property() public label?: string;
+
+  @property() public helper?: string;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  protected render() {
+    return html`
+      <ha-time-format-picker
+        .label=${this.label}
+        .value=${this.value}
+        .helper=${this.helper}
+        .disabled=${this.disabled}
+      >
+      </ha-time-format-picker>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-selector-ui_time_format": HaSelectorUiTimeFormat;
+  }
+}

--- a/src/components/ha-selector/ha-selector.ts
+++ b/src/components/ha-selector/ha-selector.ts
@@ -67,6 +67,7 @@ const LOAD_ELEMENTS = {
   ui_action: () => import("./ha-selector-ui-action"),
   ui_color: () => import("./ha-selector-ui-color"),
   ui_state_content: () => import("./ha-selector-ui-state-content"),
+  ui_time_format: () => import("./ha-selector-ui-time-format"),
 };
 
 const LEGACY_UI_SELECTORS = new Set(["ui-action", "ui-color"]);

--- a/src/components/ha-time-format-picker.ts
+++ b/src/components/ha-time-format-picker.ts
@@ -1,3 +1,4 @@
+import memoizeOne from "memoize-one";
 import { html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
@@ -20,19 +21,18 @@ export class HaTimeFormatPicker extends LitElement {
   @consumeLocalize()
   private _localize!: LocalizeFunc;
 
-  protected render() {
-    const OPTIONS = [
-      { label: this._localize("ui.common.auto"), value: "auto" },
-    ].concat(
+  private _options = memoizeOne((localize: LocalizeFunc) =>
+    [{ label: localize("ui.common.auto"), value: "auto" }].concat(
       TIMESTAMP_RENDERING_FORMATS.map((format) => ({
         label:
-          this._localize(
-            `ui.components.time-format-picker.formats.${format}`
-          ) || format,
+          localize(`ui.components.time-format-picker.formats.${format}`) ||
+          format,
         value: format,
       }))
-    );
+    )
+  );
 
+  protected render() {
     return html`
       <ha-select
         .label=${this.label ?? ""}
@@ -40,7 +40,7 @@ export class HaTimeFormatPicker extends LitElement {
         .helper=${this.helper ?? ""}
         .disabled=${this.disabled}
         @selected=${this._selectChanged}
-        .options=${OPTIONS}
+        .options=${this._options(this._localize)}
       >
       </ha-select>
     `;

--- a/src/components/ha-time-format-picker.ts
+++ b/src/components/ha-time-format-picker.ts
@@ -23,7 +23,7 @@ export class HaTimeFormatPicker extends LitElement {
 
   protected render() {
     const OPTIONS = [
-      { label: this._localize("ui.common.default"), value: "default" },
+      { label: this._localize("ui.common.auto"), value: "auto" },
     ].concat(
       TIMESTAMP_RENDERING_FORMATS.map((format) => ({
         label:
@@ -37,7 +37,7 @@ export class HaTimeFormatPicker extends LitElement {
     return html`
       <ha-select
         .label=${this.label ?? ""}
-        .value=${this.value || "default"}
+        .value=${this.value || "auto"}
         .helper=${this.helper ?? ""}
         .disabled=${this.disabled}
         @selected=${this._selectChanged}
@@ -49,7 +49,7 @@ export class HaTimeFormatPicker extends LitElement {
 
   private _selectChanged(ev) {
     ev.stopPropagation();
-    if (ev.detail?.value === "default" && this.value !== undefined) {
+    if (ev.detail?.value === "auto" && this.value !== undefined) {
       fireEvent(this, "value-changed", {
         value: undefined,
       });

--- a/src/components/ha-time-format-picker.ts
+++ b/src/components/ha-time-format-picker.ts
@@ -1,0 +1,68 @@
+import { html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../common/dom/fire_event";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import type { LocalizeFunc } from "../common/translations/localize";
+import "./ha-generic-picker";
+import "./ha-select";
+import { TIMESTAMP_RENDERING_FORMATS } from "../panels/lovelace/components/types";
+
+@customElement("ha-time-format-picker")
+export class HaTimeFormatPicker extends LitElement {
+  @property() public value?: string;
+
+  @property() public label?: string;
+
+  @property() public helper?: string;
+
+  @property({ type: Boolean, reflect: true }) public disabled = false;
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
+
+  protected render() {
+    const OPTIONS = [
+      { label: this._localize("ui.common.default"), value: "default" },
+    ].concat(
+      TIMESTAMP_RENDERING_FORMATS.map((format) => ({
+        label:
+          this._localize(
+            `ui.components.time-format-picker.formats.${format}`
+          ) || format,
+        value: format,
+      }))
+    );
+
+    return html`
+      <ha-select
+        .label=${this.label ?? ""}
+        .value=${this.value || "default"}
+        .helper=${this.helper ?? ""}
+        .disabled=${this.disabled}
+        @selected=${this._selectChanged}
+        .options=${OPTIONS}
+      >
+      </ha-select>
+    `;
+  }
+
+  private _selectChanged(ev) {
+    ev.stopPropagation();
+    if (ev.detail?.value === "default" && this.value !== undefined) {
+      fireEvent(this, "value-changed", {
+        value: undefined,
+      });
+      return;
+    }
+    fireEvent(this, "value-changed", {
+      value: ev.detail.value,
+    });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-time-format-picker": HaTimeFormatPicker;
+  }
+}

--- a/src/components/ha-time-format-picker.ts
+++ b/src/components/ha-time-format-picker.ts
@@ -3,7 +3,6 @@ import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
 import { consumeLocalize } from "../common/decorators/consume-context-entry";
 import type { LocalizeFunc } from "../common/translations/localize";
-import "./ha-generic-picker";
 import "./ha-select";
 import { TIMESTAMP_RENDERING_FORMATS } from "../panels/lovelace/components/types";
 

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -82,6 +82,7 @@ export type Selector =
   | UiActionSelector
   | UiColorSelector
   | UiStateContentSelector
+  | UiTimeFormatSelector
   | BackupLocationSelector;
 
 export interface ActionSelector {
@@ -599,6 +600,10 @@ export interface UiStateContentSelector {
     allow_name?: boolean;
     allow_context?: boolean;
   } | null;
+}
+
+export interface UiTimeFormatSelector {
+  ui_time_format: {} | null;
 }
 
 export interface EntityNameSelector {

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -264,6 +264,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
             .stateObj=${stateObj}
             .hass=${this.hass}
             .content=${this._config.state_content}
+            .timeFormat=${this._config.time_format}
           >
           </state-display>
         `;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -665,6 +665,7 @@ export interface TileCardConfig extends LovelaceCardConfig {
   icon_double_tap_action?: ActionConfig;
   features?: LovelaceCardFeatureConfig[];
   features_position?: LovelaceCardFeaturePosition;
+  time_format?: TimestampRenderingFormat;
 }
 
 export interface HeadingCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -40,10 +40,8 @@ import { entityNameStruct } from "../structs/entity-name-struct";
 import type { EditDetailElementEvent, EditSubElementEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
 import { getSupportedFeaturesType } from "./hui-card-features-editor";
-import { computeDomain } from "../../../../common/entity/compute_domain";
-import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../../../data/sensor";
-import { TIMESTAMP_STATE_DOMAINS } from "../../../../common/const";
 import { TIMESTAMP_RENDERING_FORMATS } from "../../components/types";
+import { stateContentHasTimestamp } from "../../../../state-display/state-display";
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -287,17 +285,13 @@ export class HuiTileCardEditor
 
     const entityId = this._config!.entity;
 
-    const domain = computeDomain(entityId || "");
-    const sensorDeviceClass =
-      domain === "sensor"
-        ? this.hass.states[entityId].attributes.device_class
-        : "";
     const showTimeFormat =
       !this._config.hide_state &&
-      (TIMESTAMP_STATE_DOMAINS.includes(domain) ||
-        SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(sensorDeviceClass)) &&
-      (!this._config.state_content ||
-        this._config.state_content.includes("state"));
+      stateContentHasTimestamp(
+        entityId,
+        this.hass.states[entityId],
+        this._config.state_content
+      );
 
     const schema = this._schema(
       this.hass.localize,

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -40,6 +40,10 @@ import { entityNameStruct } from "../structs/entity-name-struct";
 import type { EditDetailElementEvent, EditSubElementEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
 import { getSupportedFeaturesType } from "./hui-card-features-editor";
+import { computeDomain } from "../../../../common/entity/compute_domain";
+import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../../../data/sensor";
+import { TIMESTAMP_STATE_DOMAINS } from "../../../../common/const";
+import { TIMESTAMP_RENDERING_FORMATS } from "../../components/types";
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -60,6 +64,7 @@ const cardConfigStruct = assign(
     icon_double_tap_action: optional(actionConfigStruct),
     features: optional(array(any())),
     features_position: optional(enums(["bottom", "inline"])),
+    time_format: optional(enums(TIMESTAMP_RENDERING_FORMATS)),
   })
 );
 
@@ -89,7 +94,8 @@ export class HuiTileCardEditor
     (
       localize: LocalizeFunc,
       entityId: string | undefined,
-      hideState: boolean
+      hideState: boolean,
+      showTimeFormat: boolean
     ) =>
       [
         { name: "entity", selector: { entity: {} } },
@@ -151,6 +157,16 @@ export class HuiTileCardEditor
                     },
                     context: {
                       filter_entity: "entity",
+                    },
+                  },
+                ] as const satisfies readonly HaFormSchema[])
+              : []),
+            ...(showTimeFormat
+              ? ([
+                  {
+                    name: "time_format",
+                    selector: {
+                      ui_time_format: {},
                     },
                   },
                 ] as const satisfies readonly HaFormSchema[])
@@ -271,10 +287,23 @@ export class HuiTileCardEditor
 
     const entityId = this._config!.entity;
 
+    const domain = computeDomain(entityId || "");
+    const sensorDeviceClass =
+      domain === "sensor"
+        ? this.hass.states[entityId].attributes.device_class
+        : "";
+    const showTimeFormat =
+      !this._config.hide_state &&
+      (TIMESTAMP_STATE_DOMAINS.includes(domain) ||
+        SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(sensorDeviceClass)) &&
+      (!this._config.state_content ||
+        this._config.state_content.includes("state"));
+
     const schema = this._schema(
       this.hass.localize,
       entityId,
-      this._config.hide_state ?? false
+      this._config.hide_state ?? false,
+      showTimeFormat
     );
 
     const vertical = this._config.vertical ?? false;

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -86,7 +86,7 @@ export const stateContentHasTimestamp = (
     return false;
   }
   const domain = computeDomain(entityId);
-  if (!content || content.includes("state")) {
+  if (!content || contentArray.includes("state")) {
     if (TIMESTAMP_STATE_DOMAINS.includes(domain)) {
       return true;
     }

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -206,7 +206,7 @@ class StateDisplay extends LitElement {
       relativeDateTime = stateObj.attributes[content];
     }
 
-    if (relativeDateTime !== undefined) {
+    if (relativeDateTime || relativeDateTime === 0) {
       return html`<hui-timestamp-display
         .hass=${this.hass}
         .ts=${new Date(relativeDateTime)}

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -5,7 +5,10 @@ import { customElement, property } from "lit/decorators";
 import { join } from "lit/directives/join";
 import { ensureArray } from "../common/array/ensure-array";
 import { computeStateDomain } from "../common/entity/compute_state_domain";
-import { STRINGS_SEPARATOR_DOT } from "../common/const";
+import {
+  STRINGS_SEPARATOR_DOT,
+  TIMESTAMP_STATE_DOMAINS,
+} from "../common/const";
 import "../components/ha-relative-time";
 import { UNAVAILABLE, UNKNOWN } from "../data/entity/entity";
 import {
@@ -16,14 +19,6 @@ import type { UpdateEntity } from "../data/update";
 import { computeUpdateStateDisplay } from "../data/update";
 import "../panels/lovelace/components/hui-timestamp-display";
 import type { HomeAssistant } from "../types";
-
-const TIMESTAMP_STATE_DOMAINS = [
-  "button",
-  "infrared",
-  "input_button",
-  "radio_frequency",
-  "scene",
-];
 
 export const STATE_DISPLAY_SPECIAL_CONTENT = [
   "remaining_time",
@@ -70,6 +65,8 @@ class StateDisplay extends LitElement {
 
   @property({ attribute: false }) public name?: string;
 
+  @property({ attribute: false }) public timeFormat?: string;
+
   @property({ type: Boolean, attribute: "dash-unavailable" })
   public dashUnavailable?: boolean;
 
@@ -105,10 +102,11 @@ class StateDisplay extends LitElement {
           <hui-timestamp-display
             .hass=${this.hass}
             .ts=${new Date(stateObj.state)}
-            .format=${this.stateObj.attributes.device_class ===
+            .format=${this.timeFormat ||
+            (this.stateObj.attributes.device_class ===
             SENSOR_DEVICE_CLASS_UPTIME
               ? "total"
-              : "relative"}
+              : "relative")}
             capitalize
           ></hui-timestamp-display>
         `;

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -1,5 +1,6 @@
+import memoizeOne from "memoize-one";
 import type { HassEntity } from "home-assistant-js-websocket";
-import type { PropertyValues, TemplateResult } from "lit";
+import type { TemplateResult } from "lit";
 import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { join } from "lit/directives/join";
@@ -100,6 +101,7 @@ export const stateContentHasTimestamp = (
   }
   return (
     TIMESTAMP_DOMAIN_CONTENTS[domain] &&
+    content &&
     contentArray.some((c) => TIMESTAMP_DOMAIN_CONTENTS[domain].includes(c))
   );
 };
@@ -119,31 +121,25 @@ class StateDisplay extends LitElement {
   @property({ type: Boolean, attribute: "dash-unavailable" })
   public dashUnavailable?: boolean;
 
-  private _normalizedContent?: StateContent;
-
   protected createRenderRoot() {
     return this;
   }
 
-  protected willUpdate(changedProps: PropertyValues<this>) {
-    if (changedProps.has("content")) {
-      const migrateKey = (s) => {
-        if (s === "last-updated") return "last_updated";
-        if (s === "last-changed") return "last_changed";
-        return s;
-      };
-      if (typeof this.content === "string") {
-        this._normalizedContent = migrateKey(this.content);
-      } else if (Array.isArray(this.content)) {
-        this._normalizedContent = this.content.map(migrateKey);
-      }
-    }
-  }
+  private _normalizeContent = memoizeOne(
+    (content?: StateContent): StateContent | undefined =>
+      content == null
+        ? undefined
+        : ensureArray(content).map((s) => {
+            if (s === "last-updated") return "last_updated";
+            if (s === "last-changed") return "last_changed";
+            return s;
+          })
+  );
 
   private get _content(): StateContent {
     const domain = computeStateDomain(this.stateObj);
     return (
-      this._normalizedContent ??
+      this._normalizeContent(this.content) ??
       DEFAULT_STATE_CONTENT_DOMAINS[domain] ??
       "state"
     );
@@ -197,12 +193,12 @@ class StateDisplay extends LitElement {
       return this.hass.formatEntityName(stateObj, { type }) || undefined;
     }
 
-    let relativeDateTime: string | Date | undefined;
+    let relativeDateTime: string | number | undefined;
 
     if (TIMESTAMP_STATE_PROPS.includes(content)) {
       relativeDateTime = stateObj[content];
     } else if (domain === "input_datetime" && content === "timestamp") {
-      relativeDateTime = new Date(stateObj.attributes.timestamp * 1000);
+      relativeDateTime = stateObj.attributes.timestamp * 1000;
     } else if (
       TIMESTAMP_CONTENTS.includes(content) ||
       TIMESTAMP_DOMAIN_CONTENTS[domain]?.includes(content)
@@ -210,20 +206,10 @@ class StateDisplay extends LitElement {
       relativeDateTime = stateObj.attributes[content];
     }
 
-    if (relativeDateTime) {
-      if (!this.timeFormat) {
-        return html`
-          <ha-relative-time
-            .datetime=${relativeDateTime}
-            capitalize
-          ></ha-relative-time>
-        `;
-      }
+    if (relativeDateTime !== undefined) {
       return html`<hui-timestamp-display
         .hass=${this.hass}
-        .ts=${relativeDateTime instanceof Date
-          ? relativeDateTime
-          : new Date(relativeDateTime)}
+        .ts=${new Date(relativeDateTime)}
         .format=${this.timeFormat}
         capitalize
       ></hui-timestamp-display>`;

--- a/src/state-display/state-display.ts
+++ b/src/state-display/state-display.ts
@@ -1,5 +1,5 @@
 import type { HassEntity } from "home-assistant-js-websocket";
-import type { TemplateResult } from "lit";
+import type { PropertyValues, TemplateResult } from "lit";
 import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { join } from "lit/directives/join";
@@ -19,6 +19,7 @@ import type { UpdateEntity } from "../data/update";
 import { computeUpdateStateDisplay } from "../data/update";
 import "../panels/lovelace/components/hui-timestamp-display";
 import type { HomeAssistant } from "../types";
+import { computeDomain } from "../common/entity/compute_domain";
 
 export const STATE_DISPLAY_SPECIAL_CONTENT = [
   "remaining_time",
@@ -55,6 +56,54 @@ export const DEFAULT_STATE_CONTENT_DOMAINS: Record<string, StateContent> = {
   valve: ["state", "current_position"],
 };
 
+const TIMESTAMP_STATE_PROPS = ["last_updated", "last_changed"];
+
+const TIMESTAMP_CONTENTS = [...TIMESTAMP_STATE_PROPS, "last_triggered"];
+
+const TIMESTAMP_DOMAIN_CONTENTS = {
+  calendar: ["start_time", "end_time"],
+  input_datetime: ["timestamp"],
+  sun: [
+    "next_dawn",
+    "next_dusk",
+    "next_midnight",
+    "next_noon",
+    "next_rising",
+    "next_setting",
+  ],
+};
+
+export const stateContentHasTimestamp = (
+  entityId?: string,
+  stateObj?: HassEntity,
+  content?: StateContent
+): boolean => {
+  const contentArray = ensureArray(content);
+  if (content && contentArray.some((c) => TIMESTAMP_CONTENTS.includes(c))) {
+    return true;
+  }
+  if (!entityId) {
+    return false;
+  }
+  const domain = computeDomain(entityId);
+  if (!content || content.includes("state")) {
+    if (TIMESTAMP_STATE_DOMAINS.includes(domain)) {
+      return true;
+    }
+    if (stateObj) {
+      const sensorDeviceClass =
+        domain === "sensor" ? stateObj.attributes.device_class : "";
+      if (SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(sensorDeviceClass)) {
+        return true;
+      }
+    }
+  }
+  return (
+    TIMESTAMP_DOMAIN_CONTENTS[domain] &&
+    contentArray.some((c) => TIMESTAMP_DOMAIN_CONTENTS[domain].includes(c))
+  );
+};
+
 @customElement("state-display")
 class StateDisplay extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -70,13 +119,34 @@ class StateDisplay extends LitElement {
   @property({ type: Boolean, attribute: "dash-unavailable" })
   public dashUnavailable?: boolean;
 
+  private _normalizedContent?: StateContent;
+
   protected createRenderRoot() {
     return this;
   }
 
+  protected willUpdate(changedProps: PropertyValues<this>) {
+    if (changedProps.has("content")) {
+      const migrateKey = (s) => {
+        if (s === "last-updated") return "last_updated";
+        if (s === "last-changed") return "last_changed";
+        return s;
+      };
+      if (typeof this.content === "string") {
+        this._normalizedContent = migrateKey(this.content);
+      } else if (Array.isArray(this.content)) {
+        this._normalizedContent = this.content.map(migrateKey);
+      }
+    }
+  }
+
   private get _content(): StateContent {
     const domain = computeStateDomain(this.stateObj);
-    return this.content ?? DEFAULT_STATE_CONTENT_DOMAINS[domain] ?? "state";
+    return (
+      this._normalizedContent ??
+      DEFAULT_STATE_CONTENT_DOMAINS[domain] ??
+      "state"
+    );
   }
 
   private _computeContent(
@@ -129,40 +199,34 @@ class StateDisplay extends LitElement {
 
     let relativeDateTime: string | Date | undefined;
 
-    // Check last-changed for backwards compatibility
-    if (content === "last_changed" || content === "last-changed") {
-      relativeDateTime = stateObj.last_changed;
-    }
-    // Check last_updated for backwards compatibility
-    if (content === "last_updated" || content === "last-updated") {
-      relativeDateTime = stateObj.last_updated;
-    }
-    if (domain === "input_datetime" && content === "timestamp") {
+    if (TIMESTAMP_STATE_PROPS.includes(content)) {
+      relativeDateTime = stateObj[content];
+    } else if (domain === "input_datetime" && content === "timestamp") {
       relativeDateTime = new Date(stateObj.attributes.timestamp * 1000);
-    }
-
-    if (
-      content === "last_triggered" ||
-      (domain === "calendar" &&
-        (content === "start_time" || content === "end_time")) ||
-      (domain === "sun" &&
-        (content === "next_dawn" ||
-          content === "next_dusk" ||
-          content === "next_midnight" ||
-          content === "next_noon" ||
-          content === "next_rising" ||
-          content === "next_setting"))
+    } else if (
+      TIMESTAMP_CONTENTS.includes(content) ||
+      TIMESTAMP_DOMAIN_CONTENTS[domain]?.includes(content)
     ) {
       relativeDateTime = stateObj.attributes[content];
     }
 
     if (relativeDateTime) {
-      return html`
-        <ha-relative-time
-          .datetime=${relativeDateTime}
-          capitalize
-        ></ha-relative-time>
-      `;
+      if (!this.timeFormat) {
+        return html`
+          <ha-relative-time
+            .datetime=${relativeDateTime}
+            capitalize
+          ></ha-relative-time>
+        `;
+      }
+      return html`<hui-timestamp-display
+        .hass=${this.hass}
+        .ts=${relativeDateTime instanceof Date
+          ? relativeDateTime
+          : new Date(relativeDateTime)}
+        .format=${this.timeFormat}
+        capitalize
+      ></hui-timestamp-display>`;
     }
 
     const specialContent = (STATE_DISPLAY_SPECIAL_CONTENT_DOMAINS[domain] ??

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -465,6 +465,7 @@
       "save": "Save",
       "apply": "Apply",
       "add": "Add",
+      "auto": "Auto",
       "create": "Create",
       "edit": "Edit",
       "edit_item": "Edit {name}",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -874,6 +874,15 @@
           "floor": "Floor"
         }
       },
+      "time-format-picker": {
+        "formats": {
+          "relative": "Relative",
+          "total": "Total",
+          "datetime": "Date and time",
+          "time": "Time",
+          "date": "Date"
+        }
+      },
       "subpage-data-table": {
         "filters": "Filters",
         "show_results": "Show {number} results",
@@ -9707,6 +9716,7 @@
               "show_state": "Show state",
               "show_last_changed": "Show last changed",
               "tap_action": "Tap behavior",
+              "time_format": "Time format",
               "interactions": "Interactions",
               "title": "Title",
               "theme": "Theme",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add a time_format option to tile card. I try to follow the requested recommendations of https://github.com/home-assistant/frontend/issues/27694, even if it doesn't yet go so far as to add additional customizable formats beyond what we already support for entities card time format. 

I wrapped this field in a new UI component to make it easier to extend to whatever kind of format modifiers we eventually decide we want to support in the future ("short?"). I'm not sure exactly what that looks like in a UI yet though. 

The option is only shown in UI when a relevant entity is selected. 

Some possible open questions:
 - This only applies to state. Should it apply to last_* properties? [Currently: No] (There was some back-and-forth about this in https://github.com/home-assistant/frontend/pull/22339, though it's not clear if it was ultimately desired or not). 
 - Should it apply to timestamp-like attributes? We may have to build a whitelist of all attributes which are timestamps, which not sure if we want to do. [Currently: No]
 - Is there a more UI friendly translation than "Total"? I get it's some kind of variant on relative time, but the word doesn't make a whole lot of sense to me in this context.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
<img width="1108" height="986" alt="image" src="https://github.com/user-attachments/assets/7eeb67ce-aabf-471d-a505-efe11c438c29" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
