### PR TITLE
Sign brand images in state-badge via connection context

### DIFF
--- a/gallery/src/pages/misc/entity-state.ts
+++ b/gallery/src/pages/misc/entity-state.ts
@@ -353,7 +353,6 @@ export class DemoEntityState extends LitElement {
           title: "Icon",
           template: (entry) => html`
             <state-badge
-              .hass=${hass}
               .stateObj=${entry.stateObj}
               .stateColor=${true}
             ></state-badge>

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -161,11 +161,7 @@ export class HaEntityPicker extends LitElement {
       : undefined;
     if (stateObj) {
       return html`
-        <state-badge
-          slot="start"
-          .stateObj=${stateObj}
-          .hass=${this.hass}
-        ></state-badge>
+        <state-badge slot="start" .stateObj=${stateObj}></state-badge>
       `;
     }
     if (extraOption.icon_path) {
@@ -216,11 +212,7 @@ export class HaEntityPicker extends LitElement {
     );
 
     return html`
-      <state-badge
-        .hass=${this.hass}
-        .stateObj=${stateObj}
-        slot="start"
-      ></state-badge>
+      <state-badge .stateObj=${stateObj} slot="start"></state-badge>
       <span slot="headline">${primary}</span>
       <span slot="supporting-text">${secondary}</span>
     `;
@@ -250,7 +242,6 @@ export class HaEntityPicker extends LitElement {
               <state-badge
                 slot="start"
                 .stateObj=${item.stateObj}
-                .hass=${this.hass}
               ></state-badge>
             `}
         <span slot="headline">${item.primary}</span>

--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -343,11 +343,7 @@ export class HaStatisticPicker extends LitElement {
     return html`
       ${item.stateObj
         ? html`
-            <state-badge
-              .hass=${this.hass}
-              .stateObj=${item.stateObj}
-              slot="start"
-            ></state-badge>
+            <state-badge .stateObj=${item.stateObj} slot="start"></state-badge>
           `
         : item.icon_path
           ? html`
@@ -488,7 +484,6 @@ export class HaStatisticPicker extends LitElement {
                 <state-badge
                   slot="start"
                   .stateObj=${item.stateObj}
-                  .hass=${this.hass}
                 ></state-badge>
               `
             : nothing}

--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -1,3 +1,4 @@
+import { consume, type ContextType } from "@lit/context";
 import { mdiAlert } from "@mdi/js";
 import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup, PropertyValues } from "lit";
@@ -14,7 +15,9 @@ import {
 import { iconColorCSS } from "../../common/style/icon_color_css";
 import { cameraUrlWithWidthHeight } from "../../data/camera";
 import { CLIMATE_HVAC_ACTION_TO_MODE } from "../../data/climate";
+import { connectionContext } from "../../data/context";
 import type { HomeAssistant } from "../../types";
+import { isBrandUrl } from "../../util/brands-url";
 import "../ha-state-icon";
 
 @customElement("state-badge")
@@ -35,6 +38,10 @@ export class StateBadge extends LitElement {
 
   // @todo Consider reworking to eliminate need for attribute since it is manipulated internally
   @property({ type: Boolean, reflect: true }) public icon = true;
+
+  @state()
+  @consume({ context: connectionContext, subscribe: true })
+  private _connection?: ContextType<typeof connectionContext>;
 
   @state() private _iconStyle: Record<string, string | undefined> = {};
 
@@ -106,14 +113,15 @@ export class StateBadge extends LitElement {
     ></ha-state-icon>`;
   }
 
-  public willUpdate(changedProps: PropertyValues<this>) {
+  public willUpdate(changedProps: PropertyValues) {
     super.willUpdate(changedProps);
     if (
       !changedProps.has("stateObj") &&
       !changedProps.has("overrideImage") &&
       !changedProps.has("overrideIcon") &&
       !changedProps.has("stateColor") &&
-      !changedProps.has("color")
+      !changedProps.has("color") &&
+      !changedProps.has("_connection")
     ) {
       return;
     }
@@ -133,12 +141,10 @@ export class StateBadge extends LitElement {
             stateObj.attributes.entity_picture) &&
           !this.overrideIcon
         ) {
-          let imageUrl =
+          let imageUrl = this._resolveImageUrl(
             stateObj.attributes.entity_picture_local ||
-            stateObj.attributes.entity_picture;
-          if (this.hass) {
-            imageUrl = this.hass.hassUrl(imageUrl);
-          }
+              stateObj.attributes.entity_picture
+          );
           if (domain === "camera") {
             imageUrl = cameraUrlWithWidthHeight(imageUrl, 80, 80);
           }
@@ -179,17 +185,29 @@ export class StateBadge extends LitElement {
           }
         }
       } else if (this.overrideImage) {
-        let imageUrl = this.overrideImage;
-        if (this.hass) {
-          imageUrl = this.hass.hassUrl(imageUrl);
-        }
-        backgroundImage = `url(${imageUrl})`;
+        backgroundImage = `url(${this._resolveImageUrl(this.overrideImage)})`;
         this.icon = false;
       }
     }
 
     this._iconStyle = iconStyle;
     this.style.backgroundImage = backgroundImage;
+  }
+
+  // Sign the image URL so brand images (/api/brands/...) get their access
+  // token. `hassUrl` comes from the passed `hass` when available, falling back
+  // to the connection context so this works in components that no longer
+  // provide `hass`. Without a way to sign, a brands request would be rejected
+  // (and logged/blocked by core), so skip it until we can sign.
+  private _resolveImageUrl(url: string | undefined): string {
+    if (!url) {
+      return "";
+    }
+    const hassUrl = this.hass?.hassUrl ?? this._connection?.hassUrl;
+    if (hassUrl) {
+      return hassUrl(url);
+    }
+    return isBrandUrl(url) ? "" : url;
   }
 
   protected getClass() {

--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -16,14 +16,11 @@ import { iconColorCSS } from "../../common/style/icon_color_css";
 import { cameraUrlWithWidthHeight } from "../../data/camera";
 import { CLIMATE_HVAC_ACTION_TO_MODE } from "../../data/climate";
 import { connectionContext } from "../../data/context";
-import type { HomeAssistant } from "../../types";
 import { isBrandUrl } from "../../util/brands-url";
 import "../ha-state-icon";
 
 @customElement("state-badge")
 export class StateBadge extends LitElement {
-  public hass?: HomeAssistant;
-
   @property({ attribute: false }) public stateObj?: HassEntity;
 
   @property({ attribute: false }) public overrideIcon?: string;
@@ -194,18 +191,16 @@ export class StateBadge extends LitElement {
     this.style.backgroundImage = backgroundImage;
   }
 
-  // Sign the image URL so brand images (/api/brands/...) get their access
-  // token. `hassUrl` comes from the passed `hass` when available, falling back
-  // to the connection context so this works in components that no longer
-  // provide `hass`. Without a way to sign, a brands request would be rejected
-  // (and logged/blocked by core), so skip it until we can sign.
+  // Sign the image URL via the connection context so brand images
+  // (/api/brands/...) get their access token. Without a way to sign, a brands
+  // request would be rejected (and logged/blocked by core), so skip it until
+  // we can sign.
   private _resolveImageUrl(url: string | undefined): string {
     if (!url) {
       return "";
     }
-    const hassUrl = this.hass?.hassUrl ?? this._connection?.hassUrl;
-    if (hassUrl) {
-      return hassUrl(url);
+    if (this._connection) {
+      return this._connection.hassUrl(url);
     }
     return isBrandUrl(url) ? "" : url;
   }

--- a/src/components/entity/state-info.ts
+++ b/src/components/entity/state-info.ts
@@ -24,7 +24,6 @@ class StateInfo extends LitElement {
     const name = this.hass.formatEntityName(this.stateObj, { type: "entity" });
 
     return html`<state-badge
-        .hass=${this.hass}
         .stateObj=${this.stateObj}
         .stateColor=${true}
         .color=${this.color}

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -1233,7 +1233,6 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
                   <state-badge
                     slot="start"
                     .stateObj=${(item as EntityComboBoxItem).stateObj}
-                    .hass=${this.hass}
                   ></state-badge>
                 `
               : type === "device" && (item as DevicePickerItem).domain

--- a/src/dialogs/config-flow/previews/entity-preview-row.ts
+++ b/src/dialogs/config-flow/previews/entity-preview-row.ts
@@ -39,11 +39,7 @@ class EntityPreviewRow extends LitElement {
       return nothing;
     }
     const stateObj = this.stateObj;
-    return html`<state-badge
-        .hass=${this.hass}
-        .stateObj=${stateObj}
-        stateColor
-      ></state-badge>
+    return html`<state-badge .stateObj=${stateObj} stateColor></state-badge>
       <div class="name" .title=${computeStateName(stateObj)}>
         ${computeStateName(stateObj)}
       </div>

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -310,7 +310,6 @@ export class QuickBar extends LitElement {
               <state-badge
                 slot="start"
                 .stateObj=${(item as EntityComboBoxItem).stateObj}
-                .hass=${this.hass}
               ></state-badge>
             `
           : "domain" in item && item.domain

--- a/src/panels/config/automation/add-automation-element/ha-automation-add-search.ts
+++ b/src/panels/config/automation/add-automation-element/ha-automation-add-search.ts
@@ -375,7 +375,6 @@ export class HaAutomationAddSearch extends LitElement {
                     <state-badge
                       slot="start"
                       .stateObj=${(item as EntityComboBoxItem).stateObj}
-                      .hass=${this.hass}
                     ></state-badge>
                   `
                 : type === "device" && (item as DevicePickerItem).domain

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
@@ -91,7 +91,6 @@ class ZHADeviceCard extends SubscribeMixin(LitElement) {
                     <state-badge
                       @click=${this._openMoreInfo}
                       .title=${entity.stateName!}
-                      .hass=${this.hass}
                       .stateObj=${this.hass!.states[entity.entity_id]}
                       slot="item-icon"
                     ></state-badge>

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -454,7 +454,6 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
                             ${this._mode === "live"
                               ? html`
                                   <state-badge
-                                    .hass=${this.hass}
                                     .stateObj=${entityStateObj}
                                     slot="graphic"
                                   ></state-badge>
@@ -545,7 +544,6 @@ export class HaSceneEditor extends DirtyStateProviderMixin<number>()(
                             >
                               ${this._mode === "live"
                                 ? html` <state-badge
-                                    .hass=${this.hass}
                                     .stateObj=${entityStateObj}
                                     slot="graphic"
                                   ></state-badge>`

--- a/src/panels/home/components/home-favorite-entity-list-item.ts
+++ b/src/panels/home/components/home-favorite-entity-list-item.ts
@@ -33,11 +33,7 @@ export class HomeFavoriteEntityListItem extends LitElement {
 
     return html`
       <ha-settings-row slim>
-        <state-badge
-          slot="prefix"
-          .hass=${this.hass}
-          .stateObj=${stateObj}
-        ></state-badge>
+        <state-badge slot="prefix" .stateObj=${stateObj}></state-badge>
         <span slot="heading">${primary}</span>
         ${secondary
           ? html`<span slot="description">${secondary}</span>`

--- a/src/panels/logbook/ha-logbook-entry.ts
+++ b/src/panels/logbook/ha-logbook-entry.ts
@@ -548,7 +548,6 @@ class HaLogbookEntry extends LitElement {
       ></ha-state-icon>`;
     }
     return html`<state-badge
-      .hass=${this.hass}
       .overrideIcon=${glyph.icon}
       .overrideImage=${this._brandImage(glyph.domain)}
       .stateColor=${false}

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -278,7 +278,6 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
         ${this._config!.show_icon
           ? html`
               <state-badge
-                .hass=${this.hass}
                 .stateObj=${stateObj}
                 .overrideIcon=${entityConf.icon}
                 .overrideImage=${entityConf.image}

--- a/src/panels/lovelace/components/hui-buttons-base.ts
+++ b/src/panels/lovelace/components/hui-buttons-base.ts
@@ -72,7 +72,6 @@ export class HuiButtonsBase extends LitElement {
                 ? html`
                     <state-badge
                       title=${computeTooltip(this.hass, entityConf)}
-                      .hass=${this.hass}
                       .stateObj=${stateObj}
                       .overrideIcon=${entityConf.icon}
                       .overrideImage=${entityConf.image}

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -82,7 +82,6 @@ export class HuiGenericEntityRow extends LitElement {
         )}
       >
         <state-badge
-          .hass=${this.hass}
           .stateObj=${stateObj}
           .overrideIcon=${this.config.icon}
           .overrideImage=${this.config.image}

--- a/src/panels/lovelace/editor/card-editor/hui-entity-picker-table.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-entity-picker-table.ts
@@ -134,7 +134,6 @@ export class HuiEntityPickerTable extends LitElement {
           template: (entity) => html`
             <state-badge
               @click=${this._handleEntityClicked}
-              .hass=${this.hass!}
               .stateObj=${entity.stateObj}
             ></state-badge>
           `,

--- a/src/panels/lovelace/editor/card-editor/hui-suggestion-entity-tree.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-suggestion-entity-tree.ts
@@ -291,11 +291,7 @@ export class HuiSuggestionEntityTree extends LitElement {
         @click=${this._pickEntity}
       >
         ${stateObj
-          ? html`<state-badge
-              slot="start"
-              .hass=${this.hass}
-              .stateObj=${stateObj}
-            ></state-badge>`
+          ? html`<state-badge slot="start" .stateObj=${stateObj}></state-badge>`
           : nothing}
         <span slot="headline">${item.name}</span>
         ${secondary
@@ -514,10 +510,7 @@ export class HuiSuggestionEntityTree extends LitElement {
         <div slot="start" class="leading">
           <span class="chevron-spacer"></span>
           ${stateObj
-            ? html`<state-badge
-                .hass=${this.hass}
-                .stateObj=${stateObj}
-              ></state-badge>`
+            ? html`<state-badge .stateObj=${stateObj}></state-badge>`
             : nothing}
         </div>
         <span slot="headline">${name}</span>

--- a/src/panels/lovelace/editor/card-editor/hui-suggestion-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-suggestion-picker.ts
@@ -168,11 +168,7 @@ export class HuiSuggestionPicker extends LitElement {
       </ha-section-title>
       <ha-combo-box-item compact class="selected-entity">
         ${stateObj
-          ? html`<state-badge
-              slot="start"
-              .hass=${this.hass}
-              .stateObj=${stateObj}
-            ></state-badge>`
+          ? html`<state-badge slot="start" .stateObj=${stateObj}></state-badge>`
           : nothing}
         <span slot="headline">${primary}</span>
         ${secondary

--- a/src/panels/lovelace/elements/hui-state-icon-element.ts
+++ b/src/panels/lovelace/elements/hui-state-icon-element.ts
@@ -84,7 +84,6 @@ export class HuiStateIconElement extends LitElement implements LovelaceElement {
 
     return html`
       <state-badge
-        .hass=${this.hass}
         .stateObj=${stateObj}
         .title=${computeTooltip(this.hass, this._config)}
         @action=${this._handleAction}

--- a/src/state-summary/state-card-input_select.ts
+++ b/src/state-summary/state-card-input_select.ts
@@ -23,7 +23,7 @@ class StateCardInputSelect extends LitElement {
     }));
 
     return html`
-      <state-badge .hass=${this.hass} .stateObj=${this.stateObj}></state-badge>
+      <state-badge .stateObj=${this.stateObj}></state-badge>
       <ha-control-select-menu
         .label=${computeStateName(this.stateObj)}
         .value=${this.stateObj.state}

--- a/src/state-summary/state-card-select.ts
+++ b/src/state-summary/state-card-select.ts
@@ -23,7 +23,7 @@ class StateCardSelect extends LitElement {
     }));
 
     return html`
-      <state-badge .hass=${this.hass} .stateObj=${this.stateObj}></state-badge>
+      <state-badge .stateObj=${this.stateObj}></state-badge>
       <ha-control-select-menu
         .value=${this.stateObj.state}
         .label=${computeStateName(this.stateObj)}

--- a/src/state-summary/state-card-text.ts
+++ b/src/state-summary/state-card-text.ts
@@ -19,7 +19,7 @@ class StateCardText extends LitElement {
 
   protected render(): TemplateResult {
     return html`
-      <state-badge .hass=${this.hass} .stateObj=${this.stateObj}></state-badge>
+      <state-badge .stateObj=${this.stateObj}></state-badge>
       <ha-input
         .label=${computeStateName(this.stateObj)}
         .disabled=${this.stateObj.state === UNAVAILABLE}


### PR DESCRIPTION
## Proposed change

Brand images shown in `state-badge` (for example the integration icons on the **Settings → Updates** page) were being requested without the brands access token, so Home Assistant core rejected them with a 403 and logged them as unauthenticated requests.

`state-badge` only signed image URLs when a full `hass` object was passed to it, calling `hass.hassUrl()` to append the brands token. Components that have been migrated to Lit contexts — such as `ha-config-updates` — no longer pass `hass`, so the raw `entity_picture` URL (`/api/brands/integration/<domain>/icon.png`) was used as-is, with no token.

This change makes `state-badge` consume `connectionContext` to obtain `hassUrl`, following the existing `ha-user-badge` pattern. As a result:

- When a brand image URL cannot be signed yet (no token available), it is skipped rather than fetched, so no unauthenticated request fires and core no longer logs/blocks it.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr