### PR TITLE
Fix lost keyboard focus in virtualized list when scrolling to off-screen row

### DIFF
--- a/src/components/list/ha-list-virtualized.ts
+++ b/src/components/list/ha-list-virtualized.ts
@@ -156,7 +156,7 @@ export class HaListVirtualized extends HaListBase {
       this._activeItemFocus = focusItem;
       this._scrollToActiveItem = true;
       this.virtualizerElement
-        ?.element(index)
+        ?.element(this.activeItemIndex)
         ?.scrollIntoView({ block: "nearest" });
     }
   }


### PR DESCRIPTION
## Proposed change

In the virtualized list (`ha-list-virtualized`), `setActiveItemIndex` clamps and remaps the requested row index into `this.activeItemIndex` (clamping to the valid range, and remapping a non-focusable row to the first focusable one). When the resolved row is outside the currently rendered range, it then scrolls the row into view — but it scrolled to the **raw** `index` argument rather than the resolved `this.activeItemIndex`.

As a result, if the requested index was out of bounds or pointed at a non-focusable row, the list scrolled to the wrong element (or to nothing), the actual active row was never brought into view, and keyboard focus was lost.

The fix uses `this.activeItemIndex`, matching the two other `element(...)` call sites in the same component.

This is a follow-up regression found while reviewing #52354 (Introduce list-virtualized). It is latent with the current consumers (they only pass in-bounds, all-interactive indices), but it's a real bug in the keyboard-navigation path.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

Regression introduced in #52354.

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
