### PR TITLE
Fix add integration dialog error when picking an integration within a brand

### DIFF
--- a/src/panels/config/integrations/ha-domain-integrations.ts
+++ b/src/panels/config/integrations/ha-domain-integrations.ts
@@ -151,6 +151,7 @@ class HaDomainIntegrations extends LitElement {
             .map(
               ([dom, val]) =>
                 html`<ha-integration-list-item
+                  .domain=${dom}
                   .integration=${{
                     ...val,
                     domain: dom,


### PR DESCRIPTION
## Proposed change

In the add integration dialog, clicking a brand and then clicking one of the integrations listed under that brand resulted in a backend error:

```
required key not provided @ data['integration']. Got None
```

The list item rendered for each integration within a brand was missing the `.domain` property. The click handler (`_integrationPicked`) reads the domain from `ev.currentTarget.domain`, so it came through as `undefined` and was passed to the backend as the config flow handler, which the backend rejected.

This restores the `.domain` binding on that list item, bringing it in line with every other clickable item in the component. The binding was accidentally dropped in #52354 (Introduce list-virtualized).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

This is a regression introduced in #52354.

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
