### PR TITLE
Add `Entity Time` dashboard condition

### DIFF
--- a/src/common/condition/extract.ts
+++ b/src/common/condition/extract.ts
@@ -1,8 +1,9 @@
 import type {
   Condition,
+  EntityTimeCondition,
   TimeCondition,
 } from "../../panels/lovelace/common/validate-condition";
-
+import { validateEntityTimeCondition } from "../../panels/lovelace/common/validate-condition";
 /**
  * Extract media queries from conditions recursively
  */
@@ -23,14 +24,20 @@ export function extractMediaQueries(conditions: Condition[]): string[] {
  */
 export function extractTimeConditions(
   conditions: Condition[]
-): TimeCondition[] {
-  return conditions.reduce<TimeCondition[]>((array, c) => {
-    if ("conditions" in c && c.conditions) {
-      array.push(...extractTimeConditions(c.conditions));
-    }
-    if (c.condition === "time") {
-      array.push(c);
-    }
-    return array;
-  }, []);
+): (TimeCondition | EntityTimeCondition)[] {
+  return conditions.reduce<(TimeCondition | EntityTimeCondition)[]>(
+    (array, c) => {
+      if ("conditions" in c && c.conditions) {
+        array.push(...extractTimeConditions(c.conditions));
+      }
+      if (c.condition === "time") {
+        array.push(c);
+      }
+      if (c.condition === "entity_time" && validateEntityTimeCondition(c)) {
+        array.push(c);
+      }
+      return array;
+    },
+    []
+  );
 }

--- a/src/common/condition/listeners.ts
+++ b/src/common/condition/listeners.ts
@@ -6,7 +6,10 @@ import type {
 } from "../../panels/lovelace/common/validate-condition";
 import { checkConditionsMet } from "../../panels/lovelace/common/validate-condition";
 import { extractMediaQueries, extractTimeConditions } from "./extract";
-import { calculateNextTimeUpdate } from "./time-calculator";
+import {
+  calculateNextEntityTimeUpdate,
+  calculateNextTimeUpdate,
+} from "./time-calculator";
 
 /** Maximum delay for setTimeout (2^31 - 1 milliseconds, ~24.8 days)
  * Values exceeding this will overflow and execute immediately
@@ -67,7 +70,10 @@ export function setupTimeListeners(
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
     const scheduleUpdate = () => {
-      const delay = calculateNextTimeUpdate(hass, timeCondition);
+      const delay =
+        timeCondition.condition === "time"
+          ? calculateNextTimeUpdate(hass, timeCondition)
+          : calculateNextEntityTimeUpdate(hass, timeCondition);
 
       if (delay === undefined) return;
 

--- a/src/common/condition/time-calculator.ts
+++ b/src/common/condition/time-calculator.ts
@@ -4,11 +4,29 @@ import {
   addDays,
   addMinutes,
   differenceInMilliseconds,
+  addSeconds,
 } from "date-fns";
 import type { HomeAssistant } from "../../types";
 import { TimeZone } from "../../data/translation";
 import { parseTimeString } from "../datetime/check_time";
-import type { TimeCondition } from "../../panels/lovelace/common/validate-condition";
+import type {
+  TimeCondition,
+  EntityTimeCondition,
+} from "../../panels/lovelace/common/validate-condition";
+import type { HaDurationData } from "../../components/ha-duration-input";
+import durationToSeconds from "../datetime/duration_to_seconds";
+
+// Returns a date object consisisting of the time from an entity, adding
+// an optional offset
+export function parseEntityTime(
+  entity: string,
+  states: HomeAssistant["states"],
+  offset?: HaDurationData | string,
+  _timestamp?: "state" | "last_updated" | "last_changed"
+): Date {
+  const stateDate = new Date(states[entity].state);
+  return addSeconds(stateDate, durationToSeconds(offset || {}));
+}
 
 /**
  * Calculate milliseconds until next time boundary for a time condition
@@ -70,4 +88,32 @@ export function calculateNextTimeUpdate(
 
   // Calculate difference in milliseconds
   return differenceInMilliseconds(updateWithBuffer, now);
+}
+
+/**
+ * Calculate milliseconds until next time boundary for a time condition
+ * @param hass Home Assistant object
+ * @param condition Entity Time condition to calculate next update for
+ * @returns Milliseconds until next boundary, or undefined if no boundaries
+ */
+export function calculateNextEntityTimeUpdate(
+  hass: HomeAssistant,
+  { entity, timestamp, offset }: Omit<EntityTimeCondition, "condition">
+): number | undefined {
+  if (!entity) {
+    return undefined;
+  }
+  const timezone =
+    hass.locale.time_zone === TimeZone.server
+      ? hass.config.time_zone
+      : Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const now = new TZDate(new Date(), timezone);
+
+  const entityDate = parseEntityTime(entity, hass.states, offset, timestamp);
+  // Calculate next occurrence of after time
+
+  return entityDate > now
+    ? differenceInMilliseconds(entityDate, now)
+    : undefined;
 }

--- a/src/common/condition/time-calculator.ts
+++ b/src/common/condition/time-calculator.ts
@@ -22,9 +22,9 @@ export function parseEntityTime(
   entity: string,
   states: HomeAssistant["states"],
   offset?: HaDurationData | string,
-  _timestamp?: "state" | "last_updated" | "last_changed"
+  timestamp: "state" | "last_updated" | "last_changed" = "last_changed"
 ): Date {
-  const stateDate = new Date(states[entity].state);
+  const stateDate = new Date(states[entity][timestamp]);
   return addSeconds(stateDate, durationToSeconds(offset || {}));
 }
 

--- a/src/common/datetime/check_time.ts
+++ b/src/common/datetime/check_time.ts
@@ -3,7 +3,11 @@ import { isBefore, isAfter, isWithinInterval } from "date-fns";
 import type { HomeAssistant } from "../../types";
 import { TimeZone } from "../../data/translation";
 import { WEEKDAY_MAP } from "./weekday";
-import type { TimeCondition } from "../../panels/lovelace/common/validate-condition";
+import type {
+  TimeCondition,
+  EntityTimeCondition,
+} from "../../panels/lovelace/common/validate-condition";
+import { parseEntityTime } from "../condition/time-calculator";
 
 /**
  * Validate a time string format and value ranges without creating Date objects
@@ -128,4 +132,31 @@ export const checkTimeInRange = (
   }
 
   return true;
+};
+
+/**
+ * Check if the current time matches the entity time condition
+ * @param hass Home Assistant object
+ * @param condition Entity Time condition to check
+ * @returns true if current time matches the condition
+ */
+export const checkEntityTime = (
+  hass: HomeAssistant,
+  { entity, mode, offset, timestamp }: Omit<EntityTimeCondition, "condition">
+): boolean => {
+  if (!entity) {
+    return false;
+  }
+  const timezone =
+    hass.locale.time_zone === TimeZone.server
+      ? hass.config.time_zone
+      : Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const now = new TZDate(new Date(), timezone);
+
+  const entityDate = parseEntityTime(entity, hass.states, offset, timestamp);
+
+  return mode === "before"
+    ? isBefore(now, entityDate)
+    : isAfter(now, entityDate);
 };

--- a/src/common/datetime/duration_to_seconds.ts
+++ b/src/common/datetime/duration_to_seconds.ts
@@ -1,4 +1,15 @@
-export default function durationToSeconds(duration: string): number {
-  const parts = duration.split(":").map(Number);
-  return parts[0] * 3600 + parts[1] * 60 + parts[2];
+import type { HaDurationData } from "../../components/ha-duration-input";
+
+export default function durationToSeconds(
+  duration: string | HaDurationData
+): number {
+  if (typeof duration === "string") {
+    const parts = duration.split(":").map(Number);
+    return parts[0] * 3600 + parts[1] * 60 + parts[2];
+  }
+  const days = duration.days || 0;
+  const hours = days * 24 + (duration.hours || 0);
+  const minutes = hours * 60 + (duration.minutes || 0);
+  const seconds = minutes * 60 + (duration.seconds || 0);
+  return seconds;
 }

--- a/src/components/ha-duration-input.ts
+++ b/src/components/ha-duration-input.ts
@@ -233,7 +233,7 @@ export class HaDurationInput extends LitElement {
     ev.stopPropagation();
     const negative = (ev.detail?.value || ev.target.value) === "-";
     this._toggleNegative = negative;
-    const value = this.data;
+    const value = { ...this.data };
     if (value) {
       FIELDS.forEach((t) => {
         if (value[t]) {

--- a/src/data/entity/entity_is_timestamp.ts
+++ b/src/data/entity/entity_is_timestamp.ts
@@ -1,0 +1,19 @@
+import { TIMESTAMP_STATE_DOMAINS } from "../../common/const";
+import { computeDomain } from "../../common/entity/compute_domain";
+import type { HomeAssistant } from "../../types";
+import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../sensor";
+
+export const entityIsTimestamp = (
+  entityId: string,
+  states: HomeAssistant["states"]
+): boolean => {
+  const domain = computeDomain(entityId);
+
+  return (
+    TIMESTAMP_STATE_DOMAINS.has(domain) ||
+    (domain === "sensor" &&
+      SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
+        states[entityId]?.attributes.device_class || ""
+      ))
+  );
+};

--- a/src/panels/lovelace/cards/hui-card.ts
+++ b/src/panels/lovelace/cards/hui-card.ts
@@ -240,6 +240,10 @@ export class HuiCard extends ConditionalListenerMixin<LovelaceCardConfig>(
     if (changedProps.has("hass") || changedProps.has("preview")) {
       this._updateVisibility();
     }
+    if (changedProps.has("hass")) {
+      this.clearConditionalListeners();
+      this.setupConditionalListeners();
+    }
   }
 
   protected _updateVisibility(conditionsMet?: boolean) {

--- a/src/panels/lovelace/cards/hui-entity-filter-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.ts
@@ -8,6 +8,7 @@ import { computeCardSize } from "../common/compute-card-size";
 import { evaluateStateFilter } from "../common/evaluate-filter";
 import { findEntities } from "../common/find-entities";
 import { processConfigEntities } from "../common/process-config-entities";
+import type { Condition } from "../common/validate-condition";
 import {
   addEntityToCondition,
   checkConditionsMet,
@@ -17,10 +18,11 @@ import type { EntityFilterEntityConfig } from "../entity-rows/types";
 import type { LovelaceCard } from "../types";
 import type { HuiCard } from "./hui-card";
 import type { EntityFilterCardConfig } from "./types";
+import { ConditionalListenerMixin } from "../../../mixins/conditional-listener-mixin";
 
 @customElement("hui-entity-filter-card")
 export class HuiEntityFilterCard
-  extends ReactiveElement
+  extends ConditionalListenerMixin<EntityFilterCardConfig>(ReactiveElement)
   implements LovelaceCard
 {
   public static getStubConfig(
@@ -58,7 +60,7 @@ export class HuiEntityFilterCard
 
   @property({ type: Boolean }) public preview = false;
 
-  @state() private _config?: EntityFilterCardConfig;
+  @state() protected _config?: EntityFilterCardConfig;
 
   private _element?: HuiCard;
 
@@ -67,6 +69,8 @@ export class HuiEntityFilterCard
   private _baseCardConfig?: LovelaceCardConfig;
 
   private _oldEntities?: EntityFilterEntityConfig[];
+
+  private _forceNextUpdate = false;
 
   public getCardSize(): number | Promise<number> {
     return this._element ? computeCardSize(this._element) : 1;
@@ -143,6 +147,10 @@ export class HuiEntityFilterCard
       this._element.preview = this.preview;
       this._element.layout = this.layout;
     }
+    if (this._forceNextUpdate) {
+      this._forceNextUpdate = false;
+      return true;
+    }
     if (changedProps.has("_config") || changedProps.has("preview")) {
       return true;
     }
@@ -164,6 +172,9 @@ export class HuiEntityFilterCard
     ) {
       return;
     }
+
+    this.clearConditionalListeners();
+    this.setupConditionalListeners();
 
     const entitiesList = this._configEntities.filter((entityConf) => {
       const stateObj = this.hass!.states[entityConf.entity];
@@ -277,6 +288,37 @@ export class HuiEntityFilterCard
     element.config = cardConfig;
     element.load();
     return element;
+  }
+
+  protected setupConditionalListeners() {
+    if (!this._configEntities || !this.hass) {
+      return;
+    }
+
+    const conditions: Condition[] = [];
+
+    this._configEntities.forEach((entityConf) => {
+      const stateObj = this.hass!.states[entityConf.entity];
+      if (!stateObj) return;
+
+      const entityConditions =
+        entityConf.conditions ?? this._config!.conditions;
+      if (entityConditions && !entityConf.state_filter) {
+        entityConditions.forEach((condition) => {
+          if (condition.condition === "entity_time") {
+            conditions.push(addEntityToCondition(condition, entityConf.entity));
+          }
+        });
+      }
+    });
+
+    // Pass filtered conditions to parent implementation
+    super.setupConditionalListeners(conditions);
+  }
+
+  protected _updateVisibility() {
+    this._forceNextUpdate = true;
+    this.requestUpdate();
   }
 }
 

--- a/src/panels/lovelace/common/icon-condition.ts
+++ b/src/panels/lovelace/common/icon-condition.ts
@@ -8,6 +8,7 @@ import {
   mdiNumeric,
   mdiResponsive,
   mdiStateMachine,
+  mdiTimer,
   mdiViewColumnOutline,
 } from "@mdi/js";
 import type { Condition } from "./validate-condition";
@@ -18,6 +19,7 @@ export const ICON_CONDITION: Record<Condition["condition"], string> = {
   numeric_state: mdiNumeric,
   state: mdiStateMachine,
   screen: mdiResponsive,
+  entity_time: mdiTimer,
   time: mdiCalendarClock,
   user: mdiAccount,
   and: mdiAmpersand,

--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -2,12 +2,14 @@ import { ensureArray } from "../../../common/array/ensure-array";
 import {
   checkTimeInRange,
   isValidTimeString,
+  checkEntityTime,
 } from "../../../common/datetime/check_time";
 import {
   WEEKDAYS_SHORT,
   type WeekdayShort,
 } from "../../../common/datetime/weekday";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
+import type { HaDurationData } from "../../../components/ha-duration-input";
 import { UNKNOWN } from "../../../data/entity/entity";
 import { getUserPerson } from "../../../data/person";
 import type { HomeAssistant } from "../../../types";
@@ -18,6 +20,7 @@ export type Condition =
   | NumericStateCondition
   | StateCondition
   | ScreenCondition
+  | EntityTimeCondition
   | TimeCondition
   | UserCondition
   | OrCondition
@@ -70,6 +73,14 @@ export interface StateCondition extends BaseCondition {
 export interface ScreenCondition extends BaseCondition {
   condition: "screen";
   media_query?: string;
+}
+
+export interface EntityTimeCondition extends BaseCondition {
+  condition: "entity_time";
+  entity?: string;
+  mode?: "before" | "after";
+  offset?: string | HaDurationData;
+  timestamp?: "state" | "last_updated" | "last_changed";
 }
 
 export interface TimeCondition extends BaseCondition {
@@ -208,6 +219,13 @@ function checkScreenCondition(condition: ScreenCondition, _: HomeAssistant) {
     : false;
 }
 
+function checkEntityTimeCondition(
+  condition: Omit<EntityTimeCondition, "condition">,
+  hass: HomeAssistant
+) {
+  return checkEntityTime(hass, condition);
+}
+
 function checkTimeCondition(
   condition: Omit<TimeCondition, "condition">,
   hass: HomeAssistant
@@ -278,6 +296,8 @@ export function checkConditionsMet(
       switch (c.condition) {
         case "view_columns":
           return checkViewColumnsCondition(c, context);
+        case "entity_time":
+          return checkEntityTimeCondition(c, hass);
         case "time":
           return checkTimeCondition(c, hass);
         case "screen":
@@ -335,6 +355,12 @@ export function extractConditionEntityIds(
           entityIds.add(state);
         }
       });
+    } else if (
+      condition.condition === "entity_time" &&
+      condition.entity &&
+      isValidEntityId(condition.entity)
+    ) {
+      entityIds.add(condition.entity);
     } else if ("conditions" in condition && condition.conditions) {
       return new Set([
         ...entityIds,
@@ -351,6 +377,10 @@ function validateStateCondition(condition: StateCondition | LegacyCondition) {
 
 function validateScreenCondition(condition: ScreenCondition) {
   return condition.media_query != null;
+}
+
+export function validateEntityTimeCondition(condition: EntityTimeCondition) {
+  return condition.entity ? isValidEntityId(condition.entity) : false;
 }
 
 function validateTimeCondition(condition: TimeCondition) {
@@ -424,6 +454,8 @@ export function validateConditionalConfig(
           return validateViewColumnsCondition(c);
         case "screen":
           return validateScreenCondition(c);
+        case "entity_time":
+          return validateEntityTimeCondition(c);
         case "time":
           return validateTimeCondition(c);
         case "user":
@@ -467,7 +499,8 @@ export function addEntityToCondition(
 
   if (
     condition.condition === "state" ||
-    condition.condition === "numeric_state"
+    condition.condition === "numeric_state" ||
+    condition.condition === "entity_time"
   ) {
     return {
       entity: entityId,

--- a/src/panels/lovelace/editor/conditions/ha-card-conditions-editor.ts
+++ b/src/panels/lovelace/editor/conditions/ha-card-conditions-editor.ts
@@ -34,6 +34,7 @@ import "./types/ha-card-condition-or";
 import "./types/ha-card-condition-screen";
 import "./types/ha-card-condition-state";
 import "./types/ha-card-condition-state-no_entity";
+import "./types/ha-card-condition-entity_time";
 import "./types/ha-card-condition-time";
 import "./types/ha-card-condition-user";
 
@@ -42,6 +43,7 @@ const UI_CONDITION = [
   "numeric_state",
   "state",
   "screen",
+  "entity_time",
   "time",
   "user",
   "and",

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-entity_time.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-entity_time.ts
@@ -1,0 +1,134 @@
+import { html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import {
+  literal,
+  object,
+  optional,
+  string,
+  assert,
+  enums,
+  union,
+  number,
+} from "superstruct";
+import memoizeOne from "memoize-one";
+import type { HomeAssistant } from "../../../../../types";
+import type { LocalizeFunc } from "../../../../../common/translations/localize";
+import type { EntityTimeCondition } from "../../../common/validate-condition";
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import type {
+  HaFormSchema,
+  SchemaUnion,
+} from "../../../../../components/ha-form/types";
+import "../../../../../components/ha-form/ha-form";
+
+const durationStruct = union([
+  string(),
+  object({
+    days: optional(number()),
+    hours: optional(number()),
+    minutes: optional(number()),
+    seconds: optional(number()),
+  }),
+]);
+
+const entityTimeConditionStruct = object({
+  condition: literal("entity_time"),
+  entity: optional(string()),
+  offset: optional(durationStruct),
+  mode: optional(enums(["before", "after"])),
+  timestamp: optional(enums(["state", "last_updated", "last_changed"])),
+});
+
+@customElement("ha-card-condition-entity_time")
+export class HaCardConditionEntityTime extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public condition!: EntityTimeCondition;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  public static get defaultConfig(): EntityTimeCondition {
+    return {
+      condition: "entity_time",
+      entity: "",
+      mode: "after",
+      timestamp: "state",
+    };
+  }
+
+  protected static validateUIConfig(condition: EntityTimeCondition) {
+    return assert(condition, entityTimeConditionStruct);
+  }
+
+  private _schema = memoizeOne(
+    (localize: LocalizeFunc) =>
+      [
+        {
+          name: "entity",
+          selector: { entity: {} },
+        },
+        {
+          name: "offset",
+          selector: {
+            duration: {
+              allow_negative: true,
+              enable_day: true,
+            },
+          },
+        },
+        {
+          name: "mode",
+          selector: {
+            select: {
+              options: [
+                {
+                  value: "before",
+                  label: localize(
+                    "ui.panel.lovelace.editor.condition-editor.condition.entity_time.before"
+                  ),
+                },
+                {
+                  value: "after",
+                  label: localize(
+                    "ui.panel.lovelace.editor.condition-editor.condition.entity_time.after"
+                  ),
+                },
+              ],
+            },
+          },
+        },
+      ] as const satisfies HaFormSchema[]
+  );
+
+  protected render() {
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${this.condition}
+        .computeLabel=${this._computeLabelCallback}
+        .schema=${this._schema(this.hass.localize)}
+        .disabled=${this.disabled}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent) {
+    ev.stopPropagation();
+    const data = ev.detail.value as EntityTimeCondition;
+    fireEvent(this, "value-changed", { value: data });
+  }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ): string =>
+    this.hass.localize(
+      `ui.panel.lovelace.editor.condition-editor.condition.entity_time.${schema.name}`
+    );
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-card-condition-entity_time": HaCardConditionEntityTime;
+  }
+}

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-entity_time.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-entity_time.ts
@@ -20,6 +20,7 @@ import type {
   SchemaUnion,
 } from "../../../../../components/ha-form/types";
 import "../../../../../components/ha-form/ha-form";
+import { entityIsTimestamp } from "../../../../../data/entity/entity_is_timestamp";
 
 const durationStruct = union([
   string(),
@@ -52,7 +53,7 @@ export class HaCardConditionEntityTime extends LitElement {
       condition: "entity_time",
       entity: "",
       mode: "after",
-      timestamp: "state",
+      timestamp: "last_changed",
     };
   }
 
@@ -61,7 +62,7 @@ export class HaCardConditionEntityTime extends LitElement {
   }
 
   private _schema = memoizeOne(
-    (localize: LocalizeFunc) =>
+    (localize: LocalizeFunc, includeState: boolean) =>
       [
         {
           name: "entity",
@@ -97,16 +98,49 @@ export class HaCardConditionEntityTime extends LitElement {
             },
           },
         },
+        {
+          name: "timestamp",
+          selector: {
+            select: {
+              options: [
+                {
+                  value: "last_changed",
+                  label: localize(
+                    "ui.panel.lovelace.editor.condition-editor.condition.entity_time.last_changed"
+                  ),
+                },
+                {
+                  value: "last_updated",
+                  label: localize(
+                    "ui.panel.lovelace.editor.condition-editor.condition.entity_time.last_updated"
+                  ),
+                },
+                ...(includeState
+                  ? [
+                      {
+                        value: "state",
+                        label: localize(
+                          "ui.panel.lovelace.editor.condition-editor.condition.entity_time.state"
+                        ),
+                      },
+                    ]
+                  : []),
+              ],
+            },
+          },
+        },
       ] as const satisfies HaFormSchema[]
   );
 
   protected render() {
+    const entity = this.condition.entity || "";
+    const includeState = entityIsTimestamp(entity, this.hass.states);
     return html`
       <ha-form
         .hass=${this.hass}
         .data=${this.condition}
         .computeLabel=${this._computeLabelCallback}
-        .schema=${this._schema(this.hass.localize)}
+        .schema=${this._schema(this.hass.localize, includeState)}
         .disabled=${this.disabled}
         @value-changed=${this._valueChanged}
       ></ha-form>
@@ -116,6 +150,15 @@ export class HaCardConditionEntityTime extends LitElement {
   private _valueChanged(ev: CustomEvent) {
     ev.stopPropagation();
     const data = ev.detail.value as EntityTimeCondition;
+    if (
+      data.timestamp === "state" &&
+      !entityIsTimestamp(data.entity || "", this.hass.states)
+    ) {
+      fireEvent(this, "value-changed", {
+        value: { ...data, timestamp: "last_changed" },
+      });
+      return;
+    }
     fireEvent(this, "value-changed", { value: data });
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9287,6 +9287,12 @@
                 "before": "Before",
                 "weekdays": "Weekdays"
               },
+              "entity_time": {
+                "label": "Entity Time",
+                "after": "After",
+                "before": "Before",
+                "offset": "Offset"
+              },
               "location": {
                 "label": "Location",
                 "locations": "Locations",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9291,7 +9291,11 @@
                 "label": "Entity Time",
                 "after": "After",
                 "before": "Before",
-                "offset": "Offset"
+                "offset": "Offset",
+                "last_changed": "Last changed",
+                "last_updated": "Last updated",
+                "timestamp": "Timestamp mode",
+                "state": "Entity state"
               },
               "location": {
                 "label": "Location",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This adds a new dashboard condition which I'm calling "Entity Time". It allows you to set visibility based on doing time offsets either with an entity's state or last_changed.

This allows for capabilities like:
 - Show a card if a button hasn't been pressed in the last 24 hours (chore reminder?)
 - Show a card if a timestamp sensor is coming up in the next 24 hours. 
 - Show a filtered glance card of motion sensors / doors / windows that have changed state in the last 15 minutes.
 
 I can think of a lot of use cases where you would want to see something on the dashboard based on timestamps that have either recently happened, or are scheduled to happen in the near future.
 
 The backend automation `time` condition currently supports something like this as well, it allows you to specify a fixed time or sensor-based dynamic times. I initially started this by folding it into the time condtion in the same way that the backend automations do, but I decided this was really suboptimal and it was better as a standalone condition type:
 
  - Having a single `entity` field allows conditions to automatically assign entity ids, and allows writing like a single condition that applies to all entities in an entity_filter. Reusing the existing time condition would have two optional entity id fields (before & after), which wouldn't work well with context or entity-filter. 
  - The logic is much simplified where everywhere we touch the condition we don't have to try to decode a choose block to see if it is a fixed time or an entity id. I started with this implementation but it was pretty ugly trying to mush two quite different conditions into single logic flows.
  - Keeping the conditions separate simplifies the UI quite a bit for both time and time_entity, and I think you don't typically need both "before" and "after" conditions simulataneously when working with entities.
  
Todo:
- [x] Fix entity filter to use a listener mixin for time based conditions
- [x] Support a state/last_changed/last_updated toggle
- [x] Figure out what entities can use `state` based dates
- [x] Error handling when state is not a parseable date
- [ ] Figure out what to do with `input_datetime` (core bug https://github.com/home-assistant/core/issues/174351)
- [ ] Maybe fix https://github.com/home-assistant/frontend/issues/52761. 
- [ ] Entity selector should be pre-filled with entity context.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
