### PR TITLE
Don't mutate shared registry objects in the area page

### DIFF
--- a/src/panels/config/areas/ha-config-area-page.ts
+++ b/src/panels/config/areas/ha-config-area-page.ts
@@ -288,29 +288,28 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
       Object.values(this.hass.devices),
       this._entityReg
     );
-    const { devices, entities } = memberships;
     const quickLinkCounts = this._getQuickLinkCounts(
       memberships,
       this._related
     );
 
-    // Pre-compute the entity and device names, so we can sort by them
-    if (devices) {
-      devices.forEach((entry) => {
-        entry.name = computeDeviceNameDisplay(
-          entry,
-          this.hass.localize,
-          this.hass.states
-        );
-      });
-      sortDeviceRegistryByName(devices, this.hass.locale.language);
-    }
-    if (entities) {
-      entities.forEach((entry) => {
-        entry.name = computeEntityRegistryName(this.hass, entry);
-      });
-      sortEntityRegistryByName(entities, this.hass.locale.language);
-    }
+    // Compute the display names on shallow copies so we can sort and render by
+    // them without mutating the shared registry objects.
+    const devices = memberships.devices.map((entry) => ({
+      ...entry,
+      name: computeDeviceNameDisplay(
+        entry,
+        this.hass.localize,
+        this.hass.states
+      ),
+    }));
+    sortDeviceRegistryByName(devices, this.hass.locale.language);
+
+    const entities = memberships.entities.map((entry) => ({
+      ...entry,
+      name: computeEntityRegistryName(this.hass, entry),
+    }));
+    sortEntityRegistryByName(entities, this.hass.locale.language);
 
     // Group entities by domain
     const groupedEntities = groupBy(entities, (entity) =>


### PR DESCRIPTION
## Proposed change

The area page resolved device and entity display names by writing them back onto the registry entries returned by its (memoized) memberships. Those entries are the **shared objects** from `hass.devices` and the entity registry, so this overwrote each entry's raw `name` during render and leaked app-wide.

The most visible effect: `computeDeviceNameDisplay()` returns the localized string "Unnamed device" for a device with no name. After visiting an area page, that string was written onto the shared device object, and because `computeDeviceName()` then returns it as truthy, it short-circuits the entity-derived fallback used elsewhere. So a device that normally shows a name derived from its entities would instead show "Unnamed device" in the device list, more-info, pickers, etc., until the registry next refreshes. Devices/entities with no user name also had their name field corrupted in the settings dialog.

This computes the display names on shallow copies and sorts/renders those, leaving the shared registry objects untouched. The area page renders the exact same names and order as before.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
