### PR TITLE
Migrate registry display editors to context instead of hass

### DIFF
--- a/src/components/ha-areas-display-editor.ts
+++ b/src/components/ha-areas-display-editor.ts
@@ -1,10 +1,11 @@
+import { consume, type ContextType } from "@lit/context";
 import { mdiTextureBox } from "@mdi/js";
 import type { TemplateResult } from "lit";
 import { LitElement, html } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
 import { getAreaContext } from "../common/entity/context/get_area_context";
-import type { HomeAssistant } from "../types";
+import { areasContext, floorsContext } from "../data/context";
 import "./ha-expansion-panel";
 import "./ha-items-display-editor";
 import type { DisplayItem, DisplayValue } from "./ha-items-display-editor";
@@ -17,7 +18,13 @@ export interface AreasDisplayValue {
 
 @customElement("ha-areas-display-editor")
 export class HaAreasDisplayEditor extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @consume({ context: areasContext, subscribe: true })
+  @state()
+  private _areas!: ContextType<typeof areasContext>;
+
+  @consume({ context: floorsContext, subscribe: true })
+  @state()
+  private _floors!: ContextType<typeof floorsContext>;
 
   @property() public label?: string;
 
@@ -35,10 +42,10 @@ export class HaAreasDisplayEditor extends LitElement {
   public showNavigationButton = false;
 
   protected render(): TemplateResult {
-    const areas = Object.values(this.hass.areas);
+    const areas = Object.values(this._areas);
 
     const items: DisplayItem[] = areas.map((area) => {
-      const { floor } = getAreaContext(area, this.hass.floors);
+      const { floor } = getAreaContext(area, this._floors);
       return {
         value: area.area_id,
         label: area.name,

--- a/src/components/ha-areas-floors-display-editor.ts
+++ b/src/components/ha-areas-floors-display-editor.ts
@@ -1,15 +1,19 @@
+import { consume, type ContextType } from "@lit/context";
 import { mdiDragHorizontalVariant, mdiTextureBox } from "@mdi/js";
 import type { TemplateResult } from "lit";
 import { LitElement, css, html, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
 import memoizeOne from "memoize-one";
+import { consumeLocalize } from "../common/decorators/consume-context-entry";
 import { fireEvent } from "../common/dom/fire_event";
 import { computeFloorName } from "../common/entity/compute_floor_name";
 import { getAreaContext } from "../common/entity/context/get_area_context";
+import type { LocalizeFunc } from "../common/translations/localize";
+import { areasContext, floorsContext } from "../data/context";
 import type { FloorRegistryEntry } from "../data/floor_registry";
 import { getFloors } from "../panels/lovelace/strategies/areas/helpers/areas-strategy-helper";
-import type { HomeAssistant, ValueChangedEvent } from "../types";
+import type { ValueChangedEvent } from "../types";
 import "./ha-expansion-panel";
 import "./ha-floor-icon";
 import "./ha-items-display-editor";
@@ -30,7 +34,17 @@ const UNASSIGNED_FLOOR = "__unassigned__";
 
 @customElement("ha-areas-floors-display-editor")
 export class HaAreasFloorsDisplayEditor extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
+
+  @consume({ context: areasContext, subscribe: true })
+  @state()
+  private _areas!: ContextType<typeof areasContext>;
+
+  @consume({ context: floorsContext, subscribe: true })
+  @state()
+  private _floors!: ContextType<typeof floorsContext>;
 
   @property() public label?: string;
 
@@ -51,13 +65,14 @@ export class HaAreasFloorsDisplayEditor extends LitElement {
 
   protected render(): TemplateResult {
     const groupedAreasItems = this._groupedAreasItems(
-      this.hass.areas,
-      this.hass.floors
+      this._areas,
+      this._floors
     );
 
     const filteredFloors = this._sortedFloors(
-      this.hass.floors,
-      this.value?.floors_display?.order
+      this._floors,
+      this.value?.floors_display?.order,
+      this._localize
     ).filter(
       (floor) =>
         // Only include floors that have areas assigned to them
@@ -124,15 +139,14 @@ export class HaAreasFloorsDisplayEditor extends LitElement {
 
   private _groupedAreasItems = memoizeOne(
     (
-      hassAreas: HomeAssistant["areas"],
-      // update items if floors change
-      _hassFloors: HomeAssistant["floors"]
+      areas: ContextType<typeof areasContext>,
+      floors: ContextType<typeof floorsContext>
     ): Record<string, DisplayItem[]> => {
-      const areas = Object.values(hassAreas);
+      const areaList = Object.values(areas);
 
-      const groupedItems: Record<string, DisplayItem[]> = areas.reduce(
+      const groupedItems: Record<string, DisplayItem[]> = areaList.reduce(
         (acc, area) => {
-          const { floor } = getAreaContext(area, this.hass.floors);
+          const { floor } = getAreaContext(area, floors);
           const floorId = floor?.floor_id ?? UNASSIGNED_FLOOR;
 
           if (!acc[floorId]) {
@@ -155,23 +169,24 @@ export class HaAreasFloorsDisplayEditor extends LitElement {
 
   private _sortedFloors = memoizeOne(
     (
-      hassFloors: HomeAssistant["floors"],
-      order: string[] | undefined
+      floors: ContextType<typeof floorsContext>,
+      order: string[] | undefined,
+      localize: LocalizeFunc
     ): FloorRegistryEntry[] => {
-      const floors = getFloors(hassFloors, order);
-      const noFloors = floors.length === 0;
-      floors.push({
+      const sortedFloors = getFloors(floors, order);
+      const noFloors = sortedFloors.length === 0;
+      sortedFloors.push({
         floor_id: UNASSIGNED_FLOOR,
         name: noFloors
-          ? this.hass.localize("ui.panel.lovelace.strategy.areas.areas")
-          : this.hass.localize("ui.panel.lovelace.strategy.areas.other_areas"),
+          ? localize("ui.panel.lovelace.strategy.areas.areas")
+          : localize("ui.panel.lovelace.strategy.areas.other_areas"),
         icon: null,
         level: null,
         aliases: [],
         created_at: 0,
         modified_at: 0,
       });
-      return floors;
+      return sortedFloors;
     }
   );
 
@@ -180,8 +195,9 @@ export class HaAreasFloorsDisplayEditor extends LitElement {
     const newIndex = ev.detail.newIndex;
     const oldIndex = ev.detail.oldIndex;
     const floorIds = this._sortedFloors(
-      this.hass.floors,
-      this.value?.floors_display?.order
+      this._floors,
+      this.value?.floors_display?.order,
+      this._localize
     ).map((floor) => floor.floor_id);
     const newOrder = [...floorIds];
     const movedFloorId = newOrder.splice(oldIndex, 1)[0];
@@ -204,8 +220,9 @@ export class HaAreasFloorsDisplayEditor extends LitElement {
     const currentFloorId = (ev.currentTarget as any).floorId;
 
     const floorIds = this._sortedFloors(
-      this.hass.floors,
-      this.value?.floors_display?.order
+      this._floors,
+      this.value?.floors_display?.order,
+      this._localize
     ).map((floor) => floor.floor_id);
 
     const oldAreaDisplay = this.value?.areas_display ?? {};
@@ -223,14 +240,14 @@ export class HaAreasFloorsDisplayEditor extends LitElement {
         continue;
       }
       const hidden = oldHidden.filter((areaId) => {
-        const id = this.hass.areas[areaId]?.floor_id ?? UNASSIGNED_FLOOR;
+        const id = this._areas[areaId]?.floor_id ?? UNASSIGNED_FLOOR;
         return id === floorId;
       });
       if (hidden?.length) {
         newHidden.push(...hidden);
       }
       const order = oldOrder.filter((areaId) => {
-        const id = this.hass.areas[areaId]?.floor_id ?? UNASSIGNED_FLOOR;
+        const id = this._areas[areaId]?.floor_id ?? UNASSIGNED_FLOOR;
         return id === floorId;
       });
       if (order?.length) {

--- a/src/components/ha-entities-display-editor.ts
+++ b/src/components/ha-entities-display-editor.ts
@@ -1,10 +1,18 @@
+import { consume, type ContextType } from "@lit/context";
+import type { HassEntity } from "home-assistant-js-websocket";
 import type { TemplateResult } from "lit";
 import { LitElement, html } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { consumeEntityStates } from "../common/decorators/consume-context-entry";
 import { fireEvent } from "../common/dom/fire_event";
 import { computeStateName } from "../common/entity/compute_state_name";
+import {
+  configContext,
+  connectionContext,
+  entitiesContext,
+} from "../data/context";
 import { entityIcon } from "../data/icons";
-import type { HomeAssistant } from "../types";
 import "./ha-items-display-editor";
 import type { DisplayItem, DisplayValue } from "./ha-items-display-editor";
 
@@ -15,7 +23,21 @@ export interface EntitiesDisplayValue {
 
 @customElement("ha-entities-display-editor")
 export class HaEntitiesDisplayEditor extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state()
+  @consumeEntityStates({ entityIdPath: ["entitiesIds"] })
+  private _entityStates?: Record<string, HassEntity>;
+
+  @consume({ context: entitiesContext, subscribe: true })
+  @state()
+  private _entitiesReg!: ContextType<typeof entitiesContext>;
+
+  @consume({ context: configContext, subscribe: true })
+  @state()
+  private _config!: ContextType<typeof configContext>;
+
+  @consume({ context: connectionContext, subscribe: true })
+  @state()
+  private _connection!: ContextType<typeof connectionContext>;
 
   @property() public label?: string;
 
@@ -32,20 +54,13 @@ export class HaEntitiesDisplayEditor extends LitElement {
   @property({ type: Boolean }) public required = false;
 
   protected render(): TemplateResult {
-    const entities = this.entitiesIds
-      .map((entityId) => this.hass.states[entityId])
-      .filter(Boolean);
-
-    const items: DisplayItem[] = entities.map((entity) => ({
-      value: entity.entity_id,
-      label: computeStateName(entity),
-      icon: entityIcon(
-        this.hass.entities,
-        this.hass.config,
-        this.hass.connection,
-        entity
-      ),
-    }));
+    const items = this._items(
+      this.entitiesIds,
+      this._entityStates,
+      this._entitiesReg,
+      this._config,
+      this._connection
+    );
 
     const value: DisplayValue = {
       order: this.value?.order ?? [],
@@ -60,6 +75,31 @@ export class HaEntitiesDisplayEditor extends LitElement {
       ></ha-items-display-editor>
     `;
   }
+
+  private _items = memoizeOne(
+    (
+      entitiesIds: string[],
+      entityStates: Record<string, HassEntity> | undefined,
+      entitiesReg: ContextType<typeof entitiesContext>,
+      config: ContextType<typeof configContext>,
+      connection: ContextType<typeof connectionContext>
+    ): DisplayItem[] => {
+      const entities = entitiesIds
+        .map((entityId) => entityStates?.[entityId])
+        .filter((stateObj): stateObj is HassEntity => Boolean(stateObj));
+
+      return entities.map((entity) => ({
+        value: entity.entity_id,
+        label: computeStateName(entity),
+        icon: entityIcon(
+          entitiesReg,
+          config.config,
+          connection.connection,
+          entity
+        ),
+      }));
+    }
+  );
 
   private _itemDisplayChanged(ev) {
     ev.stopPropagation();

--- a/src/components/ha-selector/ha-selector-areas-display.ts
+++ b/src/components/ha-selector/ha-selector-areas-display.ts
@@ -23,7 +23,6 @@ export class HaAreasDisplaySelector extends LitElement {
   protected render() {
     return html`
       <ha-areas-display-editor
-        .hass=${this.hass}
         .value=${this.value}
         .label=${this.label}
         .helper=${this.helper}

--- a/src/components/media-player/dialog-join-media-players.ts
+++ b/src/components/media-player/dialog-join-media-players.ts
@@ -100,7 +100,6 @@ class DialogJoinMediaPlayers extends LitElement {
           : nothing}
         <div class="content">
           <ha-media-player-toggle
-            .hass=${this.hass}
             .entityId=${entityId}
             checked
             disabled
@@ -108,7 +107,6 @@ class DialogJoinMediaPlayers extends LitElement {
           ${this._mediaPlayerEntities(this.hass.entities).map(
             (entity) =>
               html`<ha-media-player-toggle
-                .hass=${this.hass}
                 .entityId=${entity.entity_id}
                 .checked=${this._selectedEntities.includes(entity.entity_id)}
                 @change=${this._handleSelectedChange}

--- a/src/components/media-player/ha-media-player-toggle.ts
+++ b/src/components/media-player/ha-media-player-toggle.ts
@@ -1,35 +1,66 @@
-import { type CSSResultGroup, LitElement, css, html } from "lit";
-import { customElement, property } from "lit/decorators";
+import { consume, type ContextType } from "@lit/context";
 import { mdiSpeaker, mdiSpeakerPause, mdiSpeakerPlay } from "@mdi/js";
+import type { HassEntity } from "home-assistant-js-websocket";
+import { type CSSResultGroup, LitElement, css, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 
-import type { HomeAssistant } from "../../types";
+import { consumeEntityState } from "../../common/decorators/consume-context-entry";
+import { fireEvent } from "../../common/dom/fire_event";
 import { computeEntityNameList } from "../../common/entity/compute_entity_name_display";
 import { computeRTL } from "../../common/util/compute_rtl";
-import { fireEvent } from "../../common/dom/fire_event";
+import {
+  areasContext,
+  devicesContext,
+  entitiesContext,
+  floorsContext,
+  internationalizationContext,
+} from "../../data/context";
 
 import "../ha-switch";
 import "../ha-svg-icon";
 
 @customElement("ha-media-player-toggle")
 class HaMediaPlayerToggle extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property({ attribute: false }) public entityId!: string;
 
   @property({ type: Boolean }) public checked = false;
 
   @property({ type: Boolean }) public disabled = false;
 
+  @state()
+  @consumeEntityState({ entityIdPath: ["entityId"] })
+  private _stateObj?: HassEntity;
+
+  @consume({ context: entitiesContext, subscribe: true })
+  @state()
+  private _entities!: ContextType<typeof entitiesContext>;
+
+  @consume({ context: devicesContext, subscribe: true })
+  @state()
+  private _devices!: ContextType<typeof devicesContext>;
+
+  @consume({ context: areasContext, subscribe: true })
+  @state()
+  private _areas!: ContextType<typeof areasContext>;
+
+  @consume({ context: floorsContext, subscribe: true })
+  @state()
+  private _floors!: ContextType<typeof floorsContext>;
+
+  @consume({ context: internationalizationContext, subscribe: true })
+  @state()
+  private _i18n!: ContextType<typeof internationalizationContext>;
+
   private _computeDisplayData = memoizeOne(
     (
       entityId: string,
-      entities: HomeAssistant["entities"],
-      devices: HomeAssistant["devices"],
-      areas: HomeAssistant["areas"],
-      floors: HomeAssistant["floors"],
+      entities: ContextType<typeof entitiesContext>,
+      devices: ContextType<typeof devicesContext>,
+      areas: ContextType<typeof areasContext>,
+      floors: ContextType<typeof floorsContext>,
       isRTL: boolean,
-      stateObj: HomeAssistant["states"][string]
+      stateObj: HassEntity
     ) => {
       const [entityName, deviceName, areaName] = computeEntityNameList(
         stateObj,
@@ -50,7 +81,11 @@ class HaMediaPlayerToggle extends LitElement {
   );
 
   protected render() {
-    const stateObj = this.hass.states[this.entityId];
+    const stateObj = this._stateObj;
+
+    if (!stateObj) {
+      return nothing;
+    }
 
     let icon = mdiSpeaker;
     if (stateObj.state === "playing") {
@@ -60,16 +95,16 @@ class HaMediaPlayerToggle extends LitElement {
     }
 
     const isRTL = computeRTL(
-      this.hass.language,
-      this.hass.translationMetadata.translations
+      this._i18n.language,
+      this._i18n.translationMetadata.translations
     );
 
     const { primary, secondary } = this._computeDisplayData(
       this.entityId,
-      this.hass.entities,
-      this.hass.devices,
-      this.hass.areas,
-      this.hass.floors,
+      this._entities,
+      this._devices,
+      this._areas,
+      this._floors,
       isRTL,
       stateObj
     );

--- a/src/panels/lovelace/strategies/areas/editor/hui-areas-dashboard-strategy-editor.ts
+++ b/src/panels/lovelace/strategies/areas/editor/hui-areas-dashboard-strategy-editor.ts
@@ -130,7 +130,6 @@ export class HuiAreasDashboardStrategyEditor
               ${entities.length > 0
                 ? html`
                     <ha-entities-display-editor
-                      .hass=${this.hass}
                       .value=${value}
                       .label=${group}
                       @value-changed=${this._entitiesDisplayChanged}
@@ -162,7 +161,6 @@ export class HuiAreasDashboardStrategyEditor
 
     return html`
       <ha-areas-floors-display-editor
-        .hass=${this.hass}
         .value=${value}
         .label=${this.hass.localize(
           "ui.panel.lovelace.editor.strategy.areas.areas_display"


### PR DESCRIPTION
## Proposed change

Migrates the registry display-editor leaf components off the `hass` god-object property to fine-grained Lit context (part of the ongoing `hass`→context migration):

- `ha-areas-display-editor`, `ha-areas-floors-display-editor` — `areas`/`floors` → `areasContext`/`floorsContext` (+ `@consumeLocalize()`)
- `ha-entities-display-editor` — entity states → `@consumeEntityStates`, plus `entitiesContext`/`configContext`/`connectionContext` for `entityIcon`
- `ha-media-player-toggle` — entity state → `@consumeEntityState`, name-list slices → `entitiesContext`/`devicesContext`/`areasContext`/`floorsContext` + `internationalizationContext`

All four drop their `hass` property; the now-dead `.hass=${…}` bindings on these elements are removed from their parent templates. Behavior is unchanged.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
