### PR TITLE
Speed up bulk selection in data table

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -215,10 +215,16 @@ export class HaDataTable extends LitElement {
     if (clear) {
       this._checkedRows = [];
     }
+    // Map + Set keep a large selection O(rows + ids) instead of O(rows × ids).
+    const rowLookup = new Map(
+      (this._filteredData || []).map((data) => [data[this.id], data])
+    );
+    const checkedRows = new Set(this._checkedRows);
     ids.forEach((id) => {
-      const row = this._filteredData?.find((data) => data[this.id] === id);
-      if (row?.selectable !== false && !this._checkedRows.includes(id)) {
+      const row = rowLookup.get(id);
+      if (row?.selectable !== false && !checkedRows.has(id)) {
         this._checkedRows.push(id);
+        checkedRows.add(id);
       }
     });
     this._lastSelectedRowId = null;


### PR DESCRIPTION
## Proposed change

The data table is used by every configuration table (entities, devices, automations, etc.). Its `select()` method, called when range-selecting rows or selecting all matching rows, looked up each id with a `find` over all filtered rows and checked membership with `includes` on the growing checked-rows array. Selecting a large batch was therefore O(rows × ids) plus O(ids²).

This builds a row lookup `Map` once and tracks membership with a `Set`, dropping a batch selection to O(rows + ids). The behavior is unchanged: rows are checked in the same order, non-selectable rows are still skipped, and duplicates are still deduplicated.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
