### PR TITLE
Use American English spelling for badges behavior label

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9052,7 +9052,7 @@
                 "top": "Top",
                 "bottom": "Bottom"
               },
-              "badges_wrap": "Badges behaviour",
+              "badges_wrap": "Badges behavior",
               "badges_wrap_options": {
                 "wrap": "Wrap",
                 "scroll": "Scroll",


### PR DESCRIPTION
## Proposed change

Fixes a single British English spelling so it matches the American English standard used throughout the frontend. The label for how badges behave read "Badges behaviour"; it now reads "Badges behavior".

The American spelling "behavior" is already used 12 times elsewhere in the translations, so this just aligns the one remaining straggler. Only the English source string changes (other languages are managed through Lokalise) and the translation key is untouched.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr