### PR TITLE
Use numeric timestamps instead of Date objects in history line chart data

### DIFF
--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -440,6 +440,10 @@ export class StateHistoryChartLine extends LitElement {
 
     this._chartTime = new Date();
     const endTime = this.endTime;
+    // Work with numeric epoch timestamps (ms) instead of Date objects below.
+    // Charts can hold a huge number of points, and allocating a Date per point
+    // is needless GC pressure; the "time" axis consumes numbers natively.
+    const endTimeMs = endTime.getTime();
     const names = this.names || {};
     const colors = this.colors || {};
     entityStates.forEach((states, dataIdx) => {
@@ -451,9 +455,9 @@ export class StateHistoryChartLine extends LitElement {
 
       const data: LineSeriesOption[] = [];
 
-      const pushData = (timestamp: Date, datavalues: any[] | null) => {
+      const pushData = (timestamp: number, datavalues: any[] | null) => {
         if (!datavalues) return;
-        if (timestamp > endTime) {
+        if (timestamp > endTimeMs) {
           // Drop data points that are after the requested endTime. This could happen if
           // endTime is "now" and client time is not in sync with server time.
           return;
@@ -624,11 +628,11 @@ export class StateHistoryChartLine extends LitElement {
               entityState.attributes.target_temp_low
             );
             series.push(targetHigh, targetLow);
-            pushData(new Date(entityState.last_changed), series);
+            pushData(entityState.last_changed, series);
           } else {
             const target = safeParseFloat(entityState.attributes.temperature);
             series.push(target);
-            pushData(new Date(entityState.last_changed), series);
+            pushData(entityState.last_changed, series);
           }
         });
       } else if (domain === "humidifier") {
@@ -746,31 +750,27 @@ export class StateHistoryChartLine extends LitElement {
           } else {
             series.push(entityState.state === "on" ? current : null);
           }
-          pushData(new Date(entityState.last_changed), series);
+          pushData(entityState.last_changed, series);
         });
       } else {
         addDataSet(states.entity_id, name, color);
 
         let lastValue: number;
-        let lastDate: Date;
-        let lastNullDate: Date | null = null;
+        let lastDate: number;
+        let lastNullDate: number | null = null;
 
         // Process chart data.
         // When state is `unknown`, calculate the value and break the line.
         const processData = (entityState: LineChartState) => {
           const value = safeParseFloat(entityState.state);
-          const date = new Date(entityState.last_changed);
+          const date = entityState.last_changed;
           if (value !== null && lastNullDate) {
-            const dateTime = date.getTime();
-            const lastNullDateTime = lastNullDate.getTime();
-            const lastDateTime = lastDate?.getTime();
             const tmpValue =
               (value - lastValue) *
-                ((lastNullDateTime - lastDateTime) /
-                  (dateTime - lastDateTime)) +
+                ((lastNullDate - lastDate) / (date - lastDate)) +
               lastValue;
             pushData(lastNullDate, [tmpValue]);
-            pushData(new Date(lastNullDateTime + 1), [null]);
+            pushData(lastNullDate + 1, [null]);
             pushData(date, [value]);
             lastDate = date;
             lastValue = value;
@@ -809,17 +809,17 @@ export class StateHistoryChartLine extends LitElement {
       }
 
       // Add an entry for final values
-      pushData(endTime, prevValues);
+      pushData(endTimeMs, prevValues);
 
       // For sensors, append current state if viewing recent data
-      const now = new Date();
+      const nowMs = Date.now();
       // allow 1s of leeway for "now"
-      const isUpToNow = now.getTime() - endTime.getTime() <= 1000;
+      const isUpToNow = nowMs - endTimeMs <= 1000;
       if (domain === "sensor" && isUpToNow && data.length === 1) {
         const stateObj = this.hass.states[states.entity_id];
         const currentValue = stateObj ? safeParseFloat(stateObj.state) : null;
         if (currentValue !== null) {
-          data[0].data!.push([now, currentValue]);
+          data[0].data!.push([nowMs, currentValue]);
           trackY(currentValue);
         }
       }


### PR DESCRIPTION
## Proposed change

Speeds up building large history line graphs by working with numeric epoch timestamps (ms) instead of allocating a `Date` object for every data point.

When a history line chart is generated, the code previously created a `new Date(...)` for each state it processed. A graph can hold tens of thousands of points (many entities, long time ranges), so this is tens of thousands of short-lived `Date` allocations plus the resulting garbage collection, every time the chart data is rebuilt. The interpolation math then immediately converted those Dates back to numbers with `.getTime()`.

The chart's x-axis is a `"time"` axis, which accepts numeric timestamps directly, and the rest of this component already compares timestamps as plain numbers. This change passes the already-numeric `last_changed` value straight through to the chart data and drops the redundant `Date` allocations and `.getTime()` calls.

The result is identical chart output (the numeric value is exactly what the `Date` resolved to), with less work and less memory pressure when processing a lot of data points. No user-visible behavior changes.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr