### PR TITLE
Hide redundant device name in group member list

### DIFF
--- a/src/dialogs/more-info/more-info-content.ts
+++ b/src/dialogs/more-info/more-info-content.ts
@@ -22,6 +22,7 @@ interface EntityInfo {
   entityId: string;
   entityName: string | undefined;
   areaId: string | undefined;
+  deviceId: string | undefined;
 }
 
 @customElement("more-info-content")
@@ -120,7 +121,7 @@ class MoreInfoContent extends LitElement {
           hass.entities,
           hass.devices
         );
-        const { area } = getEntityContext(
+        const { area, device } = getEntityContext(
           stateObj,
           hass.entities,
           hass.devices,
@@ -128,7 +129,8 @@ class MoreInfoContent extends LitElement {
           hass.floors
         );
         const areaId = area?.area_id;
-        return { entityId, entityName, areaId };
+        const deviceId = device?.id;
+        return { entityId, entityName, areaId, deviceId };
       })
       .filter(Boolean) as EntityInfo[];
 
@@ -140,10 +142,20 @@ class MoreInfoContent extends LitElement {
     const areaIds = new Set(entityInfos.map((info) => info.areaId));
     const allSameArea = areaIds.size === 1;
 
-    // Build name and state content config based on conditions
-    const name: EntityNameItem[] = [{ type: "device" }];
+    // Check if all entities belong to the same device
+    const deviceIds = new Set(entityInfos.map((info) => info.deviceId));
+    const allSameDevice = deviceIds.size === 1;
 
-    if (!allSameEntityName) {
+    // Build name and state content config based on conditions. The device name
+    // is redundant when every member belongs to the same device, so omit it
+    // (and fall back to the entity name so the tile still has a label).
+    const name: EntityNameItem[] = [];
+
+    if (!allSameDevice) {
+      name.push({ type: "device" });
+    }
+
+    if (!allSameEntityName || allSameDevice) {
       name.push({ type: "entity" });
     }
 


### PR DESCRIPTION
## Proposed change

The member entity list shown inside a group entity's more-info dialog (for example a WLED "Main" light listing its segments) always prefixed each tile with the device name, even when every member belongs to the same device. In that case the device name is redundant and just adds noise: "WLED Strip Segment 1", "WLED Strip Segment 2", and so on.

This mirrors the de-duplication the list already does for the area name (which is omitted when all members share an area): the device name is now omitted when all members belong to the same device, falling back to the entity name so each tile still has a label.

Behavior:
- Members across multiple devices: unchanged (device name still shown).
- Members all on the same device: device name omitted, only the entity (segment) name is shown.

## Screenshots

<!-- Reviewer note: before/after of a group member list where all members share a device (e.g. WLED segments). -->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52426
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
