### PR TITLE
Use attribute name as default label for state selector

### DIFF
--- a/src/components/entity/ha-entity-state-picker.ts
+++ b/src/components/entity/ha-entity-state-picker.ts
@@ -115,6 +115,20 @@ export class HaEntityStatePicker extends LitElement {
     return html`<span slot="headline">${item?.primary ?? value}</span>`;
   };
 
+  private _computeDefaultLabel(): string {
+    // When an attribute is configured, default to the attribute's friendly
+    // name (e.g. "Source") instead of the generic "State". Requires a concrete
+    // entity to resolve the translated name; otherwise fall back to "State".
+    if (this.attribute && this.entityId) {
+      const entityId = ensureArray(this.entityId)[0];
+      const stateObj = entityId ? this.hass.states[entityId] : undefined;
+      if (stateObj) {
+        return this.hass.formatEntityAttributeName(stateObj, this.attribute);
+      }
+    }
+    return this.hass.localize("ui.components.entity.entity-state-picker.state");
+  }
+
   protected render() {
     if (!this.hass) {
       return nothing;
@@ -129,8 +143,7 @@ export class HaEntityStatePicker extends LitElement {
         .disabled=${this.disabled || noEntity}
         .autofocus=${this.autofocus}
         .required=${this.required}
-        .label=${this.label ??
-        this.hass.localize("ui.components.entity.entity-state-picker.state")}
+        .label=${this.label ?? this._computeDefaultLabel()}
         .helper=${this.helper}
         .value=${this.value}
         .getItems=${this._getFilteredItems}


### PR DESCRIPTION
## Proposed change

The `state` selector always labeled its input box with the generic "State", even when the field targets a specific entity attribute. This is most visible in action/service editors: the `media_player.select_source` action showed a source input labeled "State" instead of "Source". The same wrong label appeared for every action field using a `state` selector with an `attribute` (for example `climate.set_preset_mode`, `climate.set_fan_mode`, `climate.set_swing_mode`, `fan.set_preset_mode`, `media_player.select_sound_mode`).

This change makes the state selector use the attribute's friendly name as its default label when an `attribute` is configured (so the source field now reads "Source", the preset field "Preset mode", and so on). When no attribute is set, or when no concrete entity is available yet to resolve the friendly name (for example before a target entity has been chosen in the action editor), it gracefully falls back to the existing "State" default.

This is a general fix for the state selector, not specific to media player.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Before:
<img width="1072" height="952" alt="CleanShot 2026-06-07 at 22 27 51@2x" src="https://github.com/user-attachments/assets/9ed66866-3f25-4d40-9548-e72138aa9c12" />

After:
<img width="1038" height="904" alt="CleanShot 2026-06-07 at 22 29 07@2x" src="https://github.com/user-attachments/assets/b528067a-589e-422a-9b7e-57437f04f7f3" />


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

https://claude.ai/code/session_01UQGb1Y4uAS8zwVzGzs8uaE

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQGb1Y4uAS8zwVzGzs8uaE)_