### PR TITLE
Add rel="noreferrer" to links opening in a new tab

### DIFF
--- a/src/panels/config/cloud/register/cloud-register.ts
+++ b/src/panels/config/cloud/register/cloud-register.ts
@@ -84,7 +84,10 @@ export class CloudRegister extends LitElement {
                 ${this.hass.localize(
                   "ui.panel.config.cloud.register.information3"
                 )}
-                <a href="https://www.nabucasa.com" target="_blank"
+                <a
+                  href="https://www.nabucasa.com"
+                  target="_blank"
+                  rel="noreferrer"
                   >Nabu&nbsp;Casa,&nbsp;Inc</a
                 >
                 ${this.hass.localize(

--- a/src/panels/config/info/ha-config-info.ts
+++ b/src/panels/config/info/ha-config-info.ts
@@ -243,8 +243,9 @@ class HaConfigInfo extends LitElement {
                     ${customUiList.map(
                       (item) => html`
                         <div>
-                          <a href=${item.url} target="_blank"> ${item.name}</a>:
-                          ${item.version}
+                          <a href=${item.url} target="_blank" rel="noreferrer">
+                            ${item.name}</a
+                          >: ${item.version}
                         </div>
                       `
                     )}

--- a/src/panels/config/integrations/ha-config-entry-row.ts
+++ b/src/panels/config/integrations/ha-config-entry-row.ts
@@ -354,6 +354,7 @@ export class HaConfigEntryRow extends LitElement {
                 <a
                   href=${getConfigEntryDiagnosticsDownloadUrl(item.entry_id)}
                   target="_blank"
+                  rel="noreferrer"
                   @click=${this._signUrl}
                 >
                   <ha-dropdown-item value="diagnostics">

--- a/src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts
@@ -92,6 +92,7 @@ export class ThreadConfigPanel extends SubscribeMixin(LitElement) {
               this._configEntryId || ""
             )}
             target="_blank"
+            rel="noreferrer"
             @click=${this._signUrl}
           >
             <ha-dropdown-item>


### PR DESCRIPTION
## Proposed change

Adds `rel="noreferrer"` to the four links in the frontend that open in a new tab (`target="_blank"`) but were missing a `rel` attribute. These were the only such links left without one; every other new-tab link already sets it.

Adding `rel="noreferrer"` prevents the opened page from receiving the referrer and from accessing the original `window` object (reverse tabnabbing), matching the convention already used across the rest of the codebase.

The affected links:

- Nabu Casa website link on the cloud registration screen.
- Custom UI source links on the "About" info page.
- Diagnostics download links on the integration entry row and the Thread configuration panel.

No behavior changes for users

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr