### PR TITLE
Use singular verb for state condition matched with any

### DIFF
--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -1124,6 +1124,9 @@ const describeLegacyCondition = (
         hasAttribute: attribute !== "" ? "true" : "false",
         attribute: attribute,
         numberOfEntities: entities.length,
+        // With "any", entities are joined with "or", which takes a singular
+        // verb in English even for multiple entities ("A or B is ...").
+        matchAny: condition.match === "any" ? "true" : "false",
         entities:
           condition.match === "any"
             ? formatListWithOrs(hass.locale, entities)

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5576,7 +5576,7 @@
                   "description": {
                     "picker": "Tests if an entity (or attribute) is in a specific state.",
                     "no_entity": "If state confirmed",
-                    "full": "If{hasAttribute, select, \n true { {attribute} of}\n other {}\n} {numberOfEntities, plural,\n =0 {an entity is}\n one {{entities} is}\n other {{entities} are}\n} {numberOfStates, plural,\n =0 {a state}\n other {{states}}\n}{hasDuration, select, \n true { for {duration}} \n other {}\n }"
+                    "full": "If{hasAttribute, select, \n true { {attribute} of}\n other {}\n} {numberOfEntities, plural,\n =0 {an entity is}\n one {{entities} is}\n other {{entities} {matchAny, select,\n true {is}\n other {are}\n}}\n} {numberOfStates, plural,\n =0 {a state}\n other {{states}}\n}{hasDuration, select, \n true { for {duration}} \n other {}\n }"
                   }
                 },
                 "sun": {

--- a/test/data/state-condition-grammar.test.ts
+++ b/test/data/state-condition-grammar.test.ts
@@ -1,0 +1,56 @@
+import { IntlMessageFormat } from "intl-messageformat";
+import { describe, expect, it } from "vitest";
+import en from "../../src/translations/en.json";
+
+// The state condition summary string. Its verb must agree with how the entity
+// list is joined: "and" (match "all") takes a plural verb, "or" (match "any")
+// takes a singular verb in English.
+const message = (en as any).ui.panel.config.automation.editor.conditions.type
+  .state.description.full;
+
+const format = (values: Record<string, unknown>) =>
+  new IntlMessageFormat(message, "en").format(values) as string;
+
+describe("state condition summary grammar", () => {
+  it("uses a singular verb for a single entity", () => {
+    expect(
+      format({
+        hasAttribute: "false",
+        numberOfEntities: 1,
+        matchAny: "false",
+        entities: "Light",
+        numberOfStates: 1,
+        states: "on",
+        hasDuration: "false",
+      })
+    ).toBe("If Light is on");
+  });
+
+  it("uses a plural verb for multiple entities matched with all (and)", () => {
+    expect(
+      format({
+        hasAttribute: "false",
+        numberOfEntities: 2,
+        matchAny: "false",
+        entities: "A and B",
+        numberOfStates: 1,
+        states: "on",
+        hasDuration: "false",
+      })
+    ).toBe("If A and B are on");
+  });
+
+  it("uses a singular verb for multiple entities matched with any (or)", () => {
+    expect(
+      format({
+        hasAttribute: "false",
+        numberOfEntities: 2,
+        matchAny: "true",
+        entities: "A or B",
+        numberOfStates: 1,
+        states: "on",
+        hasDuration: "false",
+      })
+    ).toBe("If A or B is on");
+  });
+});


### PR DESCRIPTION
## Proposed change

A state condition with `match: any` joins its entities with "or" ("If A or B …"), but the summary kept a plural verb for multiple entities, reading "If A or B **are** on". With "or" English uses singular agreement, so it should read "If A or B **is** on". The `match: all` case joins entities with "and" and correctly stays plural ("If A and B are on").

This nests a `select` on a new `matchAny` flag inside the multiple-entities plural branch of the state condition summary, so the verb agrees with how the list is joined. Other languages are unaffected: they don't reference `matchAny` and keep their existing count-based plural (the extra argument is ignored), the same approach used in #52592 and #52598.

A unit test renders the actual `en.json` string through `IntlMessageFormat` and asserts all three cases (single entity, multiple with "and", multiple with "or"), so the nested ICU is verified end to end.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue or discussion: #52592, #52598
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
