### PR TITLE
Fix serial port selector integration domain in options flows

### DIFF
--- a/src/components/ha-selector/ha-selector-serial-port.ts
+++ b/src/components/ha-selector/ha-selector-serial-port.ts
@@ -354,7 +354,10 @@ export class HaSerialPortSelector extends LitElement {
   }
 
   private get _selectorDomain(): string | undefined {
-    return this.context?.handler;
+    // Prefer `domain`: in options flows `handler` is the config entry id, not
+    // the integration domain, which would wrongly mark the integration's own
+    // ports as "not recommended".
+    return this.context?.domain ?? this.context?.handler;
   }
 
   private _memoRecommendedDomains = memoizeOne(

--- a/src/components/ha-selector/ha-selector-serial-port.ts
+++ b/src/components/ha-selector/ha-selector-serial-port.ts
@@ -354,10 +354,9 @@ export class HaSerialPortSelector extends LitElement {
   }
 
   private get _selectorDomain(): string | undefined {
-    // Prefer `domain`: in options flows `handler` is the config entry id, not
-    // the integration domain, which would wrongly mark the integration's own
-    // ports as "not recommended".
-    return this.context?.domain ?? this.context?.handler;
+    // `domain` is the integration domain even in options flows, where the flow
+    // handler is the config entry id instead.
+    return this.context?.domain;
   }
 
   private _memoRecommendedDomains = memoizeOne(

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -403,6 +403,7 @@ class DataEntryFlowDialog extends LitElement {
                           .flowConfig=${this._params.flowConfig}
                           .step=${this._step}
                           .hass=${this.hass}
+                          .domain=${this._params.domain ?? this._step.handler}
                           @flow-step-footer-state-changed=${this
                             ._handleFooterStateChanged}
                         ></step-flow-form>

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -35,6 +35,10 @@ class StepFlowForm extends LitElement {
 
   @property({ attribute: false }) public hass!: HomeAssistant;
 
+  // The integration domain this flow belongs to. Unlike `step.handler`, this is
+  // the domain even for options flows (where the handler is the config entry id).
+  @property({ attribute: false }) public domain?: string;
+
   @state() private _loading = false;
 
   @state() private _stepData?: Record<string, any>;
@@ -108,7 +112,7 @@ class StepFlowForm extends LitElement {
               .computeHelper=${this._helperCallback}
               .computeError=${this._errorCallback}
               .localizeValue=${this._localizeValueCallback}
-              .context=${{ handler: step.handler }}
+              .context=${{ handler: step.handler, domain: this.domain }}
             ></ha-form>`
           : nothing}
       </div>


### PR DESCRIPTION
## Proposed change

This PR fixes an issue where the serial port picker highlights incorrect devices when displayed in an options flow.
To fix this, the integration domain is now passed through the config flow form context.

Before, the serial port selector used `context.handler` to determine which integration's recommended ports to show. This works for config flows where the handler is the integration domain, but breaks for options flows where the handler is the config entry ID instead of the domain.

### Confirmed working

I've verified the serial port picker's recommendations correctly work in the ZHA config flow (same as before) and now also in the options flow.


### Note on comments

Some (AI-generated) comments are currently included in the code. They may be useful to explain that `context.handler` is only the integration domain in config flows and not options flows, but I can also just remove them, of course.


## Screenshots

| **Before** (broken options flow)  | **After** (working options flow, same as config flow now) |
| ------------- | ------------- |
| <img width="557" height="686" alt="Serial port picker in ZHA options flow showing an incorrect integration domain" src="https://github.com/user-attachments/assets/309f9077-0b94-461b-abf4-9f7dcb7e60c6" />  | <img width="558" height="686" alt="Serial port picker in ZHA options flow showing the correct integration domain – same as config flow now" src="https://github.com/user-attachments/assets/f4ba6714-9aeb-4795-b634-fb66ecf2649b" />  |

Note: The ZBT-2 always shows up due to extra matching done in HA Core, as it has its own integration (domain) for USB discovery. This issue affected options flows for all integrations and devices, except for the dedicated HA Connect hardware integrations in ZHA.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
