### PR TITLE
Split negative untracked energy into a toggleable series

### DIFF
--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -366,6 +366,42 @@ export function computeStatMidpoint(
   return (start + end) / 2;
 }
 
+export interface UntrackedSplit {
+  /** Untracked consumption per timestamp, clamped to >= 0. */
+  positive: Record<number, number>;
+  /** Negative untracked per timestamp — only timestamps where the raw value
+   * was below zero (tracked devices reported more than total consumption). */
+  negative: Record<number, number>;
+}
+
+/**
+ * Split untracked energy consumption into positive and negative parts per
+ * timestamp.
+ *
+ * Untracked is `used_total - sum(tracked device consumption)`. It can go
+ * negative when meters report at coarser resolution than device sensors
+ * (e.g. an integer-kWh grid meter vs fractional device sensors). The positive
+ * part is the genuine untracked consumption; the negative part is surfaced as
+ * a separate, toggleable series so users can hide it without losing it as a
+ * diagnostic signal.
+ */
+export function splitUntrackedConsumption(
+  usedTotal: Record<number, number>,
+  totalDeviceConsumption: Record<number, number>
+): UntrackedSplit {
+  const positive: Record<number, number> = {};
+  const negative: Record<number, number> = {};
+  for (const time of Object.keys(usedTotal)) {
+    const ts = Number(time);
+    const raw = usedTotal[ts] - (totalDeviceConsumption[ts] || 0);
+    positive[ts] = Math.max(0, raw);
+    if (raw < 0) {
+      negative[ts] = raw;
+    }
+  }
+  return { positive, negative };
+}
+
 export function getCompareTransform(start: Date, compareStart?: Date) {
   if (!compareStart) {
     return (ts: Date) => ts;

--- a/src/panels/lovelace/cards/energy/energy-devices-detail-graph-data.ts
+++ b/src/panels/lovelace/cards/energy/energy-devices-detail-graph-data.ts
@@ -24,6 +24,7 @@ import {
   type EnergyDataPoint,
   fillDataGapsAndRoundCaps,
   getCompareTransform,
+  splitUntrackedConsumption,
 } from "./common/energy-chart-options";
 import { getEnergyColor } from "./common/color";
 
@@ -211,7 +212,7 @@ function processUntracked(
   consumptionData,
   trackY: (v: number) => void,
   compare: boolean
-): BarSeriesOption {
+): { dataset: BarSeriesOption; negativeDataset: BarSeriesOption } {
   const totalDeviceConsumption: Record<number, number> = {};
 
   processedData.forEach((device) => {
@@ -223,7 +224,16 @@ function processUntracked(
   const compareTransform = getCompareTransform(ctx.start, ctx.compareStart!);
   const period = getSuggestedPeriod(ctx.start, ctx.end);
 
+  // Split untracked into its positive part (genuine untracked consumption) and
+  // its negative part (tracked devices over-reporting relative to the meter).
+  // The negative part becomes a separate, toggleable series.
+  const { positive, negative } = splitUntrackedConsumption(
+    consumptionData.used_total,
+    totalDeviceConsumption
+  );
+
   const untrackedConsumption: BarSeriesOption["data"] = [];
+  const negativeUntracked: BarSeriesOption["data"] = [];
   const sortedTimes = Object.keys(consumptionData.used_total).sort(
     (a, b) => Number(a) - Number(b)
   );
@@ -235,24 +245,30 @@ function processUntracked(
       : 0;
   sortedTimes.forEach((time) => {
     const ts = Number(time);
-    const value =
-      consumptionData.used_total[time] - (totalDeviceConsumption[time] || 0);
-    const dataPoint: EnergyDataPoint = [ts + periodOffset, value, ts];
-    if (compare) {
-      dataPoint[0] = compareTransform(new Date(ts)).getTime() + periodOffset;
+    const x = compare
+      ? compareTransform(new Date(ts)).getTime() + periodOffset
+      : ts + periodOffset;
+    untrackedConsumption.push([x, positive[ts], ts]);
+    trackY(positive[ts]);
+    if (ts in negative) {
+      negativeUntracked.push([x, negative[ts], ts]);
+      trackY(negative[ts]);
     }
-    untrackedConsumption.push(dataPoint);
-    trackY(value);
   });
   // random id to always add untracked at the end
   const order = ctx.untrackedOrder;
-  const dataset: BarSeriesOption = {
+  const stack = compare ? "devicesCompare" : "devices";
+  // The positive untracked and negative ("over-reported") series share styling
+  // and stack, differing only by id, name and data.
+  const makeDataset = (
+    id: string,
+    name: string,
+    data: BarSeriesOption["data"]
+  ): BarSeriesOption => ({
     type: "bar",
     cursor: "default",
-    id: compare ? `compare-untracked-${order}` : `untracked-${order}`,
-    name: ctx.hass.localize(
-      "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption"
-    ),
+    id,
+    name,
     itemStyle: {
       borderColor: getEnergyColor(
         computedStyle,
@@ -270,11 +286,43 @@ function processUntracked(
       compare,
       "--history-unknown-color"
     ),
-    data: untrackedConsumption,
-    stack: compare ? "devicesCompare" : "devices",
-  };
-  return dataset;
+    data,
+    stack,
+  });
+  const dataset = makeDataset(
+    compare ? `compare-untracked-${order}` : `untracked-${order}`,
+    ctx.hass.localize(
+      "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption"
+    ),
+    untrackedConsumption
+  );
+  // Only added by the caller when it has data.
+  const negativeDataset = makeDataset(
+    compare
+      ? `compare-untracked-negative-${order}`
+      : `untracked-negative-${order}`,
+    ctx.hass.localize(
+      "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption"
+    ),
+    negativeUntracked
+  );
+  return { dataset, negativeDataset };
 }
+
+// Legend item for an untracked series (positive or negative): not tied to an
+// entity, so the label isn't clickable, and paired with its compare series.
+const untrackedLegendItem = (
+  dataset: BarSeriesOption
+): NonNullable<CustomLegendOption["data"]>[number] => ({
+  id: dataset.id as string,
+  secondaryIds: [`compare-${dataset.id}`],
+  name: dataset.name as string,
+  itemStyle: {
+    color: dataset.color as string,
+    borderColor: dataset.itemStyle?.borderColor as string,
+  },
+  noLabelClick: true,
+});
 
 /**
  * Transforms an `EnergyData` collection update into the ECharts bar series and
@@ -366,6 +414,7 @@ export function generateEnergyDevicesDetailGraphData(
     ? computeConsumptionData(summedData, compareSummedData)
     : { consumption: undefined, compareConsumption: undefined };
 
+  let compareNegativeDataset: BarSeriesOption | undefined;
   if (compareData) {
     const processedCompareData = processDataSet(
       ctx,
@@ -382,15 +431,22 @@ export function generateEnergyDevicesDetailGraphData(
     datasets.push(...processedCompareData);
 
     if (showUntracked) {
-      const untrackedCompareData = processUntracked(
-        ctx,
-        computedStyles,
-        processedCompareData,
-        consumptionCompareData,
-        trackY,
-        true
-      );
+      const { dataset: untrackedCompareData, negativeDataset } =
+        processUntracked(
+          ctx,
+          computedStyles,
+          processedCompareData,
+          consumptionCompareData,
+          trackY,
+          true
+        );
       datasets.push(untrackedCompareData);
+      compareNegativeDataset = negativeDataset;
+      // Keep the compare negative series grouped with the other compare series
+      // (before the placeholder), mirroring the positive untracked placement.
+      if (negativeDataset.data?.length) {
+        datasets.push(negativeDataset);
+      }
     }
   }
 
@@ -430,7 +486,7 @@ export function generateEnergyDevicesDetailGraphData(
   });
 
   if (showUntracked) {
-    const untrackedData = processUntracked(
+    const { dataset: untrackedData, negativeDataset } = processUntracked(
       ctx,
       computedStyles,
       processedData,
@@ -439,16 +495,20 @@ export function generateEnergyDevicesDetailGraphData(
       false
     );
     datasets.push(untrackedData);
-    legendData.push({
-      id: untrackedData.id as string,
-      secondaryIds: [`compare-${untrackedData.id}`],
-      name: untrackedData.name as string,
-      itemStyle: {
-        color: untrackedData.color as string,
-        borderColor: untrackedData.itemStyle?.borderColor as string,
-      },
-      noLabelClick: true,
-    });
+    legendData.push(untrackedLegendItem(untrackedData));
+
+    // Only surface the negative untracked series (and its legend item) when
+    // either the main or compare period actually has negative values, so users
+    // with clean data don't get extra chart clutter. The compare series is
+    // pushed in the compare block above to keep series order consistent.
+    const hasNegative = !!negativeDataset.data?.length;
+    const hasCompareNegative = !!compareNegativeDataset?.data?.length;
+    if (hasNegative) {
+      datasets.push(negativeDataset);
+    }
+    if (hasNegative || hasCompareNegative) {
+      legendData.push(untrackedLegendItem(negativeDataset));
+    }
   }
 
   fillDataGapsAndRoundCaps(datasets);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8741,6 +8741,7 @@
             },
             "energy_devices_detail_graph": {
               "untracked_consumption": "Untracked consumption",
+              "over_reported_consumption": "Over-reported consumption",
               "untracked": "untracked",
               "other": "Other"
             },

--- a/test/panels/lovelace/cards/energy/__snapshots__/hui-energy-devices-detail-graph-data.test.ts.snap
+++ b/test/panels/lovelace/cards/energy/__snapshots__/hui-energy-devices-detail-graph-data.test.ts.snap
@@ -11,8 +11,8 @@ exports[`generateEnergyDevicesDetailGraphData > large month-of-hourly digest is 
     "start",
     "yAxisFractionDigits",
   ],
-  "numberCount": 17123,
-  "numberSum": "1.25739511128e+16",
+  "numberCount": 20100,
+  "numberSum": "1.51115931576e+16",
   "type": "object",
 }
 `;
@@ -28,8 +28,8 @@ exports[`generateEnergyDevicesDetailGraphData > large month-of-hourly digest is 
     "start",
     "yAxisFractionDigits",
   ],
-  "numberCount": 45386,
-  "numberSum": "3.14878576464e+16",
+  "numberCount": 53571,
+  "numberSum": "3.78242823564e+16",
   "type": "object",
 }
 `;
@@ -7408,6 +7408,2900 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot for 5minute per
       "data": [
         {
           "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704067350000,
+            0,
+            1704067200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704067650000,
+            0,
+            1704067500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704067950000,
+            0,
+            1704067800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704068250000,
+            0,
+            1704068100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704068550000,
+            0,
+            1704068400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704068850000,
+            0,
+            1704068700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704069150000,
+            0,
+            1704069000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704069450000,
+            0,
+            1704069300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704069750000,
+            0,
+            1704069600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704070050000,
+            0,
+            1704069900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704070350000,
+            0,
+            1704070200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704070650000,
+            0,
+            1704070500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704070950000,
+            0,
+            1704070800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704071250000,
+            0,
+            1704071100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704071550000,
+            0,
+            1704071400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704071850000,
+            0,
+            1704071700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704072150000,
+            0,
+            1704072000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704072450000,
+            0,
+            1704072300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704072750000,
+            0,
+            1704072600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704073050000,
+            0,
+            1704072900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704073350000,
+            0,
+            1704073200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704073650000,
+            0,
+            1704073500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704073950000,
+            0,
+            1704073800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704074250000,
+            0,
+            1704074100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704074550000,
+            0,
+            1704074400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704074850000,
+            0,
+            1704074700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704075150000,
+            0,
+            1704075000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704075450000,
+            0,
+            1704075300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704075750000,
+            0,
+            1704075600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704076050000,
+            0,
+            1704075900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704076350000,
+            0,
+            1704076200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704076650000,
+            0,
+            1704076500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704076950000,
+            0,
+            1704076800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704077250000,
+            0,
+            1704077100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704077550000,
+            0,
+            1704077400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704077850000,
+            0,
+            1704077700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704078150000,
+            0,
+            1704078000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704078450000,
+            0,
+            1704078300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704078750000,
+            0,
+            1704078600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704079050000,
+            0,
+            1704078900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704079350000,
+            0,
+            1704079200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704079650000,
+            0,
+            1704079500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704079950000,
+            0,
+            1704079800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704080250000,
+            0,
+            1704080100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704080550000,
+            0,
+            1704080400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704080850000,
+            0,
+            1704080700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704081150000,
+            0,
+            1704081000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704081450000,
+            0,
+            1704081300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704081750000,
+            0,
+            1704081600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704082050000,
+            0,
+            1704081900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704082350000,
+            0,
+            1704082200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704082650000,
+            0,
+            1704082500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704082950000,
+            0,
+            1704082800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704083250000,
+            0,
+            1704083100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704083550000,
+            0,
+            1704083400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704083850000,
+            0,
+            1704083700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704084150000,
+            0,
+            1704084000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704084450000,
+            0,
+            1704084300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704084750000,
+            0,
+            1704084600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704085050000,
+            0,
+            1704084900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704085350000,
+            0,
+            1704085200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704085650000,
+            0,
+            1704085500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704085950000,
+            0,
+            1704085800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704086250000,
+            0,
+            1704086100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704086550000,
+            0,
+            1704086400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704086850000,
+            0,
+            1704086700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704087150000,
+            0,
+            1704087000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704087450000,
+            0,
+            1704087300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704087750000,
+            0,
+            1704087600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704088050000,
+            0,
+            1704087900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704088350000,
+            0,
+            1704088200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704088650000,
+            0,
+            1704088500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704088950000,
+            0,
+            1704088800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704089250000,
+            0,
+            1704089100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704089550000,
+            0,
+            1704089400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704089850000,
+            0,
+            1704089700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704090150000,
+            0,
+            1704090000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704090450000,
+            0,
+            1704090300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704090750000,
+            0,
+            1704090600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704091050000,
+            0,
+            1704090900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704091350000,
+            0,
+            1704091200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704091650000,
+            0,
+            1704091500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704091950000,
+            0,
+            1704091800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704092250000,
+            0,
+            1704092100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704092550000,
+            0,
+            1704092400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704092850000,
+            0,
+            1704092700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704093150000,
+            0,
+            1704093000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704093450000,
+            0,
+            1704093300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704093750000,
+            0,
+            1704093600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704094050000,
+            0,
+            1704093900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704094350000,
+            0,
+            1704094200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704094650000,
+            0,
+            1704094500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704094950000,
+            0,
+            1704094800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704095250000,
+            0,
+            1704095100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704095550000,
+            0,
+            1704095400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704095850000,
+            0,
+            1704095700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704096150000,
+            0,
+            1704096000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704096450000,
+            0,
+            1704096300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704096750000,
+            0,
+            1704096600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704097050000,
+            0,
+            1704096900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704097350000,
+            0,
+            1704097200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704097650000,
+            0,
+            1704097500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704097950000,
+            0,
+            1704097800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704098250000,
+            0,
+            1704098100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704098550000,
+            0,
+            1704098400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704098850000,
+            0,
+            1704098700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704099150000,
+            0,
+            1704099000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704099450000,
+            0,
+            1704099300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704099750000,
+            0,
+            1704099600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704100050000,
+            0,
+            1704099900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704100350000,
+            0,
+            1704100200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704100650000,
+            0,
+            1704100500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704100950000,
+            0,
+            1704100800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704101250000,
+            0,
+            1704101100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704101550000,
+            0,
+            1704101400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704101850000,
+            0,
+            1704101700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704102150000,
+            0,
+            1704102000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704102450000,
+            0,
+            1704102300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704102750000,
+            0,
+            1704102600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704103050000,
+            0,
+            1704102900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704103350000,
+            0,
+            1704103200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704103650000,
+            0,
+            1704103500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704103950000,
+            0,
+            1704103800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704104250000,
+            0,
+            1704104100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704104550000,
+            0,
+            1704104400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704104850000,
+            0,
+            1704104700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704105150000,
+            0,
+            1704105000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704105450000,
+            0,
+            1704105300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704105750000,
+            0,
+            1704105600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704106050000,
+            0,
+            1704105900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704106350000,
+            0,
+            1704106200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704106650000,
+            0,
+            1704106500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704106950000,
+            0,
+            1704106800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704107250000,
+            0,
+            1704107100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704107550000,
+            0,
+            1704107400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704107850000,
+            0,
+            1704107700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704108150000,
+            0,
+            1704108000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704108450000,
+            0,
+            1704108300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704108750000,
+            0,
+            1704108600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704109050000,
+            0,
+            1704108900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704109350000,
+            0,
+            1704109200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704109650000,
+            0,
+            1704109500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704109950000,
+            0,
+            1704109800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704110250000,
+            0,
+            1704110100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704110550000,
+            0,
+            1704110400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704110850000,
+            0,
+            1704110700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704111150000,
+            0,
+            1704111000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704111450000,
+            0,
+            1704111300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704111750000,
+            0,
+            1704111600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704112050000,
+            0,
+            1704111900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704112350000,
+            0,
+            1704112200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704112650000,
+            0,
+            1704112500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704112950000,
+            0,
+            1704112800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704113250000,
+            0,
+            1704113100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704113550000,
+            0,
+            1704113400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704113850000,
+            0,
+            1704113700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704114150000,
+            0,
+            1704114000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704114450000,
+            0,
+            1704114300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704114750000,
+            0,
+            1704114600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704115050000,
+            0,
+            1704114900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704115350000,
+            0,
+            1704115200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704115650000,
+            0,
+            1704115500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704115950000,
+            0,
+            1704115800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704116250000,
+            0,
+            1704116100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704116550000,
+            0,
+            1704116400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704116850000,
+            0,
+            1704116700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704117150000,
+            0,
+            1704117000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704117450000,
+            0,
+            1704117300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704117750000,
+            0,
+            1704117600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704118050000,
+            0,
+            1704117900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704118350000,
+            0,
+            1704118200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704118650000,
+            0,
+            1704118500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704118950000,
+            0,
+            1704118800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704119250000,
+            0,
+            1704119100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704119550000,
+            0,
+            1704119400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704119850000,
+            0,
+            1704119700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704120150000,
+            0,
+            1704120000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704120450000,
+            0,
+            1704120300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704120750000,
+            0,
+            1704120600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704121050000,
+            0,
+            1704120900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704121350000,
+            0,
+            1704121200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704121650000,
+            0,
+            1704121500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704121950000,
+            0,
+            1704121800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704122250000,
+            0,
+            1704122100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704122550000,
+            0,
+            1704122400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704122850000,
+            0,
+            1704122700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704123150000,
+            0,
+            1704123000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704123450000,
+            0,
+            1704123300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704123750000,
+            0,
+            1704123600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704124050000,
+            0,
+            1704123900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704124350000,
+            0,
+            1704124200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704124650000,
+            0,
+            1704124500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704124950000,
+            0,
+            1704124800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704125250000,
+            0,
+            1704125100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704125550000,
+            0,
+            1704125400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704125850000,
+            0,
+            1704125700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704126150000,
+            0,
+            1704126000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704126450000,
+            0,
+            1704126300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704126750000,
+            0,
+            1704126600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704127050000,
+            0,
+            1704126900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704127350000,
+            0,
+            1704127200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704127650000,
+            0,
+            1704127500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704127950000,
+            0,
+            1704127800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704128250000,
+            0,
+            1704128100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704128550000,
+            0,
+            1704128400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704128850000,
+            0,
+            1704128700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704129150000,
+            0,
+            1704129000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704129450000,
+            0,
+            1704129300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704129750000,
+            0,
+            1704129600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704130050000,
+            0,
+            1704129900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704130350000,
+            0,
+            1704130200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704130650000,
+            0,
+            1704130500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704130950000,
+            0,
+            1704130800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704131250000,
+            0,
+            1704131100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704131550000,
+            0,
+            1704131400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704131850000,
+            0,
+            1704131700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704132150000,
+            0,
+            1704132000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704132450000,
+            0,
+            1704132300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704132750000,
+            0,
+            1704132600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704133050000,
+            0,
+            1704132900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704133350000,
+            0,
+            1704133200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704133650000,
+            0,
+            1704133500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704133950000,
+            0,
+            1704133800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704134250000,
+            0,
+            1704134100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704134550000,
+            0,
+            1704134400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704134850000,
+            0,
+            1704134700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704135150000,
+            0,
+            1704135000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704135450000,
+            0,
+            1704135300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704135750000,
+            0,
+            1704135600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704136050000,
+            0,
+            1704135900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704136350000,
+            0,
+            1704136200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704136650000,
+            0,
+            1704136500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704136950000,
+            0,
+            1704136800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704137250000,
+            0,
+            1704137100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704137550000,
+            0,
+            1704137400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704137850000,
+            0,
+            1704137700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704138150000,
+            0,
+            1704138000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704138450000,
+            0,
+            1704138300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704138750000,
+            0,
+            1704138600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704139050000,
+            0,
+            1704138900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704139350000,
+            0,
+            1704139200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704139650000,
+            0,
+            1704139500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704139950000,
+            0,
+            1704139800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704140250000,
+            0,
+            1704140100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704140550000,
+            0,
+            1704140400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704140850000,
+            0,
+            1704140700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704141150000,
+            0,
+            1704141000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704141450000,
+            0,
+            1704141300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704141750000,
+            0,
+            1704141600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704142050000,
+            0,
+            1704141900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704142350000,
+            0,
+            1704142200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704142650000,
+            0,
+            1704142500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704142950000,
+            0,
+            1704142800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704143250000,
+            0,
+            1704143100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704143550000,
+            0,
+            1704143400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704143850000,
+            0,
+            1704143700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704144150000,
+            0,
+            1704144000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704144450000,
+            0,
+            1704144300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704144750000,
+            0,
+            1704144600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704145050000,
+            0,
+            1704144900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704145350000,
+            0,
+            1704145200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704145650000,
+            0,
+            1704145500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704145950000,
+            0,
+            1704145800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704146250000,
+            0,
+            1704146100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704146550000,
+            0,
+            1704146400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704146850000,
+            0,
+            1704146700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704147150000,
+            0,
+            1704147000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704147450000,
+            0,
+            1704147300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704147750000,
+            0,
+            1704147600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704148050000,
+            0,
+            1704147900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704148350000,
+            0,
+            1704148200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704148650000,
+            0,
+            1704148500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704148950000,
+            0,
+            1704148800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704149250000,
+            0,
+            1704149100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704149550000,
+            0,
+            1704149400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704149850000,
+            0,
+            1704149700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704150150000,
+            0,
+            1704150000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704150450000,
+            0,
+            1704150300000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704150750000,
+            0,
+            1704150600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704151050000,
+            0,
+            1704150900000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704151350000,
+            0,
+            1704151200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704151650000,
+            0,
+            1704151500000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704151950000,
+            0,
+            1704151800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704152250000,
+            0,
+            1704152100000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704152550000,
+            0,
+            1704152400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704152850000,
+            0,
+            1704152700000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704153150000,
+            0,
+            1704153000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704153450000,
+            0,
+            1704153300000,
+          ],
+        },
+      ],
+      "id": "untracked-1706745600000",
+      "itemStyle": {
+        "borderColor": "#888888",
+      },
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "stack": "devices",
+      "type": "bar",
+    },
+    {
+      "barMaxWidth": 50,
+      "color": "#8888887F",
+      "cursor": "default",
+      "data": [
+        {
+          "itemStyle": {
             "borderRadius": [
               0,
               0,
@@ -11727,11 +14621,11 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot for 5minute per
           ],
         },
       ],
-      "id": "untracked-1706745600000",
+      "id": "untracked-negative-1706745600000",
       "itemStyle": {
         "borderColor": "#888888",
       },
-      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption",
       "stack": "devices",
       "type": "bar",
     },
@@ -11786,6 +14680,18 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot for 5minute per
       "noLabelClick": true,
       "secondaryIds": [
         "compare-untracked-1706745600000",
+      ],
+    },
+    {
+      "id": "untracked-negative-1706745600000",
+      "itemStyle": {
+        "borderColor": "#888888",
+        "color": "#8888887F",
+      },
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption",
+      "noLabelClick": true,
+      "secondaryIds": [
+        "compare-untracked-negative-1706745600000",
       ],
     },
   ],
@@ -12508,6 +15414,260 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot for a small hou
       "data": [
         {
           "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704069000000,
+            0,
+            1704067200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704072600000,
+            0,
+            1704070800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704076200000,
+            0,
+            1704074400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704079800000,
+            0,
+            1704078000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704083400000,
+            0,
+            1704081600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704087000000,
+            0,
+            1704085200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704090600000,
+            0,
+            1704088800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704094200000,
+            0,
+            1704092400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704097800000,
+            0,
+            1704096000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704101400000,
+            0,
+            1704099600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704105000000,
+            0,
+            1704103200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704108600000,
+            0,
+            1704106800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704112200000,
+            0,
+            1704110400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704115800000,
+            0,
+            1704114000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704119400000,
+            0,
+            1704117600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704123000000,
+            0,
+            1704121200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704126600000,
+            0,
+            1704124800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704130200000,
+            0,
+            1704128400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704133800000,
+            0,
+            1704132000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704137400000,
+            0,
+            1704135600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704141000000,
+            0,
+            1704139200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704144600000,
+            0,
+            1704142800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704148200000,
+            0,
+            1704146400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704151800000,
+            0,
+            1704150000000,
+          ],
+        },
+      ],
+      "id": "untracked-1706745600000",
+      "itemStyle": {
+        "borderColor": "#888888",
+      },
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "stack": "devices",
+      "type": "bar",
+    },
+    {
+      "barMaxWidth": 50,
+      "color": "#8888887F",
+      "cursor": "default",
+      "data": [
+        {
+          "itemStyle": {
             "borderRadius": [
               0,
               0,
@@ -12867,11 +16027,11 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot for a small hou
           ],
         },
       ],
-      "id": "untracked-1706745600000",
+      "id": "untracked-negative-1706745600000",
       "itemStyle": {
         "borderColor": "#888888",
       },
-      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption",
       "stack": "devices",
       "type": "bar",
     },
@@ -12926,6 +16086,18 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot for a small hou
       "noLabelClick": true,
       "secondaryIds": [
         "compare-untracked-1706745600000",
+      ],
+    },
+    {
+      "id": "untracked-negative-1706745600000",
+      "itemStyle": {
+        "borderColor": "#888888",
+        "color": "#8888887F",
+      },
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption",
+      "noLabelClick": true,
+      "secondaryIds": [
+        "compare-untracked-negative-1706745600000",
       ],
     },
   ],
@@ -13214,6 +16386,90 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot for daily perio
       "data": [
         {
           "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704067200000,
+            0,
+            1704067200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704153600000,
+            0,
+            1704153600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704240000000,
+            0,
+            1704240000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704326400000,
+            0,
+            1704326400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704412800000,
+            0,
+            1704412800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704499200000,
+            0,
+            1704499200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704585600000,
+            0,
+            1704585600000,
+          ],
+        },
+      ],
+      "id": "untracked-1706745600000",
+      "itemStyle": {
+        "borderColor": "#888888",
+      },
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "stack": "devices",
+      "type": "bar",
+    },
+    {
+      "barMaxWidth": 50,
+      "color": "#8888887F",
+      "cursor": "default",
+      "data": [
+        {
+          "itemStyle": {
             "borderRadius": [
               0,
               0,
@@ -13318,11 +16574,11 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot for daily perio
           ],
         },
       ],
-      "id": "untracked-1706745600000",
+      "id": "untracked-negative-1706745600000",
       "itemStyle": {
         "borderColor": "#888888",
       },
-      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption",
       "stack": "devices",
       "type": "bar",
     },
@@ -13377,6 +16633,18 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot for daily perio
       "noLabelClick": true,
       "secondaryIds": [
         "compare-untracked-1706745600000",
+      ],
+    },
+    {
+      "id": "untracked-negative-1706745600000",
+      "itemStyle": {
+        "borderColor": "#888888",
+        "color": "#8888887F",
+      },
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption",
+      "noLabelClick": true,
+      "secondaryIds": [
+        "compare-untracked-negative-1706745600000",
       ],
     },
   ],
@@ -14250,6 +17518,260 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot with child devi
       "data": [
         {
           "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704069000000,
+            0,
+            1704067200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704072600000,
+            0,
+            1704070800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704076200000,
+            0,
+            1704074400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704079800000,
+            0,
+            1704078000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704083400000,
+            0,
+            1704081600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704087000000,
+            0,
+            1704085200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704090600000,
+            0,
+            1704088800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704094200000,
+            0,
+            1704092400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704097800000,
+            0,
+            1704096000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704101400000,
+            0,
+            1704099600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704105000000,
+            0,
+            1704103200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704108600000,
+            0,
+            1704106800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704112200000,
+            0,
+            1704110400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704115800000,
+            0,
+            1704114000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704119400000,
+            0,
+            1704117600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704123000000,
+            0,
+            1704121200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704126600000,
+            0,
+            1704124800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704130200000,
+            0,
+            1704128400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704133800000,
+            0,
+            1704132000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704137400000,
+            0,
+            1704135600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704141000000,
+            0,
+            1704139200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704144600000,
+            0,
+            1704142800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704148200000,
+            0,
+            1704146400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704151800000,
+            0,
+            1704150000000,
+          ],
+        },
+      ],
+      "id": "untracked-1706745600000",
+      "itemStyle": {
+        "borderColor": "#888888",
+      },
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "stack": "devices",
+      "type": "bar",
+    },
+    {
+      "barMaxWidth": 50,
+      "color": "#8888887F",
+      "cursor": "default",
+      "data": [
+        {
+          "itemStyle": {
             "borderRadius": [
               0,
               0,
@@ -14609,11 +18131,11 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot with child devi
           ],
         },
       ],
-      "id": "untracked-1706745600000",
+      "id": "untracked-negative-1706745600000",
       "itemStyle": {
         "borderColor": "#888888",
       },
-      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption",
       "stack": "devices",
       "type": "bar",
     },
@@ -14680,6 +18202,18 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot with child devi
       "noLabelClick": true,
       "secondaryIds": [
         "compare-untracked-1706745600000",
+      ],
+    },
+    {
+      "id": "untracked-negative-1706745600000",
+      "itemStyle": {
+        "borderColor": "#888888",
+        "color": "#8888887F",
+      },
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption",
+      "noLabelClick": true,
+      "secondaryIds": [
+        "compare-untracked-negative-1706745600000",
       ],
     },
   ],
@@ -15340,6 +18874,260 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot with compare da
       "data": [
         {
           "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1703982600000,
+            0,
+            1703980800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1703986200000,
+            0,
+            1703984400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1703989800000,
+            0,
+            1703988000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1703993400000,
+            0,
+            1703991600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1703997000000,
+            0,
+            1703995200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704000600000,
+            0,
+            1703998800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704004200000,
+            0,
+            1704002400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704007800000,
+            0,
+            1704006000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704011400000,
+            0,
+            1704009600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704015000000,
+            0,
+            1704013200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704018600000,
+            0,
+            1704016800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704022200000,
+            0,
+            1704020400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704025800000,
+            0,
+            1704024000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704029400000,
+            0,
+            1704027600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704033000000,
+            0,
+            1704031200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704036600000,
+            0,
+            1704034800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704040200000,
+            0,
+            1704038400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704043800000,
+            0,
+            1704042000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704047400000,
+            0,
+            1704045600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704051000000,
+            0,
+            1704049200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704054600000,
+            0,
+            1704052800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704058200000,
+            0,
+            1704056400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704061800000,
+            0,
+            1704060000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704065400000,
+            0,
+            1704063600000,
+          ],
+        },
+      ],
+      "id": "compare-untracked-1706745600000",
+      "itemStyle": {
+        "borderColor": "#8888887F",
+      },
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "stack": "devicesCompare",
+      "type": "bar",
+    },
+    {
+      "barMaxWidth": 50,
+      "color": "#88888832",
+      "cursor": "default",
+      "data": [
+        {
+          "itemStyle": {
             "borderRadius": [
               0,
               0,
@@ -15699,11 +19487,11 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot with compare da
           ],
         },
       ],
-      "id": "compare-untracked-1706745600000",
+      "id": "compare-untracked-negative-1706745600000",
       "itemStyle": {
         "borderColor": "#8888887F",
       },
-      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption",
       "stack": "devicesCompare",
       "type": "bar",
     },
@@ -17230,6 +21018,476 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot with compare da
         },
         {
           "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704069000000,
+            0,
+            1704067200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704072600000,
+            0,
+            1704070800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704076200000,
+            0,
+            1704074400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704079800000,
+            0,
+            1704078000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704083400000,
+            0,
+            1704081600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704087000000,
+            0,
+            1704085200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704090600000,
+            0,
+            1704088800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704094200000,
+            0,
+            1704092400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704097800000,
+            0,
+            1704096000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704101400000,
+            0,
+            1704099600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704105000000,
+            0,
+            1704103200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704108600000,
+            0,
+            1704106800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704112200000,
+            0,
+            1704110400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704115800000,
+            0,
+            1704114000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704119400000,
+            0,
+            1704117600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704123000000,
+            0,
+            1704121200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704126600000,
+            0,
+            1704124800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704130200000,
+            0,
+            1704128400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704133800000,
+            0,
+            1704132000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704137400000,
+            0,
+            1704135600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704141000000,
+            0,
+            1704139200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704144600000,
+            0,
+            1704142800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704148200000,
+            0,
+            1704146400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704151800000,
+            0,
+            1704150000000,
+          ],
+        },
+      ],
+      "id": "untracked-1706745600000",
+      "itemStyle": {
+        "borderColor": "#888888",
+      },
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "stack": "devices",
+      "type": "bar",
+    },
+    {
+      "barMaxWidth": 50,
+      "color": "#8888887F",
+      "cursor": "default",
+      "data": [
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1703982600000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1703986200000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1703989800000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1703993400000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1703997000000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704000600000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704004200000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704007800000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704011400000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704015000000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704018600000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704022200000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704025800000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704029400000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704033000000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704036600000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704040200000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704043800000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704047400000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704051000000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704054600000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704058200000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704061800000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704065400000,
+            0,
+          ],
+        },
+        {
+          "itemStyle": {
             "borderRadius": [
               0,
               0,
@@ -17589,11 +21847,11 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot with compare da
           ],
         },
       ],
-      "id": "untracked-1706745600000",
+      "id": "untracked-negative-1706745600000",
       "itemStyle": {
         "borderColor": "#888888",
       },
-      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption",
       "stack": "devices",
       "type": "bar",
     },
@@ -17648,6 +21906,18 @@ exports[`generateEnergyDevicesDetailGraphData > matches snapshot with compare da
       "noLabelClick": true,
       "secondaryIds": [
         "compare-untracked-1706745600000",
+      ],
+    },
+    {
+      "id": "untracked-negative-1706745600000",
+      "itemStyle": {
+        "borderColor": "#888888",
+        "color": "#8888887F",
+      },
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption",
+      "noLabelClick": true,
+      "secondaryIds": [
+        "compare-untracked-negative-1706745600000",
       ],
     },
   ],
@@ -18153,6 +22423,295 @@ exports[`generateEnergyDevicesDetailGraphData > respects max_devices config 1`] 
       "data": [
         {
           "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704069000000,
+            0,
+            1704067200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704072600000,
+            0,
+            1704070800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704076200000,
+            0,
+            1704074400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704079800000,
+            0,
+            1704078000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderRadius": [
+              4,
+              4,
+              0,
+              0,
+            ],
+          },
+          "value": [
+            1704083400000,
+            0.1379999999999999,
+            1704081600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderRadius": [
+              4,
+              4,
+              0,
+              0,
+            ],
+          },
+          "value": [
+            1704087000000,
+            0.4450000000000003,
+            1704085200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704090600000,
+            0,
+            1704088800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderRadius": [
+              4,
+              4,
+              0,
+              0,
+            ],
+          },
+          "value": [
+            1704094200000,
+            0.3660000000000001,
+            1704092400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderRadius": [
+              4,
+              4,
+              0,
+              0,
+            ],
+          },
+          "value": [
+            1704097800000,
+            0.9510000000000001,
+            1704096000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704101400000,
+            0,
+            1704099600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704105000000,
+            0,
+            1704103200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704108600000,
+            0,
+            1704106800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderRadius": [
+              4,
+              4,
+              0,
+              0,
+            ],
+          },
+          "value": [
+            1704112200000,
+            0.3420000000000001,
+            1704110400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704115800000,
+            0,
+            1704114000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderRadius": [
+              4,
+              4,
+              0,
+              0,
+            ],
+          },
+          "value": [
+            1704119400000,
+            1.323,
+            1704117600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704123000000,
+            0,
+            1704121200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704126600000,
+            0,
+            1704124800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704130200000,
+            0,
+            1704128400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704133800000,
+            0,
+            1704132000000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704137400000,
+            0,
+            1704135600000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704141000000,
+            0,
+            1704139200000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704144600000,
+            0,
+            1704142800000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderWidth": 0,
+          },
+          "value": [
+            1704148200000,
+            0,
+            1704146400000,
+          ],
+        },
+        {
+          "itemStyle": {
+            "borderRadius": [
+              4,
+              4,
+              0,
+              0,
+            ],
+          },
+          "value": [
+            1704151800000,
+            0.34099999999999975,
+            1704150000000,
+          ],
+        },
+      ],
+      "id": "untracked-1706745600000",
+      "itemStyle": {
+        "borderColor": "#888888",
+      },
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "stack": "devices",
+      "type": "bar",
+    },
+    {
+      "barMaxWidth": 50,
+      "color": "#8888887F",
+      "cursor": "default",
+      "data": [
+        {
+          "itemStyle": {
             "borderRadius": [
               0,
               0,
@@ -18213,32 +22772,20 @@ exports[`generateEnergyDevicesDetailGraphData > respects max_devices config 1`] 
         },
         {
           "itemStyle": {
-            "borderRadius": [
-              4,
-              4,
-              0,
-              0,
-            ],
+            "borderWidth": 0,
           },
           "value": [
             1704083400000,
-            0.1379999999999999,
-            1704081600000,
+            0,
           ],
         },
         {
           "itemStyle": {
-            "borderRadius": [
-              4,
-              4,
-              0,
-              0,
-            ],
+            "borderWidth": 0,
           },
           "value": [
             1704087000000,
-            0.4450000000000003,
-            1704085200000,
+            0,
           ],
         },
         {
@@ -18258,32 +22805,20 @@ exports[`generateEnergyDevicesDetailGraphData > respects max_devices config 1`] 
         },
         {
           "itemStyle": {
-            "borderRadius": [
-              4,
-              4,
-              0,
-              0,
-            ],
+            "borderWidth": 0,
           },
           "value": [
             1704094200000,
-            0.3660000000000001,
-            1704092400000,
+            0,
           ],
         },
         {
           "itemStyle": {
-            "borderRadius": [
-              4,
-              4,
-              0,
-              0,
-            ],
+            "borderWidth": 0,
           },
           "value": [
             1704097800000,
-            0.9510000000000001,
-            1704096000000,
+            0,
           ],
         },
         {
@@ -18333,17 +22868,11 @@ exports[`generateEnergyDevicesDetailGraphData > respects max_devices config 1`] 
         },
         {
           "itemStyle": {
-            "borderRadius": [
-              4,
-              4,
-              0,
-              0,
-            ],
+            "borderWidth": 0,
           },
           "value": [
             1704112200000,
-            0.3420000000000001,
-            1704110400000,
+            0,
           ],
         },
         {
@@ -18363,17 +22892,11 @@ exports[`generateEnergyDevicesDetailGraphData > respects max_devices config 1`] 
         },
         {
           "itemStyle": {
-            "borderRadius": [
-              4,
-              4,
-              0,
-              0,
-            ],
+            "borderWidth": 0,
           },
           "value": [
             1704119400000,
-            1.323,
-            1704117600000,
+            0,
           ],
         },
         {
@@ -18496,27 +23019,12 @@ exports[`generateEnergyDevicesDetailGraphData > respects max_devices config 1`] 
             1704146400000,
           ],
         },
-        {
-          "itemStyle": {
-            "borderRadius": [
-              4,
-              4,
-              0,
-              0,
-            ],
-          },
-          "value": [
-            1704151800000,
-            0.34099999999999975,
-            1704150000000,
-          ],
-        },
       ],
-      "id": "untracked-1706745600000",
+      "id": "untracked-negative-1706745600000",
       "itemStyle": {
         "borderColor": "#888888",
       },
-      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption",
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption",
       "stack": "devices",
       "type": "bar",
     },
@@ -18559,6 +23067,18 @@ exports[`generateEnergyDevicesDetailGraphData > respects max_devices config 1`] 
       "noLabelClick": true,
       "secondaryIds": [
         "compare-untracked-1706745600000",
+      ],
+    },
+    {
+      "id": "untracked-negative-1706745600000",
+      "itemStyle": {
+        "borderColor": "#888888",
+        "color": "#8888887F",
+      },
+      "name": "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption",
+      "noLabelClick": true,
+      "secondaryIds": [
+        "compare-untracked-negative-1706745600000",
       ],
     },
   ],

--- a/test/panels/lovelace/cards/energy/common/energy-chart-options.test.ts
+++ b/test/panels/lovelace/cards/energy/common/energy-chart-options.test.ts
@@ -7,6 +7,7 @@ import {
   fillLineGaps,
   getCompareTransform,
   getSuggestedMax,
+  splitUntrackedConsumption,
 } from "../../../../../../src/panels/lovelace/cards/energy/common/energy-chart-options";
 
 // Helper to get x value from either [x,y] or {value: [x,y]} format
@@ -660,5 +661,78 @@ describe("computeStatMidpoint", () => {
       computeStatMidpoint(start, end, "hour", transform),
       (start + end) / 2 + 1000
     );
+  });
+});
+
+describe("splitUntrackedConsumption", () => {
+  it("passes through positive untracked when grid exceeds devices", () => {
+    const usedTotal = { 1000: 5, 2000: 3 };
+    const deviceTotal = { 1000: 2, 2000: 1 };
+    const result = splitUntrackedConsumption(usedTotal, deviceTotal);
+    assert.deepEqual(result.positive, { 1000: 3, 2000: 2 });
+    assert.deepEqual(result.negative, {});
+  });
+
+  it("clamps positive to zero and records negatives separately", () => {
+    // Device sensors report more than the integer grid meter
+    const usedTotal = { 1000: 0, 2000: 1 };
+    const deviceTotal = { 1000: 0.3, 2000: 1.7 };
+    const result = splitUntrackedConsumption(usedTotal, deviceTotal);
+    assert.equal(result.positive[1000], 0);
+    assert.equal(result.positive[2000], 0);
+    assert.approximately(result.negative[1000], -0.3, 0.001);
+    assert.approximately(result.negative[2000], -0.7, 0.001);
+  });
+
+  it("treats grid equal to devices as zero with no negative", () => {
+    const usedTotal = { 1000: 2.5 };
+    const deviceTotal = { 1000: 2.5 };
+    const result = splitUntrackedConsumption(usedTotal, deviceTotal);
+    assert.equal(result.positive[1000], 0);
+    assert.deepEqual(result.negative, {});
+  });
+
+  it("returns full grid value when no device data exists for timestamp", () => {
+    const usedTotal = { 1000: 4 };
+    const deviceTotal = {};
+    const result = splitUntrackedConsumption(usedTotal, deviceTotal);
+    assert.equal(result.positive[1000], 4);
+    assert.deepEqual(result.negative, {});
+  });
+
+  it("ignores device timestamps not present in usedTotal", () => {
+    const usedTotal = { 1000: 2 };
+    const deviceTotal = { 1000: 1, 9999: 5 };
+    const result = splitUntrackedConsumption(usedTotal, deviceTotal);
+    assert.deepEqual(result.positive, { 1000: 1 });
+    assert.deepEqual(result.negative, {});
+  });
+
+  it("handles mixed positive and negative across timestamps", () => {
+    const usedTotal = { 1000: 0, 2000: 3, 3000: 1 };
+    const deviceTotal = { 1000: 0.5, 2000: 1, 3000: 2 };
+    const result = splitUntrackedConsumption(usedTotal, deviceTotal);
+    assert.equal(result.positive[1000], 0); // clamped
+    assert.equal(result.positive[2000], 2); // genuine untracked
+    assert.equal(result.positive[3000], 0); // clamped
+    assert.approximately(result.negative[1000], -0.5, 0.001);
+    assert.isUndefined(result.negative[2000]); // positive, not recorded
+    assert.approximately(result.negative[3000], -1, 0.001);
+  });
+
+  it("returns empty result for empty inputs", () => {
+    const result = splitUntrackedConsumption({}, {});
+    assert.deepEqual(result.positive, {});
+    assert.deepEqual(result.negative, {});
+  });
+
+  it("does not mutate input objects", () => {
+    const usedTotal = { 1000: 5 };
+    const deviceTotal = { 1000: 2 };
+    const usedCopy = { ...usedTotal };
+    const deviceCopy = { ...deviceTotal };
+    splitUntrackedConsumption(usedTotal, deviceTotal);
+    assert.deepEqual(usedTotal, usedCopy);
+    assert.deepEqual(deviceTotal, deviceCopy);
   });
 });

--- a/test/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-data.test.ts
+++ b/test/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-data.test.ts
@@ -3,7 +3,7 @@
  * devices-detail graph data transform. Do NOT update these snapshots to make
  * an optimization pass — see test/benchmarks/README.md.
  */
-import { describe, expect, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 import type {
   DeviceConsumptionEnergyPreference,
   EnergyPreferences,
@@ -162,5 +162,98 @@ describe("generateEnergyDevicesDetailGraphData", () => {
         generateEnergyDevicesDetailGraphData({ ...baseParams, energyData })
       )
     ).toMatchSnapshot();
+  });
+
+  // The seeded fixtures above all happen to produce fully-negative untracked
+  // (devices reference the source stats, so they consume all of used_total).
+  // These two cases pin the branches those snapshots can't reach.
+  describe("negative untracked series", () => {
+    const NEGATIVE_NAME =
+      "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.over_reported_consumption";
+
+    const isNegativeSeries = (id: unknown) =>
+      typeof id === "string" && id.includes("untracked-negative");
+
+    it("omits the over-reported series when untracked is all positive", () => {
+      // Grid-only with no export keeps used_total >= 0, and the device
+      // references a stat with no data, so untracked == used_total >= 0.
+      const gridPrefs = generateEnergyPreferences({ grid: true });
+      const prefs: EnergyPreferences = {
+        ...gridPrefs,
+        energy_sources: gridPrefs.energy_sources.map((s) =>
+          s.type === "grid" ? { ...s, stat_energy_to: null } : s
+        ),
+        device_consumption: [
+          { stat_consumption: "sensor.device_without_stats", name: "Phantom" },
+        ],
+      };
+      const energyData = generateEnergyData(9, {
+        days: 1,
+        period: "hour",
+        prefs,
+      });
+      const result = generateEnergyDevicesDetailGraphData({
+        ...baseParams,
+        energyData,
+      });
+
+      // No negative series and no extra legend item for clean data.
+      assert.isFalse(result.chartData.some((d) => isNegativeSeries(d.id)));
+      assert.isUndefined(
+        result.legendData?.find((l) => l.name === NEGATIVE_NAME)
+      );
+
+      // The positive untracked series still carries the genuine (>= 0) values.
+      const untracked = result.chartData.find(
+        (d) =>
+          typeof d.id === "string" &&
+          d.id.startsWith("untracked-") &&
+          !isNegativeSeries(d.id)
+      );
+      assert.exists(untracked);
+      const ys = (untracked!.data as any[]).map((p) => p.value?.[1] ?? p?.[1]);
+      assert.isTrue(ys.every((y) => y >= 0));
+      assert.isTrue(ys.some((y) => y > 0));
+    });
+
+    it("adds a toggleable over-reported series when negatives exist", () => {
+      // buildPrefs devices reference the source stats -> negative untracked.
+      const energyData = generateEnergyData(1, {
+        days: 1,
+        period: "hour",
+        prefs: buildPrefs(false),
+      });
+      const result = generateEnergyDevicesDetailGraphData({
+        ...baseParams,
+        energyData,
+      });
+
+      const negative = result.chartData.find((d) => isNegativeSeries(d.id));
+      assert.exists(negative);
+      // It carries negative values and shares the devices stack.
+      const ys = (negative!.data as any[]).map((p) => p.value?.[1] ?? p?.[1]);
+      assert.isTrue(ys.some((y) => y < 0));
+      assert.equal(negative!.stack, "devices");
+
+      // The positive untracked is clamped to >= 0 (negatives moved to the
+      // separate series).
+      const untracked = result.chartData.find(
+        (d) =>
+          typeof d.id === "string" &&
+          d.id.startsWith("untracked-") &&
+          !isNegativeSeries(d.id)
+      );
+      const posYs = (untracked!.data as any[]).map(
+        (p) => p.value?.[1] ?? p?.[1]
+      );
+      assert.isTrue(posYs.every((y) => y >= 0));
+
+      // A dedicated, non-clickable legend item paired with the compare series.
+      const legend = result.legendData?.find((l) => l.name === NEGATIVE_NAME);
+      assert.exists(legend);
+      assert.equal(legend!.id, negative!.id);
+      assert.isTrue(legend!.noLabelClick);
+      assert.deepEqual(legend!.secondaryIds, [`compare-${negative!.id}`]);
+    });
   });
 });


### PR DESCRIPTION
## Breaking change


## Proposed change

In the energy **devices detail** graph, the "Untracked consumption" bar can go negative when a grid meter reports at coarser resolution than individual device sensors (for example, an integer-kWh meter while devices report fractional kWh). These below-zero bars are confusing and have generated user reports.

This splits the negative portion into its own **"Over-reported consumption"** series with its own legend item, so it can be toggled off. The series is only added when negative untracked actually exists, so users with clean data see no extra clutter. The positive untracked series is unchanged, and the negative values are preserved as a diagnostic signal rather than clamped away.

The legend selection is already saved per device so this is persistent.

## Screenshots
<img width="686" height="62" alt="image" src="https://github.com/user-attachments/assets/d5327871-9051-43f6-8ab1-66e6722199b3" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes home-assistant/core#125362
- This PR is related to issue or discussion: #23893
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
