### PR TITLE
Add tests for isTimestamp string utility

### DIFF
--- a/test/common/string/is_timestamp.test.ts
+++ b/test/common/string/is_timestamp.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "vitest";
+import { isTimestamp } from "../../../src/common/string/is_timestamp";
+
+test("isTimestamp accepts valid timestamps", () => {
+  expect(isTimestamp("2021-06-15T08:30:00Z")).toBe(true);
+  expect(isTimestamp("2021-06-15 08:30:00")).toBe(true);
+  expect(isTimestamp("2021-06-15T08:30")).toBe(true);
+  expect(isTimestamp("2021-12-31T23:59:59")).toBe(true);
+  expect(isTimestamp("2021-06-15T08:30:00.123+02:00")).toBe(true);
+  expect(isTimestamp("2021-06-15T24:00")).toBe(true);
+});
+
+test("isTimestamp rejects non-timestamps", () => {
+  expect(isTimestamp("not a date")).toBe(false);
+  expect(isTimestamp("2021/06/15T08:30")).toBe(false);
+  expect(isTimestamp("2021-13-01T00:00")).toBe(false);
+  expect(isTimestamp("2021-00-01T00:00")).toBe(false);
+  expect(isTimestamp("2021-06-32T00:00")).toBe(false);
+  expect(isTimestamp("2021-06-15T25:00")).toBe(false);
+});
+
+test("isTimestamp does not allow a leading plus or minus", () => {
+  expect(isTimestamp("+2021-06-15T08:30")).toBe(false);
+  expect(isTimestamp("-2021-06-15T08:30")).toBe(false);
+});
+
+test("isTimestamp requires a time component after the date", () => {
+  expect(isTimestamp("2021-06-15")).toBe(false);
+});
+
+test("isTimestamp rejects week-number dates", () => {
+  expect(isTimestamp("2021-W24-2T08:30")).toBe(false);
+});
+
+test("isTimestamp rejects a year on its own", () => {
+  expect(isTimestamp("2021")).toBe(false);
+});


### PR DESCRIPTION
## Proposed change

Adds unit tests for the `isTimestamp` string utility (`src/common/string/is_timestamp.ts`), which previously had no test coverage.

The utility uses a single regular expression with several deliberate, documented rules. The tests pin those guarantees so future changes to the regex cannot silently break them:

- Accepts valid timestamps (with `T` or space separator, optional seconds, fractional seconds, timezone offset, and `24:00`).
- Rejects out-of-range months, days, and hours, and non-date strings.
- Does not allow a leading plus or minus.
- Requires a time component after the date (a date on its own is rejected).
- Rejects ISO week-number dates.
- Rejects a year on its own.

No production code is changed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr