### PR TITLE
Fix date/datetime selectors on the design gallery and align datetime fields

### DIFF
--- a/gallery/src/pages/components/ha-selector.ts
+++ b/gallery/src/pages/components/ha-selector.ts
@@ -1,4 +1,5 @@
-import type { TemplateResult } from "lit";
+import { ContextProvider } from "@lit/context";
+import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, state } from "lit/decorators";
 import { mockAreaRegistry } from "../../../../demo/src/stubs/area_registry";
@@ -14,6 +15,11 @@ import "../../../../src/components/ha-selector/ha-selector";
 import "../../../../src/components/ha-settings-row";
 import type { AreaRegistryEntry } from "../../../../src/data/area/area_registry";
 import type { BlueprintInput } from "../../../../src/data/blueprint";
+import {
+  configContext,
+  internationalizationContext,
+} from "../../../../src/data/context";
+import { updateHassGroups } from "../../../../src/data/context/updateContext";
 import type { DeviceRegistryEntry } from "../../../../src/data/device/device_registry";
 import type { FloorRegistryEntry } from "../../../../src/data/floor_registry";
 import type { LabelRegistryEntry } from "../../../../src/data/label/label_registry";
@@ -518,6 +524,17 @@ class DemoHaSelector extends LitElement implements ProvideHassElement {
 
   private data = SCHEMAS.map(() => ({}));
 
+  // The date/datetime selectors and the date-picker dialog consume these
+  // contexts (provided by the root element in the real app). Provide them here
+  // so they work in the gallery.
+  private _i18nProvider = new ContextProvider(this, {
+    context: internationalizationContext,
+  });
+
+  private _configProvider = new ContextProvider(this, {
+    context: configContext,
+  });
+
   constructor() {
     super();
     const hass = provideHass(this);
@@ -537,6 +554,16 @@ class DemoHaSelector extends LitElement implements ProvideHassElement {
 
   public provideHass(el) {
     el.hass = this.hass;
+  }
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+    if (changedProps.has("hass") && this.hass) {
+      this._i18nProvider.setValue(
+        updateHassGroups.internationalization(this.hass)
+      );
+      this._configProvider.setValue(updateHassGroups.config(this.hass));
+    }
   }
 
   public connectedCallback() {

--- a/src/components/ha-selector/ha-selector-datetime.ts
+++ b/src/components/ha-selector/ha-selector-datetime.ts
@@ -86,7 +86,10 @@ export class HaDateTimeSelector extends LitElement {
   static styles = css`
     .input {
       display: flex;
-      align-items: center;
+      /* Align the input fields by their top edge so the date field's underline
+         lines up with the time field, since ha-date-input reserves extra space
+         below for its hint while ha-time-input does not. */
+      align-items: flex-start;
       flex-direction: row;
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Two related fixes to the date and datetime selectors:

**1. Gallery context providers (fixes #52723).** On the design gallery, the date
and datetime selectors — and the date picker dialog they open — were broken:
clicking them threw an error and no picker appeared. Since #52265 these
components read the locale (and the dialog also reads the config) from Lit
contexts. In the real app those are provided by the root element, but the
gallery's `ha-selector` demo only supplied a mock `hass` and never set up the
providers. This adds the `internationalization` and `config` context providers
to the demo page.

**2. Datetime field alignment.** In the datetime selector the date field and the
time field were vertically misaligned, because `ha-date-input` reserves space
below for its hint while `ha-time-input` does not. The fields are now aligned by
their top edge so the date field's underline lines up with the time field. This
applies wherever the datetime selector is used, not just in the gallery.

https://deploy-preview-52726--home-assistant-gallery.netlify.app/#components/ha-selector

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
Alignment before 
<img width="1106" height="202" alt="image" src="https://github.com/user-attachments/assets/c9fa9dbe-fe35-4b21-8857-8c5d99cbf1d5" />
After
<img width="1028" height="202" alt="image" src="https://github.com/user-attachments/assets/5767c34c-79ef-4e07-a717-43a2b23ed9c1" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52723
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
