### PR TITLE
Convert power source statistics to the graph unit

### DIFF
--- a/src/panels/lovelace/cards/energy/power-sources-graph-data.ts
+++ b/src/panels/lovelace/cards/energy/power-sources-graph-data.ts
@@ -5,6 +5,7 @@ import { hex2rgb } from "../../../../common/color/convert-color";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
 import type { CustomLegendOption } from "../../../../components/chart/ha-chart-base";
 import { computeYAxisFractionDigits } from "../../../../components/chart/y-axis-fraction-digits";
+import { normalizeValueBySIPrefix } from "../../../../common/number/normalize-by-si-prefix";
 import type { EnergyData } from "../../../../data/energy";
 import { getPowerFromState } from "../../../../data/energy";
 import type { StatisticValue } from "../../../../data/recorder";
@@ -165,7 +166,18 @@ export function generatePowerSourcesGraphData(
       // The interpolation breaks the stacking, so this positive/negative is a workaround
       const { positive, negative } = processData(
         meta.stats.map((id: string) => {
-          const stats = [...(energyData.stats[id] ?? [])];
+          // Stats are stored in the sensor's native unit (W, kW, MW, …).
+          // Normalize them to kW so a sensor reporting in W is not read as kW.
+          const statUnit =
+            energyData.statsMetadata[id]?.statistics_unit_of_measurement ??
+            undefined;
+          const stats = (energyData.stats[id] ?? []).map((point) => ({
+            ...point,
+            mean:
+              point.mean == null
+                ? point.mean
+                : normalizeValueBySIPrefix(point.mean, statUnit) / 1000,
+          }));
           if (showingToday) {
             // Append current state if we are showing today
             const currentStateWatts = getPowerFromState(states[id]);

--- a/test/panels/lovelace/cards/energy/power-sources-graph-data.test.ts
+++ b/test/panels/lovelace/cards/energy/power-sources-graph-data.test.ts
@@ -6,6 +6,8 @@
 import { describe, expect, it } from "vitest";
 import type { HassEntities } from "home-assistant-js-websocket";
 import type { EnergyData } from "../../../../../src/data/energy";
+import type { StatisticsMetaData } from "../../../../../src/data/recorder";
+import { StatisticMeanType } from "../../../../../src/data/recorder";
 import { generatePowerSourcesGraphData } from "../../../../../src/panels/lovelace/cards/energy/power-sources-graph-data";
 import { createMockComputedStyle } from "../../../../fixtures/computed-style";
 import { digestResult } from "../../../../fixtures/digest";
@@ -44,7 +46,29 @@ interface BuildOptions {
   grid?: boolean;
   solar?: boolean;
   battery?: boolean;
+  // Native unit the rate sensors report their statistics in. The graph plots
+  // in kW, so a "kW" sensor needs no conversion while a "W" sensor must be
+  // divided by 1000.
+  unit?: string;
 }
+
+const buildStatsMetadata = (
+  ids: string[],
+  unit: string
+): Record<string, StatisticsMetaData> =>
+  Object.fromEntries(
+    ids.map((id) => [
+      id,
+      {
+        statistic_id: id,
+        source: "recorder",
+        statistics_unit_of_measurement: unit,
+        unit_class: "power",
+        has_sum: false,
+        mean_type: StatisticMeanType.ARITHMETIC,
+      },
+    ])
+  );
 
 const buildEnergyData = (seed: number, o: BuildOptions): EnergyData => {
   const prefs = generateEnergyPreferences({
@@ -81,7 +105,11 @@ const buildEnergyData = (seed: number, o: BuildOptions): EnergyData => {
     days: o.days,
     sumStatistics: false,
   });
-  return { ...base, stats: meanStats };
+  return {
+    ...base,
+    stats: meanStats,
+    statsMetadata: buildStatsMetadata(ids, o.unit ?? "kW"),
+  };
 };
 
 describe("generatePowerSourcesGraphData", () => {
@@ -205,6 +233,41 @@ describe("generatePowerSourcesGraphData", () => {
         now,
       })
     ).toMatchSnapshot();
+  });
+
+  it("converts W-unit stats to kW (divides by 1000)", () => {
+    const options: BuildOptions = {
+      days: 1,
+      period: "hour",
+      grid: true,
+      solar: true,
+      battery: true,
+    };
+    const kwResult = generatePowerSourcesGraphData({
+      ...baseParams,
+      energyData: buildEnergyData(7, { ...options, unit: "kW" }),
+    });
+    const wResult = generatePowerSourcesGraphData({
+      ...baseParams,
+      energyData: buildEnergyData(7, { ...options, unit: "W" }),
+    });
+
+    // The series carry gap-fill nulls and derived lines, so compare the
+    // overall magnitude: the same readings in W must plot 1000x smaller than
+    // in kW.
+    const maxAbsValue = (result: { chartData: { data?: unknown }[] }): number =>
+      Math.max(
+        ...result.chartData.flatMap((series) =>
+          (series.data as [number, number | null][])
+            .map((point) => point?.[1])
+            .filter((value): value is number => typeof value === "number")
+            .map(Math.abs)
+        )
+      );
+
+    const kwMax = maxAbsValue(kwResult);
+    expect(kwMax).toBeGreaterThan(0);
+    expect(maxAbsValue(wResult)).toBeCloseTo(kwMax / 1000, 10);
   });
 
   it("large multi-day 5-minute payload digest is stable", () => {


### PR DESCRIPTION
## Proposed change

In the energy dashboard, the power sources graph plots in kW, but historical readings were used in the sensor's own unit without converting. A power sensor reporting in watts (for example a battery power sensor) was plotted a thousand times too high.

The live "now" value was already converted correctly; this applies the same conversion to the historical statistics, so sensors reporting in W, kW, or MW all show consistently on the graph.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #30318
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
