### PR TITLE
Fix negative monetary

### DIFF
--- a/src/common/entity/compute_entity_unit_display.ts
+++ b/src/common/entity/compute_entity_unit_display.ts
@@ -1,6 +1,7 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import { UNAVAILABLE, UNKNOWN } from "../../data/entity/entity";
 import type { HomeAssistant } from "../../types";
+import { unitFromParts } from "./value_parts";
 
 interface EntityUnitStubConfig {
   entity: string;
@@ -40,5 +41,5 @@ export const computeEntityUnitDisplay = (
     ? hass.formatEntityAttributeValueToParts(stateObj, config.attribute)
     : hass.formatEntityStateToParts(stateObj);
 
-  return parts.find((part) => part.type === "unit")?.value ?? "";
+  return unitFromParts(parts);
 };

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -160,7 +160,8 @@ const computeStateToPartsFromEntityAttributes = (
           const type = MONETARY_TYPE_MAP[part.type];
           if (!type) continue;
           const last = valueParts[valueParts.length - 1];
-          // Merge consecutive value parts (e.g. "-" + "12" + "." + "00" → "-12.00")
+          // Merge consecutive value parts so the number stays a single part
+          // (e.g. "-" + "12" + "." + "00" → "-12.00")
           if (type === "value" && last?.type === "value") {
             last.value += part.value;
           } else {

--- a/src/common/entity/value_parts.ts
+++ b/src/common/entity/value_parts.ts
@@ -1,0 +1,29 @@
+import type { ValuePart } from "../../types";
+
+// Joins every part except the unit, keeping native order so the sign and
+// grouping stay with the value (e.g. "-2,548.14").
+export const valueFromParts = (parts: ValuePart[]): string =>
+  parts
+    .filter((part) => part.type !== "unit")
+    .map((part) => part.value)
+    .join("")
+    .trim();
+
+export const unitFromParts = (parts: ValuePart[]): string =>
+  parts.find((part) => part.type === "unit")?.value ?? "";
+
+export type UnitPosition = "before" | "after";
+
+// Whether the unit sits before or after the value in the locale's native order
+// (e.g. "$5" / "€ 5" → "before", "5 €" / "5 %" → "after").
+export const unitPosition = (parts: ValuePart[]): UnitPosition => {
+  const unitIndex = parts.findIndex((part) => part.type === "unit");
+  if (unitIndex === -1) {
+    return "after";
+  }
+  const lastValueIndex = parts.reduceRight(
+    (acc, part, i) => (acc === -1 && part.type === "value" ? i : acc),
+    -1
+  );
+  return unitIndex < lastValueIndex ? "before" : "after";
+};

--- a/src/components/entity/ha-state-label-badge.ts
+++ b/src/components/entity/ha-state-label-badge.ts
@@ -8,6 +8,7 @@ import { arrayLiteralIncludes } from "../../common/array/literal-includes";
 import secondsToDuration from "../../common/datetime/seconds_to_duration";
 import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { computeStateName } from "../../common/entity/compute_state_name";
+import { unitFromParts, valueFromParts } from "../../common/entity/value_parts";
 import { FIXED_DOMAIN_STATES } from "../../common/entity/get_states";
 import { UNAVAILABLE, UNKNOWN } from "../../data/entity/entity";
 import type { EntityRegistryDisplayEntry } from "../../data/entity/entity_registry";
@@ -163,20 +164,18 @@ export class HaStateLabelBadge extends LitElement {
       case "sun":
       case "timer":
         return null;
-      // @ts-expect-error we don't break and go to default
       case "sensor":
         if (entry?.platform === "moon") {
           return null;
         }
-      // eslint-disable-next-line: disable=no-fallthrough
+        break;
       default:
-        return entityState.state === UNAVAILABLE ||
-          entityState.state === UNKNOWN
-          ? "—"
-          : this.hass!.formatEntityStateToParts(entityState).find(
-              (part) => part.type === "value"
-            )?.value;
+        break;
     }
+    if (entityState.state === UNAVAILABLE || entityState.state === UNKNOWN) {
+      return "—";
+    }
+    return valueFromParts(this.hass!.formatEntityStateToParts(entityState));
   }
 
   private _computeShowIcon(
@@ -225,9 +224,7 @@ export class HaStateLabelBadge extends LitElement {
       return secondsToDuration(_timerTimeRemaining);
     }
     return (
-      this.hass!.formatEntityStateToParts(entityState).find(
-        (part) => part.type === "unit"
-      )?.value || null
+      unitFromParts(this.hass!.formatEntityStateToParts(entityState)) || null
     );
   }
 

--- a/src/components/ha-attribute-value.ts
+++ b/src/components/ha-attribute-value.ts
@@ -7,6 +7,7 @@ import { customElement, property, state } from "lit/decorators";
 import { AsyncValueTask } from "../common/controllers/async-value-task";
 import { computeStateDomain } from "../common/entity/compute_state_domain";
 import { getValueAttribute } from "../common/entity/get_states";
+import { valueFromParts } from "../common/entity/value_parts";
 import { formattersContext } from "../data/context";
 
 const isObjectValue = (value: unknown): boolean =>
@@ -94,10 +95,7 @@ class HaAttributeValue extends LitElement {
         this.stateObj!,
         this.attribute
       );
-      return parts
-        .filter((part) => part.type === "value")
-        .map((part) => part.value)
-        .join("");
+      return valueFromParts(parts);
     }
 
     return this._formatters!.formatEntityAttributeValue(

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -1,5 +1,5 @@
 import type { HassEntity } from "home-assistant-js-websocket";
-import type { CSSResultGroup, PropertyValues } from "lit";
+import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
@@ -9,6 +9,10 @@ import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_elemen
 import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { computeEntityUnitDisplay } from "../../../common/entity/compute_entity_unit_display";
 import { computeStateDomain } from "../../../common/entity/compute_state_domain";
+import {
+  unitPosition,
+  valueFromParts,
+} from "../../../common/entity/value_parts";
 import {
   stateColorBrightness,
   stateColorCss,
@@ -119,15 +123,12 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
     }
 
     const domain = computeStateDomain(stateObj);
+    const customUnit = this._config.unit;
     const unit = computeEntityUnitDisplay(this.hass, stateObj, this._config);
     const stateParts = this.hass.formatEntityStateToParts(stateObj);
-
-    const indexUnit = stateParts.findIndex((part) => part.type === "unit");
-    const indexValue = stateParts.reduceRight(
-      (acc, part, i) => (acc === -1 && part.type === "value" ? i : acc),
-      -1
-    );
-    const reversedOrder = indexUnit !== -1 && indexUnit < indexValue;
+    // The unit is styled separately, so place it before or after the value
+    // following the locale's native order. A custom unit always trails.
+    const unitFirst = !customUnit && unitPosition(stateParts) === "before";
 
     const name = this.hass.formatEntityName(stateObj, this._config.name);
 
@@ -172,33 +173,23 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
           </div>
         </div>
         <div class="info">
-          <span
-            class=${classMap({
-              value: true,
-              "first-part": !reversedOrder,
-            })}
-            >${"attribute" in this._config
-              ? stateObj.attributes[this._config.attribute!] !== undefined
-                ? html`<ha-attribute-value
-                    hide-unit
-                    .stateObj=${stateObj}
-                    .attribute=${this._config.attribute!}
-                  >
-                  </ha-attribute-value>`
-                : this.hass.localize("state.default.unknown")
-              : stateParts
-                  .filter((part) => part.type === "value")
-                  .map((part) => part.value)
-                  .join("")}</span
-          >${unit
-            ? html`<span
-                class=${classMap({
-                  measurement: true,
-                  "first-part": reversedOrder,
-                })}
-                >${unit}</span
-              >`
-            : nothing}
+          ${"attribute" in this._config
+            ? this._renderValueWithUnit(
+                stateObj.attributes[this._config.attribute!] !== undefined
+                  ? html`<ha-attribute-value
+                      hide-unit
+                      .stateObj=${stateObj}
+                      .attribute=${this._config.attribute!}
+                    ></ha-attribute-value>`
+                  : this.hass.localize("state.default.unknown"),
+                unit,
+                false
+              )
+            : this._renderValueWithUnit(
+                valueFromParts(stateParts),
+                unit,
+                unitFirst
+              )}
         </div>
         <div
           class="footer"
@@ -212,6 +203,22 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
         </div>
       </ha-card>
     `;
+  }
+
+  private _renderValueWithUnit(
+    value: TemplateResult | string,
+    unit: string,
+    unitFirst: boolean
+  ) {
+    return html`<span
+        class=${classMap({ value: true, "first-part": !unitFirst })}
+        >${value}</span
+      >${unit
+        ? html`<span
+            class=${classMap({ measurement: true, "first-part": unitFirst })}
+            >${unit}</span
+          >`
+        : nothing}`;
   }
 
   private _computeColor(stateObj: HassEntity): string | undefined {

--- a/src/panels/lovelace/cards/hui-gauge-card.ts
+++ b/src/panels/lovelace/cards/hui-gauge-card.ts
@@ -6,7 +6,7 @@ import { classMap } from "lit/directives/class-map";
 import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
-import { computeEntityUnitDisplay } from "../../../common/entity/compute_entity_unit_display";
+import { valueFromParts } from "../../../common/entity/value_parts";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
 import "../../../components/ha-card";
 import "../../../components/ha-gauge";
@@ -115,7 +115,12 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
     } else {
       parts = this.hass.formatEntityStateToParts(stateObj);
     }
-    const valueToDisplay = parts.find((part) => part.type === "value")?.value;
+    const customUnit = this._config.unit;
+    // Custom unit can't keep a locale position, so append it at the end;
+    // otherwise render natively.
+    const valueToDisplay = customUnit
+      ? valueFromParts(parts)
+      : parts.map((part) => part.value).join("");
     const value = this._config.attribute
       ? stateObj.attributes[this._config.attribute]
       : stateObj.state;
@@ -134,8 +139,6 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
     }
 
     const name = this.hass.formatEntityName(stateObj, this._config.name);
-    const unit =
-      computeEntityUnitDisplay(this.hass, stateObj, this._config) ?? "";
 
     return html`
       <ha-card
@@ -159,7 +162,7 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
           .value=${value}
           .valueText=${valueToDisplay}
           .locale=${this.hass!.locale}
-          .label=${unit}
+          .label=${customUnit ?? ""}
           style=${styleMap({
             "--gauge-color": this._computeSeverity(Number(value)),
           })}

--- a/src/panels/lovelace/cards/hui-plant-status-card.ts
+++ b/src/panels/lovelace/cards/hui-plant-status-card.ts
@@ -12,6 +12,7 @@ import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_elemen
 import { fireEvent } from "../../../common/dom/fire_event";
 import { batteryLevelIcon } from "../../../common/entity/battery_icon";
 import { batteryStateColorProperty } from "../../../common/entity/color/battery_color";
+import { valueFromParts } from "../../../common/entity/value_parts";
 import "../../../components/ha-card";
 import "../../../components/ha-svg-icon";
 import { computeCssVariable } from "../../../resources/css-variables";
@@ -258,10 +259,9 @@ class HuiPlantStatusCard extends LitElement implements LovelaceCard {
       ? this.hass!.states[sensorEntityId]
       : undefined;
     if (sensorStateObj) {
-      return this.hass!.formatEntityStateToParts(sensorStateObj)
-        .filter((part) => part.type !== "unit")
-        .map((part) => part.value)
-        .join("");
+      return valueFromParts(
+        this.hass!.formatEntityStateToParts(sensorStateObj)
+      );
     }
     return stateObj.attributes[attribute] ?? "";
   }

--- a/test/common/entity/value_parts.test.ts
+++ b/test/common/entity/value_parts.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { computeStateToParts } from "../../../src/common/entity/compute_state_display";
+import {
+  unitFromParts,
+  unitPosition,
+  valueFromParts,
+} from "../../../src/common/entity/value_parts";
+import type { FrontendLocaleData } from "../../../src/data/translation";
+import {
+  DateFormat,
+  FirstWeekday,
+  NumberFormat,
+  TimeFormat,
+  TimeZone,
+} from "../../../src/data/translation";
+import { demoConfig } from "../../../src/fake_data/demo_config";
+import type { ValuePart } from "../../../src/types";
+
+describe("valueFromParts", () => {
+  it("keeps the sign and drops the unit when the symbol leads", () => {
+    const parts: ValuePart[] = [
+      { type: "value", value: "-" },
+      { type: "unit", value: "$" },
+      { type: "value", value: "12.00" },
+    ];
+    expect(valueFromParts(parts)).toBe("-12.00");
+  });
+
+  it("keeps the sign and drops the unit when the symbol trails", () => {
+    const parts: ValuePart[] = [
+      { type: "value", value: "-12,00" },
+      { type: "literal", value: " " },
+      { type: "unit", value: "€" },
+    ];
+    expect(valueFromParts(parts)).toBe("-12,00");
+  });
+
+  it("trims the literal left behind by a leading unit", () => {
+    const parts: ValuePart[] = [
+      { type: "unit", value: "€" },
+      { type: "literal", value: " " },
+      { type: "value", value: "-12,00" },
+    ];
+    expect(valueFromParts(parts)).toBe("-12,00");
+  });
+
+  it("returns the value unchanged when there is no unit", () => {
+    const parts: ValuePart[] = [{ type: "value", value: "21" }];
+    expect(valueFromParts(parts)).toBe("21");
+  });
+});
+
+describe("unitFromParts", () => {
+  it("returns the unit value", () => {
+    const parts: ValuePart[] = [
+      { type: "value", value: "21" },
+      { type: "literal", value: " " },
+      { type: "unit", value: "°C" },
+    ];
+    expect(unitFromParts(parts)).toBe("°C");
+  });
+
+  it("returns an empty string when there is no unit", () => {
+    const parts: ValuePart[] = [{ type: "value", value: "21" }];
+    expect(unitFromParts(parts)).toBe("");
+  });
+});
+
+describe("unitPosition", () => {
+  it("is before when the unit leads the value", () => {
+    const parts: ValuePart[] = [
+      { type: "value", value: "-" },
+      { type: "unit", value: "$" },
+      { type: "value", value: "12.00" },
+    ];
+    expect(unitPosition(parts)).toBe("before");
+  });
+
+  it("is after when the unit trails the value", () => {
+    const parts: ValuePart[] = [
+      { type: "value", value: "-12,00" },
+      { type: "literal", value: " " },
+      { type: "unit", value: "€" },
+    ];
+    expect(unitPosition(parts)).toBe("after");
+  });
+
+  it("is after when there is no unit", () => {
+    const parts: ValuePart[] = [{ type: "value", value: "21" }];
+    expect(unitPosition(parts)).toBe("after");
+  });
+});
+
+describe("negative monetary parts", () => {
+  const localize = ((message: string) => message) as any;
+  const localeData: FrontendLocaleData = {
+    language: "en",
+    number_format: NumberFormat.comma_decimal,
+    time_format: TimeFormat.am_pm,
+    date_format: DateFormat.language,
+    time_zone: TimeZone.local,
+    first_weekday: FirstWeekday.language,
+  };
+  const stateObj: any = {
+    entity_id: "sensor.balance",
+    state: "-12",
+    attributes: { device_class: "monetary", unit_of_measurement: "USD" },
+  };
+
+  it("keep the sign with the value and expose the symbol as the unit", () => {
+    const parts = computeStateToParts(
+      localize,
+      stateObj,
+      localeData,
+      demoConfig,
+      {}
+    );
+    expect(valueFromParts(parts)).toBe("-12.00");
+    expect(unitFromParts(parts)).toBe("$");
+  });
+
+  it("place the unit before the value (rendered as $-12.00)", () => {
+    const parts = computeStateToParts(
+      localize,
+      stateObj,
+      localeData,
+      demoConfig,
+      {}
+    );
+    const value = valueFromParts(parts);
+    const unit = unitFromParts(parts);
+    expect(unitPosition(parts)).toBe("before");
+    const display =
+      unitPosition(parts) === "before" ? `${unit}${value}` : `${value}${unit}`;
+    expect(display).toBe("$-12.00");
+  });
+});

--- a/test/common/entity/value_parts.test.ts
+++ b/test/common/entity/value_parts.test.ts
@@ -67,7 +67,7 @@ describe("unitFromParts", () => {
 });
 
 describe("unitPosition", () => {
-  it("is before when the unit leads the value", () => {
+  it("is before when the symbol sits between the sign and digits ($-12)", () => {
     const parts: ValuePart[] = [
       { type: "value", value: "-" },
       { type: "unit", value: "$" },
@@ -76,17 +76,21 @@ describe("unitPosition", () => {
     expect(unitPosition(parts)).toBe("before");
   });
 
-  it("is after when the unit trails the value", () => {
+  it("is before when the symbol leads (€ -12)", () => {
+    const parts: ValuePart[] = [
+      { type: "unit", value: "€" },
+      { type: "literal", value: " " },
+      { type: "value", value: "-12,00" },
+    ];
+    expect(unitPosition(parts)).toBe("before");
+  });
+
+  it("is after when the symbol trails (-12 €)", () => {
     const parts: ValuePart[] = [
       { type: "value", value: "-12,00" },
       { type: "literal", value: " " },
       { type: "unit", value: "€" },
     ];
-    expect(unitPosition(parts)).toBe("after");
-  });
-
-  it("is after when there is no unit", () => {
-    const parts: ValuePart[] = [{ type: "value", value: "21" }];
     expect(unitPosition(parts)).toBe("after");
   });
 });
@@ -117,21 +121,5 @@ describe("negative monetary parts", () => {
     );
     expect(valueFromParts(parts)).toBe("-12.00");
     expect(unitFromParts(parts)).toBe("$");
-  });
-
-  it("place the unit before the value (rendered as $-12.00)", () => {
-    const parts = computeStateToParts(
-      localize,
-      stateObj,
-      localeData,
-      demoConfig,
-      {}
-    );
-    const value = valueFromParts(parts);
-    const unit = unitFromParts(parts);
-    expect(unitPosition(parts)).toBe("before");
-    const display =
-      unitPosition(parts) === "before" ? `${unit}${value}` : `${value}${unit}`;
-    expect(display).toBe("$-12.00");
   });
 });


### PR DESCRIPTION
## Proposed change

Negative monetary values were broken in two cards because they read a single formatted part:

- Gauge card: the amount was dropped, leaving only the sign and currency symbol (e.g. `- $`).
- Badge: the amount was dropped, showing only the sign.

The value and unit handling now goes through shared helpers so the full signed amount is kept. The entity card already kept the sign; since it styles the unit separately, the currency symbol stays next to the value (e.g. `$ -2,548.14`) rather than following the full locale order.

Replaces https://github.com/home-assistant/frontend/pull/52751 and https://github.com/home-assistant/frontend/pull/52431

## Screenshots

<img width="1069" height="463" alt="CleanShot 2026-06-19 at 18 03 58" src="https://github.com/user-attachments/assets/1040fb8a-2606-4825-991b-8fb6ea33a336" />

<img width="1069" height="463" alt="CleanShot 2026-06-19 at 18 03 46" src="https://github.com/user-attachments/assets/11369f9b-689d-49e1-9f2a-ec96be41ff16" />

<img width="1068" height="463" alt="CleanShot 2026-06-19 at 18 03 38" src="https://github.com/user-attachments/assets/827a6cae-a05c-42d8-876e-0bfb1008ad07" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/52239
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
