### PR TITLE
Retain option value type in select form field

### DIFF
--- a/src/components/ha-form/ha-form-select.ts
+++ b/src/components/ha-form/ha-form-select.ts
@@ -12,6 +12,20 @@ import type {
   HaFormSelectSchema,
 } from "./types";
 
+/**
+ * The underlying select returns option values as strings. Map a selected value
+ * back to its original option value so the source type is retained (for example
+ * a number coming from a backend `vol.In` schema), falling back to the value
+ * itself when no option matches.
+ */
+export const matchSelectOptionValue = (
+  options: HaFormSelectSchema["options"],
+  value: string
+): HaFormSelectData => {
+  const option = options.find((opt) => String(opt[0]) === String(value));
+  return option ? option[0] : value;
+};
+
 @customElement("ha-form-select")
 export class HaFormSelect extends LitElement implements HaFormElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -66,14 +80,16 @@ export class HaFormSelect extends LitElement implements HaFormElement {
 
   private _valueChanged(ev: CustomEvent) {
     ev.stopPropagation();
-    let value: string | undefined = ev.detail.value;
-
-    if (value === this.data) {
-      return;
-    }
+    let value: HaFormSelectData | undefined = ev.detail.value;
 
     if (value === "") {
       value = undefined;
+    } else if (value != null) {
+      value = matchSelectOptionValue(this.schema.options, value);
+    }
+
+    if (value === this.data) {
+      return;
     }
 
     fireEvent(this, "value-changed", {

--- a/test/components/ha-form/ha-form-select.test.ts
+++ b/test/components/ha-form/ha-form-select.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { matchSelectOptionValue } from "../../../src/components/ha-form/ha-form-select";
+import type { HaFormSelectSchema } from "../../../src/components/ha-form/types";
+
+// The backend can send non-string option values (e.g. integers from a vol.In
+// schema) even though the type declares strings, so cast in the test.
+const asOptions = (options: (readonly [unknown, string])[]) =>
+  options as unknown as HaFormSelectSchema["options"];
+
+describe("matchSelectOptionValue", () => {
+  it("retains the numeric type of a matched option", () => {
+    const options = asOptions([
+      [1, "One"],
+      [5, "Five"],
+      [6, "Six"],
+    ]);
+    expect(matchSelectOptionValue(options, "5")).toBe(5);
+  });
+
+  it("matches a zero value correctly", () => {
+    const options = asOptions([
+      [0, "Zero"],
+      [1, "One"],
+    ]);
+    expect(matchSelectOptionValue(options, "0")).toBe(0);
+  });
+
+  it("returns string option values unchanged", () => {
+    const options = asOptions([
+      ["a", "A"],
+      ["b", "B"],
+    ]);
+    expect(matchSelectOptionValue(options, "b")).toBe("b");
+  });
+
+  it("returns the value unchanged when no option matches", () => {
+    const options = asOptions([["a", "A"]]);
+    expect(matchSelectOptionValue(options, "missing")).toBe("missing");
+  });
+});


### PR DESCRIPTION
## Proposed change

A config flow field guarded by `vol.In([1, 5, 6])` sends numeric option values to the frontend. The underlying select element returns the chosen value as a string ("1"), and `ha-form-select` forwarded that string unchanged. On submit, the backend validated `"1"` against `[1, 5, 6]` and rejected it as an invalid selection (for example the `philips_js` config flow). The value used to round-trip with its original type.

This maps the selected value back to its matching option in `ha-form-select`, so the original type is retained. String options are unaffected (the value maps to itself). The mapping is extracted into a small `matchSelectOptionValue` helper and covered by unit tests.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52502
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
