### PR TITLE
Use a picker with entity context for energy upstream device

### DIFF
--- a/src/panels/config/energy/dialogs/dialog-energy-device-settings-water.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-device-settings-water.ts
@@ -7,9 +7,8 @@ import "../../../../components/entity/ha-statistic-picker";
 import "../../../../components/ha-button";
 import "../../../../components/ha-dialog";
 import "../../../../components/ha-dialog-footer";
-import "../../../../components/ha-select";
-import type { HaSelectSelectEvent } from "../../../../components/ha-select";
 import "../../../../components/input/ha-input";
+import "./ha-energy-upstream-device-picker";
 import type { HaInput } from "../../../../components/input/ha-input";
 import type { DeviceConsumptionEnergyPreference } from "../../../../data/energy";
 import { energyStatisticHelpUrl } from "../../../../data/energy";
@@ -123,27 +122,6 @@ export class DialogEnergyDeviceSettingsWater
 
     const pickableUnit = this._volume_units?.join(", ") || "";
 
-    const includedInDeviceOptions = !this._possibleParents.length
-      ? [
-          {
-            value: "-",
-            disabled: true,
-            label: this.hass.localize(
-              "ui.panel.config.energy.device_consumption_water.dialog.no_upstream_devices"
-            ),
-          },
-        ]
-      : this._possibleParents.map((stat) => ({
-          value: stat.stat_consumption,
-          label:
-            stat.name ||
-            getStatisticLabel(
-              this.hass,
-              stat.stat_consumption,
-              this._params?.statsMetadata?.[stat.stat_consumption]
-            ),
-        }));
-
     return html`
       <ha-dialog
         .open=${this._open}
@@ -205,20 +183,23 @@ export class DialogEnergyDeviceSettingsWater
         >
         </ha-input>
 
-        <ha-select
+        <ha-energy-upstream-device-picker
+          .hass=${this.hass}
           .label=${this.hass.localize(
             "ui.panel.config.energy.device_consumption_water.dialog.included_in_device"
           )}
-          .value=${this._device?.included_in_stat || ""}
           .helper=${this.hass.localize(
             "ui.panel.config.energy.device_consumption_water.dialog.included_in_device_helper"
           )}
+          .value=${this._device?.included_in_stat}
+          .possibleParents=${this._possibleParents}
+          .statsMetadata=${this._params.statsMetadata}
+          .emptyLabel=${this.hass.localize(
+            "ui.panel.config.energy.device_consumption_water.dialog.no_upstream_devices"
+          )}
           .disabled=${!this._device}
-          @selected=${this._parentSelected}
-          clearable
-          .options=${includedInDeviceOptions}
-        >
-        </ha-select>
+          @value-changed=${this._parentChanged}
+        ></ha-energy-upstream-device-picker>
 
         <ha-dialog-footer slot="footer">
           <ha-button
@@ -293,7 +274,7 @@ export class DialogEnergyDeviceSettingsWater
     this._updateDirtyState(this._device);
   }
 
-  private _parentSelected(ev: HaSelectSelectEvent<string, true>) {
+  private _parentChanged(ev: ValueChangedEvent<string>) {
     const newDevice = {
       ...this._device!,
       included_in_stat: ev.detail.value,
@@ -324,7 +305,7 @@ export class DialogEnergyDeviceSettingsWater
           width: 100%;
           margin-bottom: var(--ha-space-4);
         }
-        ha-select {
+        ha-energy-upstream-device-picker {
           display: block;
           margin-top: var(--ha-space-4);
           width: 100%;

--- a/src/panels/config/energy/dialogs/dialog-energy-device-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-device-settings.ts
@@ -7,12 +7,8 @@ import "../../../../components/entity/ha-statistic-picker";
 import "../../../../components/ha-button";
 import "../../../../components/ha-dialog";
 import "../../../../components/ha-dialog-footer";
-import "../../../../components/ha-select";
-import type {
-  HaSelectOption,
-  HaSelectSelectEvent,
-} from "../../../../components/ha-select";
 import "../../../../components/input/ha-input";
+import "./ha-energy-upstream-device-picker";
 import type { HaInput } from "../../../../components/input/ha-input";
 import type { DeviceConsumptionEnergyPreference } from "../../../../data/energy";
 import { energyStatisticHelpUrl } from "../../../../data/energy";
@@ -123,28 +119,6 @@ export class DialogEnergyDeviceSettings
       return nothing;
     }
 
-    const includedInDeviceOptions: HaSelectOption[] = this._possibleParents
-      .length
-      ? this._possibleParents.map((stat) => ({
-          value: stat.stat_consumption,
-          label:
-            stat.name ||
-            getStatisticLabel(
-              this.hass,
-              stat.stat_consumption,
-              this._params?.statsMetadata?.[stat.stat_consumption]
-            ),
-        }))
-      : [
-          {
-            value: "-",
-            disabled: true,
-            label: this.hass.localize(
-              "ui.panel.config.energy.device_consumption.dialog.no_upstream_devices"
-            ),
-          },
-        ];
-
     return html`
       <ha-dialog
         .open=${this._open}
@@ -205,20 +179,23 @@ export class DialogEnergyDeviceSettings
         >
         </ha-input>
 
-        <ha-select
+        <ha-energy-upstream-device-picker
+          .hass=${this.hass}
           .label=${this.hass.localize(
             "ui.panel.config.energy.device_consumption.dialog.included_in_device"
           )}
-          .value=${this._device?.included_in_stat || ""}
           .helper=${this.hass.localize(
             "ui.panel.config.energy.device_consumption.dialog.included_in_device_helper"
           )}
+          .value=${this._device?.included_in_stat}
+          .possibleParents=${this._possibleParents}
+          .statsMetadata=${this._params.statsMetadata}
+          .emptyLabel=${this.hass.localize(
+            "ui.panel.config.energy.device_consumption.dialog.no_upstream_devices"
+          )}
           .disabled=${!this._device}
-          @selected=${this._parentSelected}
-          clearable
-          .options=${includedInDeviceOptions}
-        >
-        </ha-select>
+          @value-changed=${this._parentChanged}
+        ></ha-energy-upstream-device-picker>
 
         <ha-dialog-footer slot="footer">
           <ha-button
@@ -293,7 +270,7 @@ export class DialogEnergyDeviceSettings
     this._updateDirtyState(this._device);
   }
 
-  private _parentSelected(ev: HaSelectSelectEvent<string, true>) {
+  private _parentChanged(ev: ValueChangedEvent<string>) {
     const newDevice = {
       ...this._device!,
       included_in_stat: ev.detail.value,
@@ -326,7 +303,7 @@ export class DialogEnergyDeviceSettings
         ha-statistic-picker {
           width: 100%;
         }
-        ha-select {
+        ha-energy-upstream-device-picker {
           display: block;
           margin-top: var(--ha-space-4);
           width: 100%;

--- a/src/panels/config/energy/dialogs/ha-energy-upstream-device-picker.ts
+++ b/src/panels/config/energy/dialogs/ha-energy-upstream-device-picker.ts
@@ -1,0 +1,212 @@
+import type { RenderItemFunction } from "@lit-labs/virtualizer/virtualize";
+import { mdiChartLine, mdiShape } from "@mdi/js";
+import type { HassEntity } from "home-assistant-js-websocket";
+import { html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { computeEntityNameList } from "../../../../common/entity/compute_entity_name_display";
+import { computeStateName } from "../../../../common/entity/compute_state_name";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import { computeRTL } from "../../../../common/util/compute_rtl";
+import "../../../../components/entity/state-badge";
+import "../../../../components/ha-combo-box-item";
+import "../../../../components/ha-generic-picker";
+import type { PickerComboBoxItem } from "../../../../components/ha-picker-combo-box";
+import type { PickerValueRenderer } from "../../../../components/ha-picker-field";
+import "../../../../components/ha-svg-icon";
+import type { DeviceConsumptionEnergyPreference } from "../../../../data/energy";
+import {
+  getStatisticLabel,
+  type StatisticsMetaData,
+} from "../../../../data/recorder";
+import type { HomeAssistant, ValueChangedEvent } from "../../../../types";
+
+interface UpstreamDeviceComboBoxItem extends PickerComboBoxItem {
+  stateObj?: HassEntity;
+}
+
+const SEARCH_KEYS = [
+  { name: "primary", weight: 10 },
+  { name: "search_labels.entityName", weight: 10 },
+  { name: "search_labels.friendlyName", weight: 9 },
+  { name: "search_labels.deviceName", weight: 8 },
+  { name: "search_labels.areaName", weight: 6 },
+  { name: "id", weight: 2 },
+];
+
+@customElement("ha-energy-upstream-device-picker")
+export class HaEnergyUpstreamDevicePicker extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property() public value?: string;
+
+  @property() public label?: string;
+
+  @property() public helper?: string;
+
+  @property({ attribute: "empty-label" }) public emptyLabel?: string;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  @property({ attribute: false })
+  public possibleParents: DeviceConsumptionEnergyPreference[] = [];
+
+  @property({ attribute: false })
+  public statsMetadata?: Record<string, StatisticsMetaData>;
+
+  private _computeItem = (statisticId: string): UpstreamDeviceComboBoxItem => {
+    // Use the energy config's custom display name when the user has set one.
+    const name = this.possibleParents.find(
+      (parent) => parent.stat_consumption === statisticId
+    )?.name;
+    const stateObj = this.hass.states[statisticId];
+
+    if (stateObj) {
+      const [entityName, deviceName, areaName] = computeEntityNameList(
+        stateObj,
+        [{ type: "entity" }, { type: "device" }, { type: "area" }],
+        this.hass.entities,
+        this.hass.devices,
+        this.hass.areas,
+        this.hass.floors
+      );
+
+      const isRTL = computeRTL(
+        this.hass.language,
+        this.hass.translationMetadata.translations
+      );
+
+      const friendlyName = computeStateName(stateObj); // Keep this for search
+      const secondary = [areaName, entityName ? deviceName : undefined]
+        .filter(Boolean)
+        .join(isRTL ? " ◂ " : " ▸ ");
+
+      return {
+        id: statisticId,
+        primary: name || entityName || deviceName || statisticId,
+        secondary,
+        stateObj,
+        search_labels: {
+          entityName: entityName || null,
+          deviceName: deviceName || null,
+          areaName: areaName || null,
+          friendlyName,
+        },
+      };
+    }
+
+    const label = getStatisticLabel(
+      this.hass,
+      statisticId,
+      this.statsMetadata?.[statisticId]
+    );
+    const isExternal = statisticId.includes(":") && !statisticId.includes(".");
+
+    return {
+      id: statisticId,
+      primary: name || label,
+      icon_path: isExternal ? mdiChartLine : mdiShape,
+      search_labels: { label },
+    };
+  };
+
+  private _items = memoizeOne(
+    (
+      _hass: HomeAssistant,
+      _value: string | undefined,
+      _possibleParents: DeviceConsumptionEnergyPreference[],
+      _statsMetadata?: Record<string, StatisticsMetaData>
+    ): UpstreamDeviceComboBoxItem[] => {
+      const items = this.possibleParents.map((parent) =>
+        this._computeItem(parent.stat_consumption)
+      );
+
+      // Make sure the current value is selectable even if it is no longer
+      // part of the possible parents, so it doesn't render as unknown.
+      if (this.value && !items.some((item) => item.id === this.value)) {
+        items.unshift(this._computeItem(this.value));
+      }
+
+      return items;
+    }
+  );
+
+  private _getItems = () =>
+    this._items(
+      this.hass,
+      this.value,
+      this.possibleParents,
+      this.statsMetadata
+    );
+
+  private _renderItem = (item: UpstreamDeviceComboBoxItem) => html`
+    ${item.stateObj
+      ? html`
+          <state-badge
+            slot="start"
+            .stateObj=${item.stateObj}
+            .hass=${this.hass}
+          ></state-badge>
+        `
+      : item.icon_path
+        ? html`
+            <ha-svg-icon
+              style="margin: 0 4px"
+              slot="start"
+              .path=${item.icon_path}
+            ></ha-svg-icon>
+          `
+        : nothing}
+    <span slot="headline">${item.primary}</span>
+    ${item.secondary
+      ? html`<span slot="supporting-text">${item.secondary}</span>`
+      : nothing}
+  `;
+
+  private _rowRenderer: RenderItemFunction<UpstreamDeviceComboBoxItem> = (
+    item,
+    index
+  ) => html`
+    <ha-combo-box-item type="button" compact .borderTop=${index !== 0}>
+      ${this._renderItem(item)}
+    </ha-combo-box-item>
+  `;
+
+  private _valueRenderer: PickerValueRenderer = (value) =>
+    this._renderItem(
+      this._getItems().find((item) => item.id === value) ??
+        this._computeItem(value)
+    );
+
+  protected render() {
+    return html`
+      <ha-generic-picker
+        .hass=${this.hass}
+        use-top-label
+        .label=${this.label}
+        .helper=${this.helper}
+        .value=${this.value}
+        .disabled=${this.disabled}
+        .emptyLabel=${this.emptyLabel}
+        .getItems=${this._getItems}
+        .rowRenderer=${this._rowRenderer}
+        .valueRenderer=${this._valueRenderer}
+        .searchKeys=${SEARCH_KEYS}
+        @value-changed=${this._valueChanged}
+      ></ha-generic-picker>
+    `;
+  }
+
+  private _valueChanged(ev: ValueChangedEvent<string>) {
+    ev.stopPropagation();
+    const value = ev.detail.value;
+    this.value = value;
+    fireEvent(this, "value-changed", { value });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-energy-upstream-device-picker": HaEnergyUpstreamDevicePicker;
+  }
+}

--- a/src/panels/config/energy/dialogs/ha-energy-upstream-device-picker.ts
+++ b/src/panels/config/energy/dialogs/ha-energy-upstream-device-picker.ts
@@ -15,6 +15,7 @@ import type { PickerComboBoxItem } from "../../../../components/ha-picker-combo-
 import type { PickerValueRenderer } from "../../../../components/ha-picker-field";
 import "../../../../components/ha-svg-icon";
 import type { DeviceConsumptionEnergyPreference } from "../../../../data/energy";
+import { domainToName } from "../../../../data/integration";
 import {
   getStatisticLabel,
   type StatisticsMetaData,
@@ -31,6 +32,7 @@ const SEARCH_KEYS = [
   { name: "search_labels.friendlyName", weight: 9 },
   { name: "search_labels.deviceName", weight: 8 },
   { name: "search_labels.areaName", weight: 6 },
+  { name: "search_labels.domainName", weight: 4 },
   { name: "id", weight: 2 },
 ];
 
@@ -102,10 +104,25 @@ export class HaEnergyUpstreamDevicePicker extends LitElement {
     );
     const isExternal = statisticId.includes(":") && !statisticId.includes(".");
 
+    if (isExternal) {
+      const domainName = domainToName(
+        this.hass.localize,
+        statisticId.split(":")[0]
+      );
+      return {
+        id: statisticId,
+        primary: name || label,
+        secondary: domainName,
+        icon_path: mdiChartLine,
+        search_labels: { label, domainName },
+      };
+    }
+
     return {
       id: statisticId,
       primary: name || label,
-      icon_path: isExternal ? mdiChartLine : mdiShape,
+      secondary: this.hass.localize("ui.components.statistic-picker.no_state"),
+      icon_path: mdiShape,
       search_labels: { label },
     };
   };


### PR DESCRIPTION
## Proposed change

In the energy configuration, the device settings dialog (for individual electricity and water devices) lets you pick an **Upstream device** — the parent whose meter already counts this device, so its consumption isn't double-counted.

The two consumption fields in that dialog already use a rich, searchable picker that shows each entity's badge and area/device context. The **Upstream device** field, however, was a plain dropdown listing names only — no icon, no context, and no search.

This replaces that dropdown with a picker consistent with the other two fields: it shows the entity badge and `area ▸ device` context, is searchable, and is limited to valid parents. When a device has a custom display name set, that name is still shown.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
<img width="1074" height="538" alt="image" src="https://github.com/user-attachments/assets/627e82d7-1404-4537-9c26-bf1a6966abb5" />

<img width="1096" height="272" alt="image" src="https://github.com/user-attachments/assets/0f61e87b-9744-46d8-866f-b0575e2e16f2" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52759
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
