### PR TITLE
Fix clipboard fallback throwing when active element is in the light DOM

### DIFF
--- a/src/common/util/copy-clipboard.ts
+++ b/src/common/util/copy-clipboard.ts
@@ -11,6 +11,12 @@ export const copyToClipboard = async (str, rootEl?: HTMLElement) => {
   }
 
   const root = rootEl || deepActiveElement()?.getRootNode() || document.body;
+  // A document node cannot have a textarea appended directly (only the single
+  // documentElement is allowed), so fall back to its body. Shadow roots and
+  // elements can hold the textarea directly, which keeps execCommand working
+  // inside dialogs that trap focus.
+  const container: Node =
+    root.nodeType === Node.DOCUMENT_NODE ? document.body : root;
 
   const el = document.createElement("textarea");
   el.value = str;
@@ -19,8 +25,8 @@ export const copyToClipboard = async (str, rootEl?: HTMLElement) => {
   el.style.top = "0";
   el.style.left = "0";
   el.style.opacity = "0";
-  root.appendChild(el);
+  container.appendChild(el);
   el.select();
   document.execCommand("copy");
-  root.removeChild(el);
+  container.removeChild(el);
 };

--- a/test/common/util/copy-clipboard.test.ts
+++ b/test/common/util/copy-clipboard.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { copyToClipboard } from "../../../src/common/util/copy-clipboard";
+
+const deepActiveElement = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../src/common/dom/deep-active-element", () => ({
+  deepActiveElement,
+}));
+
+describe("copyToClipboard", () => {
+  const originalClipboard = navigator.clipboard;
+  const hadExecCommand = "execCommand" in document;
+
+  const setClipboard = (value: unknown) => {
+    Object.defineProperty(navigator, "clipboard", {
+      value,
+      configurable: true,
+    });
+  };
+
+  // jsdom does not implement execCommand, so provide a stub for the fallback.
+  const stubExecCommand = () => {
+    const execCommand = vi.fn().mockReturnValue(true);
+    (document as any).execCommand = execCommand;
+    return execCommand;
+  };
+
+  beforeEach(() => {
+    deepActiveElement.mockReset();
+  });
+
+  afterEach(() => {
+    setClipboard(originalClipboard);
+    if (!hadExecCommand) {
+      delete (document as any).execCommand;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("uses the async clipboard API when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard({ writeText });
+
+    await copyToClipboard("hello");
+
+    expect(writeText).toHaveBeenCalledWith("hello");
+    // The fallback should not run when the async API succeeds.
+    expect(deepActiveElement).not.toHaveBeenCalled();
+  });
+
+  it("falls back without throwing when the active element is in the light DOM", async () => {
+    setClipboard(undefined);
+    const execCommand = stubExecCommand();
+    // An element in the main document: getRootNode() returns the document,
+    // which cannot have a textarea appended to it directly.
+    const lightEl = document.createElement("div");
+    document.body.appendChild(lightEl);
+    deepActiveElement.mockReturnValue(lightEl);
+
+    const appendSpy = vi.spyOn(document.body, "appendChild");
+
+    await expect(copyToClipboard("hello")).resolves.toBeUndefined();
+
+    expect(appendSpy).toHaveBeenCalled();
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    // The temporary textarea is cleaned up.
+    expect(document.body.querySelector("textarea")).toBeNull();
+
+    document.body.removeChild(lightEl);
+  });
+
+  it("appends into the shadow root when the active element lives in one", async () => {
+    setClipboard(undefined);
+    stubExecCommand();
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: "open" });
+    const shadowEl = document.createElement("span");
+    shadow.appendChild(shadowEl);
+    deepActiveElement.mockReturnValue(shadowEl);
+
+    const shadowAppend = vi.spyOn(shadow, "appendChild");
+
+    await copyToClipboard("hello");
+
+    expect(shadowAppend).toHaveBeenCalled();
+    // The temporary textarea is cleaned up.
+    expect(shadow.querySelector("textarea")).toBeNull();
+
+    document.body.removeChild(host);
+  });
+});


### PR DESCRIPTION
## Proposed change

When the asynchronous Clipboard API is not available or rejects (for example over an insecure connection, or when the browser denies permission), `copyToClipboard` falls back to creating a hidden `<textarea>` and calling `execCommand("copy")`.

That fallback appended the temporary textarea to `deepActiveElement()?.getRootNode()`. When the deepest active element lives in the light DOM, `getRootNode()` returns the `Document` node, and appending an element to a `Document` throws `HierarchyRequestError` (a document may only contain the single `documentElement`). As a result the fallback threw and nothing was copied.

This change appends to `document.body` when the resolved root is a `Document`. Shadow roots and regular elements keep holding the textarea directly, so the existing behavior for dialogs that trap focus is preserved.

A unit test was added covering the async path, the light DOM fallback (the case that used to throw), and the shadow root case.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #52478
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
