### PR TITLE
Omit empty select fields from AI metadata suggestion task

### DIFF
--- a/src/panels/config/common/suggest-metadata-ai.ts
+++ b/src/panels/config/common/suggest-metadata-ai.ts
@@ -69,6 +69,24 @@ export async function generateMetadataSuggestionTask<T>(
     include.floor ? fetchFloors(connection) : Promise.resolve(undefined),
   ]);
 
+  const categoryOptions = categories
+    ? Object.entries(categories).map(([id, name]) => ({
+        value: id,
+        label: name,
+      }))
+    : [];
+  const floorOptions = floors
+    ? Object.values(floors).map((floor) => ({
+        value: floor.floor_id,
+        label: floor.name,
+      }))
+    : [];
+
+  // Only offer the select fields when there is at least one option. Some AI
+  // providers reject a select/enum schema with an empty options list.
+  const includeCategories = categoryOptions.length > 0;
+  const includeFloor = floorOptions.length > 0;
+
   const structure: AITaskStructure = {
     ...(include.name && {
       name: {
@@ -99,50 +117,42 @@ export async function generateMetadataSuggestionTask<T>(
         },
       },
     }),
-    ...(include.categories &&
-      categories && {
-        category: {
-          description: `The category of the ${domain}`,
-          required: false,
-          selector: {
-            select: {
-              options: Object.entries(categories).map(([id, name]) => ({
-                value: id,
-                label: name,
-              })),
-            },
+    ...(includeCategories && {
+      category: {
+        description: `The category of the ${domain}`,
+        required: false,
+        selector: {
+          select: {
+            options: categoryOptions,
           },
         },
-      }),
-    ...(include.floor &&
-      floors && {
-        floor: {
-          description: `The floor of the ${domain}`,
-          required: false,
-          selector: {
-            select: {
-              options: Object.values(floors).map((floor) => ({
-                value: floor.floor_id,
-                label: floor.name,
-              })),
-            },
+      },
+    }),
+    ...(includeFloor && {
+      floor: {
+        description: `The floor of the ${domain}`,
+        required: false,
+        selector: {
+          select: {
+            options: floorOptions,
           },
         },
-      }),
+      },
+    }),
   };
 
   const requestedParts = [
     include.name ? "a name" : null,
     include.description ? "a description" : null,
-    include.categories ? "a category" : null,
+    includeCategories ? "a category" : null,
     include.labels ? "labels" : null,
-    include.floor ? "a floor" : null,
+    includeFloor ? "a floor" : null,
   ].filter((entry): entry is string => entry !== null);
 
   const categoryLabels: string[] = [
-    include.categories ? "category" : null,
+    includeCategories ? "category" : null,
     include.labels ? "labels" : null,
-    include.floor ? "floor" : null,
+    includeFloor ? "floor" : null,
   ].filter((entry): entry is string => entry !== null);
 
   const categoryLabelsText = PROMPT_LIST_FORMAT.format(categoryLabels);
@@ -168,7 +178,7 @@ export async function generateMetadataSuggestionTask<T>(
                     `The name should be in same style and sentence capitalization as existing ${domain}s.`,
                   ]
                 : []),
-              ...(include.categories || include.labels || include.floor
+              ...(includeCategories || include.labels || includeFloor
                 ? [
                     `Suggest ${categoryLabelsText} if relevant to the ${domain}'s purpose.`,
                     `Only suggest ${categoryLabelsText} that are already used by existing ${domain}s.`,

--- a/test/panels/config/common/suggest-metadata-ai.test.ts
+++ b/test/panels/config/common/suggest-metadata-ai.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateMetadataSuggestionTask } from "../../../../src/panels/config/common/suggest-metadata-ai";
+import type { MetadataSuggestionInclude } from "../../../../src/panels/config/common/suggest-metadata-ai";
+import type { HomeAssistant } from "../../../../src/types";
+
+const fetchCategories = vi.hoisted(() => vi.fn());
+const fetchFloors = vi.hoisted(() => vi.fn());
+const fetchLabels = vi.hoisted(() => vi.fn());
+
+vi.mock(
+  "../../../../src/panels/config/common/suggest-metadata-helpers",
+  () => ({
+    fetchCategories,
+    fetchFloors,
+    fetchLabels,
+  })
+);
+
+const connection = {} as HomeAssistant["connection"];
+
+const INCLUDE_ALL: MetadataSuggestionInclude = {
+  name: true,
+  description: true,
+  categories: true,
+  labels: true,
+  floor: true,
+};
+
+const generate = (include: MetadataSuggestionInclude) =>
+  generateMetadataSuggestionTask(
+    connection,
+    "en",
+    "automation",
+    { alias: "Test" },
+    [],
+    include
+  );
+
+describe("generateMetadataSuggestionTask", () => {
+  beforeEach(() => {
+    fetchCategories.mockResolvedValue({});
+    fetchFloors.mockResolvedValue({});
+    fetchLabels.mockResolvedValue({});
+  });
+
+  it("omits the category field when there are no categories", async () => {
+    const result = await generate(INCLUDE_ALL);
+
+    expect(result.task.structure?.category).toBeUndefined();
+    expect(result.task.instructions).not.toContain("a category");
+  });
+
+  it("includes the category field when categories exist", async () => {
+    fetchCategories.mockResolvedValue({ work: "Work" });
+
+    const result = await generate(INCLUDE_ALL);
+
+    expect(result.task.structure?.category).toEqual({
+      description: "The category of the automation",
+      required: false,
+      selector: { select: { options: [{ value: "work", label: "Work" }] } },
+    });
+    expect(result.task.instructions).toContain("a category");
+  });
+
+  it("omits the floor field when there are no floors", async () => {
+    const result = await generate(INCLUDE_ALL);
+
+    expect(result.task.structure?.floor).toBeUndefined();
+    expect(result.task.instructions).not.toContain("a floor");
+  });
+
+  it("includes the floor field when floors exist", async () => {
+    fetchFloors.mockResolvedValue({
+      ground: { floor_id: "ground", name: "Ground floor" },
+    });
+
+    const result = await generate(INCLUDE_ALL);
+
+    expect(result.task.structure?.floor).toEqual({
+      description: "The floor of the automation",
+      required: false,
+      selector: {
+        select: { options: [{ value: "ground", label: "Ground floor" }] },
+      },
+    });
+  });
+
+  it("always includes the free-text labels field regardless of registries", async () => {
+    const result = await generate(INCLUDE_ALL);
+
+    expect(result.task.structure?.labels).toEqual({
+      description: "Labels for the automation",
+      required: false,
+      selector: { text: { multiple: true } },
+    });
+  });
+});


### PR DESCRIPTION
## Breaking change

## Proposed change

When using "Suggest with AI" to generate metadata (Rename → Suggest), the `category` and `floor` fields were sent to the AI task as a `select` selector with an empty `options` list when no categories or floors were configured. Some AI providers (e.g. Anthropic) reject an empty-option enum schema, which caused the whole suggestion to fail.

These fields are now omitted from the task structure (and the prompt) when there is nothing to choose from. Added unit tests covering the empty and non-empty cases.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52742
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
