### PR TITLE
Add name detail option to activity card

### DIFF
--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -42,7 +42,7 @@ export class MoreInfoLogbook extends LitElement {
         .hass=${this.hass}
         .time=${this._time}
         .entityIds=${this._entityIdAsList(this.entityId)}
-        .scope=${"entity"}
+        name-detail="none"
         narrow
         no-icon
         graph-color

--- a/src/panels/config/areas/ha-config-area-page.ts
+++ b/src/panels/config/areas/ha-config-area-page.ts
@@ -622,7 +622,7 @@ class HaConfigAreaPage extends SubscribeMixin(LitElement) {
                 .time=${this._logbookTime}
                 .entityIds=${this._allEntities(memberships)}
                 .deviceIds=${this._allDeviceIds(memberships.devices)}
-                .scope=${"area"}
+                name-detail="device"
                 virtualize
                 narrow
                 no-icon

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -925,7 +925,7 @@ export class HaConfigDevicePage extends LitElement {
               .time=${this._logbookTime}
               .entityIds=${this._entityIds(entities)}
               .deviceIds=${this._deviceIdInList(this.deviceId)}
-              .scope=${"device"}
+              name-detail="entity"
               virtualize
               narrow
               no-icon

--- a/src/panels/logbook/ha-logbook-entry.ts
+++ b/src/panels/logbook/ha-logbook-entry.ts
@@ -29,7 +29,7 @@ import type {
   LogbookCauseType,
   LogbookGlyph,
   LogbookItem,
-  LogbookScope,
+  LogbookNameDetail,
   LogbookValue,
 } from "./logbook-entry-model";
 import {
@@ -63,7 +63,8 @@ class HaLogbookEntry extends LitElement {
 
   @property({ type: Boolean, attribute: false }) public graphColor = false;
 
-  @property({ attribute: false }) public scope?: LogbookScope;
+  @property({ type: String, attribute: "name-detail" })
+  public nameDetail?: LogbookNameDetail;
 
   @property({ type: Boolean, attribute: false }) public firstOfDay = false;
 
@@ -83,7 +84,7 @@ class HaLogbookEntry extends LitElement {
     const seenEntityIds: string[] = [];
 
     const item = computeLogbookItem(this.hass, entry, {
-      scope: this.scope,
+      nameDetail: this.nameDetail,
       userIdToName: this.userIdToName,
     });
 
@@ -98,7 +99,7 @@ class HaLogbookEntry extends LitElement {
       ? `/config/${traceContext.domain}/trace/${traceContext.item_id}?run_id=${traceContext.run_id}`
       : undefined;
 
-    const hideName = this.scope === "entity";
+    const hideName = this.nameDetail === "none";
     const layout: EntryLayout =
       !this.narrow && !this.noIcon ? "timeline" : hideName ? "inline" : "list";
     const node = layout === "timeline" ? "icon" : "dot";
@@ -224,7 +225,7 @@ class HaLogbookEntry extends LitElement {
   }
 
   private _renderTimeline(ctx: LogbookRenderItem) {
-    const hideName = this.scope === "entity";
+    const hideName = this.nameDetail === "none";
     const rtl = computeRTL(
       this.hass.language,
       this.hass.translationMetadata.translations

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -13,7 +13,7 @@ import { haStyle, haStyleScrollbar } from "../../resources/styles";
 import { loadVirtualizer } from "../../resources/virtualizer";
 import type { HomeAssistant } from "../../types";
 import "./ha-logbook-entry";
-import type { LogbookScope } from "./logbook-entry-model";
+import type { LogbookNameDetail } from "./logbook-entry-model";
 import { sameDay } from "./logbook-entry-model";
 
 declare global {
@@ -47,7 +47,8 @@ class HaLogbookRenderer extends LitElement {
   @property({ type: Boolean, attribute: "show-cause" }) public showCause =
     false;
 
-  @property({ attribute: false }) public scope?: LogbookScope;
+  @property({ type: String, attribute: "name-detail" })
+  public nameDetail?: LogbookNameDetail;
 
   // @ts-ignore
   @restoreScroll(".container") private _savedScrollPos?: number;
@@ -137,7 +138,7 @@ class HaLogbookRenderer extends LitElement {
           .narrow=${this.narrow}
           .noIcon=${this.noIcon}
           .graphColor=${this.graphColor}
-          .scope=${this.scope}
+          .nameDetail=${this.nameDetail}
           .firstOfDay=${firstOfDay}
           .lastOfDay=${lastOfDay}
           .showRelative=${this._showRelative}

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -13,7 +13,7 @@ import { loadTraceContexts } from "../../data/trace";
 import { fetchUsers } from "../../data/user";
 import type { HomeAssistant } from "../../types";
 import "./ha-logbook-renderer";
-import type { LogbookScope } from "./logbook-entry-model";
+import type { LogbookNameDetail } from "./logbook-entry-model";
 
 interface LogbookTimePeriod {
   now: Date;
@@ -67,9 +67,10 @@ export class HaLogbook extends LitElement {
   @property({ type: Boolean, attribute: "show-cause" }) public showCause =
     false;
 
-  // Surface scope: removes the context (and, for "entity", the subject name)
-  // the surface already implies.
-  @property({ attribute: false }) public scope?: LogbookScope;
+  // How much naming detail an entity row shows; `none` also hides the name when
+  // the surface already implies the subject.
+  @property({ type: String, attribute: "name-detail" })
+  public nameDetail?: LogbookNameDetail;
 
   @property({ attribute: "show-more-link", type: Boolean })
   public showMoreLink = true;
@@ -130,7 +131,7 @@ export class HaLogbook extends LitElement {
         .noIcon=${this.noIcon}
         .graphColor=${this.graphColor}
         .showCause=${this.showCause}
-        .scope=${this.scope}
+        .nameDetail=${this.nameDetail}
         .entries=${this._logbookEntries}
         .traceContexts=${this._traceContexts}
         .userIdToName=${this._userIdToName}

--- a/src/panels/logbook/logbook-entry-model.ts
+++ b/src/panels/logbook/logbook-entry-model.ts
@@ -35,8 +35,10 @@ export const classifyLogbookEntry = (
   return "integration";
 };
 
-// A device lives in exactly one area, so `device` (and `entity`) imply it too.
-export type LogbookScope = "entity" | "device" | "area";
+// How much naming detail an entity row shows, from least to most. The value is
+// the broadest part shown: `none` (name hidden), `entity`, `device` (device ▸
+// entity), `area` (area ▸ device ▸ entity).
+export type LogbookNameDetail = "none" | "entity" | "device" | "area";
 
 export interface EntityDisplay {
   primary?: string;
@@ -46,7 +48,7 @@ export interface EntityDisplay {
 export const entityDisplay = (
   hass: HomeAssistant,
   entityId: string,
-  scope?: LogbookScope
+  nameDetail?: LogbookNameDetail
 ): EntityDisplay => {
   const stateObj = hass.states[entityId] as HassEntity | undefined;
   if (!stateObj) {
@@ -69,14 +71,15 @@ export const entityDisplay = (
   const deviceQualifier = entityName ? deviceName : undefined;
 
   let parts: (string | undefined)[];
-  switch (scope) {
+  switch (nameDetail) {
+    case "none":
     case "entity":
-    case "device":
       parts = [];
       break;
-    case "area":
+    case "device":
       parts = [deviceQualifier];
       break;
+    case "area":
     default:
       parts = [areaName, deviceQualifier];
   }
@@ -307,7 +310,7 @@ export interface LogbookItem {
 }
 
 export interface BuildLogbookItemOptions {
-  scope?: LogbookScope;
+  nameDetail?: LogbookNameDetail;
   userIdToName?: Record<string, string>;
 }
 
@@ -328,7 +331,7 @@ export const computeLogbookItem = (
     : undefined;
 
   const display = entry.entity_id
-    ? entityDisplay(hass, entry.entity_id, opts.scope)
+    ? entityDisplay(hass, entry.entity_id, opts.nameDetail)
     : undefined;
 
   return {

--- a/src/panels/lovelace/cards/hui-logbook-card.ts
+++ b/src/panels/lovelace/cards/hui-logbook-card.ts
@@ -9,6 +9,7 @@ import memoizeOne from "memoize-one";
 import { ensureArray } from "../../../common/array/ensure-array";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
+import { getEntityEntryContext } from "../../../common/entity/context/get_entity_context";
 import { navigate } from "../../../common/navigate";
 import { createSearchParam } from "../../../common/url/search-params";
 import "../../../components/ha-card";
@@ -17,6 +18,7 @@ import { resolveEntityIDs } from "../../../data/selector";
 import type { HomeAssistant } from "../../../types";
 import "../../logbook/ha-logbook";
 import type { HaLogbook } from "../../logbook/ha-logbook";
+import type { LogbookNameDetail } from "../../logbook/logbook-entry-model";
 import { findEntities } from "../common/find-entities";
 import { processConfigEntities } from "../common/process-config-entities";
 import "../components/hui-warning";
@@ -191,6 +193,60 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
       resolveEntityIDs(this.hass, targetPickerValue, entities, devices, areas)
   );
 
+  private _getNameDetail(): LogbookNameDetail | undefined {
+    const nameDetail = this._config?.name_detail ?? "auto";
+    if (nameDetail !== "auto") {
+      return nameDetail;
+    }
+    const entityIds = this._getEntityIds();
+    if (!entityIds) {
+      return undefined;
+    }
+    return this._getAutoNameDetail(
+      entityIds,
+      this.hass.entities,
+      this.hass.devices,
+      this.hass.areas,
+      this.hass.floors
+    );
+  }
+
+  // Pick the least detail the targeted entities need to stay unambiguous: a
+  // single entity needs no name, a shared device needs only the entity name, a
+  // shared area needs the device, otherwise show the full context.
+  private _getAutoNameDetail = memoizeOne(
+    (
+      entityIds: string[],
+      entities: HomeAssistant["entities"],
+      devices: HomeAssistant["devices"],
+      areas: HomeAssistant["areas"],
+      floors: HomeAssistant["floors"]
+    ): LogbookNameDetail => {
+      if (entityIds.length <= 1) {
+        return "none";
+      }
+      const deviceIds = new Set<string | undefined>();
+      const areaIds = new Set<string | undefined>();
+      for (const entityId of entityIds) {
+        const entry = entities[entityId];
+        const { device, area } = entry
+          ? getEntityEntryContext(entry, entities, devices, areas, floors)
+          : { device: null, area: null };
+        deviceIds.add(device?.id);
+        areaIds.add(area?.area_id);
+      }
+      // An entity without a device or area counts as its own group: it does not
+      // share the context, so it must not collapse the level.
+      if (deviceIds.size === 1 && !deviceIds.has(undefined)) {
+        return "entity";
+      }
+      if (areaIds.size === 1 && !areaIds.has(undefined)) {
+        return "device";
+      }
+      return "area";
+    }
+  );
+
   protected update(changedProperties: PropertyValues<this>) {
     super.update(changedProperties);
     if (changedProperties.has("layout")) {
@@ -256,6 +312,7 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
             .time=${this._time}
             .entityIds=${this._getEntityIds()}
             .stateFilter=${this._stateFilter}
+            .nameDetail=${this._getNameDetail()}
             narrow
             no-icon
             virtualize

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -25,6 +25,7 @@ import type {
 import type { LegacyStateFilter } from "../common/evaluate-filter";
 import type { Condition, LegacyCondition } from "../common/validate-condition";
 import type { HuiImage } from "../components/hui-image";
+import type { LogbookNameDetail } from "../../logbook/logbook-entry-model";
 import type { TimestampRenderingFormat } from "../components/types";
 import type { LovelaceElementConfig } from "../elements/types";
 import type {
@@ -387,6 +388,7 @@ export interface LogbookCardConfig extends LovelaceCardConfig {
   hours_to_show?: number;
   theme?: string;
   state_filter?: string[];
+  name_detail?: "auto" | LogbookNameDetail;
 }
 
 export interface MapEntityConfig extends EntityConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-logbook-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-logbook-card-editor.ts
@@ -6,6 +6,7 @@ import {
   array,
   assert,
   assign,
+  enums,
   number,
   object,
   optional,
@@ -35,31 +36,11 @@ const cardConfigStruct = assign(
     theme: optional(string()),
     target: optional(targetStruct),
     state_filter: optional(array(string())),
+    name_detail: optional(enums(["auto", "none", "entity", "device", "area"])),
   })
 );
 
-const SCHEMA = [
-  { name: "title", selector: { text: {} } },
-  {
-    name: "",
-    type: "grid",
-    schema: [
-      { name: "theme", selector: { theme: {} } },
-      {
-        name: "hours_to_show",
-        default: DEFAULT_HOURS_TO_SHOW,
-        selector: { number: { mode: "box", min: 1 } },
-      },
-    ],
-  },
-  {
-    name: "state_filter",
-    context: {
-      filter_entity: "context_entities",
-    },
-    selector: { state: { multiple: true } },
-  },
-] as const;
+const NAME_DETAILS = ["auto", "none", "entity", "device", "area"] as const;
 
 @customElement("hui-logbook-card-editor")
 export class HuiLogbookCardEditor
@@ -69,6 +50,45 @@ export class HuiLogbookCardEditor
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: LogbookCardConfig;
+
+  private _schema = memoizeOne(
+    (localize: HomeAssistant["localize"]) =>
+      [
+        { name: "title", selector: { text: {} } },
+        {
+          name: "",
+          type: "grid",
+          schema: [
+            { name: "theme", selector: { theme: {} } },
+            {
+              name: "hours_to_show",
+              default: DEFAULT_HOURS_TO_SHOW,
+              selector: { number: { mode: "box", min: 1 } },
+            },
+          ],
+        },
+        {
+          name: "name_detail",
+          required: true,
+          selector: {
+            select: {
+              mode: "dropdown",
+              options: NAME_DETAILS.map((value) => ({
+                value,
+                label: localize(
+                  `ui.panel.lovelace.editor.card.logbook.name_detail_options.${value}`
+                ),
+              })),
+            },
+          },
+        },
+        {
+          name: "state_filter",
+          context: { filter_entity: "context_entities" },
+          selector: { state: { multiple: true } },
+        },
+      ] as const
+  );
 
   public setConfig(config: LogbookCardConfig): void {
     assert(config, cardConfigStruct);
@@ -106,7 +126,7 @@ export class HuiLogbookCardEditor
           this.hass.devices,
           this.hass.areas
         )}
-        .schema=${SCHEMA}
+        .schema=${this._schema(this.hass.localize)}
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
       ></ha-form>
@@ -129,6 +149,7 @@ export class HuiLogbookCardEditor
       areas: HomeAssistant["areas"]
     ) => ({
       ...config,
+      name_detail: config.name_detail ?? "auto",
       context_entities: resolveEntityIDs(
         this.hass!,
         target,
@@ -153,7 +174,9 @@ export class HuiLogbookCardEditor
     fireEvent(this, "config-changed", { config: newConfig });
   }
 
-  private _computeLabelCallback = (schema: SchemaUnion<typeof SCHEMA>) => {
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
     switch (schema.name) {
       case "theme":
         return `${this.hass!.localize(
@@ -164,6 +187,10 @@ export class HuiLogbookCardEditor
       case "state_filter":
         return this.hass!.localize(
           "ui.panel.lovelace.editor.card.logbook.state_filter"
+        );
+      case "name_detail":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.card.logbook.name_detail"
         );
       default:
         return this.hass!.localize(

--- a/src/panels/lovelace/editor/config-elements/hui-logbook-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-logbook-card-editor.ts
@@ -27,6 +27,8 @@ import type { LogbookCardConfig } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 
+const NAME_DETAILS = ["auto", "none", "entity", "device", "area"] as const;
+
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
   object({
@@ -36,11 +38,9 @@ const cardConfigStruct = assign(
     theme: optional(string()),
     target: optional(targetStruct),
     state_filter: optional(array(string())),
-    name_detail: optional(enums(["auto", "none", "entity", "device", "area"])),
+    name_detail: optional(enums(NAME_DETAILS)),
   })
 );
-
-const NAME_DETAILS = ["auto", "none", "entity", "device", "area"] as const;
 
 @customElement("hui-logbook-card-editor")
 export class HuiLogbookCardEditor

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9460,7 +9460,15 @@
             "logbook": {
               "name": "Activity",
               "description": "This card shows a list of events for entities.",
-              "state_filter": "State filter"
+              "state_filter": "State filter",
+              "name_detail": "Name detail",
+              "name_detail_options": {
+                "auto": "Automatic",
+                "none": "None",
+                "entity": "Entity",
+                "device": "Device ▸ Entity",
+                "area": "Area ▸ Device ▸ Entity"
+              }
             },
             "history-graph": {
               "name": "History graph",

--- a/test/panels/logbook/logbook-entry-model.test.ts
+++ b/test/panels/logbook/logbook-entry-model.test.ts
@@ -97,29 +97,36 @@ describe("entityDisplay", () => {
     areas: { area_1: mockArea({ area_id: "area_1", name: "Allée" }) },
   });
 
-  it("shows 'Area ▸ Device' with no scope", () => {
+  it("shows 'Area ▸ Device' with no name detail (defaults to full)", () => {
     expect(entityDisplay(hass, "sensor.allee_battery")).toEqual({
       primary: "Battery state",
       secondary: "Allée ▸ Caméra Allée",
     });
   });
 
-  it("shows device only in an area-scoped logbook", () => {
+  it("shows 'Area ▸ Device' for the 'area' name detail", () => {
     expect(entityDisplay(hass, "sensor.allee_battery", "area")).toEqual({
+      primary: "Battery state",
+      secondary: "Allée ▸ Caméra Allée",
+    });
+  });
+
+  it("shows the device only for the 'device' name detail", () => {
+    expect(entityDisplay(hass, "sensor.allee_battery", "device")).toEqual({
       primary: "Battery state",
       secondary: "Caméra Allée",
     });
   });
 
-  it("shows no context in a device-scoped logbook", () => {
-    expect(entityDisplay(hass, "sensor.allee_battery", "device")).toEqual({
+  it("shows no context for the 'entity' name detail", () => {
+    expect(entityDisplay(hass, "sensor.allee_battery", "entity")).toEqual({
       primary: "Battery state",
       secondary: undefined,
     });
   });
 
-  it("shows no context in an entity-scoped logbook", () => {
-    expect(entityDisplay(hass, "sensor.allee_battery", "entity")).toEqual({
+  it("shows no context for the 'none' name detail", () => {
+    expect(entityDisplay(hass, "sensor.allee_battery", "none")).toEqual({
       primary: "Battery state",
       secondary: undefined,
     });


### PR DESCRIPTION
## Breaking change

The name detail default to "auto". Previous version of the card used friendly name so user may need to adapt their dashboard to select the best level for their card.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add a **Name detail** option to the Activity (logbook) card that controls how much naming context each row shows.

Available detail options : 
- automatic
- none
- entity
- device ▸ entity
- area ▸ device ▸ entity. 

The default "Automatic" derives the right level from the card's target, so a single entity shows no repeated name, entities on one device show just the entity name, and a mix across areas shows the full area ▸ device ▸ entity path.

## Screenshots

<img width="981" height="709" alt="CleanShot 2026-06-23 at 11 29 51" src="https://github.com/user-attachments/assets/8dc7192d-3fc2-439c-9af9-bbe2bfe236d6" />
<img width="978" height="768" alt="CleanShot 2026-06-23 at 11 29 31" src="https://github.com/user-attachments/assets/ea6bc921-1867-469f-9ca5-28e8212299d6" />
<img width="980" height="834" alt="CleanShot 2026-06-23 at 11 29 43" src="https://github.com/user-attachments/assets/4c95dfac-e1ae-41b7-9174-27aaa537da43" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46410
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
