### PR TITLE
Show dash for unavailable number entity in slider row

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
@@ -5,7 +5,7 @@ import { debounce } from "../../../common/util/debounce";
 import "../../../components/ha-slider";
 import "../../../components/input/ha-input";
 import type { HaInput } from "../../../components/input/ha-input";
-import { UNAVAILABLE } from "../../../data/entity/entity";
+import { UNAVAILABLE, UNKNOWN } from "../../../data/entity/entity";
 import { setValue } from "../../../data/input_text";
 import type { HomeAssistant } from "../../../types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
@@ -91,7 +91,9 @@ class HuiNumberEntityRow extends LitElement implements LovelaceRow {
                   @change=${this._selectedValueChanged}
                 ></ha-slider>
                 <span class="state">
-                  ${this.hass.formatEntityState(stateObj)}
+                  ${stateObj.state === UNAVAILABLE || stateObj.state === UNKNOWN
+                    ? "—"
+                    : this.hass.formatEntityState(stateObj)}
                 </span>
               </div>
             `


### PR DESCRIPTION
## Proposed change

When a number entity backing a slider row is unavailable or unknown, the row now shows a dash (`—`) instead of "Unavailable". The slider stays visible but disabled, matching the entity heading badge convention.

## Screenshots

**Before**
<img width="433" height="211" alt="CleanShot 2026-06-25 at 13 16 33" src="https://github.com/user-attachments/assets/4989365b-9ebd-4527-9585-eb69910b687d" />

**After**
<img width="433" height="211" alt="CleanShot 2026-06-25 at 13 16 46" src="https://github.com/user-attachments/assets/d8bebdab-9489-4c90-8f6e-ba73693c18e5" />


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
