### PR TITLE
Count not-ready Z-Wave devices separately from not included

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -135,9 +135,11 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
     const offlineDevices = nodes.filter(
       (node) => node.status === NodeStatus.Dead
     ).length;
-    const notReadyDevices =
-      nodes.filter((node) => !node.ready && node.status !== NodeStatus.Dead)
-        .length + provisioningDevices;
+    // Not-ready nodes are included but their interview has not completed yet.
+    // They are distinct from the provisioning entries, which are not included.
+    const notReadyDevices = nodes.filter(
+      (node) => !node.ready && node.status !== NodeStatus.Dead
+    ).length;
 
     return html`
       <hass-subpage
@@ -201,8 +203,15 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
     }
     if (notReadyDevices > 0) {
       statusParts.push(
-        this.hass.localize("ui.panel.config.zwave_js.dashboard.not_included", {
+        this.hass.localize("ui.panel.config.zwave_js.dashboard.not_ready", {
           count: notReadyDevices,
+        })
+      );
+    }
+    if (provisioningDevices > 0) {
+      statusParts.push(
+        this.hass.localize("ui.panel.config.zwave_js.dashboard.not_included", {
+          count: provisioningDevices,
         })
       );
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7492,6 +7492,7 @@
             "provisioned_devices": "Provisioned devices",
             "provisioned_count": "{count} {count, plural,\n  one {provisioned device}\n  other {provisioned devices}\n}",
             "not_included": "{count} not included",
+            "not_ready": "{count} not ready",
             "devices_offline": "{count} offline",
             "rebuild_routes_description": "Rebuilding routes creates heavy traffic and may degrade performance for minutes to hours",
             "rebuild_routes_action": "Rebuild",


### PR DESCRIPTION
## Proposed change

On the Z-Wave dashboard, the network status counted devices that are included but still being interviewed (not ready) together with devices that are not part of the network yet, and labeled them all as "not included". That is confusing, since not-ready devices _are_ included.

This reports not-ready devices as "not ready" and keeps "not included" for the provisioning entries that have not joined the network yet, restoring the earlier behavior.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #51343
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
