### PR TITLE
Align scene editor entity names with the entity picker

### DIFF
--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -26,7 +26,6 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDeviceNameDisplay } from "../../../common/entity/compute_device_name";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { computeEntityPickerDisplay } from "../../../common/entity/compute_entity_name_display";
-import { computeStateName } from "../../../common/entity/compute_state_name";
 import { goBack, navigate } from "../../../common/navigate";
 import { computeRTL } from "../../../common/util/compute_rtl";
 import { promiseTimeout } from "../../../common/util/promise-timeout";
@@ -431,10 +430,8 @@ export class HaSceneEditor extends PreventUnsavedMixin(
                         if (!entityStateObj) {
                           return nothing;
                         }
-                        const { secondary } = computeEntityPickerDisplay(
-                          this.hass,
-                          entityStateObj
-                        );
+                        const { primary, secondary } =
+                          computeEntityPickerDisplay(this.hass, entityStateObj);
                         const platform =
                           entityRegistryLookup[entityId]?.platform;
                         const integrationName = platform
@@ -462,7 +459,7 @@ export class HaSceneEditor extends PreventUnsavedMixin(
                                   ></state-badge>
                                 `
                               : nothing}
-                            ${computeStateName(entityStateObj)}
+                            ${primary}
                             ${secondary
                               ? html`<span slot="secondary">${secondary}</span>`
                               : nothing}
@@ -522,10 +519,11 @@ export class HaSceneEditor extends PreventUnsavedMixin(
                           if (!entityStateObj) {
                             return nothing;
                           }
-                          const { secondary } = computeEntityPickerDisplay(
-                            this.hass,
-                            entityStateObj
-                          );
+                          const { primary, secondary } =
+                            computeEntityPickerDisplay(
+                              this.hass,
+                              entityStateObj
+                            );
                           const domainName = domainToName(
                             this.hass.localize,
                             computeDomain(entityId)
@@ -551,7 +549,7 @@ export class HaSceneEditor extends PreventUnsavedMixin(
                                     slot="graphic"
                                   ></state-badge>`
                                 : nothing}
-                              ${computeStateName(entityStateObj)}
+                              ${primary}
                               ${secondary
                                 ? html`<span slot="secondary"
                                     >${secondary}</span


### PR DESCRIPTION
## Proposed change

Aligns the entity names shown in the scene editor's device and entity lists with
the name the entity picker shows when you add an entity.

Previously the lists rendered the full friendly name via `computeStateName`,
while the picker uses the context-aware `primary` from
`computeEntityPickerDisplay` (entity name with the device prefix stripped,
falling back to the device name, then the entity id). That meant an entity could
appear under one name in the picker and a different name once listed.

This switches both lists to the picker's `primary`, so the name you pick is the
name you see in the list. The area/device secondary line is unchanged.

## Screenshots

The scene editor lists now show the same context-aware entity name as the entity picker (the device prefix is stripped). Standalone entities **before → after**, with the entity picker as the reference - the "after" names match what the picker shows:

![Entity names before, after, and the picker reference](https://raw.githubusercontent.com/pszypowicz/frontend/pr-screenshots/screenshots/names-before-after-picker.png)

Full editor view (before | after):

![Review mode, before and after](https://raw.githubusercontent.com/pszypowicz/frontend/pr-screenshots/screenshots/names-review.png)

![Live edit mode, before and after](https://raw.githubusercontent.com/pszypowicz/frontend/pr-screenshots/screenshots/names-live.png)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr





