### PR TITLE
Replace until() in icon components with a shared async controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@lit-labs/virtualizer": "2.1.1",
     "@lit/context": "1.1.6",
     "@lit/reactive-element": "2.1.2",
+    "@lit/task": "1.0.3",
     "@material/mwc-formfield": "patch:@material/mwc-formfield@npm%3A0.27.0#~/.yarn/patches/@material-mwc-formfield-npm-0.27.0-9528cb60f6.patch",
     "@material/mwc-list": "patch:@material/mwc-list@npm%3A0.27.0#~/.yarn/patches/@material-mwc-list-npm-0.27.0-5344fc9de4.patch",
     "@material/web": "2.4.1",

--- a/src/common/controllers/async-value-task.ts
+++ b/src/common/controllers/async-value-task.ts
@@ -1,0 +1,29 @@
+import { Task, type TaskConfig } from "@lit/task";
+import type { ReactiveControllerHost } from "lit";
+
+/**
+ * A `@lit/task` Task with a sticky `resolved` flag: false until the task has
+ * completed once, then true. Lets callers tell "still loading" apart from
+ * "resolved with an empty value" without a null sentinel, while keeping the
+ * previous value during a re-run.
+ */
+export class AsyncValueTask<T extends readonly unknown[], R> extends Task<
+  T,
+  R
+> {
+  private _resolved = false;
+
+  constructor(host: ReactiveControllerHost, config: TaskConfig<T, R>) {
+    super(host, {
+      ...config,
+      onComplete: (value) => {
+        this._resolved = true;
+        config.onComplete?.(value);
+      },
+    });
+  }
+
+  public get resolved(): boolean {
+    return this._resolved;
+  }
+}

--- a/src/components/ha-attribute-icon.ts
+++ b/src/components/ha-attribute-icon.ts
@@ -1,9 +1,10 @@
 import { consume } from "@lit/context";
 import type { ContextType } from "@lit/context";
+import { initialState } from "@lit/task";
 import type { HassEntity } from "home-assistant-js-websocket";
-import type { PropertyValues } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { AsyncValueTask } from "../common/controllers/async-value-task";
 import {
   configContext,
   connectionContext,
@@ -35,53 +36,46 @@ export class HaAttributeIcon extends LitElement {
   @consume({ context: entitiesContext, subscribe: true })
   private _entities?: ContextType<typeof entitiesContext>;
 
-  @state() private _resolvedIcon?: string;
-
-  // Resolving the icon in render() created a new promise (and a `until()`
-  // directive chain) on every render. Resolve it into state instead, guarded so
-  // only the latest resolution wins.
-  private _iconRequest = 0;
-
-  protected willUpdate(changedProps: PropertyValues): void {
-    super.willUpdate(changedProps);
-    if (
-      changedProps.has("icon") ||
-      changedProps.has("stateObj") ||
-      changedProps.has("attribute") ||
-      changedProps.has("attributeValue") ||
-      changedProps.has("_config") ||
-      changedProps.has("_connection") ||
-      changedProps.has("_entities")
-    ) {
-      this._loadIcon();
-    }
-  }
-
-  private async _loadIcon(): Promise<void> {
-    if (
-      this.icon ||
-      !this.stateObj ||
-      !this.attribute ||
-      !this._config ||
-      !this._connection ||
-      !this._entities
-    ) {
-      this._resolvedIcon = undefined;
-      return;
-    }
-    const request = ++this._iconRequest;
-    const icon = await attributeIcon(
-      this._config.config,
-      this._connection.connection,
-      this._entities,
-      this.stateObj,
-      this.attribute,
-      this.attributeValue
-    );
-    if (request === this._iconRequest) {
-      this._resolvedIcon = icon || undefined;
-    }
-  }
+  private _iconTask = new AsyncValueTask(this, {
+    task: ([
+      icon,
+      config,
+      connection,
+      entities,
+      stateObj,
+      attribute,
+      attributeValue,
+    ]) => {
+      if (
+        icon ||
+        !config ||
+        !connection ||
+        !entities ||
+        !stateObj ||
+        !attribute
+      ) {
+        return initialState;
+      }
+      return attributeIcon(
+        config.config,
+        connection.connection,
+        entities,
+        stateObj,
+        attribute,
+        attributeValue
+      );
+    },
+    args: () =>
+      [
+        this.icon,
+        this._config,
+        this._connection,
+        this._entities,
+        this.stateObj,
+        this.attribute,
+        this.attributeValue,
+      ] as const,
+  });
 
   protected render() {
     if (this.icon) {
@@ -96,11 +90,9 @@ export class HaAttributeIcon extends LitElement {
       return nothing;
     }
 
-    if (this._resolvedIcon) {
-      return html`<ha-icon .icon=${this._resolvedIcon}></ha-icon>`;
-    }
-
-    return nothing;
+    return this._iconTask.value
+      ? html`<ha-icon .icon=${this._iconTask.value}></ha-icon>`
+      : nothing;
   }
 }
 

--- a/src/components/ha-attribute-value.ts
+++ b/src/components/ha-attribute-value.ts
@@ -1,9 +1,10 @@
 import { consume } from "@lit/context";
 import type { ContextType } from "@lit/context";
+import { initialState } from "@lit/task";
 import type { HassEntity } from "home-assistant-js-websocket";
-import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { AsyncValueTask } from "../common/controllers/async-value-task";
 import { computeStateDomain } from "../common/entity/compute_state_domain";
 import { getValueAttribute } from "../common/entity/get_states";
 import { formattersContext } from "../data/context";
@@ -24,32 +25,16 @@ class HaAttributeValue extends LitElement {
 
   @property({ type: Boolean, attribute: "hide-unit" }) public hideUnit = false;
 
-  @state() private _yaml?: string;
-
-  // Dumping the value to YAML in render() created a new promise (and a `until()`
-  // directive chain) on every render. Resolve it into state instead, guarded so
-  // only the latest resolution wins.
-  private _yamlRequest = 0;
-
-  protected willUpdate(changedProps: PropertyValues): void {
-    super.willUpdate(changedProps);
-    if (changedProps.has("stateObj") || changedProps.has("attribute")) {
-      this._loadYaml();
-    }
-  }
-
-  private async _loadYaml(): Promise<void> {
-    const attributeValue = this.stateObj?.attributes[this.attribute];
-    if (!isObjectValue(attributeValue)) {
-      this._yaml = undefined;
-      return;
-    }
-    const request = ++this._yamlRequest;
-    const { dump } = await import("js-yaml");
-    if (request === this._yamlRequest) {
-      this._yaml = dump(attributeValue);
-    }
-  }
+  private _yamlTask = new AsyncValueTask(this, {
+    task: async ([attributeValue]) => {
+      if (!isObjectValue(attributeValue)) {
+        return initialState;
+      }
+      const { dump } = await import("js-yaml");
+      return dump(attributeValue);
+    },
+    args: () => [this.stateObj?.attributes[this.attribute]] as const,
+  });
 
   protected render() {
     if (!this.stateObj) {
@@ -81,7 +66,7 @@ class HaAttributeValue extends LitElement {
     }
 
     if (isObjectValue(attributeValue)) {
-      return html`<pre>${this._yaml ?? ""}</pre>`;
+      return html`<pre>${this._yamlTask.value ?? ""}</pre>`;
     }
 
     // Options-list attributes (effect_list, preset_modes, …) translated through

--- a/src/components/ha-condition-icon.ts
+++ b/src/components/ha-condition-icon.ts
@@ -12,10 +12,11 @@ import {
   mdiWeatherSunny,
 } from "@mdi/js";
 import { consume } from "@lit/context";
+import { initialState } from "@lit/task";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { until } from "lit/directives/until";
 import type { HassConfig, Connection } from "home-assistant-js-websocket";
+import { AsyncValueTask } from "../common/controllers/async-value-task";
 import { computeDomain } from "../common/entity/compute_domain";
 import { transform } from "../common/decorators/transform";
 import { configContext, connectionContext } from "../data/context";
@@ -57,6 +58,17 @@ export class HaConditionIcon extends LitElement {
   })
   private _connection?: Connection;
 
+  private _iconTask = new AsyncValueTask(this, {
+    task: ([icon, connection, config, condition]) => {
+      if (icon || !connection || !config || !condition) {
+        return initialState;
+      }
+      return conditionIcon(connection, config, condition);
+    },
+    args: () =>
+      [this.icon, this._connection, this._config, this.condition] as const,
+  });
+
   protected render() {
     if (this.icon) {
       return html`<ha-icon .icon=${this.icon}></ha-icon>`;
@@ -70,18 +82,12 @@ export class HaConditionIcon extends LitElement {
       return this._renderFallback();
     }
 
-    const icon = conditionIcon(
-      this._connection,
-      this._config,
-      this.condition
-    ).then((icn) => {
-      if (icn) {
-        return html`<ha-icon .icon=${icn}></ha-icon>`;
-      }
-      return this._renderFallback();
-    });
-
-    return html`${until(icon)}`;
+    if (!this._iconTask.resolved) {
+      return nothing;
+    }
+    return this._iconTask.value
+      ? html`<ha-icon .icon=${this._iconTask.value}></ha-icon>`
+      : this._renderFallback();
   }
 
   private _renderFallback() {

--- a/src/components/ha-domain-icon.ts
+++ b/src/components/ha-domain-icon.ts
@@ -1,7 +1,8 @@
 import { consume, type ContextType } from "@lit/context";
-import type { PropertyValues } from "lit";
+import { initialState } from "@lit/task";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { AsyncValueTask } from "../common/controllers/async-value-task";
 import { configContext, connectionContext, uiContext } from "../data/context";
 import {
   DEFAULT_DOMAIN_ICON,
@@ -36,46 +37,29 @@ export class HaDomainIcon extends LitElement {
   @consume({ context: uiContext, subscribe: true })
   private _hassUi?: ContextType<typeof uiContext>;
 
-  // undefined: not resolved yet (render nothing, as the old `until` did).
-  // null: resolved, but no icon found (render the fallback).
-  @state() private _resolvedIcon?: string | null;
-
-  // Resolving the icon in render() created a new promise (and a `until()`
-  // directive chain) on every render. Resolve it into state instead, guarded so
-  // only the latest resolution wins.
-  private _iconRequest = 0;
-
-  protected willUpdate(changedProps: PropertyValues): void {
-    super.willUpdate(changedProps);
-    if (
-      changedProps.has("icon") ||
-      changedProps.has("domain") ||
-      changedProps.has("deviceClass") ||
-      changedProps.has("state") ||
-      changedProps.has("_connection") ||
-      changedProps.has("_hassConfig")
-    ) {
-      this._loadIcon();
-    }
-  }
-
-  private async _loadIcon(): Promise<void> {
-    if (this.icon || !this.domain || !this._connection || !this._hassConfig) {
-      this._resolvedIcon = undefined;
-      return;
-    }
-    const request = ++this._iconRequest;
-    const icon = await domainIcon(
-      this._connection.connection,
-      this._hassConfig.config,
-      this.domain,
-      this.deviceClass,
-      this.state
-    );
-    if (request === this._iconRequest) {
-      this._resolvedIcon = icon || null;
-    }
-  }
+  private _iconTask = new AsyncValueTask(this, {
+    task: ([icon, connection, config, domain, deviceClass, domainState]) => {
+      if (icon || !connection || !config || !domain) {
+        return initialState;
+      }
+      return domainIcon(
+        connection.connection,
+        config.config,
+        domain,
+        deviceClass,
+        domainState
+      );
+    },
+    args: () =>
+      [
+        this.icon,
+        this._connection,
+        this._hassConfig,
+        this.domain,
+        this.deviceClass,
+        this.state,
+      ] as const,
+  });
 
   protected render() {
     if (this.icon) {
@@ -90,15 +74,12 @@ export class HaDomainIcon extends LitElement {
       return this._renderFallback();
     }
 
-    if (this._resolvedIcon === undefined) {
+    if (!this._iconTask.resolved) {
       return nothing;
     }
-
-    if (this._resolvedIcon) {
-      return html`<ha-icon .icon=${this._resolvedIcon}></ha-icon>`;
-    }
-
-    return this._renderFallback();
+    return this._iconTask.value
+      ? html`<ha-icon .icon=${this._iconTask.value}></ha-icon>`
+      : this._renderFallback();
   }
 
   private _renderFallback() {

--- a/src/components/ha-selector/ha-selector-icon.ts
+++ b/src/components/ha-selector/ha-selector-icon.ts
@@ -1,6 +1,8 @@
+import { initialState } from "@lit/task";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
-import { until } from "lit/directives/until";
+import type { HassEntity } from "home-assistant-js-websocket";
+import { AsyncValueTask } from "../../common/controllers/async-value-task";
 import { fireEvent } from "../../common/dom/fire_event";
 import { entityIcon } from "../../data/icons";
 import type { IconSelector } from "../../data/selector";
@@ -28,23 +30,45 @@ export class HaIconSelector extends LitElement {
     icon_entity?: string;
   };
 
-  protected render() {
+  private get _stateObj(): HassEntity | undefined {
     const iconEntity = this.context?.icon_entity;
+    return iconEntity ? this.hass.states[iconEntity] : undefined;
+  }
 
-    const stateObj = iconEntity ? this.hass.states[iconEntity] : undefined;
+  private _placeholderTask = new AsyncValueTask(this, {
+    task: ([
+      placeholder,
+      attributeIcon,
+      entities,
+      config,
+      connection,
+      stateObj,
+    ]) => {
+      if (placeholder || attributeIcon || !stateObj) {
+        return initialState;
+      }
+      return entityIcon(entities, config, connection, stateObj);
+    },
+    args: () => {
+      const stateObj = this._stateObj;
+      return [
+        this.selector.icon?.placeholder,
+        stateObj?.attributes.icon,
+        this.hass.entities,
+        this.hass.config,
+        this.hass.connection,
+        stateObj,
+      ] as const;
+    },
+  });
+
+  protected render() {
+    const stateObj = this._stateObj;
 
     const placeholder =
       this.selector.icon?.placeholder ||
       stateObj?.attributes.icon ||
-      (stateObj &&
-        until(
-          entityIcon(
-            this.hass.entities,
-            this.hass.config,
-            this.hass.connection,
-            stateObj
-          )
-        ));
+      (stateObj && this._placeholderTask.value);
 
     return html`
       <ha-icon-picker

--- a/src/components/ha-service-icon.ts
+++ b/src/components/ha-service-icon.ts
@@ -1,8 +1,9 @@
 import { consume } from "@lit/context";
-import type { PropertyValues } from "lit";
+import { initialState } from "@lit/task";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import type { Connection, HassConfig } from "home-assistant-js-websocket";
+import { AsyncValueTask } from "../common/controllers/async-value-task";
 import { computeDomain } from "../common/entity/compute_domain";
 import { transform } from "../common/decorators/transform";
 import { configContext, connectionContext } from "../data/context";
@@ -34,42 +35,16 @@ export class HaServiceIcon extends LitElement {
   })
   private _connection?: Connection;
 
-  // undefined: not resolved yet (render nothing, as the old `until` did).
-  // null: resolved, but no icon found (render the fallback).
-  @state() private _resolvedIcon?: string | null;
-
-  // Resolving the icon in render() created a new promise (and a `until()`
-  // directive chain) on every render. Resolve it into state instead, guarded so
-  // only the latest resolution wins.
-  private _iconRequest = 0;
-
-  protected willUpdate(changedProps: PropertyValues): void {
-    super.willUpdate(changedProps);
-    if (
-      changedProps.has("icon") ||
-      changedProps.has("service") ||
-      changedProps.has("_connection") ||
-      changedProps.has("_config")
-    ) {
-      this._loadIcon();
-    }
-  }
-
-  private async _loadIcon(): Promise<void> {
-    if (this.icon || !this.service || !this._connection || !this._config) {
-      this._resolvedIcon = undefined;
-      return;
-    }
-    const request = ++this._iconRequest;
-    const icon = await serviceIcon(
-      this._connection,
-      this._config,
-      this.service
-    );
-    if (request === this._iconRequest) {
-      this._resolvedIcon = icon || null;
-    }
-  }
+  private _iconTask = new AsyncValueTask(this, {
+    task: ([icon, connection, config, service]) => {
+      if (icon || !connection || !config || !service) {
+        return initialState;
+      }
+      return serviceIcon(connection, config, service);
+    },
+    args: () =>
+      [this.icon, this._connection, this._config, this.service] as const,
+  });
 
   protected render() {
     if (this.icon) {
@@ -84,15 +59,12 @@ export class HaServiceIcon extends LitElement {
       return this._renderFallback();
     }
 
-    if (this._resolvedIcon === undefined) {
+    if (!this._iconTask.resolved) {
       return nothing;
     }
-
-    if (this._resolvedIcon) {
-      return html`<ha-icon .icon=${this._resolvedIcon}></ha-icon>`;
-    }
-
-    return this._renderFallback();
+    return this._iconTask.value
+      ? html`<ha-icon .icon=${this._iconTask.value}></ha-icon>`
+      : this._renderFallback();
   }
 
   private _renderFallback() {

--- a/src/components/ha-service-section-icon.ts
+++ b/src/components/ha-service-section-icon.ts
@@ -1,8 +1,9 @@
 import { consume } from "@lit/context";
+import { initialState } from "@lit/task";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { until } from "lit/directives/until";
 import type { Connection, HassConfig } from "home-assistant-js-websocket";
+import { AsyncValueTask } from "../common/controllers/async-value-task";
 import { transform } from "../common/decorators/transform";
 import { configContext, connectionContext } from "../data/context";
 import { serviceSectionIcon } from "../data/icons";
@@ -31,6 +32,23 @@ export class HaServiceSectionIcon extends LitElement {
   })
   private _connection?: Connection;
 
+  private _iconTask = new AsyncValueTask(this, {
+    task: ([icon, connection, config, service, section]) => {
+      if (icon || !connection || !config || !service || !section) {
+        return initialState;
+      }
+      return serviceSectionIcon(connection, config, service, section);
+    },
+    args: () =>
+      [
+        this.icon,
+        this._connection,
+        this._config,
+        this.service,
+        this.section,
+      ] as const,
+  });
+
   protected render() {
     if (this.icon) {
       return html`<ha-icon .icon=${this.icon}></ha-icon>`;
@@ -44,19 +62,12 @@ export class HaServiceSectionIcon extends LitElement {
       return this._renderFallback();
     }
 
-    const icon = serviceSectionIcon(
-      this._connection,
-      this._config,
-      this.service,
-      this.section
-    ).then((icn) => {
-      if (icn) {
-        return html`<ha-icon .icon=${icn}></ha-icon>`;
-      }
-      return this._renderFallback();
-    });
-
-    return html`${until(icon)}`;
+    if (!this._iconTask.resolved) {
+      return nothing;
+    }
+    return this._iconTask.value
+      ? html`<ha-icon .icon=${this._iconTask.value}></ha-icon>`
+      : this._renderFallback();
   }
 
   private _renderFallback() {

--- a/src/components/ha-state-icon.ts
+++ b/src/components/ha-state-icon.ts
@@ -1,8 +1,9 @@
 import { consume, type ContextType } from "@lit/context";
+import { initialState } from "@lit/task";
 import type { HassEntity } from "home-assistant-js-websocket";
-import type { PropertyValues } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { AsyncValueTask } from "../common/controllers/async-value-task";
 import { computeStateDomain } from "../common/entity/compute_state_domain";
 import {
   configContext,
@@ -37,16 +38,6 @@ export class HaStateIcon extends LitElement {
   @consume({ context: entitiesContext, subscribe: true })
   protected _entities?: ContextType<typeof entitiesContext>;
 
-  // undefined: not resolved yet (render nothing, as the old `until` did).
-  // null: resolved, but no icon found (render the fallback).
-  @state() private _resolvedIcon?: string | null;
-
-  // Resolving the icon in render() created a new promise (and a `until()`
-  // directive chain) on every render, so on every state update, which leaked
-  // memory on busy dashboards. Resolve it into state instead, guarded so only
-  // the latest resolution wins.
-  private _iconRequest = 0;
-
   private get _overrideIcon(): string | undefined {
     return (
       this.icon ||
@@ -55,43 +46,36 @@ export class HaStateIcon extends LitElement {
     );
   }
 
-  protected willUpdate(changedProps: PropertyValues): void {
-    super.willUpdate(changedProps);
-    if (
-      changedProps.has("icon") ||
-      changedProps.has("stateObj") ||
-      changedProps.has("stateValue") ||
-      changedProps.has("_entities") ||
-      changedProps.has("_config") ||
-      changedProps.has("_connection")
-    ) {
-      this._loadIcon();
-    }
-  }
-
-  private async _loadIcon(): Promise<void> {
-    if (
-      this._overrideIcon ||
-      !this.stateObj ||
-      !this._config ||
-      !this._connection ||
-      !this._entities
-    ) {
-      this._resolvedIcon = undefined;
-      return;
-    }
-    const request = ++this._iconRequest;
-    const icon = await entityIcon(
-      this._entities,
-      this._config.config,
-      this._connection.connection,
-      this.stateObj,
-      this.stateValue
-    );
-    if (request === this._iconRequest) {
-      this._resolvedIcon = icon || null;
-    }
-  }
+  private _iconTask = new AsyncValueTask(this, {
+    task: ([
+      overrideIcon,
+      entities,
+      config,
+      connection,
+      stateObj,
+      stateValue,
+    ]) => {
+      if (overrideIcon || !entities || !config || !connection || !stateObj) {
+        return initialState;
+      }
+      return entityIcon(
+        entities,
+        config.config,
+        connection.connection,
+        stateObj,
+        stateValue
+      );
+    },
+    args: () =>
+      [
+        this._overrideIcon,
+        this._entities,
+        this._config,
+        this._connection,
+        this.stateObj,
+        this.stateValue,
+      ] as const,
+  });
 
   protected render() {
     const overrideIcon = this._overrideIcon;
@@ -104,13 +88,12 @@ export class HaStateIcon extends LitElement {
     if (!this._config || !this._connection || !this._entities) {
       return this._renderFallback();
     }
-    if (this._resolvedIcon === undefined) {
+    if (!this._iconTask.resolved) {
       return nothing;
     }
-    if (this._resolvedIcon) {
-      return html`<ha-icon .icon=${this._resolvedIcon}></ha-icon>`;
-    }
-    return this._renderFallback();
+    return this._iconTask.value
+      ? html`<ha-icon .icon=${this._iconTask.value}></ha-icon>`
+      : this._renderFallback();
   }
 
   private _renderFallback() {

--- a/src/components/ha-trigger-icon.ts
+++ b/src/components/ha-trigger-icon.ts
@@ -18,10 +18,11 @@ import {
   mdiWebhook,
 } from "@mdi/js";
 import { consume } from "@lit/context";
+import { initialState } from "@lit/task";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { until } from "lit/directives/until";
 import type { Connection, HassConfig } from "home-assistant-js-websocket";
+import { AsyncValueTask } from "../common/controllers/async-value-task";
 import { computeDomain } from "../common/entity/compute_domain";
 import { transform } from "../common/decorators/transform";
 import { configContext, connectionContext } from "../data/context";
@@ -71,6 +72,17 @@ export class HaTriggerIcon extends LitElement {
   })
   private _connection?: Connection;
 
+  private _iconTask = new AsyncValueTask(this, {
+    task: ([icon, connection, config, trigger]) => {
+      if (icon || !connection || !config || !trigger) {
+        return initialState;
+      }
+      return triggerIcon(connection, config, trigger);
+    },
+    args: () =>
+      [this.icon, this._connection, this._config, this.trigger] as const,
+  });
+
   protected render() {
     if (this.icon) {
       return html`<ha-icon .icon=${this.icon}></ha-icon>`;
@@ -84,16 +96,12 @@ export class HaTriggerIcon extends LitElement {
       return this._renderFallback();
     }
 
-    const icon = triggerIcon(this._connection, this._config, this.trigger).then(
-      (icn) => {
-        if (icn) {
-          return html`<ha-icon .icon=${icn}></ha-icon>`;
-        }
-        return this._renderFallback();
-      }
-    );
-
-    return html`${until(icon)}`;
+    if (!this._iconTask.resolved) {
+      return nothing;
+    }
+    return this._iconTask.value
+      ? html`<ha-icon .icon=${this._iconTask.value}></ha-icon>`
+      : this._renderFallback();
   }
 
   private _renderFallback() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,6 +2326,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lit/task@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@lit/task@npm:1.0.3"
+  dependencies:
+    "@lit/reactive-element": "npm:^1.0.0 || ^2.0.0"
+  checksum: 10/9b6a907585a8a34c7418138624f9f25a76820747a095d6a4748e91d3a36bc113c73f677e91f2a32367a33c7482dd4af06b2780ffbedd82bf69147dc05e28b0ef
+  languageName: node
+  linkType: hard
+
 "@lokalise/node-api@npm:16.0.0":
   version: 16.0.0
   resolution: "@lokalise/node-api@npm:16.0.0"
@@ -8551,6 +8560,7 @@ __metadata:
     "@lit-labs/virtualizer": "npm:2.1.1"
     "@lit/context": "npm:1.1.6"
     "@lit/reactive-element": "npm:2.1.2"
+    "@lit/task": "npm:1.0.3"
     "@lokalise/node-api": "npm:16.0.0"
     "@material/mwc-formfield": "patch:@material/mwc-formfield@npm%3A0.27.0#~/.yarn/patches/@material-mwc-formfield-npm-0.27.0-9528cb60f6.patch"
     "@material/mwc-list": "patch:@material/mwc-list@npm%3A0.27.0#~/.yarn/patches/@material-mwc-list-npm-0.27.0-5344fc9de4.patch"


### PR DESCRIPTION
## Proposed change

Follow-up to #52743, which fixed the `until()` leak (#51774) in 5 icon components but duplicated the boilerplate and left 4 components with the same leaky pattern.

This adds `@lit/task` plus a small subclass (`AsyncValueTask`, which adds a sticky `resolved` flag), then moves all 9 icon components onto it, including the 4 that still leaked: `ha-trigger-icon`, `ha-condition-icon`, `ha-service-section-icon`, `ha-selector-icon`.

`ha-selector-icon` is the only behavior change. It used `until()` in a plain expression and passed the directive result as a string placeholder. It now resolves into the task, and shows `<ha-state-icon>` in the picker slot while the icon loads.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51774
- This PR is related to issue or discussion: #52743

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
