### PR TITLE
Fix time zone picker data gaps (UTC and Asia/Sakhalin)

### DIFF
--- a/src/components/ha-timezone-picker.ts
+++ b/src/components/ha-timezone-picker.ts
@@ -21,14 +21,23 @@ const ADDITIONAL_TIMEZONES: PickerComboBoxItem[] = [
   { id: "Etc/UTC", primary: "(GMT+00:00) UTC", secondary: "Etc/UTC" },
 ];
 
+// google-timezones-json also ships an invalid IANA identifier. Correct it so
+// the zone can be selected (the backend rejects the invalid id).
+const TIMEZONE_ID_CORRECTIONS: Record<string, string> = {
+  "Asia/Yuzhno-Sakhalinsk": "Asia/Sakhalin",
+};
+
 export const getTimezoneOptions = (): PickerComboBoxItem[] => {
   const options: PickerComboBoxItem[] = Object.entries(
     timezones as Record<string, string>
-  ).map(([key, value]) => ({
-    id: key,
-    primary: value,
-    secondary: key,
-  }));
+  ).map(([key, value]) => {
+    const id = TIMEZONE_ID_CORRECTIONS[key] ?? key;
+    return {
+      id,
+      primary: value,
+      secondary: id,
+    };
+  });
 
   for (const timezone of ADDITIONAL_TIMEZONES) {
     if (!options.some((option) => option.id === timezone.id)) {

--- a/src/components/ha-timezone-picker.ts
+++ b/src/components/ha-timezone-picker.ts
@@ -13,12 +13,31 @@ const SEARCH_KEYS = [
   { name: "secondary", weight: 8 },
 ];
 
-export const getTimezoneOptions = (): PickerComboBoxItem[] =>
-  Object.entries(timezones as Record<string, string>).map(([key, value]) => ({
+// google-timezones-json is missing the bare "UTC" and "Etc/UTC" zones, even
+// though both are valid IANA identifiers and common server defaults. Without
+// them a "UTC" configuration shows up as an unknown time zone. Add them back.
+const ADDITIONAL_TIMEZONES: PickerComboBoxItem[] = [
+  { id: "UTC", primary: "(GMT+00:00) UTC", secondary: "UTC" },
+  { id: "Etc/UTC", primary: "(GMT+00:00) UTC", secondary: "Etc/UTC" },
+];
+
+export const getTimezoneOptions = (): PickerComboBoxItem[] => {
+  const options: PickerComboBoxItem[] = Object.entries(
+    timezones as Record<string, string>
+  ).map(([key, value]) => ({
     id: key,
     primary: value,
     secondary: key,
   }));
+
+  for (const timezone of ADDITIONAL_TIMEZONES) {
+    if (!options.some((option) => option.id === timezone.id)) {
+      options.push(timezone);
+    }
+  }
+
+  return options;
+};
 
 @customElement("ha-timezone-picker")
 export class HaTimeZonePicker extends LitElement {

--- a/src/panels/lovelace/editor/config-elements/hui-clock-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-clock-card-editor.ts
@@ -1,4 +1,3 @@
-import timezones from "google-timezones-json";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -26,6 +25,7 @@ import type { ClockCardConfig } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import { TimeFormat } from "../../../../data/translation";
+import { getTimezoneOptions } from "../../../../components/ha-timezone-picker";
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -36,7 +36,7 @@ const cardConfigStruct = assign(
       union([literal("small"), literal("medium"), literal("large")])
     ),
     time_format: optional(enums(Object.values(TimeFormat))),
-    time_zone: optional(enums(Object.keys(timezones))),
+    time_zone: optional(enums(getTimezoneOptions().map((option) => option.id))),
     show_seconds: optional(boolean()),
     no_background: optional(boolean()),
     // Analog clock options

--- a/test/components/ha-timezone-picker.test.ts
+++ b/test/components/ha-timezone-picker.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { getTimezoneOptions } from "../../src/components/ha-timezone-picker";
+
+describe("getTimezoneOptions", () => {
+  const options = getTimezoneOptions();
+
+  it("includes the bare UTC zone so a UTC config is recognized", () => {
+    const utc = options.find((option) => option.id === "UTC");
+    expect(utc).toBeDefined();
+    expect(utc?.primary).toContain("UTC");
+  });
+
+  it("includes the Etc/UTC zone", () => {
+    expect(options.some((option) => option.id === "Etc/UTC")).toBe(true);
+  });
+
+  it("does not duplicate any zone id", () => {
+    const ids = options.map((option) => option.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("keeps the zones from the source list", () => {
+    // A sanity check that the base list is still present alongside the additions.
+    expect(options.some((option) => option.id === "Europe/Amsterdam")).toBe(
+      true
+    );
+    expect(options.length).toBeGreaterThan(100);
+  });
+});

--- a/test/components/ha-timezone-picker.test.ts
+++ b/test/components/ha-timezone-picker.test.ts
@@ -26,4 +26,13 @@ describe("getTimezoneOptions", () => {
     );
     expect(options.length).toBeGreaterThan(100);
   });
+
+  it("corrects the invalid Asia/Yuzhno-Sakhalinsk id to Asia/Sakhalin", () => {
+    expect(
+      options.some((option) => option.id === "Asia/Yuzhno-Sakhalinsk")
+    ).toBe(false);
+    const sakhalin = options.find((option) => option.id === "Asia/Sakhalin");
+    expect(sakhalin).toBeDefined();
+    expect(sakhalin?.secondary).toBe("Asia/Sakhalin");
+  });
 });


### PR DESCRIPTION
## Proposed change

The time zone picker is built from the `google-timezones-json` dataset, which has a couple of data gaps. This fixes two of them:

- The bare `UTC` and `Etc/UTC` zones were missing, so an instance configured with `UTC` (a common default on bare-metal installs) showed up as an unknown time zone in Settings → System → General.
- The dataset ships `Asia/Yuzhno-Sakhalinsk`, which is not a valid IANA identifier. Selecting it failed with a backend validation error. It is now corrected to `Asia/Sakhalin`.

The clock card's config validation is updated to use the same shared time zone list, so it accepts these zones too.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51408
- This PR fixes or closes issue: fixes #27001
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
