### PR TITLE
HTTP config: confirm or revert pending changes after restart

### DIFF
--- a/src/data/http.ts
+++ b/src/data/http.ts
@@ -15,11 +15,26 @@ export interface HttpConfig {
   ssl_profile?: "modern" | "intermediate";
 }
 
-export const fetchHttpConfig = (hass: HomeAssistant) =>
-  hass.callWS<HttpConfig>({ type: "http/config" });
+export interface HttpConfigState {
+  stable: HttpConfig;
+  pending: HttpConfig | null;
+}
 
-export const saveHttpConfig = (hass: HomeAssistant, config: HttpConfig) =>
-  hass.callWS<undefined>({
+export interface SaveHttpConfigResult {
+  restart: boolean;
+}
+
+export const fetchHttpConfig = (hass: HomeAssistant) =>
+  hass.callWS<HttpConfigState>({ type: "http/config" });
+
+export const saveHttpConfig = (
+  hass: HomeAssistant,
+  config: HttpConfig | null
+) =>
+  hass.callWS<SaveHttpConfigResult>({
     type: "http/config/configure",
     config,
   });
+
+export const promoteHttpConfig = (hass: HomeAssistant) =>
+  hass.callWS<undefined>({ type: "http/config/promote" });

--- a/src/dialogs/http-pending-config/dialog-http-pending-config.ts
+++ b/src/dialogs/http-pending-config/dialog-http-pending-config.ts
@@ -1,0 +1,229 @@
+import { ERR_CONNECTION_LOST } from "home-assistant-js-websocket";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../common/dom/fire_event";
+import "../../components/ha-alert";
+import "../../components/ha-button";
+import "../../components/ha-dialog-footer";
+import "../../components/ha-dialog";
+import type { HttpConfig } from "../../data/http";
+import { promoteHttpConfig, saveHttpConfig } from "../../data/http";
+import { haStyleDialog } from "../../resources/styles";
+import type { HomeAssistant } from "../../types";
+import type { HassDialog } from "../make-dialog-manager";
+import type { HttpPendingConfigDialogParams } from "./show-dialog-http-pending-config";
+
+const HTTP_FIELDS: (keyof HttpConfig)[] = [
+  "server_port",
+  "server_host",
+  "ssl_certificate",
+  "ssl_key",
+  "ssl_peer_certificate",
+  "ssl_profile",
+  "cors_allowed_origins",
+  "use_x_forwarded_for",
+  "trusted_proxies",
+  "use_x_frame_options",
+  "ip_ban_enabled",
+  "login_attempts_threshold",
+];
+
+@customElement("dialog-http-pending-config")
+export class DialogHttpPendingConfig
+  extends LitElement
+  implements HassDialog<HttpPendingConfigDialogParams>
+{
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _params?: HttpPendingConfigDialogParams;
+
+  @state() private _open = false;
+
+  @state() private _busy: "confirm" | "revert" | undefined;
+
+  @state() private _error?: string;
+
+  public showDialog(params: HttpPendingConfigDialogParams): void {
+    this._params = params;
+    this._open = true;
+    this._busy = undefined;
+    this._error = undefined;
+  }
+
+  public closeDialog(): boolean {
+    this._open = false;
+    return true;
+  }
+
+  private _dialogClosed(): void {
+    this._params = undefined;
+    this._busy = undefined;
+    this._error = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  private get _changedFields(): (keyof HttpConfig)[] {
+    if (!this._params?.state.pending) {
+      return [];
+    }
+    const { stable, pending } = this._params.state;
+    return HTTP_FIELDS.filter(
+      (key) => JSON.stringify(stable[key]) !== JSON.stringify(pending[key])
+    );
+  }
+
+  protected render() {
+    if (!this._params) {
+      return nothing;
+    }
+
+    const changes = this._changedFields;
+
+    return html`
+      <ha-dialog
+        .open=${this._open}
+        .headerTitle=${this.hass.localize(
+          "ui.dialogs.http_pending_config.title"
+        )}
+        prevent-scrim-close
+        width="medium"
+        @closed=${this._dialogClosed}
+      >
+        <span slot="headerNavigationIcon"></span>
+        <div class="content">
+          <p>
+            ${this.hass.localize("ui.dialogs.http_pending_config.description")}
+          </p>
+          ${changes.length
+            ? html`
+                <p class="changes-label">
+                  ${this.hass.localize(
+                    "ui.dialogs.http_pending_config.changes_label"
+                  )}
+                </p>
+                <ul>
+                  ${changes.map(
+                    (key) => html`
+                      <li>
+                        ${this.hass.localize(
+                          `ui.panel.config.network.http.fields.${key}` as any
+                        )}
+                      </li>
+                    `
+                  )}
+                </ul>
+              `
+            : nothing}
+          ${this._error
+            ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
+            : nothing}
+        </div>
+        <ha-dialog-footer slot="footer">
+          <ha-button
+            slot="secondaryAction"
+            appearance="plain"
+            .loading=${this._busy === "revert"}
+            .disabled=${this._busy === "confirm"}
+            @click=${this._revert}
+          >
+            ${this.hass.localize("ui.dialogs.http_pending_config.revert")}
+          </ha-button>
+          <ha-button
+            slot="primaryAction"
+            .loading=${this._busy === "confirm"}
+            .disabled=${this._busy === "revert"}
+            @click=${this._confirm}
+          >
+            ${this.hass.localize("ui.dialogs.http_pending_config.confirm")}
+          </ha-button>
+        </ha-dialog-footer>
+      </ha-dialog>
+    `;
+  }
+
+  private async _confirm(): Promise<void> {
+    if (this._busy) {
+      return;
+    }
+    this._busy = "confirm";
+    this._error = undefined;
+    try {
+      await promoteHttpConfig(this.hass);
+      this._notifyResolved();
+      this._open = false;
+    } catch (err: any) {
+      this._error = this.hass.localize(
+        "ui.dialogs.http_pending_config.confirm_error",
+        { error: err.message ?? "" }
+      );
+      this._busy = undefined;
+    }
+  }
+
+  private async _revert(): Promise<void> {
+    if (this._busy || !this._params) {
+      return;
+    }
+    this._busy = "revert";
+    this._error = undefined;
+    try {
+      await saveHttpConfig(this.hass, null);
+      this._notifyResolved();
+      this._open = false;
+    } catch (err: any) {
+      // The restart triggered by clearing pending may cut the WS connection
+      // before we get a reply. The disconnected overlay takes over from here.
+      if (err?.error?.code === ERR_CONNECTION_LOST) {
+        this._notifyResolved();
+        this._open = false;
+        return;
+      }
+      this._error = this.hass.localize(
+        "ui.dialogs.http_pending_config.revert_error",
+        { error: err.message ?? "" }
+      );
+      this._busy = undefined;
+    }
+  }
+
+  private _notifyResolved(): void {
+    this._params?.onResolved?.();
+    // The form on Settings > System > Network may be mounted and showing
+    // stale state; let it know to refetch.
+    window.dispatchEvent(new Event("http-config-resolved"));
+  }
+
+  static styles = [
+    haStyleDialog,
+    css`
+      .content {
+        line-height: var(--ha-line-height-normal);
+      }
+      p {
+        margin: 0 0 var(--ha-space-4) 0;
+      }
+      .changes-label {
+        font-weight: var(--ha-font-weight-medium);
+        margin-bottom: var(--ha-space-2);
+      }
+      ul {
+        margin: 0 0 var(--ha-space-4) 0;
+        padding-left: var(--ha-space-6);
+        color: var(--secondary-text-color);
+      }
+      li {
+        margin-bottom: var(--ha-space-1);
+      }
+      ha-alert {
+        display: block;
+        margin-top: var(--ha-space-4);
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-http-pending-config": DialogHttpPendingConfig;
+  }
+}

--- a/src/dialogs/http-pending-config/show-dialog-http-pending-config.ts
+++ b/src/dialogs/http-pending-config/show-dialog-http-pending-config.ts
@@ -1,0 +1,22 @@
+import { fireEvent } from "../../common/dom/fire_event";
+import type { HttpConfigState } from "../../data/http";
+
+export interface HttpPendingConfigDialogParams {
+  state: HttpConfigState;
+  onResolved?: () => void;
+}
+
+export const loadHttpPendingConfigDialog = () =>
+  import("./dialog-http-pending-config");
+
+export const showHttpPendingConfigDialog = (
+  element: HTMLElement,
+  dialogParams: HttpPendingConfigDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-http-pending-config",
+    dialogImport: loadHttpPendingConfigDialog,
+    dialogParams,
+    addHistory: false,
+  });
+};

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -5,9 +5,12 @@ import { customElement, state } from "lit/decorators";
 import { storage } from "../common/decorators/storage";
 import { isNavigationClick } from "../common/dom/is-navigation-click";
 import { navigate } from "../common/navigate";
+import { fetchHttpConfig } from "../data/http";
+import type { HttpConfigState } from "../data/http";
 import type { WindowWithPreloads } from "../data/preloads";
 import type { RecorderInfo } from "../data/recorder";
 import { getRecorderInfo } from "../data/recorder";
+import { showHttpPendingConfigDialog } from "../dialogs/http-pending-config/show-dialog-http-pending-config";
 import "../resources/custom-card-support";
 import { HassElement } from "../state/hass-element";
 import QuickBarMixin from "../state/quick-bar-mixin";
@@ -38,6 +41,8 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
   @state() private _route: Route;
 
   @state() private _databaseMigration?: boolean;
+
+  private _httpPendingDialogOpen = false;
 
   private _panelUrl: string;
 
@@ -70,13 +75,23 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
 
   protected willUpdate(changedProps: PropertyValues<this>) {
     super.willUpdate(changedProps);
+    const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
     if (
       this._databaseMigration === undefined &&
       changedProps.has("hass") &&
       this.hass?.config &&
-      changedProps.get("hass")?.config !== this.hass?.config
+      oldHass?.config !== this.hass.config
     ) {
       this.checkDataBaseMigration();
+    }
+    // Wait for `hass.user` to populate so the admin guard can run; it arrives
+    // asynchronously after `hass.config`.
+    if (
+      changedProps.has("hass") &&
+      this.hass?.user &&
+      oldHass?.user !== this.hass.user
+    ) {
+      this.checkHttpPendingConfig();
     }
   }
 
@@ -206,6 +221,32 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
         location.reload(true);
       }
     }
+  }
+
+  protected async checkHttpPendingConfig() {
+    if (__DEMO__ || this._httpPendingDialogOpen) {
+      return;
+    }
+    if (!this.hass?.user?.is_admin) {
+      return;
+    }
+    let httpConfig: HttpConfigState;
+    try {
+      httpConfig = await fetchHttpConfig(this.hass);
+    } catch (_err) {
+      // The check re-runs on the next reconnect; ignore transient failures.
+      return;
+    }
+    if (!httpConfig.pending || this._httpPendingDialogOpen) {
+      return;
+    }
+    this._httpPendingDialogOpen = true;
+    showHttpPendingConfigDialog(this, {
+      state: httpConfig,
+      onResolved: () => {
+        this._httpPendingDialogOpen = false;
+      },
+    });
   }
 
   protected async checkDataBaseMigration() {

--- a/src/panels/config/network/ha-config-http-form.ts
+++ b/src/panels/config/network/ha-config-http-form.ts
@@ -1,16 +1,18 @@
+import { ERR_CONNECTION_LOST } from "home-assistant-js-websocket";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import type { LocalizeFunc } from "../../../common/translations/localize";
 import "../../../components/ha-alert";
 import "../../../components/ha-button";
 import "../../../components/ha-card";
 import "../../../components/ha-form/ha-form";
+import type { HaForm } from "../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../components/ha-form/types";
 import { fetchHttpConfig, saveHttpConfig } from "../../../data/http";
-import type { HttpConfig } from "../../../data/http";
-import { showRestartDialog } from "../../../dialogs/restart/show-dialog-restart";
+import type { HttpConfig, HttpConfigState } from "../../../data/http";
+import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 
@@ -123,6 +125,8 @@ const SCHEMA = memoizeOne(
 class HaConfigHttpForm extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
+  @state() private _state?: HttpConfigState;
+
   @state() private _config?: HttpConfig;
 
   @state() private _error?: string;
@@ -131,19 +135,36 @@ class HaConfigHttpForm extends LitElement {
 
   @state() private _saving = false;
 
-  @state() private _saved = false;
+  @state() private _showNoChanges = false;
+
+  @query("ha-form") private _form?: HaForm;
+
+  @query("ha-alert") private _firstAlert?: HTMLElement;
+
+  private _onConfigResolved = () => this._fetchConfig();
 
   protected override firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     this._fetchConfig();
   }
 
+  public override connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener("http-config-resolved", this._onConfigResolved);
+  }
+
+  public override disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener("http-config-resolved", this._onConfigResolved);
+  }
+
   protected render() {
-    if (!this._config && !this._error) {
+    if (!this._state && !this._error) {
       return nothing;
     }
 
     const schema = SCHEMA(this.hass.localize);
+    const hasPending = !!this._state?.pending;
 
     return html`
       <ha-card
@@ -155,25 +176,29 @@ class HaConfigHttpForm extends LitElement {
             ${this.hass.localize("ui.panel.config.network.http.description")}
           </p>
 
-          ${this._error
-            ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
-            : nothing}
-          ${this._saved
+          ${hasPending
             ? html`
                 <ha-alert
                   alert-type="info"
                   .title=${this.hass.localize(
-                    "ui.panel.config.network.http.restart_required_title"
+                    "ui.panel.config.network.http.pending_banner.title"
                   )}
                 >
                   ${this.hass.localize(
-                    "ui.panel.config.network.http.restart_required_description"
+                    "ui.panel.config.network.http.pending_banner.description"
                   )}
-                  <ha-button slot="action" @click=${this._restart}>
-                    ${this.hass.localize(
-                      "ui.panel.config.network.http.restart"
-                    )}
-                  </ha-button>
+                </ha-alert>
+              `
+            : nothing}
+          ${this._error
+            ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
+            : nothing}
+          ${this._showNoChanges
+            ? html`
+                <ha-alert alert-type="success">
+                  ${this.hass.localize(
+                    "ui.panel.config.network.http.save_no_changes"
+                  )}
                 </ha-alert>
               `
             : nothing}
@@ -195,7 +220,11 @@ class HaConfigHttpForm extends LitElement {
         ${this._config
           ? html`
               <div class="card-actions">
-                <ha-button @click=${this._save} .disabled=${this._saving}>
+                <ha-button
+                  @click=${this._save}
+                  .disabled=${this._saving}
+                  .loading=${this._saving}
+                >
                   ${this.hass.localize("ui.panel.config.network.http.save")}
                 </ha-button>
               </div>
@@ -207,7 +236,8 @@ class HaConfigHttpForm extends LitElement {
 
   private async _fetchConfig(): Promise<void> {
     try {
-      this._config = await fetchHttpConfig(this.hass);
+      this._state = await fetchHttpConfig(this.hass);
+      this._config = { ...(this._state.pending ?? this._state.stable) };
     } catch (err: any) {
       this._error = err.message;
     }
@@ -240,26 +270,63 @@ class HaConfigHttpForm extends LitElement {
 
   private _valueChanged(ev: CustomEvent): void {
     this._config = ev.detail.value;
-    this._saved = false;
     this._error = undefined;
     this._fieldErrors = {};
+    this._showNoChanges = false;
   }
 
   private async _save(): Promise<void> {
-    if (!this._config) {
+    if (!this._config || !this._state) {
       return;
     }
-    const form = this.renderRoot.querySelector("ha-form");
-    if (form && !form.reportValidity()) {
+    if (this._form && !this._form.reportValidity()) {
       return;
     }
+
+    const current = this._state.pending ?? this._state.stable;
+    if (JSON.stringify(current) === JSON.stringify(this._config)) {
+      this._showNoChanges = true;
+      return;
+    }
+
+    const confirmed = await showConfirmationDialog(this, {
+      title: this.hass.localize(
+        "ui.panel.config.network.http.save_confirm.title"
+      ),
+      text: this.hass.localize(
+        "ui.panel.config.network.http.save_confirm.text"
+      ),
+      confirmText: this.hass.localize(
+        "ui.panel.config.network.http.save_confirm.confirm"
+      ),
+    });
+    if (!confirmed) {
+      return;
+    }
+
     this._saving = true;
     this._error = undefined;
     this._fieldErrors = {};
+    this._showNoChanges = false;
     try {
-      await saveHttpConfig(this.hass, this._config);
-      this._saved = true;
+      const result = await saveHttpConfig(this.hass, this._config);
+      if (!result.restart) {
+        // No-op save (server already had this config). Refresh state so the
+        // banner stays accurate.
+        this._showNoChanges = true;
+        await this._fetchConfig();
+      }
+      // restart === true: a restart is in flight. The reply usually races with
+      // the connection drop; if we do reach this branch, the disconnected
+      // overlay will appear in moments. Leave the form as is.
     } catch (err: any) {
+      // The restart kills the WS connection before the ack — that's expected.
+      if (
+        err?.error?.code === ERR_CONNECTION_LOST ||
+        err === ERR_CONNECTION_LOST
+      ) {
+        return;
+      }
       // voluptuous formats errors as "<message> @ data['<field>']".
       // If a field is identified, mark it inline; otherwise show a card-level
       // alert.
@@ -273,18 +340,13 @@ class HaConfigHttpForm extends LitElement {
       this._saving = false;
     }
     await this.updateComplete;
-    const haForm = this.renderRoot.querySelector("ha-form");
-    await haForm?.updateComplete;
+    await this._form?.updateComplete;
     // Inline field errors render inside ha-form's shadow root, so fall back to
     // it when no top-level alert is present.
     const target =
-      this.renderRoot.querySelector<HTMLElement>("ha-alert") ??
-      haForm?.shadowRoot?.querySelector<HTMLElement>("ha-alert");
+      this._firstAlert ??
+      this._form?.shadowRoot?.querySelector<HTMLElement>("ha-alert");
     target?.scrollIntoView({ behavior: "smooth", block: "center" });
-  }
-
-  private _restart(): void {
-    showRestartDialog(this);
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/network/ha-config-http-form.ts
+++ b/src/panels/config/network/ha-config-http-form.ts
@@ -11,7 +11,7 @@ import "../../../components/ha-form/ha-form";
 import type { HaForm } from "../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../components/ha-form/types";
 import { fetchHttpConfig, saveHttpConfig } from "../../../data/http";
-import type { HttpConfig, HttpConfigState } from "../../../data/http";
+import type { HttpConfig } from "../../../data/http";
 import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
@@ -125,7 +125,7 @@ const SCHEMA = memoizeOne(
 class HaConfigHttpForm extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @state() private _state?: HttpConfigState;
+  @state() private _stable?: HttpConfig;
 
   @state() private _config?: HttpConfig;
 
@@ -159,12 +159,11 @@ class HaConfigHttpForm extends LitElement {
   }
 
   protected render() {
-    if (!this._state && !this._error) {
+    if (!this._stable && !this._error) {
       return nothing;
     }
 
     const schema = SCHEMA(this.hass.localize);
-    const hasPending = !!this._state?.pending;
 
     return html`
       <ha-card
@@ -175,21 +174,6 @@ class HaConfigHttpForm extends LitElement {
           <p class="description">
             ${this.hass.localize("ui.panel.config.network.http.description")}
           </p>
-
-          ${hasPending
-            ? html`
-                <ha-alert
-                  alert-type="info"
-                  .title=${this.hass.localize(
-                    "ui.panel.config.network.http.pending_banner.title"
-                  )}
-                >
-                  ${this.hass.localize(
-                    "ui.panel.config.network.http.pending_banner.description"
-                  )}
-                </ha-alert>
-              `
-            : nothing}
           ${this._error
             ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
             : nothing}
@@ -236,8 +220,11 @@ class HaConfigHttpForm extends LitElement {
 
   private async _fetchConfig(): Promise<void> {
     try {
-      this._state = await fetchHttpConfig(this.hass);
-      this._config = { ...(this._state.pending ?? this._state.stable) };
+      // Pending is exclusively handled by the global confirm/revert dialog, so
+      // the form only ever displays stable.
+      const { stable } = await fetchHttpConfig(this.hass);
+      this._stable = stable;
+      this._config = { ...stable };
     } catch (err: any) {
       this._error = err.message;
     }
@@ -276,15 +263,14 @@ class HaConfigHttpForm extends LitElement {
   }
 
   private async _save(): Promise<void> {
-    if (!this._config || !this._state) {
+    if (!this._config || !this._stable) {
       return;
     }
     if (this._form && !this._form.reportValidity()) {
       return;
     }
 
-    const current = this._state.pending ?? this._state.stable;
-    if (JSON.stringify(current) === JSON.stringify(this._config)) {
+    if (JSON.stringify(this._stable) === JSON.stringify(this._config)) {
       this._showNoChanges = true;
       return;
     }
@@ -311,10 +297,7 @@ class HaConfigHttpForm extends LitElement {
     try {
       const result = await saveHttpConfig(this.hass, this._config);
       if (!result.restart) {
-        // No-op save (server already had this config). Refresh state so the
-        // banner stays accurate.
         this._showNoChanges = true;
-        await this._fetchConfig();
       }
       // restart === true: a restart is in flight. The reply usually races with
       // the connection drop; if we do reach this branch, the disconnected

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -352,6 +352,7 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         }
         this._updateHass({ config });
         this.checkDataBaseMigration();
+        this.checkHttpPendingConfig();
       });
     }
 

--- a/src/state/hass-base-mixin.ts
+++ b/src/state/hass-base-mixin.ts
@@ -36,6 +36,9 @@ export class HassBaseEl extends LitElement {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   protected checkDataBaseMigration() {}
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  protected checkHttpPendingConfig() {}
+
   protected hassChanged(hass, _oldHass) {
     this.__provideHass.forEach((el) => {
       (el as any).hass = hass;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8304,10 +8304,6 @@
               "text": "Saving will restart Home Assistant to apply the new HTTP settings.",
               "confirm": "Save and restart"
             },
-            "pending_banner": {
-              "title": "Unconfirmed configuration",
-              "description": "The values below are running but not yet confirmed. Use the confirmation popup to keep or revert them."
-            },
             "ssl_profile_modern": "Modern",
             "ssl_profile_intermediate": "Intermediate",
             "sections": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1523,6 +1523,15 @@
         "title": "Safe mode",
         "text": "Home Assistant is running in safe mode, custom integrations and community frontend modules are not available. Restart Home Assistant to exit safe mode."
       },
+      "http_pending_config": {
+        "title": "Confirm new network configuration",
+        "description": "Home Assistant has restarted with new HTTP server settings. Confirm to keep them, or revert to undo the change.",
+        "changes_label": "Changed settings:",
+        "confirm": "Confirm",
+        "revert": "Revert",
+        "confirm_error": "Failed to confirm the new configuration: {error}",
+        "revert_error": "Failed to revert the configuration: {error}"
+      },
       "quick-bar": {
         "commands_title": "Commands",
         "navigate_title": "Navigate",
@@ -8287,11 +8296,18 @@
           },
           "http": {
             "caption": "HTTP server",
-            "description": "Configure how Home Assistant serves its web interface. Changes take effect after a restart.",
+            "description": "Configure how Home Assistant serves its web interface. Saving restarts Home Assistant.",
             "save": "Save",
-            "restart": "Restart",
-            "restart_required_title": "Restart required",
-            "restart_required_description": "Restart Home Assistant to apply the new HTTP settings.",
+            "save_no_changes": "Nothing changed — no restart needed.",
+            "save_confirm": {
+              "title": "Restart required",
+              "text": "Saving will restart Home Assistant to apply the new HTTP settings.",
+              "confirm": "Save and restart"
+            },
+            "pending_banner": {
+              "title": "Unconfirmed configuration",
+              "description": "The values below are running but not yet confirmed. Use the confirmation popup to keep or revert them."
+            },
             "ssl_profile_modern": "Modern",
             "ssl_profile_intermediate": "Intermediate",
             "sections": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1524,7 +1524,7 @@
         "text": "Home Assistant is running in safe mode, custom integrations and community frontend modules are not available. Restart Home Assistant to exit safe mode."
       },
       "http_pending_config": {
-        "title": "Confirm new network configuration",
+        "title": "Confirm new HTTP server configuration",
         "description": "Home Assistant has restarted with new HTTP server settings. Confirm to keep them, or revert to undo the change.",
         "changes_label": "Changed settings:",
         "confirm": "Confirm",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Stacked on top of #51981 to consume the new wire contract from home-assistant/core#173103. Saving HTTP settings now auto-restarts Home Assistant with the new config as *pending* while the previous stable config stays available for recovery.

When the admin returns after the restart, a non-dismissable dialog asks them to **Confirm** (promote pending → stable) or **Revert** (clear pending → another restart). Until they act, the HTTP form renders an info banner pointing back to the dialog.

Behavior summary:
- `http/config` now returns `{ stable, pending }`; the form shows pending when set (it's what's running) and reverts to stable otherwise.
- A pre-save confirmation dialog warns about the auto-restart before sending `http/config/configure`.
- The non-dismissable popup is admin-only and re-checks on connect / reconnect.
- Revert sends `configure(null)`, which clears pending on the backend and triggers a restart back to stable.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
<img width="1161" height="353" alt="image" src="https://github.com/user-attachments/assets/6a5f50bd-5c57-4f9c-9e60-fae78ecbe0aa" />

<img width="1165" height="582" alt="image" src="https://github.com/user-attachments/assets/dbd720c9-f5da-4753-8a96-ecd38dab55d8" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #51808
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: home-assistant/core#173103

## Checklist
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[perfect-pr]: https://developers.home-assistant.io/docs/development_checklist#9-creating-a-pull-request
[docs-repository]: https://github.com/home-assistant/home-assistant.io
