### PR TITLE
List main entities first on the device page

### DIFF
--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -211,7 +211,7 @@ export class HaDeviceEntitiesCard extends LitElement {
     .divider {
       height: 1px;
       background-color: var(--divider-color);
-      margin: 8px 16px;
+      margin: var(--ha-space-2) var(--ha-space-4);
     }
     .move-up {
       margin-top: -13px;

--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -9,6 +9,7 @@ import "../../../../components/ha-card";
 import "../../../../components/ha-icon";
 import "../../../../components/ha-list";
 import "../../../../components/ha-list-item";
+import { computeEntityEntryName } from "../../../../common/entity/compute_entity_name";
 import type { EntityRegistryEntry } from "../../../../data/entity/entity_registry";
 import { entryIcon } from "../../../../data/icons";
 import { showMoreInfoDialog } from "../../../../dialogs/more-info/show-ha-more-info-dialog";
@@ -57,20 +58,29 @@ export class HaDeviceEntitiesCard extends LitElement {
       }
     });
 
+    // Main entities (those without their own name, shown as the device name)
+    // are listed first, separated from the additional entities by a divider.
+    const mainEntities: EntityRegistryStateEntry[] = [];
+    const additionalEntities: EntityRegistryStateEntry[] = [];
+    enabledEntities.forEach((entry) => {
+      if (computeEntityEntryName(entry, this.hass.devices)) {
+        additionalEntities.push(entry);
+      } else {
+        mainEntities.push(entry);
+      }
+    });
+
     return html`
       <ha-card outlined .header=${this.header}>
         ${enabledEntities.length
           ? html`
               <div id="entities" class="move-up">
                 <ha-list>
-                  ${repeat(
-                    enabledEntities,
-                    (entry) => entry.entity_id,
-                    (entry) =>
-                      this.hass.states[entry.entity_id]
-                        ? this._renderEntity(entry)
-                        : this._renderUnavailableEntity(entry)
-                  )}
+                  ${this._renderEntities(mainEntities)}
+                  ${mainEntities.length && additionalEntities.length
+                    ? html`<div class="divider" role="separator"></div>`
+                    : nothing}
+                  ${this._renderEntities(additionalEntities)}
                 </ha-list>
               </div>
             `
@@ -113,6 +123,17 @@ export class HaDeviceEntitiesCard extends LitElement {
 
   private _toggleShowHidden() {
     this.showHidden = !this.showHidden;
+  }
+
+  private _renderEntities(entries: EntityRegistryStateEntry[]) {
+    return repeat(
+      entries,
+      (entry) => entry.entity_id,
+      (entry) =>
+        this.hass.states[entry.entity_id]
+          ? this._renderEntity(entry)
+          : this._renderUnavailableEntity(entry)
+    );
   }
 
   private _renderEntity(entry: EntityRegistryStateEntry): TemplateResult {
@@ -186,6 +207,11 @@ export class HaDeviceEntitiesCard extends LitElement {
     }
     .disabled-entry {
       color: var(--secondary-text-color);
+    }
+    .divider {
+      height: 1px;
+      background-color: var(--divider-color);
+      margin: 8px 16px;
     }
     .move-up {
       margin-top: -13px;


### PR DESCRIPTION
## Proposed change

On the device page, the device's main entities (those without a name of their own, shown as the device name) are now listed first in each group, with a divider separating them from the additional entities. This makes it clearer which entity represents the device itself.

It applies to every group on the device page (controls, sensors, configuration, diagnostic). The divider only shows when a group has both main and additional entities.

## Screenshots

<img width="421" height="355" alt="CleanShot 2026-06-18 at 14 39 26" src="https://github.com/user-attachments/assets/4fd4a4b6-958d-4883-abf1-2e57e22539f9" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: home-assistant/frontend#51684
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
