### PR TITLE
Allow to open tabs in Developer tools to new tabs (middle-click, CTRL+Click...)

### DIFF
--- a/src/panels/config/developer-tools/ha-panel-developer-tools.ts
+++ b/src/panels/config/developer-tools/ha-panel-developer-tools.ts
@@ -2,6 +2,7 @@ import { mdiDotsVertical } from "@mdi/js";
 import type { CSSResultGroup, TemplateResult, PropertyValues } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
+import { isNavigationClick } from "../../../common/dom/is-navigation-click";
 import { navigate } from "../../../common/navigate";
 import "../../../components/ha-dropdown";
 import "../../../components/ha-dropdown-item";
@@ -110,14 +111,13 @@ class PanelDeveloperTools extends LitElement {
   }
 
   private _handleTabAnchorClick(ev: MouseEvent) {
-    // Allow middle-click and modifier-key clicks to open in a new tab/window
-    // natively via the anchor href. Only prevent default for plain left-clicks
-    // so the SPA routing (via wa-tab-show) handles navigation instead.
-    if (!ev.ctrlKey && !ev.metaKey && !ev.shiftKey && ev.button === 0) {
-      ev.preventDefault();
-    } else {
+    if (!isNavigationClick(ev)) {
+      // Middle-click, ctrl/meta/shift+click: let the browser open in a new
+      // tab/window via the anchor href, but stop the tab-group from switching.
       ev.stopPropagation();
     }
+    // For plain left-click, isNavigationClick already called preventDefault()
+    // so the anchor won't navigate; the click bubbles to tab-group for SPA routing.
   }
 
   private _handlePageSelected(ev: CustomEvent<{ name: string }>) {

--- a/src/panels/config/developer-tools/ha-panel-developer-tools.ts
+++ b/src/panels/config/developer-tools/ha-panel-developer-tools.ts
@@ -111,17 +111,11 @@ class PanelDeveloperTools extends LitElement {
   }
 
   private _handleTabAnchorClick(ev: MouseEvent) {
-    // Always stop propagation so the tab-group never sees the click.
-    // This prevents wa-tab-show from firing and double-navigating.
     ev.stopPropagation();
     const href = isNavigationClick(ev);
     if (href) {
-      // Plain left-click: isNavigationClick already called preventDefault()
-      // (prevents full-page anchor navigation); now SPA-navigate directly.
       navigate(href);
     }
-    // For modifier/middle-click: isNavigationClick returned undefined (no
-    // preventDefault), so the browser opens a new tab/window natively.
   }
 
   private _handlePageSelected(ev: CustomEvent<{ name: string }>) {

--- a/src/panels/config/developer-tools/ha-panel-developer-tools.ts
+++ b/src/panels/config/developer-tools/ha-panel-developer-tools.ts
@@ -111,13 +111,17 @@ class PanelDeveloperTools extends LitElement {
   }
 
   private _handleTabAnchorClick(ev: MouseEvent) {
-    if (!isNavigationClick(ev)) {
-      // Middle-click, ctrl/meta/shift+click: let the browser open in a new
-      // tab/window via the anchor href, but stop the tab-group from switching.
-      ev.stopPropagation();
+    // Always stop propagation so the tab-group never sees the click.
+    // This prevents wa-tab-show from firing and double-navigating.
+    ev.stopPropagation();
+    const href = isNavigationClick(ev);
+    if (href) {
+      // Plain left-click: isNavigationClick already called preventDefault()
+      // (prevents full-page anchor navigation); now SPA-navigate directly.
+      navigate(href);
     }
-    // For plain left-click, isNavigationClick already called preventDefault()
-    // so the anchor won't navigate; the click bubbles to tab-group for SPA routing.
+    // For modifier/middle-click: isNavigationClick returned undefined (no
+    // preventDefault), so the browser opens a new tab/window natively.
   }
 
   private _handlePageSelected(ev: CustomEvent<{ name: string }>) {

--- a/src/panels/config/developer-tools/ha-panel-developer-tools.ts
+++ b/src/panels/config/developer-tools/ha-panel-developer-tools.ts
@@ -155,9 +155,15 @@ class PanelDeveloperTools extends LitElement {
       --ha-tab-indicator-color: var(--app-header-text-color, white);
       --ha-tab-track-color: transparent;
     }
+    ha-tab-group-tab::part(base) {
+      padding: 0;
+    }
     ha-tab-group-tab a {
       color: inherit;
       text-decoration: none;
+      display: flex;
+      align-items: center;
+      padding: 1em 1.5em;
     }
   `;
 }

--- a/src/panels/config/developer-tools/ha-panel-developer-tools.ts
+++ b/src/panels/config/developer-tools/ha-panel-developer-tools.ts
@@ -91,7 +91,11 @@ class PanelDeveloperTools extends LitElement {
                 panel=${tab.panel}
                 .active=${page === tab.panel}
               >
-                ${this.hass.localize(tab.translationKey)}
+                <a
+                  href="/config/developer-tools/${tab.panel}"
+                  @click=${this._handleTabAnchorClick}
+                  >${this.hass.localize(tab.translationKey)}</a
+                >
               </ha-tab-group-tab>
             `
           )}
@@ -103,6 +107,17 @@ class PanelDeveloperTools extends LitElement {
         ></developer-tools-router>
       </ha-top-app-bar-fixed>
     `;
+  }
+
+  private _handleTabAnchorClick(ev: MouseEvent) {
+    // Allow middle-click and modifier-key clicks to open in a new tab/window
+    // natively via the anchor href. Only prevent default for plain left-clicks
+    // so the SPA routing (via wa-tab-show) handles navigation instead.
+    if (!ev.ctrlKey && !ev.metaKey && !ev.shiftKey && ev.button === 0) {
+      ev.preventDefault();
+    } else {
+      ev.stopPropagation();
+    }
   }
 
   private _handlePageSelected(ev: CustomEvent<{ name: string }>) {
@@ -141,6 +156,10 @@ class PanelDeveloperTools extends LitElement {
       --ha-tab-active-text-color: var(--app-header-text-color, white);
       --ha-tab-indicator-color: var(--app-header-text-color, white);
       --ha-tab-track-color: transparent;
+    }
+    ha-tab-group-tab a {
+      color: inherit;
+      text-decoration: none;
     }
   `;
 }


### PR DESCRIPTION
## Proposed change

Allow to open tabs in Developer tools in new tabs (middle-click, CTRL+Click...)
<img width="611" height="106" alt="image" src="https://github.com/user-attachments/assets/00c9749e-cba2-4790-ac86-ae1c07df057b" />

Opening tabs in new tab is possible in other menus, like "Devices & services", "Automations & scenes"..., but not in Developer tools which annoyed me :)

## Screenshots
Showing first how middle-click doesn't work in current version, then how it correctly opens tabs in new tabs with my code:

https://github.com/user-attachments/assets/d1b0e419-2756-447f-a069-862a153e211b



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes `<none`>
- This PR is related to issue or discussion: `<none`>
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to backend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

> [!TIP]
> This is generated code. I understand what it does, and it fixes the issue for me, but I'm not a frontend developer so I can't say for sure that it's the best way, especially in compliance with project standards.


If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
