### PR TITLE
Use the Jinja block comment for toggle-comment in templates

### DIFF
--- a/src/resources/codemirror.ts
+++ b/src/resources/codemirror.ts
@@ -56,8 +56,18 @@ export { tags } from "@lezer/highlight";
 
 const _yamlWithJinja = jinja({ base: yaml() });
 
+// The jinja2 mode is rendered on a YAML base, whose line comment is "#". In a
+// template that is meaningless, so toggle-comment (Ctrl+/) should use the Jinja
+// block comment "{# #}" instead. Scope this to the jinja2 language only so the
+// plain YAML mode keeps its "#" comment.
+const _jinjaCommentTokens = Prec.highest(
+  EditorState.languageData.of(() => [
+    { commentTokens: { block: { open: "{#", close: "#}" } } },
+  ])
+);
+
 export const langs = {
-  jinja2: _yamlWithJinja,
+  jinja2: [_yamlWithJinja, _jinjaCommentTokens],
   yaml: _yamlWithJinja,
 };
 


### PR DESCRIPTION
## Proposed change

In the template editor (and other Jinja editors), pressing Ctrl+/ inserted a `#`, which does nothing useful in a template. That mode is rendered on a YAML base, whose comment character is `#`.

This gives the Jinja editor mode the Jinja block comment token, so toggle-comment now wraps the selection (or cursor) with `{# #}`. The plain YAML editor mode is unchanged and keeps using `#`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52809
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
