### PR TITLE
Fix left column resizing in add automation element dialog

### DIFF
--- a/src/panels/config/automation/add-automation-element-dialog.ts
+++ b/src/panels/config/automation/add-automation-element-dialog.ts
@@ -2464,7 +2464,9 @@ class DialogAddAutomationElement
         ha-automation-add-from-target,
         .groups {
           overflow: auto;
-          flex: 4;
+          /* Fixed-width left column so it does not resize as the right
+             panel's content width changes between groups. */
+          flex: 0 0 360px;
           margin-inline-end: 0;
         }
 
@@ -2500,7 +2502,8 @@ class DialogAddAutomationElement
         }
 
         ha-automation-add-items {
-          flex: 6;
+          flex: 1;
+          min-width: 0;
         }
 
         .content.column ha-automation-add-from-target,


### PR DESCRIPTION
## Proposed change

In the **Add trigger / condition / action** dialog, the left column (the list of integrations / groups) changed width while browsing different groups on the left.

The two columns were sized with `flex: 4` (left list) against `flex: 6` (right items panel). Because flex items default to `min-width: auto`, the right panel's content — which varies per selected group — could dictate the split, so the left column width shifted as you moved between groups.

This pins the left column to a fixed width (`flex: 0 0 360px`) and lets the right panel take the remaining space with `min-width: 0`, so its content shrinks within its column instead of pushing the left column around. The mobile/column layout is unchanged.

## Screenshots

<!-- Drag the screenshot showing the truncated/shifting left column here -->
**Before:** the left column was narrow and its labels were truncated (e.g. "Music Assist", "Perform acti", "Persistent N", "Set conversa"), and its width shifted between groups.

<img width="1042" height="937" alt="CleanShot 2026-06-19 at 09 46 03" src="https://github.com/user-attachments/assets/e5dcd974-995b-412e-a7ec-58db5682ff42" />

**After:** the left column stays a fixed 360px wide regardless of which group is selected.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
