### PR TITLE
Auto-select first voice in required TTS voice picker

### DIFF
--- a/src/components/ha-tts-voice-picker.ts
+++ b/src/components/ha-tts-voice-picker.ts
@@ -85,15 +85,25 @@ export class HaTTSVoicePicker extends LitElement {
       await listTTSVoices(this.hass, this.engineId, this.language)
     ).voices;
 
-    if (!this.value) {
+    const valueIsValid =
+      this.value &&
+      this._voices?.some((voice) => voice.voice_id === this.value);
+
+    if (valueIsValid) {
       return;
     }
 
-    if (
-      !this._voices ||
-      !this._voices.find((voice) => voice.voice_id === this.value)
-    ) {
-      this.value = undefined;
+    // The current value is missing or no longer valid for the loaded voices.
+    // When a voice is required, auto-select the first one (the <ha-select>
+    // already displays it) so the value is propagated to the parent;
+    // otherwise clear it.
+    const newValue =
+      this.required && this._voices?.length
+        ? this._voices[0].voice_id
+        : undefined;
+
+    if (newValue !== this.value) {
+      this.value = newValue;
       fireEvent(this, "value-changed", { value: this.value });
     }
   }


### PR DESCRIPTION
## Proposed change

In the TTS test card (media browser) the voice dropdown showed the first voice as selected, but you could not actually start synthesis and the selected voice id was missing below the card. This was most noticeable for a language that offers only a single voice, where you could not change the selection to work around it.

The cause was in `ha-tts-voice-picker`. When a voice was required and no value had been set yet, the picker rendered the first voice in the `<ha-select>` for display, but its own `value` stayed undefined and it never fired a `value-changed` event. The parent component therefore never learned which voice was selected, so it had no voice to show or to include when synthesizing.

This change makes the picker auto-select and emit the first voice when a voice is required and the current value is missing or no longer valid for the loaded voices, so the value matches what the dropdown displays. It also covers switching to a language whose previously selected voice no longer exists. Non-required usages keep clearing the value as before.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52429
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
