### PR TITLE
Allow color config on state-label-badge

### DIFF
--- a/src/panels/lovelace/badges/hui-state-label-badge.ts
+++ b/src/panels/lovelace/badges/hui-state-label-badge.ts
@@ -16,6 +16,7 @@ export class HuiStateLabelBadge extends HuiEntityBadge {
     const entityBadgeConfig: EntityBadgeConfig = {
       type: "entity",
       entity: config.entity,
+      color: config.color,
       show_name: config.show_name ?? true,
     };
 

--- a/src/panels/lovelace/badges/types.ts
+++ b/src/panels/lovelace/badges/types.ts
@@ -23,6 +23,7 @@ export interface StateLabelBadgeConfig extends LovelaceBadgeConfig {
   name?: string;
   icon?: string;
   image?: string;
+  color?: string;
   show_name?: boolean;
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;

--- a/src/panels/lovelace/editor/config-elements/hui-state-label-badge-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-state-label-badge-editor.ts
@@ -14,6 +14,7 @@ const badgeConfigStruct = assign(
     entity: optional(string()),
     name: optional(string()),
     icon: optional(string()),
+    color: optional(string()),
     show_entity_picture: optional(boolean()),
     tap_action: optional(actionConfigStruct),
     show_name: optional(boolean()),
@@ -30,6 +31,7 @@ export class HuiStateLabelBadgeEditor extends HuiEntityBadgeEditor {
     const entityBadgeConfig: EntityBadgeConfig = {
       type: "entity",
       entity: config.entity,
+      color: config.color,
       show_name: config.show_name ?? true,
     };
 


### PR DESCRIPTION
## Proposed change

Expose the existing `color` option on `state-label-badge`. `hui-entity-badge` already supports a `color` config field (with the `ui_color` selector defaulting to `"state"`), but `hui-state-label-badge` and its editor were dropping the field when converting the legacy config to the entity-badge config — so users could not pick a color for state-label-badges.

This forwards `color` through both the runtime badge and the editor, so state-label-badges get the same tile-card-style color picker, applied to the icon via `--badge-color` with the automatic state-color fallback when no color is set.

Requested by a community member at the Home Assistant meetup in Rome.

## Screenshots

<!-- Add a screenshot of the color picker in the state-label-badge editor and an example badge with a custom color. -->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


---
_Generated by [Claude Code](https://claude.ai/code/session_01P8PswKDYa7UmbfbitpVRQT)_