### PR TITLE
Fix clipped descenders in chart legend labels

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -1520,7 +1520,9 @@ export class HaChartBase extends LitElement {
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
-      line-height: 1;
+      /* overflow: hidden clips descenders (e.g. "g", parentheses) with a tight
+         line-height, so give the line box room to contain them */
+      line-height: var(--ha-line-height-condensed);
     }
     @media (hover: hover) {
       .chart-legend .label.clickable:hover {


### PR DESCRIPTION
## Proposed change

The labels in the chart legend (used by the energy device usage card and other history/statistics charts) clipped the bottom of glyphs with descenders — for example the `g` in "Garage" or the parentheses in "(untracked)".

The `.label` element needs `overflow: hidden` for its ellipsis truncation, but it also had `line-height: 1`. At the legend's 12px font size that makes the line box exactly as tall as the font, so descenders spill just below the box and get clipped. Bumping the label to the existing `--ha-line-height-condensed` (1.2) token gives the line box enough room to contain descenders. The row is a fixed-height, vertically centered flex item, so nothing else shifts.

## Screenshots

<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
Before:
<img width="274" height="60" alt="image" src="https://github.com/user-attachments/assets/bf890dad-6b01-4beb-90d2-e7e4cf96aa31" />

After:
<img width="268" height="52" alt="image" src="https://github.com/user-attachments/assets/416f7b0e-5876-4e69-872e-c041c5bea36a" />

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
