### PR TITLE
Add a blocking labels workflow

### DIFF
--- a/.github/workflows/blocking-labels.yaml
+++ b/.github/workflows/blocking-labels.yaml
@@ -1,0 +1,42 @@
+name: Blocking labels
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+    branches:
+      - dev
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check blocking labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for blocking labels
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const blockingLabels = [
+              "wait for backend",
+              "Needs UX",
+              "Do Not Review",
+              "Blocked",
+              "has-parent",
+            ];
+            const prLabels = context.payload.pull_request.labels.map(
+              (l) => l.name
+            );
+            const found = blockingLabels.filter((bl) => prLabels.includes(bl));
+            if (found.length > 0) {
+              core.setFailed(
+                `This PR is blocked by label${found.length > 1 ? "s" : ""}: ${found.join(", ")}`
+              );
+            }

--- a/.github/workflows/blocking-labels.yaml
+++ b/.github/workflows/blocking-labels.yaml
@@ -17,10 +17,10 @@ permissions:
 
 jobs:
   check:
-    name: Check blocking labels
+    name: Check for blocking labels
     runs-on: ubuntu-latest
     steps:
-      - name: Check for blocking labels
+      - name: Check for labels which should block the PR from being merged
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/blocking-labels.yaml
+++ b/.github/workflows/blocking-labels.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   check:
-    name: Check for labels which block the PR from being merged
+    name: Check for labels which block the Pull Request from being merged
     runs-on: ubuntu-latest
     steps:
       - name: Check for blocking labels
@@ -36,7 +36,7 @@ jobs:
             );
             const found = blockingLabels.filter((bl) => prLabels.includes(bl));
             if (found.length > 0) {
-              const message = `This PR is blocked by label${found.length > 1 ? "s" : ""}: ${found.join(", ")}`;
+              const message = `This Pull Request is blocked by label${found.length > 1 ? "s" : ""}: ${found.join(", ")}`;
               await core.summary
                 .addHeading(":no_entry_sign: Pull Request is blocked", 2)
                 .addRaw(message)
@@ -45,6 +45,6 @@ jobs:
             } else {
               await core.summary
                 .addHeading(":white_check_mark: Pull Request is clear to merge after review", 2)
-                .addRaw("This PR is not blocked by any labels which prevent it from being merged.")
+                .addRaw("This Pull Request is not blocked by any labels which prevent it from being merged.")
                 .write();
             }

--- a/.github/workflows/blocking-labels.yaml
+++ b/.github/workflows/blocking-labels.yaml
@@ -38,13 +38,13 @@ jobs:
             if (found.length > 0) {
               const message = `This PR is blocked by label${found.length > 1 ? "s" : ""}: ${found.join(", ")}`;
               await core.summary
-                .addHeading(":no_entry_sign: PR is blocked", 2)
+                .addHeading(":no_entry_sign: Pull Request is blocked", 2)
                 .addRaw(message)
                 .write();
               core.setFailed(message);
             } else {
               await core.summary
-                .addHeading(":white_check_mark: No blocking labels", 2)
-                .addRaw("This PR is not blocked by any labels.")
+                .addHeading(":white_check_mark: Pull Request is clear to merge after review", 2)
+                .addRaw("This PR is not blocked by any labels which should prevent it from being merged.")
                 .write();
             }

--- a/.github/workflows/blocking-labels.yaml
+++ b/.github/workflows/blocking-labels.yaml
@@ -17,10 +17,10 @@ permissions:
 
 jobs:
   check:
-    name: Check for blocking labels
+    name: Check for labels which should block the PR from being merged
     runs-on: ubuntu-latest
     steps:
-      - name: Check for labels which should block the PR from being merged
+      - name: Check for blocking labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/blocking-labels.yaml
+++ b/.github/workflows/blocking-labels.yaml
@@ -36,7 +36,15 @@ jobs:
             );
             const found = blockingLabels.filter((bl) => prLabels.includes(bl));
             if (found.length > 0) {
-              core.setFailed(
-                `This PR is blocked by label${found.length > 1 ? "s" : ""}: ${found.join(", ")}`
-              );
+              const message = `This PR is blocked by label${found.length > 1 ? "s" : ""}: ${found.join(", ")}`;
+              await core.summary
+                .addHeading(":no_entry_sign: PR is blocked", 2)
+                .addRaw(message)
+                .write();
+              core.setFailed(message);
+            } else {
+              await core.summary
+                .addHeading(":white_check_mark: No blocking labels", 2)
+                .addRaw("This PR is not blocked by any labels.")
+                .write();
             }

--- a/.github/workflows/blocking-labels.yaml
+++ b/.github/workflows/blocking-labels.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   check:
-    name: Check for labels which should block the PR from being merged
+    name: Check for labels which block the PR from being merged
     runs-on: ubuntu-latest
     steps:
       - name: Check for blocking labels
@@ -45,6 +45,6 @@ jobs:
             } else {
               await core.summary
                 .addHeading(":white_check_mark: Pull Request is clear to merge after review", 2)
-                .addRaw("This PR is not blocked by any labels which should prevent it from being merged.")
+                .addRaw("This PR is not blocked by any labels which prevent it from being merged.")
                 .write();
             }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Would need to set this workflow to required in the branch protections.

`blocking-label-wait-for backend` is still active, I think this is the bot? No harm in keeping both

Testing: https://github.com/home-assistant/frontend/actions/workflows/blocking-labels.yaml

Blocks (fails) for:

- `wait for backend` (original)
- `Needs UX`
- `Do Not Review`
-  `Blocked`
- `has-parent`

Alternative is to edit the bot, I dont know where this is or how it works (guessing its a github app)

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
