### PR TITLE
Include diagnostic battery binary sensors in maintenance view

### DIFF
--- a/src/panels/maintenance/strategies/maintenance-view-strategy.ts
+++ b/src/panels/maintenance/strategies/maintenance-view-strategy.ts
@@ -32,7 +32,6 @@ export const maintenanceEntityFilters: EntityFilter[] = [
   {
     domain: "binary_sensor",
     device_class: ["battery"],
-    entity_category: "none",
   },
 ];
 


### PR DESCRIPTION
## Proposed change

The Maintenance view (and the home summary battery count, which shares the same filters) was excluding battery binary sensors that are marked as diagnostic.

The `binary_sensor` battery filter had `entity_category: "none"`, which only matches entities with no entity category, so it dropped battery binary sensors that integrations correctly mark as diagnostic (for example, Ecowitt). The `sensor` battery filter has no such restriction, so the two were inconsistent.

This removes `entity_category: "none"` from the `binary_sensor` filter so both filters behave the same and diagnostic battery binary sensors are included.

The `entity_category: "none"` was an unintentional carry-over from the original implementation (#30372); the only later change to this filter (#51835) removed `battery_charging` from the device classes but left this restriction in place.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51905
- This PR is related to issue or discussion: home-assistant/core#173866
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
