### PR TITLE
Fix inverted managed check for cloud webhook disable

### DIFF
--- a/src/panels/config/cloud/dialog-manage-cloudhook/dialog-manage-cloudhook.ts
+++ b/src/panels/config/cloud/dialog-manage-cloudhook/dialog-manage-cloudhook.ts
@@ -60,7 +60,7 @@ export class DialogManageCloudhook extends LitElement {
       >
         <div>
           <p>
-            ${!cloudhook.managed
+            ${cloudhook.managed
               ? html`
                   ${this.hass!.localize(
                     "ui.panel.config.cloud.dialog_cloudhook.managed_by_integration"


### PR DESCRIPTION
## Proposed change

In the cloud panel, when you open the "Manage" dialog for a cloud webhook, it could incorrectly tell you a webhook was "managed by an integration and cannot be disabled" — even for webhooks you enabled yourself (for example, a webhook from an automation). At the same time, webhooks that really are managed by an integration (like the mobile app) were offering a disable link.

Each cloud webhook has a `managed` flag set by Home Assistant Core: it's `true` only for cloudhooks an integration creates programmatically, and `false` for hooks you create manually through the cloud panel. The dialog was negating this flag, so the informational message and the disable link were shown for the opposite cases.

This change checks the flag directly, so:
- Webhooks you enabled yourself now correctly show the "disable it" link.
- Webhooks managed by an integration correctly show the informational message instead.

## Screenshots

<!-- UI text/behavior change; before/after screenshots to be added. -->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuvU786Re5Rm1iCa8BhT8d

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuvU786Re5Rm1iCa8BhT8d)_