### PR TITLE
Fix multi-term picker search ranking

### DIFF
--- a/src/components/ha-area-controls-picker.ts
+++ b/src/components/ha-area-controls-picker.ts
@@ -173,7 +173,6 @@ export class HaAreaControlsPicker extends LitElement {
             domainItems = multiTermSortedSearch(
               domainItems,
               searchString,
-              this._domainSearchKeys,
               (item) => item.id,
               fuseIndex
             );
@@ -226,7 +225,6 @@ export class HaAreaControlsPicker extends LitElement {
             entityItems = multiTermSortedSearch(
               entityItems,
               searchString,
-              this._entitySearchKeys,
               (item) => item.id,
               fuseIndex
             );

--- a/src/components/ha-navigation-picker.ts
+++ b/src/components/ha-navigation-picker.ts
@@ -243,7 +243,6 @@ export class HaNavigationPicker extends LitElement {
         items = multiTermSortedSearch(
           items,
           searchString,
-          DEFAULT_SEARCH_KEYS,
           (item) => item.id,
           fuseIndex
         );

--- a/src/components/ha-picker-combo-box.ts
+++ b/src/components/ha-picker-combo-box.ts
@@ -492,7 +492,6 @@ export class HaPickerComboBox extends ScrollableFadeMixin(LitElement) {
       let filteredItems = multiTermSortedSearch<PickerComboBoxItem>(
         this._allItems,
         searchString,
-        this.searchKeys || DEFAULT_SEARCH_KEYS,
         (item) => item.id,
         index
       );

--- a/src/components/ha-selector/ha-selector-serial-port.ts
+++ b/src/components/ha-selector/ha-selector-serial-port.ts
@@ -1,5 +1,6 @@
 import type { RenderItemFunction } from "@lit-labs/virtualizer/virtualize";
 import { mdiClose, mdiConnection, mdiMemory, mdiPencil, mdiUsb } from "@mdi/js";
+import Fuse from "fuse.js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
@@ -405,11 +406,12 @@ export class HaSerialPortSelector extends LitElement {
       }
       let groupItems: SerialPickerItem[] = grouped[type];
       if (searchString) {
+        const fuseIndex = Fuse.createIndex(DEFAULT_SEARCH_KEYS, groupItems);
         groupItems = multiTermSortedSearch(
           groupItems,
           searchString,
-          DEFAULT_SEARCH_KEYS,
-          (item) => item.id
+          (item) => item.id,
+          fuseIndex
         );
       }
       if (!groupItems.length) {

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -1116,7 +1116,6 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
       return multiTermSortedSearch(
         items,
         searchTerm,
-        weightedKeys,
         (item) => item.id,
         fuseIndex
       );

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -461,8 +461,7 @@ export class QuickBar extends LitElement {
           navigateItems = this._filterGroup(
             "navigate",
             navigateItems,
-            filter,
-            navigateComboBoxKeys
+            filter
           ) as NavigationComboBoxItem[];
         }
 
@@ -483,8 +482,7 @@ export class QuickBar extends LitElement {
           commandItems = this._filterGroup(
             "command",
             commandItems,
-            filter,
-            commandComboBoxKeys
+            filter
           ) as ActionCommandComboBoxItem[];
         }
 
@@ -514,8 +512,7 @@ export class QuickBar extends LitElement {
             this._filterGroup(
               "entity",
               entityItems,
-              filter,
-              entityComboBoxKeys
+              filter
             ) as EntityComboBoxItem[]
           );
         } else {
@@ -551,7 +548,7 @@ export class QuickBar extends LitElement {
 
         if (filter) {
           deviceItems = sortRelatedFirst(
-            this._filterGroup("device", deviceItems, filter, deviceComboBoxKeys)
+            this._filterGroup("device", deviceItems, filter)
           );
         } else {
           deviceItems = this._sortRelatedByLabel(deviceItems);
@@ -583,7 +580,7 @@ export class QuickBar extends LitElement {
 
         if (filter) {
           areaItems = sortRelatedFirst(
-            this._filterGroup("area", areaItems, filter, areaComboBoxKeys)
+            this._filterGroup("area", areaItems, filter)
           );
         } else {
           areaItems = this._sortRelatedByLabel(areaItems);
@@ -661,15 +658,13 @@ export class QuickBar extends LitElement {
   private _filterGroup(
     type: QuickBarSection,
     items: PickerComboBoxItem[],
-    searchTerm: string,
-    weightedKeys: FuseWeightedKey[]
+    searchTerm: string
   ) {
     const fuseIndex = this._fuseIndexes[type](items);
 
     return multiTermSortedSearch(
       items,
       searchTerm,
-      weightedKeys,
       (item: PickerComboBoxItem) => item.id,
       fuseIndex
     );

--- a/src/panels/config/automation/add-automation-element/ha-automation-add-search.ts
+++ b/src/panels/config/automation/add-automation-element/ha-automation-add-search.ts
@@ -780,7 +780,6 @@ export class HaAutomationAddSearch extends LitElement {
       return multiTermSortedSearch<PickerComboBoxItem>(
         items,
         searchTerm,
-        searchKeys,
         (item) => item.id,
         fuseIndex
       );

--- a/src/panels/lovelace/editor/card-editor/entity-tree-builder.ts
+++ b/src/panels/lovelace/editor/card-editor/entity-tree-builder.ts
@@ -86,7 +86,7 @@ export type EntityFuseIndex = FuseIndex<SearchableEntity>;
 // Fuse.createIndex (50-100ms on large registries).
 export const buildSearchIndex = (
   entities: SearchableEntity[]
-): EntityFuseIndex => Fuse.createIndex(FUSE_KEY_NAMES, entities);
+): EntityFuseIndex => Fuse.createIndex(entityComboBoxKeys, entities);
 
 export const OTHER_AREAS_ID = "__other_areas__";
 const SEP = "~";
@@ -99,8 +99,6 @@ export const deviceKey = (parent: string, id: string) =>
 export const domainKey = (parent: string, domain: string) =>
   `${parent}${SEP}dom|${domain}`;
 export const childKeyPrefix = (key: string) => `${key}${SEP}`;
-
-const FUSE_KEY_NAMES = entityComboBoxKeys.map((k) => k.name as string);
 
 export interface BuildEntityTreeInput {
   states: HomeAssistant["states"];
@@ -372,7 +370,6 @@ export function searchEntities(
   return multiTermSortedSearch(
     entities,
     filter,
-    entityComboBoxKeys,
     (item) => item.id,
     index
   ).slice(0, limit);

--- a/src/resources/fuseMultiTerm.ts
+++ b/src/resources/fuseMultiTerm.ts
@@ -2,7 +2,6 @@ import type {
   Expression,
   FuseIndex,
   FuseOptionKey,
-  FuseResult,
   IFuseOptions,
 } from "fuse.js";
 import Fuse from "fuse.js";
@@ -126,13 +125,12 @@ export function multiTermSearch<T>(
  * This function splits the search string into individual terms and searches for each term
  * independently. Results are aggregated and scored based on:
  * - Number of terms matched (items must match ALL terms to be included)
- * - Fuse.js match score for each term
- * - Weight of the matched keys
+ * - The Fuse.js relevance score of each term, which reflects key weight,
+ *   match quality and field length
  *
  * @template T - The type of items being searched
  * @param items - The array of items to search through
  * @param search - The search string, which will be split by spaces into multiple terms
- * @param searchKeys - Array of weighted keys configuration for Fuse.js search
  * @param getItemId - Function to extract a unique identifier from each item
  * @param fuseIndex - Optional but highly recommended! Pre-built Fuse.js index for improved performance
  * @param options - Optional Fuse.js options to customize search behavior
@@ -142,7 +140,6 @@ export function multiTermSearch<T>(
 export function multiTermSortedSearch<T>(
   items: T[],
   search: string,
-  searchKeys: FuseWeightedKey[],
   getItemId: (item: T) => string,
   fuseIndex?: FuseIndex<T>,
   options: IFuseOptions<T> = {}
@@ -178,7 +175,6 @@ export function multiTermSortedSearch<T>(
       ...options,
       shouldSort: false,
       includeScore: true,
-      includeMatches: true,
     });
 
     if (termResults.length) {
@@ -195,12 +191,9 @@ export function multiTermSortedSearch<T>(
 
         searchResults[itemId].hits += 1;
 
-        const weight = _getMatchedKeyHighestWeight<T>(r, searchKeys);
-
-        const score = r.score ? 1 - r.score : 0;
-        const weightedScore = score * weight;
-
-        searchResults[itemId].score += weightedScore;
+        // Multiply the terms' scores to combine them; summing -log does the same
+        // while turning a lower (better) Fuse score into a bigger contribution.
+        searchResults[itemId].score += -Math.log(r.score || Number.MIN_VALUE);
       });
     }
   });
@@ -215,41 +208,8 @@ export function multiTermSortedSearch<T>(
     ({ hits }) => hits === terms.length
   );
 
-  // Sort by score descending
+  // Sort by aggregated relevance (higher is better)
   results.sort((a, b) => b.score - a.score);
 
   return results.map(({ item }) => item);
-}
-
-/**
- * Finds the highest weight among all matched keys in a Fuse.js search result.
- *
- * @typeParam T - The type of items being searched
- * @param result - A single Fuse.js search result containing match information
- * @param searchKeys - Array of weighted search keys configured for the Fuse instance
- * @returns The highest weight value among matched keys, or 1 if no matches exist or no weights are defined
- */
-function _getMatchedKeyHighestWeight<T>(
-  result: FuseResult<T>,
-  searchKeys: FuseWeightedKey[]
-): number {
-  if (!result.matches || result.matches.length === 0) {
-    return 1;
-  }
-
-  // Find the highest weighted key that matched
-  let maxWeight = 1;
-  for (const match of result.matches) {
-    const keyConfig = searchKeys.find((k) => {
-      if (typeof k.name === "string") {
-        return k.name === match.key;
-      }
-      return k.name.join(".") === match.key;
-    });
-    if (keyConfig && keyConfig.weight && keyConfig.weight > maxWeight) {
-      maxWeight = keyConfig.weight;
-    }
-  }
-
-  return maxWeight;
 }

--- a/test/resources/fuseMultiTerm.test.ts
+++ b/test/resources/fuseMultiTerm.test.ts
@@ -1,0 +1,158 @@
+import Fuse from "fuse.js";
+import { describe, expect, it } from "vitest";
+import {
+  multiTermSortedSearch,
+  type FuseWeightedKey,
+} from "../../src/resources/fuseMultiTerm";
+
+interface Item {
+  id: string;
+  name: string;
+  description: string;
+}
+
+const keys: FuseWeightedKey[] = [
+  { name: "name", weight: 10 },
+  { name: "description", weight: 1 },
+];
+
+const getId = (i: Item) => i.id;
+
+const search = (items: Item[], query: string) => {
+  const index = Fuse.createIndex(keys, items);
+  return multiTermSortedSearch(items, query, getId, index);
+};
+
+const ids = (items: Item[], query: string) => search(items, query).map(getId);
+
+const item = (id: string, name: string, description = ""): Item => ({
+  id,
+  name,
+  description,
+});
+
+describe("multiTermSortedSearch", () => {
+  describe("filtering", () => {
+    it("returns all items for a blank search", () => {
+      const items = [item("1", "Alpha"), item("2", "Beta")];
+
+      expect(search(items, "   ")).toEqual(items);
+    });
+
+    it("returns an empty array when there are no items", () => {
+      expect(search([], "alpha")).toEqual([]);
+    });
+
+    it("filters to matching items for a single term", () => {
+      const items = [item("match", "Apple pie"), item("miss", "Banana bread")];
+
+      expect(ids(items, "apple")).toEqual(["match"]);
+    });
+
+    it("keeps only items that match every term", () => {
+      const items = [item("both", "Red apple"), item("one", "Red onion")];
+
+      expect(ids(items, "red apple")).toEqual(["both"]);
+    });
+
+    it("returns nothing when a term matches no item", () => {
+      const items = [item("1", "Red apple"), item("2", "Green apple")];
+
+      expect(search(items, "apple zzzzz")).toEqual([]);
+    });
+
+    it("matches case-insensitively", () => {
+      const items = [item("1", "Red Apple")];
+
+      expect(ids(items, "RED apple")).toEqual(["1"]);
+    });
+
+    it("ignores diacritics", () => {
+      const items = [item("1", "Crème brûlée")];
+
+      expect(ids(items, "creme brulee")).toEqual(["1"]);
+    });
+
+    it("ignores extra whitespace between terms", () => {
+      const items = [item("both", "Red apple"), item("one", "Red onion")];
+
+      expect(ids(items, "red    apple")).toEqual(["both"]);
+    });
+
+    it("tolerates a small typo", () => {
+      const items = [item("1", "Strawberry"), item("2", "Blueberry")];
+
+      expect(ids(items, "strawbery")).toEqual(["1"]);
+    });
+  });
+
+  describe("ranking", () => {
+    it("ranks a match in a higher-weighted field first", () => {
+      const inName = item("name", "ripe mango from the orchard");
+      const inDescription = item("description", "Smoothie", "ripe mango");
+
+      expect(ids([inDescription, inName], "ripe mango")[0]).toBe("name");
+    });
+
+    it("ranks the shorter match first when weights are equal", () => {
+      const short = item("short", "ripe mango");
+      const long = item("long", "ripe mango from the orchard");
+
+      expect(ids([long, short], "ripe mango")[0]).toBe("short");
+    });
+
+    it("ranks an exact match above a fuzzy one", () => {
+      const exact = item("exact", "Red apple");
+      const fuzzy = item("fuzzy", "Red aple");
+
+      expect(ids([fuzzy, exact], "red apple")[0]).toBe("exact");
+    });
+  });
+
+  describe("parameters", () => {
+    it("uses getItemId to aggregate an item across terms", () => {
+      const items = [item("both", "Red apple"), item("one", "Red onion")];
+
+      const result = multiTermSortedSearch(
+        items,
+        "red apple",
+        getId,
+        Fuse.createIndex(keys, items)
+      );
+
+      expect(result.map((i) => i.id)).toEqual(["both"]);
+    });
+
+    it("builds the index from keys passed in options when none is provided", () => {
+      const items = [item("1", "Red apple"), item("2", "Green apple")];
+
+      const result = multiTermSortedSearch(
+        items,
+        "red apple",
+        getId,
+        undefined,
+        { keys }
+      );
+
+      expect(result.map((i) => i.id)).toEqual(["1"]);
+    });
+
+    it("returns nothing without an index or keys", () => {
+      const items = [item("1", "Red apple")];
+
+      expect(multiTermSortedSearch(items, "red apple", getId)).toEqual([]);
+    });
+
+    it("forwards Fuse options, like a stricter threshold", () => {
+      const items = [item("1", "Strawberry")];
+      const index = Fuse.createIndex(keys, items);
+
+      // The default threshold accepts this typo; a threshold of 0 rejects it.
+      expect(
+        multiTermSortedSearch(items, "strawbery", getId, index, {
+          threshold: 0,
+        })
+      ).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Searching a picker with several words ranked good matches poorly. An entity shown only by its device name (with no name of its own) landed last when searching that device name, and a longer name with an incidental match could rank above a shorter, exact one.

The cause was the multi-word scoring: it ignored how well each term actually matched, so strong and weak matches scored the same. It now ranks by the Fuse.js relevance score, which accounts for match quality, field importance, and field length, the same signal single-word search already used.

This scoring is shared by all pickers (entities, devices, areas, labels, quick bar, target picker), so ranking improves everywhere. The PR also:

- Fixes the suggestion picker (entity tree), whose search index was missing field weights.
- Fixes the serial port selector search, which returned no results because it searched without an index.
- Removes a now-unused parameter from the shared search helper and adds tests for the search behavior.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
