### PR TITLE
Preserve unchanged device, area, and floor registry entries

### DIFF
--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -283,21 +283,42 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         for (const device of deviceReg) {
           devices[device.id] = device;
         }
-        this._updateHass({ devices });
+        const updatedDevices = preserveUnchangedRecord(
+          this.hass?.devices,
+          devices,
+          deepEqual
+        );
+        if (updatedDevices !== this.hass?.devices) {
+          this._updateHass({ devices: updatedDevices });
+        }
       });
       subscribeAreaRegistry(conn, (areaReg) => {
         const areas: HomeAssistant["areas"] = {};
         for (const area of areaReg) {
           areas[area.area_id] = area;
         }
-        this._updateHass({ areas });
+        const updatedAreas = preserveUnchangedRecord(
+          this.hass?.areas,
+          areas,
+          deepEqual
+        );
+        if (updatedAreas !== this.hass?.areas) {
+          this._updateHass({ areas: updatedAreas });
+        }
       });
       subscribeFloorRegistry(conn, (floorReg) => {
         const floors: HomeAssistant["floors"] = {};
         for (const floor of floorReg) {
           floors[floor.floor_id] = floor;
         }
-        this._updateHass({ floors });
+        const updatedFloors = preserveUnchangedRecord(
+          this.hass?.floors,
+          floors,
+          deepEqual
+        );
+        if (updatedFloors !== this.hass?.floors) {
+          this._updateHass({ floors: updatedFloors });
+        }
       });
       subscribeConfig(conn, (config) => this._updateHass({ config }));
       subscribeServices(conn, (services) => this._updateHass({ services }));


### PR DESCRIPTION
## Proposed change

Follow-up to #52641, which added the `preserveUnchangedRecord` helper and applied it to the entity registry. This applies the exact same pattern to the device, area, and floor registries.

Those three registries are re-fetched and rebuilt in full on every registry-updated event, producing brand-new objects for every item even when nothing relevant changed. That gives every item a new reference, so all device/area/floor-bound consumers re-render unnecessarily. On top of that, the entity name and state formatters are rebuilt whenever `hass.devices`, `hass.areas`, or `hass.floors` change, so a registry event that doesn't actually change them currently churns the formatters and re-renders everything that formats entity names and states.

With this change, unchanged items keep their object identity, and when nothing changed at all the update is skipped entirely. Only genuinely-changed items (and their consumers) update. There is no behavior change for users; it only avoids needless work.

This reuses the helper already introduced in #52641, so there is no new utility code here, just the three call sites.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #52641
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr