### PR TITLE
Render entity states formatted from the first frame

### DIFF
--- a/src/state/state-display-mixin.ts
+++ b/src/state/state-display-mixin.ts
@@ -35,31 +35,46 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) => {
       }
     }
 
+    // Sensor numeric device classes, fetched once. Until they load we format
+    // with an empty list so entities render formatted instead of raw.
+    private _sensorNumericDeviceClasses?: string[];
+
+    // Guards against a slower, stale computation overwriting a newer one.
+    private _formatFunctionsVersion = 0;
+
     private _updateFormatFunctions = async () => {
-      if (!this.hass || !this.hass.config) {
+      if (!this.hass?.config) {
         return;
       }
 
-      let sensorNumericDeviceClasses: string[] = [];
-
-      if (isComponentLoaded(this.hass.config, "sensor")) {
-        try {
-          sensorNumericDeviceClasses = (
-            await getSensorNumericDeviceClasses(this.hass)
-          ).numeric_device_classes;
-        } catch (_err: any) {
-          // ignore
-        }
+      // Don't block formatting on the device classes round-trip: format with
+      // what we have now and refine once it resolves.
+      if (
+        this._sensorNumericDeviceClasses === undefined &&
+        isComponentLoaded(this.hass.config, "sensor")
+      ) {
+        getSensorNumericDeviceClasses(this.hass)
+          .then((res) => {
+            this._sensorNumericDeviceClasses = res.numeric_device_classes;
+            return this._setFormatFunctions(res.numeric_device_classes);
+          })
+          .catch(() => {
+            // Keep the empty list; it's retried on the next update.
+          });
       }
 
-      const {
-        formatEntityState,
-        formatEntityStateToParts,
-        formatEntityAttributeName,
-        formatEntityAttributeValue,
-        formatEntityAttributeValueToParts,
-        formatEntityName,
-      } = await computeFormatFunctions(
+      await this._setFormatFunctions(this._sensorNumericDeviceClasses ?? []);
+    };
+
+    private _setFormatFunctions = async (
+      sensorNumericDeviceClasses: string[]
+    ) => {
+      if (!this.hass?.config) {
+        return;
+      }
+
+      const version = ++this._formatFunctionsVersion;
+      const formatFunctions = await computeFormatFunctions(
         this.hass.localize,
         this.hass.locale,
         this.hass.config,
@@ -69,14 +84,11 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) => {
         this.hass.floors,
         sensorNumericDeviceClasses
       );
-      this._updateHass({
-        formatEntityState,
-        formatEntityStateToParts,
-        formatEntityAttributeName,
-        formatEntityAttributeValue,
-        formatEntityAttributeValueToParts,
-        formatEntityName,
-      });
+
+      // Ignore the result if a newer computation has since started.
+      if (version === this._formatFunctionsVersion) {
+        this._updateHass(formatFunctions);
+      }
     };
   }
   return StateDisplayMixin;


### PR DESCRIPTION
## Proposed change

On first dashboard load, entity cards briefly showed raw, unformatted states (e.g. `22.22222` instead of `22.2`, `on` instead of `On`) until the state formatters finished initializing.

The formatters were held back by an awaited websocket round-trip (`getSensorNumericDeviceClasses`) before being installed. They are now installed immediately with the data already available and refined once the device classes resolve, so values render formatted from the first frame. A version guard prevents a slower, stale computation from overwriting a newer one.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52599
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
