### PR TITLE
Remove pulsing animation from running app state dot

### DIFF
--- a/src/panels/config/apps/components/supervisor-apps-state.ts
+++ b/src/panels/config/apps/components/supervisor-apps-state.ts
@@ -45,7 +45,6 @@ class SupervisorAppsState extends LitElement {
     }
     .dot.state-started {
       background-color: var(--ha-color-green-80);
-      animation: state-dot-pulse 1.8s infinite;
     }
     .dot.state-startup {
       background-color: var(--ha-color-on-warning-normal);
@@ -55,19 +54,6 @@ class SupervisorAppsState extends LitElement {
     }
     ha-svg-icon {
       --mdc-icon-size: 20px;
-    }
-    @keyframes state-dot-pulse {
-      0% {
-        box-shadow: 0 0 0 0 rgba(var(--rgb-success-color), 0.6);
-      }
-      100% {
-        box-shadow: 0 0 0 6px rgba(var(--rgb-success-color), 0);
-      }
-    }
-    @media (prefers-reduced-motion) {
-      .dot.state-started {
-        animation: none;
-      }
     }
   `;
 }


### PR DESCRIPTION
## Proposed change

Removes the pulsing animation from the green status dot shown for running apps in the apps panel. The dot is now a static green indicator.

We're removing it for two reasons:

- It constantly claims the user's attention even though a running app is a normal, low-importance state that doesn't need to be highlighted.
- The pulsing effect reads as a stereotypically "AI-designed" flourish and undercuts the feel of a deliberately designed interface.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

https://claude.ai/code/session_01EdRFbxzrdFZkCppLipMVXn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdRFbxzrdFZkCppLipMVXn)_