### PR TITLE
Use choose selector for legacy trigger fields

### DIFF
--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
@@ -1,16 +1,188 @@
-import type { PropertyValues } from "lit";
 import { css, html, LitElement } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { ensureArray } from "../../../../../common/array/ensure-array";
 import { createDurationData } from "../../../../../common/datetime/create_duration_data";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { hasTemplate } from "../../../../../common/string/has-template";
-import type { LocalizeFunc } from "../../../../../common/translations/localize";
 import "../../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../../components/ha-form/types";
 import type { NumericStateTrigger } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
+
+const SCHEMA = [
+  {
+    name: "entity_id",
+    required: true,
+    selector: { entity: { multiple: true } },
+  },
+  {
+    name: "attribute",
+    context: { filter_entity: "entity_id" },
+    selector: {
+      attribute: {
+        hide_attributes: [
+          "access_token",
+          "auto_update",
+          "available_modes",
+          "away_mode",
+          "changed_by",
+          "code_arm_required",
+          "code_format",
+          "color_mode",
+          "color_modes",
+          "current_activity",
+          "device_class",
+          "editable",
+          "effect_list",
+          "effect",
+          "entity_id",
+          "entity_picture",
+          "event_type",
+          "event_types",
+          "fan_mode",
+          "fan_modes",
+          "fan_speed_list",
+          "forecast",
+          "friendly_name",
+          "frontend_stream_type",
+          "has_date",
+          "has_time",
+          "hs_color",
+          "hvac_mode",
+          "hvac_modes",
+          "icon",
+          "id",
+          "latest_version",
+          "max_color_temp_kelvin",
+          "max_mireds",
+          "max_temp",
+          "media_album_name",
+          "media_artist",
+          "media_content_type",
+          "media_position_updated_at",
+          "media_title",
+          "min_color_temp_kelvin",
+          "min_mireds",
+          "min_temp",
+          "mode",
+          "next_dawn",
+          "next_dusk",
+          "next_midnight",
+          "next_noon",
+          "next_rising",
+          "next_setting",
+          "operation_list",
+          "operation_mode",
+          "options",
+          "percentage_step",
+          "precipitation_unit",
+          "preset_mode",
+          "preset_modes",
+          "pressure_unit",
+          "release_notes",
+          "release_summary",
+          "release_url",
+          "restored",
+          "rgb_color",
+          "rgbw_color",
+          "shuffle",
+          "skipped_version",
+          "sound_mode_list",
+          "sound_mode",
+          "source_list",
+          "source_type",
+          "source",
+          "state_class",
+          "step",
+          "supported_color_modes",
+          "supported_features",
+          "swing_mode",
+          "swing_modes",
+          "target_temp_step",
+          "temperature_unit",
+          "title",
+          "token",
+          "unit_of_measurement",
+          "user_id",
+          "uuid",
+          "visibility_unit",
+          "wind_speed_unit",
+          "xy_color",
+        ],
+      },
+    },
+  },
+  {
+    name: "above",
+    selector: {
+      choose: {
+        translation_key:
+          "ui.panel.config.automation.editor.triggers.type.numeric_state.threshold_type",
+        choices: {
+          value: {
+            selector: {
+              number: {
+                mode: "box",
+                min: Number.MIN_SAFE_INTEGER,
+                max: Number.MAX_SAFE_INTEGER,
+                step: 0.1,
+              },
+            },
+          },
+          input: {
+            selector: {
+              entity: { domain: ["input_number", "number", "sensor"] },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    name: "below",
+    selector: {
+      choose: {
+        translation_key:
+          "ui.panel.config.automation.editor.triggers.type.numeric_state.threshold_type",
+        choices: {
+          value: {
+            selector: {
+              number: {
+                mode: "box",
+                min: Number.MIN_SAFE_INTEGER,
+                max: Number.MAX_SAFE_INTEGER,
+                step: 0.1,
+              },
+            },
+          },
+          input: {
+            selector: {
+              entity: { domain: ["input_number", "number", "sensor"] },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    name: "value_template",
+    selector: { template: {} },
+  },
+  {
+    name: "for",
+    selector: {
+      choose: {
+        translation_key:
+          "ui.panel.config.automation.editor.triggers.type.numeric_state.for_type",
+        choices: {
+          duration: { selector: { duration: {} } },
+          template: { selector: { template: {} } },
+        },
+      },
+    },
+  },
+] as const;
 
 @customElement("ha-automation-trigger-numeric_state")
 export class HaNumericStateTrigger extends LitElement {
@@ -20,236 +192,6 @@ export class HaNumericStateTrigger extends LitElement {
 
   @property({ type: Boolean }) public disabled = false;
 
-  @state() private _inputAboveIsEntity?: boolean;
-
-  @state() private _inputBelowIsEntity?: boolean;
-
-  private _schema = memoizeOne(
-    (
-      localize: LocalizeFunc,
-      inputAboveIsEntity?: boolean,
-      inputBelowIsEntity?: boolean
-    ) =>
-      [
-        {
-          name: "entity_id",
-          required: true,
-          selector: { entity: { multiple: true } },
-        },
-        {
-          name: "attribute",
-          context: { filter_entity: "entity_id" },
-          selector: {
-            attribute: {
-              hide_attributes: [
-                "access_token",
-                "auto_update",
-                "available_modes",
-                "away_mode",
-                "changed_by",
-                "code_arm_required",
-                "code_format",
-                "color_mode",
-                "color_modes",
-                "current_activity",
-                "device_class",
-                "editable",
-                "effect_list",
-                "effect",
-                "entity_id",
-                "entity_picture",
-                "event_type",
-                "event_types",
-                "fan_mode",
-                "fan_modes",
-                "fan_speed_list",
-                "forecast",
-                "friendly_name",
-                "frontend_stream_type",
-                "has_date",
-                "has_time",
-                "hs_color",
-                "hvac_mode",
-                "hvac_modes",
-                "icon",
-                "id",
-                "latest_version",
-                "max_color_temp_kelvin",
-                "max_mireds",
-                "max_temp",
-                "media_album_name",
-                "media_artist",
-                "media_content_type",
-                "media_position_updated_at",
-                "media_title",
-                "min_color_temp_kelvin",
-                "min_mireds",
-                "min_temp",
-                "mode",
-                "next_dawn",
-                "next_dusk",
-                "next_midnight",
-                "next_noon",
-                "next_rising",
-                "next_setting",
-                "operation_list",
-                "operation_mode",
-                "options",
-                "percentage_step",
-                "precipitation_unit",
-                "preset_mode",
-                "preset_modes",
-                "pressure_unit",
-                "release_notes",
-                "release_summary",
-                "release_url",
-                "restored",
-                "rgb_color",
-                "rgbw_color",
-                "shuffle",
-                "skipped_version",
-                "sound_mode_list",
-                "sound_mode",
-                "source_list",
-                "source_type",
-                "source",
-                "state_class",
-                "step",
-                "supported_color_modes",
-                "supported_features",
-                "swing_mode",
-                "swing_modes",
-                "target_temp_step",
-                "temperature_unit",
-                "title",
-                "token",
-                "unit_of_measurement",
-                "user_id",
-                "uuid",
-                "visibility_unit",
-                "wind_speed_unit",
-                "xy_color",
-              ],
-            },
-          },
-        },
-        {
-          name: "lower_limit",
-          type: "select",
-          required: true,
-          options: [
-            [
-              "value",
-              localize(
-                "ui.panel.config.automation.editor.triggers.type.numeric_state.type_value"
-              ),
-            ],
-            [
-              "input",
-              localize(
-                "ui.panel.config.automation.editor.triggers.type.numeric_state.type_input"
-              ),
-            ],
-          ],
-        },
-        ...(inputAboveIsEntity
-          ? ([
-              {
-                name: "above",
-                selector: {
-                  entity: { domain: ["input_number", "number", "sensor"] },
-                },
-              },
-            ] as const)
-          : ([
-              {
-                name: "above",
-                selector: {
-                  number: {
-                    mode: "box",
-                    min: Number.MIN_SAFE_INTEGER,
-                    max: Number.MAX_SAFE_INTEGER,
-                    step: 0.1,
-                  },
-                },
-              },
-            ] as const)),
-        {
-          name: "upper_limit",
-          type: "select",
-          required: true,
-          options: [
-            [
-              "value",
-              localize(
-                "ui.panel.config.automation.editor.triggers.type.numeric_state.type_value"
-              ),
-            ],
-            [
-              "input",
-              localize(
-                "ui.panel.config.automation.editor.triggers.type.numeric_state.type_input"
-              ),
-            ],
-          ],
-        },
-        ...(inputBelowIsEntity
-          ? ([
-              {
-                name: "below",
-                selector: {
-                  entity: { domain: ["input_number", "number", "sensor"] },
-                },
-              },
-            ] as const)
-          : ([
-              {
-                name: "below",
-                selector: {
-                  number: {
-                    mode: "box",
-                    min: Number.MIN_SAFE_INTEGER,
-                    max: Number.MAX_SAFE_INTEGER,
-                    step: 0.1,
-                  },
-                },
-              },
-            ] as const)),
-        {
-          name: "value_template",
-          selector: { template: {} },
-        },
-        { name: "for", selector: { duration: {} } },
-      ] as const
-  );
-
-  public willUpdate(changedProperties: PropertyValues<this>) {
-    this._inputAboveIsEntity =
-      this._inputAboveIsEntity ??
-      (typeof this.trigger.above === "string" &&
-        ((this.trigger.above as string).startsWith("input_number.") ||
-          (this.trigger.above as string).startsWith("number.") ||
-          (this.trigger.above as string).startsWith("sensor.")));
-    this._inputBelowIsEntity =
-      this._inputBelowIsEntity ??
-      (typeof this.trigger.below === "string" &&
-        ((this.trigger.below as string).startsWith("input_number.") ||
-          (this.trigger.below as string).startsWith("number.") ||
-          (this.trigger.below as string).startsWith("sensor.")));
-
-    if (!changedProperties.has("trigger")) {
-      return;
-    }
-    // Check for templates in trigger. If found, revert to YAML mode.
-    if (this.trigger && hasTemplate(this.trigger.for)) {
-      fireEvent(
-        this,
-        "ui-mode-not-available",
-        Error(this.hass.localize("ui.errors.config.no_template_editor_support"))
-      );
-    }
-  }
-
   public static get defaultConfig(): NumericStateTrigger {
     return {
       trigger: "numeric_state",
@@ -257,39 +199,61 @@ export class HaNumericStateTrigger extends LitElement {
     };
   }
 
-  private _data = memoizeOne(
-    (
-      inputAboveIsEntity: boolean,
-      inputBelowIsEntity: boolean,
-      trigger: NumericStateTrigger
-    ) => ({
-      lower_limit: inputAboveIsEntity ? "input" : "value",
-      upper_limit: inputBelowIsEntity ? "input" : "value",
-      ...trigger,
-      entity_id: ensureArray(trigger.entity_id),
-      for: createDurationData(trigger.for),
-    })
-  );
+  private _wrapForValue(
+    forValue: NumericStateTrigger["for"]
+  ): Record<string, unknown> | undefined {
+    if (forValue === undefined) {
+      return undefined;
+    }
+    if (typeof forValue === "string" && hasTemplate(forValue)) {
+      return { active_choice: "template", template: forValue };
+    }
+    return {
+      active_choice: "duration",
+      duration: createDurationData(forValue),
+    };
+  }
+
+  private _unwrapForValue(
+    forValue: Record<string, unknown> | undefined
+  ): NumericStateTrigger["for"] {
+    if (!forValue || !forValue.active_choice) {
+      return forValue as NumericStateTrigger["for"];
+    }
+    if (forValue.active_choice === "template") {
+      return forValue.template as string;
+    }
+    return forValue.duration as NumericStateTrigger["for"];
+  }
+
+  private _unwrapThresholdValue(
+    value: Record<string, unknown> | number | string | undefined
+  ): number | string | undefined {
+    if (value === undefined || typeof value !== "object") {
+      return value as number | string | undefined;
+    }
+    if (!value.active_choice) {
+      return undefined;
+    }
+    return value[value.active_choice as string] as number | string | undefined;
+  }
+
+  private _data = memoizeOne((trigger: NumericStateTrigger) => ({
+    ...trigger,
+    entity_id: ensureArray(trigger.entity_id),
+    for: this._wrapForValue(trigger.for),
+  }));
 
   public render() {
-    const schema = this._schema(
-      this.hass.localize,
-      this._inputAboveIsEntity,
-      this._inputBelowIsEntity
-    );
-
-    const data = this._data(
-      this._inputAboveIsEntity!,
-      this._inputBelowIsEntity!,
-      this.trigger
-    );
+    const data = this._data(this.trigger);
 
     return html`
       <ha-form
         .hass=${this.hass}
         .data=${data}
-        .schema=${schema}
+        .schema=${SCHEMA}
         .disabled=${this.disabled}
+        .localizeValue=${this.hass.localize}
         @value-changed=${this._valueChanged}
         .computeLabel=${this._computeLabelCallback}
       ></ha-form>
@@ -300,11 +264,9 @@ export class HaNumericStateTrigger extends LitElement {
     ev.stopPropagation();
     const newTrigger = { ...ev.detail.value };
 
-    this._inputAboveIsEntity = newTrigger.lower_limit === "input";
-    this._inputBelowIsEntity = newTrigger.upper_limit === "input";
-
-    delete newTrigger.lower_limit;
-    delete newTrigger.upper_limit;
+    newTrigger.above = this._unwrapThresholdValue(newTrigger.above);
+    newTrigger.below = this._unwrapThresholdValue(newTrigger.below);
+    newTrigger.for = this._unwrapForValue(newTrigger.for);
 
     if (newTrigger.value_template === "") {
       delete newTrigger.value_template;
@@ -314,7 +276,7 @@ export class HaNumericStateTrigger extends LitElement {
   }
 
   private _computeLabelCallback = (
-    schema: SchemaUnion<ReturnType<typeof this._schema>>
+    schema: SchemaUnion<typeof SCHEMA>
   ): string => {
     switch (schema.name) {
       case "entity_id":

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
@@ -174,7 +174,19 @@ export class HaStateTrigger extends LitElement implements TriggerElement {
             },
           },
         },
-        { name: "for", selector: { duration: {} } },
+        {
+          name: "for",
+          selector: {
+            choose: {
+              translation_key:
+                "ui.panel.config.automation.editor.triggers.type.state.for_type",
+              choices: {
+                duration: { selector: { duration: {} } },
+                template: { selector: { template: {} } },
+              },
+            },
+          },
+        },
       ] as const satisfies HaFormSchema[]
   );
 
@@ -190,7 +202,9 @@ export class HaStateTrigger extends LitElement implements TriggerElement {
       delete this.trigger.for.milliseconds;
     }
     // Check for templates in trigger. If found, revert to YAML mode.
-    if (this.trigger && hasTemplate(this.trigger)) {
+    // Exclude "for" since the UI now supports templates there via choose.
+    const { for: _for, ...triggerWithoutFor } = this.trigger;
+    if (triggerWithoutFor && hasTemplate(triggerWithoutFor)) {
       fireEvent(
         this,
         "ui-mode-not-available",
@@ -207,13 +221,38 @@ export class HaStateTrigger extends LitElement implements TriggerElement {
     return true;
   }
 
-  protected render() {
-    const trgFor = createDurationData(this.trigger.for);
+  private _wrapForValue(
+    forValue: StateTrigger["for"]
+  ): Record<string, unknown> | undefined {
+    if (forValue === undefined) {
+      return undefined;
+    }
+    if (typeof forValue === "string" && hasTemplate(forValue)) {
+      return { active_choice: "template", template: forValue };
+    }
+    return {
+      active_choice: "duration",
+      duration: createDurationData(forValue),
+    };
+  }
 
+  private _unwrapForValue(
+    forValue: Record<string, unknown> | undefined
+  ): StateTrigger["for"] {
+    if (!forValue || !forValue.active_choice) {
+      return forValue as StateTrigger["for"];
+    }
+    if (forValue.active_choice === "template") {
+      return forValue.template as string;
+    }
+    return forValue.duration as StateTrigger["for"];
+  }
+
+  protected render() {
     const data = {
       ...this.trigger,
       entity_id: ensureArray(this.trigger.entity_id),
-      for: trgFor,
+      for: this._wrapForValue(this.trigger.for),
     };
 
     data.to = this._normalizeStates(this.trigger.to, data.attribute);
@@ -230,6 +269,7 @@ export class HaStateTrigger extends LitElement implements TriggerElement {
         .hass=${this.hass}
         .data=${data}
         .schema=${schema}
+        .localizeValue=${this.hass.localize}
         @value-changed=${this._valueChanged}
         .computeLabel=${this._computeLabelCallback}
         .disabled=${this.disabled}
@@ -240,6 +280,8 @@ export class HaStateTrigger extends LitElement implements TriggerElement {
   private _valueChanged(ev: CustomEvent): void {
     ev.stopPropagation();
     const newTrigger = ev.detail.value;
+
+    newTrigger.for = this._unwrapForValue(newTrigger.for);
 
     newTrigger.to = this._applyAnyStateExclusive(
       newTrigger.to,

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-template.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-template.ts
@@ -1,4 +1,3 @@
-import type { PropertyValues } from "lit";
 import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import type { TemplateTrigger } from "../../../../../data/automation";
@@ -11,7 +10,19 @@ import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 const SCHEMA = [
   { name: "value_template", required: true, selector: { template: {} } },
-  { name: "for", selector: { duration: {} } },
+  {
+    name: "for",
+    selector: {
+      choose: {
+        translation_key:
+          "ui.panel.config.automation.editor.triggers.type.template.for_type",
+        choices: {
+          duration: { selector: { duration: {} } },
+          template: { selector: { template: {} } },
+        },
+      },
+    },
+  },
 ] as const;
 
 @customElement("ha-automation-trigger-template")
@@ -26,26 +37,37 @@ export class HaTemplateTrigger extends LitElement {
     return { trigger: "template", value_template: "" };
   }
 
-  public willUpdate(changedProperties: PropertyValues<this>) {
-    if (!changedProperties.has("trigger")) {
-      return;
+  private _wrapForValue(
+    forValue: TemplateTrigger["for"]
+  ): Record<string, unknown> | undefined {
+    if (forValue === undefined) {
+      return undefined;
     }
-    // Check for templates in trigger. If found, revert to YAML mode.
-    if (this.trigger && hasTemplate(this.trigger.for)) {
-      fireEvent(
-        this,
-        "ui-mode-not-available",
-        Error(this.hass.localize("ui.errors.config.no_template_editor_support"))
-      );
+    if (typeof forValue === "string" && hasTemplate(forValue)) {
+      return { active_choice: "template", template: forValue };
     }
+    return {
+      active_choice: "duration",
+      duration: createDurationData(forValue),
+    };
+  }
+
+  private _unwrapForValue(
+    forValue: Record<string, unknown> | undefined
+  ): TemplateTrigger["for"] {
+    if (!forValue || !forValue.active_choice) {
+      return forValue as TemplateTrigger["for"];
+    }
+    if (forValue.active_choice === "template") {
+      return forValue.template as string;
+    }
+    return forValue.duration as TemplateTrigger["for"];
   }
 
   protected render() {
-    const trgFor = createDurationData(this.trigger.for);
-
     const data = {
       ...this.trigger,
-      for: trgFor,
+      for: this._wrapForValue(this.trigger.for),
     };
 
     return html`
@@ -53,6 +75,7 @@ export class HaTemplateTrigger extends LitElement {
         .hass=${this.hass}
         .data=${data}
         .schema=${SCHEMA}
+        .localizeValue=${this.hass.localize}
         @value-changed=${this._valueChanged}
         .computeLabel=${this._computeLabelCallback}
         .disabled=${this.disabled}
@@ -64,8 +87,11 @@ export class HaTemplateTrigger extends LitElement {
     ev.stopPropagation();
     const newTrigger = ev.detail.value;
 
+    newTrigger.for = this._unwrapForValue(newTrigger.for);
+
     if (
       newTrigger.for &&
+      typeof newTrigger.for === "object" &&
       Object.values(newTrigger.for).every((value) => value === 0)
     ) {
       delete newTrigger.for;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5287,7 +5287,7 @@
                   "upper_limit": "Upper limit",
                   "value_template": "Value template",
                   "type_value": "Fixed number",
-                  "type_input": "Numeric value of another entity",
+                  "type_input": "Value of an entity",
                   "description": {
                     "picker": "Triggers when the numeric value of an entity''s state (or attribute''s value) crosses a given threshold.",
                     "above": "When {attribute, select, \n undefined {} \n other {{attribute} from }\n }{entity} {numberOfEntities, plural,\n one {is}\n other {is}\n} above {above}{duration, select, \n undefined {} \n other { for {duration}}\n }",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5251,6 +5251,12 @@
                   "description": {
                     "picker": "Triggers when the state of an entity (or attribute) changes.",
                     "full": "When{hasAttribute, select, \n true { {attribute} of} \n other {}\n} {hasEntity, select, \n true {{entity}} \n other {something}\n} changes{fromChoice, select, \n fromUsed { from {fromString}}\n null { from any state} \n other {}\n}{toChoice, select, \n toUsed { to {toString}} \n null { to any state} \n special { state or any attributes} \n other {}\n}{hasDuration, select, \n true { for {duration}} \n other {}\n}"
+                  },
+                  "for_type": {
+                    "choices": {
+                      "duration": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::for_type::choices::duration%]",
+                      "template": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::for_type::choices::template%]"
+                    }
                   }
                 },
                 "homeassistant": {
@@ -5287,6 +5293,18 @@
                     "above": "When {attribute, select, \n undefined {} \n other {{attribute} from }\n }{entity} {numberOfEntities, plural,\n one {is}\n other {is}\n} above {above}{duration, select, \n undefined {} \n other { for {duration}}\n }",
                     "below": "When {attribute, select, \n undefined {} \n other {{attribute} from }\n }{entity} {numberOfEntities, plural,\n one {is}\n other {is}\n} below {below}{duration, select, \n undefined {} \n other { for {duration}}\n }",
                     "above-below": "When {attribute, select, \n undefined {} \n other {{attribute} from }\n }{entity} {numberOfEntities, plural,\n one {is}\n other {is}\n} above {above} and below {below}{duration, select, \n undefined {} \n other { for {duration}}\n }"
+                  },
+                  "threshold_type": {
+                    "choices": {
+                      "value": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::type_value%]",
+                      "input": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::type_input%]"
+                    }
+                  },
+                  "for_type": {
+                    "choices": {
+                      "duration": "Duration",
+                      "template": "Template"
+                    }
                   }
                 },
                 "persistent_notification": {
@@ -5344,6 +5362,12 @@
                   "description": {
                     "picker": "Triggers when a template evaluates to true.",
                     "full": "When a template changes from false to true{hasDuration, select, \n true { for {duration}} \n other {}\n }"
+                  },
+                  "for_type": {
+                    "choices": {
+                      "duration": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::for_type::choices::duration%]",
+                      "template": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::for_type::choices::template%]"
+                    }
                   }
                 },
                 "time": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Replace hand-rolled dual-mode field patterns in legacy trigger UIs with the new `choose` selector.

**`for` field (state, numeric_state, template triggers):**
The `for` field previously used a plain duration selector and would fall back to YAML mode when a template was detected. It now uses a choose selector with duration and template choices, allowing users to pick either option directly in the UI without needing YAML.

**`above`/`below` fields (numeric_state trigger):**
These fields previously used a synthetic `lower_limit`/`upper_limit` select dropdown with `@state()` tracking and conditional schema spreading to switch between a number input and an entity picker. The choose selector replaces all of that with a standard toggle between "Fixed number" and "Numeric value of another entity". The choose selector auto-detects the correct toggle state from existing plain values (numbers vs entity IDs), so no wrapping is needed on load.

The numeric_state trigger schema is now fully static (a `const` instead of a `memoizeOne` function), which is a nice simplification.

Translation entries were added for the choose selector toggle button labels.

<img width="1682" height="974" alt="CleanShot 2026-06-25 at 09 47 06" src="https://github.com/user-attachments/assets/7303f0a7-a2d1-4b1e-b2f0-bbe25139f1c0" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr