### PR TITLE
Avoid mutating the input array in computeCssVariable

### DIFF
--- a/src/resources/css-variables.ts
+++ b/src/resources/css-variables.ts
@@ -2,11 +2,12 @@ export function computeCssVariable(
   props: string | string[]
 ): string | undefined {
   if (Array.isArray(props)) {
-    return props
-      .reverse()
-      .reduce<
-        string | undefined
-      >((str, variable) => `var(${variable}${str ? `, ${str}` : ""})`, undefined);
+    // reduceRight builds the nested var() fallback chain from last to first
+    // without mutating the caller's array (unlike reverse()).
+    return props.reduceRight<string | undefined>(
+      (str, variable) => `var(${variable}${str ? `, ${str}` : ""})`,
+      undefined
+    );
   }
   return `var(${props})`;
 }

--- a/test/resources/css-variables.test.ts
+++ b/test/resources/css-variables.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeCssVariable,
+  computeCssValue,
+} from "../../src/resources/css-variables";
+
+describe("computeCssVariable", () => {
+  it("wraps a single property in var()", () => {
+    expect(computeCssVariable("--primary-color")).toBe("var(--primary-color)");
+  });
+
+  it("builds a nested fallback chain in order for an array", () => {
+    expect(computeCssVariable(["--a", "--b", "--c"])).toBe(
+      "var(--a, var(--b, var(--c)))"
+    );
+  });
+
+  it("handles a single-element array", () => {
+    expect(computeCssVariable(["--only"])).toBe("var(--only)");
+  });
+
+  it("returns undefined for an empty array", () => {
+    expect(computeCssVariable([])).toBeUndefined();
+  });
+
+  it("does not mutate the input array", () => {
+    const props = ["--a", "--b", "--c"];
+    computeCssVariable(props);
+    expect(props).toEqual(["--a", "--b", "--c"]);
+  });
+
+  it("returns the same result when called repeatedly with the same array", () => {
+    const props = ["--a", "--b", "--c"];
+    const first = computeCssVariable(props);
+    const second = computeCssVariable(props);
+    expect(second).toBe(first);
+  });
+});
+
+describe("computeCssValue", () => {
+  const computedStyles = {
+    getPropertyValue: (prop: string) =>
+      ({
+        "--a-color": "  red  ",
+        "--b-color": "blue",
+      })[prop] ?? "",
+  } as CSSStyleDeclaration;
+
+  it("returns the trimmed value of a color property", () => {
+    expect(computeCssValue("--a-color", computedStyles)).toBe("red");
+  });
+
+  it("ignores properties that do not end with -color", () => {
+    expect(computeCssValue("--a-size", computedStyles)).toBeUndefined();
+  });
+
+  it("returns the first resolved value from an array", () => {
+    expect(
+      computeCssValue(["--missing-color", "--b-color"], computedStyles)
+    ).toBe("blue");
+  });
+
+  it("returns undefined when no property resolves", () => {
+    expect(
+      computeCssValue(
+        ["--missing-color", "--also-missing-color"],
+        computedStyles
+      )
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Proposed change

`computeCssVariable` builds a nested `var(--a, var(--b, var(--c)))` fallback chain from an array of property names. It did this with `props.reverse()`, which reverses the caller's array in place.

It sits on the state color path (`stateColorCss` runs for every colored entity icon and badge). Every current caller passes a freshly built array, so there is no visible corruption today, but mutating an input parameter is a latent trap: a shared, memoized, or frozen array would produce wrong output or throw.

This switches to `reduceRight`, which builds the exact same chain walking from last to first, without mutating or copying the array. The output is unchanged.

The file had no test coverage, so this also adds tests for `computeCssVariable` (including a no-mutation guarantee) and `computeCssValue`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
