### PR TITLE
Migrate state-display leaves to context instead of hass

### DIFF
--- a/src/components/entity/ha-state-label-badge.ts
+++ b/src/components/entity/ha-state-label-badge.ts
@@ -1,3 +1,5 @@
+import { consume } from "@lit/context";
+import type { ContextType } from "@lit/context";
 import { mdiAlert } from "@mdi/js";
 import type { HassEntity } from "home-assistant-js-websocket";
 import type { PropertyValues, TemplateResult } from "lit";
@@ -6,14 +8,19 @@ import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { arrayLiteralIncludes } from "../../common/array/literal-includes";
 import secondsToDuration from "../../common/datetime/seconds_to_duration";
+import {
+  consumeEntityRegistryEntry,
+  consumeLocalize,
+} from "../../common/decorators/consume-context-entry";
 import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { computeStateName } from "../../common/entity/compute_state_name";
 import { unitFromParts, valueFromParts } from "../../common/entity/value_parts";
 import { FIXED_DOMAIN_STATES } from "../../common/entity/get_states";
+import type { LocalizeFunc } from "../../common/translations/localize";
+import { formattersContext } from "../../data/context";
 import { UNAVAILABLE, UNKNOWN } from "../../data/entity/entity";
 import type { EntityRegistryDisplayEntry } from "../../data/entity/entity_registry";
 import { timerTimeRemaining } from "../../data/timer";
-import type { HomeAssistant } from "../../types";
 import "../ha-label-badge";
 import "../ha-state-icon";
 
@@ -41,7 +48,15 @@ const getTruncatedKey = (domainKey: string, stateKey: string) => {
 
 @customElement("ha-state-label-badge")
 export class HaStateLabelBadge extends LitElement {
-  @property({ attribute: false }) public hass?: HomeAssistant;
+  @state()
+  @consume({ context: formattersContext, subscribe: true })
+  private _formatters?: ContextType<typeof formattersContext>;
+
+  @state() @consumeLocalize() private _localize!: LocalizeFunc;
+
+  @state()
+  @consumeEntityRegistryEntry({ entityIdPath: ["state", "entity_id"] })
+  private _entry?: EntityRegistryDisplayEntry;
 
   @property({ attribute: false }) public state?: HassEntity;
 
@@ -78,10 +93,8 @@ export class HaStateLabelBadge extends LitElement {
       return html`
         <ha-label-badge
           class="warning"
-          label=${this.hass!.localize("state_badge.default.error")}
-          description=${this.hass!.localize(
-            "state_badge.default.entity_not_found"
-          )}
+          label=${this._localize("state_badge.default.error")}
+          description=${this._localize("state_badge.default.entity_not_found")}
         >
           <ha-svg-icon .path=${mdiAlert}></ha-svg-icon>
         </ha-label-badge>
@@ -95,7 +108,7 @@ export class HaStateLabelBadge extends LitElement {
     // 4. Icon determined via entity state
     // 5. Value string as fallback
     const domain = computeStateDomain(entityState);
-    const entry = this.hass?.entities[entityState.entity_id];
+    const entry = this._entry;
 
     const showIcon =
       this.icon || this._computeShowIcon(domain, entityState, entry);
@@ -175,7 +188,12 @@ export class HaStateLabelBadge extends LitElement {
     if (entityState.state === UNAVAILABLE || entityState.state === UNKNOWN) {
       return "—";
     }
-    return valueFromParts(this.hass!.formatEntityStateToParts(entityState));
+    if (!this._formatters) {
+      return null;
+    }
+    return valueFromParts(
+      this._formatters.formatEntityStateToParts(entityState)
+    );
   }
 
   private _computeShowIcon(
@@ -210,11 +228,11 @@ export class HaStateLabelBadge extends LitElement {
   ) {
     // For unavailable states or certain domains, use a special translation that is truncated to fit within the badge label
     if (entityState.state === UNAVAILABLE || entityState.state === UNKNOWN) {
-      return this.hass!.localize(`state_badge.default.${entityState.state}`);
+      return this._localize(`state_badge.default.${entityState.state}`);
     }
     const domainStateKey = getTruncatedKey(domain, entityState.state);
     if (domainStateKey) {
-      return this.hass!.localize(`state_badge.${domainStateKey}`);
+      return this._localize(`state_badge.${domainStateKey}`);
     }
     // Person and device tracker state can be zone name
     if (domain === "person" || domain === "device_tracker") {
@@ -223,8 +241,12 @@ export class HaStateLabelBadge extends LitElement {
     if (domain === "timer") {
       return secondsToDuration(_timerTimeRemaining);
     }
+    if (!this._formatters) {
+      return null;
+    }
     return (
-      unitFromParts(this.hass!.formatEntityStateToParts(entityState)) || null
+      unitFromParts(this._formatters.formatEntityStateToParts(entityState)) ||
+      null
     );
   }
 

--- a/src/components/ha-file-upload.ts
+++ b/src/components/ha-file-upload.ts
@@ -1,13 +1,18 @@
+import { consume } from "@lit/context";
 import { mdiDelete, mdiFileUpload } from "@mdi/js";
 import type { PropertyValues, TemplateResult } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { ensureArray } from "../common/array/ensure-array";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import { transform } from "../common/decorators/transform";
 import { fireEvent } from "../common/dom/fire_event";
 import { blankBeforePercent } from "../common/translations/blank_before_percent";
 import type { LocalizeFunc } from "../common/translations/localize";
-import type { HomeAssistant } from "../types";
+import { internationalizationContext } from "../data/context";
+import type { FrontendLocaleData } from "../data/translation";
+import type { HomeAssistantInternationalization } from "../types";
 import { bytesToString } from "../util/bytes-to-string";
 import "./ha-button";
 import "./ha-icon-button";
@@ -22,9 +27,16 @@ declare global {
 
 @customElement("ha-file-upload")
 export class HaFileUpload extends LitElement {
-  @property({ attribute: false }) public hass?: HomeAssistant;
-
   @property({ attribute: false }) public localize?: LocalizeFunc;
+
+  @state() @consumeLocalize() private _localize?: LocalizeFunc;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale?: FrontendLocaleData;
 
   @property() public accept!: string;
 
@@ -80,7 +92,7 @@ export class HaFileUpload extends LitElement {
   }
 
   public render(): TemplateResult {
-    const localize = this.localize || this.hass!.localize;
+    const localize = this.localize || this._localize!;
     return html`
       ${this.uploading
         ? html`<div class="container">
@@ -95,8 +107,8 @@ export class HaFileUpload extends LitElement {
               >
               ${this.progress
                 ? html`<div class="progress">
-                    ${this.progress}${this.hass &&
-                    blankBeforePercent(this.hass!.locale)}%
+                    ${this.progress}${this._locale &&
+                    blankBeforePercent(this._locale)}%
                   </div>`
                 : nothing}
             </div>

--- a/src/components/ha-picture-upload.ts
+++ b/src/components/ha-picture-upload.ts
@@ -78,7 +78,6 @@ export class HaPictureUpload extends LitElement {
 
       return html`
         <ha-file-upload
-          .hass=${this.hass}
           .icon=${mdiImagePlus}
           .label=${this.label ||
           this.hass.localize("ui.components.picture-upload.label")}

--- a/src/components/ha-selector/ha-selector-file.ts
+++ b/src/components/ha-selector/ha-selector-file.ts
@@ -37,7 +37,6 @@ export class HaFileSelector extends LitElement {
   protected render() {
     return html`
       <ha-file-upload
-        .hass=${this.hass}
         .accept=${this.selector.file?.accept}
         .icon=${mdiFile}
         .label=${this.label}

--- a/src/components/ha-water_heater-state.ts
+++ b/src/components/ha-water_heater-state.ts
@@ -1,14 +1,39 @@
-import { customElement, property } from "lit/decorators";
+import { consume } from "@lit/context";
+import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { LitElement, css, html } from "lit";
-import type { HassEntity } from "home-assistant-js-websocket";
+import { customElement, property, state } from "lit/decorators";
+import { transform } from "../common/decorators/transform";
 import { formatNumber } from "../common/number/format_number";
+import {
+  configContext,
+  formattersContext,
+  internationalizationContext,
+} from "../data/context";
+import type { FrontendLocaleData } from "../data/translation";
 import { haStyle } from "../resources/styles";
-import type { HomeAssistant } from "../types";
+import type {
+  HomeAssistantConfig,
+  HomeAssistantFormatters,
+  HomeAssistantInternationalization,
+} from "../types";
 
 @customElement("ha-water_heater-state")
 export class HaWaterHeaterState extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state()
+  @consume({ context: formattersContext, subscribe: true })
+  private _formatters?: HomeAssistantFormatters;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, FrontendLocaleData>({
+    transformer: ({ locale }) => locale,
+  })
+  private _locale?: FrontendLocaleData;
+
+  @state()
+  @consume({ context: configContext, subscribe: true })
+  private _hassConfig?: HomeAssistantConfig;
 
   @property({ attribute: false }) public stateObj!: HassEntity;
 
@@ -16,17 +41,16 @@ export class HaWaterHeaterState extends LitElement {
     return html`
       <div class="target">
         <span class="state-label label">
-          ${this.hass.formatEntityState(this.stateObj)}
+          ${this._formatters?.formatEntityState(this.stateObj)}
         </span>
-        <span class="label"
-          >${this._computeTarget(this.hass, this.stateObj)}</span
-        >
+        <span class="label">${this._computeTarget()}</span>
       </div>
     `;
   }
 
-  private _computeTarget(hass: HomeAssistant, stateObj: HassEntity) {
-    if (!hass || !stateObj) return null;
+  private _computeTarget() {
+    if (!this._locale || !this._hassConfig || !this.stateObj) return null;
+    const stateObj = this.stateObj;
     // We're using "!= null" on purpose so that we match both null and undefined.
 
     if (
@@ -35,17 +59,17 @@ export class HaWaterHeaterState extends LitElement {
     ) {
       return `${formatNumber(
         stateObj.attributes.target_temp_low,
-        this.hass.locale
+        this._locale
       )} – ${formatNumber(
         stateObj.attributes.target_temp_high,
-        this.hass.locale
-      )} ${hass.config.unit_system.temperature}`;
+        this._locale
+      )} ${this._hassConfig.config.unit_system.temperature}`;
     }
     if (stateObj.attributes.temperature != null) {
       return `${formatNumber(
         stateObj.attributes.temperature,
-        this.hass.locale
-      )} ${hass.config.unit_system.temperature}`;
+        this._locale
+      )} ${this._hassConfig.config.unit_system.temperature}`;
     }
 
     return "";

--- a/src/panels/config/backup/dialogs/dialog-upload-backup.ts
+++ b/src/panels/config/backup/dialogs/dialog-upload-backup.ts
@@ -86,7 +86,6 @@ export class DialogUploadBackup
           ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
           : nothing}
         <ha-file-upload
-          .hass=${this.hass}
           .uploading=${this._uploading}
           .icon=${mdiFolderUpload}
           .accept=${SUPPORTED_UPLOAD_FORMAT}

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
@@ -130,7 +130,6 @@ class DialogZWaveJSUpdateFirmwareNode extends DirtyStateProviderMixin<FirmwareFo
     }
 
     const beginFirmwareUpdateHTML = html`<ha-file-upload
-        .hass=${this.hass}
         .uploading=${this._uploading}
         .icon=${mdiFileUpload}
         .label=${this.hass.localize(

--- a/src/panels/lovelace/elements/hui-state-badge-element.ts
+++ b/src/panels/lovelace/elements/hui-state-badge-element.ts
@@ -86,7 +86,6 @@ export class HuiStateBadgeElement
 
     return html`
       <ha-state-label-badge
-        .hass=${this.hass}
         .state=${stateObj}
         .name=${this._config.name === undefined
           ? computeStateName(stateObj)

--- a/src/state-summary/state-card-water_heater.ts
+++ b/src/state-summary/state-card-water_heater.ts
@@ -25,7 +25,6 @@ class StateCardWaterHeater extends LitElement {
         >
         </state-info>
         <ha-water_heater-state
-          .hass=${this.hass}
           .stateObj=${this.stateObj}
         ></ha-water_heater-state>
       </div>


### PR DESCRIPTION
## Proposed change

Migrates state-display leaf components off the `hass` god-object property to fine-grained Lit context (part of the ongoing `hass`→context migration):

- `ha-state-label-badge` — `localize` → `@consumeLocalize()`, `formatEntityStateToParts` → `formattersContext`, registry entry → `@consumeEntityRegistryEntry`
- `ha-water_heater-state` — `formatEntityState` → `formattersContext`, `locale` → `internationalizationContext`, `config.unit_system` → `configContext`
- `ha-file-upload` — `localize` → `@consumeLocalize()`, `locale` → `internationalizationContext`

Now-dead `.hass=${…}` bindings on these elements are removed from their parent templates. Behavior is unchanged.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
