### PR TITLE
Reduce per-entity work when building entity picker items

### DIFF
--- a/src/data/entity/entity_picker.ts
+++ b/src/data/entity/entity_picker.ts
@@ -73,29 +73,43 @@ export const getEntities = (
 
   let entityIds = Object.keys(hass.states);
 
+  // These run over every entity, so use Sets for O(1) membership instead of
+  // repeated Array.includes scans.
   if (includeEntities) {
+    const includeEntitiesSet = new Set(includeEntities);
     entityIds = entityIds.filter((entityId) =>
-      includeEntities.includes(entityId)
+      includeEntitiesSet.has(entityId)
     );
   }
 
   if (excludeEntities) {
+    const excludeEntitiesSet = new Set(excludeEntities);
     entityIds = entityIds.filter(
-      (entityId) => !excludeEntities.includes(entityId)
+      (entityId) => !excludeEntitiesSet.has(entityId)
     );
   }
 
   if (includeDomains) {
+    const includeDomainsSet = new Set(includeDomains);
     entityIds = entityIds.filter((eid) =>
-      includeDomains.includes(computeDomain(eid))
+      includeDomainsSet.has(computeDomain(eid))
     );
   }
 
   if (excludeDomains) {
+    const excludeDomainsSet = new Set(excludeDomains);
     entityIds = entityIds.filter(
-      (eid) => !excludeDomains.includes(computeDomain(eid))
+      (eid) => !excludeDomainsSet.has(computeDomain(eid))
     );
   }
+
+  // These values are the same for every entity, so compute them once instead
+  // of inside the map over (potentially thousands of) entities.
+  const isRTL = computeRTL(
+    hass.language,
+    hass.translationMetadata.translations
+  );
+  const domainNames = new Map<string, string>();
 
   items = entityIds.map<EntityComboBoxItem>((entityId) => {
     const stateObj = hass.states[entityId];
@@ -110,12 +124,12 @@ export const getEntities = (
       hass.floors
     );
 
-    const domainName = domainToName(hass.localize, computeDomain(entityId));
-
-    const isRTL = computeRTL(
-      hass.language,
-      hass.translationMetadata.translations
-    );
+    const domain = computeDomain(entityId);
+    let domainName = domainNames.get(domain);
+    if (domainName === undefined) {
+      domainName = domainToName(hass.localize, domain);
+      domainNames.set(domain, domainName);
+    }
 
     const primary = entityName || deviceName || entityId;
     const secondary = [areaName, entityName ? deviceName : undefined]

--- a/test/data/entity/entity_picker.test.ts
+++ b/test/data/entity/entity_picker.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { getEntities } from "../../../src/data/entity/entity_picker";
+import type { HomeAssistant } from "../../../src/types";
+
+const makeHass = (entityIds: string[]): HomeAssistant => {
+  const states: Record<string, any> = {};
+  for (const id of entityIds) {
+    states[id] = {
+      entity_id: id,
+      state: "on",
+      attributes: { friendly_name: id },
+      last_changed: "",
+      last_updated: "",
+      context: { id: "", parent_id: null, user_id: null },
+    };
+  }
+  return {
+    states,
+    entities: {},
+    devices: {},
+    areas: {},
+    floors: {},
+    language: "en",
+    localize: ((key: string) => key) as any,
+    translationMetadata: { translations: {} },
+  } as unknown as HomeAssistant;
+};
+
+const ids = (items: { id: string }[]) => items.map((item) => item.id).sort();
+
+describe("getEntities", () => {
+  const hass = makeHass([
+    "light.kitchen",
+    "light.living",
+    "switch.fan",
+    "sensor.temp",
+  ]);
+
+  it("returns all entities when no filters are given", () => {
+    expect(ids(getEntities(hass))).toEqual([
+      "light.kitchen",
+      "light.living",
+      "sensor.temp",
+      "switch.fan",
+    ]);
+  });
+
+  it("filters by includeDomains", () => {
+    expect(ids(getEntities(hass, { includeDomains: ["light"] }))).toEqual([
+      "light.kitchen",
+      "light.living",
+    ]);
+  });
+
+  it("filters by excludeDomains", () => {
+    expect(
+      ids(getEntities(hass, { excludeDomains: ["light", "switch"] }))
+    ).toEqual(["sensor.temp"]);
+  });
+
+  it("filters by includeEntities", () => {
+    expect(
+      ids(
+        getEntities(hass, {
+          includeEntities: ["light.kitchen", "sensor.temp"],
+        })
+      )
+    ).toEqual(["light.kitchen", "sensor.temp"]);
+  });
+
+  it("filters by excludeEntities", () => {
+    expect(
+      ids(
+        getEntities(hass, {
+          excludeEntities: ["light.kitchen", "light.living"],
+        })
+      )
+    ).toEqual(["sensor.temp", "switch.fan"]);
+  });
+
+  it("combines include and exclude filters", () => {
+    expect(
+      ids(
+        getEntities(hass, {
+          includeDomains: ["light"],
+          excludeEntities: ["light.living"],
+        })
+      )
+    ).toEqual(["light.kitchen"]);
+  });
+
+  it("applies idPrefix to the item id", () => {
+    const items = getEntities(hass, {
+      includeEntities: ["sensor.temp"],
+      idPrefix: "entity-",
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe("entity-sensor.temp");
+  });
+});


### PR DESCRIPTION
## Proposed change

`getEntities` builds the entity item list over every entity in `hass.states`. It runs each time an entity picker, the quick bar, or a target picker is opened (and again on the next open if `hass` changed in between). On a large installation with thousands of entities, that list construction did avoidable per-entity work:

- the include/exclude entity and domain filters used `Array.includes`, a linear scan run for every entity, making each filter O(entities × filter size);
- `computeRTL` was recomputed inside the loop for every entity, even though it only depends on the language and translation metadata;
- `domainToName` (a `localize` lookup) was called for every entity, even though entities share a small number of domains.

This builds Sets for the filters (O(1) membership), hoists `computeRTL` out of the loop (computed once), and caches the domain name per domain (one lookup per distinct domain instead of one per entity). The result is that opening a picker on a large installation has less work to do. Behavior is unchanged.

`getEntities` had no test coverage, so this adds tests for the filtering behavior.

To be precise about scope: this is a picker-open (and explicit refresh) improvement, not a per-state-change one. The picker passes the items function by reference and the parent memoizes on `hass`, so `getEntities` is not re-run on every state update while a picker is open.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
