### PR TITLE
Add narrow timestamp style

### DIFF
--- a/src/components/ha-time-format-picker.ts
+++ b/src/components/ha-time-format-picker.ts
@@ -8,6 +8,7 @@ import "./ha-select";
 import type { TimestampRenderingFormat } from "../panels/lovelace/components/types";
 import { TIMESTAMP_RENDERING_FORMATS } from "../panels/lovelace/components/types";
 
+const NARROW_FORMATS = ["relative", "total"];
 @customElement("ha-time-format-picker")
 export class HaTimeFormatPicker extends LitElement {
   @property() public value?: TimestampRenderingFormat;
@@ -33,17 +34,27 @@ export class HaTimeFormatPicker extends LitElement {
     )
   );
 
-  private _styleOptions = memoizeOne((localize: LocalizeFunc) => [
-    { label: localize("ui.common.auto"), value: "auto" },
-    {
-      label: localize("ui.components.time-format-picker.styles.short"),
-      value: "short",
-    },
-    {
-      label: localize("ui.components.time-format-picker.styles.long"),
-      value: "long",
-    },
-  ]);
+  private _styleOptions = memoizeOne(
+    (localize: LocalizeFunc, narrow: boolean) => [
+      { label: localize("ui.common.auto"), value: "auto" },
+      ...(narrow
+        ? [
+            {
+              label: localize("ui.components.time-format-picker.styles.narrow"),
+              value: "narrow",
+            },
+          ]
+        : []),
+      {
+        label: localize("ui.components.time-format-picker.styles.short"),
+        value: "short",
+      },
+      {
+        label: localize("ui.components.time-format-picker.styles.long"),
+        value: "long",
+      },
+    ]
+  );
 
   protected render() {
     const type = typeof this.value === "object" ? this.value.type : this.value;
@@ -68,7 +79,10 @@ export class HaTimeFormatPicker extends LitElement {
                 .value=${style || "auto"}
                 .disabled=${this.disabled}
                 @selected=${this._styleChanged}
-                .options=${this._styleOptions(this._localize)}
+                .options=${this._styleOptions(
+                  this._localize,
+                  !!type && NARROW_FORMATS.includes(type)
+                )}
               >
               </ha-select>
             `
@@ -85,17 +99,23 @@ export class HaTimeFormatPicker extends LitElement {
       });
       return;
     }
-    if (this.value && typeof this.value === "object" && this.value.style) {
+    const newType = ev.detail.value;
+    if (
+      this.value &&
+      typeof this.value === "object" &&
+      this.value.style &&
+      (this.value.style !== "narrow" || NARROW_FORMATS.includes(newType))
+    ) {
       fireEvent(this, "value-changed", {
         value: {
-          type: ev.detail.value,
+          type: newType,
           style: this.value.style,
         },
       });
       return;
     }
     fireEvent(this, "value-changed", {
-      value: ev.detail.value,
+      value: newType,
     });
   }
 

--- a/src/panels/lovelace/components/types.ts
+++ b/src/panels/lovelace/components/types.ts
@@ -20,7 +20,7 @@ export type TimestampRenderingFormat =
   | (typeof TIMESTAMP_RENDERING_FORMATS)[number]
   | {
       type: (typeof TIMESTAMP_RENDERING_FORMATS)[number];
-      style?: "short" | "long";
+      style?: "short" | "long" | "narrow";
     };
 
 export const timeFormatConfigStruct = optional(
@@ -28,7 +28,7 @@ export const timeFormatConfigStruct = optional(
     enums(TIMESTAMP_RENDERING_FORMATS),
     object({
       type: enums(TIMESTAMP_RENDERING_FORMATS),
-      style: optional(enums(["short", "long"])),
+      style: optional(enums(["short", "long", "narrow"])),
     }),
   ])
 );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -810,6 +810,7 @@
           "date": "Date"
         },
         "styles": {
+          "narrow": "Narrow",
           "short": "Short",
           "long": "Long"
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Adds a support for 'narrow' mode to relative & total timestamp format styles. Currently we have just "short" & "long". Narrow was mentioned on and off in a couple previous discussions but it wasn't clear if it was intentionally dropped from the plan, or just sort of forgotten about. 

I don't have any good ideas for how to make narrow different from short for date/time so those will just still support short and long only. 

Summary of rendering formats:
| Unit    | Narrow  (new)       | Short   | Long              |
|---------|----------------|---------|-------------------|
| Years   | 2y             | 2 yrs   | 2 years           |
| Months  | 3m **            | 3 mths  | 3 months          |
| Weeks   | 1w             | 1 wk    | 1 week            |
| Days    | 3d             | 3 days * | 3 days *|
| Hours   | 14h            | 14 hr   | 14 hours          |
| Minutes | 1m ** | 1 min  | 1 minutes         |
| Seconds | 30s            | 30 sec  | 30 seconds        |

*: short & long days render the same
**: `m` is used for both months and minutes

Original spec by Paul: https://github.com/home-assistant/frontend/pull/52450#pullrequestreview-4465787321

If narrow is explicitly not wanted, we can just close this. But I think there are user requests for it. 

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
