### PR TITLE
Fix inverted vertical sliders in RTL languages

### DIFF
--- a/src/components/ha-control-slider.ts
+++ b/src/components/ha-control-slider.ts
@@ -388,7 +388,10 @@ export class HaControlSlider extends LitElement {
   private _isVisuallyInverted() {
     let inverted = this.inverted;
 
-    if (mainWindow.document.dir === "rtl") {
+    // RTL only mirrors the horizontal axis. A vertical slider always fills
+    // bottom-to-top regardless of text direction, so it must not be flipped,
+    // otherwise its value mapping ends up upside down in RTL languages.
+    if (!this.vertical && mainWindow.document.dir === "rtl") {
       inverted = !inverted;
     }
 

--- a/test/components/ha-control-slider.test.ts
+++ b/test/components/ha-control-slider.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from "vitest";
+import "../../src/components/ha-control-slider";
+import type { HaControlSlider } from "../../src/components/ha-control-slider";
+
+const createSlider = (props: Partial<HaControlSlider>): HaControlSlider => {
+  const el = document.createElement("ha-control-slider") as HaControlSlider;
+  Object.assign(el, props);
+  return el;
+};
+
+describe("ha-control-slider value mapping", () => {
+  afterEach(() => {
+    document.dir = "ltr";
+  });
+
+  it("maps a vertical slider bottom-to-top in LTR", () => {
+    const el = createSlider({ vertical: true, min: 0, max: 100 });
+    expect(el.valueToPercentage(100)).toBe(1);
+    expect(el.valueToPercentage(0)).toBe(0);
+    expect(el.percentageToValue(1)).toBe(100);
+  });
+
+  it("does not invert a vertical slider in RTL", () => {
+    document.dir = "rtl";
+    const el = createSlider({ vertical: true, min: 0, max: 100 });
+    // A vertical slider must ignore RTL: the top stays at the maximum.
+    expect(el.valueToPercentage(100)).toBe(1);
+    expect(el.percentageToValue(1)).toBe(100);
+    expect(el.percentageToValue(0)).toBe(0);
+  });
+
+  it("still mirrors a horizontal slider in RTL", () => {
+    document.dir = "rtl";
+    const el = createSlider({ vertical: false, min: 0, max: 100 });
+    expect(el.valueToPercentage(100)).toBe(0);
+    expect(el.percentageToValue(0)).toBe(100);
+  });
+
+  it("keeps an explicitly inverted vertical slider inverted in both directions", () => {
+    const el = createSlider({
+      vertical: true,
+      inverted: true,
+      min: 0,
+      max: 100,
+    });
+    expect(el.valueToPercentage(100)).toBe(0);
+    document.dir = "rtl";
+    expect(el.valueToPercentage(100)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Proposed change

In right-to-left languages, the brightness and color temperature sliders in the light more info dialog worked upside down: setting the slider to 1% gave the brightest output and 100% gave the dimmest, with warm and cold reversed for color temperature.

The control slider mirrored its value mapping for any right-to-left layout, but right-to-left only mirrors the horizontal direction. These light sliders are vertical, so they were flipped when they should not be. This change mirrors the slider for right-to-left only when it is horizontal, leaving vertical sliders alone.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52525
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
