### PR TITLE
Add type and integration context to scene editor entity rows

### DIFF
--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -25,7 +25,7 @@ import { transform } from "../../../common/decorators/transform";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDeviceNameDisplay } from "../../../common/entity/compute_device_name";
 import { computeDomain } from "../../../common/entity/compute_domain";
-import { computeStateName } from "../../../common/entity/compute_state_name";
+import { computeEntityPickerDisplay } from "../../../common/entity/compute_entity_name_display";
 import { goBack, navigate } from "../../../common/navigate";
 import { computeRTL } from "../../../common/util/compute_rtl";
 import { promiseTimeout } from "../../../common/util/promise-timeout";
@@ -423,9 +423,12 @@ export class HaSceneEditor extends PreventUnsavedMixin(
                         if (!entityStateObj) {
                           return nothing;
                         }
+                        const { primary, secondary } =
+                          computeEntityPickerDisplay(this.hass, entityStateObj);
                         return html`
                           <ha-list-item
                             hasMeta
+                            ?twoline=${!!secondary}
                             .graphic=${this._mode === "live"
                               ? "icon"
                               : undefined}
@@ -444,7 +447,10 @@ export class HaSceneEditor extends PreventUnsavedMixin(
                                   ></state-badge>
                                 `
                               : nothing}
-                            ${computeStateName(entityStateObj)}
+                            ${primary}
+                            ${secondary
+                              ? html`<span slot="secondary">${secondary}</span>`
+                              : nothing}
                           </ha-list-item>
                         `;
                       })}
@@ -496,10 +502,16 @@ export class HaSceneEditor extends PreventUnsavedMixin(
                           if (!entityStateObj) {
                             return nothing;
                           }
+                          const { primary, secondary } =
+                            computeEntityPickerDisplay(
+                              this.hass,
+                              entityStateObj
+                            );
                           return html`
                             <ha-list-item
                               class="entity"
                               hasMeta
+                              ?twoline=${!!secondary}
                               .graphic=${this._mode === "live"
                                 ? "icon"
                                 : undefined}
@@ -516,7 +528,12 @@ export class HaSceneEditor extends PreventUnsavedMixin(
                                     slot="graphic"
                                   ></state-badge>`
                                 : nothing}
-                              ${computeStateName(entityStateObj)}
+                              ${primary}
+                              ${secondary
+                                ? html`<span slot="secondary"
+                                    >${secondary}</span
+                                  >`
+                                : nothing}
                               <div slot="meta">
                                 <ha-icon-button
                                   .path=${mdiDelete}

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -26,6 +26,7 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDeviceNameDisplay } from "../../../common/entity/compute_device_name";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { computeEntityPickerDisplay } from "../../../common/entity/compute_entity_name_display";
+import { computeStateName } from "../../../common/entity/compute_state_name";
 import { goBack, navigate } from "../../../common/navigate";
 import { computeRTL } from "../../../common/util/compute_rtl";
 import { promiseTimeout } from "../../../common/util/promise-timeout";
@@ -47,7 +48,11 @@ import {
 } from "../../../data/context";
 import type { DeviceRegistryEntry } from "../../../data/device/device_registry";
 import type { EntityRegistryEntry } from "../../../data/entity/entity_registry";
-import { updateEntityRegistryEntry } from "../../../data/entity/entity_registry";
+import {
+  entityRegistryByEntityId,
+  updateEntityRegistryEntry,
+} from "../../../data/entity/entity_registry";
+import { domainToName } from "../../../data/integration";
 import type {
   SceneConfig,
   SceneEntities,
@@ -344,6 +349,9 @@ export class HaSceneEditor extends PreventUnsavedMixin(
       this._deviceEntityLookup,
       Object.values(this.hass.devices)
     );
+    const entityRegistryLookup = entityRegistryByEntityId(
+      this._entityRegistryEntries
+    );
     return html` <div
       id="root"
       class=${classMap({
@@ -423,8 +431,15 @@ export class HaSceneEditor extends PreventUnsavedMixin(
                         if (!entityStateObj) {
                           return nothing;
                         }
-                        const { primary, secondary } =
-                          computeEntityPickerDisplay(this.hass, entityStateObj);
+                        const { secondary } = computeEntityPickerDisplay(
+                          this.hass,
+                          entityStateObj
+                        );
+                        const platform =
+                          entityRegistryLookup[entityId]?.platform;
+                        const integrationName = platform
+                          ? domainToName(this.hass.localize, platform)
+                          : undefined;
                         return html`
                           <ha-list-item
                             hasMeta
@@ -447,9 +462,14 @@ export class HaSceneEditor extends PreventUnsavedMixin(
                                   ></state-badge>
                                 `
                               : nothing}
-                            ${primary}
+                            ${computeStateName(entityStateObj)}
                             ${secondary
                               ? html`<span slot="secondary">${secondary}</span>`
+                              : nothing}
+                            ${integrationName
+                              ? html`<span slot="meta" class="domain"
+                                  >${integrationName}</span
+                                >`
                               : nothing}
                           </ha-list-item>
                         `;
@@ -502,11 +522,14 @@ export class HaSceneEditor extends PreventUnsavedMixin(
                           if (!entityStateObj) {
                             return nothing;
                           }
-                          const { primary, secondary } =
-                            computeEntityPickerDisplay(
-                              this.hass,
-                              entityStateObj
-                            );
+                          const { secondary } = computeEntityPickerDisplay(
+                            this.hass,
+                            entityStateObj
+                          );
+                          const domainName = domainToName(
+                            this.hass.localize,
+                            computeDomain(entityId)
+                          );
                           return html`
                             <ha-list-item
                               class="entity"
@@ -528,13 +551,14 @@ export class HaSceneEditor extends PreventUnsavedMixin(
                                     slot="graphic"
                                   ></state-badge>`
                                 : nothing}
-                              ${primary}
+                              ${computeStateName(entityStateObj)}
                               ${secondary
                                 ? html`<span slot="secondary"
                                     >${secondary}</span
                                   >`
                                 : nothing}
                               <div slot="meta">
+                                <span class="domain">${domainName}</span>
                                 <ha-icon-button
                                   .path=${mdiDelete}
                                   .entityId=${entityId}
@@ -1372,9 +1396,20 @@ export class HaSceneEditor extends PreventUnsavedMixin(
           display: flex;
           justify-content: center;
           align-items: center;
+          gap: 8px;
+        }
+        ha-list-item {
+          /* let the trailing label size to its content instead of the default
+             fixed meta width, which would clip it */
+          --mdc-list-item-meta-size: auto;
         }
         ha-list-item.entity {
           padding-right: 28px;
+        }
+        .domain {
+          font-size: var(--ha-font-size-s);
+          color: var(--secondary-text-color);
+          white-space: nowrap;
         }
       `,
     ];


### PR DESCRIPTION
## Proposed change

In the scene editor, entities already part of a scene were shown with only their name. When several entities share a name (for example multiple lights all named "LED"), they became impossible to tell apart in the list.

This gives each entity row the same context its picker shows when you add it. The label shown per section deliberately mirrors the picker you originally select from, so the scene editor stays consistent with the rest of the UI:

- A second line with the entity's area and device (`area ▸ device`), the same secondary text the pickers use.
- A trailing label that matches the relevant picker:
  - entities grouped under a device card show their **integration** (for example "Matter"), matching the **device picker**;
  - standalone entities show their **type / domain** (for example "Light"), matching the **entity picker**.

Entities without an area or device omit the second line. Existing helpers (`computeEntityPickerDisplay`, `domainToName`, `computeDomain`, `entityRegistryByEntityId`) are reused, so no new resolution logic and no extra data subscription are introduced.

## Screenshots

The pickers used to add scene members already show this context. The device picker shows the integration, and the entity picker shows the entity type:

| Device picker (integration) | Entity picker (type) |
| --- | --- |
| ![Device picker showing LED devices with their area and the Matter integration](https://raw.githubusercontent.com/pszypowicz/frontend/pr-assets/device-picker.png) | ![Entity picker showing LED entities with their area and the Light type](https://raw.githubusercontent.com/pszypowicz/frontend/pr-assets/entity-picker.png) |

Once added to a scene, that context was lost - every entity just read "LED":

**Before**

![Before: scene editor rows show only the entity name, several identical "LED" rows](https://raw.githubusercontent.com/pszypowicz/frontend/pr-assets/before.png)

**After**

![After: each row shows area and device on a second line, integration for device-grouped entities and type for standalone entities](https://raw.githubusercontent.com/pszypowicz/frontend/pr-assets/after.png)

> **Documentation:** the [scene editor docs page](https://www.home-assistant.io/docs/scene/editor/) screenshot ([`source/images/docs/scenes/editor.png`](https://github.com/home-assistant/home-assistant.io/blob/current/source/images/docs/scenes/editor.png)) still shows the old name-only rows. No documented text becomes inaccurate, but the screenshot is now slightly out of date - should I open a follow-up PR against the docs repo to refresh it? Happy to.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

