### PR TITLE
Offer category and floor names to the AI suggestion model

### DIFF
--- a/src/panels/config/common/suggest-metadata-ai.ts
+++ b/src/panels/config/common/suggest-metadata-ai.ts
@@ -69,15 +69,18 @@ export async function generateMetadataSuggestionTask<T>(
     include.floor ? fetchFloors(connection) : Promise.resolve(undefined),
   ]);
 
+  // Offer the names (not the internal IDs) to the model. The model has no idea
+  // what an ID means, and processMetadataSuggestion maps the chosen name back
+  // to its ID.
   const categoryOptions = categories
-    ? Object.entries(categories).map(([id, name]) => ({
-        value: id,
+    ? Object.values(categories).map((name) => ({
+        value: name,
         label: name,
       }))
     : [];
   const floorOptions = floors
     ? Object.values(floors).map((floor) => ({
-        value: floor.floor_id,
+        value: floor.name,
         label: floor.name,
       }))
     : [];

--- a/test/panels/config/common/suggest-metadata-ai.test.ts
+++ b/test/panels/config/common/suggest-metadata-ai.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { generateMetadataSuggestionTask } from "../../../../src/panels/config/common/suggest-metadata-ai";
-import type { MetadataSuggestionInclude } from "../../../../src/panels/config/common/suggest-metadata-ai";
+import {
+  generateMetadataSuggestionTask,
+  processMetadataSuggestion,
+} from "../../../../src/panels/config/common/suggest-metadata-ai";
+import type {
+  MetadataSuggestionInclude,
+  MetadataSuggestionResult,
+} from "../../../../src/panels/config/common/suggest-metadata-ai";
+import type { GenDataTaskResult } from "../../../../src/data/ai_task";
 import type { HomeAssistant } from "../../../../src/types";
 
 const fetchCategories = vi.hoisted(() => vi.fn());
@@ -58,7 +65,8 @@ describe("generateMetadataSuggestionTask", () => {
     expect(result.task.structure?.category).toEqual({
       description: "The category of the automation",
       required: false,
-      selector: { select: { options: [{ value: "work", label: "Work" }] } },
+      // The model is offered the category name, not its internal ID.
+      selector: { select: { options: [{ value: "Work", label: "Work" }] } },
     });
     expect(result.task.instructions).toContain("a category");
   });
@@ -80,8 +88,11 @@ describe("generateMetadataSuggestionTask", () => {
     expect(result.task.structure?.floor).toEqual({
       description: "The floor of the automation",
       required: false,
+      // The model is offered the floor name, not its internal ID.
       selector: {
-        select: { options: [{ value: "ground", label: "Ground floor" }] },
+        select: {
+          options: [{ value: "Ground floor", label: "Ground floor" }],
+        },
       },
     });
   });
@@ -94,5 +105,50 @@ describe("generateMetadataSuggestionTask", () => {
       required: false,
       selector: { text: { multiple: true } },
     });
+  });
+});
+
+describe("processMetadataSuggestion", () => {
+  beforeEach(() => {
+    fetchCategories.mockResolvedValue({});
+    fetchFloors.mockResolvedValue({});
+    fetchLabels.mockResolvedValue({});
+  });
+
+  const result = (
+    data: MetadataSuggestionResult
+  ): GenDataTaskResult<MetadataSuggestionResult> => ({
+    conversation_id: "test",
+    data,
+  });
+
+  // The model is offered the category name, so the result carries a name that
+  // has to map back to the internal ID.
+  it("maps a category name from the model back to its ID", async () => {
+    fetchCategories.mockResolvedValue({ work: "Work" });
+
+    const processed = await processMetadataSuggestion(
+      connection,
+      "automation",
+      result({ category: "Work" }),
+      INCLUDE_ALL
+    );
+
+    expect(processed.category).toBe("work");
+  });
+
+  it("maps a floor name from the model back to its ID", async () => {
+    fetchFloors.mockResolvedValue({
+      ground: { floor_id: "ground", name: "Ground floor" },
+    });
+
+    const processed = await processMetadataSuggestion(
+      connection,
+      "automation",
+      result({ floor: "Ground floor" }),
+      INCLUDE_ALL
+    );
+
+    expect(processed.floor).toBe("ground");
   });
 });


### PR DESCRIPTION
## Proposed change

When suggesting a name, labels, category, and floor for an automation, script, scene, or area with AI, the category and floor choices were sent to the model as their internal IDs instead of their names. The model has no idea what an ID means, so it could never pick a sensible category or floor.

This offers the names to the model instead. The result is still mapped back to the matching ID afterwards, so the rest of the flow is unchanged.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #29157
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
