### PR TITLE
Filter expired camera/image proxy requests in service worker

### DIFF
--- a/src/entrypoints/service-worker.ts
+++ b/src/entrypoints/service-worker.ts
@@ -19,6 +19,64 @@ declare const __WB_MANIFEST__: Parameters<typeof precacheAndRoute>[0];
 const noFallBackRegEx =
   /\/(api|static|auth|frontend_latest|frontend_es5|local)\/.*/;
 
+// Camera / image proxy endpoints that carry credentials in the URL.
+// We pre-validate the credential in the service worker so obviously invalid
+// requests (signature expired, token missing) never reach the server and
+// don't trigger spurious "Login attempt" warnings from http.ban after BFCache
+// restore, tab resume, network change, or any other browser-initiated replay
+// of a stale `<img>` URL.
+const proxyPathRegEx =
+  /^\/api\/(camera_proxy_stream|camera_proxy|image_proxy)\//;
+
+// Reject signatures this many ms before their nominal expiry to absorb small
+// client/server clock differences. Erring this direction only ever turns a
+// would-be valid request into a local 401; we cannot err the other way without
+// re-introducing the warnings this filter exists to prevent.
+const JWT_EXPIRY_SKEW_MS = 5000;
+
+const base64UrlDecode = (input: string): string => {
+  const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  return atob(padded);
+};
+
+const isJwtExpired = (jwt: string): boolean => {
+  try {
+    const parts = jwt.split(".");
+    if (parts.length !== 3) {
+      return false;
+    }
+    const payload = JSON.parse(base64UrlDecode(parts[1]));
+    if (typeof payload.exp !== "number") {
+      return false;
+    }
+    return payload.exp * 1000 < Date.now() + JWT_EXPIRY_SKEW_MS;
+  } catch (_err) {
+    // If we can't parse the JWT for any reason, defer to the server.
+    return false;
+  }
+};
+
+const handleProxyRequest: RouteHandler = async ({ request }) => {
+  const req = request as Request;
+  const url = new URL(req.url);
+
+  const token = url.searchParams.get("token");
+  if (token === "undefined" || token === "null" || token === "") {
+    return new Response(null, { status: 401, statusText: "Invalid token" });
+  }
+
+  const authSig = url.searchParams.get("authSig");
+  if (authSig && isJwtExpired(authSig)) {
+    return new Response(null, {
+      status: 401,
+      statusText: "Signature expired",
+    });
+  }
+
+  return fetch(req);
+};
+
 const initRouting = () => {
   precacheAndRoute(__WB_MANIFEST__, {
     // Ignore all URL parameters.
@@ -57,6 +115,15 @@ const initRouting = () => {
         }),
       ],
     })
+  );
+
+  // Short-circuit camera/image proxy requests with an expired signature or a
+  // missing/undefined token so they don't hit core and get logged as invalid
+  // login attempts. Registered before the generic /api route below so it wins.
+  registerRoute(
+    ({ url, request }) =>
+      proxyPathRegEx.test(url.pathname) && request.method === "GET",
+    handleProxyRequest
   );
 
   // Get api from network.


### PR DESCRIPTION
## Proposed change

Pre-validate the credential on `camera_proxy`, `camera_proxy_stream` and `image_proxy` URLs inside the service worker. Requests with a missing or `undefined` token, or with an `authSig` JWT whose `exp` has passed, are short-circuited to a synthetic `401` and never reach core.

This silences spurious `Login attempt or request with invalid authentication` warnings from `homeassistant.components.http.ban` that fire when the browser replays a stale `<img src>` after BFCache restore, tab resume, or a network change. The default signed-path TTL is short (~30s) while `<img>` elements happily hold onto the URL long after that, so any browser-initiated retry races the expiry and hits core with a now-invalid credential.

The filter is registered before the generic `/api/.*` `NetworkOnly` route so it wins for the targeted endpoints, and only matches `GET` requests.

### How it works

- `proxyPathRegEx` scopes the filter to `/api/(camera_proxy_stream|camera_proxy|image_proxy)/`.
- If the URL carries `token=undefined`, `token=null` or `token=`, return `401` locally — this is belt-and-suspenders for the data-layer fix in #52514 and would catch any future regression that produces these URLs.
- If the URL carries `authSig=<jwt>`, decode the JWT payload (base64url, no signature verification — the server remains the source of truth) and reject locally when `exp` is in the past. A 5 s `JWT_EXPIRY_SKEW_MS` is applied in the conservative direction (treat tokens as expired slightly early) so small clock skew never re-introduces the warnings; biasing the other way would defeat the purpose.
- If the JWT can't be parsed or has no `exp`, the request falls through to the network — the server stays authoritative.

### Limitations (called out for reviewers)

- Service workers only register on secure contexts. Users on plain-HTTP LAN access (`http://192.168.x.x`, `http://homeassistant.local`) do **not** get this benefit. The principled fix is on the core side — distinguishing an expired-but-validly-signed path from a real failed login in `http.ban` — and would cover all clients. This PR is defense-in-depth on top of that, not a replacement for it.
- The image still shows broken when the credential is expired; this is purely about preventing the server-side warning. UX recovery (refetch on `<img onerror>`) is a separate change.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/core/issues/173230, https://github.com/home-assistant/core/issues/173202; follow-up to #52514
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr