### PR TITLE
Return to the device page from the Z-Wave node config view

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -121,8 +121,7 @@ class ZWaveJSNodeConfig extends LitElement {
         .header=${this.hass.localize(
           "ui.panel.config.zwave_js.node_config.header"
         )}
-        back-path="/config/zwave_js/dashboard?config_entry=${this
-          .configEntryId}"
+        back-path="/config/devices/device/${this.deviceId}"
       >
         <ha-config-section
           .narrow=${this.narrow}


### PR DESCRIPTION
## Proposed change

Fixes the back navigation from the Z-Wave device configuration view.

When you open a Z-Wave device's page and click "Configure", the node configuration view opens. Pressing the back arrow took you to the Z-Wave network overview instead of the device page you came from, which is disorienting.

The view had its back path hardcoded to the Z-Wave dashboard. This view is only ever reached from a device page (the device's "Configure" action links to `/config/zwave_js/node_config/<device_id>`), and it already knows the device it belongs to, so the back path now points to that device's page.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51698
- This PR is related to issue or discussion: #52665
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr