### PR TITLE
Fix update entity progress text not showing when version is newer

### DIFF
--- a/src/common/entity/update_icon.ts
+++ b/src/common/entity/update_icon.ts
@@ -4,9 +4,10 @@ import { updateIsInstalling } from "../../data/update";
 
 export const updateIcon = (stateObj: HassEntity, state?: string) => {
   const compareState = state ?? stateObj.state;
-  return compareState === "on"
-    ? updateIsInstalling(stateObj as UpdateEntity)
-      ? "mdi:package-down"
-      : "mdi:package-up"
-    : "mdi:package";
+  // An install can be in progress even when the state is "off", e.g. when
+  // downgrading firmware. Show the installing icon regardless of state.
+  if (updateIsInstalling(stateObj as UpdateEntity)) {
+    return "mdi:package-down";
+  }
+  return compareState === "on" ? "mdi:package-up" : "mdi:package";
 };

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -231,6 +231,24 @@ export const computeUpdateStateDisplay = (
   const state = stateObj.state;
   const attributes = stateObj.attributes;
 
+  // An install can be in progress even when the state is "off", e.g. when
+  // downgrading firmware (installed_version is newer than latest_version).
+  // Show the installing status regardless of state in that case.
+  if (updateIsInstalling(stateObj)) {
+    const supportsProgress =
+      supportsFeature(stateObj, UpdateEntityFeature.PROGRESS) &&
+      attributes.update_percentage !== null;
+    if (supportsProgress) {
+      return hass.localize("ui.card.update.installing_with_progress", {
+        progress: formatNumber(attributes.update_percentage!, hass.locale, {
+          maximumFractionDigits: attributes.display_precision,
+          minimumFractionDigits: attributes.display_precision,
+        }),
+      });
+    }
+    return hass.localize("ui.card.update.installing");
+  }
+
   if (state === "off") {
     const isSkipped =
       attributes.latest_version &&
@@ -239,23 +257,6 @@ export const computeUpdateStateDisplay = (
       return attributes.latest_version!;
     }
     return hass.formatEntityState(stateObj);
-  }
-
-  if (state === "on") {
-    if (updateIsInstalling(stateObj)) {
-      const supportsProgress =
-        supportsFeature(stateObj, UpdateEntityFeature.PROGRESS) &&
-        attributes.update_percentage !== null;
-      if (supportsProgress) {
-        return hass.localize("ui.card.update.installing_with_progress", {
-          progress: formatNumber(attributes.update_percentage!, hass.locale, {
-            maximumFractionDigits: attributes.display_precision,
-            minimumFractionDigits: attributes.display_precision,
-          }),
-        });
-      }
-      return hass.localize("ui.card.update.installing");
-    }
   }
 
   return hass.formatEntityState(stateObj);


### PR DESCRIPTION
## Proposed change

### Background

HA Core allows an install to be in-progress even when the entity state is "off" (e.g. when downgrading firmware via service/action, or when an upgrade is still in progress but the integration already bumped the latest version HA state, before fully finishing, or when downgrading through the manufacturer app with the HA update entity reflecting that state).

The entity state is just "off" when `installed_version` is newer than `latest_version`. It isn't related to whether an update is taking place or not.

Before, the update entity always showed "Up-to-date" in those cases, even though the more info dialog also showed the progress bar. This happened because the installing check was nested inside the `state === "on"` branch.

### Change

With this PR, the in-progress now correctly has a higher priority than just the "is a newer version available" on/off state.
So now, the text is also correct when downgrading, or when an install that's still in progress already bumped the latest version in HA state, even though the install is not complete yet. I've tested this change, and it works as expected.

A similar logic change is also applied to the icon that's used by integrations not providing a picture. I've confirmed this works as expected as well.

### Code comments

There are some (AI) comments in-place currently that may or may not be helpful, depending on how much the code is self-explanatory now. I've left them for now, but I can just remove them completely (or shorten them), of course.

## Screenshots

**Before** (image showing progress bar because downgrade is in progress, but "Up-to-date" text instead of installing):

<img width="562" height="228" alt="image showing progress bar because downgrade is in progress, but Up-to-date text instead of Installing with progress" src="https://github.com/user-attachments/assets/fe0411bb-6c3f-445c-8487-ce7b725d4553" />


**After** (image showing correct text as well now):

<img width="557" height="228" alt="Image now correctly showing progress bar and install text" src="https://github.com/user-attachments/assets/b7bd2caa-5b4e-4295-8b6c-3b29b013ef17" />



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
