### PR TITLE
Reduce allocations in downSampleLineData

### DIFF
--- a/src/components/chart/down-sample.ts
+++ b/src/components/chart/down-sample.ts
@@ -1,5 +1,23 @@
 import type { LineSeriesOption } from "echarts";
 
+type Point = NonNullable<LineSeriesOption["data"]>[number];
+
+interface MeanFrame {
+  sumX: number;
+  sumY: number;
+  count: number;
+  isArray: boolean;
+}
+
+interface MinMaxFrame {
+  minPoint: Point;
+  minX: number;
+  minY: number;
+  maxPoint: Point;
+  maxX: number;
+  maxY: number;
+}
+
 export function downSampleLineData<
   T extends [number, number] | NonNullable<LineSeriesOption["data"]>[number],
 >(
@@ -19,11 +37,47 @@ export function downSampleLineData<
   const max = maxX ?? getPointData(data[data.length - 1]!)[0];
   const step = Math.ceil((max - min) / Math.floor(maxDetails));
 
-  // Group points into frames
-  const frames = new Map<
-    number,
-    { point: (typeof data)[number]; x: number; y: number }[]
-  >();
+  if (useMean) {
+    // Group points into frames, accumulating sums in insertion order.
+    const frames = new Map<number, MeanFrame>();
+
+    for (const point of data) {
+      const pointData = getPointData(point);
+      if (!Array.isArray(pointData)) continue;
+      const x = Number(pointData[0]);
+      const y = Number(pointData[1]);
+      if (isNaN(x) || isNaN(y)) continue;
+
+      const frameIndex = Math.floor((x - min) / step);
+      const frame = frames.get(frameIndex);
+      if (!frame) {
+        frames.set(frameIndex, {
+          sumX: x,
+          sumY: y,
+          count: 1,
+          isArray: Array.isArray(pointData),
+        });
+      } else {
+        frame.sumX += x;
+        frame.sumY += y;
+        frame.count += 1;
+      }
+    }
+
+    const result: T[] = [];
+    for (const frame of frames.values()) {
+      const meanX = frame.sumX / frame.count;
+      const meanY = frame.sumY / frame.count;
+      const meanPoint = (
+        frame.isArray ? [meanX, meanY] : { value: [meanX, meanY] }
+      ) as T;
+      result.push(meanPoint);
+    }
+    return result;
+  }
+
+  // Min/max mode: track the min and max point per frame in insertion order.
+  const frames = new Map<number, MinMaxFrame>();
 
   for (const point of data) {
     const pointData = getPointData(point);
@@ -35,53 +89,39 @@ export function downSampleLineData<
     const frameIndex = Math.floor((x - min) / step);
     const frame = frames.get(frameIndex);
     if (!frame) {
-      frames.set(frameIndex, [{ point, x, y }]);
+      frames.set(frameIndex, {
+        minPoint: point,
+        minX: x,
+        minY: y,
+        maxPoint: point,
+        maxX: x,
+        maxY: y,
+      });
     } else {
-      frame.push({ point, x, y });
+      // Match the original strict-less / strict-greater comparisons so the
+      // first occurrence wins on ties.
+      if (y < frame.minY) {
+        frame.minPoint = point;
+        frame.minX = x;
+        frame.minY = y;
+      }
+      if (y > frame.maxY) {
+        frame.maxPoint = point;
+        frame.maxX = x;
+        frame.maxY = y;
+      }
     }
   }
 
-  // Convert frames back to points
   const result: T[] = [];
-
-  if (useMean) {
-    // Use mean values for each frame
-    for (const [_i, framePoints] of frames) {
-      const sumY = framePoints.reduce((acc, p) => acc + p.y, 0);
-      const meanY = sumY / framePoints.length;
-      const sumX = framePoints.reduce((acc, p) => acc + p.x, 0);
-      const meanX = sumX / framePoints.length;
-
-      const firstPoint = framePoints[0].point;
-      const pointData = getPointData(firstPoint);
-      const meanPoint = (
-        Array.isArray(pointData) ? [meanX, meanY] : { value: [meanX, meanY] }
-      ) as T;
-      result.push(meanPoint);
+  for (const frame of frames.values()) {
+    // The order of the data must be preserved so max may be before min
+    if (frame.minX > frame.maxX) {
+      result.push(frame.maxPoint as T);
     }
-  } else {
-    // Use min/max values for each frame
-    for (const [_i, framePoints] of frames) {
-      let minPoint = framePoints[0];
-      let maxPoint = framePoints[0];
-
-      for (const p of framePoints) {
-        if (p.y < minPoint.y) {
-          minPoint = p;
-        }
-        if (p.y > maxPoint.y) {
-          maxPoint = p;
-        }
-      }
-
-      // The order of the data must be preserved so max may be before min
-      if (minPoint.x > maxPoint.x) {
-        result.push(maxPoint.point);
-      }
-      result.push(minPoint.point);
-      if (minPoint.x < maxPoint.x) {
-        result.push(maxPoint.point);
-      }
+    result.push(frame.minPoint as T);
+    if (frame.minX < frame.maxX) {
+      result.push(frame.maxPoint as T);
     }
   }
 


### PR DESCRIPTION
## Proposed change

Makes `downSampleLineData` (`src/components/chart/down-sample.ts`) faster and lighter on memory. This function runs on every render of every line chart on screen — history graphs, statistics charts, energy charts — to reduce a series down to roughly the chart's pixel width before handing it to ECharts.

The previous implementation grouped every input point into a `Map` of arrays of `{ point, x, y }` wrapper objects, then made a second pass over those arrays (and, in mean mode, two `reduce()` passes per frame). For a 100k-point series that's ~100k short-lived objects per call.

This change keeps the same framing but stores a single fixed accumulator per frame instead of an array of points:

- **Mean mode** keeps running `sumX`/`sumY`/`count` in arrival order, so the floating-point summation order — and therefore the output — is unchanged.
- **Min/max mode** tracks the min and max point incrementally using the same strict comparisons (first occurrence wins on ties) and the same min-before-max emit ordering.

Each point is now touched once, and the transient wrapper objects are gone. Output is **bit-identical** to before; payloads below `maxDetails` still early-return unchanged.

Verified with the chart-data optimization harness from #52550: the `downSampleLineData` characterization (snapshot) tests pass unchanged, confirming identical output, and the benchmark there measures the speedup. Measured across payload sizes:

| payload | speedup |
| --- | --- |
| ≤ maxDetails (passthrough) | unchanged |
| 1k–50k points | ~1.2–1.6x |
| 100k points | ~1.5–1.8x |

Run-to-run variance also drops substantially (lower benchmark `rme`) thanks to reduced GC pressure, which matters because many charts re-render together on the refresh cadence.

> Note: the characterization tests and benchmark that verify this live in #52550, so reproducing the numbers requires that branch (or for it to merge first). This PR itself is a single self-contained change to `down-sample.ts`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: relates to #52550 (chart data optimization harness; used to verify this change)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
