### PR TITLE
Fix ha-textarea resize="auto" growing past max-height instead of scrolling

### DIFF
--- a/gallery/src/pages/components/ha-textarea.ts
+++ b/gallery/src/pages/components/ha-textarea.ts
@@ -5,6 +5,11 @@ import { applyThemesOnElement } from "../../../../src/common/dom/apply_themes_on
 import "../../../../src/components/ha-card";
 import "../../../../src/components/ha-textarea";
 
+const LONG_VALUE = Array.from(
+  { length: 30 },
+  (_, i) => `Line ${i + 1}: this content overflows the max-height and scrolls.`
+).join("\n");
+
 @customElement("demo-components-ha-textarea")
 export class DemoHaTextarea extends LitElement {
   protected render(): TemplateResult {
@@ -37,6 +42,11 @@ export class DemoHaTextarea extends LitElement {
                     label="Autogrow with value"
                     resize="auto"
                     value="This textarea will grow as you type more content into it. Try adding more lines to see the effect."
+                  ></ha-textarea>
+                  <ha-textarea
+                    label="Autogrow capped (scrolls past max-height)"
+                    resize="auto"
+                    .value=${LONG_VALUE}
                   ></ha-textarea>
                 </div>
 

--- a/src/components/ha-textarea.ts
+++ b/src/components/ha-textarea.ts
@@ -258,6 +258,14 @@ export class HaTextArea extends WaInputMixin(LitElement) {
         overflow-y: auto;
       }
 
+      /* The size-adjuster shares a grid cell with the textarea and is given an
+         inline height matching the content's scrollHeight. Without capping it
+         too, it inflates the grid row past the max-height and pushes the
+         textarea down instead of scrolling. */
+      :host([resize="auto"]) wa-textarea::part(textarea-adjuster) {
+        max-height: var(--ha-textarea-max-height, 200px);
+      }
+
       wa-textarea:hover::part(base),
       wa-textarea:hover::part(label) {
         background-color: var(--ha-color-form-background-hover);


### PR DESCRIPTION
## Proposed change

When an `ha-textarea` uses `resize="auto"` and its content grows taller than the configured max height (`--ha-textarea-max-height`, default 200px), the textarea was being pushed down inside a huge empty area instead of staying capped and scrolling.

This was most visible on the ZHA "Add device" page with the pairing logs open: the log box could balloon to thousands of pixels tall, pushing all the content down.

Under the hood, Web Awesome's `wa-textarea` lays out its base as a CSS grid where the real `<textarea>` and an invisible `size-adjuster` element share the same grid cell. On every change it writes an inline `height` (equal to the content's `scrollHeight`) onto *both* elements. We only capped the textarea's `max-height`, so the size-adjuster kept its full height, inflated the shared grid row, and — because the grid is centered — the capped textarea was pushed down.

The fix applies the same `max-height` cap to the `textarea-adjuster` part so it can no longer inflate the grid row. The textarea now stays capped and scrolls, as intended. This is scoped to `ha-textarea`, so it fixes every `resize="auto"` usage.

A capped autogrow example was also added to the `ha-textarea` gallery page so the behaviour can be previewed and to guard against regressions.

## Screenshots


Gallery with fix disabled

<img width="1281" height="417" alt="image" src="https://github.com/user-attachments/assets/2360b041-2f74-4bf9-bbc3-9c7b1092c08f" />

Gallery with fix

<img width="1245" height="306" alt="image" src="https://github.com/user-attachments/assets/d1197f9b-966b-494c-8480-39ace193cbe8" />


<!-- Gallery preview will be available once the design preview build completes. -->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

https://claude.ai/code/session_01MeLz2as43Ryq1yN3HySD3q

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeLz2as43Ryq1yN3HySD3q)_