### PR TITLE
Cache Intl.NumberFormat instances in formatNumber

### DIFF
--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -40,6 +40,25 @@ export const numberFormatToLocale = (
   }
 };
 
+// Constructing an Intl.NumberFormat is comparatively expensive, and these
+// formatters are created on every numeric state render. The number of distinct
+// (locale, options) combinations is small and bounded in practice, so cache the
+// instances instead of rebuilding them on every call.
+const numberFormatCache = new Map<string, Intl.NumberFormat>();
+
+const getNumberFormatter = (
+  locale: string | string[] | undefined,
+  options: Intl.NumberFormatOptions
+): Intl.NumberFormat => {
+  const key = JSON.stringify([locale, options]);
+  let formatter = numberFormatCache.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, options);
+    numberFormatCache.set(key, formatter);
+  }
+  return formatter;
+};
+
 /**
  * Formats a number based on the user's preference with thousands separator(s) and decimal character for better legibility.
  *
@@ -75,7 +94,7 @@ export const formatNumberToParts = (
     localeOptions?.number_format !== NumberFormat.none &&
     !Number.isNaN(Number(num))
   ) {
-    return new Intl.NumberFormat(
+    return getNumberFormatter(
       locale,
       getDefaultFormatOptions(num, options)
     ).formatToParts(Number(num));
@@ -87,7 +106,7 @@ export const formatNumberToParts = (
     localeOptions?.number_format === NumberFormat.none
   ) {
     // If NumberFormat is none, use en-US format without grouping.
-    return new Intl.NumberFormat(
+    return getNumberFormatter(
       "en-US",
       getDefaultFormatOptions(num, {
         ...options,

--- a/test/common/string/format_number.test.ts
+++ b/test/common/string/format_number.test.ts
@@ -64,6 +64,26 @@ describe("formatNumber", () => {
     assert.strictEqual(formatNumber("", defaultLocale), "0");
   });
 
+  it("Returns consistent results for interleaved calls with different options (formatter cache)", () => {
+    // Exercises the cached Intl.NumberFormat instances: alternating option
+    // shapes must each keep producing their own correct output.
+    for (let i = 0; i < 3; i++) {
+      assert.strictEqual(formatNumber(1234.5, defaultLocale), "1,234.5");
+      assert.strictEqual(
+        formatNumber(1234.5, defaultLocale, { minimumFractionDigits: 2 }),
+        "1,234.50"
+      );
+      assert.strictEqual(formatNumber("1234.50", defaultLocale), "1,234.50");
+      assert.strictEqual(
+        formatNumber(1234.5, {
+          ...defaultLocale,
+          number_format: NumberFormat.none,
+        }),
+        "1234.5"
+      );
+    }
+  });
+
   it("Formats number with options", () => {
     assert.strictEqual(
       formatNumber(1234.5, defaultLocale, {


### PR DESCRIPTION
## Proposed change

`formatNumber` (via `formatNumberToParts`) is called for essentially every numeric state that gets rendered in the UI. Each call constructed a brand new `Intl.NumberFormat`, which is comparatively expensive to create.

This caches the `Intl.NumberFormat` instances in a `Map` keyed by the locale and options, so repeated formatting reuses an existing formatter instead of rebuilding one each time. The formatted output is unchanged.

The date and string formatters in the codebase already memoize their `Intl` instances, but with single-entry `memoizeOne`, because their options are static and only the (stable) locale varies. For numbers the options are derived per value (fraction digits depend on the value), so a single-entry cache would thrash. A small string-keyed `Map` gives a true multi-entry cache. The number of distinct locale/options combinations is small and bounded in practice.

An existing unit test covers the output for the various formatting cases; this PR adds one more that interleaves different option shapes across repeated calls to verify the cached formatters keep returning the correct result.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
