### PR TITLE
Show auto-revert countdown in HTTP pending-config dialog

### DIFF
--- a/src/data/http.ts
+++ b/src/data/http.ts
@@ -18,6 +18,7 @@ export interface HttpConfig {
 export interface HttpConfigState {
   stable: HttpConfig;
   pending: HttpConfig | null;
+  revert_at: string | null;
 }
 
 export interface SaveHttpConfigResult {

--- a/src/dialogs/http-pending-config/dialog-http-pending-config.ts
+++ b/src/dialogs/http-pending-config/dialog-http-pending-config.ts
@@ -1,6 +1,7 @@
 import { ERR_CONNECTION_LOST } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import secondsToDuration from "../../common/datetime/seconds_to_duration";
 import { fireEvent } from "../../common/dom/fire_event";
 import "../../components/ha-alert";
 import "../../components/ha-button";
@@ -43,23 +44,69 @@ export class DialogHttpPendingConfig
 
   @state() private _error?: string;
 
+  @state() private _secondsRemaining?: number;
+
+  @state() private _reverted = false;
+
+  private _interval?: number;
+
   public showDialog(params: HttpPendingConfigDialogParams): void {
     this._params = params;
     this._open = true;
     this._busy = undefined;
     this._error = undefined;
+    this._reverted = false;
+    this._startCountdown();
   }
 
   public closeDialog(): boolean {
     this._open = false;
+    this._stopCountdown();
     return true;
+  }
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._stopCountdown();
   }
 
   private _dialogClosed(): void {
     this._params = undefined;
     this._busy = undefined;
     this._error = undefined;
+    this._reverted = false;
+    this._secondsRemaining = undefined;
+    this._stopCountdown();
     fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  private _startCountdown(): void {
+    this._stopCountdown();
+    const revertAt = this._params?.state.revert_at;
+    if (!revertAt) {
+      this._secondsRemaining = undefined;
+      return;
+    }
+    const target = new Date(revertAt).getTime();
+    const tick = () => {
+      const remaining = Math.max(0, Math.ceil((target - Date.now()) / 1000));
+      this._secondsRemaining = remaining;
+      if (remaining === 0) {
+        this._stopCountdown();
+        this._reverted = true;
+      }
+    };
+    tick();
+    if (this._secondsRemaining && this._secondsRemaining > 0) {
+      this._interval = window.setInterval(tick, 1000);
+    }
+  }
+
+  private _stopCountdown(): void {
+    if (this._interval) {
+      window.clearInterval(this._interval);
+      this._interval = undefined;
+    }
   }
 
   private get _changedFields(): (keyof HttpConfig)[] {
@@ -91,9 +138,34 @@ export class DialogHttpPendingConfig
       >
         <span slot="headerNavigationIcon"></span>
         <div class="content">
-          <p>
-            ${this.hass.localize("ui.dialogs.http_pending_config.description")}
-          </p>
+          ${this._reverted
+            ? html`
+                <ha-alert alert-type="info">
+                  ${this.hass.localize(
+                    "ui.dialogs.http_pending_config.reverted"
+                  )}
+                </ha-alert>
+              `
+            : html`
+                <p>
+                  ${this.hass.localize(
+                    "ui.dialogs.http_pending_config.description"
+                  )}
+                </p>
+                ${this._secondsRemaining !== undefined
+                  ? html`
+                      <p class="countdown">
+                        ${this.hass.localize(
+                          "ui.dialogs.http_pending_config.auto_revert",
+                          {
+                            time:
+                              secondsToDuration(this._secondsRemaining) ?? "0",
+                          }
+                        )}
+                      </p>
+                    `
+                  : nothing}
+              `}
           ${changes.length
             ? html`
                 <p class="changes-label">
@@ -119,23 +191,33 @@ export class DialogHttpPendingConfig
             : nothing}
         </div>
         <ha-dialog-footer slot="footer">
-          <ha-button
-            slot="secondaryAction"
-            appearance="plain"
-            .loading=${this._busy === "revert"}
-            .disabled=${this._busy === "confirm"}
-            @click=${this._revert}
-          >
-            ${this.hass.localize("ui.dialogs.http_pending_config.revert")}
-          </ha-button>
-          <ha-button
-            slot="primaryAction"
-            .loading=${this._busy === "confirm"}
-            .disabled=${this._busy === "revert"}
-            @click=${this._confirm}
-          >
-            ${this.hass.localize("ui.dialogs.http_pending_config.confirm")}
-          </ha-button>
+          ${this._reverted
+            ? html`
+                <ha-button slot="primaryAction" @click=${this._close}>
+                  ${this.hass.localize("ui.dialogs.http_pending_config.close")}
+                </ha-button>
+              `
+            : html`
+                <ha-button
+                  slot="secondaryAction"
+                  appearance="plain"
+                  .loading=${this._busy === "revert"}
+                  .disabled=${this._busy === "confirm"}
+                  @click=${this._revert}
+                >
+                  ${this.hass.localize("ui.dialogs.http_pending_config.revert")}
+                </ha-button>
+                <ha-button
+                  slot="primaryAction"
+                  .loading=${this._busy === "confirm"}
+                  .disabled=${this._busy === "revert"}
+                  @click=${this._confirm}
+                >
+                  ${this.hass.localize(
+                    "ui.dialogs.http_pending_config.confirm"
+                  )}
+                </ha-button>
+              `}
         </ha-dialog-footer>
       </ha-dialog>
     `;
@@ -152,12 +234,25 @@ export class DialogHttpPendingConfig
       this._notifyResolved();
       this._open = false;
     } catch (err: any) {
+      // A confirm fired right as the backend auto-reverts may race the
+      // restart and surface as a connection-lost error. Treat it as resolved;
+      // the disconnected overlay takes over.
+      if (err?.error?.code === ERR_CONNECTION_LOST) {
+        this._notifyResolved();
+        this._open = false;
+        return;
+      }
       this._error = this.hass.localize(
         "ui.dialogs.http_pending_config.confirm_error",
         { error: err.message ?? "" }
       );
       this._busy = undefined;
     }
+  }
+
+  private _close(): void {
+    this._notifyResolved();
+    this._open = false;
   }
 
   private async _revert(): Promise<void> {
@@ -201,6 +296,9 @@ export class DialogHttpPendingConfig
       }
       p {
         margin: 0 0 var(--ha-space-4) 0;
+      }
+      .countdown {
+        color: var(--secondary-text-color);
       }
       .changes-label {
         font-weight: var(--ha-font-weight-medium);

--- a/src/dialogs/http-pending-config/dialog-http-pending-config.ts
+++ b/src/dialogs/http-pending-config/dialog-http-pending-config.ts
@@ -315,6 +315,7 @@ export class DialogHttpPendingConfig
       ha-alert {
         display: block;
         margin-top: var(--ha-space-4);
+        margin-bottom: var(--ha-space-4);
       }
     `,
   ];

--- a/src/dialogs/http-pending-config/dialog-http-pending-config.ts
+++ b/src/dialogs/http-pending-config/dialog-http-pending-config.ts
@@ -1,7 +1,7 @@
 import { ERR_CONNECTION_LOST } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import secondsToDuration from "../../common/datetime/seconds_to_duration";
+import { formatNumericDuration } from "../../common/datetime/format_duration";
 import { fireEvent } from "../../common/dom/fire_event";
 import "../../components/ha-alert";
 import "../../components/ha-button";
@@ -159,7 +159,12 @@ export class DialogHttpPendingConfig
                           "ui.dialogs.http_pending_config.auto_revert",
                           {
                             time:
-                              secondsToDuration(this._secondsRemaining) ?? "0",
+                              formatNumericDuration(this.hass.locale, {
+                                minutes: Math.floor(
+                                  this._secondsRemaining / 60
+                                ),
+                                seconds: this._secondsRemaining % 60,
+                              }) ?? "0",
                           }
                         )}
                       </p>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1472,9 +1472,12 @@
       "http_pending_config": {
         "title": "Confirm new HTTP server configuration",
         "description": "Home Assistant has restarted with new HTTP server settings. Confirm to keep them, or revert to undo the change.",
+        "auto_revert": "Settings will revert in {time}.",
+        "reverted": "Home Assistant reverted the HTTP server settings.",
         "changes_label": "Changed settings:",
         "confirm": "Confirm",
         "revert": "Revert",
+        "close": "Close",
         "confirm_error": "Failed to confirm the new configuration: {error}",
         "revert_error": "Failed to revert the configuration: {error}"
       },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1472,7 +1472,7 @@
       "http_pending_config": {
         "title": "Confirm new HTTP server configuration",
         "description": "Home Assistant has restarted with new HTTP server settings. Confirm to keep them, or revert to undo the change.",
-        "auto_revert": "Settings will revert in {time}.",
+        "auto_revert": "Settings will automatically revert in {time}.",
         "reverted": "Home Assistant reverted the HTTP server settings.",
         "changes_label": "Changed settings:",
         "confirm": "Confirm",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Core auto-reverts a pending HTTP config to stable if the admin does not confirm or revert it within 5 minutes. This PR surfaces that deadline in the existing pending-config popup:

- While the countdown is running, the dialog shows a ticking \`Settings will revert in M:SS.\` line below the description, alongside the existing Confirm and Revert buttons.
- When the deadline passes, the countdown line and the Confirm/Revert buttons are replaced by an info alert (\`Home Assistant reverted the HTTP server settings.\`) and a single Close button. The backend restart that follows is covered by the global disconnected overlay.

Stacked on #52452.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
Timer:
<img width="1000" height="992" alt="image" src="https://github.com/user-attachments/assets/929a95aa-b3f9-4c9d-bdf4-be0c4cbc5026" />

Reverted:
<img width="1000" height="992" alt="image" src="https://github.com/user-attachments/assets/a03ef8e8-e291-45a0-8f45-181c54b2d35d" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: home-assistant/core#174428

## Checklist
<!--
  Put an \`x\` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr