### PR TITLE
Prevent error logger from crashing on unparseable stack traces

### DIFF
--- a/src/resources/log-message.ts
+++ b/src/resources/log-message.ts
@@ -60,16 +60,24 @@ export const createLogMessage = async (
   // - a possible list of aggregated errors
   if (error instanceof Error) {
     lines.push(error.toString() || messageFallback);
-    const stackLines = (await fromError(error))
-      .slice(0, MAX_STACK_FRAMES)
-      .map((frame) => {
-        frame.fileName ??= "";
-        if (URL.canParse(frame.fileName)) {
-          frame.fileName = new URL(frame.fileName).pathname;
-        }
-        frame.fileName = frame.fileName.replace(REMOVAL_PATHS, "");
-        return frame.toString();
-      });
+    let stackLines: (string | undefined)[];
+    try {
+      stackLines = (await fromError(error))
+        .slice(0, MAX_STACK_FRAMES)
+        .map((frame) => {
+          frame.fileName ??= "";
+          if (URL.canParse(frame.fileName)) {
+            frame.fileName = new URL(frame.fileName).pathname;
+          }
+          frame.fileName = frame.fileName.replace(REMOVAL_PATHS, "");
+          return frame.toString();
+        });
+    } catch {
+      // stacktrace-js cannot always parse a stack (for example a DOMException
+      // with no, or an unrecognized, stack), so fall back to the raw stack
+      // instead of letting the error logger itself throw.
+      stackLines = error.stack ? [error.stack] : [];
+    }
     lines.push(...(stackLines.length > 0 ? stackLines : [stackFallback]));
     // @ts-expect-error Requires library bump to ES2022
     if (error.cause) {

--- a/test/resources/log-message.test.ts
+++ b/test/resources/log-message.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLogMessage } from "../../src/resources/log-message";
+
+const fromError = vi.hoisted(() => vi.fn());
+
+vi.mock("stacktrace-js", () => ({ fromError }));
+
+describe("createLogMessage", () => {
+  beforeEach(() => {
+    fromError.mockReset();
+  });
+
+  it("includes the error message and parsed stack frames", async () => {
+    fromError.mockResolvedValue([
+      { fileName: "https://example.com/foo.js", toString: () => "at foo.js" },
+    ]);
+    const error = new Error("boom");
+
+    const message = await createLogMessage(error);
+
+    expect(message).toContain("Error: boom");
+    expect(message).toContain("at foo.js");
+  });
+
+  it("does not throw when stacktrace-js cannot parse the stack", async () => {
+    fromError.mockRejectedValue(new Error("Cannot parse given Error object"));
+    const error = new Error("boom");
+    error.stack = "Error: boom\n    at <anonymous>";
+
+    const message = await createLogMessage(error);
+
+    expect(message).toContain("Error: boom");
+    // Falls back to the raw stack instead of crashing the logger.
+    expect(message).toContain("at <anonymous>");
+  });
+
+  it("falls back to the provided stack fallback when no stack is available", async () => {
+    fromError.mockRejectedValue(new Error("Cannot parse given Error object"));
+    const error = new Error("boom");
+    error.stack = undefined;
+
+    const message = await createLogMessage(
+      error,
+      undefined,
+      undefined,
+      "@unknown:0:0"
+    );
+
+    expect(message).toContain("@unknown:0:0");
+  });
+});


### PR DESCRIPTION
## Proposed change

When an unhandled error or promise rejection occurs, the frontend logs it to the system log via `createLogMessage`. That helper runs the error through `stacktrace-js` (`fromError`) to produce a readable stack trace.

Some errors carry a stack that `stacktrace-js` cannot parse. A `DOMException` is a good example: the `AbortError: Transition was skipped` that a skipped view transition produces makes `fromError` throw `Cannot parse given Error object`. Because that throw was not caught, it escaped `createLogMessage` entirely, so the global `unhandledrejection` handler fell into its own catch, printed `Failure writing unhandled promise rejection to system log`, and the original error was never recorded. The error logger was effectively crashing on the very errors it was trying to log.

This change wraps the stack extraction in a `try/catch`. If `stacktrace-js` cannot parse the stack, it falls back to the raw `error.stack` (or the existing stack fallback) instead of throwing. The original error is still logged, just with a less processed stack.

This addresses the error logger robustness part of #52427 (the third of the three defects described there). The other two points in that issue (reconnecting a dropped log-follow stream, and the skipped view transition itself) are out of scope for this change.

A unit test was added covering the normal path, the unparseable-stack fallback, and the no-stack fallback.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52427
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
