### PR TITLE
Stop icon components leaking memory on every state update

### DIFF
--- a/src/components/ha-attribute-icon.ts
+++ b/src/components/ha-attribute-icon.ts
@@ -1,9 +1,9 @@
 import { consume } from "@lit/context";
 import type { ContextType } from "@lit/context";
 import type { HassEntity } from "home-assistant-js-websocket";
+import type { PropertyValues } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { until } from "lit/directives/until";
 import {
   configContext,
   connectionContext,
@@ -35,6 +35,54 @@ export class HaAttributeIcon extends LitElement {
   @consume({ context: entitiesContext, subscribe: true })
   private _entities?: ContextType<typeof entitiesContext>;
 
+  @state() private _resolvedIcon?: string;
+
+  // Resolving the icon in render() created a new promise (and a `until()`
+  // directive chain) on every render. Resolve it into state instead, guarded so
+  // only the latest resolution wins.
+  private _iconRequest = 0;
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+    if (
+      changedProps.has("icon") ||
+      changedProps.has("stateObj") ||
+      changedProps.has("attribute") ||
+      changedProps.has("attributeValue") ||
+      changedProps.has("_config") ||
+      changedProps.has("_connection") ||
+      changedProps.has("_entities")
+    ) {
+      this._loadIcon();
+    }
+  }
+
+  private async _loadIcon(): Promise<void> {
+    if (
+      this.icon ||
+      !this.stateObj ||
+      !this.attribute ||
+      !this._config ||
+      !this._connection ||
+      !this._entities
+    ) {
+      this._resolvedIcon = undefined;
+      return;
+    }
+    const request = ++this._iconRequest;
+    const icon = await attributeIcon(
+      this._config.config,
+      this._connection.connection,
+      this._entities,
+      this.stateObj,
+      this.attribute,
+      this.attributeValue
+    );
+    if (request === this._iconRequest) {
+      this._resolvedIcon = icon || undefined;
+    }
+  }
+
   protected render() {
     if (this.icon) {
       return html`<ha-icon .icon=${this.icon}></ha-icon>`;
@@ -48,21 +96,11 @@ export class HaAttributeIcon extends LitElement {
       return nothing;
     }
 
-    const icon = attributeIcon(
-      this._config.config,
-      this._connection.connection,
-      this._entities,
-      this.stateObj,
-      this.attribute,
-      this.attributeValue
-    ).then((icn) => {
-      if (icn) {
-        return html`<ha-icon .icon=${icn}></ha-icon>`;
-      }
-      return nothing;
-    });
+    if (this._resolvedIcon) {
+      return html`<ha-icon .icon=${this._resolvedIcon}></ha-icon>`;
+    }
 
-    return html`${until(icon)}`;
+    return nothing;
   }
 }
 

--- a/src/components/ha-attribute-value.ts
+++ b/src/components/ha-attribute-value.ts
@@ -1,12 +1,16 @@
 import { consume } from "@lit/context";
 import type { ContextType } from "@lit/context";
 import type { HassEntity } from "home-assistant-js-websocket";
+import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { until } from "lit/directives/until";
 import { computeStateDomain } from "../common/entity/compute_state_domain";
 import { getValueAttribute } from "../common/entity/get_states";
 import { formattersContext } from "../data/context";
+
+const isObjectValue = (value: unknown): boolean =>
+  (Array.isArray(value) && value.some((val) => val instanceof Object)) ||
+  (!Array.isArray(value) && value instanceof Object);
 
 @customElement("ha-attribute-value")
 class HaAttributeValue extends LitElement {
@@ -19,6 +23,33 @@ class HaAttributeValue extends LitElement {
   @property() public attribute!: string;
 
   @property({ type: Boolean, attribute: "hide-unit" }) public hideUnit = false;
+
+  @state() private _yaml?: string;
+
+  // Dumping the value to YAML in render() created a new promise (and a `until()`
+  // directive chain) on every render. Resolve it into state instead, guarded so
+  // only the latest resolution wins.
+  private _yamlRequest = 0;
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+    if (changedProps.has("stateObj") || changedProps.has("attribute")) {
+      this._loadYaml();
+    }
+  }
+
+  private async _loadYaml(): Promise<void> {
+    const attributeValue = this.stateObj?.attributes[this.attribute];
+    if (!isObjectValue(attributeValue)) {
+      this._yaml = undefined;
+      return;
+    }
+    const request = ++this._yamlRequest;
+    const { dump } = await import("js-yaml");
+    if (request === this._yamlRequest) {
+      this._yaml = dump(attributeValue);
+    }
+  }
 
   protected render() {
     if (!this.stateObj) {
@@ -49,13 +80,8 @@ class HaAttributeValue extends LitElement {
       }
     }
 
-    if (
-      (Array.isArray(attributeValue) &&
-        attributeValue.some((val) => val instanceof Object)) ||
-      (!Array.isArray(attributeValue) && attributeValue instanceof Object)
-    ) {
-      const yaml = import("js-yaml").then(({ dump }) => dump(attributeValue));
-      return html`<pre>${until(yaml, "")}</pre>`;
+    if (isObjectValue(attributeValue)) {
+      return html`<pre>${this._yaml ?? ""}</pre>`;
     }
 
     // Options-list attributes (effect_list, preset_modes, …) translated through

--- a/src/components/ha-domain-icon.ts
+++ b/src/components/ha-domain-icon.ts
@@ -1,7 +1,7 @@
 import { consume, type ContextType } from "@lit/context";
+import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { until } from "lit/directives/until";
 import { configContext, connectionContext, uiContext } from "../data/context";
 import {
   DEFAULT_DOMAIN_ICON,
@@ -36,6 +36,47 @@ export class HaDomainIcon extends LitElement {
   @consume({ context: uiContext, subscribe: true })
   private _hassUi?: ContextType<typeof uiContext>;
 
+  // undefined: not resolved yet (render nothing, as the old `until` did).
+  // null: resolved, but no icon found (render the fallback).
+  @state() private _resolvedIcon?: string | null;
+
+  // Resolving the icon in render() created a new promise (and a `until()`
+  // directive chain) on every render. Resolve it into state instead, guarded so
+  // only the latest resolution wins.
+  private _iconRequest = 0;
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+    if (
+      changedProps.has("icon") ||
+      changedProps.has("domain") ||
+      changedProps.has("deviceClass") ||
+      changedProps.has("state") ||
+      changedProps.has("_connection") ||
+      changedProps.has("_hassConfig")
+    ) {
+      this._loadIcon();
+    }
+  }
+
+  private async _loadIcon(): Promise<void> {
+    if (this.icon || !this.domain || !this._connection || !this._hassConfig) {
+      this._resolvedIcon = undefined;
+      return;
+    }
+    const request = ++this._iconRequest;
+    const icon = await domainIcon(
+      this._connection.connection,
+      this._hassConfig.config,
+      this.domain,
+      this.deviceClass,
+      this.state
+    );
+    if (request === this._iconRequest) {
+      this._resolvedIcon = icon || null;
+    }
+  }
+
   protected render() {
     if (this.icon) {
       return html`<ha-icon .icon=${this.icon}></ha-icon>`;
@@ -49,21 +90,15 @@ export class HaDomainIcon extends LitElement {
       return this._renderFallback();
     }
 
-    const icon = domainIcon(
-      this._connection.connection,
-      this._hassConfig.config,
-      this.domain,
-      this.deviceClass,
-      this.state
-    ).then((icn) => {
-      if (icn) {
-        return html`<ha-icon .icon=${icn}></ha-icon>`;
-      }
+    if (this._resolvedIcon === undefined) {
+      return nothing;
+    }
 
-      return this._renderFallback();
-    });
+    if (this._resolvedIcon) {
+      return html`<ha-icon .icon=${this._resolvedIcon}></ha-icon>`;
+    }
 
-    return html`${until(icon)}`;
+    return this._renderFallback();
   }
 
   private _renderFallback() {

--- a/src/components/ha-service-icon.ts
+++ b/src/components/ha-service-icon.ts
@@ -1,7 +1,7 @@
 import { consume } from "@lit/context";
+import type { PropertyValues } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { until } from "lit/directives/until";
 import type { Connection, HassConfig } from "home-assistant-js-websocket";
 import { computeDomain } from "../common/entity/compute_domain";
 import { transform } from "../common/decorators/transform";
@@ -34,6 +34,43 @@ export class HaServiceIcon extends LitElement {
   })
   private _connection?: Connection;
 
+  // undefined: not resolved yet (render nothing, as the old `until` did).
+  // null: resolved, but no icon found (render the fallback).
+  @state() private _resolvedIcon?: string | null;
+
+  // Resolving the icon in render() created a new promise (and a `until()`
+  // directive chain) on every render. Resolve it into state instead, guarded so
+  // only the latest resolution wins.
+  private _iconRequest = 0;
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+    if (
+      changedProps.has("icon") ||
+      changedProps.has("service") ||
+      changedProps.has("_connection") ||
+      changedProps.has("_config")
+    ) {
+      this._loadIcon();
+    }
+  }
+
+  private async _loadIcon(): Promise<void> {
+    if (this.icon || !this.service || !this._connection || !this._config) {
+      this._resolvedIcon = undefined;
+      return;
+    }
+    const request = ++this._iconRequest;
+    const icon = await serviceIcon(
+      this._connection,
+      this._config,
+      this.service
+    );
+    if (request === this._iconRequest) {
+      this._resolvedIcon = icon || null;
+    }
+  }
+
   protected render() {
     if (this.icon) {
       return html`<ha-icon .icon=${this.icon}></ha-icon>`;
@@ -47,16 +84,15 @@ export class HaServiceIcon extends LitElement {
       return this._renderFallback();
     }
 
-    const icon = serviceIcon(this._connection, this._config, this.service).then(
-      (icn) => {
-        if (icn) {
-          return html`<ha-icon .icon=${icn}></ha-icon>`;
-        }
-        return this._renderFallback();
-      }
-    );
+    if (this._resolvedIcon === undefined) {
+      return nothing;
+    }
 
-    return html`${until(icon)}`;
+    if (this._resolvedIcon) {
+      return html`<ha-icon .icon=${this._resolvedIcon}></ha-icon>`;
+    }
+
+    return this._renderFallback();
   }
 
   private _renderFallback() {

--- a/src/components/ha-state-icon.ts
+++ b/src/components/ha-state-icon.ts
@@ -1,8 +1,8 @@
 import { consume, type ContextType } from "@lit/context";
 import type { HassEntity } from "home-assistant-js-websocket";
+import type { PropertyValues } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { until } from "lit/directives/until";
 import { computeStateDomain } from "../common/entity/compute_state_domain";
 import {
   configContext,
@@ -37,11 +37,64 @@ export class HaStateIcon extends LitElement {
   @consume({ context: entitiesContext, subscribe: true })
   protected _entities?: ContextType<typeof entitiesContext>;
 
-  protected render() {
-    const overrideIcon =
+  // undefined: not resolved yet (render nothing, as the old `until` did).
+  // null: resolved, but no icon found (render the fallback).
+  @state() private _resolvedIcon?: string | null;
+
+  // Resolving the icon in render() created a new promise (and a `until()`
+  // directive chain) on every render, so on every state update, which leaked
+  // memory on busy dashboards. Resolve it into state instead, guarded so only
+  // the latest resolution wins.
+  private _iconRequest = 0;
+
+  private get _overrideIcon(): string | undefined {
+    return (
       this.icon ||
       (this.stateObj && this._entities?.[this.stateObj.entity_id]?.icon) ||
-      this.stateObj?.attributes.icon;
+      this.stateObj?.attributes.icon
+    );
+  }
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+    if (
+      changedProps.has("icon") ||
+      changedProps.has("stateObj") ||
+      changedProps.has("stateValue") ||
+      changedProps.has("_entities") ||
+      changedProps.has("_config") ||
+      changedProps.has("_connection")
+    ) {
+      this._loadIcon();
+    }
+  }
+
+  private async _loadIcon(): Promise<void> {
+    if (
+      this._overrideIcon ||
+      !this.stateObj ||
+      !this._config ||
+      !this._connection ||
+      !this._entities
+    ) {
+      this._resolvedIcon = undefined;
+      return;
+    }
+    const request = ++this._iconRequest;
+    const icon = await entityIcon(
+      this._entities,
+      this._config.config,
+      this._connection.connection,
+      this.stateObj,
+      this.stateValue
+    );
+    if (request === this._iconRequest) {
+      this._resolvedIcon = icon || null;
+    }
+  }
+
+  protected render() {
+    const overrideIcon = this._overrideIcon;
     if (overrideIcon) {
       return html`<ha-icon .icon=${overrideIcon}></ha-icon>`;
     }
@@ -51,19 +104,13 @@ export class HaStateIcon extends LitElement {
     if (!this._config || !this._connection || !this._entities) {
       return this._renderFallback();
     }
-    const icon = entityIcon(
-      this._entities,
-      this._config.config,
-      this._connection.connection,
-      this.stateObj,
-      this.stateValue
-    ).then((icn) => {
-      if (icn) {
-        return html`<ha-icon .icon=${icn}></ha-icon>`;
-      }
-      return this._renderFallback();
-    });
-    return html`${until(icon)}`;
+    if (this._resolvedIcon === undefined) {
+      return nothing;
+    }
+    if (this._resolvedIcon) {
+      return html`<ha-icon .icon=${this._resolvedIcon}></ha-icon>`;
+    }
+    return this._renderFallback();
   }
 
   private _renderFallback() {


### PR DESCRIPTION
## Proposed change

Fixes a memory leak that made the browser use more and more memory the longer a dashboard stayed open.

The icon components figured out which icon to show while rendering, and they did this again on every state update. Each time, it left behind objects that were never cleaned up, so on a busy dashboard memory kept growing.

They now figure out the icon once and remember the result, only redoing it when something that affects the icon actually changes. The icons look and behave exactly the same, they just stop piling up in memory.

This covers the icon components that had the problem: `ha-state-icon`, `ha-domain-icon`, `ha-attribute-icon`, `ha-service-icon`, and the attribute value display.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51774
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr