### PR TITLE
Use related context in entity picker, send context on edit card/badge

### DIFF
--- a/src/common/search/related-context.ts
+++ b/src/common/search/related-context.ts
@@ -1,5 +1,5 @@
 import type { PickerComboBoxItem } from "../../components/ha-picker-combo-box";
-import type { RelatedResult } from "../../data/search";
+import type { ItemType, RelatedResult } from "../../data/search";
 
 export interface RelatedIdSets {
   areas: Set<string>;
@@ -8,14 +8,30 @@ export interface RelatedIdSets {
 }
 
 /**
- * Build a set of related IDs for a given related result.
+ * Build a set of related IDs, merging in the current (queried) item.
+ * `search/related` does not echo the queried item back, but it is the closest
+ * related item (e.g. a card editor's own entity), so it is merged into the
+ * matching group when it is an area, device, or entity.
  * @param related - The related result to build the sets from.
- * @returns The related ID sets.
+ * @param current - The queried item to merge in.
+ * @returns The related ID sets, including the current item.
  */
-export const buildRelatedIdSets = (related?: RelatedResult): RelatedIdSets => ({
-  areas: new Set(related?.area || []),
-  devices: new Set(related?.device || []),
-  entities: new Set(related?.entity || []),
+export const buildRelatedIdSets = (
+  related?: RelatedResult,
+  current?: { itemType: ItemType; itemId: string }
+): RelatedIdSets => ({
+  areas: new Set([
+    ...(related?.area || []),
+    ...(current?.itemType === "area" ? [current.itemId] : []),
+  ]),
+  devices: new Set([
+    ...(related?.device || []),
+    ...(current?.itemType === "device" ? [current.itemId] : []),
+  ]),
+  entities: new Set([
+    ...(related?.entity || []),
+    ...(current?.itemType === "entity" ? [current.itemId] : []),
+  ]),
 });
 
 /**

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -1,4 +1,5 @@
 import type { RenderItemFunction } from "@lit-labs/virtualizer/virtualize";
+import { consume } from "@lit/context";
 import { mdiPlus, mdiShape } from "@mdi/js";
 import { html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
@@ -6,10 +7,14 @@ import memoizeOne from "memoize-one";
 import { fireEvent } from "../../common/dom/fire_event";
 import { computeEntityPickerDisplay } from "../../common/entity/compute_entity_name_display";
 import { isValidEntityId } from "../../common/entity/valid_entity_id";
+import type { RelatedIdSets } from "../../common/search/related-context";
+import { relatedContext } from "../../data/context";
 import type { HaEntityPickerEntityFilterFunc } from "../../data/entity/entity";
 import {
   entityComboBoxKeys,
   getEntities,
+  markEntitiesRelated,
+  sortEntitiesByRelatedRank,
   type EntityComboBoxItem,
 } from "../../data/entity/entity_picker";
 import { domainToName } from "../../data/integration";
@@ -130,6 +135,20 @@ export class HaEntityPicker extends LitElement {
   @query("ha-generic-picker") private _picker?: HaGenericPicker;
 
   @state() private _pendingEntityId?: string;
+
+  @state()
+  @consume({ context: relatedContext, subscribe: true })
+  private _relatedIdSets?: RelatedIdSets;
+
+  private get _hasRelatedContext(): boolean {
+    const related = this._relatedIdSets;
+    return (
+      !!related &&
+      (related.entities.size > 0 ||
+        related.devices.size > 0 ||
+        related.areas.size > 0)
+    );
+  }
 
   protected willUpdate(changedProperties: PropertyValues<this>) {
     if (
@@ -324,8 +343,22 @@ export class HaEntityPicker extends LitElement {
       })
   );
 
+  private _sortByRelatedContext = memoizeOne(
+    (
+      items: EntityComboBoxItem[],
+      related: RelatedIdSets,
+      entities: HomeAssistant["entities"],
+      devices: HomeAssistant["devices"],
+      language: string
+    ): EntityComboBoxItem[] =>
+      sortEntitiesByRelatedRank(
+        markEntitiesRelated(items, related, entities, devices),
+        language
+      )
+  );
+
   private _getItems = () => {
-    const items = this._getEntitiesMemoized(
+    const entityItems = this._getEntitiesMemoized(
       this.hass,
       this.includeDomains,
       this.excludeDomains,
@@ -336,14 +369,23 @@ export class HaEntityPicker extends LitElement {
       this.excludeEntities,
       this.value
     );
+    const sortedItems = this._hasRelatedContext
+      ? this._sortByRelatedContext(
+          entityItems,
+          this._relatedIdSets!,
+          this.hass.entities,
+          this.hass.devices,
+          this.hass.locale.language
+        )
+      : entityItems;
     if (this.extraOptions?.length) {
       const resolvedExtras = this.extraOptions.map((opt) => ({
         ...opt,
         stateObj: opt.entity_id ? this.hass.states[opt.entity_id] : undefined,
       }));
-      return [...resolvedExtras, ...items];
+      return [...resolvedExtras, ...sortedItems];
     }
-    return items;
+    return sortedItems;
   };
 
   private _shouldHideClearIcon() {
@@ -375,6 +417,7 @@ export class HaEntityPicker extends LitElement {
         .searchFn=${this._searchFn}
         .valueRenderer=${this._valueRenderer}
         .searchKeys=${entityComboBoxKeys}
+        .noSort=${this._hasRelatedContext}
         use-top-label
         .addButtonLabel=${this.addButton
           ? (this.addButtonLabel ??
@@ -393,17 +436,23 @@ export class HaEntityPicker extends LitElement {
     search,
     filteredItems
   ) => {
+    // Float related items to the top by closeness, keeping search relevance
+    // order within each tier.
+    const items = this._hasRelatedContext
+      ? sortEntitiesByRelatedRank(filteredItems)
+      : filteredItems;
+
     // If there is exact match for entity id, put it first
-    const index = filteredItems.findIndex(
+    const index = items.findIndex(
       (item) => item.stateObj?.entity_id === search
     );
     if (index === -1) {
-      return filteredItems;
+      return items;
     }
 
-    const [exactMatch] = filteredItems.splice(index, 1);
-    filteredItems.unshift(exactMatch);
-    return filteredItems;
+    const [exactMatch] = items.splice(index, 1);
+    items.unshift(exactMatch);
+    return items;
   };
 
   public async open() {

--- a/src/data/context/index.ts
+++ b/src/data/context/index.ts
@@ -1,6 +1,6 @@
 import { createContext } from "@lit/context";
 import type { HassConfig } from "home-assistant-js-websocket";
-import type { HASSDomEvent } from "../../common/dom/fire_event";
+import { fireEvent, type HASSDomEvent } from "../../common/dom/fire_event";
 import type {
   HomeAssistant,
   HomeAssistantApi,
@@ -195,5 +195,22 @@ declare global {
     "hass-related-context": HASSDomEvent<RelatedContextItem | undefined>;
   }
 }
+
+/**
+ * Set the related context to an entity (or clear it when no entity), so nearby
+ * pickers float relevant entities. Fired by editors.
+ * @param node - The node to fire the event on.
+ * @param entityId - The entity to set, or undefined to clear.
+ */
+export const fireEntityRelatedContext = (
+  node: HTMLElement,
+  entityId: string | undefined
+): void => {
+  fireEvent(
+    node,
+    "hass-related-context",
+    entityId ? { itemType: "entity", itemId: entityId } : undefined
+  );
+};
 
 // #endregion related-context

--- a/src/data/context/index.ts
+++ b/src/data/context/index.ts
@@ -198,6 +198,19 @@ declare global {
 
 /**
  * Set the related context to an entity (or clear it when no entity), so nearby
+ * pickers float relevant entities.
+ * @param node - The node to fire the event on.
+ * @param context - The context to set, or undefined to clear.
+ */
+export const fireRelatedContext = (
+  node: HTMLElement,
+  context: RelatedContextItem | undefined
+): void => {
+  fireEvent(node, "hass-related-context", context);
+};
+
+/**
+ * Set the related context to an entity (or clear it when no entity), so nearby
  * pickers float relevant entities. Fired by editors.
  * @param node - The node to fire the event on.
  * @param entityId - The entity to set, or undefined to clear.
@@ -206,9 +219,8 @@ export const fireEntityRelatedContext = (
   node: HTMLElement,
   entityId: string | undefined
 ): void => {
-  fireEvent(
+  fireRelatedContext(
     node,
-    "hass-related-context",
     entityId ? { itemType: "entity", itemId: entityId } : undefined
   );
 };

--- a/src/data/entity/entity_picker.ts
+++ b/src/data/entity/entity_picker.ts
@@ -1,7 +1,10 @@
 import type { HassEntity } from "home-assistant-js-websocket";
+import { getEntityAreaId } from "../../common/entity/context/get_entity_context";
 import { computeDomain } from "../../common/entity/compute_domain";
 import { computeEntityNameList } from "../../common/entity/compute_entity_name_display";
 import { computeStateName } from "../../common/entity/compute_state_name";
+import type { RelatedIdSets } from "../../common/search/related-context";
+import { caseInsensitiveStringCompare } from "../../common/string/compare";
 import { computeRTL } from "../../common/util/compute_rtl";
 import type { PickerComboBoxItem } from "../../components/ha-picker-combo-box";
 import type { FuseWeightedKey } from "../../resources/fuseMultiTerm";
@@ -12,6 +15,11 @@ import type { HaEntityPickerEntityFilterFunc } from "./entity";
 export interface EntityComboBoxItem extends PickerComboBoxItem {
   domain_name?: string;
   stateObj?: HassEntity;
+  /**
+   * Closeness to the active related context: 0 = the entity itself, 1 = its
+   * device, 2 = its area, 3 = unrelated. Lower sorts first.
+   */
+  relatedRank?: number;
 }
 
 export const entityComboBoxKeys: FuseWeightedKey[] = [
@@ -186,3 +194,72 @@ export const getEntities = (
 
   return items;
 };
+
+const RELATED_RANK_UNRELATED = 3;
+
+const entityRelatedRank = (
+  entityId: string | undefined,
+  related: RelatedIdSets,
+  entities: HomeAssistant["entities"],
+  devices: HomeAssistant["devices"]
+): number => {
+  if (!entityId) {
+    return RELATED_RANK_UNRELATED;
+  }
+  if (related.entities.has(entityId)) {
+    return 0;
+  }
+  const deviceId = entities[entityId]?.device_id;
+  if (deviceId && related.devices.has(deviceId)) {
+    return 1;
+  }
+  const areaId = getEntityAreaId(entityId, entities, devices);
+  if (areaId && related.areas.has(areaId)) {
+    return 2;
+  }
+  return RELATED_RANK_UNRELATED;
+};
+
+/**
+ * Annotate entity items with their closeness to the related context, so they
+ * can be floated to the top. The entity itself ranks closest, then its device,
+ * then its area; anything unrelated keeps the lowest rank.
+ */
+export const markEntitiesRelated = (
+  items: EntityComboBoxItem[],
+  related: RelatedIdSets,
+  entities: HomeAssistant["entities"],
+  devices: HomeAssistant["devices"]
+): EntityComboBoxItem[] =>
+  items.map((item) => ({
+    ...item,
+    relatedRank: entityRelatedRank(
+      item.stateObj?.entity_id,
+      related,
+      entities,
+      devices
+    ),
+  }));
+
+/**
+ * Sort entity items by related closeness (entity, then device, then area, then
+ * the rest). Pass `language` to break ties within a tier alphabetically by
+ * label; omit it to keep the incoming order (e.g. search relevance).
+ */
+export const sortEntitiesByRelatedRank = (
+  items: EntityComboBoxItem[],
+  language?: string
+): EntityComboBoxItem[] =>
+  [...items].sort((a, b) => {
+    const rankDiff =
+      (a.relatedRank ?? RELATED_RANK_UNRELATED) -
+      (b.relatedRank ?? RELATED_RANK_UNRELATED);
+    if (rankDiff !== 0 || language === undefined) {
+      return rankDiff;
+    }
+    return caseInsensitiveStringCompare(
+      a.sorting_label ?? "",
+      b.sorting_label ?? "",
+      language
+    );
+  });

--- a/src/data/entity/entity_picker.ts
+++ b/src/data/entity/entity_picker.ts
@@ -15,10 +15,6 @@ import type { HaEntityPickerEntityFilterFunc } from "./entity";
 export interface EntityComboBoxItem extends PickerComboBoxItem {
   domain_name?: string;
   stateObj?: HassEntity;
-  /**
-   * Closeness to the active related context: 0 = the entity itself, 1 = its
-   * device, 2 = its area, 3 = unrelated. Lower sorts first.
-   */
   relatedRank?: number;
 }
 

--- a/src/panels/lovelace/common/get-config-related-context.ts
+++ b/src/panels/lovelace/common/get-config-related-context.ts
@@ -1,0 +1,13 @@
+import type { RelatedContextItem } from "../../../data/context";
+import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
+import { getConfigEntityId } from "./get-config-entity-id";
+
+export const getConfigRelatedContext = (
+  config: LovelaceCardConfig
+): RelatedContextItem | undefined => {
+  if (config.type === "area" && typeof config.area === "string") {
+    return { itemType: "area", itemId: config.area };
+  }
+  const entityId = getConfigEntityId(config);
+  return entityId ? { itemType: "entity", itemId: entityId } : undefined;
+};

--- a/src/panels/lovelace/editor/badge-editor/hui-dialog-edit-badge.ts
+++ b/src/panels/lovelace/editor/badge-editor/hui-dialog-edit-badge.ts
@@ -5,6 +5,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import { fireEntityRelatedContext } from "../../../../data/context";
 import { computeRTLDirection } from "../../../../common/util/compute_rtl";
 import { stripDefaults } from "../../../../common/util/strip-defaults";
 import { withViewTransition } from "../../../../common/util/view-transition";
@@ -31,6 +32,7 @@ import {
 import type { HomeAssistant } from "../../../../types";
 import { showSaveSuccessToast } from "../../../../util/toast-saved-success";
 import "../../badges/hui-badge";
+import { getConfigEntityId } from "../../common/get-config-entity-id";
 import "../../sections/hui-section";
 import { addBadge, replaceBadge } from "../config-util";
 import { getBadgeDefaultConfig } from "../get-badge-default-config";
@@ -139,25 +141,38 @@ export class HuiDialogEditBadge
     this._badgeConfig = undefined;
     this._error = undefined;
     this._documentationURL = undefined;
+    this._updateRelatedContext(undefined);
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
   protected updated(changedProps: PropertyValues): void {
-    if (
-      !this._badgeConfig ||
-      this._documentationURL !== undefined ||
-      !changedProps.has("_badgeConfig")
-    ) {
+    if (!changedProps.has("_badgeConfig")) {
       return;
     }
 
-    const oldConfig = changedProps.get("_badgeConfig") as LovelaceBadgeConfig;
+    if (this._badgeConfig && this._documentationURL === undefined) {
+      const oldConfig = changedProps.get("_badgeConfig") as LovelaceBadgeConfig;
 
-    if (oldConfig?.type !== this._badgeConfig!.type) {
-      this._documentationURL = this._badgeConfig!.type
-        ? getBadgeDocumentationURL(this.hass, this._badgeConfig!.type)
-        : undefined;
+      if (oldConfig?.type !== this._badgeConfig.type) {
+        this._documentationURL = this._badgeConfig.type
+          ? getBadgeDocumentationURL(this.hass, this._badgeConfig.type)
+          : undefined;
+      }
     }
+
+    this._updateRelatedContext(
+      this._badgeConfig ? getConfigEntityId(this._badgeConfig) : undefined
+    );
+  }
+
+  private _relatedEntityId?: string;
+
+  private _updateRelatedContext(entityId: string | undefined): void {
+    if (entityId === this._relatedEntityId) {
+      return;
+    }
+    this._relatedEntityId = entityId;
+    fireEntityRelatedContext(this, entityId);
   }
 
   protected render() {

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -6,6 +6,7 @@ import { customElement, property, query, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import { fireEntityRelatedContext } from "../../../../data/context";
 import { computeRTLDirection } from "../../../../common/util/compute_rtl";
 import { stripDefaults } from "../../../../common/util/strip-defaults";
 import { withViewTransition } from "../../../../common/util/view-transition";
@@ -33,6 +34,7 @@ import type { HomeAssistant } from "../../../../types";
 import { showToast } from "../../../../util/toast";
 import { showSaveSuccessToast } from "../../../../util/toast-saved-success";
 import "../../cards/hui-card";
+import { getConfigEntityId } from "../../common/get-config-entity-id";
 import "../../sections/hui-section";
 import { getCardDefaultConfig } from "../get-card-default-config";
 import { getCardDocumentationURL } from "../get-dashboard-documentation-url";
@@ -125,6 +127,7 @@ export class HuiDialogEditCard
     this._cardConfig = undefined;
     this._error = undefined;
     this._documentationURL = undefined;
+    this._updateRelatedContext(undefined);
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
@@ -141,6 +144,18 @@ export class HuiDialogEditCard
         this._cardConfig!.type
       );
     }
+
+    this._updateRelatedContext(getConfigEntityId(this._cardConfig));
+  }
+
+  private _relatedEntityId?: string;
+
+  private _updateRelatedContext(entityId: string | undefined): void {
+    if (entityId === this._relatedEntityId) {
+      return;
+    }
+    this._relatedEntityId = entityId;
+    fireEntityRelatedContext(this, entityId);
   }
 
   protected render() {

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -6,7 +6,10 @@ import { customElement, property, query, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { fireEntityRelatedContext } from "../../../../data/context";
+import {
+  fireRelatedContext,
+  type RelatedContextItem,
+} from "../../../../data/context";
 import { computeRTLDirection } from "../../../../common/util/compute_rtl";
 import { stripDefaults } from "../../../../common/util/strip-defaults";
 import { withViewTransition } from "../../../../common/util/view-transition";
@@ -34,7 +37,7 @@ import type { HomeAssistant } from "../../../../types";
 import { showToast } from "../../../../util/toast";
 import { showSaveSuccessToast } from "../../../../util/toast-saved-success";
 import "../../cards/hui-card";
-import { getConfigEntityId } from "../../common/get-config-entity-id";
+import { getConfigRelatedContext } from "../../common/get-config-related-context";
 import "../../sections/hui-section";
 import { getCardDefaultConfig } from "../get-card-default-config";
 import { getCardDocumentationURL } from "../get-dashboard-documentation-url";
@@ -145,17 +148,20 @@ export class HuiDialogEditCard
       );
     }
 
-    this._updateRelatedContext(getConfigEntityId(this._cardConfig));
+    this._updateRelatedContext(getConfigRelatedContext(this._cardConfig));
   }
 
-  private _relatedEntityId?: string;
+  private _relatedContext?: RelatedContextItem;
 
-  private _updateRelatedContext(entityId: string | undefined): void {
-    if (entityId === this._relatedEntityId) {
+  private _updateRelatedContext(context: RelatedContextItem | undefined): void {
+    if (
+      context?.itemType === this._relatedContext?.itemType &&
+      context?.itemId === this._relatedContext?.itemId
+    ) {
       return;
     }
-    this._relatedEntityId = entityId;
-    fireEntityRelatedContext(this, entityId);
+    this._relatedContext = context;
+    fireRelatedContext(this, context);
   }
 
   protected render() {

--- a/src/state/related-context-provider.ts
+++ b/src/state/related-context-provider.ts
@@ -121,7 +121,7 @@ export class RelatedContextProvider {
         context.itemId
       );
       if (this._contextMatches(context)) {
-        this._setValue(buildRelatedIdSets(related));
+        this._setValue(buildRelatedIdSets(related, context));
       }
     } catch (_err) {
       if (this._contextMatches(context)) {

--- a/src/state/related-context-provider.ts
+++ b/src/state/related-context-provider.ts
@@ -78,9 +78,12 @@ export class RelatedContextProvider {
   private _onRelatedContext = (
     ev: HASSDomEvent<RelatedContextItem | undefined>
   ): void => {
-    this._relatedContext = ev.detail;
-    this._contextPathname = mainWindow.location.pathname;
-    this._resolveRelatedContext(this._relatedContext);
+    // `fireEvent` coerces an undefined detail to `{}`, so a clear arrives
+    // without an itemId; normalise that back to undefined.
+    const context = ev.detail?.itemId ? ev.detail : undefined;
+    this._relatedContext = context;
+    this._contextPathname = context ? mainWindow.location.pathname : undefined;
+    this._resolveRelatedContext(context);
   };
 
   /**

--- a/test/common/search/related-context.test.ts
+++ b/test/common/search/related-context.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { buildRelatedIdSets } from "../../../src/common/search/related-context";
+import type { RelatedIdSets } from "../../../src/common/search/related-context";
+import type { RelatedResult } from "../../../src/data/search";
+
+const toArrays = (value: RelatedIdSets) => ({
+  entities: [...value.entities].sort(),
+  devices: [...value.devices].sort(),
+  areas: [...value.areas].sort(),
+});
+
+describe("buildRelatedIdSets", () => {
+  it("builds empty sets with no arguments", () => {
+    expect(toArrays(buildRelatedIdSets())).toEqual({
+      entities: [],
+      devices: [],
+      areas: [],
+    });
+  });
+
+  it("builds sets from a related result", () => {
+    const related: RelatedResult = {
+      entity: ["light.kitchen"],
+      device: ["dev1"],
+      area: ["area1"],
+    };
+    expect(toArrays(buildRelatedIdSets(related))).toEqual({
+      entities: ["light.kitchen"],
+      devices: ["dev1"],
+      areas: ["area1"],
+    });
+  });
+
+  it("merges a current entity into the entities group", () => {
+    const related: RelatedResult = { device: ["dev1"], area: ["area1"] };
+    const result = buildRelatedIdSets(related, {
+      itemType: "entity",
+      itemId: "light.ac",
+    });
+    expect(toArrays(result)).toEqual({
+      entities: ["light.ac"],
+      devices: ["dev1"],
+      areas: ["area1"],
+    });
+  });
+
+  it("merges a current device into the devices group", () => {
+    const result = buildRelatedIdSets(undefined, {
+      itemType: "device",
+      itemId: "dev1",
+    });
+    expect([...result.devices]).toEqual(["dev1"]);
+  });
+
+  it("merges a current area into the areas group", () => {
+    const result = buildRelatedIdSets(undefined, {
+      itemType: "area",
+      itemId: "area1",
+    });
+    expect([...result.areas]).toEqual(["area1"]);
+  });
+
+  it("ignores a current item whose type is not tracked", () => {
+    const result = buildRelatedIdSets(undefined, {
+      itemType: "automation",
+      itemId: "auto1",
+    });
+    expect(toArrays(result)).toEqual({ entities: [], devices: [], areas: [] });
+  });
+
+  it("deduplicates a current item already in the related result", () => {
+    const related: RelatedResult = { entity: ["light.ac"] };
+    const result = buildRelatedIdSets(related, {
+      itemType: "entity",
+      itemId: "light.ac",
+    });
+    expect([...result.entities]).toEqual(["light.ac"]);
+  });
+});

--- a/test/common/search/related-context.test.ts
+++ b/test/common/search/related-context.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildRelatedIdSets } from "../../../src/common/search/related-context";
+import {
+  buildRelatedIdSets,
+  sortRelatedFirst,
+} from "../../../src/common/search/related-context";
 import type { RelatedIdSets } from "../../../src/common/search/related-context";
+import type { PickerComboBoxItem } from "../../../src/components/ha-picker-combo-box";
 import type { RelatedResult } from "../../../src/data/search";
 
 const toArrays = (value: RelatedIdSets) => ({
@@ -8,6 +12,14 @@ const toArrays = (value: RelatedIdSets) => ({
   devices: [...value.devices].sort(),
   areas: [...value.areas].sort(),
 });
+
+const item = (id: string, isRelated?: boolean): PickerComboBoxItem => ({
+  id,
+  primary: id,
+  ...(isRelated === undefined ? {} : { isRelated }),
+});
+
+const orderOf = (items: PickerComboBoxItem[]) => items.map((i) => i.id);
 
 describe("buildRelatedIdSets", () => {
   it("builds empty sets with no arguments", () => {
@@ -75,5 +87,50 @@ describe("buildRelatedIdSets", () => {
       itemId: "light.ac",
     });
     expect([...result.entities]).toEqual(["light.ac"]);
+  });
+});
+
+describe("sortRelatedFirst", () => {
+  it("floats related items above unrelated ones", () => {
+    const items = [
+      item("a", false),
+      item("b", true),
+      item("c", false),
+      item("d", true),
+    ];
+    expect(orderOf(sortRelatedFirst(items))).toEqual(["b", "d", "a", "c"]);
+  });
+
+  it("preserves relative order within each group (stable)", () => {
+    const items = [
+      item("r1", true),
+      item("u1", false),
+      item("r2", true),
+      item("u2", false),
+      item("r3", true),
+    ];
+    expect(orderOf(sortRelatedFirst(items))).toEqual([
+      "r1",
+      "r2",
+      "r3",
+      "u1",
+      "u2",
+    ]);
+  });
+
+  it("treats a missing isRelated flag as unrelated", () => {
+    const items = [item("plain"), item("related", true)];
+    expect(orderOf(sortRelatedFirst(items))).toEqual(["related", "plain"]);
+  });
+
+  it("keeps order when nothing is related", () => {
+    const items = [item("a"), item("b"), item("c")];
+    expect(orderOf(sortRelatedFirst(items))).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const items = [item("a", false), item("b", true)];
+    sortRelatedFirst(items);
+    expect(orderOf(items)).toEqual(["a", "b"]);
   });
 });

--- a/test/data/entity/entity_picker.test.ts
+++ b/test/data/entity/entity_picker.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { getEntities } from "../../../src/data/entity/entity_picker";
+import type { RelatedIdSets } from "../../../src/common/search/related-context";
+import {
+  getEntities,
+  markEntitiesRelated,
+  sortEntitiesByRelatedRank,
+  type EntityComboBoxItem,
+} from "../../../src/data/entity/entity_picker";
 import type { HomeAssistant } from "../../../src/types";
 
 const makeHass = (entityIds: string[]): HomeAssistant => {
@@ -96,5 +102,130 @@ describe("getEntities", () => {
     });
     expect(items).toHaveLength(1);
     expect(items[0].id).toBe("entity-sensor.temp");
+  });
+});
+
+const item = (entityId: string): EntityComboBoxItem => ({
+  id: entityId,
+  primary: entityId,
+  sorting_label: entityId,
+  stateObj: { entity_id: entityId } as any,
+});
+
+const emptyRelated = (): RelatedIdSets => ({
+  areas: new Set(),
+  devices: new Set(),
+  entities: new Set(),
+});
+
+// entity.in_area sits on device "dev" in area "area";
+// entity.in_device sits on device "dev"; entity.lonely has no device or area.
+const relatedHass = {
+  entities: {
+    "light.in_area": { entity_id: "light.in_area", device_id: "dev" },
+    "light.in_device": { entity_id: "light.in_device", device_id: "dev2" },
+    "light.lonely": { entity_id: "light.lonely" },
+  },
+  devices: {
+    dev: { id: "dev", area_id: "area" },
+    dev2: { id: "dev2" },
+  },
+} as unknown as HomeAssistant;
+
+describe("markEntitiesRelated", () => {
+  it("ranks the entity itself closest", () => {
+    const related = emptyRelated();
+    related.entities.add("light.lonely");
+    const [marked] = markEntitiesRelated(
+      [item("light.lonely")],
+      related,
+      relatedHass.entities,
+      relatedHass.devices
+    );
+    expect(marked.relatedRank).toBe(0);
+  });
+
+  it("ranks an entity by its device when not directly related", () => {
+    const related = emptyRelated();
+    related.devices.add("dev2");
+    const [marked] = markEntitiesRelated(
+      [item("light.in_device")],
+      related,
+      relatedHass.entities,
+      relatedHass.devices
+    );
+    expect(marked.relatedRank).toBe(1);
+  });
+
+  it("ranks an entity by its (device-inherited) area", () => {
+    const related = emptyRelated();
+    related.areas.add("area");
+    const [marked] = markEntitiesRelated(
+      [item("light.in_area")],
+      related,
+      relatedHass.entities,
+      relatedHass.devices
+    );
+    expect(marked.relatedRank).toBe(2);
+  });
+
+  it("marks unrelated entities with the lowest rank", () => {
+    const related = emptyRelated();
+    related.entities.add("light.other");
+    const [marked] = markEntitiesRelated(
+      [item("light.lonely")],
+      related,
+      relatedHass.entities,
+      relatedHass.devices
+    );
+    expect(marked.relatedRank).toBe(3);
+  });
+});
+
+describe("sortEntitiesByRelatedRank", () => {
+  it("sorts by closeness: entity, then device, then area, then the rest", () => {
+    const related = emptyRelated();
+    related.entities.add("light.in_device"); // direct entity match wins
+    related.devices.add("dev"); // covers light.in_area via its device
+    related.areas.add("area");
+    const marked = markEntitiesRelated(
+      [item("light.lonely"), item("light.in_area"), item("light.in_device")],
+      related,
+      relatedHass.entities,
+      relatedHass.devices
+    );
+    const sorted = sortEntitiesByRelatedRank(marked, "en");
+    expect(sorted.map((i) => i.id)).toEqual([
+      "light.in_device", // rank 0 (entity)
+      "light.in_area", // rank 1 (device)
+      "light.lonely", // rank 3 (unrelated)
+    ]);
+  });
+
+  it("breaks ties alphabetically by label when a language is given", () => {
+    const sorted = sortEntitiesByRelatedRank(
+      [item("light.zebra"), item("light.apple")],
+      "en"
+    );
+    expect(sorted.map((i) => i.id)).toEqual(["light.apple", "light.zebra"]);
+  });
+
+  it("keeps incoming order within a tier when no language is given", () => {
+    const sorted = sortEntitiesByRelatedRank([
+      item("light.zebra"),
+      item("light.apple"),
+    ]);
+    expect(sorted.map((i) => i.id)).toEqual(["light.zebra", "light.apple"]);
+  });
+
+  it("falls back to plain alphabetical when nothing is related", () => {
+    const marked = markEntitiesRelated(
+      [item("light.zebra"), item("light.apple")],
+      emptyRelated(),
+      relatedHass.entities,
+      relatedHass.devices
+    );
+    const sorted = sortEntitiesByRelatedRank(marked, "en");
+    expect(sorted.map((i) => i.id)).toEqual(["light.apple", "light.zebra"]);
   });
 });

--- a/test/panels/lovelace/common/get-config-related-context.test.ts
+++ b/test/panels/lovelace/common/get-config-related-context.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { getConfigRelatedContext } from "../../../../src/panels/lovelace/common/get-config-related-context";
+
+describe("getConfigRelatedContext", () => {
+  it("returns an area context for area cards", () => {
+    expect(getConfigRelatedContext({ type: "area", area: "kitchen" })).toEqual({
+      itemType: "area",
+      itemId: "kitchen",
+    });
+  });
+
+  it("returns an entity context for entity cards", () => {
+    expect(
+      getConfigRelatedContext({ type: "entity", entity: "light.kitchen" })
+    ).toEqual({
+      itemType: "entity",
+      itemId: "light.kitchen",
+    });
+  });
+
+  it("prefers the area context for area cards with entity-like fields", () => {
+    expect(
+      getConfigRelatedContext({
+        type: "area",
+        area: "kitchen",
+        entity: "light.kitchen",
+      })
+    ).toEqual({
+      itemType: "area",
+      itemId: "kitchen",
+    });
+  });
+
+  it("returns undefined when no related context can be derived", () => {
+    expect(getConfigRelatedContext({ type: "markdown" })).toBeUndefined();
+  });
+});

--- a/test/state/related-context-provider.test.ts
+++ b/test/state/related-context-provider.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RelatedIdSets } from "../../src/common/search/related-context";
+import type { RelatedContextItem } from "../../src/data/context";
+import { findRelated } from "../../src/data/search";
+import type { RelatedResult } from "../../src/data/search";
+import type { HassBaseEl } from "../../src/state/hass-base-mixin";
+import { RelatedContextProvider } from "../../src/state/related-context-provider";
+
+vi.mock("../../src/data/search", () => ({
+  findRelated: vi.fn(),
+}));
+
+const findRelatedMock = vi.mocked(findRelated);
+
+const tick = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const toArrays = (value: RelatedIdSets | undefined) =>
+  value && {
+    entities: [...value.entities].sort(),
+    devices: [...value.devices].sort(),
+    areas: [...value.areas].sort(),
+  };
+
+describe("RelatedContextProvider", () => {
+  let host: HassBaseEl;
+  let provider: RelatedContextProvider;
+
+  // Read the value the provider has published to its context consumers.
+  const published = () =>
+    (provider as unknown as { _provider: { value: RelatedIdSets | undefined } })
+      ._provider.value;
+
+  const createProvider = (hass: unknown) => {
+    const el = document.createElement("div");
+    (el as unknown as { hass: unknown }).hass = hass;
+    host = el as unknown as HassBaseEl;
+    provider = new RelatedContextProvider(host);
+    provider.connect();
+  };
+
+  const dispatch = (detail: unknown) => {
+    const event = new Event("hass-related-context");
+    (event as unknown as { detail: unknown }).detail = detail;
+    host.dispatchEvent(event);
+  };
+
+  const fireItem = (item: RelatedContextItem) => dispatch(item);
+
+  const navigate = (path: string) => {
+    window.history.pushState({}, "", path);
+    window.dispatchEvent(new Event("popstate"));
+  };
+
+  beforeEach(() => {
+    findRelatedMock.mockReset();
+    window.history.pushState({}, "", "/lovelace");
+  });
+
+  afterEach(() => {
+    provider?.disconnect();
+  });
+
+  it("resolves an item and publishes the related set, merging the item itself", async () => {
+    findRelatedMock.mockResolvedValue({ device: ["dev1"], area: ["area1"] });
+    createProvider({});
+
+    fireItem({ itemType: "entity", itemId: "light.ac" });
+    await tick();
+
+    expect(findRelatedMock).toHaveBeenCalledWith(
+      host.hass,
+      "entity",
+      "light.ac"
+    );
+    expect(toArrays(published())).toEqual({
+      entities: ["light.ac"],
+      devices: ["dev1"],
+      areas: ["area1"],
+    });
+  });
+
+  it("clears when the detail has no itemId (fireEvent coerces undefined to {})", async () => {
+    findRelatedMock.mockResolvedValue({ device: ["dev1"] });
+    createProvider({});
+
+    fireItem({ itemType: "entity", itemId: "light.ac" });
+    await tick();
+    expect(published()).toBeDefined();
+
+    findRelatedMock.mockClear();
+    dispatch({});
+    await tick();
+
+    expect(published()).toBeUndefined();
+    expect(findRelatedMock).not.toHaveBeenCalled();
+  });
+
+  it("publishes nothing when hass is not available", async () => {
+    createProvider(undefined);
+
+    fireItem({ itemType: "entity", itemId: "light.ac" });
+    await tick();
+
+    expect(findRelatedMock).not.toHaveBeenCalled();
+    expect(published()).toBeUndefined();
+  });
+
+  it("publishes nothing when the related lookup fails", async () => {
+    findRelatedMock.mockRejectedValue(new Error("boom"));
+    createProvider({});
+
+    fireItem({ itemType: "entity", itemId: "light.ac" });
+    await tick();
+
+    expect(published()).toBeUndefined();
+  });
+
+  it("ignores a stale in-flight resolve superseded by a newer item", async () => {
+    const first = deferred<RelatedResult>();
+    const second = deferred<RelatedResult>();
+    findRelatedMock
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    createProvider({});
+
+    fireItem({ itemType: "entity", itemId: "light.first" });
+    fireItem({ itemType: "entity", itemId: "light.second" });
+
+    second.resolve({ device: ["dev2"] });
+    await tick();
+    expect(toArrays(published())!.entities).toEqual(["light.second"]);
+
+    // The older lookup resolves late and must not overwrite the newer value.
+    first.resolve({ device: ["dev1"] });
+    await tick();
+    expect(toArrays(published())!.entities).toEqual(["light.second"]);
+    expect(toArrays(published())!.devices).toEqual(["dev2"]);
+  });
+
+  it("memoizes repeated identical items", async () => {
+    findRelatedMock.mockResolvedValue({ device: ["dev1"] });
+    createProvider({});
+
+    fireItem({ itemType: "entity", itemId: "light.ac" });
+    await tick();
+    fireItem({ itemType: "entity", itemId: "light.ac" });
+    await tick();
+
+    expect(findRelatedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the context on a real navigation (pathname change)", async () => {
+    findRelatedMock.mockResolvedValue({ device: ["dev1"] });
+    createProvider({});
+
+    fireItem({ itemType: "entity", itemId: "light.ac" });
+    await tick();
+    expect(published()).toBeDefined();
+
+    navigate("/config/devices");
+    await tick();
+
+    expect(published()).toBeUndefined();
+  });
+
+  it("keeps the context on a same-path popstate (dialog history)", async () => {
+    findRelatedMock.mockResolvedValue({ device: ["dev1"] });
+    createProvider({});
+
+    fireItem({ itemType: "entity", itemId: "light.ac" });
+    await tick();
+    const before = toArrays(published());
+
+    // popstate without a pathname change (dialog open/close)
+    window.dispatchEvent(new Event("popstate"));
+    await tick();
+
+    expect(toArrays(published())).toEqual(before);
+  });
+
+  it("stops responding to events after disconnect", async () => {
+    findRelatedMock.mockResolvedValue({ device: ["dev1"] });
+    createProvider({});
+    provider.disconnect();
+
+    fireItem({ itemType: "entity", itemId: "light.ac" });
+    await tick();
+
+    expect(findRelatedMock).not.toHaveBeenCalled();
+    expect(published()).toBeUndefined();
+  });
+});

--- a/test/state/related-context-provider.test.ts
+++ b/test/state/related-context-provider.test.ts
@@ -66,11 +66,13 @@ describe("RelatedContextProvider", () => {
 
   beforeEach(() => {
     findRelatedMock.mockReset();
+    window.haContext = {};
     window.history.pushState({}, "", "/lovelace");
   });
 
   afterEach(() => {
     provider?.disconnect();
+    delete window.haContext;
   });
 
   it("resolves an item and publishes the related set, merging the item itself", async () => {
@@ -90,6 +92,11 @@ describe("RelatedContextProvider", () => {
       devices: ["dev1"],
       areas: ["area1"],
     });
+    expect(toArrays(window.haContext?.related)).toEqual({
+      entities: ["light.ac"],
+      devices: ["dev1"],
+      areas: ["area1"],
+    });
   });
 
   it("clears when the detail has no itemId (fireEvent coerces undefined to {})", async () => {
@@ -105,6 +112,7 @@ describe("RelatedContextProvider", () => {
     await tick();
 
     expect(published()).toBeUndefined();
+    expect(window.haContext?.related).toBeUndefined();
     expect(findRelatedMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
~Related PR which was used during testing: #52793~ (merged)

Adds related context to edit card/badge, clears when closed.

Makes entity picker use related context, applies to edit card/badge, automations/scripts etc. that send related context to the provider,

Uses:

- Entity picker in automation triggers/conditions/actions, use area and in use items as context, so searching for "air conditioner" will return the area's air conditioner first and not the same "Air Conditioner" in another room.
- Visibility conditions for entity state, these would start with current entity, but now also sort the related items first, so the sensor in that room can control the visibility of that entity card/badge. Gives them a higher rank over items from other areas   

Also built test suite for related context, including `window.haContext.related` and specific scenarios

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
