### PR TITLE
Fix oversized top-app-bar-fixed-adjust wrapper in gallery pages

### DIFF
--- a/gallery/src/ha-gallery.ts
+++ b/gallery/src/ha-gallery.ts
@@ -94,55 +94,55 @@ class HaGallery extends LitElement {
             <div slot="title">
               ${PAGES[this._page].metadata.title || this._page.split("/")[1]}
             </div>
+            <div class="content">
+              ${PAGES[this._page].description
+                ? html`
+                    <page-description .page=${this._page}></page-description>
+                  `
+                : ""}
+              ${dynamicElement(`demo-${this._page.replace("/", "-")}`)}
+            </div>
+            <div class="page-footer">
+              <div class="edit-docs">
+                <div class="header">Help us to improve our documentation</div>
+                <div class="secondary">
+                  Suggest an edit to this page, or provide/view feedback for
+                  this page.
+                </div>
+                <div>
+                  ${PAGES[this._page].description ||
+                  Object.keys(PAGES[this._page].metadata).length > 0
+                    ? html`
+                        <a
+                          href=${`${GITHUB_DEMO_URL}${this._page}.markdown`}
+                          target="_blank"
+                        >
+                          Edit text
+                        </a>
+                      `
+                    : ""}
+                  ${PAGES[this._page].demo
+                    ? html`
+                        <a
+                          href=${`${GITHUB_DEMO_URL}${this._page}.ts`}
+                          target="_blank"
+                        >
+                          Edit demo
+                        </a>
+                      `
+                    : ""}
+                </div>
+              </div>
+              <div class="rtl-toggle">
+                <ha-icon-button
+                  @click=${this._toggleRtl}
+                  .label=${this._rtl ? "Switch to LTR" : "Switch to RTL"}
+                >
+                  <ha-svg-icon .path=${mdiSwapHorizontal}></ha-svg-icon>
+                </ha-icon-button>
+              </div>
+            </div>
           </ha-top-app-bar-fixed>
-          <div class="content">
-            ${PAGES[this._page].description
-              ? html`
-                  <page-description .page=${this._page}></page-description>
-                `
-              : ""}
-            ${dynamicElement(`demo-${this._page.replace("/", "-")}`)}
-          </div>
-          <div class="page-footer">
-            <div class="edit-docs">
-              <div class="header">Help us to improve our documentation</div>
-              <div class="secondary">
-                Suggest an edit to this page, or provide/view feedback for this
-                page.
-              </div>
-              <div>
-                ${PAGES[this._page].description ||
-                Object.keys(PAGES[this._page].metadata).length > 0
-                  ? html`
-                      <a
-                        href=${`${GITHUB_DEMO_URL}${this._page}.markdown`}
-                        target="_blank"
-                      >
-                        Edit text
-                      </a>
-                    `
-                  : ""}
-                ${PAGES[this._page].demo
-                  ? html`
-                      <a
-                        href=${`${GITHUB_DEMO_URL}${this._page}.ts`}
-                        target="_blank"
-                      >
-                        Edit demo
-                      </a>
-                    `
-                  : ""}
-              </div>
-            </div>
-            <div class="rtl-toggle">
-              <ha-icon-button
-                @click=${this._toggleRtl}
-                .label=${this._rtl ? "Switch to LTR" : "Switch to RTL"}
-              >
-                <ha-svg-icon .path=${mdiSwapHorizontal}></ha-svg-icon>
-              </ha-icon-button>
-            </div>
-          </div>
         </div>
       </ha-drawer>
       <notification-manager


### PR DESCRIPTION
## Proposed change

Gallery pages were rendering a huge empty area that pushed the actual page content far down the screen, almost out of view.

The cause: the gallery placed each page's content and footer *next to* `ha-top-app-bar-fixed` instead of *inside* it. The component wraps its slotted content in an adjust container that is sized to nearly the full viewport height to clear the fixed header. With nothing slotted in, that container became a big empty block, and the real content ended up below it.

This change moves the page content and footer inside `ha-top-app-bar-fixed` (its default slot), matching how the component is meant to be used elsewhere (e.g. the developer tools panel). The content now sits correctly below the header.

## Screenshots

before:

<img width="1470" height="923" alt="image" src="https://github.com/user-attachments/assets/d58fe4a2-3fad-4100-a56f-30fee4aac648" />


after:

<img width="1470" height="923" alt="image" src="https://github.com/user-attachments/assets/25121fc9-2f68-4f05-a6ff-23692fb47362" />


<!-- Reminder for the author: please add before/after screenshots of a gallery page. -->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

https://claude.ai/code/session_012yXzrqLXgfyNpW3PPtLCrq

---
_Generated by [Claude Code](https://claude.ai/code/session_012yXzrqLXgfyNpW3PPtLCrq)_