### PR TITLE
Optimize state history line chart hot loop

### DIFF
--- a/src/components/chart/state-history-chart-line-data.ts
+++ b/src/components/chart/state-history-chart-line-data.ts
@@ -87,19 +87,26 @@ export function generateStateHistoryChartLineData(
         // endTime is "now" and client time is not in sync with server time.
         return;
       }
-      data.forEach((d, i) => {
-        if (datavalues[i] === null && prevValues && prevValues[i] !== null) {
+      const prev = prevValues;
+      for (let i = 0, len = data.length; i < len; i++) {
+        const seriesData = data[i].data!;
+        const value = datavalues[i];
+        if (value === null && prev && prev[i] !== null) {
           // null data values show up as gaps in the chart.
           // If the current value for the dataset is null and the previous
           // value of the data set is not null, then add an 'end' point
           // to the chart for the previous value. Otherwise the gap will
           // be too big. It will go from the start of the previous data
           // value until the start of the next data value.
-          d.data!.push([timestamp, prevValues[i]]);
+          seriesData.push([timestamp, prev[i]]);
         }
-        d.data!.push([timestamp, datavalues[i]]);
-        trackY(datavalues[i]);
-      });
+        seriesData.push([timestamp, value]);
+        // inlined trackY (still used as a function for the sensor append below)
+        if (typeof value === "number" && Number.isFinite(value)) {
+          if (value < yMin) yMin = value;
+          if (value > yMax) yMax = value;
+        }
+      }
       prevValues = datavalues;
     };
 


### PR DESCRIPTION
## Breaking change

<!-- Not a breaking change. -->

## Proposed change

Performance optimization of the per-state hot loop (`pushData`) in `generateStateHistoryChartLineData`, with **no change in output**.

The loop, which runs once per state and iterates every dataset, used `Array.prototype.forEach` with a per-value `trackY` closure call. It is now a plain indexed `for` loop (with `data.length` hoisted) that inlines the min/max tracking and reads `datavalues[i]` / `data[i].data` once into locals — removing the per-call callback closure and a function call per value. `trackY` is kept as a function for the single out-of-loop sensor current-state append.

Iteration order, push order (gap-end point then value), the null/finite checks, and the yMin/yMax updates are all preserved, so output is bit-identical (verified by the existing characterization tests). This builds on #52631, which already moved this path to numeric timestamps. No public API changes.

## Screenshots

<!-- No visual changes. -->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
