### PR TITLE
Remove orphaned vacuum segments when saving area mapping

### DIFF
--- a/src/data/vacuum.ts
+++ b/src/data/vacuum.ts
@@ -79,3 +79,21 @@ export const getVacuumSegments = (
     type: "vacuum/get_segments",
     entity_id,
   });
+
+// Drop segment IDs the vacuum no longer reports from an area mapping. Orphaned
+// IDs left behind make area cleaning fail, so they have to go. Areas left
+// without any segment are removed entirely.
+export const pruneOrphanedSegments = (
+  areaMapping: Record<string, string[]>,
+  segments: Segment[]
+): Record<string, string[]> => {
+  const knownIds = new Set(segments.map((segment) => segment.id));
+  const pruned: Record<string, string[]> = {};
+  for (const [areaId, segmentIds] of Object.entries(areaMapping)) {
+    const kept = segmentIds.filter((id) => knownIds.has(id));
+    if (kept.length) {
+      pruned[areaId] = kept;
+    }
+  }
+  return pruned;
+};

--- a/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
+++ b/src/panels/config/entities/dialogs/dialog-vacuum-segment-mapping.ts
@@ -26,6 +26,7 @@ import {
   getExtendedEntityRegistryEntry,
   updateEntityRegistryEntry,
 } from "../../../../data/entity/entity_registry";
+import { pruneOrphanedSegments } from "../../../../data/vacuum";
 import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
 import { DirtyStateProviderMixin } from "../../../../mixins/dirty-state-provider-mixin";
 import { haStyleDialog } from "../../../../resources/styles";
@@ -105,11 +106,18 @@ export class DialogVacuumSegmentMapping
 
     try {
       const mapper = this._mapper!;
+      const lastSeenSegments = mapper.lastSeenSegments;
+
+      // Only prune when segments actually loaded, to avoid wiping the mapping
+      // on a transient load error.
+      const areaMapping = lastSeenSegments
+        ? pruneOrphanedSegments(this._areaMapping, lastSeenSegments)
+        : this._areaMapping;
 
       const options: VacuumEntityOptions = {
         ...(this._entry?.options?.vacuum ?? {}),
-        area_mapping: this._areaMapping,
-        last_seen_segments: mapper.lastSeenSegments,
+        area_mapping: areaMapping,
+        last_seen_segments: lastSeenSegments,
       };
 
       await updateEntityRegistryEntry(this.hass, this._params.entityId, {

--- a/test/data/vacuum.test.ts
+++ b/test/data/vacuum.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { pruneOrphanedSegments } from "../../src/data/vacuum";
+import type { Segment } from "../../src/data/vacuum";
+
+const segment = (id: string): Segment => ({ id, name: `Segment ${id}` });
+
+describe("pruneOrphanedSegments", () => {
+  it("removes segment IDs that are no longer reported", () => {
+    const result = pruneOrphanedSegments({ kitchen: ["1", "2"], hall: ["3"] }, [
+      segment("1"),
+      segment("3"),
+    ]);
+    // "2" is gone from the kitchen, "3" stays in the hall.
+    expect(result).toEqual({ kitchen: ["1"], hall: ["3"] });
+  });
+
+  it("drops areas left without any reported segment", () => {
+    const result = pruneOrphanedSegments({ kitchen: ["1"], attic: ["99"] }, [
+      segment("1"),
+    ]);
+    expect(result).toEqual({ kitchen: ["1"] });
+  });
+
+  it("keeps the mapping unchanged when all segments are still reported", () => {
+    const mapping = { kitchen: ["1", "2"], hall: ["3"] };
+    const result = pruneOrphanedSegments(mapping, [
+      segment("1"),
+      segment("2"),
+      segment("3"),
+    ]);
+    expect(result).toEqual(mapping);
+  });
+
+  it("returns an empty mapping when no segments are reported", () => {
+    const result = pruneOrphanedSegments({ kitchen: ["1"], hall: ["2"] }, []);
+    expect(result).toEqual({});
+  });
+});


### PR DESCRIPTION
## Proposed change

When a robot vacuum reports a new set of cleaning segments (for example after a remap), the segment to area assignment could keep segment IDs that the vacuum no longer reports. Those orphaned IDs stayed assigned to areas, and starting an area cleaning later could fail because the segment ID is no longer valid.

This removes segment IDs that are no longer reported when saving the area assignment, and drops any area that ends up without a segment. Pruning only happens once the current segments have loaded, so a temporary loading error does not clear an existing assignment.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52324
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
