### PR TITLE
Use light.adjust for active light groups

### DIFF
--- a/src/data/light.ts
+++ b/src/data/light.ts
@@ -3,6 +3,7 @@ import type {
   HassEntityBase,
 } from "home-assistant-js-websocket";
 import { temperature2rgb } from "../common/color/convert-light-color";
+import type { HomeAssistant } from "../types";
 
 export const enum LightEntityFeature {
   EFFECT = 4,
@@ -95,10 +96,24 @@ export interface LightEntity extends HassEntityBase {
   attributes: LightEntityAttributes;
 }
 
-export const computeLightAttributeService = (entity: LightEntity) =>
-  entity.state === "on" && Array.isArray(entity.attributes.entity_id)
+export const computeLightAttributeService = (
+  hass: HomeAssistant,
+  entity: LightEntity
+) => {
+  const memberIds = entity.attributes.entity_id;
+
+  if (!Array.isArray(memberIds)) {
+    return "turn_on";
+  }
+
+  if (entity.state === "on") {
+    return "adjust";
+  }
+
+  return memberIds.some((entityId) => hass.states[entityId]?.state === "on")
     ? "adjust"
     : "turn_on";
+};
 
 export type LightColor =
   | {

--- a/src/data/light.ts
+++ b/src/data/light.ts
@@ -72,6 +72,7 @@ export const getLightCurrentModeRgbColor = (
       : entity.attributes.rgb_color;
 
 interface LightEntityAttributes extends HassEntityAttributeBase {
+  entity_id?: string[];
   min_color_temp_kelvin?: number;
   max_color_temp_kelvin?: number;
   min_mireds?: number;
@@ -93,6 +94,11 @@ interface LightEntityAttributes extends HassEntityAttributeBase {
 export interface LightEntity extends HassEntityBase {
   attributes: LightEntityAttributes;
 }
+
+export const computeLightAttributeService = (entity: LightEntity) =>
+  entity.state === "on" && Array.isArray(entity.attributes.entity_id)
+    ? "adjust"
+    : "turn_on";
 
 export type LightColor =
   | {

--- a/src/dialogs/more-info/components/lights/ha-more-info-light-favorite-colors.ts
+++ b/src/dialogs/more-info/components/lights/ha-more-info-light-favorite-colors.ts
@@ -6,8 +6,12 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import { UNAVAILABLE } from "../../../../data/entity/entity";
 import type { ExtEntityRegistryEntry } from "../../../../data/entity/entity_registry";
 import { updateEntityRegistryEntry } from "../../../../data/entity/entity_registry";
-import type { LightColor, LightEntity } from "../../../../data/light";
-import { computeDefaultFavoriteColors } from "../../../../data/light";
+import {
+  computeDefaultFavoriteColors,
+  computeLightAttributeService,
+  type LightColor,
+  type LightEntity,
+} from "../../../../data/light";
 import type { HomeAssistant } from "../../../../types";
 import { showConfirmationDialog } from "../../../generic/show-dialog-box";
 import "../ha-more-info-favorites";
@@ -53,10 +57,14 @@ export class HaMoreInfoLightFavoriteColors extends LitElement {
 
   private _apply(index: number): void {
     const favorite = this._favoriteColors[index];
-    this.hass.callService("light", "turn_on", {
-      entity_id: this.stateObj.entity_id,
-      ...favorite,
-    });
+    this.hass.callService(
+      "light",
+      computeLightAttributeService(this.stateObj),
+      {
+        entity_id: this.stateObj.entity_id,
+        ...favorite,
+      }
+    );
   }
 
   private async _save(newFavoriteColors: LightColor[]): Promise<void> {

--- a/src/dialogs/more-info/components/lights/ha-more-info-light-favorite-colors.ts
+++ b/src/dialogs/more-info/components/lights/ha-more-info-light-favorite-colors.ts
@@ -59,7 +59,7 @@ export class HaMoreInfoLightFavoriteColors extends LitElement {
     const favorite = this._favoriteColors[index];
     this.hass.callService(
       "light",
-      computeLightAttributeService(this.stateObj),
+      computeLightAttributeService(this.hass, this.stateObj),
       {
         entity_id: this.stateObj.entity_id,
         ...favorite,

--- a/src/dialogs/more-info/components/lights/light-color-rgb-picker.ts
+++ b/src/dialogs/more-info/components/lights/light-color-rgb-picker.ts
@@ -350,7 +350,7 @@ class LightRgbColorPicker extends LitElement {
     fireEvent(this, "color-changed", color);
     this.hass.callService(
       "light",
-      computeLightAttributeService(this.stateObj),
+      computeLightAttributeService(this.hass, this.stateObj),
       {
         entity_id: this.stateObj!.entity_id,
         ...color,

--- a/src/dialogs/more-info/components/lights/light-color-rgb-picker.ts
+++ b/src/dialogs/more-info/components/lights/light-color-rgb-picker.ts
@@ -16,11 +16,13 @@ import "../../../../components/ha-hs-color-picker";
 import "../../../../components/ha-icon";
 import "../../../../components/ha-icon-button-prev";
 import "../../../../components/ha-labeled-slider";
-import type { LightColor, LightEntity } from "../../../../data/light";
 import {
+  computeLightAttributeService,
   getLightCurrentModeRgbColor,
   LightColorMode,
   lightSupportsColorMode,
+  type LightColor,
+  type LightEntity,
 } from "../../../../data/light";
 import type { HomeAssistant } from "../../../../types";
 
@@ -346,11 +348,15 @@ class LightRgbColorPicker extends LitElement {
 
   private _applyColor(color: LightColor, params?: Record<string, any>) {
     fireEvent(this, "color-changed", color);
-    this.hass.callService("light", "turn_on", {
-      entity_id: this.stateObj!.entity_id,
-      ...color,
-      ...params,
-    });
+    this.hass.callService(
+      "light",
+      computeLightAttributeService(this.stateObj),
+      {
+        entity_id: this.stateObj!.entity_id,
+        ...color,
+        ...params,
+      }
+    );
   }
 
   private _colorBrightnessSliderChanged(ev: CustomEvent) {

--- a/src/dialogs/more-info/components/lights/light-color-temp-picker.ts
+++ b/src/dialogs/more-info/components/lights/light-color-temp-picker.ts
@@ -165,7 +165,7 @@ class LightColorTempPicker extends LitElement {
     fireEvent(this, "color-changed", color);
     this.hass.callService(
       "light",
-      computeLightAttributeService(this.stateObj),
+      computeLightAttributeService(this.hass, this.stateObj),
       {
         entity_id: this.stateObj!.entity_id,
         ...color,

--- a/src/dialogs/more-info/components/lights/light-color-temp-picker.ts
+++ b/src/dialogs/more-info/components/lights/light-color-temp-picker.ts
@@ -15,8 +15,12 @@ import { throttle } from "../../../../common/util/throttle";
 import "../../../../components/ha-control-slider";
 import { UNAVAILABLE } from "../../../../data/entity/entity";
 import { DOMAIN_ATTRIBUTES_UNITS } from "../../../../data/entity/entity_attributes";
-import type { LightColor, LightEntity } from "../../../../data/light";
-import { LightColorMode } from "../../../../data/light";
+import {
+  computeLightAttributeService,
+  LightColorMode,
+  type LightColor,
+  type LightEntity,
+} from "../../../../data/light";
 import type { HomeAssistant } from "../../../../types";
 
 declare global {
@@ -159,11 +163,15 @@ class LightColorTempPicker extends LitElement {
 
   private _applyColor(color: LightColor, params?: Record<string, any>) {
     fireEvent(this, "color-changed", color);
-    this.hass.callService("light", "turn_on", {
-      entity_id: this.stateObj!.entity_id,
-      ...color,
-      ...params,
-    });
+    this.hass.callService(
+      "light",
+      computeLightAttributeService(this.stateObj),
+      {
+        entity_id: this.stateObj!.entity_id,
+        ...color,
+        ...params,
+      }
+    );
   }
 
   static get styles(): CSSResultGroup {

--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -309,7 +309,7 @@ class MoreInfoLight extends LitElement {
   private _setWhite = () => {
     this.hass.callService(
       "light",
-      computeLightAttributeService(this.stateObj!),
+      computeLightAttributeService(this.hass, this.stateObj!),
       {
         entity_id: this.stateObj!.entity_id,
         white: true,
@@ -325,7 +325,7 @@ class MoreInfoLight extends LitElement {
 
     this.hass.callService(
       "light",
-      computeLightAttributeService(this.stateObj!),
+      computeLightAttributeService(this.hass, this.stateObj!),
       {
         entity_id: this.stateObj!.entity_id,
         effect: newVal,

--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -21,14 +21,15 @@ import {
   type ExtEntityRegistryEntry,
 } from "../../../data/entity/entity_registry";
 import { forwardHaptic } from "../../../data/haptics";
-import type { LightEntity } from "../../../data/light";
 import {
+  computeLightAttributeService,
   LightColorMode,
   LightEntityFeature,
   lightSupportsBrightness,
   lightSupportsColor,
   lightSupportsColorMode,
   lightSupportsFavoriteColors,
+  type LightEntity,
 } from "../../../data/light";
 import "../../../state-control/ha-state-control-toggle";
 import "../../../state-control/light/ha-state-control-light-brightness";
@@ -306,10 +307,14 @@ class MoreInfoLight extends LitElement {
   };
 
   private _setWhite = () => {
-    this.hass.callService("light", "turn_on", {
-      entity_id: this.stateObj!.entity_id,
-      white: true,
-    });
+    this.hass.callService(
+      "light",
+      computeLightAttributeService(this.stateObj!),
+      {
+        entity_id: this.stateObj!.entity_id,
+        white: true,
+      }
+    );
   };
 
   private _handleEffect(ev: HaDropdownSelectEvent) {
@@ -318,10 +323,14 @@ class MoreInfoLight extends LitElement {
 
     if (!newVal || oldVal === newVal) return;
 
-    this.hass.callService("light", "turn_on", {
-      entity_id: this.stateObj!.entity_id,
-      effect: newVal,
-    });
+    this.hass.callService(
+      "light",
+      computeLightAttributeService(this.stateObj!),
+      {
+        entity_id: this.stateObj!.entity_id,
+        effect: newVal,
+      }
+    );
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/lovelace/card-features/hui-light-brightness-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-light-brightness-card-feature.ts
@@ -100,7 +100,7 @@ class HuiLightBrightnessCardFeature
 
     this.hass!.callService(
       "light",
-      computeLightAttributeService(this._stateObj!),
+      computeLightAttributeService(this.hass!, this._stateObj!),
       {
         entity_id: this._stateObj!.entity_id,
         brightness_pct: value,

--- a/src/panels/lovelace/card-features/hui-light-brightness-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-light-brightness-card-feature.ts
@@ -4,7 +4,11 @@ import { computeDomain } from "../../../common/entity/compute_domain";
 import { stateActive } from "../../../common/entity/state_active";
 import "../../../components/ha-control-slider";
 import { UNAVAILABLE } from "../../../data/entity/entity";
-import { lightSupportsBrightness, type LightEntity } from "../../../data/light";
+import {
+  computeLightAttributeService,
+  lightSupportsBrightness,
+  type LightEntity,
+} from "../../../data/light";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceCardFeature } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
@@ -94,10 +98,14 @@ class HuiLightBrightnessCardFeature
     ev.stopPropagation();
     const value = ev.detail.value;
 
-    this.hass!.callService("light", "turn_on", {
-      entity_id: this._stateObj!.entity_id,
-      brightness_pct: value,
-    });
+    this.hass!.callService(
+      "light",
+      computeLightAttributeService(this._stateObj!),
+      {
+        entity_id: this._stateObj!.entity_id,
+        brightness_pct: value,
+      }
+    );
   }
 
   static get styles() {

--- a/src/panels/lovelace/card-features/hui-light-color-favorites-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-light-color-favorites-card-feature.ts
@@ -6,6 +6,7 @@ import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { UNAVAILABLE } from "../../../data/entity/entity";
 import {
+  computeLightAttributeService,
   computeDefaultFavoriteColors,
   type LightEntity,
   type LightColor,
@@ -189,10 +190,14 @@ class HuiLightColorFavoritesCardFeature
     const index = (ev.target! as any).index!;
 
     const favorite = this._favoriteColors[index];
-    this.hass!.callService("light", "turn_on", {
-      entity_id: this._stateObj!.entity_id,
-      ...favorite,
-    });
+    this.hass!.callService(
+      "light",
+      computeLightAttributeService(this._stateObj!),
+      {
+        entity_id: this._stateObj!.entity_id,
+        ...favorite,
+      }
+    );
   }
 
   static get styles() {

--- a/src/panels/lovelace/card-features/hui-light-color-favorites-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-light-color-favorites-card-feature.ts
@@ -192,7 +192,7 @@ class HuiLightColorFavoritesCardFeature
     const favorite = this._favoriteColors[index];
     this.hass!.callService(
       "light",
-      computeLightAttributeService(this._stateObj!),
+      computeLightAttributeService(this.hass!, this._stateObj!),
       {
         entity_id: this._stateObj!.entity_id,
         ...favorite,

--- a/src/panels/lovelace/card-features/hui-light-color-temp-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-light-color-temp-card-feature.ts
@@ -124,7 +124,7 @@ class HuiLightColorTempCardFeature
 
     this.hass!.callService(
       "light",
-      computeLightAttributeService(this._stateObj!),
+      computeLightAttributeService(this.hass!, this._stateObj!),
       {
         entity_id: this._stateObj!.entity_id,
         color_temp_kelvin: value,

--- a/src/panels/lovelace/card-features/hui-light-color-temp-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-light-color-temp-card-feature.ts
@@ -12,6 +12,7 @@ import "../../../components/ha-control-slider";
 import { UNAVAILABLE } from "../../../data/entity/entity";
 import { DOMAIN_ATTRIBUTES_UNITS } from "../../../data/entity/entity_attributes";
 import {
+  computeLightAttributeService,
   LightColorMode,
   lightSupportsColorMode,
   type LightEntity,
@@ -121,10 +122,14 @@ class HuiLightColorTempCardFeature
     ev.stopPropagation();
     const value = ev.detail.value;
 
-    this.hass!.callService("light", "turn_on", {
-      entity_id: this._stateObj!.entity_id,
-      color_temp_kelvin: value,
-    });
+    this.hass!.callService(
+      "light",
+      computeLightAttributeService(this._stateObj!),
+      {
+        entity_id: this._stateObj!.entity_id,
+        color_temp_kelvin: value,
+      }
+    );
   }
 
   static get styles() {

--- a/src/panels/lovelace/cards/hui-light-card.ts
+++ b/src/panels/lovelace/cards/hui-light-card.ts
@@ -217,10 +217,14 @@ export class HuiLightCard extends LitElement implements LovelaceCard {
 
   private _setBrightness(e: any): void {
     const stateObj = this.hass!.states[this._config!.entity] as LightEntity;
-    this.hass!.callService("light", computeLightAttributeService(stateObj), {
-      entity_id: stateObj.entity_id,
-      brightness_pct: e.detail.value,
-    });
+    this.hass!.callService(
+      "light",
+      computeLightAttributeService(this.hass!, stateObj),
+      {
+        entity_id: stateObj.entity_id,
+        brightness_pct: e.detail.value,
+      }
+    );
   }
 
   private _computeBrightness(stateObj: LightEntity): string {

--- a/src/panels/lovelace/cards/hui-light-card.ts
+++ b/src/panels/lovelace/cards/hui-light-card.ts
@@ -12,8 +12,11 @@ import "../../../components/ha-card";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-state-icon";
 import { UNAVAILABLE, UNKNOWN } from "../../../data/entity/entity";
-import type { LightEntity } from "../../../data/light";
-import { lightSupportsBrightness } from "../../../data/light";
+import {
+  computeLightAttributeService,
+  lightSupportsBrightness,
+  type LightEntity,
+} from "../../../data/light";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import type { HomeAssistant } from "../../../types";
 import { actionHandler } from "../common/directives/action-handler-directive";
@@ -213,8 +216,9 @@ export class HuiLightCard extends LitElement implements LovelaceCard {
   }
 
   private _setBrightness(e: any): void {
-    this.hass!.callService("light", "turn_on", {
-      entity_id: this._config!.entity,
+    const stateObj = this.hass!.states[this._config!.entity] as LightEntity;
+    this.hass!.callService("light", computeLightAttributeService(stateObj), {
+      entity_id: stateObj.entity_id,
       brightness_pct: e.detail.value,
     });
   }

--- a/src/state-control/light/ha-state-control-light-brightness.ts
+++ b/src/state-control/light/ha-state-control-light-brightness.ts
@@ -8,7 +8,10 @@ import { stateActive } from "../../common/entity/state_active";
 import { stateColorCss } from "../../common/entity/state_color";
 import "../../components/ha-control-slider";
 import { UNAVAILABLE } from "../../data/entity/entity";
-import type { LightEntity } from "../../data/light";
+import {
+  computeLightAttributeService,
+  type LightEntity,
+} from "../../data/light";
 import type { HomeAssistant } from "../../types";
 
 @customElement("ha-state-control-light-brightness")
@@ -35,10 +38,14 @@ export class HaStateControlLightBrightness extends LitElement {
     const { value } = ev.detail;
     if (typeof value !== "number" || isNaN(value)) return;
 
-    this.hass.callService("light", "turn_on", {
-      entity_id: this.stateObj!.entity_id,
-      brightness_pct: value,
-    });
+    this.hass.callService(
+      "light",
+      computeLightAttributeService(this.stateObj),
+      {
+        entity_id: this.stateObj!.entity_id,
+        brightness_pct: value,
+      }
+    );
   }
 
   protected render(): TemplateResult {

--- a/src/state-control/light/ha-state-control-light-brightness.ts
+++ b/src/state-control/light/ha-state-control-light-brightness.ts
@@ -40,7 +40,7 @@ export class HaStateControlLightBrightness extends LitElement {
 
     this.hass.callService(
       "light",
-      computeLightAttributeService(this.stateObj),
+      computeLightAttributeService(this.hass, this.stateObj),
       {
         entity_id: this.stateObj!.entity_id,
         brightness_pct: value,

--- a/test/data/light.test.ts
+++ b/test/data/light.test.ts
@@ -1,0 +1,68 @@
+import type { HomeAssistant } from "../../src/types";
+import {
+  computeLightAttributeService,
+  type LightEntity,
+} from "../../src/data/light";
+import { describe, expect, it } from "vitest";
+
+const createHass = (states: HomeAssistant["states"]) =>
+  ({ states }) as HomeAssistant;
+
+const createLight = (state: string, entityIds?: string[]) =>
+  ({
+    entity_id: "light.test_group",
+    state,
+    attributes: entityIds ? { entity_id: entityIds } : {},
+  }) as LightEntity;
+
+describe("computeLightAttributeService", () => {
+  it("keeps turn_on for non-group lights", () => {
+    expect(
+      computeLightAttributeService(createHass({}), createLight("on"))
+    ).toBe("turn_on");
+  });
+
+  it("uses adjust for active light groups", () => {
+    expect(
+      computeLightAttributeService(
+        createHass({}),
+        createLight("on", ["light.candela", "light.svet_na_stole"])
+      )
+    ).toBe("adjust");
+  });
+
+  it("uses adjust for partially-on all-mode light groups", () => {
+    expect(
+      computeLightAttributeService(
+        createHass({
+          "light.candela": {
+            entity_id: "light.candela",
+            state: "on",
+            attributes: {},
+          } as LightEntity,
+          "light.svet_na_stole": {
+            entity_id: "light.svet_na_stole",
+            state: "off",
+            attributes: {},
+          } as LightEntity,
+        }),
+        createLight("off", ["light.candela", "light.svet_na_stole"])
+      )
+    ).toBe("adjust");
+  });
+
+  it("keeps turn_on for fully-off light groups", () => {
+    expect(
+      computeLightAttributeService(
+        createHass({
+          "light.candela": {
+            entity_id: "light.candela",
+            state: "off",
+            attributes: {},
+          } as LightEntity,
+        }),
+        createLight("off", ["light.candela"])
+      )
+    ).toBe("turn_on");
+  });
+});


### PR DESCRIPTION
## Summary

Updates HA light group UI controls to call `light.adjust` for attribute-only changes when interacting with active Home Assistant light groups.

This keeps current behavior for off targets:

- active HA light groups use `light.adjust`
- off or fully-off groups continue to use `light.turn_on`
- non-group lights continue using existing `light.turn_on` semantics

This PR is paired with the backend implementation in core:

- Companion core PR: https://github.com/home-assistant/core/pull/173239

The user-facing rationale and proposal shape were described in the recent architecture discussion comment:

- Architecture discussion comment: https://github.com/home-assistant/architecture/discussions/537#discussioncomment-17171378

## Why

The more-info and Lovelace light controls currently express a user intent closer to "adjust the lights that are already active in this group" than "turn on every light in the group".

Without a more precise backend action, sliders and color controls on partially-on groups end up waking lights that are off. This PR switches those group-only attribute controls to the new `light.adjust` action, which matches the intended semantics.

## What Changed

- add `computeLightAttributeService` helper in `src/data/light.ts`
- use that helper from:
  - more-info brightness controls
  - more-info color temperature controls
  - more-info RGB/favorite color controls
  - Lovelace light card features
  - state control brightness UI
- only choose `light.adjust` for Home Assistant light groups that expose `attributes.entity_id`
- keep `light.turn_on` behavior for off/all-off groups and non-group lights

## Edge Cases Resolved

- partially-on HA light groups now adjust only active members instead of waking lights that are off
- fully-off groups still stay on normal `light.turn_on` semantics so power-on UX remains unchanged
- `all: true` group flows are aligned with the backend adjust semantics and current active-member selection
- Home Assistant light groups with member entities are detected explicitly, while ordinary lights and non-HA groups stay on the existing call path
- brightness, color temperature, RGB, favorite color, Lovelace, and state-control entry points all route through the same service-choice helper

## Relation To Core

This frontend change depends on the new `light.adjust` service/action from the companion core PR. The two PRs are intentionally linked and should be reviewed together.

The backend/core PR defines the semantics:

- off lights default to no-op
- active HA light groups expand only to currently-on members
- service metadata makes the action render as a normal human-readable action in the UI

## Testing

- Prettier / local formatting check on changed frontend files
- `test/data/light.test.ts`
- live HOME HA verification against the paired core patch:
  - partially-on group brightness changes no longer turned on off members
  - all-off groups still used normal turn-on semantics

## References

- Architecture discussion: https://github.com/home-assistant/architecture/discussions/537
- Recent proposal comment used as the rationale baseline: https://github.com/home-assistant/architecture/discussions/537#discussioncomment-17171378
- Companion core PR: https://github.com/home-assistant/core/pull/173239