### PR TITLE
Provide Lit contexts to gallery demos; stop ignoring init errors

### DIFF
--- a/demo/src/ha-demo.ts
+++ b/demo/src/ha-demo.ts
@@ -65,7 +65,9 @@ export class HaDemo extends HomeAssistantAppEl {
         this._updateHass(hassUpdate),
     };
 
-    const hass = provideHass(this, initial, true);
+    // `false` for contexts: HomeAssistantAppEl already provides them via
+    // `contextMixin`, so let provideHass skip them to avoid duplicate providers.
+    const hass = provideHass(this, initial, true, false);
     const localizePromise =
       // @ts-ignore
       this._loadFragmentTranslations(hass.language, "page-demo").then(

--- a/gallery/src/ha-gallery.ts
+++ b/gallery/src/ha-gallery.ts
@@ -22,11 +22,17 @@ import "../../src/managers/notification-manager";
 import { haStyle } from "../../src/resources/styles";
 import {
   apiContext,
+  areasContext,
   configContext,
   connectionContext,
+  devicesContext,
+  entitiesContext,
+  floorsContext,
   formattersContext,
   internationalizationContext,
   registriesContext,
+  servicesContext,
+  statesContext,
   uiContext,
 } from "../../src/data/context";
 import { updateHassGroups } from "../../src/data/context/updateContext";
@@ -142,6 +148,18 @@ class HaGallery extends LitElement {
     formatters: new ContextProvider(this, { context: formattersContext }),
   };
 
+  // The individual (non-grouped) contexts contextMixin also provides. Components
+  // such as ha-area-picker / ha-entity-picker consume these directly, so the
+  // fallback must cover them too.
+  private _singleContextProviders = {
+    states: new ContextProvider(this, { context: statesContext }),
+    services: new ContextProvider(this, { context: servicesContext }),
+    entities: new ContextProvider(this, { context: entitiesContext }),
+    devices: new ContextProvider(this, { context: devicesContext }),
+    areas: new ContextProvider(this, { context: areasContext }),
+    floors: new ContextProvider(this, { context: floorsContext }),
+  };
+
   protected willUpdate(changedProps: PropertyValues<this>) {
     super.willUpdate(changedProps);
     // Refresh the fallback contexts before each render so theme/page changes in
@@ -157,6 +175,14 @@ class HaGallery extends LitElement {
           hass,
           provider.value
         )
+      );
+    });
+    (
+      Object.keys(this._singleContextProviders) as (keyof typeof this
+        ._singleContextProviders)[]
+    ).forEach((key) => {
+      (this._singleContextProviders[key] as ContextProvider<any>).setValue(
+        hass[key]
       );
     });
   }

--- a/gallery/src/ha-gallery.ts
+++ b/gallery/src/ha-gallery.ts
@@ -166,8 +166,9 @@ class HaGallery extends LitElement {
     // the gallery hass propagate to consuming components.
     const hass = this._galleryHass;
     (
-      Object.keys(this._contextProviders) as (keyof typeof this
-        ._contextProviders)[]
+      Object.keys(
+        this._contextProviders
+      ) as (keyof typeof this._contextProviders)[]
     ).forEach((group) => {
       const provider = this._contextProviders[group];
       provider.setValue(
@@ -178,8 +179,9 @@ class HaGallery extends LitElement {
       );
     });
     (
-      Object.keys(this._singleContextProviders) as (keyof typeof this
-        ._singleContextProviders)[]
+      Object.keys(
+        this._singleContextProviders
+      ) as (keyof typeof this._singleContextProviders)[]
     ).forEach((key) => {
       (this._singleContextProviders[key] as ContextProvider<any>).setValue(
         hass[key]

--- a/gallery/src/ha-gallery.ts
+++ b/gallery/src/ha-gallery.ts
@@ -1,3 +1,4 @@
+import { ContextProvider } from "@lit/context";
 import { mdiCog, mdiMenu } from "@mdi/js";
 import type { Connection } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
@@ -19,6 +20,16 @@ import "../../src/components/ha-svg-icon";
 import "../../src/components/ha-top-app-bar-fixed";
 import "../../src/managers/notification-manager";
 import { haStyle } from "../../src/resources/styles";
+import {
+  apiContext,
+  configContext,
+  connectionContext,
+  formattersContext,
+  internationalizationContext,
+  registriesContext,
+  uiContext,
+} from "../../src/data/context";
+import { updateHassGroups } from "../../src/data/context/updateContext";
 import type { HomeAssistant, ThemeSettings } from "../../src/types";
 import { PAGES, SIDEBAR } from "../build/import-pages";
 import {
@@ -112,6 +123,43 @@ class HaGallery extends LitElement {
   private _narrow = window.matchMedia("(max-width: 600px)").matches;
 
   @state() private _drawerOpen = !this._narrow;
+
+  // Fallback Lit context providers for the whole gallery. The real app's root
+  // element provides these via `contextMixin`; here we mirror that so demos
+  // which render context-consuming components without setting up their own hass
+  // (e.g. bare component demos) still resolve `localize`, formatters, config,
+  // etc. instead of throwing during init. Demos that call `provideHass`
+  // register their own providers closer in the tree, which take precedence.
+  private _contextProviders = {
+    registries: new ContextProvider(this, { context: registriesContext }),
+    internationalization: new ContextProvider(this, {
+      context: internationalizationContext,
+    }),
+    api: new ContextProvider(this, { context: apiContext }),
+    connection: new ContextProvider(this, { context: connectionContext }),
+    ui: new ContextProvider(this, { context: uiContext }),
+    config: new ContextProvider(this, { context: configContext }),
+    formatters: new ContextProvider(this, { context: formattersContext }),
+  };
+
+  protected willUpdate(changedProps: PropertyValues<this>) {
+    super.willUpdate(changedProps);
+    // Refresh the fallback contexts before each render so theme/page changes in
+    // the gallery hass propagate to consuming components.
+    const hass = this._galleryHass;
+    (
+      Object.keys(this._contextProviders) as (keyof typeof this
+        ._contextProviders)[]
+    ).forEach((group) => {
+      const provider = this._contextProviders[group];
+      provider.setValue(
+        (updateHassGroups[group] as (h: HomeAssistant, v?: any) => any)(
+          hass,
+          provider.value
+        )
+      );
+    });
+  }
 
   render() {
     const isSettingsPage = this._page === SETTINGS_PAGE;
@@ -576,6 +624,21 @@ class HaGallery extends LitElement {
       callWS: async () => undefined,
       fetchWithAuth: async () => new Response(),
       sendWS: () => undefined,
+      formatEntityState: (stateObj, stateValue) =>
+        (stateValue != null ? stateValue : stateObj.state) ?? "",
+      formatEntityStateToParts: (stateObj, stateValue) => [
+        {
+          type: "value",
+          value: (stateValue != null ? stateValue : stateObj.state) ?? "",
+        },
+      ],
+      formatEntityAttributeName: (_stateObj, attribute) => attribute,
+      formatEntityAttributeValue: (stateObj, attribute, value) =>
+        value != null ? value : (stateObj.attributes[attribute] ?? ""),
+      formatEntityName: (stateObj, type) =>
+        typeof type === "string"
+          ? type
+          : (stateObj.attributes.friendly_name ?? stateObj.entity_id),
     } as unknown as HomeAssistant;
   }
 

--- a/gallery/src/pages/components/ha-selector.ts
+++ b/gallery/src/pages/components/ha-selector.ts
@@ -1,5 +1,4 @@
-import { ContextProvider } from "@lit/context";
-import type { PropertyValues, TemplateResult } from "lit";
+import type { TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, state } from "lit/decorators";
 import { mockAreaRegistry } from "../../../../demo/src/stubs/area_registry";
@@ -15,11 +14,6 @@ import "../../../../src/components/ha-selector/ha-selector";
 import "../../../../src/components/ha-settings-row";
 import type { AreaRegistryEntry } from "../../../../src/data/area/area_registry";
 import type { BlueprintInput } from "../../../../src/data/blueprint";
-import {
-  configContext,
-  internationalizationContext,
-} from "../../../../src/data/context";
-import { updateHassGroups } from "../../../../src/data/context/updateContext";
 import type { DeviceRegistryEntry } from "../../../../src/data/device/device_registry";
 import type { FloorRegistryEntry } from "../../../../src/data/floor_registry";
 import type { LabelRegistryEntry } from "../../../../src/data/label/label_registry";
@@ -528,17 +522,6 @@ class DemoHaSelector extends LitElement implements ProvideHassElement {
 
   private data = SCHEMAS.map(() => ({}));
 
-  // The date/datetime selectors and the date-picker dialog consume these
-  // contexts (provided by the root element in the real app). Provide them here
-  // so they work in the gallery.
-  private _i18nProvider = new ContextProvider(this, {
-    context: internationalizationContext,
-  });
-
-  private _configProvider = new ContextProvider(this, {
-    context: configContext,
-  });
-
   constructor() {
     super();
     const hass = provideHass(this);
@@ -558,16 +541,6 @@ class DemoHaSelector extends LitElement implements ProvideHassElement {
 
   public provideHass(el) {
     el.hass = this.hass;
-  }
-
-  protected willUpdate(changedProps: PropertyValues): void {
-    super.willUpdate(changedProps);
-    if (changedProps.has("hass") && this.hass) {
-      this._i18nProvider.setValue(
-        updateHassGroups.internationalization(this.hass)
-      );
-      this._configProvider.setValue(updateHassGroups.config(this.hass));
-    }
   }
 
   public connectedCallback() {

--- a/gallery/src/pages/lovelace/thermostat-card.ts
+++ b/gallery/src/pages/lovelace/thermostat-card.ts
@@ -248,7 +248,7 @@ class DemoThermostatEntity extends LitElement {
 
   protected firstUpdated(changedProperties: PropertyValues<this>) {
     super.firstUpdated(changedProperties);
-    const hass = provideHass(this._demoRoot, {}, false, true);
+    const hass = provideHass(this._demoRoot);
     hass.updateTranslations(null, "en");
     hass.updateTranslations("lovelace", "en");
     hass.addEntities(ENTITIES);

--- a/gallery/src/pages/more-info/climate.ts
+++ b/gallery/src/pages/more-info/climate.ts
@@ -151,7 +151,7 @@ class DemoMoreInfoClimate extends LitElement {
 
   protected firstUpdated(changedProperties: PropertyValues<this>) {
     super.firstUpdated(changedProperties);
-    const hass = provideHass(this._demoRoot, {}, false, true);
+    const hass = provideHass(this._demoRoot);
     hass.updateTranslations(null, "en");
     hass.addEntities(ENTITIES);
   }

--- a/gallery/src/pages/more-info/humidifier.ts
+++ b/gallery/src/pages/more-info/humidifier.ts
@@ -54,7 +54,7 @@ class DemoMoreInfoHumidifier extends LitElement {
 
   protected firstUpdated(changedProperties: PropertyValues<this>) {
     super.firstUpdated(changedProperties);
-    const hass = provideHass(this._demoRoot, {}, false, true);
+    const hass = provideHass(this._demoRoot);
     hass.updateTranslations(null, "en");
     hass.addEntities(ENTITIES);
   }

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -9,11 +9,17 @@ import { computeFormatFunctions } from "../common/translations/entity-state";
 import { computeLocalize } from "../common/translations/localize";
 import {
   apiContext,
+  areasContext,
   configContext,
   connectionContext,
+  devicesContext,
+  entitiesContext,
+  floorsContext,
   formattersContext,
   internationalizationContext,
   registriesContext,
+  servicesContext,
+  statesContext,
   uiContext,
 } from "../data/context";
 import { updateHassGroups } from "../data/context/updateContext";
@@ -132,21 +138,46 @@ export const provideHass = (
       }
     : undefined;
 
+  // The individual (non-grouped) contexts that contextMixin also provides.
+  // Components such as ha-area-picker / ha-entity-picker consume these directly
+  // (e.g. `Object.values(areas)`), so they must be provided alongside the
+  // grouped contexts or those components throw once they render.
+  const singleContextProviders = provideContexts
+    ? {
+        states: new ContextProvider(baseEl(), { context: statesContext }),
+        services: new ContextProvider(baseEl(), { context: servicesContext }),
+        entities: new ContextProvider(baseEl(), { context: entitiesContext }),
+        devices: new ContextProvider(baseEl(), { context: devicesContext }),
+        areas: new ContextProvider(baseEl(), { context: areasContext }),
+        floors: new ContextProvider(baseEl(), { context: floorsContext }),
+      }
+    : undefined;
+
   const updateContextProviders = (newHass: HomeAssistant) => {
-    if (!contextProviders) {
-      return;
+    if (contextProviders) {
+      (
+        Object.keys(contextProviders) as (keyof typeof contextProviders)[]
+      ).forEach((group) => {
+        const provider = contextProviders[group];
+        provider.setValue(
+          (updateHassGroups[group] as (h: HomeAssistant, v?: any) => any)(
+            newHass,
+            provider.value
+          )
+        );
+      });
     }
-    (
-      Object.keys(contextProviders) as (keyof typeof contextProviders)[]
-    ).forEach((group) => {
-      const provider = contextProviders[group];
-      provider.setValue(
-        (updateHassGroups[group] as (h: HomeAssistant, v?: any) => any)(
-          newHass,
-          provider.value
-        )
-      );
-    });
+    if (singleContextProviders) {
+      (
+        Object.keys(
+          singleContextProviders
+        ) as (keyof typeof singleContextProviders)[]
+      ).forEach((key) => {
+        (singleContextProviders[key] as ContextProvider<any>).setValue(
+          newHass[key]
+        );
+      });
+    }
   };
 
   const wsCommands = {};

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -97,11 +97,15 @@ export const provideHass = (
   elements,
   overrideData: Partial<HomeAssistant> = {},
   setHassProperty = false,
-  // Opt-in to providing the grouped Lit contexts (config, formatters, api, …)
-  // that the real app's root element provides via `contextMixin`. Needed for
-  // gallery demos that render context-consuming components (e.g. the climate
-  // temperature control) without the full app shell.
-  provideContexts = false
+  // Provide the grouped Lit contexts (registries, internationalization, api,
+  // connection, ui, config, formatters) that the real app's root element
+  // provides via `contextMixin`. On by default so that any standalone hass root
+  // (e.g. a gallery demo) automatically feeds context-consuming components the
+  // same way the real app does, instead of each demo wiring up a partial set by
+  // hand. Pass `false` for hosts that already provide these contexts themselves
+  // via `contextMixin` (the full app shell — `ha-demo`, `ha-test`), to avoid
+  // registering duplicate providers on the same element.
+  provideContexts = true
 ): MockHomeAssistant => {
   elements = ensureArray(elements);
   // Can happen because we store sidebar, more info etc on hass.

--- a/test/e2e/app/src/ha-test.ts
+++ b/test/e2e/app/src/ha-test.ts
@@ -66,7 +66,9 @@ export class HaTest extends HomeAssistantAppEl {
         this._updateHass(hassUpdate),
     };
 
-    const hass = provideHass(this, initial, true);
+    // `false` for contexts: HomeAssistantAppEl already provides them via
+    // `contextMixin`, so let provideHass skip them to avoid duplicate providers.
+    const hass = provideHass(this, initial, true, false);
     const localizePromise =
       // @ts-ignore
       this._loadFragmentTranslations(hass.language, "page-demo").then(

--- a/test/e2e/gallery.spec.ts
+++ b/test/e2e/gallery.spec.ts
@@ -54,29 +54,16 @@ async function assertPageLoads(page: Page, hash: string, selector: string) {
 }
 
 // Errors that are gallery-harness artifacts rather than bugs in the component
-// under test. The gallery feeds demos a synchronous mock `hass`, but migrated
-// components now read `localize`/formatters from Lit context, which resolves
-// asynchronously — so a demo can render one frame before the context lands and
-// throw a transient "undefined" error during init. These don't prevent the
-// demo from rendering (the toBeAttached check above still has to pass), and
-// they're timing-dependent, so we filter the whole init-error family here.
+// under test. The Lit-context init-error family that used to live here is gone:
+// ha-gallery now provides fallback contexts for every demo (mirroring the real
+// app's root), so context-consuming components resolve `localize`, formatters,
+// config, etc. synchronously instead of throwing during init.
 const IGNORED_ERRORS: RegExp[] = [
   /ResizeObserver/,
   /Non-Error/,
   /Extension context/,
   // Plain objects thrown by mock WebSocket/data-fetch show up as "Object".
   /^Object$/,
-  // localize consumed from context before it resolves (`this.localize` /
-  // `this._localize is not a function`, or `hass.localize` read as undefined).
-  /_?localize is not a function/,
-  /Cannot read properties of undefined \(reading 'localize'\)/,
-  // Formatters consumed from context before it resolves.
-  /Cannot read properties of undefined \(reading 'format[A-Za-z]+'\)/,
-  // hass API methods consumed from context before it resolves (e.g. the
-  // update demo fetches release notes via callWS during init).
-  /Cannot read properties of undefined \(reading 'call(WS|Api|Service)'\)/,
-  // locale fields read before the mock locale is wired up.
-  /Cannot read properties of undefined \(reading '(time|number|date)_format'\)/,
   // hui-group-entity-row calls .some() on a possibly-undefined entity_id array
   // from mock state data — pre-existing gallery data issue.
   /Cannot read properties of undefined \(reading 'some'\)/,


### PR DESCRIPTION
## Proposed change

The `ha-selector` gallery E2E test was failing repo-wide (`Cannot convert undefined or null to object`), and the test was carrying a whole family of filtered "init errors" to stay green. This fixes the root cause and removes the need to ignore those errors.

The gallery feeds each demo a synchronous mock `hass`, but components migrated to fine-grained Lit contexts now read state / registries / internationalization / formatters / config / ui from **context** instead of from `hass`. Demos that didn't provide those contexts let consumers read `undefined` during init and throw.

The fix mirrors the full set of contexts the real app's root element provides via `contextMixin`, in two layers:

1. **`provideHass` provides all contexts by default.** Any standalone hass root (every more-info / lovelace / interactive demo) now wires up context-consuming components synchronously, instead of each demo hand-rolling a partial set. This covers both the grouped contexts (registries, internationalization, api, connection, ui, config, formatters) and the individual ones (states, services, entities, devices, areas, floors) — the latter matter because components like `ha-area-picker` / `ha-entity-picker` consume them directly (e.g. `Object.values(areas)`). The full app shell (`ha-demo`, `ha-test`) already provides these via `contextMixin`, so it opts out (`provideContexts: false`) to avoid duplicate providers.

2. **`ha-gallery` provides fallback contexts for every demo.** Bare component demos (`ha-alert`, `ha-tip`, `ha-dialog`, `ha-input`, `ha-select-box`, …) render context-consuming components without setting up their own hass. The gallery shell now provides the same grouped + individual contexts from its gallery hass. Demos that call `provideHass` register their own providers closer in the tree, which take precedence.

With every demo covered, the entire context-timing family is removed from `IGNORED_ERRORS` — only genuine harness noise (`ResizeObserver`, browser-extension noise, plain-object throws) and one unrelated pre-existing mock-data bug remain filtered.

Changes:
- `provide_hass`: default `provideContexts` to `true`; provide grouped + individual contexts; document the opt-out
- `ha-demo` / `ha-test`: opt out (their `contextMixin` already provides contexts)
- `ha-gallery`: provide grouped + individual fallback contexts; add formatter stubs to the gallery hass
- `ha-selector` demo: remove its hand-rolled partial i18n/config providers
- `climate` / `humidifier` / `thermostat-card` demos: drop the now-redundant `true` argument
- `gallery.spec.ts`: remove the context-timing `IGNORED_ERRORS`

Verified locally: built the gallery and ran the full Playwright gallery suite — **all 83 tests pass**. `yarn lint:types` and ESLint are clean for all changed files.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

