### PR TITLE
Add untracked consumption to intermediate devices in energy and water sankey cards

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sankey-card.ts
@@ -303,6 +303,43 @@ class HuiEnergySankeyCard
       }
       deviceNodes.push(node);
     });
+
+    // Add untracked consumption nodes for parent devices whose sub-devices
+    // don't account for the parent's full consumption
+    const parentDeviceIds = new Set(Object.values(parentLinks));
+    parentDeviceIds.forEach((parentId) => {
+      const parentNode = deviceNodes.find((node) => node.id === parentId);
+      if (!parentNode) {
+        return;
+      }
+      const childrenSum = deviceNodes.reduce(
+        (sum, node) =>
+          parentLinks[node.id] === parentId ? sum + node.value : sum,
+        0
+      );
+      const untracked = parentNode.value - childrenSum;
+      if (untracked > 0) {
+        const untrackedNodeId = `untracked_${parentId}`;
+        deviceNodes.push({
+          id: untrackedNodeId,
+          label: this.hass.localize(
+            "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption"
+          ),
+          value: untracked,
+          color: computedStyle
+            .getPropertyValue("--state-unavailable-color")
+            .trim(),
+          index: 4,
+        });
+        parentLinks[untrackedNodeId] = parentId;
+        links.push({
+          source: parentId,
+          target: untrackedNodeId,
+          value: untracked,
+        });
+      }
+    });
+
     const devicesWithoutParent = deviceNodes.filter(
       (node) => !parentLinks[node.id]
     );

--- a/src/panels/lovelace/cards/water/hui-water-flow-sankey-card.ts
+++ b/src/panels/lovelace/cards/water/hui-water-flow-sankey-card.ts
@@ -383,6 +383,43 @@ class HuiWaterFlowSankeyCard
       }
     });
 
+    // Add untracked consumption nodes for parent devices whose sub-devices
+    // don't account for the parent's full flow
+    const parentDeviceIds = new Set(Object.values(parentLinks));
+    parentDeviceIds.forEach((parentId) => {
+      const parentNode = deviceNodes.find((node) => node.id === parentId);
+      if (!parentNode) {
+        return;
+      }
+      const childrenSum = deviceNodes.reduce(
+        (sum, node) =>
+          parentLinks[node.id] === parentId ? sum + node.value : sum,
+        0
+      );
+      const untracked = parentNode.value - childrenSum;
+      // only show if larger than 1 L/min
+      if (untracked > 1) {
+        const untrackedNodeId = `untracked_${parentId}`;
+        deviceNodes.push({
+          id: untrackedNodeId,
+          label: this.hass.localize(
+            "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption"
+          ),
+          value: untracked,
+          color: computedStyle
+            .getPropertyValue("--state-unavailable-color")
+            .trim(),
+          index: 4,
+        });
+        parentLinks[untrackedNodeId] = parentId;
+        links.push({
+          source: parentId,
+          target: untrackedNodeId,
+          value: untracked,
+        });
+      }
+    });
+
     const devicesWithoutParent = deviceNodes.filter(
       (node) => !parentLinks[node.id]
     );

--- a/src/panels/lovelace/cards/water/hui-water-sankey-card.ts
+++ b/src/panels/lovelace/cards/water/hui-water-sankey-card.ts
@@ -246,6 +246,43 @@ class HuiWaterSankeyCard
       }
       deviceNodes.push(node);
     });
+
+    // Add untracked consumption nodes for parent devices whose sub-devices
+    // don't account for the parent's full consumption
+    const parentDeviceIds = new Set(Object.values(parentLinks));
+    parentDeviceIds.forEach((parentId) => {
+      const parentNode = deviceNodes.find((node) => node.id === parentId);
+      if (!parentNode) {
+        return;
+      }
+      const childrenSum = deviceNodes.reduce(
+        (sum, node) =>
+          parentLinks[node.id] === parentId ? sum + node.value : sum,
+        0
+      );
+      const untracked = parentNode.value - childrenSum;
+      if (untracked > 0) {
+        const untrackedNodeId = `untracked_${parentId}`;
+        deviceNodes.push({
+          id: untrackedNodeId,
+          label: this.hass.localize(
+            "ui.panel.lovelace.cards.energy.energy_devices_detail_graph.untracked_consumption"
+          ),
+          value: untracked,
+          color: computedStyle
+            .getPropertyValue("--state-unavailable-color")
+            .trim(),
+          index: 4,
+        });
+        parentLinks[untrackedNodeId] = parentId;
+        links.push({
+          source: parentId,
+          target: untrackedNodeId,
+          value: untracked,
+        });
+      }
+    });
+
     const devicesWithoutParent = deviceNodes.filter(
       (node) => !parentLinks[node.id]
     );


### PR DESCRIPTION
## Breaking change

## Proposed change

The power sankey card recently gained an "Untracked consumption" node on intermediate (upstream) devices, so you can see at a glance how much of a parent device's consumption isn't accounted for by its tracked sub-devices (#52882).

This applies the same behavior to the other three sankey cards for consistency:

- Energy sankey card
- Water sankey card
- Water flow sankey card

For each parent device whose tracked sub-devices don't add up to the parent's own total, an "Untracked consumption" node is now shown alongside those sub-devices, instead of leaving that portion of the parent unexplained. The display threshold matches each card's existing home-level untracked node, and the existing "Untracked consumption" label is reused (no new translation strings).

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #52882
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
