### PR TITLE
Migrate UI/config leaf components to context instead of hass

### DIFF
--- a/src/components/ha-filter-voice-assistants.ts
+++ b/src/components/ha-filter-voice-assistants.ts
@@ -8,7 +8,6 @@ import { consumeLocalize } from "../common/decorators/consume-context-entry";
 import type { LocalizeFunc } from "../common/translations/localize";
 import { fireEvent } from "../common/dom/fire_event";
 import { haStyleScrollbar } from "../resources/styles";
-import type { HomeAssistant } from "../types";
 import "./ha-check-list-item";
 import "./ha-expansion-panel";
 import "./ha-icon";
@@ -22,8 +21,6 @@ import "../panels/config/voice-assistants/expose/expose-assistant-icon";
 
 @customElement("ha-filter-voice-assistants")
 export class HaFilterVoiceAssistants extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @state()
   @consumeLocalize()
   private _localize!: LocalizeFunc;
@@ -78,7 +75,6 @@ export class HaFilterVoiceAssistants extends LitElement {
                     <voice-assistant-brand-icon
                       slot="graphic"
                       .voiceAssistantId=${voiceAssistantId}
-                      .hass=${this.hass}
                     >
                     </voice-assistant-brand-icon>
                     ${voiceAssistants[voiceAssistantId].name}

--- a/src/components/ha-selector/ha-selector-theme.ts
+++ b/src/components/ha-selector/ha-selector-theme.ts
@@ -23,7 +23,6 @@ export class HaThemeSelector extends LitElement {
   protected render() {
     return html`
       <ha-theme-picker
-        .hass=${this.hass}
         .value=${this.value}
         .label=${this.label}
         .helper=${this.helper}

--- a/src/components/ha-theme-picker.ts
+++ b/src/components/ha-theme-picker.ts
@@ -1,10 +1,12 @@
+import { consume, type ContextType } from "@lit/context";
 import type { TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../common/dom/fire_event";
 import { caseInsensitiveStringCompare } from "../common/string/compare";
-import type { HomeAssistant, ValueChangedEvent } from "../types";
+import { internationalizationContext, uiContext } from "../data/context";
+import type { ValueChangedEvent } from "../types";
 import "./ha-generic-picker";
 import type { PickerComboBoxItem } from "./ha-picker-combo-box";
 
@@ -23,7 +25,13 @@ export class HaThemePicker extends LitElement {
   @property({ attribute: "include-default", type: Boolean })
   public includeDefault = false;
 
-  @property({ attribute: false }) public hass?: HomeAssistant;
+  @state()
+  @consume({ context: uiContext, subscribe: true })
+  private _ui?: ContextType<typeof uiContext>;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  private _i18n?: ContextType<typeof internationalizationContext>;
 
   @property({ type: Boolean, reflect: true }) public disabled = false;
 
@@ -56,8 +64,8 @@ export class HaThemePicker extends LitElement {
 
   private _getItems = () =>
     this._getThemeOptions(
-      this.hass?.themes.themes || {},
-      this.hass?.locale.language || "en",
+      this._ui?.themes.themes || {},
+      this._i18n?.locale.language || "en",
       this.includeDefault
     );
 
@@ -70,10 +78,10 @@ export class HaThemePicker extends LitElement {
     return html`
       <ha-generic-picker
         .label=${this.label ??
-        this.hass?.localize("ui.components.theme-picker.theme") ??
+        this._i18n?.localize("ui.components.theme-picker.theme") ??
         "Theme"}
         .placeholder=${this.noThemeLabel ??
-        this.hass?.localize("ui.components.theme-picker.no_theme")}
+        this._i18n?.localize("ui.components.theme-picker.no_theme")}
         .helper=${this.helper}
         .value=${this.value}
         .valueRenderer=${this._valueRenderer}

--- a/src/components/ha-theme-settings.ts
+++ b/src/components/ha-theme-settings.ts
@@ -73,7 +73,6 @@ export class HaThemeSettings extends LitElement {
         ${this.showThemePicker
           ? html`
               <ha-theme-picker
-                .hass=${this.hass}
                 .label=${this.labels?.theme}
                 .noThemeLabel=${this.labels?.noTheme}
                 .value=${themeSettings?.theme || undefined}

--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -101,7 +101,6 @@ class DialogMediaPlayerBrowse extends LitElement {
           </span>
           <ha-media-manage-button
             slot="actionItems"
-            .hass=${this.hass}
             .currentItem=${this._currentItem}
             @media-refresh=${this._refreshMedia}
           ></ha-media-manage-button>

--- a/src/components/media-player/ha-media-manage-button.ts
+++ b/src/components/media-player/ha-media-manage-button.ts
@@ -1,13 +1,16 @@
+import { consume, type ContextType } from "@lit/context";
 import { mdiFolderEdit } from "@mdi/js";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { consumeLocalize } from "../../common/decorators/consume-context-entry";
 import { fireEvent } from "../../common/dom/fire_event";
+import { configContext } from "../../data/context";
 import type { MediaPlayerItem } from "../../data/media-player";
 import {
   isLocalMediaSourceContentId,
   isImageUploadMediaSourceContentId,
 } from "../../data/media_source";
-import type { HomeAssistant } from "../../types";
+import type { LocalizeFunc } from "../../common/translations/localize";
 import "../ha-svg-icon";
 import "../ha-button";
 import { showMediaManageDialog } from "./show-media-manage-dialog";
@@ -20,7 +23,13 @@ declare global {
 
 @customElement("ha-media-manage-button")
 class MediaManageButton extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state()
+  @consume({ context: configContext, subscribe: true })
+  private _config!: ContextType<typeof configContext>;
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
 
   @property({ attribute: false }) currentItem?: MediaPlayerItem;
 
@@ -31,7 +40,7 @@ class MediaManageButton extends LitElement {
       !this.currentItem ||
       !(
         isLocalMediaSourceContentId(this.currentItem.media_content_id || "") ||
-        (this.hass!.user?.is_admin &&
+        (this._config.user?.is_admin &&
           isImageUploadMediaSourceContentId(this.currentItem.media_content_id))
       )
     ) {
@@ -40,9 +49,7 @@ class MediaManageButton extends LitElement {
     return html`
       <ha-button appearance="filled" size="s" @click=${this._manage}>
         <ha-svg-icon .path=${mdiFolderEdit} slot="start"></ha-svg-icon>
-        ${this.hass.localize(
-          "ui.components.media-browser.file_management.manage"
-        )}
+        ${this._localize("ui.components.media-browser.file_management.manage")}
       </ha-button>
     `;
   }

--- a/src/components/voice-assistant-brand-icon.ts
+++ b/src/components/voice-assistant-brand-icon.ts
@@ -1,14 +1,21 @@
-import { customElement, property } from "lit/decorators";
+import { consume, type ContextType } from "@lit/context";
+import { customElement, property, state } from "lit/decorators";
 import type { CSSResultGroup } from "lit";
 import { LitElement, css, html } from "lit";
 import { haStyle } from "../resources/styles";
-import type { HomeAssistant } from "../types";
+import { configContext, uiContext } from "../data/context";
 import { voiceAssistants } from "../data/expose";
 import { brandsUrl } from "../util/brands-url";
 
 @customElement("voice-assistant-brand-icon")
 export class VoiceAssistantBrandicon extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state()
+  @consume({ context: uiContext, subscribe: true })
+  private _ui!: ContextType<typeof uiContext>;
+
+  @state()
+  @consume({ context: configContext, subscribe: true })
+  private _config!: ContextType<typeof configContext>;
 
   @property({ attribute: false }) public voiceAssistantId!: string;
 
@@ -21,9 +28,9 @@ export class VoiceAssistantBrandicon extends LitElement {
           {
             domain: voiceAssistants[this.voiceAssistantId].domain,
             type: "icon",
-            darkOptimized: this.hass.themes?.darkMode,
+            darkOptimized: this._ui.themes?.darkMode,
           },
-          this.hass.auth.data.hassUrl
+          this._config.auth.data.hassUrl
         )}
         crossorigin="anonymous"
         referrerpolicy="no-referrer"

--- a/src/dialogs/voice-assistant-setup/cloud/cloud-step-intro.ts
+++ b/src/dialogs/voice-assistant-setup/cloud/cloud-step-intro.ts
@@ -64,13 +64,9 @@ export class CloudStepIntro extends LitElement {
             <div class="logos">
               <voice-assistant-brand-icon
                 .voiceAssistantId=${"cloud.google_assistant"}
-                .hass=${this.hass}
               >
               </voice-assistant-brand-icon>
-              <voice-assistant-brand-icon
-                .voiceAssistantId=${"cloud.alexa"}
-                .hass=${this.hass}
-              >
+              <voice-assistant-brand-icon .voiceAssistantId=${"cloud.alexa"}>
               </voice-assistant-brand-icon>
             </div>
             <h2>

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -542,7 +542,6 @@ class HaAutomationPicker extends SubscribeMixin(LitElement) {
           @expanded-changed=${this._filterExpanded}
         ></ha-filter-categories>
         <ha-filter-voice-assistants
-          .hass=${this.hass}
           .value=${this._filters["ha-filter-voice-assistants"]?.value}
           @data-table-filter-changed=${this._filterChanged}
           slot="filter-pane"

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -1044,7 +1044,6 @@ export class HaConfigEntities extends LitElement {
           @expanded-changed=${this._filterExpanded}
         ></ha-filter-labels>
         <ha-filter-voice-assistants
-          .hass=${this.hass}
           .value=${this._filters["ha-filter-voice-assistants"]}
           @data-table-filter-changed=${this._filterChanged}
           slot="filter-pane"

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -708,7 +708,6 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
           @expanded-changed=${this._filterExpanded}
         ></ha-filter-categories>
         <ha-filter-voice-assistants
-          .hass=${this.hass}
           .value=${this._filters["ha-filter-voice-assistants"]}
           @data-table-filter-changed=${this._filterChanged}
           slot="filter-pane"

--- a/src/panels/config/scene/ha-scene-dashboard.ts
+++ b/src/panels/config/scene/ha-scene-dashboard.ts
@@ -561,7 +561,6 @@ class HaSceneDashboard extends SubscribeMixin(LitElement) {
           @expanded-changed=${this._filterExpanded}
         ></ha-filter-categories>
         <ha-filter-voice-assistants
-          .hass=${this.hass}
           .value=${this._filters["ha-filter-voice-assistants"]?.value}
           @data-table-filter-changed=${this._filterChanged}
           slot="filter-pane"

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -532,7 +532,6 @@ class HaScriptPicker extends SubscribeMixin(LitElement) {
           @expanded-changed=${this._filterExpanded}
         ></ha-filter-categories>
         <ha-filter-voice-assistants
-          .hass=${this.hass}
           .value=${this._filters["ha-filter-voice-assistants"]?.value}
           @data-table-filter-changed=${this._filterChanged}
           slot="filter-pane"

--- a/src/panels/config/voice-assistants/assist-pref.ts
+++ b/src/panels/config/voice-assistants/assist-pref.ts
@@ -107,10 +107,7 @@ export class AssistPref extends LitElement {
     return html`
       <ha-card outlined>
         <h1 class="card-header">
-          <voice-assistant-brand-icon
-            .voiceAssistantId=${"conversation"}
-            .hass=${this.hass}
-          >
+          <voice-assistant-brand-icon .voiceAssistantId=${"conversation"}>
           </voice-assistant-brand-icon
           >Assist
         </h1>

--- a/src/panels/config/voice-assistants/cloud-alexa-pref.ts
+++ b/src/panels/config/voice-assistants/cloud-alexa-pref.ts
@@ -64,10 +64,7 @@ export class CloudAlexaPref extends LitElement {
     return html`
       <ha-card outlined>
         <h1 class="card-header">
-          <voice-assistant-brand-icon
-            .voiceAssistantId=${"cloud.alexa"}
-            .hass=${this.hass}
-          >
+          <voice-assistant-brand-icon .voiceAssistantId=${"cloud.alexa"}>
           </voice-assistant-brand-icon
           >${this.hass.localize("ui.panel.config.cloud.account.alexa.title")}
         </h1>

--- a/src/panels/config/voice-assistants/cloud-discover.ts
+++ b/src/panels/config/voice-assistants/cloud-discover.ts
@@ -49,13 +49,9 @@ export class CloudDiscover extends LitElement {
               <div class="logos">
                 <voice-assistant-brand-icon
                   .voiceAssistantId=${"cloud.google_assistant"}
-                  .hass=${this.hass}
                 >
                 </voice-assistant-brand-icon>
-                <voice-assistant-brand-icon
-                  .voiceAssistantId=${"cloud.alexa"}
-                  .hass=${this.hass}
-                >
+                <voice-assistant-brand-icon .voiceAssistantId=${"cloud.alexa"}>
                 </voice-assistant-brand-icon>
               </div>
               <h2>

--- a/src/panels/config/voice-assistants/cloud-google-pref.ts
+++ b/src/panels/config/voice-assistants/cloud-google-pref.ts
@@ -72,7 +72,6 @@ export class CloudGooglePref extends LitElement {
         <h1 class="card-header">
           <voice-assistant-brand-icon
             .voiceAssistantId=${"cloud.google_assistant"}
-            .hass=${this.hass}
           >
           </voice-assistant-brand-icon
           >${this.hass.localize("ui.panel.config.cloud.account.google.title")}

--- a/src/panels/config/voice-assistants/entity-voice-settings.ts
+++ b/src/panels/config/voice-assistants/entity-voice-settings.ts
@@ -217,7 +217,6 @@ export class EntityVoiceSettings extends SubscribeMixin(LitElement) {
                 <voice-assistant-brand-icon
                   slot="start"
                   .voiceAssistantId=${key}
-                  .hass=${this.hass}
                 >
                 </voice-assistant-brand-icon>
                 <span slot="headline">${voiceAssistants[key].name}</span>

--- a/src/panels/config/voice-assistants/expose/expose-assistant-icon.ts
+++ b/src/panels/config/voice-assistants/expose/expose-assistant-icon.ts
@@ -32,7 +32,6 @@ export class VoiceAssistantExposeAssistantIcon extends LitElement {
             filter: this.manual ? "grayscale(100%)" : undefined,
           })}
           .voiceAssistantId=${this.assistant}
-          .hass=${this.hass}
         >
         </voice-assistant-brand-icon>
         ${this.unsupported

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -260,7 +260,6 @@ export class HuiEntitiesCardEditor
           @input=${this._valueChanged}
         ></ha-input>
         <ha-theme-picker
-          .hass=${this.hass}
           .value=${this._theme}
           .label=${`${this.hass!.localize(
             "ui.panel.lovelace.editor.card.generic.theme"

--- a/src/panels/media-browser/ha-panel-media-browser.ts
+++ b/src/panels/media-browser/ha-panel-media-browser.ts
@@ -109,7 +109,6 @@ class PanelMediaBrowser extends LitElement {
         </h1>
         <ha-media-manage-button
           slot="actionItems"
-          .hass=${this.hass}
           .currentItem=${this._currentItem}
           @media-refresh=${this._refreshMedia}
         ></ha-media-manage-button>


### PR DESCRIPTION
## Proposed change

Migrates small UI/config leaf components off the `hass` god-object property to fine-grained Lit context (part of the ongoing `hass`→context migration):

- `voice-assistant-brand-icon` — `themes.darkMode` → `uiContext`, `auth.data.hassUrl` → `configContext`
- `ha-media-manage-button` — `user.is_admin` → `configContext`, `localize` → `@consumeLocalize()`
- `ha-theme-picker` — `themes` → `uiContext`, `locale` → `internationalizationContext`, `localize` → `@consumeLocalize()`

Now-dead `.hass=${…}` bindings on these elements are removed from their parent templates. Behavior is unchanged.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
