### PR TITLE
Add time_format selector to entities card entity-row-editor

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
@@ -6,8 +6,12 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import { computeDomain } from "../../../../common/entity/compute_domain";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-form/ha-form";
-import type { SchemaUnion } from "../../../../components/ha-form/types";
+import type {
+  HaFormSchema,
+  SchemaUnion,
+} from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
+import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../../../data/sensor";
 import type { EntitiesCardEntityConfig } from "../../cards/types";
 import type { LovelaceRowEditor } from "../../types";
 import { entitiesConfigStruct } from "../structs/entities-struct";
@@ -41,55 +45,77 @@ export class HuiGenericEntityRowEditor
     this._config = config;
   }
 
-  private _schema = memoizeOne((entity: string, localize: LocalizeFunc) => {
-    const domain = computeDomain(entity);
+  private _schema = memoizeOne(
+    (entity: string, localize: LocalizeFunc, showTimeFormat?: boolean) => {
+      const domain = computeDomain(entity);
 
-    return [
-      { name: "entity", required: true, selector: { entity: {} } },
-      {
-        name: "name",
-        selector: { entity_name: {} },
-        context: { entity: "entity" },
-      },
-      {
-        name: "icon",
-        selector: {
-          icon: {},
+      return [
+        { name: "entity", required: true, selector: { entity: {} } },
+        {
+          name: "name",
+          selector: { entity_name: {} },
+          context: { entity: "entity" },
         },
-        context: {
-          icon_entity: "entity",
-        },
-      },
-      {
-        name: "secondary_info",
-        selector: {
-          select: {
-            options: (
-              Object.keys(SECONDARY_INFO_VALUES).filter(
-                (info) =>
-                  !("domains" in SECONDARY_INFO_VALUES[info]) ||
-                  ("domains" in SECONDARY_INFO_VALUES[info] &&
-                    SECONDARY_INFO_VALUES[info].domains!.includes(domain))
-              ) as (keyof typeof SECONDARY_INFO_VALUES)[]
-            ).map((info) => ({
-              value: info,
-              label: localize(
-                `ui.panel.lovelace.editor.card.entities.secondary_info_values.${info}`
-              ),
-            })),
+        {
+          name: "icon",
+          selector: {
+            icon: {},
+          },
+          context: {
+            icon_entity: "entity",
           },
         },
-      },
-    ] as const;
-  });
+        {
+          name: "secondary_info",
+          selector: {
+            select: {
+              options: (
+                Object.keys(SECONDARY_INFO_VALUES).filter(
+                  (info) =>
+                    !("domains" in SECONDARY_INFO_VALUES[info]) ||
+                    ("domains" in SECONDARY_INFO_VALUES[info] &&
+                      SECONDARY_INFO_VALUES[info].domains!.includes(domain))
+                ) as (keyof typeof SECONDARY_INFO_VALUES)[]
+              ).map((info) => ({
+                value: info,
+                label: localize(
+                  `ui.panel.lovelace.editor.card.entities.secondary_info_values.${info}`
+                ),
+              })),
+            },
+          },
+        },
+        ...(showTimeFormat
+          ? ([
+              {
+                name: "format",
+                selector: {
+                  ui_time_format: {},
+                },
+              },
+            ] as const satisfies readonly HaFormSchema[])
+          : []),
+      ] as const;
+    }
+  );
 
   protected render() {
     if (!this.hass || !this._config) {
       return nothing;
     }
 
+    const entity = this._config.entity;
+    const domain = entity ? computeDomain(entity) : undefined;
+    const showTimeFormat =
+      domain === "event" ||
+      (domain === "sensor" &&
+        SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
+          this.hass.states[entity]?.attributes.device_class
+        ));
+
     const schema =
-      this.schema || this._schema(this._config.entity, this.hass.localize);
+      this.schema ||
+      this._schema(this._config.entity, this.hass.localize, showTimeFormat);
 
     return html`
       <ha-form
@@ -113,6 +139,10 @@ export class HuiGenericEntityRowEditor
       case "secondary_info":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.entity-row.${schema.name}`
+        );
+      case "format":
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.generic.time_format`
         );
       default:
         return this.hass!.localize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Adds a UI selector to select the `format` option for the entity-row-editor, when an entity is selected that honors the format option.

This is a more limited usage than what was added to tile card, as format in entities does not affect secondary info like state-machine timestamps in the same way it does for tile card state content. Also many of the timestamp-type domains don't actually show the state, but rather they show buttons and other controls. Also several timestamp-domains currently do not honor the format option. This could be expanded to wider usage in future PRs.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
<img width="1108" height="974" alt="image" src="https://github.com/user-attachments/assets/c5d8c8c2-c4cb-4e02-b85c-96bbb5dd6ff9" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
