### PR TITLE
Show supported frequencies column in radio frequency devices list

### DIFF
--- a/src/data/radio_frequency.ts
+++ b/src/data/radio_frequency.ts
@@ -1,3 +1,5 @@
+import { formatNumber } from "../common/number/format_number";
+import type { FrontendLocaleData } from "./translation";
 import type { HomeAssistant } from "../types";
 
 export const DOMAIN = "radio_frequency";
@@ -20,3 +22,41 @@ export const fetchRadioFrequencyTransmitters = (
   hass.callWS({
     type: "radio_frequency/list",
   });
+
+const FREQUENCY_UNITS: [number, string][] = [
+  [1e9, "GHz"],
+  [1e6, "MHz"],
+  [1e3, "kHz"],
+  [1, "Hz"],
+];
+
+// Format a frequency in hertz using the largest unit that keeps the value >= 1.
+export const formatFrequency = (
+  hz: number,
+  locale: FrontendLocaleData
+): string => {
+  const [divisor, unit] = FREQUENCY_UNITS.find(
+    ([threshold]) => Math.abs(hz) >= threshold
+  ) ?? [1, "Hz"];
+  return `${formatNumber(hz / divisor, locale, {
+    maximumFractionDigits: 3,
+  })} ${unit}`;
+};
+
+// Format a single [min, max] range; collapses to a single value when min === max.
+export const formatFrequencyRange = (
+  range: readonly [number, number],
+  locale: FrontendLocaleData
+): string => {
+  const [min, max] = range;
+  return min === max
+    ? formatFrequency(min, locale)
+    : `${formatFrequency(min, locale)} – ${formatFrequency(max, locale)}`;
+};
+
+// Format a list of frequency ranges into a human-readable, comma-separated string.
+export const formatFrequencyRanges = (
+  ranges: readonly (readonly [number, number])[],
+  locale: FrontendLocaleData
+): string =>
+  ranges.map((range) => formatFrequencyRange(range, locale)).join(", ");

--- a/src/panels/config/integrations/integration-panels/radio_frequency/radio-frequency-devices-page.ts
+++ b/src/panels/config/integrations/integration-panels/radio_frequency/radio-frequency-devices-page.ts
@@ -12,7 +12,10 @@ import type {
 } from "../../../../../components/data-table/ha-data-table";
 import "../../../../../components/ha-relative-time";
 import { UNAVAILABLE, UNKNOWN } from "../../../../../data/entity/entity";
-import type { RadioFrequencyTransmitter } from "../../../../../data/radio_frequency";
+import {
+  formatFrequencyRanges,
+  type RadioFrequencyTransmitter,
+} from "../../../../../data/radio_frequency";
 import "../../../../../layouts/hass-tabs-subpage-data-table";
 import type { PageNavigation } from "../../../../../layouts/hass-tabs-subpage";
 import { haStyle } from "../../../../../resources/styles";
@@ -22,6 +25,7 @@ interface RadioFrequencyTransmitterRow {
   id: string;
   name: string;
   type: string;
+  frequencies: string;
   last_used?: string;
   device_id: string | null;
 }
@@ -64,6 +68,13 @@ export class RadioFrequencyDevicesPage extends LitElement {
           filterable: true,
           groupable: true,
         },
+        frequencies: {
+          title: localize("ui.panel.config.radio_frequency.frequencies"),
+          sortable: true,
+          filterable: true,
+          flex: 2,
+          template: (transmitter) => transmitter.frequencies || "—",
+        },
         last_used: {
           title: localize("ui.panel.config.radio_frequency.last_used"),
           sortable: true,
@@ -86,7 +97,8 @@ export class RadioFrequencyDevicesPage extends LitElement {
     (
       transmitters: RadioFrequencyTransmitter[],
       states: HomeAssistant["states"],
-      localize: LocalizeFunc
+      localize: LocalizeFunc,
+      locale: HomeAssistant["locale"]
     ): RadioFrequencyTransmitterRow[] =>
       transmitters.map((transmitter) => {
         const stateObj = states[transmitter.entity_id];
@@ -104,6 +116,10 @@ export class RadioFrequencyDevicesPage extends LitElement {
           id: transmitter.entity_id,
           name: stateObj ? computeStateName(stateObj) : transmitter.entity_id,
           type: localize("component.radio_frequency.entity_component._.name"),
+          frequencies: formatFrequencyRanges(
+            transmitter.supported_frequency_ranges,
+            locale
+          ),
           last_used,
           device_id: transmitter.device_id,
         };
@@ -122,7 +138,8 @@ export class RadioFrequencyDevicesPage extends LitElement {
         .data=${this._data(
           this.transmitters,
           this.hass.states,
-          this.hass.localize
+          this.hass.localize,
+          this.hass.locale
         )}
         .noDataText=${this.hass.localize(
           "ui.panel.config.radio_frequency.no_devices"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7168,6 +7168,7 @@
           "loading_error": "Failed to load radio frequency devices",
           "name": "Name",
           "type": "Type",
+          "frequencies": "Frequencies",
           "last_used": "Last used",
           "devices_navigation": "Devices"
         },

--- a/test/data/radio_frequency.test.ts
+++ b/test/data/radio_frequency.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatFrequency,
+  formatFrequencyRange,
+  formatFrequencyRanges,
+} from "../../src/data/radio_frequency";
+import {
+  DateFormat,
+  FirstWeekday,
+  type FrontendLocaleData,
+  NumberFormat,
+  TimeFormat,
+  TimeZone,
+} from "../../src/data/translation";
+
+const locale: FrontendLocaleData = {
+  language: "en",
+  number_format: NumberFormat.language,
+  time_format: TimeFormat.language,
+  date_format: DateFormat.language,
+  time_zone: TimeZone.local,
+  first_weekday: FirstWeekday.language,
+};
+
+describe("formatFrequency", () => {
+  it("picks the largest unit that keeps the value >= 1", () => {
+    expect(formatFrequency(50, locale)).toBe("50 Hz");
+    expect(formatFrequency(2400, locale)).toBe("2.4 kHz");
+    expect(formatFrequency(433_920_000, locale)).toBe("433.92 MHz");
+    expect(formatFrequency(2_400_000_000, locale)).toBe("2.4 GHz");
+  });
+
+  it("rounds to at most three fractional digits", () => {
+    expect(formatFrequency(868_300_000, locale)).toBe("868.3 MHz");
+    expect(formatFrequency(123_456_789, locale)).toBe("123.457 MHz");
+  });
+});
+
+describe("formatFrequencyRange", () => {
+  it("collapses a range to a single value when min equals max", () => {
+    expect(formatFrequencyRange([433_920_000, 433_920_000], locale)).toBe(
+      "433.92 MHz"
+    );
+  });
+
+  it("formats a range with both bounds", () => {
+    expect(formatFrequencyRange([863_000_000, 870_000_000], locale)).toBe(
+      "863 MHz – 870 MHz"
+    );
+  });
+});
+
+describe("formatFrequencyRanges", () => {
+  it("joins multiple ranges with commas", () => {
+    expect(
+      formatFrequencyRanges(
+        [
+          [433_920_000, 433_920_000],
+          [868_000_000, 870_000_000],
+        ],
+        locale
+      )
+    ).toBe("433.92 MHz, 868 MHz – 870 MHz");
+  });
+
+  it("returns an empty string for no ranges", () => {
+    expect(formatFrequencyRanges([], locale)).toBe("");
+  });
+});


### PR DESCRIPTION
## Proposed change

Forgot this in the new frequencies panel. Data is already there 🙃 

Adds a **Frequencies** column to the radio frequency devices (proxy) list so you can see at a glance which frequency bands each device supports, without having to open every device.

The supported frequency ranges already returned by the backend are now formatted into a friendly, locale-aware string. The unit is chosen automatically (Hz, kHz, MHz, or GHz), single-point ranges are shown as one value (for example `433.92 MHz`) and wider ranges as a span (for example `863 MHz – 870 MHz`). The new column is sortable and filterable, and shows a dash when a device reports no frequencies.

## Screenshots

<img width="3358" height="2526" alt="CleanShot 2026-06-24 at 15 13 04@2x" src="https://github.com/user-attachments/assets/64037f84-1f8f-4765-a106-9b05effe63b3" />


<!-- Screenshot to be added. -->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYyMTtBdrt7EBrVEt869Uw)_