### PR TITLE
Group Sankey flow siblings under their parent to fix segment crossovers

### DIFF
--- a/src/resources/echarts/components/sankey/sankey-layout.ts
+++ b/src/resources/echarts/components/sankey/sankey-layout.ts
@@ -504,10 +504,34 @@ function countAllCrossings(
   return total;
 }
 
-// Allow a couple of extra sweeps beyond what a single pass needs: a plateau
-// move (see tryReplace) often only pays off once a neighbouring section is
-// re-sorted on a later pass, and that can ripple across several depths.
-const MAX_SORT_ITERATIONS = 6;
+// A section is "multi-parent" when at least one of its real nodes draws from
+// two or more distinct parents in the previous section. In the energy/power/
+// water cards only the source/home layers do this (grid/solar/battery feed
+// home + battery_in + grid_return); every later section (floors, areas,
+// devices) is a pure single-parent tree level. Pass-throughs are always
+// single-parent (one source/target chain) and never make a section multi-parent.
+function sectionHasMultipleParents(
+  section: Node[],
+  prevDepth: number,
+  depths: number[]
+): boolean {
+  return section.some((node) => {
+    if (isPassThroughNode(node)) {
+      return false;
+    }
+    const parentIds = new Set(
+      getNeighborIds(node, "source", prevDepth, depths).map((n) => n.id)
+    );
+    return parentIds.size > 1;
+  });
+}
+
+// The head barycenter sweep (STEP 1) only touches the multi-parent head
+// sections (the single-parent tree below is placed deterministically in
+// STEP 2), so a single forward+backward pass converges in practice and the loop
+// early-exits on the first no-change sweep. The cap is just headroom for unusual
+// topologies with several interacting head sections.
+const MAX_SORT_ITERATIONS = 4;
 
 export function sortNodesInSections(
   nodesPerSection: Record<number, Node[]>,
@@ -515,30 +539,30 @@ export function sortNodesInSections(
   edges: GraphEdge[]
 ): Record<number, Node[]> {
   const sections: Node[][] = depths.map((d) => [...(nodesPerSection[d] || [])]);
-  // Id→index lookup per section, kept in sync with sections. Rebuilt only when
-  // a section's order actually changes (inside tryReplace).
+  // Id→index lookup per section, kept in sync with sections.
   const sectionMaps: Map<string, number>[] = sections.map(buildIdIndexMap);
 
-  // Running total of crossings across every boundary. A section reorder only
-  // touches its two adjacent boundaries, so the live total can be maintained
-  // incrementally: it never increases (tryReplace rejects worsening moves), so
-  // it is monotonically non-increasing across the whole sweep.
-  let liveCrossings = countAllCrossings(sections, sectionMaps, depths, edges);
+  // Classify each section past the root. Multi-parent sections (the
+  // intentionally-ordered source/home layers) are minimized by barycenter in
+  // PASS 2; the rest are single-parent tree levels placed deterministically in
+  // PASS 1. Classification reads only the graph, so it is stable across passes.
+  const multiParent = depths.map(
+    (_d, i) =>
+      i >= 1 && sectionHasMultipleParents(sections[i], depths[i - 1], depths)
+  );
 
-  // Best (fewest-crossing) layout seen so far, captured the instant a move
-  // strictly improves on it. We return THIS, not the live `sections`.
+  // Best (fewest-crossing) head ordering seen so far, seeded from the original
+  // input so the head is provably never worse than the seed.
   const snapshot = (): Node[][] => sections.map((s) => s.slice());
+  let liveCrossings = countAllCrossings(sections, sectionMaps, depths, edges);
   let bestCrossings = liveCrossings;
   let bestSections = snapshot();
 
-  // Replace a section with a candidate ordering when crossings on its adjacent
-  // boundaries do not increase. Accepting equal-crossing ("plateau") moves lets
-  // the sweep realign a section with its parents even when the payoff only
-  // appears after a neighbouring section is re-sorted on a later pass — the
-  // local optimum a strict gate gets stuck in. Whenever an accepted move
-  // strictly lowers the global total we snapshot it as the best; that snapshot
-  // is what guarantees the result is never worse than the seed and keeps the
-  // output deterministic and idempotent despite plateau churn.
+  // Replace a multi-parent section with a candidate ordering when crossings on
+  // its adjacent boundaries do not increase. Accepting equal-crossing
+  // ("plateau") moves lets the sweep escape local optima; the best snapshot
+  // (captured only on a strict global decrease) is what seeds the head order,
+  // so the result is deterministic and never worse than the seed.
   const tryReplace = (i: number, candidate: Node[]): boolean => {
     const before = crossingsAdjacentTo(i, sections, sectionMaps, depths, edges);
     const sectionSnapshot = sections[i];
@@ -559,39 +583,97 @@ export function sortNodesInSections(
     return false;
   };
 
-  for (let iter = 0; iter < MAX_SORT_ITERATIONS; iter++) {
-    let changed = false;
+  // STEP 1 — settle the multi-parent head sections (sources → home/battery_in/
+  // grid_return) by barycenter. These layers have nodes with several parents and
+  // so no single parent position to inherit; we minimize their crossings by the
+  // weighted average of neighbour positions, iterating forward then backward
+  // until the order is stable. The backward sweep is restricted to multi-parent
+  // neighbours, so the head order never depends on its single-parent children —
+  // that is what keeps the whole result idempotent, because STEP 2 re-derives
+  // those children purely from the settled head. The root section (index 0) is
+  // never reordered.
+  if (multiParent.some(Boolean)) {
+    for (let iter = 0; iter < MAX_SORT_ITERATIONS; iter++) {
+      let changed = false;
 
-    for (let i = 1; i < sections.length; i++) {
-      const prevDepth = depths[i - 1];
-      const result = sortSectionByBarycenter(
-        sections[i],
-        sectionMaps[i - 1],
-        (node) => getNeighborIds(node, "source", prevDepth, depths)
-      );
-      if (result.changed && tryReplace(i, result.sorted)) {
-        changed = true;
+      for (let i = 1; i < sections.length; i++) {
+        if (!multiParent[i]) {
+          continue;
+        }
+        const prevDepth = depths[i - 1];
+        const result = sortSectionByBarycenter(
+          sections[i],
+          sectionMaps[i - 1],
+          (node) => getNeighborIds(node, "source", prevDepth, depths)
+        );
+        if (result.changed && tryReplace(i, result.sorted)) {
+          changed = true;
+        }
       }
-    }
 
-    for (let i = sections.length - 2; i >= 0; i--) {
-      const nextDepth = depths[i + 1];
-      const result = sortSectionByBarycenter(
-        sections[i],
-        sectionMaps[i + 1],
-        (node) => getNeighborIds(node, "target", nextDepth, depths)
-      );
-      if (result.changed && tryReplace(i, result.sorted)) {
-        changed = true;
+      for (let i = sections.length - 2; i >= 1; i--) {
+        if (!multiParent[i] || !multiParent[i + 1]) {
+          continue;
+        }
+        const nextDepth = depths[i + 1];
+        const result = sortSectionByBarycenter(
+          sections[i],
+          sectionMaps[i + 1],
+          (node) => getNeighborIds(node, "target", nextDepth, depths)
+        );
+        if (result.changed && tryReplace(i, result.sorted)) {
+          changed = true;
+        }
       }
-    }
 
-    if (!changed || bestCrossings === 0) break;
+      if (!changed || bestCrossings === 0) break;
+    }
   }
+
+  // STEP 2 — deterministic hierarchy placement. Starting from the best head
+  // ordering, walk left to right and order every single-parent section by the
+  // position of each node's single parent in the already-final previous section
+  // (sortSectionByBarycenter with one parent reduces to a stable sort by that
+  // parent's index). This is the classic layered-tree drawing: each parent's
+  // children stay contiguous, every single-parent boundary is crossing-free,
+  // pass-throughs travel along their chain, and the user-configured floor/area
+  // order is preserved because same-parent siblings keep their seed index.
+  // It runs unconditionally — grouping a parent's children under it must win
+  // even on a crossing-neutral plateau (the #52852 fix) — and because it is a
+  // pure function of the settled head, re-running yields the identical layout.
+  const finalSections = bestSections.map((s) => s.slice());
+  const finalMaps = finalSections.map(buildIdIndexMap);
+  for (let i = 1; i < finalSections.length; i++) {
+    if (multiParent[i]) {
+      continue;
+    }
+    const prevDepth = depths[i - 1];
+    const { sorted } = sortSectionByBarycenter(
+      finalSections[i],
+      finalMaps[i - 1],
+      (node) => getNeighborIds(node, "source", prevDepth, depths)
+    );
+    finalSections[i] = sorted;
+    finalMaps[i] = buildIdIndexMap(sorted);
+  }
+
+  // Hierarchy placement makes every single-parent boundary crossing-free, so on
+  // the energy/water cards (multi-parent only at the head) it can only lower the
+  // total. Guard the general graph: if regrouping somehow raised crossings (only
+  // possible for a multi-parent section sitting *below* single-parent ones,
+  // which the cards never produce), fall back to the gated best head so the
+  // never-worse-than-seed guarantee always holds. Ties keep the grouped layout.
+  const finalCrossings = countAllCrossings(
+    finalSections,
+    finalMaps,
+    depths,
+    edges
+  );
+  const chosen = finalCrossings <= bestCrossings ? finalSections : bestSections;
 
   const sortedSections: Record<number, Node[]> = {};
   depths.forEach((depth, i) => {
-    sortedSections[depth] = bestSections[i];
+    sortedSections[depth] = chosen[i];
   });
   return sortedSections;
 }

--- a/src/resources/echarts/components/sankey/sankey-layout.ts
+++ b/src/resources/echarts/components/sankey/sankey-layout.ts
@@ -331,6 +331,28 @@ export function computeBarycenter(
   return totalWeight > 0 ? weightedSum / totalWeight : fallback;
 }
 
+// Index of the single highest-weight neighbor present in the reference
+// section (ties on weight broken by the earliest edge). Used only as a
+// barycenter tie-break so a node stays beside its dominant neighbor's group
+// instead of falling back to a stale seed index. Falls back to the node's own
+// index when it has no resolvable neighbor, matching computeBarycenter.
+export function dominantNeighborIndex(
+  neighbors: WeightedNeighbor[],
+  referenceIdIndexMap: Map<string, number>,
+  fallback: number
+): number {
+  let bestIdx = fallback;
+  let bestWeight = -Infinity;
+  neighbors.forEach(({ id, weight }) => {
+    const idx = referenceIdIndexMap.get(id);
+    if (idx !== undefined && weight > bestWeight) {
+      bestWeight = weight;
+      bestIdx = idx;
+    }
+  });
+  return bestIdx;
+}
+
 function buildIdIndexMap(section: Node[]): Map<string, number> {
   const map = new Map<string, number>();
   section.forEach((node, index) => map.set(node.id, index));
@@ -342,12 +364,20 @@ function sortSectionByBarycenter(
   referenceMap: Map<string, number>,
   getNeighbors: (node: Node) => WeightedNeighbor[]
 ): { sorted: Node[]; changed: boolean } {
-  const decorated = section.map((node, index) => ({
-    node,
-    index,
-    barycenter: computeBarycenter(getNeighbors(node), referenceMap, index),
-  }));
-  decorated.sort((a, b) => a.barycenter - b.barycenter || a.index - b.index);
+  const decorated = section.map((node, index) => {
+    const neighbors = getNeighbors(node);
+    return {
+      node,
+      index,
+      barycenter: computeBarycenter(neighbors, referenceMap, index),
+      // Tie-break that keeps a node next to its dominant neighbor's group.
+      anchor: dominantNeighborIndex(neighbors, referenceMap, index),
+    };
+  });
+  decorated.sort(
+    (a, b) =>
+      a.barycenter - b.barycenter || a.anchor - b.anchor || a.index - b.index
+  );
   const sorted = decorated.map((d) => d.node);
   const changed = sorted.some((n, idx) => n !== section[idx]);
   return { sorted, changed };
@@ -452,7 +482,32 @@ function crossingsAdjacentTo(
   return total;
 }
 
-const MAX_SORT_ITERATIONS = 4;
+function countAllCrossings(
+  sections: Node[][],
+  sectionMaps: Map<string, number>[],
+  depths: number[],
+  edges: GraphEdge[]
+): number {
+  let total = 0;
+  for (let i = 0; i < sections.length - 1; i++) {
+    total += countCrossings(
+      getEdgeSegmentsBetween(
+        depths[i],
+        depths[i + 1],
+        depths,
+        edges,
+        sectionMaps[i],
+        sectionMaps[i + 1]
+      )
+    );
+  }
+  return total;
+}
+
+// Allow a couple of extra sweeps beyond what a single pass needs: a plateau
+// move (see tryReplace) often only pays off once a neighbouring section is
+// re-sorted on a later pass, and that can ripple across several depths.
+const MAX_SORT_ITERATIONS = 6;
 
 export function sortNodesInSections(
   nodesPerSection: Record<number, Node[]>,
@@ -464,9 +519,26 @@ export function sortNodesInSections(
   // a section's order actually changes (inside tryReplace).
   const sectionMaps: Map<string, number>[] = sections.map(buildIdIndexMap);
 
-  // Replace a section with a candidate ordering only when crossings strictly
-  // drop on either side. This keeps user-intended ordering intact when
-  // barycenter would shuffle nodes without improving the layout.
+  // Running total of crossings across every boundary. A section reorder only
+  // touches its two adjacent boundaries, so the live total can be maintained
+  // incrementally: it never increases (tryReplace rejects worsening moves), so
+  // it is monotonically non-increasing across the whole sweep.
+  let liveCrossings = countAllCrossings(sections, sectionMaps, depths, edges);
+
+  // Best (fewest-crossing) layout seen so far, captured the instant a move
+  // strictly improves on it. We return THIS, not the live `sections`.
+  const snapshot = (): Node[][] => sections.map((s) => s.slice());
+  let bestCrossings = liveCrossings;
+  let bestSections = snapshot();
+
+  // Replace a section with a candidate ordering when crossings on its adjacent
+  // boundaries do not increase. Accepting equal-crossing ("plateau") moves lets
+  // the sweep realign a section with its parents even when the payoff only
+  // appears after a neighbouring section is re-sorted on a later pass — the
+  // local optimum a strict gate gets stuck in. Whenever an accepted move
+  // strictly lowers the global total we snapshot it as the best; that snapshot
+  // is what guarantees the result is never worse than the seed and keeps the
+  // output deterministic and idempotent despite plateau churn.
   const tryReplace = (i: number, candidate: Node[]): boolean => {
     const before = crossingsAdjacentTo(i, sections, sectionMaps, depths, edges);
     const sectionSnapshot = sections[i];
@@ -474,7 +546,12 @@ export function sortNodesInSections(
     sections[i] = candidate;
     sectionMaps[i] = buildIdIndexMap(candidate);
     const after = crossingsAdjacentTo(i, sections, sectionMaps, depths, edges);
-    if (after < before) {
+    if (after <= before) {
+      liveCrossings += after - before;
+      if (liveCrossings < bestCrossings) {
+        bestCrossings = liveCrossings;
+        bestSections = snapshot();
+      }
       return true;
     }
     sections[i] = sectionSnapshot;
@@ -509,12 +586,12 @@ export function sortNodesInSections(
       }
     }
 
-    if (!changed) break;
+    if (!changed || bestCrossings === 0) break;
   }
 
   const sortedSections: Record<number, Node[]> = {};
   depths.forEach((depth, i) => {
-    sortedSections[depth] = sections[i];
+    sortedSections[depth] = bestSections[i];
   });
   return sortedSections;
 }

--- a/test/resources/echarts/components/sankey/sankey-layout.test.ts
+++ b/test/resources/echarts/components/sankey/sankey-layout.test.ts
@@ -12,6 +12,7 @@ import {
   getPassThroughSections,
   createPassThroughNode,
   computeBarycenter,
+  dominantNeighborIndex,
   sortNodesInSections,
 } from "../../../../../src/resources/echarts/components/sankey/sankey-layout";
 
@@ -755,6 +756,188 @@ describe("Sankey Layout Functions", () => {
         1: ["B"],
       });
       expectIdentityPreserved(result, input);
+    });
+
+    it("untangles a plateau-trapped subtree to remove an avoidable crossing (#52852)", () => {
+      // Realistic consumption tree: home → floors → areas → devices, plus two
+      // devices that attach higher up — one on a floor with no area
+      // (dev_floor_outside) and one straight on home (dev_home) — which the
+      // engine threads through with pass-throughs. The seed splits
+      // floor_outside's subtree: its pass-through child sits *after*
+      // floor_foundation's area. Pulling it back trades a crossing from the
+      // (1,2) boundary to the (2,3) boundary — a net-zero "plateau" the old
+      // strict gate refused, leaving the crossing. The plateau-escape must now
+      // take that step and let the device section follow, reaching 0 crossings.
+      const e = {
+        homeFo: { source: "home", target: "floor_outside", value: 1 },
+        homeFf: { source: "home", target: "floor_foundation", value: 1 },
+        foHvac: { source: "floor_outside", target: "area_hvac", value: 1 },
+        ffParking: {
+          source: "floor_foundation",
+          target: "area_parking",
+          value: 1,
+        },
+        hvacDev: { source: "area_hvac", target: "dev_hvac", value: 1 },
+        parkingDev: { source: "area_parking", target: "dev_parking", value: 1 },
+        foDev: {
+          source: "floor_outside",
+          target: "dev_floor_outside",
+          value: 1,
+        },
+        homeDev: { source: "home", target: "dev_home", value: 1 },
+      };
+      const testNodes: Record<string, TestNode> = {
+        home: {
+          id: "home",
+          depth: 0,
+          value: 4,
+          inEdges: [],
+          outEdges: [e.homeFo, e.homeFf, e.homeDev],
+        },
+        floor_outside: {
+          id: "floor_outside",
+          depth: 1,
+          value: 2,
+          inEdges: [e.homeFo],
+          outEdges: [e.foHvac, e.foDev],
+        },
+        floor_foundation: {
+          id: "floor_foundation",
+          depth: 1,
+          value: 1,
+          inEdges: [e.homeFf],
+          outEdges: [e.ffParking],
+        },
+        area_hvac: {
+          id: "area_hvac",
+          depth: 2,
+          value: 1,
+          inEdges: [e.foHvac],
+          outEdges: [e.hvacDev],
+        },
+        area_parking: {
+          id: "area_parking",
+          depth: 2,
+          value: 1,
+          inEdges: [e.ffParking],
+          outEdges: [e.parkingDev],
+        },
+        dev_hvac: {
+          id: "dev_hvac",
+          depth: 3,
+          value: 1,
+          inEdges: [e.hvacDev],
+          outEdges: [],
+        },
+        dev_parking: {
+          id: "dev_parking",
+          depth: 3,
+          value: 1,
+          inEdges: [e.parkingDev],
+          outEdges: [],
+        },
+        dev_floor_outside: {
+          id: "dev_floor_outside",
+          depth: 3,
+          value: 1,
+          inEdges: [e.foDev],
+          outEdges: [],
+        },
+        dev_home: {
+          id: "dev_home",
+          depth: 3,
+          value: 1,
+          inEdges: [e.homeDev],
+          outEdges: [],
+        },
+      };
+      const { nodes: graph, edges } = buildGraph(testNodes);
+      const ptHome1 = createPassThroughNode("home", "dev_home", 1, 1);
+      const ptFo2 = createPassThroughNode(
+        "floor_outside",
+        "dev_floor_outside",
+        2,
+        1
+      );
+      const ptHome2 = createPassThroughNode("home", "dev_home", 2, 1);
+
+      // Seed order from ha-sankey-chart: pass-throughs appended after the real
+      // children, so floor_outside's subtree is broken across the section.
+      const input = {
+        0: [graph.home],
+        1: [graph.floor_outside, graph.floor_foundation, ptHome1],
+        2: [graph.area_hvac, graph.area_parking, ptFo2, ptHome2],
+        3: [
+          graph.dev_hvac,
+          graph.dev_parking,
+          graph.dev_floor_outside,
+          graph.dev_home,
+        ],
+      };
+      const result = sortNodesInSections(input, [0, 1, 2, 3], edges);
+
+      // floor_outside's children (area_hvac and its pass-through) are now
+      // contiguous, ahead of floor_foundation's; the layout is crossing-free.
+      expect(sectionIds(result)).toEqual({
+        0: ["home"],
+        1: ["floor_outside", "floor_foundation", "home-dev_home-1"],
+        2: [
+          "area_hvac",
+          "floor_outside-dev_floor_outside-2",
+          "area_parking",
+          "home-dev_home-2",
+        ],
+        3: ["dev_hvac", "dev_floor_outside", "dev_parking", "dev_home"],
+      });
+      expectIdentityPreserved(result, input);
+
+      // Re-running on the result must not drift: plateau churn is discarded and
+      // the best snapshot is returned, so the order is stable (idempotent).
+      const again = sortNodesInSections(result, [0, 1, 2, 3], edges);
+      expect(sectionIds(again)).toEqual(sectionIds(result));
+    });
+  });
+
+  describe("dominantNeighborIndex", () => {
+    it("returns the index of the single heaviest neighbor", () => {
+      const map = new Map([
+        ["light", 0],
+        ["heavy", 3],
+      ]);
+      const result = dominantNeighborIndex(
+        [
+          { id: "light", weight: 1 },
+          { id: "heavy", weight: 5 },
+        ],
+        map,
+        9
+      );
+      expect(result).toBe(3);
+    });
+
+    it("breaks weight ties by the earliest edge", () => {
+      const map = new Map([
+        ["a", 2],
+        ["b", 4],
+      ]);
+      const result = dominantNeighborIndex(
+        [
+          { id: "a", weight: 1 },
+          { id: "b", weight: 1 },
+        ],
+        map,
+        9
+      );
+      expect(result).toBe(2);
+    });
+
+    it("falls back when no neighbor is in the reference section", () => {
+      const result = dominantNeighborIndex(
+        [{ id: "missing", weight: 1 }],
+        new Map(),
+        7
+      );
+      expect(result).toBe(7);
     });
   });
 });

--- a/test/resources/echarts/components/sankey/sankey-layout.test.ts
+++ b/test/resources/echarts/components/sankey/sankey-layout.test.ts
@@ -896,6 +896,289 @@ describe("Sankey Layout Functions", () => {
       const again = sortNodesInSections(result, [0, 1, 2, 3], edges);
       expect(sectionIds(again)).toEqual(sectionIds(result));
     });
+
+    it("groups single-parent siblings under their parent and keeps configured sibling order", () => {
+      // Two floors, two areas each, fed to the engine interleaved (not grouped
+      // by floor). The deterministic hierarchy pass must regroup areas under
+      // their floor, and within a floor preserve the configured (seed) order:
+      // a1 before a2, b1 before b2.
+      const e = {
+        hFa: { source: "home", target: "floor_a", value: 2 },
+        hFb: { source: "home", target: "floor_b", value: 2 },
+        faA1: { source: "floor_a", target: "a1", value: 1 },
+        faA2: { source: "floor_a", target: "a2", value: 1 },
+        fbB1: { source: "floor_b", target: "b1", value: 1 },
+        fbB2: { source: "floor_b", target: "b2", value: 1 },
+      };
+      const testNodes: Record<string, TestNode> = {
+        home: {
+          id: "home",
+          depth: 0,
+          value: 4,
+          inEdges: [],
+          outEdges: [e.hFa, e.hFb],
+        },
+        floor_a: {
+          id: "floor_a",
+          depth: 1,
+          value: 2,
+          inEdges: [e.hFa],
+          outEdges: [e.faA1, e.faA2],
+        },
+        floor_b: {
+          id: "floor_b",
+          depth: 1,
+          value: 2,
+          inEdges: [e.hFb],
+          outEdges: [e.fbB1, e.fbB2],
+        },
+        a1: { id: "a1", depth: 2, value: 1, inEdges: [e.faA1], outEdges: [] },
+        a2: { id: "a2", depth: 2, value: 1, inEdges: [e.faA2], outEdges: [] },
+        b1: { id: "b1", depth: 2, value: 1, inEdges: [e.fbB1], outEdges: [] },
+        b2: { id: "b2", depth: 2, value: 1, inEdges: [e.fbB2], outEdges: [] },
+      };
+      const { nodes: graph, edges } = buildGraph(testNodes);
+      const input = {
+        0: [graph.home],
+        1: [graph.floor_a, graph.floor_b],
+        2: [graph.a1, graph.b1, graph.a2, graph.b2], // interleaved
+      };
+      const result = sortNodesInSections(input, [0, 1, 2], edges);
+
+      expect(sectionIds(result)).toEqual({
+        0: ["home"],
+        1: ["floor_a", "floor_b"],
+        2: ["a1", "a2", "b1", "b2"],
+      });
+      expectIdentityPreserved(result, input);
+    });
+
+    it("orders a single-parent section by parent position, ignoring flow magnitude", () => {
+      // childB carries a far larger flow than childA, but a single-parent
+      // section is ordered by parent position (hierarchy), never by value.
+      const edgeACa = { source: "A", target: "childA", value: 1 };
+      const edgeBCb = { source: "B", target: "childB", value: 100 };
+      const testNodes: Record<string, TestNode> = {
+        A: { id: "A", depth: 0, value: 1, inEdges: [], outEdges: [edgeACa] },
+        B: { id: "B", depth: 0, value: 100, inEdges: [], outEdges: [edgeBCb] },
+        childA: {
+          id: "childA",
+          depth: 1,
+          value: 1,
+          inEdges: [edgeACa],
+          outEdges: [],
+        },
+        childB: {
+          id: "childB",
+          depth: 1,
+          value: 100,
+          inEdges: [edgeBCb],
+          outEdges: [],
+        },
+      };
+      const { nodes: graph, edges } = buildGraph(testNodes);
+      const input = { 0: [graph.A, graph.B], 1: [graph.childB, graph.childA] };
+      const result = sortNodesInSections(input, [0, 1], edges);
+
+      expect(sectionIds(result)).toEqual({
+        0: ["A", "B"],
+        1: ["childA", "childB"],
+      });
+      expectIdentityPreserved(result, input);
+    });
+
+    it("keeps the single-parent tree hierarchical below a multi-parent source layer", () => {
+      // grid + solar feed home (a genuine multi-parent section that stays under
+      // the barycenter sweep); the floor/area tree below is single-parent and
+      // must regroup by parent regardless of the multi-parent head.
+      const e = {
+        gH: { source: "grid", target: "home", value: 2 },
+        sH: { source: "solar", target: "home", value: 2 },
+        hFa: { source: "home", target: "floor_a", value: 2 },
+        hFb: { source: "home", target: "floor_b", value: 2 },
+        faA: { source: "floor_a", target: "area_a", value: 2 },
+        fbB: { source: "floor_b", target: "area_b", value: 2 },
+      };
+      const testNodes: Record<string, TestNode> = {
+        grid: { id: "grid", depth: 0, value: 2, inEdges: [], outEdges: [e.gH] },
+        solar: {
+          id: "solar",
+          depth: 0,
+          value: 2,
+          inEdges: [],
+          outEdges: [e.sH],
+        },
+        home: {
+          id: "home",
+          depth: 1,
+          value: 4,
+          inEdges: [e.gH, e.sH],
+          outEdges: [e.hFa, e.hFb],
+        },
+        floor_a: {
+          id: "floor_a",
+          depth: 2,
+          value: 2,
+          inEdges: [e.hFa],
+          outEdges: [e.faA],
+        },
+        floor_b: {
+          id: "floor_b",
+          depth: 2,
+          value: 2,
+          inEdges: [e.hFb],
+          outEdges: [e.fbB],
+        },
+        area_a: {
+          id: "area_a",
+          depth: 3,
+          value: 2,
+          inEdges: [e.faA],
+          outEdges: [],
+        },
+        area_b: {
+          id: "area_b",
+          depth: 3,
+          value: 2,
+          inEdges: [e.fbB],
+          outEdges: [],
+        },
+      };
+      const { nodes: graph, edges } = buildGraph(testNodes);
+      const input = {
+        0: [graph.grid, graph.solar],
+        1: [graph.home],
+        2: [graph.floor_a, graph.floor_b],
+        3: [graph.area_b, graph.area_a], // reversed; must regroup under floors
+      };
+      const result = sortNodesInSections(input, [0, 1, 2, 3], edges);
+
+      expect(sectionIds(result)).toEqual({
+        0: ["grid", "solar"],
+        1: ["home"],
+        2: ["floor_a", "floor_b"],
+        3: ["area_a", "area_b"],
+      });
+      expectIdentityPreserved(result, input);
+    });
+
+    it("regroups single-parent children after a multi-parent head is reordered (idempotent)", () => {
+      // A multi-parent head section [H0,H1,H2] (only H1 draws from two sources)
+      // gets reordered by the barycenter sweep. Its single-parent children must
+      // then be regrouped under the *settled* head — H1's children before H2's
+      // child — and the result must be idempotent. Before the head/tree passes
+      // were ordered correctly the children stayed grouped against the head's
+      // SEED order, which both mis-grouped them and broke f(f(x)) === f(x).
+      const e = {
+        s0h0: { source: "S0", target: "H0", value: 6 },
+        s0h1: { source: "S0", target: "H1", value: 7 },
+        s1h1: { source: "S1", target: "H1", value: 5 },
+        s2h2: { source: "S2", target: "H2", value: 6 },
+        h1d0: { source: "H1", target: "D0", value: 7 },
+        h1d2: { source: "H1", target: "D2", value: 9 },
+        h2d1: { source: "H2", target: "D1", value: 7 },
+      };
+      const testNodes: Record<string, TestNode> = {
+        S0: {
+          id: "S0",
+          depth: 0,
+          value: 13,
+          inEdges: [],
+          outEdges: [e.s0h0, e.s0h1],
+        },
+        S1: { id: "S1", depth: 0, value: 5, inEdges: [], outEdges: [e.s1h1] },
+        S2: { id: "S2", depth: 0, value: 6, inEdges: [], outEdges: [e.s2h2] },
+        H0: { id: "H0", depth: 1, value: 6, inEdges: [e.s0h0], outEdges: [] },
+        H1: {
+          id: "H1",
+          depth: 1,
+          value: 12,
+          inEdges: [e.s1h1, e.s0h1],
+          outEdges: [e.h1d0, e.h1d2],
+        },
+        H2: {
+          id: "H2",
+          depth: 1,
+          value: 6,
+          inEdges: [e.s2h2],
+          outEdges: [e.h2d1],
+        },
+        D0: { id: "D0", depth: 2, value: 7, inEdges: [e.h1d0], outEdges: [] },
+        D1: { id: "D1", depth: 2, value: 7, inEdges: [e.h2d1], outEdges: [] },
+        D2: { id: "D2", depth: 2, value: 9, inEdges: [e.h1d2], outEdges: [] },
+      };
+      const { nodes: graph, edges } = buildGraph(testNodes);
+      const input = {
+        0: [graph.S0, graph.S1, graph.S2],
+        1: [graph.H2, graph.H1, graph.H0],
+        2: [graph.D1, graph.D2, graph.D0],
+      };
+      const result = sortNodesInSections(input, [0, 1, 2], edges);
+
+      // Head settles to barycenter order [H0,H1,H2]; children regroup under it:
+      // H1's children (D2,D0) precede H2's child (D1).
+      expect(sectionIds(result)).toEqual({
+        0: ["S0", "S1", "S2"],
+        1: ["H0", "H1", "H2"],
+        2: ["D2", "D0", "D1"],
+      });
+      expectIdentityPreserved(result, input);
+
+      // Idempotent: re-feeding the output yields the identical order.
+      const again = sortNodesInSections(result, [0, 1, 2], edges);
+      expect(sectionIds(again)).toEqual(sectionIds(result));
+    });
+
+    it("lets single-parent children follow their reordered multi-parent parent to reach 0 crossings", () => {
+      // root [a,b,c,d]; section 1 [m1,m2] is multi-parent with a clean split
+      // (c,d -> m1 ; a,b -> m2); section 2 [x<-m1, y<-m2] single-parent. The
+      // optimum needs BOTH the parent order swapped (m2,m1) AND the children to
+      // follow (y,x) — placing the tree after the head settles reaches it.
+      const e = {
+        am2: { source: "a", target: "m2", value: 1 },
+        bm2: { source: "b", target: "m2", value: 1 },
+        cm1: { source: "c", target: "m1", value: 1 },
+        dm1: { source: "d", target: "m1", value: 1 },
+        m1x: { source: "m1", target: "x", value: 2 },
+        m2y: { source: "m2", target: "y", value: 2 },
+      };
+      const testNodes: Record<string, TestNode> = {
+        a: { id: "a", depth: 0, value: 1, inEdges: [], outEdges: [e.am2] },
+        b: { id: "b", depth: 0, value: 1, inEdges: [], outEdges: [e.bm2] },
+        c: { id: "c", depth: 0, value: 1, inEdges: [], outEdges: [e.cm1] },
+        d: { id: "d", depth: 0, value: 1, inEdges: [], outEdges: [e.dm1] },
+        m1: {
+          id: "m1",
+          depth: 1,
+          value: 2,
+          inEdges: [e.cm1, e.dm1],
+          outEdges: [e.m1x],
+        },
+        m2: {
+          id: "m2",
+          depth: 1,
+          value: 2,
+          inEdges: [e.am2, e.bm2],
+          outEdges: [e.m2y],
+        },
+        x: { id: "x", depth: 2, value: 2, inEdges: [e.m1x], outEdges: [] },
+        y: { id: "y", depth: 2, value: 2, inEdges: [e.m2y], outEdges: [] },
+      };
+      const { nodes: graph, edges } = buildGraph(testNodes);
+      const input = {
+        0: [graph.a, graph.b, graph.c, graph.d],
+        1: [graph.m1, graph.m2],
+        2: [graph.x, graph.y],
+      };
+      const result = sortNodesInSections(input, [0, 1, 2], edges);
+
+      expect(sectionIds(result)).toEqual({
+        0: ["a", "b", "c", "d"],
+        1: ["m2", "m1"],
+        2: ["y", "x"],
+      });
+      expectIdentityPreserved(result, input);
+    });
   });
 
   describe("dominantNeighborIndex", () => {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The layout engine now orders nodes in two steps: it settles the multi-parent source/home layers by barycenter, then places the single-parent floor → area → device tree deterministically against that settled order, so each parent's children stay grouped beneath it. The user-configured floor/area order is preserved, and the result is idempotent and never increases crossings over the input.

Behaviour is covered by unit tests for the grouping, ordering, idempotency, and never-worse guarantees.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52852
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
