### PR TITLE
Mask password values in object selector previews

### DIFF
--- a/gallery/src/pages/components/ha-selector.ts
+++ b/gallery/src/pages/components/ha-selector.ts
@@ -502,6 +502,10 @@ const SCHEMAS: {
                   },
                 },
               },
+              password: {
+                label: "Password",
+                selector: { text: { type: "password" } },
+              },
             },
           },
         },

--- a/src/data/selector/format_selector_value.ts
+++ b/src/data/selector/format_selector_value.ts
@@ -18,9 +18,15 @@ export const formatSelectorValue = (
   }
 
   if ("text" in selector) {
-    const { prefix, suffix } = selector.text || {};
+    const { prefix, suffix, type } = selector.text || {};
 
     const texts = ensureArray(value);
+
+    // Never reveal secret values in a read-only preview.
+    if (type === "password") {
+      return texts.map(() => "••••••••").join(", ");
+    }
+
     return texts
       .map((text) => `${prefix || ""}${text}${suffix || ""}`)
       .join(", ");

--- a/test/data/format_selector_value.test.ts
+++ b/test/data/format_selector_value.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { formatSelectorValue } from "../../src/data/selector/format_selector_value";
+import type { HomeAssistant } from "../../src/types";
+
+// formatSelectorValue only touches hass for floor/area/entity/device
+// selectors, none of which these tests exercise.
+const hass = {} as HomeAssistant;
+
+describe("formatSelectorValue", () => {
+  it("returns an empty string for nullish values", () => {
+    expect(formatSelectorValue(hass, null)).toBe("");
+    expect(formatSelectorValue(hass, undefined)).toBe("");
+  });
+
+  it("renders a plain text value", () => {
+    expect(formatSelectorValue(hass, "hello", { text: { type: "text" } })).toBe(
+      "hello"
+    );
+  });
+
+  it("applies prefix and suffix for text selectors", () => {
+    expect(
+      formatSelectorValue(hass, "5", {
+        text: { type: "text", prefix: "$", suffix: " each" },
+      })
+    ).toBe("$5 each");
+  });
+
+  it("masks a password text value instead of revealing it", () => {
+    const result = formatSelectorValue(hass, "hunter2", {
+      text: { type: "password" },
+    });
+    expect(result).not.toContain("hunter2");
+    expect(result).toBe("••••••••");
+  });
+
+  it("masks every value of a multiple password selector", () => {
+    const result = formatSelectorValue(hass, ["one", "two"], {
+      text: { type: "password" },
+    });
+    expect(result).not.toContain("one");
+    expect(result).not.toContain("two");
+    expect(result).toBe("••••••••, ••••••••");
+  });
+
+  it("masks a nested password field in an object selector preview", () => {
+    const result = formatSelectorValue(
+      hass,
+      { username: "admin", password: "hunter2" },
+      {
+        object: {
+          fields: {
+            username: { selector: { text: { type: "text" } } },
+            password: { selector: { text: { type: "password" } } },
+          },
+        },
+      }
+    );
+    expect(result).toContain("admin");
+    expect(result).not.toContain("hunter2");
+    expect(result).toContain("••••••••");
+  });
+});


### PR DESCRIPTION
## Proposed change

When an add-on (or any object selector) has a list option that includes a password field, the collapsed preview row for each item showed the password in plain text. The edit form already masks it, but the read-only summary did not.

This masks password-type values in the selector preview, so the row shows bullets instead of the secret. Only the displayed text changes: the stored value is untouched, so editing and submitting still use the real password.

Reported for the Mosquitto broker add-on credentials, but it applies to any object selector with a password field.

To preview: open the gallery (`gallery/script/develop_gallery`), go to Components -> Selector, find the "Items" object selector, add an item, type a password, and the collapsed row shows the masked value. A password field was added to that demo so the behavior is visible.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52436
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
