### PR TITLE
Cache parsed card entities in hasConfigOrEntitiesChanged

### DIFF
--- a/src/common/util/weak-memoize.ts
+++ b/src/common/util/weak-memoize.ts
@@ -1,0 +1,21 @@
+/**
+ * Memoizes a single-argument function keyed by its argument's object identity,
+ * caching results in a `WeakMap`.
+ *
+ * Unlike `memoizeOne`, this keeps every distinct argument cached, not just the
+ * most recent one. That suits pure derivations from stable config objects that
+ * are evaluated for many different configs and on a hot path, e.g. card
+ * `shouldUpdate` helpers running on every state change. Entries are garbage
+ * collected once the key object is no longer referenced.
+ */
+export const weakMemoize = <K extends object, V>(
+  func: (arg: K) => V
+): ((arg: K) => V) => {
+  const cache = new WeakMap<K, V>();
+  return (arg) => {
+    if (!cache.has(arg)) {
+      cache.set(arg, func(arg));
+    }
+    return cache.get(arg)!;
+  };
+};

--- a/src/panels/lovelace/common/has-changed.ts
+++ b/src/panels/lovelace/common/has-changed.ts
@@ -4,6 +4,22 @@ import type { EntityRegistryDisplayEntry } from "../../../data/entity/entity_reg
 import type { HomeAssistant } from "../../../types";
 import { processConfigEntities } from "./process-config-entities";
 
+// `hasConfigOrEntitiesChanged` runs in `shouldUpdate` on every state change, but
+// the entities config only changes on (re)configure. Cache the parsed result per
+// config array so it is parsed once and reused instead of re-allocated on every
+// state change. A new config array misses the cache; a non-array still throws via
+// `processConfigEntities`.
+const processedConfigEntitiesCache = new WeakMap<object, any[]>();
+
+const getConfigEntities = (entities: any): any[] => {
+  let processed = processedConfigEntitiesCache.get(entities);
+  if (!processed) {
+    processed = processConfigEntities(entities, false);
+    processedConfigEntitiesCache.set(entities, processed);
+  }
+  return processed;
+};
+
 export function hasConfigChanged(
   element: any,
   changedProps: PropertyValues
@@ -102,7 +118,7 @@ export function hasConfigOrEntitiesChanged(
   const oldHass = changedProps.get("hass") as HomeAssistant;
   const newHass = element.hass as HomeAssistant;
 
-  const entities = processConfigEntities(element._config!.entities, false);
+  const entities = getConfigEntities(element._config!.entities);
 
   return entities.some((entity) => {
     if (!("entity" in entity)) {

--- a/src/panels/lovelace/common/has-changed.ts
+++ b/src/panels/lovelace/common/has-changed.ts
@@ -2,23 +2,16 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
 import type { EntityRegistryDisplayEntry } from "../../../data/entity/entity_registry";
 import type { HomeAssistant } from "../../../types";
+import { weakMemoize } from "../../../common/util/weak-memoize";
 import { processConfigEntities } from "./process-config-entities";
 
 // `hasConfigOrEntitiesChanged` runs in `shouldUpdate` on every state change, but
-// the entities config only changes on (re)configure. Cache the parsed result per
-// config array so it is parsed once and reused instead of re-allocated on every
-// state change. A new config array misses the cache; a non-array still throws via
-// `processConfigEntities`.
-const processedConfigEntitiesCache = new WeakMap<object, any[]>();
-
-const getConfigEntities = (entities: any): any[] => {
-  let processed = processedConfigEntitiesCache.get(entities);
-  if (!processed) {
-    processed = processConfigEntities(entities, false);
-    processedConfigEntitiesCache.set(entities, processed);
-  }
-  return processed;
-};
+// the entities config only changes on (re)configure. Memoize the parsed result
+// per config array so it is parsed once and reused instead of re-allocated on
+// every state change.
+const getConfigEntities = weakMemoize((entities: any[]) =>
+  processConfigEntities(entities, false)
+);
 
 export function hasConfigChanged(
   element: any,

--- a/test/common/util/weak-memoize.test.ts
+++ b/test/common/util/weak-memoize.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { weakMemoize } from "../../../src/common/util/weak-memoize";
+
+describe("weakMemoize", () => {
+  it("computes once per key and returns the cached result", () => {
+    const spy = vi.fn((arg: { id: number }) => ({ doubled: arg.id * 2 }));
+    const memoized = weakMemoize(spy);
+
+    const key = { id: 21 };
+    const first = memoized(key);
+    const second = memoized(key);
+
+    expect(first).toEqual({ doubled: 42 });
+    expect(second).toBe(first);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("computes separately for different keys", () => {
+    const spy = vi.fn((arg: { id: number }) => arg.id);
+    const memoized = weakMemoize(spy);
+
+    const a = { id: 1 };
+    const b = { id: 1 };
+    expect(memoized(a)).toBe(1);
+    expect(memoized(b)).toBe(1);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches falsy results without recomputing", () => {
+    const spy = vi.fn(() => undefined);
+    const memoized = weakMemoize(spy);
+
+    const key = {};
+    memoized(key);
+    memoized(key);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives each memoized function its own cache", () => {
+    const memoizedA = weakMemoize((arg: object) => arg);
+    const memoizedB = weakMemoize(() => "b");
+    const key = {};
+    expect(memoizedA(key)).toBe(key);
+    expect(memoizedB(key)).toBe("b");
+  });
+});

--- a/test/panels/lovelace/common/has-changed.test.ts
+++ b/test/panels/lovelace/common/has-changed.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { hasConfigOrEntitiesChanged } from "../../../../src/panels/lovelace/common/has-changed";
+import type { HomeAssistant } from "../../../../src/types";
+
+const state = (entity_id: string, value: string) => ({
+  entity_id,
+  state: value,
+  attributes: {},
+  last_changed: "",
+  last_updated: "",
+  context: { id: "" },
+});
+
+// Shared references for everything hasConfigChanged compares, so that only
+// the `states` differences drive the result in these tests.
+const SHARED = {
+  connected: true,
+  entities: {},
+  config: { state: "RUNNING" },
+  themes: {},
+  locale: {},
+  localize: () => "",
+  formatEntityState: () => "",
+  formatEntityAttributeName: () => "",
+  formatEntityAttributeValue: () => "",
+};
+
+const createHass = (states: Record<string, any>): HomeAssistant =>
+  ({ ...SHARED, states }) as unknown as HomeAssistant;
+
+const changedProps = (oldHass: HomeAssistant) =>
+  new Map([["hass", oldHass]]) as any;
+
+describe("hasConfigOrEntitiesChanged", () => {
+  it("returns true when a configured entity's state changes", () => {
+    const oldHass = createHass({
+      "light.a": state("light.a", "on"),
+      "light.b": state("light.b", "on"),
+    });
+    const newHass = createHass({
+      "light.a": state("light.a", "off"),
+      "light.b": oldHass.states["light.b"],
+    });
+    const element = {
+      hass: newHass,
+      _config: { entities: ["light.a", "light.b"] },
+    };
+    expect(hasConfigOrEntitiesChanged(element, changedProps(oldHass))).toBe(
+      true
+    );
+  });
+
+  it("returns false when only unconfigured entities change", () => {
+    const sharedA = state("light.a", "on");
+    const oldHass = createHass({
+      "light.a": sharedA,
+      "light.other": state("light.other", "on"),
+    });
+    const newHass = createHass({
+      "light.a": sharedA,
+      "light.other": state("light.other", "off"),
+    });
+    const element = {
+      hass: newHass,
+      _config: { entities: ["light.a"] },
+    };
+    expect(hasConfigOrEntitiesChanged(element, changedProps(oldHass))).toBe(
+      false
+    );
+  });
+
+  it("keeps detecting changes across repeated calls (cached config parsing)", () => {
+    const config = { entities: ["light.a"] };
+    const base = state("light.a", "on");
+    const hass1 = createHass({ "light.a": base });
+
+    // First call: config parsed and cached.
+    expect(
+      hasConfigOrEntitiesChanged(
+        { hass: hass1, _config: config },
+        changedProps(hass1)
+      )
+    ).toBe(false);
+
+    // Second call with a real change still detected (cache must not mask it).
+    const hass2 = createHass({ "light.a": state("light.a", "off") });
+    expect(
+      hasConfigOrEntitiesChanged(
+        { hass: hass2, _config: config },
+        changedProps(hass1)
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Proposed change

Avoids re-parsing a card's entity config on every state change.

`hasConfigOrEntitiesChanged` is the `shouldUpdate` gate used by the multi-entity cards (glance, history graph, statistics graph, map). It runs on every state change in the system. On each run it called `processConfigEntities(config.entities)`, which walks the configured entities and allocates a new object for each one, every single time, even though the configuration only changes when the card is (re)configured. On a dashboard with several such cards and many entities, that is a lot of needless parsing and object allocation on the hottest path.

The parsed result is now memoized per config array, so it is parsed once and reused. A configuration change produces a new array, which misses the cache and is parsed once more; old configs are garbage collected automatically. There is no behavior change for users.

This adds a small, reusable `weakMemoize` helper (`src/common/util/weak-memoize.ts`) for the underlying pattern: memoizing a pure single-argument function keyed by its argument's object identity. Unlike `memoizeOne`, it keeps every distinct argument cached (not just the most recent), which is what this case needs since many cards each call with their own config.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr