### PR TITLE
Add editable duration to timer more-info dialog

### DIFF
--- a/src/data/timer.ts
+++ b/src/data/timer.ts
@@ -3,8 +3,10 @@ import type {
   HassEntityAttributeBase,
   HassEntityBase,
 } from "home-assistant-js-websocket";
+import { createDurationData } from "../common/datetime/create_duration_data";
 import durationToSeconds from "../common/datetime/duration_to_seconds";
 import secondsToDuration from "../common/datetime/seconds_to_duration";
+import type { HaDurationData } from "../components/ha-duration-input";
 import type { HomeAssistant } from "../types";
 
 export type TimerEntity = HassEntityBase & {
@@ -100,3 +102,11 @@ export const computeDisplayTimer = (
 
   return display;
 };
+
+// Prefill for the duration input: always the configured duration, independent
+// of the live countdown. The field is meant to be edited, not to mirror the
+// remaining time.
+export const timerDurationData = (
+  stateObj: HassEntity
+): HaDurationData | undefined =>
+  createDurationData(stateObj.attributes.duration);

--- a/src/dialogs/more-info/controls/more-info-timer.ts
+++ b/src/dialogs/more-info/controls/more-info-timer.ts
@@ -1,8 +1,12 @@
+import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import "../../../components/ha-button";
+import "../../../components/ha-duration-input";
+import type { HaDurationData } from "../../../components/ha-duration-input";
 import type { TimerEntity } from "../../../data/timer";
-import type { HomeAssistant } from "../../../types";
+import { timerDurationData } from "../../../data/timer";
+import type { HomeAssistant, ValueChangedEvent } from "../../../types";
 
 @customElement("more-info-timer")
 class MoreInfoTimer extends LitElement {
@@ -10,26 +14,46 @@ class MoreInfoTimer extends LitElement {
 
   @property({ attribute: false }) public stateObj?: TimerEntity;
 
+  @state() private _duration?: HaDurationData;
+
+  protected willUpdate(changedProps: PropertyValues<this>): void {
+    super.willUpdate(changedProps);
+    // Seed the field once from the configured duration and keep it static,
+    // so it never jumps to the live remaining time as the timer ticks.
+    if (this._duration === undefined && this.stateObj) {
+      this._duration = timerDurationData(this.stateObj);
+    }
+  }
+
   protected render() {
     if (!this.hass || !this.stateObj) {
       return nothing;
     }
 
+    const timerState = this.stateObj.state;
+
     return html`
+      <ha-duration-input
+        .data=${this._duration}
+        required
+        @value-changed=${this._durationChanged}
+      ></ha-duration-input>
       <div class="actions">
-        ${this.stateObj.state === "idle" || this.stateObj.state === "paused"
+        ${timerState === "idle"
           ? html`
-              <ha-button
-                appearance="plain"
-                size="s"
-                .action=${"start"}
-                @click=${this._handleActionClick}
-              >
-                ${this.hass!.localize("ui.card.timer.actions.start")}
+              <ha-button appearance="plain" size="s" @click=${this._start}>
+                ${this.hass.localize("ui.card.timer.actions.start")}
               </ha-button>
             `
-          : ""}
-        ${this.stateObj.state === "active"
+          : nothing}
+        ${timerState === "active" || timerState === "paused"
+          ? html`
+              <ha-button appearance="plain" size="s" @click=${this._start}>
+                ${this.hass.localize("ui.card.timer.actions.set")}
+              </ha-button>
+            `
+          : nothing}
+        ${timerState === "active"
           ? html`
               <ha-button
                 appearance="plain"
@@ -37,11 +61,23 @@ class MoreInfoTimer extends LitElement {
                 .action=${"pause"}
                 @click=${this._handleActionClick}
               >
-                ${this.hass!.localize("ui.card.timer.actions.pause")}
+                ${this.hass.localize("ui.card.timer.actions.pause")}
               </ha-button>
             `
-          : ""}
-        ${this.stateObj.state === "active" || this.stateObj.state === "paused"
+          : nothing}
+        ${timerState === "paused"
+          ? html`
+              <ha-button
+                appearance="plain"
+                size="s"
+                .action=${"start"}
+                @click=${this._handleActionClick}
+              >
+                ${this.hass.localize("ui.card.timer.actions.start")}
+              </ha-button>
+            `
+          : nothing}
+        ${timerState === "active" || timerState === "paused"
           ? html`
               <ha-button
                 appearance="plain"
@@ -49,7 +85,7 @@ class MoreInfoTimer extends LitElement {
                 .action=${"cancel"}
                 @click=${this._handleActionClick}
               >
-                ${this.hass!.localize("ui.card.timer.actions.cancel")}
+                ${this.hass.localize("ui.card.timer.actions.cancel")}
               </ha-button>
               <ha-button
                 appearance="plain"
@@ -57,12 +93,28 @@ class MoreInfoTimer extends LitElement {
                 .action=${"finish"}
                 @click=${this._handleActionClick}
               >
-                ${this.hass!.localize("ui.card.timer.actions.finish")}
+                ${this.hass.localize("ui.card.timer.actions.finish")}
               </ha-button>
             `
-          : ""}
+          : nothing}
       </div>
     `;
+  }
+
+  private _durationChanged(
+    ev: ValueChangedEvent<HaDurationData | undefined>
+  ): void {
+    this._duration = ev.detail.value;
+  }
+
+  // Used by idle "Start" and active/paused "Set": (re)starts the timer with the
+  // entered duration. timer.start has no upper bound, so values beyond the
+  // configured duration are accepted.
+  private _start(): void {
+    this.hass.callService("timer", "start", {
+      entity_id: this.stateObj!.entity_id,
+      ...(this._duration ? { duration: this._duration } : {}),
+    });
   }
 
   private _handleActionClick(e: MouseEvent): void {
@@ -73,10 +125,16 @@ class MoreInfoTimer extends LitElement {
   }
 
   static styles = css`
+    ha-duration-input {
+      display: flex;
+      justify-content: center;
+      margin: var(--ha-space-4) 0 var(--ha-space-2);
+    }
     .actions {
       margin: var(--ha-space-2) 0;
       display: flex;
       flex-wrap: wrap;
+      gap: var(--ha-space-2);
       justify-content: center;
     }
   `;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -312,7 +312,8 @@
           "start": "Start",
           "pause": "Pause",
           "cancel": "Cancel",
-          "finish": "Finish"
+          "finish": "Finish",
+          "set": "Set"
         }
       },
       "vacuum": {

--- a/test/data/timer.test.ts
+++ b/test/data/timer.test.ts
@@ -1,0 +1,45 @@
+import { assert, describe, it } from "vitest";
+
+import { timerDurationData } from "../../src/data/timer";
+
+describe("timerDurationData", () => {
+  it("derives the input prefill from the configured duration", () => {
+    assert.deepEqual(
+      timerDurationData({
+        state: "idle",
+        attributes: {
+          duration: "0:03:00",
+          remaining: "0:03:00",
+        },
+      } as any),
+      { hours: 0, minutes: 3, seconds: 0, milliseconds: 0 }
+    );
+  });
+
+  it("uses the configured duration, not the remaining time, when running", () => {
+    assert.deepEqual(
+      timerDurationData({
+        state: "active",
+        attributes: {
+          duration: "2:00:00",
+          remaining: "1:30:00",
+          finishes_at: "2018-01-17T16:16:35Z",
+        },
+      } as any),
+      { hours: 2, minutes: 0, seconds: 0, milliseconds: 0 }
+    );
+  });
+
+  it("handles durations beyond an hour", () => {
+    assert.deepEqual(
+      timerDurationData({
+        state: "idle",
+        attributes: {
+          duration: "3:30:00",
+          remaining: "3:30:00",
+        },
+      } as any),
+      { hours: 3, minutes: 30, seconds: 0, milliseconds: 0 }
+    );
+  });
+});


### PR DESCRIPTION
Lets you set or change a timer's countdown directly from the more-info dialog via timer.start, including durations beyond the configured maximum.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
N/A

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The timer -> more-info dialog previously only allowed Start / Pause / Cancel / Finish. The countdown duration could only be changed in the timer helper's settings.

However, there are use cases when I wanted to have more control over that duration right before starting it (like a classical egg timer).

This adds an editable duration field (`ha-duration-input`) to the dialog:

- Idle: the field is prefilled with the pre-configured duration. Optionally edit it and press **Start** to run the timer for a one-off duration without changing the saved default.

- Active / paused: enter a value and press **Set** to (re)start the countdown from it — including durations beyond the configured maximum.

It reuses the existing `timer.start` action's `duration` parameter, so there are no backend changes required. The field is seeded once from the configured duration and stays static (it does not mirror the live countdown - otherwise editing it while timer is running would be hard to do). The existing buttons all keep their current behavior.

It does not reconfigure the default duration of the timer, instead it's meant to customize the duration of the next timer start only. That was not possible yet, you had to a) go into the timer settings to change duration and b) the change was permanent. Now you can have and keep the pre-defined default setting (e.g. 2 hours) but can also selectively override it with another duration (e.g. 3h) before start. On next execution timer will again be at its default (2h).

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
Before:
<img width="591" height="230" alt="before" src="https://github.com/user-attachments/assets/2204e7cb-558d-488d-b233-d971ab1bef76" />

After (stopped)
<img width="589" height="302" alt="stopped" src="https://github.com/user-attachments/assets/87847f1d-49df-418d-8840-00b47b5750cb" />

After (running)
<img width="589" height="302" alt="running" src="https://github.com/user-attachments/assets/0688bb79-0eda-4013-a83d-00ea66ccea7e" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: no backend changes required

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
