### PR TITLE
Fix logbook padding and margin

### DIFF
--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -1044,8 +1044,7 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
         }
 
         ha-more-info-history-and-logbook {
-          padding: var(--ha-space-2) var(--ha-space-6) var(--ha-space-6)
-            var(--ha-space-6);
+          padding: var(--ha-space-2) 0 var(--ha-space-6) 0;
           display: block;
         }
 

--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -278,6 +278,7 @@ export class MoreInfoHistory extends LitElement {
         justify-content: space-between;
         align-items: center;
         margin-bottom: var(--ha-space-2);
+        padding-inline: var(--ha-space-6);
       }
       .header > a,
       a:visited {
@@ -289,6 +290,12 @@ export class MoreInfoHistory extends LitElement {
       }
       h2 {
         margin: 0;
+      }
+      ha-alert,
+      state-history-charts,
+      statistics-chart {
+        display: block;
+        padding-inline: var(--ha-space-6);
       }
     `,
   ];

--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -70,6 +70,7 @@ export class MoreInfoLogbook extends LitElement {
       css`
         ha-logbook {
           --logbook-max-height: 250px;
+          --logbook-horizontal-padding: var(--ha-space-6);
         }
         @media all and (max-width: 450px), all and (max-height: 500px) {
           ha-logbook {
@@ -82,6 +83,7 @@ export class MoreInfoLogbook extends LitElement {
           justify-content: space-between;
           align-items: center;
           margin-bottom: var(--ha-space-2);
+          padding-inline: var(--ha-space-6);
         }
         .header > a,
         a:visited {

--- a/src/panels/logbook/ha-logbook-entry.ts
+++ b/src/panels/logbook/ha-logbook-entry.ts
@@ -8,6 +8,7 @@ import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import { computeTimelineColor } from "../../components/chart/timeline-color";
 import { computeDomain } from "../../common/entity/compute_domain";
 import { formatTimeWithSeconds } from "../../common/datetime/format_time";
+import { useAmPm } from "../../common/datetime/use_am_pm";
 import { fireEvent } from "../../common/dom/fire_event";
 import { navigate } from "../../common/navigate";
 import { computeRTL } from "../../common/util/compute_rtl";
@@ -126,6 +127,7 @@ class HaLogbookEntry extends LitElement {
           [`node-${node}`]: true,
           "last-of-day": this.lastOfDay,
           [`category-${ctx.category}`]: true,
+          "time-am-pm": useAmPm(this.hass.locale),
         })}"
       >
         ${layout === "timeline"
@@ -591,7 +593,7 @@ class HaLogbookEntry extends LitElement {
           width: 100%;
           box-sizing: border-box;
           /* No vertical padding: the rail must reach the row edges to stay continuous between nodes. */
-          padding: 0 var(--ha-space-4);
+          padding: 0 var(--logbook-horizontal-padding, var(--ha-space-4));
           grid-auto-rows: minmax(60px, auto);
           line-height: var(--ha-line-height-normal);
           align-items: stretch;
@@ -913,12 +915,21 @@ class HaLogbookEntry extends LitElement {
 
         .time-chip {
           flex-shrink: 0;
+          text-align: end;
           line-height: 1;
           font-size: var(--ha-font-size-s);
           color: var(--secondary-text-color);
           font-variant-numeric: tabular-nums;
           cursor: pointer;
           user-select: none;
+        }
+
+        .time-chip {
+          min-width: 4.5em;
+        }
+
+        .entry.time-am-pm .time-chip {
+          min-width: 6em;
         }
 
         .time-chip:hover {

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -197,7 +197,8 @@ class HaLogbookRenderer extends LitElement {
 
         .date {
           margin: var(--ha-space-2) 0 0;
-          padding: var(--ha-space-2) var(--ha-space-4) 0;
+          padding: var(--ha-space-2)
+            var(--logbook-horizontal-padding, var(--ha-space-4)) 0;
           font-weight: var(--ha-font-weight-medium);
         }
 

--- a/src/panels/lovelace/cards/hui-logbook-card.ts
+++ b/src/panels/lovelace/cards/hui-logbook-card.ts
@@ -1,4 +1,3 @@
-import { mdiChevronRight } from "@mdi/js";
 import { startOfYesterday } from "date-fns";
 import type { HassServiceTarget } from "home-assistant-js-websocket";
 import type { CSSResultGroup, PropertyValues } from "lit";
@@ -10,10 +9,10 @@ import { ensureArray } from "../../../common/array/ensure-array";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { getEntityEntryContext } from "../../../common/entity/context/get_entity_context";
-import { navigate } from "../../../common/navigate";
 import { createSearchParam } from "../../../common/url/search-params";
 import "../../../components/ha-card";
-import "../../../components/ha-icon-button";
+import "../../../components/ha-icon-next";
+import "../../../components/ha-tooltip";
 import { resolveEntityIDs } from "../../../data/selector";
 import type { HomeAssistant } from "../../../types";
 import "../../logbook/ha-logbook";
@@ -72,6 +71,8 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
   @state() private _targetPickerValue: HassServiceTarget = {};
 
   @state() private _stateFilter?: string[];
+
+  private _showMoreLinkId = `logbook-${Math.random().toString(36).substring(2, 9)}`;
 
   public getCardSize(): number {
     return 9 + (this._config?.title ? 1 : 0);
@@ -140,10 +141,6 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
     this._targetPickerValue = target;
 
     this._stateFilter = ensureArray(config.state_filter);
-  }
-
-  private _showMore() {
-    navigate(this._showMoreUrl());
   }
 
   private _showMoreUrl(): string {
@@ -291,16 +288,21 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
     return html`
       <ha-card class=${classMap({ "no-header": !this._config!.title })}>
         ${this._config!.title
-          ? html`<div class="card-header">
-              <h1 class="name">${this._config!.title}</h1>
-              <ha-icon-button
-                .path=${mdiChevronRight}
-                .label=${this.hass.localize(
+          ? html`<h1 class="card-header">
+              ${this._config!.title}
+              <a
+                id=${this._showMoreLinkId}
+                href=${this._showMoreUrl()}
+                aria-label=${this.hass.localize(
                   "ui.dialogs.more_info_control.show_more"
                 )}
-                @click=${this._showMore}
-              ></ha-icon-button>
-            </div>`
+              >
+                <ha-icon-next></ha-icon-next>
+              </a>
+              <ha-tooltip for=${this._showMoreLinkId} placement="left">
+                ${this.hass.localize("ui.dialogs.more_info_control.show_more")}
+              </ha-tooltip>
+            </h1>`
           : nothing}
         <div class="content">
           <ha-logbook
@@ -336,26 +338,18 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
           display: flex;
           justify-content: space-between;
           align-items: center;
-          padding: 16px 16px 0;
+          padding-bottom: 0;
         }
 
-        .card-header .name {
-          margin: 0;
-          font-size: var(--ha-card-header-font-size, 1.4rem);
-          font-weight: var(--ha-card-header-font-weight, 500);
-          color: var(--ha-card-header-color, var(--primary-text-color));
-        }
-
-        .card-header a {
+        .card-header ha-icon-next {
+          --ha-icon-button-size: 24px;
+          line-height: 24px;
           color: var(--primary-text-color);
-          margin-right: calc(var(--ha-space-2) * -1);
-          margin-inline-end: calc(var(--ha-space-2) * -1);
-          margin-inline-start: initial;
         }
 
         .content {
           height: 100%;
-          padding: 0 16px 16px;
+          padding: 0 0 16px;
         }
 
         .no-header .content {


### PR DESCRIPTION
## Proposed change

Fixes alignment issues in the logbook UI:

- Reserve a fixed width for the time so the trailing icon stays in a column instead of shifting between entries. The width adapts to the locale (narrower for 24-hour, wider for 12-hour) and stays stable when toggling between absolute and relative time.
- Move the horizontal padding off the more-info container and onto each inner element, so the History title, chart, Activity title, date headers, and logbook rows all share the same edge instead of the rows being double-inset.
- Drop the duplicate inset in the logbook card and align its header with the standard card header (used by the history and statistics cards), replacing the hand-rolled title styling and icon button with the shared `ha-icon-next` link.

## Screenshots

**Logbook card**
<img width="514" height="388" alt="CleanShot 2026-06-25 at 12 55 01" src="https://github.com/user-attachments/assets/6709e8c6-c82a-4e25-83ee-12d5dfcac24b" />

**Device page*
<img width="798" height="516" alt="CleanShot 2026-06-25 at 12 50 27" src="https://github.com/user-attachments/assets/26469ffb-af0d-4dd7-aeff-818848a24297" />

**More info**
<img width="599" height="525" alt="CleanShot 2026-06-25 at 12 49 25" src="https://github.com/user-attachments/assets/beae7699-7869-4058-b3c1-bbf57109b694" />


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
