### PR TITLE
Add accessible labels to automation editor icon buttons

### DIFF
--- a/src/panels/config/automation/condition/types/ha-automation-condition-platform.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-platform.ts
@@ -164,6 +164,9 @@ export class HaPlatformCondition extends LitElement {
               <ha-icon-button
                 .path=${mdiHelpCircleOutline}
                 class="help-icon"
+                .label=${this.hass.localize(
+                  "ui.components.service-control.integration_doc"
+                )}
               ></ha-icon-button>
             </a>`
           : nothing}

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-conversation.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-conversation.ts
@@ -55,6 +55,9 @@ export class HaConversationTrigger
                     @click=${this._removeOption}
                     slot="end"
                     .path=${mdiClose}
+                    .label=${this.hass.localize(
+                      "ui.panel.config.automation.editor.triggers.type.conversation.delete"
+                    )}
                   ></ha-icon-button>
                 </ha-input>
               `
@@ -78,6 +81,9 @@ export class HaConversationTrigger
           @click=${this._addOption}
           slot="end"
           .path=${mdiPlus}
+          .label=${this.hass.localize(
+            "ui.panel.config.automation.editor.triggers.type.conversation.add_sentence"
+          )}
         ></ha-icon-button>
       </ha-input>`;
   }

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
@@ -201,6 +201,9 @@ export class HaPlatformTrigger extends LitElement {
               <ha-icon-button
                 .path=${mdiHelpCircleOutline}
                 class="help-icon"
+                .label=${this.hass.localize(
+                  "ui.components.service-control.integration_doc"
+                )}
               ></ha-icon-button>
             </a>`
           : nothing}


### PR DESCRIPTION
## Proposed change

Several icon-only `ha-icon-button`s in the automation editor have no accessible name, so screen readers have nothing to announce for them. This adds labels (using existing translation keys, no new strings):

- Conversation trigger: the add-sentence and remove-sentence buttons.
- Trigger and condition platform editors: the integration documentation button.

The remove-sentence button reuses the component's existing "Delete sentence" string for consistency with its other wording.

The change is purely additive (it only adds `.label` props), with no behavior change beyond the accessible name.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
