### PR TITLE
Disconnect helpers table updates from hass states updates

### DIFF
--- a/src/components/ha-state-icon.ts
+++ b/src/components/ha-state-icon.ts
@@ -17,10 +17,17 @@ import {
 } from "../data/icons";
 import "./ha-icon";
 import "./ha-svg-icon";
+import { consumeEntityState } from "../common/decorators/consume-context-entry";
 
 @customElement("ha-state-icon")
 export class HaStateIcon extends LitElement {
   @property({ attribute: false }) public stateObj?: HassEntity;
+
+  @state()
+  @consumeEntityState({ entityIdPath: ["entityId"] })
+  private _consumeStateObj?: HassEntity;
+
+  @property({ attribute: false }) public entityId?: string;
 
   @property({ attribute: false }) public stateValue?: string;
 
@@ -38,11 +45,15 @@ export class HaStateIcon extends LitElement {
   @consume({ context: entitiesContext, subscribe: true })
   protected _entities?: ContextType<typeof entitiesContext>;
 
+  private get _stateObj(): HassEntity | undefined {
+    return this.stateObj ?? this._consumeStateObj;
+  }
+
   private get _overrideIcon(): string | undefined {
     return (
       this.icon ||
-      (this.stateObj && this._entities?.[this.stateObj.entity_id]?.icon) ||
-      this.stateObj?.attributes.icon
+      (this._stateObj && this._entities?.[this._stateObj.entity_id]?.icon) ||
+      this._stateObj?.attributes.icon
     );
   }
 
@@ -72,7 +83,7 @@ export class HaStateIcon extends LitElement {
         this._entities,
         this._config,
         this._connection,
-        this.stateObj,
+        this._stateObj,
         this.stateValue,
       ] as const,
   });
@@ -82,7 +93,7 @@ export class HaStateIcon extends LitElement {
     if (overrideIcon) {
       return html`<ha-icon .icon=${overrideIcon}></ha-icon>`;
     }
-    if (!this.stateObj) {
+    if (!this._stateObj) {
       return nothing;
     }
     if (!this._config || !this._connection || !this._entities) {
@@ -97,7 +108,7 @@ export class HaStateIcon extends LitElement {
   }
 
   private _renderFallback() {
-    const domain = computeStateDomain(this.stateObj!);
+    const domain = computeStateDomain(this._stateObj!);
 
     return html`
       <ha-svg-icon

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -133,6 +133,23 @@ import {
 import { getAvailableAssistants } from "../voice-assistants/expose/available-assistants";
 import { isHelperDomain, type HelperDomain } from "./const";
 import { showHelperDetailDialog } from "./show-dialog-helper-detail";
+import { computeDomain } from "../../../common/entity/compute_domain";
+
+interface LimitedEntity {
+  entity_id: HassEntity["entity_id"];
+  attributes: {
+    friendly_name?: HassEntity["attributes"]["friendly_name"];
+    editable?: HassEntity["attributes"]["editable"];
+  };
+}
+function equalLimitedEntity(a: LimitedEntity, b: LimitedEntity): boolean {
+  return (
+    a === b ||
+    (a.entity_id === b.entity_id &&
+      a.attributes?.friendly_name === b.attributes?.friendly_name &&
+      a.attributes?.editable === b.attributes?.editable)
+  );
+}
 
 interface HelperItem {
   id: string;
@@ -142,7 +159,7 @@ interface HelperItem {
   editable?: boolean;
   type: string;
   configEntry?: ConfigEntry;
-  entity?: HassEntity;
+  entity?: LimitedEntity;
   category: string | undefined;
   area?: string;
   label_entries: LabelRegistryEntry[];
@@ -221,7 +238,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
   })
   private _activeHiddenColumns?: string[];
 
-  @state() private _helperEntities?: HassEntity[];
+  @state() private _helperEntities?: LimitedEntity[];
 
   @state() private _disabledEntityEntries?: EntityRegistryEntry[];
 
@@ -338,7 +355,9 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
         moveable: false,
         template: (helper) =>
           helper.entity
-            ? html`<ha-state-icon .stateObj=${helper.entity}></ha-state-icon>`
+            ? html`<ha-state-icon
+                .entityId=${helper.entity_id}
+              ></ha-state-icon>`
             : html`<ha-svg-icon
                 .path=${helper.icon}
                 style="color: var(--error-color)"
@@ -465,7 +484,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
   private _getItems = memoizeOne(
     (
       localize: LocalizeFunc,
-      stateItems: HassEntity[],
+      stateItems: LimitedEntity[],
       disabledEntries: EntityRegistryEntry[],
       entityEntries: Record<string, EntityRegistryEntry>,
       configEntries: Record<string, ConfigEntry>,
@@ -500,7 +519,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
           type: configEntry
             ? configEntry.domain
             : this._entitySource![entityState.entity_id] ||
-              computeStateDomain(entityState),
+              computeDomain(entityState.entity_id),
           configEntry,
           entity: entityState,
         };
@@ -1269,7 +1288,9 @@ ${rejected
     if (
       !this._helperEntities ||
       this._helperEntities.length !== newHelpers.length ||
-      !this._helperEntities.every((val, idx) => newHelpers[idx] === val)
+      !this._helperEntities.every((val, idx) =>
+        equalLimitedEntity(newHelpers[idx], val)
+      )
     ) {
       this._helperEntities = newHelpers;
       if (Object.keys(this._filters).length > 0) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The config/helpers table is unique from our other big data tables in that it is pretty tightly coupled to hass states updates, this means that anytime a single helper entity has a state update we must:

- regenerate all new table data
- re-sort all the table rows
- re-filter all the table rows
- re-group all the table rows
- re-render the ha-data-table

This is quite a lot of activity given that the state objects are not really used for much, and it could be quite busy for someone with a lot of templates or other helpers that update frequently. 

The only thing the state object is used for is:
- get the friendly name of the entity
- check the editable state of the entity
- pass the stateObj to ha-state-icon

The first two are pretty trivial to fix, given that when preparing to update we can just check if the entities changed friendly name or editable (even though i don't think editable ever changes), and limit updates to when they actually change, rather than just checking if the stateObj changed at all.

The ha-state-icon was a little less obvious to fix, as just by inspecting the stateObj it's not really obvious if the icon is going to change. My idea for this is to provide a feature to ha-state-icon to accept an entity-id instead of a stateObj, and then ha-state-icon can use context subscribe to just that entity id to get changes to the stateObj, instead of requiring the parent to manage the stateObj. Then the ha-data-table is no longer responsible for passthrough updates of any stateObjects, and it doesn't have to care about stateObj changes, but we still get to keep dynamic updates of the icon.

As I did not want to make global changes to all ha-state-icon everywhere, and I'm not 100% certain of the perf implications of switching from passed stateObj to subscribed stateObj, it is just left supporting both options, and the instancing code can decide whether to pass entity-id or stateObj.

In the pathological case of a thousand helpers and many state updates per second I was able to drop my browser CPU usage from ~40% to ~5% on this page  (but that's on a pretty powerful desktop)

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
