### PR TITLE
Refactor energy dashboard card visibility to a single source of truth

### DIFF
--- a/src/panels/energy/strategies/energy-cards.ts
+++ b/src/panels/energy/strategies/energy-cards.ts
@@ -19,9 +19,11 @@ export type EnergyViewPath =
   | "now";
 
 // --- Applicability helpers -------------------------------------------------
-// These mirror, one-to-one, the conditions the individual view strategies use
-// to decide whether to emit a card. The catalog and the strategies must agree
-// on what "applicable" means, so the conditions live here and are reused.
+// Source-shape predicates shared by the catalog entries below, the view
+// strategies (for view-level decisions and badges), and the dashboard
+// strategy. Card applicability itself lives in the catalog: strategies decide
+// whether to emit a card through `isEnergyCardVisible()`, so they never
+// re-derive these conditions inline and can never disagree with the catalog.
 
 export const hasGridSource = (prefs: EnergyPreferences): boolean =>
   prefs.energy_sources.some(
@@ -40,6 +42,12 @@ export const hasSolar = (prefs: EnergyPreferences): boolean =>
 
 export const hasBattery = (prefs: EnergyPreferences): boolean =>
   prefs.energy_sources.some((source) => source.type === "battery");
+
+/** Any electricity-relevant source: grid, solar, or battery. */
+export const hasEnergySource = (prefs: EnergyPreferences): boolean =>
+  prefs.energy_sources.some((source) =>
+    ["grid", "solar", "battery"].includes(source.type)
+  );
 
 export const hasGasSource = (prefs: EnergyPreferences): boolean =>
   prefs.energy_sources.some((source) => source.type === "gas");
@@ -66,8 +74,20 @@ export const hasPowerSources = (prefs: EnergyPreferences): boolean =>
 export const hasPowerDevices = (prefs: EnergyPreferences): boolean =>
   prefs.device_consumption.some((device) => device.stat_rate);
 
-export const hasPowerWaterDevices = (prefs: EnergyPreferences): boolean =>
+export const hasWaterRateDevices = (prefs: EnergyPreferences): boolean =>
   (prefs.device_consumption_water ?? []).some((device) => device.stat_rate);
+
+/** A water source exposing a live flow-rate statistic. */
+export const hasWaterRateSource = (prefs: EnergyPreferences): boolean =>
+  prefs.energy_sources.some(
+    (source) => source.type === "water" && !!source.stat_rate
+  );
+
+/** A gas source exposing a live flow-rate statistic. */
+export const hasGasRateSource = (prefs: EnergyPreferences): boolean =>
+  prefs.energy_sources.some(
+    (source) => source.type === "gas" && !!source.stat_rate
+  );
 
 // --- Card catalog ----------------------------------------------------------
 
@@ -262,17 +282,49 @@ export const ENERGY_CARD_CATALOG: readonly EnergyCardCatalogEntry[] = [
     "now",
     "water-flow-sankey",
     "ui.panel.energy.cards.water_flow_sankey_title",
-    (p) => hasPowerWaterDevices(p)
+    (p) => hasWaterRateDevices(p)
   ),
 ];
 
 // --- Lookup helpers --------------------------------------------------------
+
+const ENERGY_CARD_CATALOG_BY_KEY = new Map<string, EnergyCardCatalogEntry>(
+  ENERGY_CARD_CATALOG.map((c) => [c.key, c])
+);
+
+/** The catalog entry for a `(view, cardType)` pair, or undefined if unknown. */
+export const energyCardEntry = (
+  view: EnergyViewPath,
+  cardType: string
+): EnergyCardCatalogEntry | undefined =>
+  ENERGY_CARD_CATALOG_BY_KEY.get(energyCardKey(view, cardType));
 
 export const isEnergyCardHidden = (
   view: EnergyViewPath,
   cardType: string,
   hidden: string[] | undefined
 ): boolean => !!hidden?.includes(energyCardKey(view, cardType));
+
+/**
+ * Single source of truth for whether a view strategy should emit a card: the
+ * card must be in the catalog, apply to the current preferences, and not be
+ * hidden by the user. Strategies call this instead of re-deriving the
+ * applicability conditions inline, so the catalog and the strategies can never
+ * disagree on what "applicable" means.
+ */
+export const isEnergyCardVisible = (
+  view: EnergyViewPath,
+  cardType: string,
+  prefs: EnergyPreferences,
+  hidden: string[] | undefined
+): boolean => {
+  const cardEntry = energyCardEntry(view, cardType);
+  return (
+    !!cardEntry &&
+    cardEntry.isApplicable(prefs) &&
+    !hidden?.includes(cardEntry.key)
+  );
+};
 
 /** Keys of all catalog cards that apply to the given preferences for a view. */
 export const applicableEnergyCardKeys = (

--- a/src/panels/energy/strategies/energy-dashboard-strategy.ts
+++ b/src/panels/energy/strategies/energy-dashboard-strategy.ts
@@ -16,7 +16,16 @@ import {
   DEFAULT_POWER_COLLECTION_KEY,
 } from "../constants";
 import type { EnergyViewPath } from "./energy-cards";
-import { isEnergyViewEmpty } from "./energy-cards";
+import {
+  hasDeviceConsumption,
+  hasEnergySource,
+  hasGasSource,
+  hasPowerDevices,
+  hasPowerSources,
+  hasWaterDevices,
+  hasWaterSource,
+  isEnergyViewEmpty,
+} from "./energy-cards";
 
 const OVERVIEW_VIEW = {
   path: "overview",
@@ -91,37 +100,18 @@ export class EnergyDashboardStrategy extends ReactiveElement {
       };
     }
 
-    const hasEnergy = prefs.energy_sources.some((source) =>
-      ["grid", "solar", "battery"].includes(source.type)
-    );
-
-    const hasPowerSource = prefs.energy_sources.some((source) => {
-      if (source.type === "solar" && source.stat_rate) return true;
-      if (source.type === "battery" && source.stat_rate) return true;
-      if (source.type === "grid") {
-        return !!source.stat_rate || !!source.power_config;
-      }
-      return false;
-    });
-
-    const hasDevicePower = prefs.device_consumption.some(
-      (device) => device.stat_rate
-    );
-
+    const hasEnergy = hasEnergySource(prefs);
+    const hasPowerSource = hasPowerSources(prefs);
+    const hasDevicePower = hasPowerDevices(prefs);
     const hasPower = hasPowerSource || hasDevicePower;
-
-    const hasWater =
-      prefs.energy_sources.some((source) => source.type === "water") ||
-      prefs.device_consumption_water?.length > 0;
-
-    const hasGas = prefs.energy_sources.some((source) => source.type === "gas");
-
-    const hasDeviceConsumption = prefs.device_consumption.length > 0;
+    const hasWater = hasWaterSource(prefs) || hasWaterDevices(prefs);
+    const hasGas = hasGasSource(prefs);
+    const hasDevices = hasDeviceConsumption(prefs);
 
     const hidden = _config.hidden_cards;
 
     const candidateViews: LovelaceStrategyViewConfig[] = [];
-    if (hasEnergy || hasDeviceConsumption) {
+    if (hasEnergy || hasDevices) {
       candidateViews.push(ENERGY_VIEW);
     }
     if (hasGas) {

--- a/src/panels/energy/strategies/energy-overview-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-overview-view-strategy.ts
@@ -1,13 +1,12 @@
 import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
-import type { GridSourceTypeEnergyPreference } from "../../../data/energy";
 import { getEnergyDataCollection } from "../../../data/energy";
 import type { HomeAssistant } from "../../../types";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { LovelaceStrategyDependency } from "../../lovelace/strategies/types";
 import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 import type { EnergyViewStrategyConfig } from "./energy-cards";
-import { isEnergyCardHidden } from "./energy-cards";
+import { hasWaterSource, isEnergyCardVisible } from "./energy-cards";
 
 @customElement("energy-overview-view-strategy")
 export class EnergyOverviewViewStrategy extends ReactiveElement {
@@ -53,35 +52,7 @@ export class EnergyOverviewViewStrategy extends ReactiveElement {
       return view;
     }
 
-    const hasGrid = prefs.energy_sources.find(
-      (source): source is GridSourceTypeEnergyPreference =>
-        source.type === "grid" &&
-        (!!source.stat_energy_from || !!source.stat_energy_to)
-    );
-    const hasGas = prefs.energy_sources.some((source) => source.type === "gas");
-    const hasBattery = prefs.energy_sources.some(
-      (source) => source.type === "battery"
-    );
-    const hasSolar = prefs.energy_sources.some(
-      (source) => source.type === "solar"
-    );
-    const hasWaterSources = prefs.energy_sources.some(
-      (source) => source.type === "water"
-    );
-    const hasWaterDevices = prefs.device_consumption_water?.length;
-    const hasPowerSources = prefs.energy_sources.find((source) => {
-      if (source.type === "solar" && source.stat_rate) return true;
-      if (source.type === "battery" && source.stat_rate) return true;
-      if (source.type === "grid") {
-        return !!source.stat_rate || !!source.power_config;
-      }
-      return false;
-    });
-
-    if (
-      (hasGrid || hasBattery || hasSolar) &&
-      !isEnergyCardHidden("overview", "energy-distribution", hidden)
-    ) {
+    if (isEnergyCardVisible("overview", "energy-distribution", prefs, hidden)) {
       view.sections!.push({
         type: "grid",
         cards: [
@@ -97,8 +68,7 @@ export class EnergyOverviewViewStrategy extends ReactiveElement {
     }
 
     if (
-      prefs.energy_sources.length &&
-      !isEnergyCardHidden("overview", "energy-sources-table", hidden)
+      isEnergyCardVisible("overview", "energy-sources-table", prefs, hidden)
     ) {
       view.sections!.push({
         type: "grid",
@@ -115,10 +85,7 @@ export class EnergyOverviewViewStrategy extends ReactiveElement {
       });
     }
 
-    if (
-      hasPowerSources &&
-      !isEnergyCardHidden("overview", "power-sources-graph", hidden)
-    ) {
+    if (isEnergyCardVisible("overview", "power-sources-graph", prefs, hidden)) {
       view.sections!.push({
         type: "grid",
         cards: [
@@ -134,10 +101,7 @@ export class EnergyOverviewViewStrategy extends ReactiveElement {
       });
     }
 
-    if (
-      (hasGrid || hasBattery) &&
-      !isEnergyCardHidden("overview", "energy-usage-graph", hidden)
-    ) {
+    if (isEnergyCardVisible("overview", "energy-usage-graph", prefs, hidden)) {
       view.sections!.push({
         type: "grid",
         cards: [
@@ -152,7 +116,7 @@ export class EnergyOverviewViewStrategy extends ReactiveElement {
       });
     }
 
-    if (hasGas && !isEnergyCardHidden("overview", "energy-gas-graph", hidden)) {
+    if (isEnergyCardVisible("overview", "energy-gas-graph", prefs, hidden)) {
       view.sections!.push({
         type: "grid",
         cards: [
@@ -167,14 +131,11 @@ export class EnergyOverviewViewStrategy extends ReactiveElement {
       });
     }
 
-    if (
-      (hasWaterSources || hasWaterDevices) &&
-      !isEnergyCardHidden("overview", "energy-water-graph", hidden)
-    ) {
+    if (isEnergyCardVisible("overview", "energy-water-graph", prefs, hidden)) {
       view.sections!.push({
         type: "grid",
         cards: [
-          hasWaterSources
+          hasWaterSource(prefs)
             ? {
                 title: hass.localize(
                   "ui.panel.energy.cards.energy_water_graph_title"

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -1,13 +1,12 @@
 import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
-import type { GridSourceTypeEnergyPreference } from "../../../data/energy";
 import { getEnergyDataCollection } from "../../../data/energy";
 import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
 import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 import type { EnergyViewStrategyConfig } from "./energy-cards";
-import { isEnergyCardHidden } from "./energy-cards";
+import { isEnergyCardVisible } from "./energy-cards";
 import { shouldShowFloorsAndAreas } from "./show-floors-and-areas";
 import {
   LARGE_SCREEN_CONDITION,
@@ -61,28 +60,12 @@ export class EnergyViewStrategy extends ReactiveElement {
       return view;
     }
 
-    const hasGrid = prefs.energy_sources.find(
-      (source): source is GridSourceTypeEnergyPreference =>
-        source.type === "grid" &&
-        (!!source.stat_energy_from || !!source.stat_energy_to)
-    );
-    const hasReturn = prefs.energy_sources.some(
-      (source) => source.type === "grid" && !!source.stat_energy_to
-    );
-    const hasSolar = prefs.energy_sources.some(
-      (source) => source.type === "solar"
-    );
-    const hasBattery = prefs.energy_sources.some(
-      (source) => source.type === "battery"
-    );
-
     const mainCards: LovelaceCardConfig[] = [];
     const gaugeCards: LovelaceCardConfig[] = [];
     const sidebarSection = view.sidebar!.sections![0];
 
     if (
-      (hasGrid || hasBattery || hasSolar) &&
-      !isEnergyCardHidden("electricity", "energy-distribution", hidden)
+      isEnergyCardVisible("electricity", "energy-distribution", prefs, hidden)
     ) {
       const distributionCard = {
         title: hass.localize("ui.panel.energy.cards.energy_distribution_title"),
@@ -100,9 +83,7 @@ export class EnergyViewStrategy extends ReactiveElement {
 
     // Only include if we have both grid import and export configured
     if (
-      hasGrid &&
-      hasReturn &&
-      !isEnergyCardHidden("electricity", "energy-grid-balance", hidden)
+      isEnergyCardVisible("electricity", "energy-grid-balance", prefs, hidden)
     ) {
       const gridResultCard = {
         type: "energy-grid-balance",
@@ -119,58 +100,62 @@ export class EnergyViewStrategy extends ReactiveElement {
 
     // Only include if we have a grid source & return.
     if (
-      hasReturn &&
-      !isEnergyCardHidden("electricity", "energy-grid-neutrality-gauge", hidden)
+      isEnergyCardVisible(
+        "electricity",
+        "energy-grid-neutrality-gauge",
+        prefs,
+        hidden
+      )
     ) {
-      const card = {
+      gaugeCards.push({
         type: "energy-grid-neutrality-gauge",
         collection_key: collectionKey,
-      };
-      gaugeCards.push(card);
+      });
     }
 
-    // Only include if we have a solar source.
-    if (hasSolar) {
-      if (
-        hasReturn &&
-        !isEnergyCardHidden(
-          "electricity",
-          "energy-solar-consumed-gauge",
-          hidden
-        )
-      ) {
-        const card = {
-          type: "energy-solar-consumed-gauge",
-          collection_key: collectionKey,
-        };
-        gaugeCards.push(card);
-      }
-      if (
-        hasGrid &&
-        !isEnergyCardHidden(
-          "electricity",
-          "energy-self-sufficiency-gauge",
-          hidden
-        )
-      ) {
-        const card = {
-          type: "energy-self-sufficiency-gauge",
-          collection_key: collectionKey,
-        };
-        gaugeCards.push(card);
-      }
+    // Only include if we have a solar source & return.
+    if (
+      isEnergyCardVisible(
+        "electricity",
+        "energy-solar-consumed-gauge",
+        prefs,
+        hidden
+      )
+    ) {
+      gaugeCards.push({
+        type: "energy-solar-consumed-gauge",
+        collection_key: collectionKey,
+      });
+    }
+
+    // Only include if we have a solar source & grid.
+    if (
+      isEnergyCardVisible(
+        "electricity",
+        "energy-self-sufficiency-gauge",
+        prefs,
+        hidden
+      )
+    ) {
+      gaugeCards.push({
+        type: "energy-self-sufficiency-gauge",
+        collection_key: collectionKey,
+      });
     }
 
     // Only include if we have a grid
     if (
-      hasGrid &&
-      !isEnergyCardHidden("electricity", "energy-carbon-consumed-gauge", hidden)
+      isEnergyCardVisible(
+        "electricity",
+        "energy-carbon-consumed-gauge",
+        prefs,
+        hidden
+      )
     ) {
-      const card = {
+      gaugeCards.push({
         type: "energy-carbon-consumed-gauge",
         collection_key: collectionKey,
-      };
-      gaugeCards.push(card);
+      });
     }
 
     if (gaugeCards.length) {
@@ -201,8 +186,7 @@ export class EnergyViewStrategy extends ReactiveElement {
 
     // Only include if we have a grid or battery.
     if (
-      (hasGrid || hasBattery) &&
-      !isEnergyCardHidden("electricity", "energy-usage-graph", hidden)
+      isEnergyCardVisible("electricity", "energy-usage-graph", prefs, hidden)
     ) {
       mainCards.push({
         title: hass.localize("ui.panel.energy.cards.energy_usage_graph_title"),
@@ -214,8 +198,7 @@ export class EnergyViewStrategy extends ReactiveElement {
 
     // Only include if we have a solar source.
     if (
-      hasSolar &&
-      !isEnergyCardHidden("electricity", "energy-solar-graph", hidden)
+      isEnergyCardVisible("electricity", "energy-solar-graph", prefs, hidden)
     ) {
       mainCards.push({
         title: hass.localize("ui.panel.energy.cards.energy_solar_graph_title"),
@@ -226,8 +209,7 @@ export class EnergyViewStrategy extends ReactiveElement {
     }
 
     if (
-      (hasGrid || hasSolar || hasBattery) &&
-      !isEnergyCardHidden("electricity", "energy-sources-table", hidden)
+      isEnergyCardVisible("electricity", "energy-sources-table", prefs, hidden)
     ) {
       mainCards.push({
         title: hass.localize(
@@ -240,49 +222,50 @@ export class EnergyViewStrategy extends ReactiveElement {
       });
     }
 
-    // Only include if we have at least 1 device in the config.
-    if (prefs.device_consumption.length) {
-      if (
-        !isEnergyCardHidden(
-          "electricity",
-          "energy-devices-detail-graph",
-          hidden
-        )
-      ) {
-        mainCards.push({
-          title: hass.localize(
-            "ui.panel.energy.cards.energy_devices_detail_graph_title"
-          ),
-          type: "energy-devices-detail-graph",
-          collection_key: collectionKey,
-          grid_options: { columns: 36 },
-        });
-      }
-      if (!isEnergyCardHidden("electricity", "energy-devices-graph", hidden)) {
-        mainCards.push({
-          title: hass.localize(
-            "ui.panel.energy.cards.energy_devices_graph_title"
-          ),
-          type: "energy-devices-graph",
-          collection_key: collectionKey,
-          grid_options: { columns: 36 },
-        });
-      }
-      if (!isEnergyCardHidden("electricity", "energy-sankey", hidden)) {
-        const showFloorsAndAreas = shouldShowFloorsAndAreas(
-          prefs.device_consumption,
-          hass,
-          (d) => d.stat_consumption
-        );
-        mainCards.push({
-          title: hass.localize("ui.panel.energy.cards.energy_sankey_title"),
-          type: "energy-sankey",
-          collection_key: collectionKey,
-          group_by_floor: showFloorsAndAreas,
-          group_by_area: showFloorsAndAreas,
-          grid_options: { columns: 36 },
-        });
-      }
+    // Device cards: each only included if we have at least 1 device configured.
+    if (
+      isEnergyCardVisible(
+        "electricity",
+        "energy-devices-detail-graph",
+        prefs,
+        hidden
+      )
+    ) {
+      mainCards.push({
+        title: hass.localize(
+          "ui.panel.energy.cards.energy_devices_detail_graph_title"
+        ),
+        type: "energy-devices-detail-graph",
+        collection_key: collectionKey,
+        grid_options: { columns: 36 },
+      });
+    }
+    if (
+      isEnergyCardVisible("electricity", "energy-devices-graph", prefs, hidden)
+    ) {
+      mainCards.push({
+        title: hass.localize(
+          "ui.panel.energy.cards.energy_devices_graph_title"
+        ),
+        type: "energy-devices-graph",
+        collection_key: collectionKey,
+        grid_options: { columns: 36 },
+      });
+    }
+    if (isEnergyCardVisible("electricity", "energy-sankey", prefs, hidden)) {
+      const showFloorsAndAreas = shouldShowFloorsAndAreas(
+        prefs.device_consumption,
+        hass,
+        (d) => d.stat_consumption
+      );
+      mainCards.push({
+        title: hass.localize("ui.panel.energy.cards.energy_sankey_title"),
+        type: "energy-sankey",
+        collection_key: collectionKey,
+        group_by_floor: showFloorsAndAreas,
+        group_by_area: showFloorsAndAreas,
+        grid_options: { columns: 36 },
+      });
     }
 
     view.sections!.push({

--- a/src/panels/energy/strategies/gas-view-strategy.ts
+++ b/src/panels/energy/strategies/gas-view-strategy.ts
@@ -5,7 +5,7 @@ import type { HomeAssistant } from "../../../types";
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 import type { EnergyViewStrategyConfig } from "./energy-cards";
-import { isEnergyCardHidden } from "./energy-cards";
+import { hasGasSource, isEnergyCardVisible } from "./energy-cards";
 import type { LovelaceSectionConfig } from "../../../data/lovelace/config/section";
 import type { LovelaceStrategyDependency } from "../../lovelace/strategies/types";
 
@@ -43,12 +43,8 @@ export class GasViewStrategy extends ReactiveElement {
     }
     const prefs = energyCollection.prefs;
 
-    const hasGasSources = prefs?.energy_sources.some(
-      (source) => source.type === "gas"
-    );
-
     // No gas sources available
-    if (!prefs || !hasGasSources) {
+    if (!prefs || !hasGasSource(prefs)) {
       return view;
     }
 
@@ -62,7 +58,7 @@ export class GasViewStrategy extends ReactiveElement {
       },
     });
 
-    if (!isEnergyCardHidden("gas", "energy-gas-graph", hidden)) {
+    if (isEnergyCardVisible("gas", "energy-gas-graph", prefs, hidden)) {
       section.cards!.push({
         title: hass.localize("ui.panel.energy.cards.energy_gas_graph_title"),
         type: "energy-gas-graph",
@@ -73,7 +69,7 @@ export class GasViewStrategy extends ReactiveElement {
       });
     }
 
-    if (!isEnergyCardHidden("gas", "energy-sources-table", hidden)) {
+    if (isEnergyCardVisible("gas", "energy-sources-table", prefs, hidden)) {
       section.cards!.push({
         title: hass.localize(
           "ui.panel.energy.cards.energy_sources_table_title"

--- a/src/panels/energy/strategies/power-view-strategy.ts
+++ b/src/panels/energy/strategies/power-view-strategy.ts
@@ -5,7 +5,14 @@ import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { HomeAssistant } from "../../../types";
 import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 import type { EnergyViewStrategyConfig } from "./energy-cards";
-import { isEnergyCardHidden } from "./energy-cards";
+import {
+  hasGasRateSource,
+  hasPowerDevices,
+  hasPowerSources,
+  hasWaterRateDevices,
+  hasWaterRateSource,
+  isEnergyCardVisible,
+} from "./energy-cards";
 import { shouldShowFloorsAndAreas } from "./show-floors-and-areas";
 import type { LovelaceSectionConfig } from "../../../data/lovelace/config/section";
 import type { LovelaceBadgeConfig } from "../../../data/lovelace/config/badge";
@@ -31,27 +38,6 @@ export class PowerViewStrategy extends ReactiveElement {
     }
     const prefs = energyCollection.prefs;
 
-    const hasPowerSources = prefs?.energy_sources.some((source) => {
-      if (source.type === "solar" && source.stat_rate) return true;
-      if (source.type === "battery" && source.stat_rate) return true;
-      if (source.type === "grid") {
-        return !!source.stat_rate || !!source.power_config;
-      }
-      return false;
-    });
-    const hasPowerDevices = prefs?.device_consumption.some(
-      (device) => device.stat_rate
-    );
-    const hasWaterDevices = prefs?.device_consumption_water.some(
-      (device) => device.stat_rate
-    );
-    const hasWaterSources = prefs?.energy_sources.some(
-      (source) => source.type === "water" && source.stat_rate
-    );
-    const hasGasSources = prefs?.energy_sources.some(
-      (source) => source.type === "gas" && source.stat_rate
-    );
-
     const chartsSection: LovelaceSectionConfig = {
       type: "grid",
       cards: [],
@@ -63,46 +49,50 @@ export class PowerViewStrategy extends ReactiveElement {
       sections: [chartsSection],
     };
 
+    const hasPowerSrc = !!prefs && hasPowerSources(prefs);
+    const hasPowerDev = !!prefs && hasPowerDevices(prefs);
+    const hasWaterDev = !!prefs && hasWaterRateDevices(prefs);
+    const hasWaterSrc = !!prefs && hasWaterRateSource(prefs);
+    const hasGasSrc = !!prefs && hasGasRateSource(prefs);
+
     // No sources configured
     if (
       !prefs ||
-      (!hasPowerSources &&
-        !hasPowerDevices &&
-        !hasWaterDevices &&
-        !hasWaterSources &&
-        !hasGasSources)
+      (!hasPowerSrc &&
+        !hasPowerDev &&
+        !hasWaterDev &&
+        !hasWaterSrc &&
+        !hasGasSrc)
     ) {
       return view;
     }
 
-    if (hasPowerSources) {
+    if (hasPowerSrc) {
       badges.push({
         type: "power-total",
         collection_key: collectionKey,
       });
-
-      if (!isEnergyCardHidden("now", "power-sources-graph", hidden)) {
-        chartsSection.cards!.push({
-          title: hass.localize(
-            "ui.panel.energy.cards.power_sources_graph_title"
-          ),
-          type: "power-sources-graph",
-          collection_key: collectionKey,
-          grid_options: {
-            columns: 36,
-          },
-        });
-      }
     }
 
-    if (hasGasSources) {
+    if (isEnergyCardVisible("now", "power-sources-graph", prefs, hidden)) {
+      chartsSection.cards!.push({
+        title: hass.localize("ui.panel.energy.cards.power_sources_graph_title"),
+        type: "power-sources-graph",
+        collection_key: collectionKey,
+        grid_options: {
+          columns: 36,
+        },
+      });
+    }
+
+    if (hasGasSrc) {
       badges.push({
         type: "gas-total",
         collection_key: collectionKey,
       });
     }
 
-    if (hasWaterSources) {
+    if (hasWaterSrc) {
       badges.push({
         type: "water-total",
         collection_key: collectionKey,
@@ -118,7 +108,7 @@ export class PowerViewStrategy extends ReactiveElement {
       }
     });
 
-    if (hasPowerDevices && !isEnergyCardHidden("now", "power-sankey", hidden)) {
+    if (isEnergyCardVisible("now", "power-sankey", prefs, hidden)) {
       const showFloorsAndAreas = shouldShowFloorsAndAreas(
         prefs.device_consumption,
         hass,
@@ -136,10 +126,7 @@ export class PowerViewStrategy extends ReactiveElement {
       });
     }
 
-    if (
-      hasWaterDevices &&
-      !isEnergyCardHidden("now", "water-flow-sankey", hidden)
-    ) {
+    if (isEnergyCardVisible("now", "water-flow-sankey", prefs, hidden)) {
       const showFloorsAndAreas = shouldShowFloorsAndAreas(
         prefs.device_consumption_water,
         hass,

--- a/src/panels/energy/strategies/water-view-strategy.ts
+++ b/src/panels/energy/strategies/water-view-strategy.ts
@@ -7,7 +7,11 @@ import type { HomeAssistant } from "../../../types";
 import type { LovelaceStrategyDependency } from "../../lovelace/strategies/types";
 import { DEFAULT_ENERGY_COLLECTION_KEY } from "../constants";
 import type { EnergyViewStrategyConfig } from "./energy-cards";
-import { isEnergyCardHidden } from "./energy-cards";
+import {
+  hasWaterDevices,
+  hasWaterSource,
+  isEnergyCardVisible,
+} from "./energy-cards";
 import { shouldShowFloorsAndAreas } from "./show-floors-and-areas";
 
 @customElement("water-view-strategy")
@@ -44,13 +48,8 @@ export class WaterViewStrategy extends ReactiveElement {
     }
     const prefs = energyCollection.prefs;
 
-    const hasWaterSources = prefs?.energy_sources.some(
-      (source) => source.type === "water"
-    );
-    const hasWaterDevices = prefs?.device_consumption_water?.length;
-
-    // No water sources available
-    if (!prefs || (!hasWaterDevices && !hasWaterSources)) {
+    // No water sources or devices available
+    if (!prefs || (!hasWaterDevices(prefs) && !hasWaterSource(prefs))) {
       return view;
     }
 
@@ -64,39 +63,33 @@ export class WaterViewStrategy extends ReactiveElement {
       },
     });
 
-    if (hasWaterSources) {
-      if (!isEnergyCardHidden("water", "energy-water-graph", hidden)) {
-        section.cards!.push({
-          title: hass.localize(
-            "ui.panel.energy.cards.energy_water_graph_title"
-          ),
-          type: "energy-water-graph",
-          collection_key: collectionKey,
-          grid_options: {
-            columns: 24,
-          },
-        });
-      }
-      if (!isEnergyCardHidden("water", "energy-sources-table", hidden)) {
-        section.cards!.push({
-          title: hass.localize(
-            "ui.panel.energy.cards.energy_sources_table_title"
-          ),
-          type: "energy-sources-table",
-          collection_key: collectionKey,
-          types: ["water"],
-          grid_options: {
-            columns: 12,
-          },
-        });
-      }
+    if (isEnergyCardVisible("water", "energy-water-graph", prefs, hidden)) {
+      section.cards!.push({
+        title: hass.localize("ui.panel.energy.cards.energy_water_graph_title"),
+        type: "energy-water-graph",
+        collection_key: collectionKey,
+        grid_options: {
+          columns: 24,
+        },
+      });
+    }
+
+    if (isEnergyCardVisible("water", "energy-sources-table", prefs, hidden)) {
+      section.cards!.push({
+        title: hass.localize(
+          "ui.panel.energy.cards.energy_sources_table_title"
+        ),
+        type: "energy-sources-table",
+        collection_key: collectionKey,
+        types: ["water"],
+        grid_options: {
+          columns: 12,
+        },
+      });
     }
 
     // Only include if we have at least 1 water device in the config.
-    if (
-      hasWaterDevices &&
-      !isEnergyCardHidden("water", "water-sankey", hidden)
-    ) {
+    if (isEnergyCardVisible("water", "water-sankey", prefs, hidden)) {
       const showFloorsAndAreas = shouldShowFloorsAndAreas(
         prefs.device_consumption_water,
         hass,

--- a/test/panels/energy/strategies/energy-cards.test.ts
+++ b/test/panels/energy/strategies/energy-cards.test.ts
@@ -7,7 +7,11 @@ import {
   applicableEnergyCardKeys,
   ENERGY_CARD_CATALOG,
   energyCardKey,
+  hasEnergySource,
+  hasGasRateSource,
+  hasWaterRateSource,
   isEnergyCardHidden,
+  isEnergyCardVisible,
   isEnergyViewEmpty,
 } from "../../../../src/panels/energy/strategies/energy-cards";
 
@@ -31,6 +35,16 @@ const GRID_RETURN = source({
 const SOLAR = source({ type: "solar", stat_energy_from: "sensor.solar" });
 const GAS = source({ type: "gas", stat_energy_from: "sensor.gas" });
 const WATER = source({ type: "water", stat_energy_from: "sensor.water" });
+const GAS_RATE = source({
+  type: "gas",
+  stat_energy_from: "sensor.gas",
+  stat_rate: "sensor.gas_rate",
+});
+const WATER_RATE = source({
+  type: "water",
+  stat_energy_from: "sensor.water",
+  stat_rate: "sensor.water_rate",
+});
 
 describe("energyCardKey", () => {
   it("joins the view path and card type", () => {
@@ -126,5 +140,88 @@ describe("isEnergyViewEmpty", () => {
   it("is false when the view has no applicable cards at all", () => {
     // Water source configured, but the gas view has nothing applicable.
     expect(isEnergyViewEmpty("gas", prefs, [])).toBe(false);
+  });
+});
+
+describe("source predicates", () => {
+  it("hasEnergySource matches grid/solar/battery sources only", () => {
+    expect(hasEnergySource(makePrefs({ energy_sources: [SOLAR] }))).toBe(true);
+    expect(hasEnergySource(makePrefs({ energy_sources: [GRID_RETURN] }))).toBe(
+      true
+    );
+    expect(hasEnergySource(makePrefs({ energy_sources: [GAS, WATER] }))).toBe(
+      false
+    );
+  });
+
+  it("hasWaterRateSource / hasGasRateSource require a rate statistic", () => {
+    expect(hasWaterRateSource(makePrefs({ energy_sources: [WATER] }))).toBe(
+      false
+    );
+    expect(
+      hasWaterRateSource(makePrefs({ energy_sources: [WATER_RATE] }))
+    ).toBe(true);
+    expect(hasGasRateSource(makePrefs({ energy_sources: [GAS] }))).toBe(false);
+    expect(hasGasRateSource(makePrefs({ energy_sources: [GAS_RATE] }))).toBe(
+      true
+    );
+  });
+});
+
+describe("isEnergyCardVisible", () => {
+  const solarPrefs = makePrefs({ energy_sources: [SOLAR] });
+
+  it("is true when the card applies and is not hidden", () => {
+    expect(
+      isEnergyCardVisible(
+        "electricity",
+        "energy-solar-graph",
+        solarPrefs,
+        undefined
+      )
+    ).toBe(true);
+  });
+
+  it("is false when the card applies but is hidden", () => {
+    expect(
+      isEnergyCardVisible("electricity", "energy-solar-graph", solarPrefs, [
+        "electricity.energy-solar-graph",
+      ])
+    ).toBe(false);
+  });
+
+  it("is false when the card does not apply to the preferences", () => {
+    // No solar source -> the solar graph never applies, hidden or not.
+    expect(
+      isEnergyCardVisible(
+        "electricity",
+        "energy-solar-graph",
+        makePrefs({ energy_sources: [GRID_RETURN] }),
+        undefined
+      )
+    ).toBe(false);
+  });
+
+  it("is false for a card type that is not in the catalog for the view", () => {
+    expect(
+      isEnergyCardVisible("gas", "energy-solar-graph", solarPrefs, undefined)
+    ).toBe(false);
+  });
+
+  it("equals isApplicable && !hidden for every catalog entry", () => {
+    // A config that exercises every source type, so many cards apply.
+    const richPrefs = makePrefs({
+      energy_sources: [GRID_RETURN, SOLAR, GAS, WATER],
+    });
+    for (const card of ENERGY_CARD_CATALOG) {
+      const cardType = card.key.slice(card.view.length + 1);
+      expect(
+        isEnergyCardVisible(card.view, cardType, richPrefs, undefined)
+      ).toBe(card.isApplicable(richPrefs));
+      // Hiding the card's own key always wins.
+      expect(
+        isEnergyCardVisible(card.view, cardType, richPrefs, [card.key])
+      ).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Which energy dashboard cards are shown depends on the user's energy configuration. Until now that "is this card applicable?" logic lived in two places: the declarative `ENERGY_CARD_CATALOG` (already consumed by the customise dialog and the dashboard strategy), and re-implemented inline in each of the five view strategies — a duplication the catalog's own comment flagged as a drift risk.

This makes the catalog the single source of truth. The view strategies and the dashboard strategy now decide whether to emit a card through a shared `isEnergyCardVisible(view, cardType, prefs, hidden)` helper backed by the catalog, instead of re-deriving the conditions inline. Card layout and config building stay in the strategies, since they are genuinely per-view.

The change is behavior-preserving and adds a contract test pinning `isEnergyCardVisible` to the catalog's `isApplicable` for every entry.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

No visual changes — behavior-preserving refactor.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
