### PR TITLE
Center the to-do list reorder drag handle

### DIFF
--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -1047,7 +1047,7 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
       cursor: move; /* fallback if grab cursor is unsupported */
       cursor: grab;
       height: 24px;
-      padding: 16px 4px;
+      padding: 0 4px;
     }
 
     .deleteItemButton {


### PR DESCRIPTION
## Proposed change

In the to-do list, the reorder drag handle was not vertically centered within its row. It sat noticeably below the row center, making it look like it belonged between rows rather than to its own row.

The handle sits in the list item's meta slot, which is a fixed 24px tall box. The handle had 16px of vertical padding, which made the icon 56px tall and pushed it down out of the center of that box. Removing the vertical padding lets the 24px icon fit the 24px meta slot and stay centered. The horizontal spacing is unchanged.

## Screenshots

<img width="765" height="386" alt="CleanShot 2026-06-13 at 14 11 21" src="https://github.com/user-attachments/assets/adbb4f7a-c9e7-4ea4-8538-9af59d5d0f7e" />

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52488
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
