### PR TITLE
Migrate action/service button rows to context instead of hass

### DIFF
--- a/src/components/buttons/ha-call-service-button.ts
+++ b/src/components/buttons/ha-call-service-button.ts
@@ -1,16 +1,18 @@
+import { consume, type ContextType } from "@lit/context";
 import type { TemplateResult } from "lit";
 import { LitElement, html } from "lit";
 import { customElement, property } from "lit/decorators";
 import type { HassServiceTarget } from "home-assistant-js-websocket";
 import { showConfirmationDialog } from "../../dialogs/generic/show-dialog-box";
 import "./ha-progress-button";
-import type { HomeAssistant } from "../../types";
+import { apiContext } from "../../data/context";
 import { fireEvent } from "../../common/dom/fire_event";
 import type { Appearance } from "../ha-button";
 
 @customElement("ha-call-service-button")
 class HaCallServiceButton extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @consume({ context: apiContext, subscribe: true })
+  private _api!: ContextType<typeof apiContext>;
 
   @property({ type: Boolean }) public disabled = false;
 
@@ -56,7 +58,7 @@ class HaCallServiceButton extends LitElement {
       this.shadowRoot!.querySelector("ha-progress-button")!;
 
     try {
-      await this.hass.callService(
+      await this._api.callService(
         this.domain,
         this.service,
         this.data,

--- a/src/components/entity/ha-entity-toggle.ts
+++ b/src/components/entity/ha-entity-toggle.ts
@@ -1,3 +1,4 @@
+import { consume, type ContextType } from "@lit/context";
 import { mdiFlash, mdiFlashOff } from "@mdi/js";
 import type { HassEntity } from "home-assistant-js-websocket";
 import type { PropertyValues, TemplateResult } from "lit";
@@ -6,9 +7,9 @@ import { customElement, property, state } from "lit/decorators";
 import { STATES_OFF } from "../../common/const";
 import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { computeStateName } from "../../common/entity/compute_state_name";
+import { apiContext } from "../../data/context";
 import { UNAVAILABLE, UNKNOWN } from "../../data/entity/entity";
 import { forwardHaptic } from "../../data/haptics";
-import type { HomeAssistant } from "../../types";
 import "../ha-formfield";
 import "../ha-icon-button";
 import "../ha-switch";
@@ -29,8 +30,8 @@ const isOn = (stateObj?: HassEntity) =>
 
 @customElement("ha-entity-toggle")
 export class HaEntityToggle extends LitElement {
-  // hass is not a property so that we only re-render on stateObj changes
-  public hass?: HomeAssistant;
+  @consume({ context: apiContext, subscribe: true })
+  private _api?: ContextType<typeof apiContext>;
 
   @property({ attribute: false }) public stateObj?: HassEntity;
 
@@ -118,7 +119,7 @@ export class HaEntityToggle extends LitElement {
   // result in the entity to be turned on. Since the state is not changing,
   // the resync is not called automatic.
   private async _callService(turnOn): Promise<void> {
-    if (!this.hass || !this.stateObj) {
+    if (!this._api || !this.stateObj) {
       return;
     }
     forwardHaptic(this, "light");
@@ -149,7 +150,7 @@ export class HaEntityToggle extends LitElement {
     this._isOn = turnOn;
 
     try {
-      await this.hass.callService(serviceDomain, service, {
+      await this._api.callService(serviceDomain, service, {
         entity_id: this.stateObj.entity_id,
       });
     } finally {

--- a/src/components/ha-lawn_mower-action-button.ts
+++ b/src/components/ha-lawn_mower-action-button.ts
@@ -1,10 +1,13 @@
+import { consume, type ContextType } from "@lit/context";
 import { LitElement, css, html } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
 import { supportsFeature } from "../common/entity/supports-feature";
+import type { LocalizeFunc } from "../common/translations/localize";
+import { apiContext, formattersContext } from "../data/context";
 import "./ha-button";
 import type { LawnMowerEntity, LawnMowerEntityState } from "../data/lawn_mower";
 import { LawnMowerEntityFeature } from "../data/lawn_mower";
-import type { HomeAssistant } from "../types";
 
 interface LawnMowerAction {
   action: string;
@@ -39,13 +42,19 @@ const LAWN_MOWER_ACTIONS: Partial<
 
 @customElement("ha-lawn_mower-action-button")
 class HaLawnMowerActionButton extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state() @consumeLocalize() private _localize!: LocalizeFunc;
+
+  @state()
+  @consume({ context: formattersContext, subscribe: true })
+  private _formatters?: ContextType<typeof formattersContext>;
+
+  @consume({ context: apiContext, subscribe: true })
+  private _api!: ContextType<typeof apiContext>;
 
   @property({ attribute: false }) public stateObj!: LawnMowerEntity;
 
   public render() {
-    const state = this.stateObj.state;
-    const action = LAWN_MOWER_ACTIONS[state];
+    const action = LAWN_MOWER_ACTIONS[this.stateObj.state];
 
     if (action && supportsFeature(this.stateObj, action.feature)) {
       return html`
@@ -55,14 +64,14 @@ class HaLawnMowerActionButton extends LitElement {
           .service=${action.service}
           size="s"
         >
-          ${this.hass.localize(`ui.card.lawn_mower.actions.${action.action}`)}
+          ${this._localize(`ui.card.lawn_mower.actions.${action.action}`)}
         </ha-button>
       `;
     }
 
     return html`
       <ha-button appearance="plain" disabled>
-        ${this.hass.formatEntityState(this.stateObj)}
+        ${this._formatters?.formatEntityState(this.stateObj)}
       </ha-button>
     `;
   }
@@ -71,7 +80,7 @@ class HaLawnMowerActionButton extends LitElement {
     ev.stopPropagation();
     const stateObj = this.stateObj;
     const service = ev.target.service;
-    this.hass.callService("lawn_mower", service, {
+    this._api.callService("lawn_mower", service, {
       entity_id: stateObj.entity_id,
     });
   }

--- a/src/components/ha-vacuum-state.ts
+++ b/src/components/ha-vacuum-state.ts
@@ -1,9 +1,12 @@
+import { consume, type ContextType } from "@lit/context";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { LitElement, css, html } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import type { HassEntity } from "home-assistant-js-websocket";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import type { LocalizeFunc } from "../common/translations/localize";
+import { apiContext } from "../data/context";
 import { haStyle } from "../resources/styles";
-import type { HomeAssistant } from "../types";
 import "./ha-button";
 
 const STATES_INTERCEPTABLE: Record<
@@ -46,7 +49,10 @@ const STATES_INTERCEPTABLE: Record<
 
 @customElement("ha-vacuum-state")
 export class HaVacuumState extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state() @consumeLocalize() private _localize!: LocalizeFunc;
+
+  @consume({ context: apiContext, subscribe: true })
+  private _api!: ContextType<typeof apiContext>;
 
   @property({ attribute: false }) public stateObj!: HassEntity;
 
@@ -68,19 +74,19 @@ export class HaVacuumState extends LitElement {
   }
 
   private _computeInterceptable(
-    state: string,
+    stateString: string,
     supportedFeatures: number | undefined
   ) {
-    return state in STATES_INTERCEPTABLE && supportedFeatures !== 0;
+    return stateString in STATES_INTERCEPTABLE && supportedFeatures !== 0;
   }
 
-  private _computeLabel(state: string, interceptable: boolean) {
+  private _computeLabel(stateString: string, interceptable: boolean) {
     return interceptable
-      ? this.hass.localize(
-          `ui.card.vacuum.actions.${STATES_INTERCEPTABLE[state].action}`
+      ? this._localize(
+          `ui.card.vacuum.actions.${STATES_INTERCEPTABLE[stateString].action}`
         )
-      : this.hass.localize(
-          `component.vacuum.entity_component._.state.${state}`
+      : this._localize(
+          `component.vacuum.entity_component._.state.${stateString}`
         );
   }
 
@@ -88,7 +94,7 @@ export class HaVacuumState extends LitElement {
     ev.stopPropagation();
     const stateObj = this.stateObj;
     const service = STATES_INTERCEPTABLE[stateObj.state].service;
-    await this.hass.callService("vacuum", service, {
+    await this._api.callService("vacuum", service, {
       entity_id: stateObj.entity_id,
     });
   }

--- a/src/dialogs/config-flow/previews/entity-preview-row.ts
+++ b/src/dialogs/config-flow/previews/entity-preview-row.ts
@@ -201,12 +201,7 @@ class EntityPreviewRow extends LitElement {
         stateObj.state === "on" || stateObj.state === "off" || noValue;
       return html`
         ${showToggle
-          ? html`
-              <ha-entity-toggle
-                .hass=${this.hass}
-                .stateObj=${stateObj}
-              ></ha-entity-toggle>
-            `
+          ? html` <ha-entity-toggle .stateObj=${stateObj}></ha-entity-toggle> `
           : this.hass.formatEntityState(stateObj)}
       `;
     }

--- a/src/panels/config/developer-tools/yaml_configuration/developer-yaml-config.ts
+++ b/src/panels/config/developer-tools/yaml_configuration/developer-yaml-config.ts
@@ -171,10 +171,7 @@ export class DeveloperYamlConfig extends LitElement {
             )}
           </div>
           <div class="card-actions">
-            <ha-call-service-button
-              .hass=${this.hass}
-              domain="homeassistant"
-              service="reload_all"
+            <ha-call-service-button domain="homeassistant" service="reload_all"
               >${this.hass.localize(
                 "ui.panel.config.developer-tools.tabs.yaml.section.reloading.all"
               )}
@@ -182,7 +179,6 @@ export class DeveloperYamlConfig extends LitElement {
           </div>
           <div class="card-actions">
             <ha-call-service-button
-              .hass=${this.hass}
               domain="homeassistant"
               service="reload_core_config"
               >${this.hass.localize(
@@ -194,7 +190,6 @@ export class DeveloperYamlConfig extends LitElement {
             (reloadable) => html`
               <div class="card-actions">
                 <ha-call-service-button
-                  .hass=${this.hass}
                   .domain=${reloadable.domain}
                   service="reload"
                   >${reloadable.name}

--- a/src/panels/config/integrations/integration-panels/zha/zha-cluster-attributes.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-cluster-attributes.ts
@@ -109,7 +109,6 @@ export class ZHAClusterAttributes extends LitElement {
       </div>
       <div class="card-actions">
         <ha-call-service-button
-          .hass=${this.hass}
           domain="zha"
           service="set_zigbee_cluster_attribute"
           .data=${this._setAttributeServiceData}

--- a/src/panels/config/integrations/integration-panels/zha/zha-cluster-commands.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-cluster-commands.ts
@@ -96,7 +96,6 @@ export class ZHAClusterCommands extends LitElement {
               </div>
               <div class="card-actions">
                 <ha-call-service-button
-                  .hass=${this.hass}
                   domain="zha"
                   service="issue_zigbee_cluster_command"
                   .data=${this._issueClusterCommandServiceData}

--- a/src/panels/config/logs/system-log-card.ts
+++ b/src/panels/config/logs/system-log-card.ts
@@ -190,10 +190,7 @@ export class SystemLogCard extends LitElement {
                       >`}
 
                 <div class="card-actions">
-                  <ha-call-service-button
-                    .hass=${this.hass}
-                    domain="system_log"
-                    service="clear"
+                  <ha-call-service-button domain="system_log" service="clear"
                     >${this.hass.localize(
                       "ui.panel.config.logs.clear"
                     )}</ha-call-service-button

--- a/src/panels/lovelace/elements/hui-service-button-element.ts
+++ b/src/panels/lovelace/elements/hui-service-button-element.ts
@@ -69,7 +69,6 @@ export class HuiServiceButtonElement
 
     return html`
       <ha-call-service-button
-        .hass=${this.hass}
         .domain=${this._domain}
         .service=${this._service}
         .data=${this._config.data ?? this._config.service_data}

--- a/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
@@ -58,12 +58,7 @@ class HuiGroupEntityRow extends LitElement implements LovelaceRow {
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         ${this._computeCanToggle(this.hass, stateObj.attributes.entity_id)
-          ? html`
-              <ha-entity-toggle
-                .hass=${this.hass}
-                .stateObj=${stateObj}
-              ></ha-entity-toggle>
-            `
+          ? html` <ha-entity-toggle .stateObj=${stateObj}></ha-entity-toggle> `
           : html`
               <div class="text-content">
                 ${this.hass.formatEntityState(stateObj)}

--- a/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
@@ -54,12 +54,7 @@ class HuiToggleEntityRow extends LitElement implements LovelaceRow {
         .catchInteraction=${!showToggle}
       >
         ${showToggle
-          ? html`
-              <ha-entity-toggle
-                .hass=${this.hass}
-                .stateObj=${stateObj}
-              ></ha-entity-toggle>
-            `
+          ? html` <ha-entity-toggle .stateObj=${stateObj}></ha-entity-toggle> `
           : html`
               <div class="text-content">
                 ${this.hass.formatEntityState(stateObj)}

--- a/src/panels/lovelace/entity-rows/hui-valve-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-valve-entity-row.ts
@@ -54,12 +54,7 @@ class HuiValveEntityRow extends LitElement implements LovelaceRow {
         .catchInteraction=${!showToggle}
       >
         ${showToggle
-          ? html`
-              <ha-entity-toggle
-                .hass=${this.hass}
-                .stateObj=${stateObj}
-              ></ha-entity-toggle>
-            `
+          ? html` <ha-entity-toggle .stateObj=${stateObj}></ha-entity-toggle> `
           : html`
               <div class="text-content">
                 ${this.hass.formatEntityState(stateObj)}

--- a/src/state-summary/state-card-alert.ts
+++ b/src/state-summary/state-card-alert.ts
@@ -28,7 +28,6 @@ class StateCardAlert extends LitElement {
         <div class="state">
           ${stateActive(this.stateObj)
             ? html`<ha-entity-toggle
-                .hass=${this.hass}
                 .stateObj=${this.stateObj}
               ></ha-entity-toggle>`
             : this.hass.formatEntityState(this.stateObj)}

--- a/src/state-summary/state-card-lawn_mower.ts
+++ b/src/state-summary/state-card-lawn_mower.ts
@@ -25,7 +25,6 @@ class StateCardLawnMower extends LitElement {
           .inDialog=${this.inDialog}
         ></state-info>
         <ha-lawn_mower-action-button
-          .hass=${this.hass}
           .stateObj=${stateObj}
         ></ha-lawn_mower-action-button>
       </div>

--- a/src/state-summary/state-card-toggle.ts
+++ b/src/state-summary/state-card-toggle.ts
@@ -24,10 +24,7 @@ class StateCardToggle extends LitElement {
           .inDialog=${this.inDialog}
         >
         </state-info>
-        <ha-entity-toggle
-          .hass=${this.hass}
-          .stateObj=${this.stateObj}
-        ></ha-entity-toggle>
+        <ha-entity-toggle .stateObj=${this.stateObj}></ha-entity-toggle>
       </div>
     `;
   }

--- a/src/state-summary/state-card-vacuum.ts
+++ b/src/state-summary/state-card-vacuum.ts
@@ -25,10 +25,7 @@ class StateCardVacuum extends LitElement {
         >
         </state-info>
 
-        <ha-vacuum-state
-          .hass=${this.hass}
-          .stateObj=${this.stateObj}
-        ></ha-vacuum-state>
+        <ha-vacuum-state .stateObj=${this.stateObj}></ha-vacuum-state>
       </div>
     `;
   }


### PR DESCRIPTION
## Proposed change

Migrates four action/service-button leaf components off the `hass` god-object property to fine-grained Lit context (part of the ongoing `hass`→context migration):

- `ha-call-service-button` and `ha-entity-toggle` — `callService` → `apiContext`
- `ha-vacuum-state` — `localize` → `@consumeLocalize()`, `callService` → `apiContext`
- `ha-lawn_mower-action-button` — `localize` → `@consumeLocalize()`, `formatEntityState` → `formattersContext`, `callService` → `apiContext`

All four drop their `hass` property; the now-dead `.hass=${…}` bindings on these elements are removed from their parent templates. Behavior is unchanged.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
