### PR TITLE
Use singular verb in zone condition summary

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5641,7 +5641,7 @@
                   "zone": "[%key:ui::panel::config::automation::editor::triggers::type::zone::label%]",
                   "description": {
                     "picker": "Tests if someone (or something) is in a zone.",
-                    "full": "If {entity} {numberOfEntities, plural,\n one {is}\n other {are}\n} in {zone} {numberOfZones, plural,\n one {zone} \n other {zones}\n}"
+                    "full": "If {entity} {numberOfEntities, plural,\n one {is}\n other {is}\n} in {zone} {numberOfZones, plural,\n one {zone} \n other {zones}\n}"
                   }
                 }
               }


### PR DESCRIPTION
## Proposed change

The zone condition summary joins multiple entities with "or" (the condition is described as "If A or B is in zone X"), but it switched the English verb to plural for multiple entities, reading "If A or B **are** in zone X". English uses singular agreement with "or", so it should be "If A or B **is** in zone X".

This makes both branches of the plural render "is". The `{numberOfEntities, plural, ...}` placeholder is kept (rather than replaced by a plain "is") so it stays visible in the source language and translators can keep a real plural where their language needs it. No code change is required.

This is the same grammar fix as #52592 (numeric state trigger), applied to the zone condition. The numeric state condition is intentionally not touched: it joins entities with "and" and requires all to match, so its plural is correct.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue or discussion: #52592
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
