### PR TITLE
Remove unused PageNavigation.not_component

### DIFF
--- a/src/common/config/can_show_page.ts
+++ b/src/common/config/can_show_page.ts
@@ -4,8 +4,7 @@ import { ensureArray } from "../array/ensure-array";
 import { isComponentLoaded } from "./is_component_loaded";
 
 export const canShowPage = (hass: HomeAssistant, page: PageNavigation) =>
-  (isCore(page) || isLoadedIntegration(hass, page)) &&
-  isNotLoadedIntegration(hass, page);
+  isCore(page) || isLoadedIntegration(hass, page);
 
 export const isLoadedIntegration = (
   hass: HomeAssistant,
@@ -13,15 +12,6 @@ export const isLoadedIntegration = (
 ) =>
   !page.component ||
   ensureArray(page.component).some((integration) =>
-    isComponentLoaded(hass.config, integration)
-  );
-
-export const isNotLoadedIntegration = (
-  hass: HomeAssistant,
-  page: PageNavigation
-) =>
-  !page.not_component ||
-  !ensureArray(page.not_component).some((integration) =>
     isComponentLoaded(hass.config, integration)
   );
 

--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -33,7 +33,6 @@ export interface PageNavigation {
   translationKey?: string;
   component?: string | string[];
   name?: string;
-  not_component?: string | string[];
   core?: boolean;
   /** Hide from non-admin users in filtered navigation and quick bar. */
   adminOnly?: boolean;

--- a/test/common/config/can_show_page.test.ts
+++ b/test/common/config/can_show_page.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import {
   canShowPage,
   isLoadedIntegration,
-  isNotLoadedIntegration,
   isCore,
 } from "../../../src/common/config/can_show_page";
 import type { PageNavigation } from "../../../src/layouts/hass-tabs-subpage";
@@ -47,28 +46,6 @@ describe("isLoadedIntegration", () => {
     } as unknown as HomeAssistant;
     const page = { component: "other_component" } as unknown as PageNavigation;
     expect(isLoadedIntegration(hass, page)).toBe(false);
-  });
-});
-
-describe("isNotLoadedIntegration", () => {
-  it("should return true if the integration is not loaded", () => {
-    const hass = {
-      config: { components: ["test_component"] },
-    } as unknown as HomeAssistant;
-    const page = {
-      not_component: "other_component",
-    } as unknown as PageNavigation;
-    expect(isNotLoadedIntegration(hass, page)).toBe(true);
-  });
-
-  it("should return false if the integration is loaded", () => {
-    const hass = {
-      config: { components: ["test_component"] },
-    } as unknown as HomeAssistant;
-    const page = {
-      not_component: "test_component",
-    } as unknown as PageNavigation;
-    expect(isNotLoadedIntegration(hass, page)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Proposed change

The `not_component` property on the `PageNavigation` interface is not used anywhere in the codebase — no navigation page ever sets it. This PR removes the unused property along with all the helper code that only existed to support it:

- Removed `not_component` from the `PageNavigation` interface (`hass-tabs-subpage.ts`).
- Removed the `isNotLoadedIntegration` helper from `can_show_page.ts`, so `canShowPage` now simply checks `isCore(page) || isLoadedIntegration(hass, page)`.
- Removed the corresponding `isNotLoadedIntegration` unit tests.

No behavior changes for users, since the removed code was never exercised.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

https://claude.ai/code/session_014Dpw4x5xbKeh5GYoixC7x5

---
_Generated by [Claude Code](https://claude.ai/code/session_014Dpw4x5xbKeh5GYoixC7x5)_