### PR TITLE
Show real repeat iteration number in trace details

### DIFF
--- a/src/components/trace/ha-trace-path-details.ts
+++ b/src/components/trace/ha-trace-path-details.ts
@@ -33,6 +33,12 @@ const TRACE_PATH_TABS = [
   "logbook",
 ] as const;
 
+// A repeat keeps only its last iterations, so the array index is not the real
+// one. Use the recorded repeat.index when we have it.
+const iterationNumber = (trace: ActionTraceStep, index: number): number =>
+  (trace.changed_variables?.repeat as { index?: number } | undefined)?.index ??
+  index + 1;
+
 @customElement("ha-trace-path-details")
 export class HaTracePathDetails extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -214,7 +220,7 @@ export class HaTracePathDetails extends LitElement {
               : html`<h3>
                   ${this.hass!.localize(
                     "ui.panel.config.automation.trace.path.iteration",
-                    { number: idx + 1 }
+                    { number: iterationNumber(trace, idx) }
                   )}
                 </h3>`}
             ${curPath
@@ -318,7 +324,7 @@ export class HaTracePathDetails extends LitElement {
               ? html`<p>
                   ${this.hass!.localize(
                     "ui.panel.config.automation.trace.path.iteration",
-                    { number: idx + 1 }
+                    { number: iterationNumber(trace, idx) }
                   )}
                 </p>`
               : ""}


### PR DESCRIPTION
## Proposed change

Fixes the iteration number shown in the trace details for repeat loops.

Only the last iterations of a repeat are kept in a trace. The details view numbered them by their position in that kept list, so a repeat with more iterations than are retained restarted at "Iteration 1" instead of showing the real number. For example, a loop with 21 iterations keeps the last 20 but labelled them 1 to 20 instead of 2 to 21.

It now uses the `repeat.index` recorded in each step's changed variables, so the shown number matches the actual iteration (and the `repeat.index` value used in templates). It falls back to the position when there is no repeat context.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #24847
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr