### PR TITLE
Fix duplicate logbook entries in more info dialog after reconnect

### DIFF
--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -144,7 +144,13 @@ export const subscribeLogbook = (
   }
   return hass.connection.subscribeMessage<LogbookStreamMessage>(
     (message) => callbackFunction(message, subscriptionId),
-    params
+    params,
+    // Disable the library's auto-resubscribe. On reconnect it would replay this
+    // exact call with the now-stale `start_time`, and the consumer (ha-logbook)
+    // appends streamed events without deduplicating, so the replayed historical
+    // chunk would show up as duplicate entries. ha-logbook instead listens for
+    // the connection `ready` event and resubscribes from a clean state.
+    { resubscribe: false }
   );
 };
 

--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -145,11 +145,8 @@ export const subscribeLogbook = (
   return hass.connection.subscribeMessage<LogbookStreamMessage>(
     (message) => callbackFunction(message, subscriptionId),
     params,
-    // Disable the library's auto-resubscribe. On reconnect it would replay this
-    // exact call with the now-stale `start_time`, and the consumer (ha-logbook)
-    // appends streamed events without deduplicating, so the replayed historical
-    // chunk would show up as duplicate entries. ha-logbook instead listens for
-    // the connection `ready` event and resubscribes from a clean state.
+    // Don't auto-resubscribe: the replay uses a stale start_time and ha-logbook
+    // appends events without deduping, so it resubscribes on `ready` instead.
     { resubscribe: false }
   );
 };

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -276,13 +276,9 @@ export class HaLogbook extends LitElement {
   }
 
   private _handleConnectionReady = () => {
-    // The connection dropped (e.g. the app was backgrounded) and just
-    // reconnected. The previous subscription died with the old connection and
-    // was not restored on the server because auto-resubscribe is disabled in
-    // subscribeLogbook. Drop the stale handle without unsubscribing it (the
-    // connection that owned it is gone) and resubscribe from a clean state.
-    // Without this, the replayed historical chunk would be appended on top of
-    // the existing entries, showing every entry two or three times.
+    // The old subscription died with the dropped connection and isn't restored
+    // server-side. Drop the stale handle and resubscribe from scratch, else the
+    // replayed history would duplicate the entries we already have.
     if (!this._unsubLogbook) {
       return;
     }
@@ -326,8 +322,7 @@ export class HaLogbook extends LitElement {
       return;
     }
 
-    // hass is guaranteed here, so attach the reconnect listener if the initial
-    // connectedCallback ran before hass was set.
+    // connectedCallback may have run before hass was set; attach now.
     this._attachReadyListener();
 
     try {

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -96,6 +96,8 @@ export class HaLogbook extends LitElement {
 
   private _logbookSubscriptionId = 0;
 
+  private _readyListenerAttached = false;
+
   protected render() {
     if (!isComponentLoaded(this.hass.config, "logbook")) {
       return nothing;
@@ -241,6 +243,7 @@ export class HaLogbook extends LitElement {
 
   public connectedCallback() {
     super.connectedCallback();
+    this._attachReadyListener();
     if (this.hasUpdated) {
       // Ensure clean state before subscribing
       this._subscribeLogbookPeriod(this._calculateLogbookPeriod());
@@ -249,8 +252,46 @@ export class HaLogbook extends LitElement {
 
   public disconnectedCallback() {
     super.disconnectedCallback();
+    this._detachReadyListener();
     this._unsubscribe(true);
   }
+
+  private _attachReadyListener(): void {
+    if (this._readyListenerAttached || !this.hass) {
+      return;
+    }
+    this.hass.connection.addEventListener("ready", this._handleConnectionReady);
+    this._readyListenerAttached = true;
+  }
+
+  private _detachReadyListener(): void {
+    if (!this._readyListenerAttached) {
+      return;
+    }
+    this.hass?.connection.removeEventListener(
+      "ready",
+      this._handleConnectionReady
+    );
+    this._readyListenerAttached = false;
+  }
+
+  private _handleConnectionReady = () => {
+    // The connection dropped (e.g. the app was backgrounded) and just
+    // reconnected. The previous subscription died with the old connection and
+    // was not restored on the server because auto-resubscribe is disabled in
+    // subscribeLogbook. Drop the stale handle without unsubscribing it (the
+    // connection that owned it is gone) and resubscribe from a clean state.
+    // Without this, the replayed historical chunk would be appended on top of
+    // the existing entries, showing every entry two or three times.
+    if (!this._unsubLogbook) {
+      return;
+    }
+    this._unsubLogbook = undefined;
+    this._logbookEntries = undefined;
+    this._pendingStreamMessages = [];
+    this._liveUpdatesEnabled = true;
+    this._throttleGetLogbookEntries();
+  };
 
   private _calculateLogbookPeriod() {
     const now = new Date();
@@ -284,6 +325,10 @@ export class HaLogbook extends LitElement {
     if (this._unsubLogbook) {
       return;
     }
+
+    // hass is guaranteed here, so attach the reconnect listener if the initial
+    // connectedCallback ran before hass was set.
+    this._attachReadyListener();
 
     try {
       this._logbookSubscriptionId++;


### PR DESCRIPTION
## Proposed change

Fixes duplicated entries in the **Activity** (logbook) list of the more info dialog.

**Symptom:** Leave a more info dialog open, send the app to the background, and reopen it later (which usually triggers a WebSocket reconnect). The Activity log then shows every entry twice. Background and reopen again and a third copy of each entry is added. (See screenshot below.)

**Cause:** The logbook event stream relied on `home-assistant-js-websocket`'s automatic resubscribe. On reconnect the library replays the original subscription with its now-stale `start_time`, so the backend resends the entire historical chunk. `ha-logbook` appends streamed events onto its accumulated list without deduplicating, so the replayed history is added on top of what's already shown — once per reconnect cycle.

**Fix:** Mirror the approach already used for the history stream (`src/data/history.ts`): disable the library's auto-resubscribe for the logbook event stream (`{ resubscribe: false }`) and have `ha-logbook` listen for the connection `ready` event, resubscribing from a clean state on reconnect instead of appending a replayed history chunk.

The two streams differ in how they merge data — history *replaces* its full state on every message, while logbook *appends* incrementally — so the reconnect handler lives in the `ha-logbook` component (which owns the accumulated entries and resets them) rather than entirely in the data layer.

> ⚠️ **This change has not been tested or type-checked locally** — dependency install kept failing in the environment it was written in, so `yarn lint` / `yarn test` could not be run. The reasoning and the parallel to the history-stream fix are sound, but it needs a real verification pass.
>
> @piitaya would you mind reviewing and/or testing this when you get a chance? You know this area well and I'd like a second pair of eyes before it's marked ready.

## Screenshots
<!-- The reported symptom: each Activity entry repeated 2–3× after background/reconnect cycles. -->
_Reporter's screenshot shows each "On"/"Off" entry repeated three times with identical timestamps after two background/reconnect cycles._

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYMwT7ZQJrjyzrNfGQyWaU)_