### PR TITLE
Remove misleading "Total exported" line from energy usage tooltip

### DIFF
--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -267,8 +267,6 @@ function formatTooltip(
 
   let sumPositive = 0;
   let countPositive = 0;
-  let sumNegative = 0;
-  let countNegative = 0;
   const rows: TemplateResult[] = [];
   for (const param of params) {
     const y = param.value?.[1] as number;
@@ -280,14 +278,12 @@ function formatTooltip(
     if (value === "0") {
       continue;
     }
-    if (param.componentSubType === "bar") {
-      if (y > 0) {
-        sumPositive += y;
-        countPositive++;
-      } else {
-        sumNegative += y;
-        countNegative++;
-      }
+    // Only the positive bars (consumption) are summed into a total. Negative
+    // bars mix unrelated categories (grid export and battery charge), so they
+    // are not totaled.
+    if (param.componentSubType === "bar" && y > 0) {
+      sumPositive += y;
+      countPositive++;
     }
     rows.push(
       html`<ha-chart-tooltip-marker
@@ -305,8 +301,6 @@ function formatTooltip(
       (row, i) => html`${i > 0 ? html`<br />` : nothing}${row}`
     )}${sumPositive !== 0 && countPositive > 1 && formatTotal
       ? html`<br /><b>${formatTotal(sumPositive)}</b>`
-      : nothing}${sumNegative !== 0 && countNegative > 1 && formatTotal
-      ? html`<br /><b>${formatTotal(sumNegative)}</b>`
       : nothing}`;
 }
 

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -181,15 +181,10 @@ export class HuiEnergyUsageGraphCard
   }
 
   private _formatTotal = (total: number) =>
-    total > 0
-      ? this.hass.localize(
-          "ui.panel.lovelace.cards.energy.energy_usage_graph.total_consumed",
-          { num: formatNumber(total, this.hass.locale) }
-        )
-      : this.hass.localize(
-          "ui.panel.lovelace.cards.energy.energy_usage_graph.total_returned",
-          { num: formatNumber(-total, this.hass.locale) }
-        );
+    this.hass.localize(
+      "ui.panel.lovelace.cards.energy.energy_usage_graph.total_consumed",
+      { num: formatNumber(total, this.hass.locale) }
+    );
 
   private _createOptions = memoizeOne(
     (

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8733,7 +8733,6 @@
             "no_data_period": "There is no data for this period.",
             "energy_usage_graph": {
               "total_consumed": "Total consumed {num} kWh",
-              "total_returned": "Total exported {num} kWh",
               "total_usage": "+{num} kWh",
               "combined_from_grid": "Combined from grid",
               "consumed_solar": "Consumed solar",


### PR DESCRIPTION
## Breaking change


## Proposed change

The energy "Electricity consumption" graph tooltip showed a **"Total exported"** line that summed grid export together with battery charge. Because both are stored as negative values, the line drastically misrepresented actual grid export (e.g. an hour with `0.04 kWh` exported and `7.3 kWh` charged to the battery showed "Total exported: 7.34 kWh"). It also appeared inconsistently, only when grid export was non-zero.

Export and battery charge are two different things (energy leaving the home vs. energy stored), so the negative total has been removed. The individual "Grid exported" and "Battery charged" rows are unchanged, and the positive "Total consumed" line is unaffected.

## Screenshots

<!-- UI change: the misleading "Total exported" line no longer appears in the tooltip. Before/after screenshots to be added. -->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52580
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
