### PR TITLE
Discard stale results in the template developer tool

### DIFF
--- a/src/panels/config/developer-tools/template/developer-tools-template.ts
+++ b/src/panels/config/developer-tools/template/developer-tools-template.ts
@@ -64,6 +64,10 @@ class HaPanelDevTemplate extends LitElement {
 
   private _inited = false;
 
+  // Bumped on every (re)subscribe so a superseded render can be detected and
+  // its late-arriving results discarded.
+  private _subscribeRequestId = 0;
+
   private _tipResizeObserver?: ResizeObserver;
 
   public connectedCallback() {
@@ -502,8 +506,14 @@ ${type === "object"
   }
 
   private async _subscribeTemplate() {
+    const requestId = ++this._subscribeRequestId;
     this._rendering = true;
     await this._unsubscribeTemplate();
+    // A newer render started while we were unsubscribing; let it win so we do
+    // not leave a stale subscription running that overwrites the result.
+    if (requestId !== this._subscribeRequestId) {
+      return;
+    }
     this._error = undefined;
     this._errorLevel = undefined;
     this._templateResult = undefined;
@@ -511,6 +521,10 @@ ${type === "object"
       this._unsubRenderTemplate = subscribeRenderTemplate(
         this.hass.connection,
         (result) => {
+          // Ignore results from a render that has since been superseded.
+          if (requestId !== this._subscribeRequestId) {
+            return;
+          }
           if ("error" in result) {
             // We show the latest error, or a warning if there are no errors
             if (result.level === "ERROR" || this._errorLevel !== "ERROR") {


### PR DESCRIPTION
## Proposed change

In Developer Tools → Template, the result panel could keep showing the output of a previously entered template until you nudged the editor. Subscribing to a template render is asynchronous and is started from a few places, so two renders could overlap: the newer subscription overwrote the handle of the older one, leaving it running, and its late results overwrote the current output.

This tracks a render id so a superseded render stops before subscribing and its late results are ignored.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #13205
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
