### PR TITLE
Support a list of entities in the zone trigger editor

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -180,7 +180,7 @@ export interface PersistentNotificationTrigger extends BaseTrigger {
 
 export interface ZoneTrigger extends BaseTrigger {
   trigger: "zone";
-  entity_id: string;
+  entity_id: string | string[];
   zone: string;
   event: "enter" | "leave";
 }

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-zone.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-zone.ts
@@ -1,8 +1,10 @@
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
+import { ensureArray } from "../../../../../common/array/ensure-array";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { computeStateDomain } from "../../../../../common/entity/compute_state_domain";
 import { hasLocation } from "../../../../../common/entity/has_location";
+import "../../../../../components/entity/ha-entities-picker";
 import "../../../../../components/entity/ha-entity-picker";
 import "../../../../../components/radio/ha-radio-group";
 import type { HaRadioGroup } from "../../../../../components/radio/ha-radio-group";
@@ -27,7 +29,7 @@ export class HaZoneTrigger extends LitElement {
   public static get defaultConfig(): ZoneTrigger {
     return {
       trigger: "zone",
-      entity_id: "",
+      entity_id: [],
       zone: "",
       event: "enter" as ZoneTrigger["event"],
     };
@@ -36,16 +38,16 @@ export class HaZoneTrigger extends LitElement {
   protected render() {
     const { entity_id, zone, event } = this.trigger;
     return html`
-      <ha-entity-picker
+      <ha-entities-picker
         .label=${this.hass.localize(
           "ui.panel.config.automation.editor.triggers.type.zone.entity"
         )}
-        .value=${entity_id}
+        .value=${entity_id ? ensureArray(entity_id) : []}
         .disabled=${this.disabled}
         @value-changed=${this._entityPicked}
         .hass=${this.hass}
         .entityFilter=${zoneAndLocationFilter}
-      ></ha-entity-picker>
+      ></ha-entities-picker>
       <ha-entity-picker
         .label=${this.hass.localize(
           "ui.panel.config.automation.editor.triggers.type.zone.zone"
@@ -81,7 +83,7 @@ export class HaZoneTrigger extends LitElement {
     `;
   }
 
-  private _entityPicked(ev: ValueChangedEvent<string>) {
+  private _entityPicked(ev: ValueChangedEvent<string[]>) {
     ev.stopPropagation();
     fireEvent(this, "value-changed", {
       value: { ...this.trigger, entity_id: ev.detail.value },


### PR DESCRIPTION
## Proposed change

Fixes the zone trigger editor when the trigger watches more than one entity.

A zone trigger accepts a list of entities (core uses `cv.entity_ids_or_uuids` for `entity_id`), and the collapsed trigger summary already renders such a list correctly ("When Person A or Person B enters Store zone"). When expanded for editing, the entity field used a single entity picker, so a list got concatenated into one string and shown as an unknown entity.

The entity field now uses the multiple entity picker (`ha-entities-picker`), the same as the state trigger. The `zone` field stays a single picker, since the trigger targets a single zone. The `entity_id` type now allows `string | string[]`, existing single values are wrapped with `ensureArray`, and the default config starts as an empty list.

Like the state trigger, a single selected entity is now stored as a one-item list. Core accepts both forms and runtime behavior is unchanged.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51588
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr