### PR TITLE
fix: wait for dashboard config to load before redirecting to home (#3…

### DIFF
--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -278,7 +278,7 @@ export class LovelacePanel extends LitElement {
   }
 
   public get urlPath() {
-    return this.panel!.url_path;
+    return this.panel?.url_path ?? null;
   }
 
   private _forceFetchConfig() {
@@ -286,18 +286,24 @@ export class LovelacePanel extends LitElement {
   }
 
   private async _fetchConfig(forceDiskRefresh: boolean) {
-    this._loading = true;
+    if (!this.panel) {
+      return;
+    }
 
     let conf: LovelaceConfig;
     let rawConf: LovelaceRawConfig | undefined;
-    const confMode = this.panel!.config?.mode;
+    const confMode = this.panel.config?.mode;
 
     // If no mode, redirect to /home as there is no "lovelace" dashboard
     if (!confMode) {
+      if (this.panel.config === null || this.panel.config === undefined) {
+        return;
+      }
       navigate("/home", { replace: true });
       return;
     }
 
+    this._loading = true;
     let confProm: Promise<LovelaceRawConfig> | undefined;
     const preloadWindow = window as WindowWithPreloads;
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When a user navigates directly to a custom dashboard URL (e.g. `/dashboard-test` or `/dashboard-test#/lovelace/home`) on page load, the frontend previously redirected them prematurely to `/home` (the default overview page) because the dashboard configurations list is fetched asynchronously and `this.panel.config` is initially `null` or `undefined`.

This PR fixes this race condition:
- Safely guards the `urlPath` getter and `_fetchConfig` method from reading an undefined `this.panel` during early initialization.
- Checks if the panel configuration is still loading (`null` or `undefined`) when `confMode` is missing. If it is loading, the component returns early to remain in the loading state instead of redirecting.
- Defers setting `this._loading = true` until after the initial checks to prevent loading flag leakage during early returns.
- Retains the safety redirect to `/home` if the configuration finishes loading and indeed has no valid mode.

### Testing and Verification Steps

Since this issue is a race condition during page load, it is best verified in a demo environment by applying a simulated async network loading delay.

1. **Apply the Reproduction Patch:**
   Apply the reproduction patch provided below to configure the demo environment with a custom test dashboard (`/dashboard-test`) that has a simulated loading delay of 1 second.
   ```bash
   git apply <patch_file_content>
   ```

2. **Start the Demo Server:**
   Start the Home Assistant frontend demo server:
   ```bash
   yarn start:demo
   ```

3. **Verify the Bug (Without the Fix):**
   * Navigate directly to: `http://localhost:8090/dashboard-test`
   * *Observed behavior:* The page immediately redirects you to `http://localhost:8090/home` (or `/lovelace/home`), preventing access to the test dashboard.

4. **Verify the Fix (With the Fix):**
   * Apply this PR's code change on `src/panels/lovelace/ha-panel-lovelace.ts`.
   * Navigate directly to: `http://localhost:8090/dashboard-test`
   * *Observed behavior:* The app shows the loading/progress spinner state for 1 second (while the dashboard configuration is loading) and then correctly renders the **Test Dashboard** without redirecting you.

### Demo Environment Reproduction Patch

The following patch configures the demo environment with the custom `dashboard-test` panel, a simulated 1-second delay, and enables dev server history API fallbacks:

```diff
diff --git a/build-scripts/bundle.cjs b/build-scripts/bundle.cjs
index 2778a3230..c7b89bb75 100644
--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -35,7 +35,7 @@ module.exports.definedVars = ({ isProdBuild, latestBuild, defineOverlay }) => ({
   __DEV__: !isProdBuild,
   __BUILD__: JSON.stringify(latestBuild ? "modern" : "legacy"),
   __VERSION__: JSON.stringify(env.version()),
-  __DEMO__: false,
+  __DEMO__: true,
   __BACKWARDS_COMPAT__: false,
   __STATIC_PATH__: "/static/",
   __HASS_URL__: `\`${
diff --git a/build-scripts/gulp/rspack.js b/build-scripts/gulp/rspack.js
index b4cbb5176..d73c1edaa 100644
--- a/build-scripts/gulp/rspack.js
+++ b/build-scripts/gulp/rspack.js
@@ -42,6 +42,7 @@ const runDevServer = async ({
   port,
   listenHost = undefined,
   proxy = undefined,
+  historyApiFallback = undefined,
 }) => {
   if (listenHost === undefined) {
     // For dev container, we need to listen on all hosts
@@ -53,14 +54,14 @@ const runDevServer = async ({
       open: true,
       host: listenHost,
       port,
+      historyApiFallback,
       static: {
         directory: contentBase,
         watch: true,
       },
       client: {
         overlay: {
-          runtimeErrors: (error) =>
-            !error?.message?.includes("ResizeObserver loop"),
+          runtimeErrors: false,
         },
       },
       proxy,
@@ -132,6 +133,11 @@ gulp.task("rspack-dev-server-demo", () =>
     ),
     contentBase: paths.demo_output_root,
     port: 8090,
+    listenHost: "0.0.0.0",
+    historyApiFallback: {
+      disableDotRule: true,
+      index: "index.html",
+    },
   })
 );
 
diff --git a/build-scripts/rspack.cjs b/build-scripts/rspack.cjs
index 207cd1013..07473bb9f 100644
--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -300,6 +300,12 @@ const createRspackConfig = ({
     experiments: {
       outputModule: true,
     },
+    devServer: {
+      historyApiFallback: {
+        index: "/index.html",
+        disableDotRule: true,
+      },
+    },
   };
 };
 
diff --git a/demo/src/stubs/lovelace.ts b/demo/src/stubs/lovelace.ts
index 06d687145..f526fc7b2 100644
--- a/demo/src/stubs/lovelace.ts
+++ b/demo/src/stubs/lovelace.ts
@@ -13,6 +13,21 @@ export const mockLovelace = (
   hass: MockHomeAssistant,
   localizePromise: Promise<LocalizeFunc>
 ) => {
+  // Simulate realistic race condition: 
+  // 1. Initial state has config: null (set in demo_panels.ts)
+  // 2. We 'finish loading' the config after a short delay
+  setTimeout(() => {
+    hass.updateHass({
+      panels: {
+        ...hass.panels,
+        "dashboard-test": {
+          ...hass.panels["dashboard-test"],
+          config: { mode: "storage" },
+        },
+      },
+    });
+  }, 1000);
+
   hass.mockWS("lovelace/config", ({ url_path }) => {
     if (url_path === "map") {
       hass.addEntities(mapEntities());
@@ -22,6 +37,43 @@ export const mockLovelace = (
         },
       };
     }
+    if (url_path === "dashboard-test") {
+      return Promise.resolve({
+        title: "Test Dashboard (issue-30072)",
+        views: [
+          {
+            title: "Overview",
+            path: "overview",
+            background: "yellow",
+            cards: [
+              {
+                type: "markdown",
+                content: "# Test Dashboard\nThis dashboard is used to verify bug **issue-30072** (Incorrect Dashboard Redirection).",
+              },
+              {
+                type: "entities",
+                title: "Test Entities",
+                entities: [
+                  "light.kitchen_lights",
+                  "switch.ac",
+                  "sensor.outside_temperature",
+                ],
+              },
+              {
+                type: "weather-forecast",
+                entity: "weather.home",
+                show_forecast: true,
+              },
+              {
+                type: "sensor",
+                entity: "sensor.outside_temperature",
+                graph: "line",
+              },
+            ],
+          },
+        ],
+      });
+    }
     return Promise.all([selectedDemoConfig, localizePromise]).then(
       ([config, localize]) => config.lovelace(localize)
     );
@@ -29,7 +81,20 @@ export const mockLovelace = (
 
   hass.mockWS("lovelace/config/save", () => Promise.resolve());
   hass.mockWS("lovelace/resources", () => Promise.resolve([]));
-  hass.mockWS("lovelace/dashboards/list", () => Promise.resolve([]));
+  hass.mockWS("lovelace/dashboards/list", () =>
+    Promise.resolve([
+      {
+        id: "1",
+        url_path: "dashboard-test",
+        title: "Test Dashboard",
+        icon: "mdi:flask",
+        require_admin: false,
+        show_in_sidebar: true,
+        mode: "storage",
+        component_name: "lovelace",
+      },
+    ])
+  );
 };
 
 customElements.whenDefined("hui-root").then(() => {
diff --git a/src/fake_data/demo_panels.ts b/src/fake_data/demo_panels.ts
index d9d313d7a..5d254f357 100644
--- a/src/fake_data/demo_panels.ts
+++ b/src/fake_data/demo_panels.ts
@@ -80,6 +80,13 @@ export const demoPanels: Panels = {
     config: { mode: "storage" },
     url_path: "map",
   },
+  "dashboard-test": {
+    component_name: "lovelace",
+    icon: "mdi:flask",
+    title: "Test Dashboard",
+    config: null,
+    url_path: "dashboard-test",
+  },
   energy: {
     component_name: "energy",
     icon: "mdi:lightning-bolt",
```

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Video of current undesired behavior: 

https://github.com/user-attachments/assets/d8f450a0-c29d-4bbc-9cdf-648d63cc7ec1

Video of corrected/desired behavior:

https://github.com/user-attachments/assets/aacef6cd-36dc-4bd2-9ebd-ebd099e8f089




## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #30072
- Suspected regression introduced in commit [b991a8122](https://github.com/home-assistant/frontend/commit/b991a8122c4f45447b85590b1784918e906e3ea8) (#28446, "Set home as default dashboard").
  - **Explanation of regression:** In commit `b991a8122`, a check was added to redirect to `/home` if `confMode` was falsy. However, on page load, `panel.config` is initially `null` or `undefined` while it is loaded asynchronously from the backend. This caused the frontend to prematurely decide that the custom dashboard had no mode and redirect to `/home` before the panels list could finish loading.
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
