### PR TITLE
Accept backup uploads by .tar extension, not just MIME type

### DIFF
--- a/src/data/backup.ts
+++ b/src/data/backup.ts
@@ -486,6 +486,12 @@ export const getFormattedBackupTime = memoizeOne(
 
 export const SUPPORTED_UPLOAD_FORMAT = "application/x-tar";
 
+// Browsers report the MIME type of a .tar inconsistently (Firefox on Windows
+// gives an empty or different type), so accept it by extension as well.
+export const isSupportedBackupFile = (file: File): boolean =>
+  file.type === SUPPORTED_UPLOAD_FORMAT ||
+  file.name.toLowerCase().endsWith(".tar");
+
 export interface BackupUploadFileFormData {
   file?: File;
 }

--- a/src/onboarding/restore-backup/onboarding-restore-backup-upload.ts
+++ b/src/onboarding/restore-backup/onboarding-restore-backup-upload.ts
@@ -9,6 +9,7 @@ import { showAlertDialog } from "../../dialogs/generic/show-dialog-box";
 import {
   CORE_LOCAL_AGENT,
   HASSIO_LOCAL_AGENT,
+  isSupportedBackupFile,
   SUPPORTED_UPLOAD_FORMAT,
 } from "../../data/backup";
 import type { LocalizeFunc } from "../../common/translations/localize";
@@ -76,7 +77,7 @@ class OnboardingRestoreBackupUpload extends LitElement {
     this._error = undefined;
     const file = ev.detail.files[0];
 
-    if (!file || file.type !== SUPPORTED_UPLOAD_FORMAT) {
+    if (!file || !isSupportedBackupFile(file)) {
       showAlertDialog(this, {
         title: this.localize(
           "ui.panel.page-onboarding.restore.unsupported.title"

--- a/src/panels/config/backup/dialogs/dialog-upload-backup.ts
+++ b/src/panels/config/backup/dialogs/dialog-upload-backup.ts
@@ -16,6 +16,7 @@ import {
   CORE_LOCAL_AGENT,
   HASSIO_LOCAL_AGENT,
   INITIAL_UPLOAD_FORM_DATA,
+  isSupportedBackupFile,
   SUPPORTED_UPLOAD_FORMAT,
   uploadBackup,
   type BackupUploadFileFormData,
@@ -141,7 +142,7 @@ export class DialogUploadBackup
 
   private async _upload() {
     const { file } = this._formData!;
-    if (!file || file.type !== SUPPORTED_UPLOAD_FORMAT) {
+    if (!file || !isSupportedBackupFile(file)) {
       showAlertDialog(this, {
         title: this.hass.localize(
           "ui.panel.config.backup.dialogs.upload.unsupported.title"

--- a/test/data/backup.test.ts
+++ b/test/data/backup.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { isSupportedBackupFile } from "../../src/data/backup";
+
+const makeFile = (name: string, type: string): File =>
+  new File([""], name, { type });
+
+describe("isSupportedBackupFile", () => {
+  it("accepts a .tar with the correct MIME type", () => {
+    expect(
+      isSupportedBackupFile(makeFile("backup.tar", "application/x-tar"))
+    ).toBe(true);
+  });
+
+  it("accepts a .tar when the browser reports no MIME type (Firefox on Windows)", () => {
+    expect(isSupportedBackupFile(makeFile("backup.tar", ""))).toBe(true);
+  });
+
+  it("accepts a .tar reported as a generic binary type", () => {
+    expect(
+      isSupportedBackupFile(makeFile("backup.tar", "application/octet-stream"))
+    ).toBe(true);
+  });
+
+  it("accepts regardless of extension casing", () => {
+    expect(isSupportedBackupFile(makeFile("BACKUP.TAR", ""))).toBe(true);
+  });
+
+  it("rejects a non-tar file", () => {
+    expect(isSupportedBackupFile(makeFile("photo.png", "image/png"))).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Proposed change

Fixes uploading a `.tar` backup being rejected with "Unsupported file format" in Firefox on Windows.

The upload checks (both the onboarding restore screen and Settings, System, Backups, Upload backup) only accepted a file when the browser reported its MIME type as `application/x-tar`. Firefox on Windows reports a different (or empty) type for the exact same `.tar` file, so a valid backup was rejected, while Chrome and Edge accepted it.

The check now also accepts the file by its `.tar` extension, which is reliable across browsers, so a valid backup is accepted everywhere. Files with the correct MIME type keep working as before.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52563
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr