### PR TITLE
time_format migration and enhancements in entities and glance cards

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -64,7 +64,7 @@ export const migrateEntitiesCardConfig = (
     const { format, ...rest } = e;
     return {
       ...rest,
-      time_format: format,
+      time_format: (rest as EntityConfig).time_format ?? format,
     };
   });
   if (!changed) {
@@ -180,12 +180,12 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
       throw new Error("Entities must be specified");
     }
 
-    const migrateConfig = migrateEntitiesCardConfig(config);
-    const entities = processConfigEntities(migrateConfig.entities);
+    const migratedConfig = migrateEntitiesCardConfig(config);
+    const entities = processConfigEntities(migratedConfig.entities);
 
-    this._config = migrateConfig;
+    this._config = migratedConfig;
     this._configEntities = entities;
-    this._showHeaderToggle = computeShowHeaderToggle(migrateConfig, entities);
+    this._showHeaderToggle = computeShowHeaderToggle(migratedConfig, entities);
     if (this._config.header) {
       this._headerElement = createHeaderFooterElement(
         this._config.header

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -49,6 +49,33 @@ export const computeShowHeaderToggle = <
   return !!config.show_header_toggle;
 };
 
+export const migrateEntitiesCardConfig = (
+  config: EntitiesCardConfig
+): EntitiesCardConfig => {
+  let changed = false;
+  const newEntities = config.entities?.map((e) => {
+    if (typeof e !== "object") {
+      return e;
+    }
+    if (!("format" in e)) {
+      return e;
+    }
+    changed = true;
+    const { format, ...rest } = e;
+    return {
+      ...rest,
+      time_format: format,
+    };
+  });
+  if (!changed) {
+    return config;
+  }
+  return {
+    ...config,
+    entities: newEntities as (LovelaceRowConfig | string)[],
+  };
+};
+
 @customElement("hui-entities-card")
 class HuiEntitiesCard extends LitElement implements LovelaceCard {
   public static async getConfigElement(): Promise<LovelaceCardEditor> {
@@ -153,11 +180,12 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
       throw new Error("Entities must be specified");
     }
 
-    const entities = processConfigEntities(config.entities);
+    const migrateConfig = migrateEntitiesCardConfig(config);
+    const entities = processConfigEntities(migrateConfig.entities);
 
-    this._config = config;
+    this._config = migrateConfig;
     this._configEntities = entities;
-    this._showHeaderToggle = computeShowHeaderToggle(config, entities);
+    this._showHeaderToggle = computeShowHeaderToggle(migrateConfig, entities);
     if (this._config.header) {
       this._headerElement = createHeaderFooterElement(
         this._config.header

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -49,7 +49,7 @@ export const migrateGlanceCardConfig = (
     const { format, ...rest } = e;
     return {
       ...rest,
-      time_format: format,
+      time_format: rest.time_format ?? format,
     };
   });
   if (!changed) {
@@ -60,6 +60,7 @@ export const migrateGlanceCardConfig = (
     entities: newEntities as (GlanceConfigEntity | string)[],
   };
 };
+
 @customElement("hui-glance-card")
 export class HuiGlanceCard extends LitElement implements LovelaceCard {
   public static async getConfigElement(): Promise<LovelaceCardEditor> {
@@ -105,15 +106,15 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
   }
 
   public setConfig(config: GlanceCardConfig): void {
-    const migrateConfig = migrateGlanceCardConfig(config);
+    const migratedConfig = migrateGlanceCardConfig(config);
     this._config = {
       show_name: true,
       show_state: true,
       show_icon: true,
       state_color: true,
-      ...migrateConfig,
+      ...migratedConfig,
     };
-    const entities = processConfigEntities(migrateConfig.entities).map(
+    const entities = processConfigEntities(migratedConfig.entities).map(
       (entityConf) => ({
         hold_action: { action: "more-info" } as MoreInfoActionConfig,
         ...entityConf,
@@ -136,7 +137,7 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
     }
 
     const columns =
-      migrateConfig.columns || Math.min(migrateConfig.entities.length, 5);
+      migratedConfig.columns || Math.min(migratedConfig.entities.length, 5);
     this.style.setProperty("--glance-column-width", `${100 / columns}%`);
 
     this._configEntities = entities;

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -32,7 +32,34 @@ import { createEntityNotFoundWarning } from "../components/hui-warning";
 import "../components/hui-warning-element";
 import type { LovelaceCard, LovelaceCardEditor } from "../types";
 import type { GlanceCardConfig, GlanceConfigEntity } from "./types";
+import { TIMESTAMP_STATE_DOMAINS } from "../../../common/const";
 
+export const migrateGlanceCardConfig = (
+  config: GlanceCardConfig
+): GlanceCardConfig => {
+  let changed = false;
+  const newEntities = config.entities?.map((e) => {
+    if (typeof e !== "object") {
+      return e;
+    }
+    if (!("format" in e)) {
+      return e;
+    }
+    changed = true;
+    const { format, ...rest } = e;
+    return {
+      ...rest,
+      time_format: format,
+    };
+  });
+  if (!changed) {
+    return config;
+  }
+  return {
+    ...config,
+    entities: newEntities as (GlanceConfigEntity | string)[],
+  };
+};
 @customElement("hui-glance-card")
 export class HuiGlanceCard extends LitElement implements LovelaceCard {
   public static async getConfigElement(): Promise<LovelaceCardEditor> {
@@ -78,14 +105,15 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
   }
 
   public setConfig(config: GlanceCardConfig): void {
+    const migrateConfig = migrateGlanceCardConfig(config);
     this._config = {
       show_name: true,
       show_state: true,
       show_icon: true,
       state_color: true,
-      ...config,
+      ...migrateConfig,
     };
-    const entities = processConfigEntities(config.entities).map(
+    const entities = processConfigEntities(migrateConfig.entities).map(
       (entityConf) => ({
         hold_action: { action: "more-info" } as MoreInfoActionConfig,
         ...entityConf,
@@ -107,7 +135,8 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
       }
     }
 
-    const columns = config.columns || Math.min(config.entities.length, 5);
+    const columns =
+      migrateConfig.columns || Math.min(migrateConfig.entities.length, 5);
     this.style.setProperty("--glance-column-width", `${100 / columns}%`);
 
     this._configEntities = entities;
@@ -256,6 +285,7 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
     }
 
     const name = this.hass!.formatEntityName(stateObj, entityConf.name);
+    const domain = computeDomain(entityConf.entity);
 
     return html`
       <div
@@ -290,17 +320,18 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
         ${this._config!.show_state && entityConf.show_state !== false
           ? html`
               <div>
-                ${computeDomain(entityConf.entity) === "sensor" &&
-                SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
-                  stateObj.attributes.device_class
-                ) &&
+                ${(TIMESTAMP_STATE_DOMAINS.has(domain) ||
+                  (domain === "sensor" &&
+                    SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
+                      stateObj.attributes.device_class
+                    ))) &&
                 stateObj.state !== UNAVAILABLE &&
                 stateObj.state !== UNKNOWN
                   ? html`
                       <hui-timestamp-display
                         .hass=${this.hass}
                         .ts=${new Date(stateObj.state)}
-                        .format=${entityConf.format ??
+                        .format=${entityConf.time_format ??
                         (stateObj.attributes.device_class ===
                         SENSOR_DEVICE_CLASS_UPTIME
                           ? "total"

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -334,7 +334,7 @@ export interface GlanceConfigEntity extends ConfigEntity {
   image?: string;
   show_state?: boolean;
   state_color?: boolean;
-  format?: TimestampRenderingFormat;
+  time_format?: TimestampRenderingFormat;
 }
 
 export interface GlanceCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/create-element/create-row-element.ts
+++ b/src/panels/lovelace/create-element/create-row-element.ts
@@ -60,7 +60,7 @@ const LAZY_LOAD_TYPES = {
   attribute: () => import("../special-rows/hui-attribute-row"),
   text: () => import("../special-rows/hui-text-row"),
 };
-const DOMAIN_TO_ELEMENT_TYPE = {
+export const DOMAIN_TO_ELEMENT_TYPE = {
   _domain_not_found: "simple",
   alert: "toggle",
   automation: "toggle",

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -29,7 +29,10 @@ import "../../../../components/ha-theme-picker";
 import "../../../../components/input/ha-input";
 import { isCustomType } from "../../../../data/lovelace_custom_cards";
 import type { HomeAssistant } from "../../../../types";
-import { computeShowHeaderToggle } from "../../cards/hui-entities-card";
+import {
+  computeShowHeaderToggle,
+  migrateEntitiesCardConfig,
+} from "../../cards/hui-entities-card";
 import type { EntitiesCardConfig } from "../../cards/types";
 import { processConfigEntities } from "../../common/process-config-entities";
 import { timeFormatConfigStruct } from "../../components/types";
@@ -119,7 +122,7 @@ const attributeEntitiesRowConfigStruct = object({
   suffix: optional(string()),
   name: optional(string()),
   icon: optional(string()),
-  format: optional(timeFormatConfigStruct),
+  time_format: optional(timeFormatConfigStruct),
 });
 
 const textEntitiesRowConfigStruct = object({
@@ -207,9 +210,10 @@ export class HuiEntitiesCardEditor
   @state() private _subElementEditorConfig?: SubElementEditorConfig;
 
   public setConfig(config: EntitiesCardConfig): void {
-    assert(config, cardConfigStruct);
-    this._config = config;
-    this._configEntities = processEditorEntities(config.entities);
+    const newConfig = migrateEntitiesCardConfig(config);
+    assert(newConfig, cardConfigStruct);
+    this._config = newConfig;
+    this._configEntities = processEditorEntities(newConfig.entities);
   }
 
   private _showHeaderToggle = memoizeOne((config: EntitiesCardConfig) => {

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -210,10 +210,10 @@ export class HuiEntitiesCardEditor
   @state() private _subElementEditorConfig?: SubElementEditorConfig;
 
   public setConfig(config: EntitiesCardConfig): void {
-    const newConfig = migrateEntitiesCardConfig(config);
-    assert(newConfig, cardConfigStruct);
-    this._config = newConfig;
-    this._configEntities = processEditorEntities(newConfig.entities);
+    const migratedConfig = migrateEntitiesCardConfig(config);
+    assert(migratedConfig, cardConfigStruct);
+    this._config = migratedConfig;
+    this._configEntities = processEditorEntities(migratedConfig.entities);
   }
 
   private _showHeaderToggle = memoizeOne((config: EntitiesCardConfig) => {

--- a/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
@@ -15,6 +15,8 @@ import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../../../data/sensor";
 import type { EntitiesCardEntityConfig } from "../../cards/types";
 import type { LovelaceRowEditor } from "../../types";
 import { entitiesConfigStruct } from "../structs/entities-struct";
+import { DOMAIN_TO_ELEMENT_TYPE } from "../../create-element/create-row-element";
+import { TIMESTAMP_STATE_DOMAINS } from "../../../../common/const";
 
 const SECONDARY_INFO_VALUES = {
   none: {},
@@ -88,7 +90,7 @@ export class HuiGenericEntityRowEditor
         ...(showTimeFormat
           ? ([
               {
-                name: "format",
+                name: "time_format",
                 selector: {
                   ui_time_format: {},
                 },
@@ -105,13 +107,17 @@ export class HuiGenericEntityRowEditor
     }
 
     const entity = this._config.entity;
-    const domain = entity ? computeDomain(entity) : undefined;
-    const showTimeFormat =
-      domain === "event" ||
-      (domain === "sensor" &&
-        SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
-          this.hass.states[entity]?.attributes.device_class
-        ));
+    const domain = entity ? computeDomain(entity) : "";
+    const simpleEntity =
+      (DOMAIN_TO_ELEMENT_TYPE[domain] ||
+        DOMAIN_TO_ELEMENT_TYPE["_domain_not_found"]) === "simple";
+    const showTimeFormat = simpleEntity
+      ? TIMESTAMP_STATE_DOMAINS.has(domain)
+      : domain === "event" ||
+        (domain === "sensor" &&
+          SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
+            this.hass.states[entity]?.attributes.device_class
+          ));
 
     const schema =
       this.schema ||
@@ -139,10 +145,6 @@ export class HuiGenericEntityRowEditor
       case "secondary_info":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.entity-row.${schema.name}`
-        );
-      case "format":
-        return this.hass!.localize(
-          `ui.panel.lovelace.editor.card.generic.time_format`
         );
       default:
         return this.hass!.localize(

--- a/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
@@ -11,10 +11,15 @@ import {
   string,
   union,
 } from "superstruct";
+import memoizeOne from "memoize-one";
+import { computeDomain } from "../../../../common/entity/compute_domain";
 import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-form/ha-form";
-import type { SchemaUnion } from "../../../../components/ha-form/types";
+import type {
+  SchemaUnion,
+  HaFormSchema,
+} from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
 import type { ConfigEntity, GlanceCardConfig } from "../../cards/types";
 import "../../components/hui-entity-editor";
@@ -26,6 +31,8 @@ import { processEditorEntities } from "../process-editor-entities";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import { entitiesConfigStruct } from "../structs/entities-struct";
 import type { EditDetailElementEvent, SubElementEditorConfig } from "../types";
+import { TIMESTAMP_STATE_DOMAINS } from "../../../../common/const";
+import { SENSOR_TIMESTAMP_DEVICE_CLASSES } from "../../../../data/sensor";
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -40,59 +47,6 @@ const cardConfigStruct = assign(
     entities: array(entitiesConfigStruct),
   })
 );
-
-const SUB_FORM = {
-  schema: [
-    { name: "entity", selector: { entity: {} }, required: true },
-    {
-      name: "name",
-      selector: { entity_name: {} },
-      context: {
-        entity: "entity",
-      },
-    },
-    {
-      type: "grid",
-      name: "",
-      schema: [
-        {
-          name: "icon",
-          selector: {
-            icon: {},
-          },
-          context: {
-            icon_entity: "entity",
-          },
-        },
-        { name: "show_last_changed", selector: { boolean: {} } },
-        { name: "show_state", selector: { boolean: {} }, default: true },
-      ],
-    },
-    {
-      name: "tap_action",
-      selector: {
-        ui_action: {
-          default_action: "more-info",
-        },
-      },
-      context: ACTION_RELATED_CONTEXT,
-    },
-    {
-      name: "",
-      type: "optional_actions",
-      flatten: true,
-      schema: (["hold_action", "double_tap_action"] as const).map((action) => ({
-        name: action,
-        selector: {
-          ui_action: {
-            default_action: "none" as const,
-          },
-        },
-        context: ACTION_RELATED_CONTEXT,
-      })),
-    },
-  ] as const,
-};
 
 const SCHEMA = [
   { name: "title", selector: { text: {} } },
@@ -136,17 +90,91 @@ export class HuiGlanceCardEditor
     this._configEntities = processEditorEntities(config.entities);
   }
 
+  private _subForm = memoizeOne((showTimeFormat?: boolean) => ({
+    schema: [
+      { name: "entity", selector: { entity: {} }, required: true },
+      {
+        name: "name",
+        selector: { entity_name: {} },
+        context: {
+          entity: "entity",
+        },
+      },
+      {
+        type: "grid",
+        name: "",
+        schema: [
+          {
+            name: "icon",
+            selector: {
+              icon: {},
+            },
+            context: {
+              icon_entity: "entity",
+            },
+          },
+          { name: "show_last_changed", selector: { boolean: {} } },
+          { name: "show_state", selector: { boolean: {} }, default: true },
+        ],
+      },
+      ...(showTimeFormat
+        ? ([
+            {
+              name: "time_format",
+              selector: {
+                ui_time_format: {},
+              },
+            },
+          ] as const satisfies readonly HaFormSchema[])
+        : []),
+      {
+        name: "tap_action",
+        selector: {
+          ui_action: {
+            default_action: "more-info",
+          },
+        },
+        context: ACTION_RELATED_CONTEXT,
+      },
+      {
+        name: "",
+        type: "optional_actions",
+        flatten: true,
+        schema: (["hold_action", "double_tap_action"] as const).map(
+          (action) => ({
+            name: action,
+            selector: {
+              ui_action: {
+                default_action: "none" as const,
+              },
+            },
+            context: ACTION_RELATED_CONTEXT,
+          })
+        ),
+      },
+    ] as const,
+  }));
+
   protected render() {
     if (!this.hass || !this._config) {
       return nothing;
     }
 
     if (this._subElementEditorConfig) {
+      const entity =
+        this._configEntities![this._subElementEditorConfig.index!]?.entity;
+      const domain = entity ? computeDomain(entity) : "";
+      const showTimeFormat =
+        TIMESTAMP_STATE_DOMAINS.has(domain) ||
+        (domain === "sensor" &&
+          SENSOR_TIMESTAMP_DEVICE_CLASSES.includes(
+            this.hass.states[entity]?.attributes.device_class
+          ));
       return html`
         <hui-sub-element-editor
           .hass=${this.hass}
           .config=${this._subElementEditorConfig}
-          .form=${SUB_FORM}
+          .form=${this._subForm(showTimeFormat)}
           @go-back=${this._goBack}
           @config-changed=${this._handleSubEntityChanged}
         >

--- a/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
@@ -21,6 +21,7 @@ import type {
   HaFormSchema,
 } from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
+import { migrateGlanceCardConfig } from "../../cards/hui-glance-card";
 import type { ConfigEntity, GlanceCardConfig } from "../../cards/types";
 import "../../components/hui-entity-editor";
 import type { EntityConfig } from "../../entity-rows/types";
@@ -85,9 +86,10 @@ export class HuiGlanceCardEditor
   @state() private _configEntities?: ConfigEntity[];
 
   public setConfig(config: GlanceCardConfig): void {
-    assert(config, cardConfigStruct);
-    this._config = config;
-    this._configEntities = processEditorEntities(config.entities);
+    const migratedConfig = migrateGlanceCardConfig(config);
+    assert(migratedConfig, cardConfigStruct);
+    this._config = migratedConfig;
+    this._configEntities = processEditorEntities(migratedConfig.entities);
   }
 
   private _subForm = memoizeOne((showTimeFormat?: boolean) => ({

--- a/src/panels/lovelace/editor/structs/entities-struct.ts
+++ b/src/panels/lovelace/editor/structs/entities-struct.ts
@@ -13,7 +13,7 @@ export const entitiesConfigStruct = union([
     icon: optional(string()),
     image: optional(string()),
     secondary_info: optional(string()),
-    format: optional(timeFormatConfigStruct),
+    time_format: optional(timeFormatConfigStruct),
     state_color: optional(boolean()),
     tap_action: optional(actionConfigStruct),
     hold_action: optional(actionConfigStruct),

--- a/src/panels/lovelace/entity-rows/hui-event-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-event-entity-row.ts
@@ -73,7 +73,7 @@ class HuiEventEntityRow extends LitElement implements LovelaceRow {
               : html`<hui-timestamp-display
                   .hass=${this.hass}
                   .ts=${new Date(stateObj.state)}
-                  .format=${this._config.format}
+                  .format=${this._config.time_format}
                   capitalize
                 ></hui-timestamp-display>`}
           </div>

--- a/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
@@ -12,12 +12,9 @@ import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
 import "../components/hui-timestamp-display";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
-import type { TimestampRenderingFormat } from "../components/types";
 import type { LovelaceRow } from "./types";
 
-interface SensorEntityConfig extends EntitiesCardEntityConfig {
-  format?: TimestampRenderingFormat;
-}
+interface SensorEntityConfig extends EntitiesCardEntityConfig {}
 
 @customElement("hui-sensor-entity-row")
 class HuiSensorEntityRow extends LitElement implements LovelaceRow {
@@ -62,7 +59,7 @@ class HuiSensorEntityRow extends LitElement implements LovelaceRow {
               <hui-timestamp-display
                 .hass=${this.hass}
                 .ts=${new Date(stateObj.state)}
-                .format=${this._config.format ??
+                .format=${this._config.time_format ??
                 (stateObj.attributes.device_class === SENSOR_DEVICE_CLASS_UPTIME
                   ? "total"
                   : undefined)}

--- a/src/panels/lovelace/entity-rows/hui-simple-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-simple-entity-row.ts
@@ -5,8 +5,12 @@ import type { HomeAssistant } from "../../../types";
 import type { EntitiesCardEntityConfig } from "../cards/types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
+import "../components/hui-timestamp-display";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import type { LovelaceRow } from "./types";
+import { TIMESTAMP_STATE_DOMAINS } from "../../../common/const";
+import { UNAVAILABLE, UNKNOWN } from "../../../data/entity/entity";
+import { computeDomain } from "../../../common/entity/compute_domain";
 
 @customElement("hui-simple-entity-row")
 class HuiSimpleEntityRow extends LitElement implements LovelaceRow {
@@ -42,7 +46,18 @@ class HuiSimpleEntityRow extends LitElement implements LovelaceRow {
 
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
-        ${this.hass.formatEntityState(stateObj)}
+        ${TIMESTAMP_STATE_DOMAINS.has(computeDomain(this._config.entity)) &&
+        stateObj.state !== UNAVAILABLE &&
+        stateObj.state !== UNKNOWN
+          ? html`
+              <hui-timestamp-display
+                .hass=${this.hass}
+                .ts=${new Date(stateObj.state)}
+                .format=${this._config.time_format}
+                capitalize
+              ></hui-timestamp-display>
+            `
+          : this.hass.formatEntityState(stateObj)}
       </hui-generic-entity-row>
     `;
   }

--- a/src/panels/lovelace/entity-rows/types.ts
+++ b/src/panels/lovelace/entity-rows/types.ts
@@ -14,6 +14,7 @@ export interface EntityConfig {
   name?: string | EntityNameItem | EntityNameItem[];
   icon?: string;
   image?: string;
+  time_format?: TimestampRenderingFormat;
 }
 
 export interface ConfirmableRowConfig extends EntityConfig {
@@ -107,5 +108,4 @@ export interface AttributeRowConfig extends EntityConfig {
   attribute: string;
   prefix?: string;
   suffix?: string;
-  format?: TimestampRenderingFormat;
 }

--- a/src/panels/lovelace/special-rows/hui-attribute-row.ts
+++ b/src/panels/lovelace/special-rows/hui-attribute-row.ts
@@ -50,18 +50,18 @@ class HuiAttributeRow extends LitElement implements LovelaceRow {
 
     const attribute = stateObj.attributes[this._config.attribute];
     let date: Date | undefined;
-    if (this._config.format) {
+    if (this._config.time_format) {
       date = new Date(attribute);
     }
 
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         ${this._config.prefix}
-        ${this._config.format && checkValidDate(date)
+        ${this._config.time_format && checkValidDate(date)
           ? html` <hui-timestamp-display
               .hass=${this.hass}
               .ts=${date}
-              .format=${this._config.format}
+              .format=${this._config.time_format}
               capitalize
             ></hui-timestamp-display>`
           : attribute !== undefined


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Some entities or glance card entities will switch from default datetime rendering to relative time rendering. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Apply some more consistency to use of time_format throughout the frontend:

 - Migrate the `format` key of entities card to `time_format`, to match the new key in tile & badge.
 - Migrate the `format` key of glance card to `time_format`. This usage has never been documented, but it was implemented.
 - The `time_format` of entities card previously applied only to sensors. This expands support to all timestamp-based domains that render using the simple-entity-row. 
 - The `time_format` of glance card previously applied only to sensors. This expands support to all timestamp-based domains.
 - Timestamp-domain sensors in entities and glance card previously rendered with a long datetime format. This change matches the behavior of tile card, wherein by default all timestamp-domain sensors render by default with `hui-timestamp-display`, and default to `relative` time.  
 - Add the time format selector to glance card visual editor.
 - Add the time format selector to entities card visual editor for timestamp-domain sensors using simple-entity row.  

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
