### PR TITLE
Only re-render context consumers when the selected value changes

### DIFF
--- a/src/common/decorators/consume-context-entry.ts
+++ b/src/common/decorators/consume-context-entry.ts
@@ -1,5 +1,7 @@
-import { consume } from "@lit/context";
+import { ContextEvent } from "@lit/context";
+import type { Context, ContextCallback } from "@lit/context";
 import type { HassEntities, HassEntity } from "home-assistant-js-websocket";
+import type { ReactiveController, ReactiveElement } from "lit";
 import type {
   HomeAssistant,
   HomeAssistantInternationalization,
@@ -49,8 +51,86 @@ export const preserveUnchangedEntityStatesRecord = <
   return previous;
 };
 
+/**
+ * Reactive controller that subscribes to a Lit context and assigns each
+ * delivered value to a host property — WITHOUT forcing a host update on every
+ * delivery.
+ *
+ * `@lit/context`'s built-in `ContextConsumer` calls `host.requestUpdate()`
+ * unconditionally on every provider notification. For a hot context such as
+ * `statesContext` (replaced on every entity state change) that means every
+ * consumer runs an (often empty) update/render cycle on every unrelated state
+ * change, even when the value it actually reads is unchanged.
+ *
+ * This controller instead leaves update scheduling to the property's own
+ * setter. Combined with {@link transform}, that setter only requests an update
+ * when the *selected* value changes (Lit gates `requestUpdate(key, oldValue)`
+ * with `hasChanged`), so unrelated context churn no longer triggers renders.
+ */
+class ContextSubscriptionController<ValueType> implements ReactiveController {
+  private _unsubscribe?: () => void;
+
+  constructor(
+    private readonly _host: ReactiveElement,
+    private readonly _context: Context<unknown, ValueType>,
+    private readonly _assign: (value: ValueType) => void
+  ) {
+    this._host.addController(this);
+  }
+
+  public hostConnected(): void {
+    this._host.dispatchEvent(
+      new ContextEvent(this._context, this._host, this._callback, true)
+    );
+  }
+
+  public hostDisconnected(): void {
+    this._unsubscribe?.();
+    this._unsubscribe = undefined;
+  }
+
+  // Class field arrow function so the identity is stable per instance, which the
+  // provider's subscription bookkeeping and `ContextRoot` deduping rely on.
+  private readonly _callback: ContextCallback<ValueType> = (
+    value,
+    unsubscribe
+  ) => {
+    // A different provider answered (e.g. re-parenting); drop the stale one.
+    if (this._unsubscribe && this._unsubscribe !== unsubscribe) {
+      this._unsubscribe();
+    }
+    this._unsubscribe = unsubscribe;
+    // Assign through the property setter, which decides — via `hasChanged` —
+    // whether an update is actually needed. We intentionally never call
+    // `host.requestUpdate()` here.
+    this._assign(value);
+  };
+}
+
+/**
+ * Like `@consume({ subscribe: true })` from `@lit/context`, but does not force a
+ * host update on every provider notification — see
+ * {@link ContextSubscriptionController}. Pair with {@link transform} so an
+ * update is scheduled only when the derived value actually changes.
+ */
+const subscribeContext =
+  <ValueType>(context: Context<unknown, ValueType>) =>
+  (proto: object, propertyKey: string): void => {
+    (proto.constructor as unknown as typeof ReactiveElement).addInitializer(
+      (host) => {
+        new ContextSubscriptionController<ValueType>(
+          host as ReactiveElement,
+          context,
+          (value) => {
+            (host as unknown as Record<string, unknown>)[propertyKey] = value;
+          }
+        );
+      }
+    );
+  };
+
 const composeDecorator = <T, V>(
-  context: Parameters<typeof consume>[0]["context"],
+  context: Context<unknown, T>,
   watchKey: string | undefined,
   select: (this: unknown, value: T) => V | undefined
 ) => {
@@ -60,7 +140,7 @@ const composeDecorator = <T, V>(
     },
     watch: watchKey ? [watchKey] : [],
   });
-  const consumeDec = consume<any>({ context, subscribe: true });
+  const consumeDec = subscribeContext<T>(context);
   return (proto: any, propertyKey: string) => {
     transformDec(proto, propertyKey);
     consumeDec(proto, propertyKey);
@@ -124,10 +204,7 @@ export const consumeEntityStates = (config: ConsumeEntryConfig) => {
       },
       watch: watchKey ? [watchKey] : [],
     });
-    const consumeDec = consume<any>({
-      context: statesContext,
-      subscribe: true,
-    });
+    const consumeDec = subscribeContext<HassEntities>(statesContext);
     transformDec(proto as never, propertyKey);
     consumeDec(proto as never, propertyKey);
   };
@@ -151,7 +228,7 @@ export const consumeEntityRegistryEntry = (config: ConsumeEntryConfig) =>
 /**
  * Consumes `internationalizationContext` and narrows it to the `localize`
  * function. No host watching is needed — the decorated property updates
- * whenever the i18n context changes.
+ * whenever `localize` changes.
  */
 export const consumeLocalize = () =>
   composeDecorator<HomeAssistantInternationalization, LocalizeFunc>(

--- a/test/common/decorators/consume-context-entry.test.ts
+++ b/test/common/decorators/consume-context-entry.test.ts
@@ -1,0 +1,417 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { ContextProvider } from "@lit/context";
+import { html, LitElement } from "lit";
+import type { PropertyValues } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import type { HassEntity } from "home-assistant-js-websocket";
+import {
+  entitiesContext,
+  internationalizationContext,
+  statesContext,
+} from "../../../src/data/context";
+import {
+  consumeEntityRegistryEntry,
+  consumeEntityState,
+  consumeEntityStates,
+  consumeLocalize,
+} from "../../../src/common/decorators/consume-context-entry";
+import type { EntityRegistryDisplayEntry } from "../../../src/data/entity/entity_registry";
+import type { HomeAssistantInternationalization } from "../../../src/types";
+import type { LocalizeFunc } from "../../../src/common/translations/localize";
+
+const makeEntity = (entityId: string, stateValue: string): HassEntity =>
+  ({
+    entity_id: entityId,
+    state: stateValue,
+    attributes: {},
+    last_changed: "2024-01-01T00:00:00Z",
+    last_updated: "2024-01-01T00:00:00Z",
+    context: { id: "", parent_id: null, user_id: null },
+  }) as HassEntity;
+
+const makeRegistryEntry = (
+  entityId: string,
+  name: string
+): EntityRegistryDisplayEntry => ({
+  entity_id: entityId,
+  name,
+  labels: [],
+});
+
+const makeI18n = (localize: LocalizeFunc): HomeAssistantInternationalization =>
+  ({ localize }) as HomeAssistantInternationalization;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "test-consume-entity-state": TestConsumeEntityState;
+    "test-consume-entity-states": TestConsumeEntityStates;
+    "test-consume-registry-entry": TestConsumeRegistryEntry;
+    "test-consume-localize": TestConsumeLocalize;
+    "test-consume-localize-no-state": TestConsumeLocalizeNoState;
+  }
+}
+
+// --- Test consumers ----------------------------------------------------------
+
+// Counts update cycles via `updated()` (not `render()`, which lint forbids
+// assigning to `this` in). One render() runs per update cycle, so this is the
+// render count. With the fix, an unrelated context change schedules no update,
+// so this counter does not advance.
+class RenderCounter extends LitElement {
+  public renderCount = 0;
+
+  protected updated(changed: PropertyValues) {
+    super.updated(changed);
+    this.renderCount += 1;
+  }
+}
+
+@customElement("test-consume-entity-state")
+class TestConsumeEntityState extends RenderCounter {
+  @property({ attribute: false }) public entityId = "light.kitchen";
+
+  @state()
+  @consumeEntityState({ entityIdPath: ["entityId"] })
+  public stateObj?: HassEntity;
+
+  protected render() {
+    return html`${this.stateObj?.state ?? "none"}`;
+  }
+}
+
+@customElement("test-consume-entity-states")
+class TestConsumeEntityStates extends RenderCounter {
+  @property({ attribute: false }) public entityIds: string[] = [
+    "light.kitchen",
+  ];
+
+  @state()
+  @consumeEntityStates({ entityIdPath: ["entityIds"] })
+  public stateObjs?: Record<string, HassEntity>;
+
+  protected render() {
+    return html`${Object.keys(this.stateObjs ?? {}).length}`;
+  }
+}
+
+@customElement("test-consume-registry-entry")
+class TestConsumeRegistryEntry extends RenderCounter {
+  @property({ attribute: false }) public entityId = "light.kitchen";
+
+  @state()
+  @consumeEntityRegistryEntry({ entityIdPath: ["entityId"] })
+  public entry?: EntityRegistryDisplayEntry;
+
+  protected render() {
+    return html`${this.entry?.name ?? "none"}`;
+  }
+}
+
+@customElement("test-consume-localize")
+class TestConsumeLocalize extends RenderCounter {
+  @state()
+  @consumeLocalize()
+  public localize?: LocalizeFunc;
+
+  protected render() {
+    return html`${this.localize ? "set" : "none"}`;
+  }
+}
+
+// Mirrors the ~10 call sites that use `@consumeLocalize()` WITHOUT `@state()`.
+@customElement("test-consume-localize-no-state")
+class TestConsumeLocalizeNoState extends RenderCounter {
+  @consumeLocalize()
+  public localize?: LocalizeFunc;
+
+  protected render() {
+    return html`${this.localize ? "set" : "none"}`;
+  }
+}
+
+// --- Helpers -----------------------------------------------------------------
+
+let host: HTMLDivElement | undefined;
+
+afterEach(() => {
+  host?.remove();
+  host = undefined;
+});
+
+const mount = async <T extends LitElement>(
+  tag: string,
+  context: any,
+  initialValue: unknown
+): Promise<{ el: T; provider: ContextProvider<any> }> => {
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  const provider = new ContextProvider(host, {
+    context,
+    initialValue,
+  });
+  const el = document.createElement(tag) as T;
+  // The consumer must be a connected DOM descendant of the provider host.
+  host.appendChild(el);
+  await el.updateComplete;
+  return { el, provider };
+};
+
+// --- Tests -------------------------------------------------------------------
+
+describe("consumeEntityState", () => {
+  it("renders on mount and reads the watched entity", async () => {
+    const { el } = await mount<TestConsumeEntityState>(
+      "test-consume-entity-state",
+      statesContext,
+      {
+        "light.kitchen": makeEntity("light.kitchen", "on"),
+        "light.bedroom": makeEntity("light.bedroom", "on"),
+      }
+    );
+    expect(el.stateObj?.state).toBe("on");
+    expect(el.renderCount).toBe(1);
+  });
+
+  it("does NOT re-render when an unrelated entity changes", async () => {
+    const kitchen = makeEntity("light.kitchen", "on");
+    const { el, provider } = await mount<TestConsumeEntityState>(
+      "test-consume-entity-state",
+      statesContext,
+      { "light.kitchen": kitchen, "light.bedroom": makeEntity("b", "on") }
+    );
+    expect(el.renderCount).toBe(1);
+
+    // New states object, but the watched entity keeps the same reference.
+    provider.setValue({
+      "light.kitchen": kitchen,
+      "light.bedroom": makeEntity("light.bedroom", "off"),
+    });
+    await el.updateComplete;
+    expect(el.renderCount).toBe(1);
+  });
+
+  it("re-renders when the watched entity changes", async () => {
+    const kitchen = makeEntity("light.kitchen", "on");
+    const { el, provider } = await mount<TestConsumeEntityState>(
+      "test-consume-entity-state",
+      statesContext,
+      { "light.kitchen": kitchen }
+    );
+    expect(el.renderCount).toBe(1);
+
+    provider.setValue({ "light.kitchen": makeEntity("light.kitchen", "off") });
+    await el.updateComplete;
+    expect(el.stateObj?.state).toBe("off");
+    expect(el.renderCount).toBe(2);
+  });
+
+  it("re-renders when the watched host property changes", async () => {
+    const { el, provider } = await mount<TestConsumeEntityState>(
+      "test-consume-entity-state",
+      statesContext,
+      {
+        "light.kitchen": makeEntity("light.kitchen", "on"),
+        "light.bedroom": makeEntity("light.bedroom", "off"),
+      }
+    );
+    expect(el.stateObj?.state).toBe("on");
+
+    el.entityId = "light.bedroom";
+    await el.updateComplete;
+    expect(el.stateObj?.state).toBe("off");
+
+    // The provider is still wired, but churn that leaves the watched entity
+    // untouched must not render.
+    const renderCount = el.renderCount;
+    provider.setValue({
+      "light.kitchen": makeEntity("light.kitchen", "on"),
+      "light.bedroom": el.stateObj!,
+    });
+    await el.updateComplete;
+    expect(el.renderCount).toBe(renderCount);
+  });
+
+  it("clears the value and re-renders when the watched entity is removed", async () => {
+    const { el, provider } = await mount<TestConsumeEntityState>(
+      "test-consume-entity-state",
+      statesContext,
+      { "light.kitchen": makeEntity("light.kitchen", "on") }
+    );
+    expect(el.stateObj?.state).toBe("on");
+    expect(el.renderCount).toBe(1);
+
+    provider.setValue({});
+    await el.updateComplete;
+    expect(el.stateObj).toBeUndefined();
+    expect(el.renderCount).toBe(2);
+  });
+});
+
+describe("ContextSubscriptionController lifecycle", () => {
+  it("mounts without a provider: value stays undefined and renders once", async () => {
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    const el = document.createElement(
+      "test-consume-entity-state"
+    ) as TestConsumeEntityState;
+    host.appendChild(el);
+    await el.updateComplete;
+
+    expect(el.stateObj).toBeUndefined();
+    expect(el.renderCount).toBe(1);
+  });
+
+  it("unsubscribes on disconnect and re-subscribes on reconnect", async () => {
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    const provider = new ContextProvider(host, {
+      context: statesContext,
+      initialValue: { "light.kitchen": makeEntity("light.kitchen", "on") },
+    });
+    const el = document.createElement(
+      "test-consume-entity-state"
+    ) as TestConsumeEntityState;
+    host.appendChild(el);
+    await el.updateComplete;
+    expect(el.stateObj?.state).toBe("on");
+
+    // Disconnect, then push an update — the disconnected element must not render.
+    el.remove();
+    const renderCount = el.renderCount;
+    provider.setValue({ "light.kitchen": makeEntity("light.kitchen", "off") });
+    await el.updateComplete;
+    expect(el.renderCount).toBe(renderCount);
+
+    // Reconnect — it must re-subscribe and pick up the current value.
+    host.appendChild(el);
+    await el.updateComplete;
+    expect(el.stateObj?.state).toBe("off");
+  });
+});
+
+describe("consumeEntityStates", () => {
+  it("does NOT re-render when an entity outside the watched set changes", async () => {
+    const kitchen = makeEntity("light.kitchen", "on");
+    const { el, provider } = await mount<TestConsumeEntityStates>(
+      "test-consume-entity-states",
+      statesContext,
+      { "light.kitchen": kitchen, "light.bedroom": makeEntity("b", "on") }
+    );
+    expect(el.renderCount).toBe(1);
+
+    provider.setValue({
+      "light.kitchen": kitchen,
+      "light.bedroom": makeEntity("light.bedroom", "off"),
+    });
+    await el.updateComplete;
+    expect(el.renderCount).toBe(1);
+  });
+
+  it("re-renders when a watched entity changes", async () => {
+    const kitchen = makeEntity("light.kitchen", "on");
+    const { el, provider } = await mount<TestConsumeEntityStates>(
+      "test-consume-entity-states",
+      statesContext,
+      { "light.kitchen": kitchen }
+    );
+    expect(el.renderCount).toBe(1);
+
+    provider.setValue({ "light.kitchen": makeEntity("light.kitchen", "off") });
+    await el.updateComplete;
+    expect(el.renderCount).toBe(2);
+  });
+});
+
+describe("consumeEntityRegistryEntry", () => {
+  it("does NOT re-render when an unrelated registry entry changes", async () => {
+    const kitchen = makeRegistryEntry("light.kitchen", "Kitchen");
+    const { el, provider } = await mount<TestConsumeRegistryEntry>(
+      "test-consume-registry-entry",
+      entitiesContext,
+      {
+        "light.kitchen": kitchen,
+        "light.bedroom": makeRegistryEntry("light.bedroom", "Bedroom"),
+      }
+    );
+    expect(el.entry?.name).toBe("Kitchen");
+    expect(el.renderCount).toBe(1);
+
+    provider.setValue({
+      "light.kitchen": kitchen,
+      "light.bedroom": makeRegistryEntry("light.bedroom", "Bedroom 2"),
+    });
+    await el.updateComplete;
+    expect(el.renderCount).toBe(1);
+  });
+
+  it("re-renders when the watched registry entry changes", async () => {
+    const { el, provider } = await mount<TestConsumeRegistryEntry>(
+      "test-consume-registry-entry",
+      entitiesContext,
+      {
+        "light.kitchen": makeRegistryEntry("light.kitchen", "Kitchen"),
+      }
+    );
+    expect(el.renderCount).toBe(1);
+
+    provider.setValue({
+      "light.kitchen": makeRegistryEntry("light.kitchen", "Kitchen renamed"),
+    });
+    await el.updateComplete;
+    expect(el.entry?.name).toBe("Kitchen renamed");
+    expect(el.renderCount).toBe(2);
+  });
+});
+
+describe("consumeLocalize", () => {
+  const localizeA = (() => "A") as LocalizeFunc;
+  const localizeB = (() => "B") as LocalizeFunc;
+
+  it("does NOT re-render when the i18n context changes but localize is identical", async () => {
+    const { el, provider } = await mount<TestConsumeLocalize>(
+      "test-consume-localize",
+      internationalizationContext,
+      makeI18n(localizeA)
+    );
+    expect(el.localize).toBe(localizeA);
+    expect(el.renderCount).toBe(1);
+
+    // New i18n object, same localize reference (e.g. only locale changed).
+    provider.setValue(makeI18n(localizeA));
+    await el.updateComplete;
+    expect(el.renderCount).toBe(1);
+  });
+
+  it("re-renders when localize changes", async () => {
+    const { el, provider } = await mount<TestConsumeLocalize>(
+      "test-consume-localize",
+      internationalizationContext,
+      makeI18n(localizeA)
+    );
+    expect(el.renderCount).toBe(1);
+
+    provider.setValue(makeI18n(localizeB));
+    await el.updateComplete;
+    expect(el.localize).toBe(localizeB);
+    expect(el.renderCount).toBe(2);
+  });
+
+  it("works without @state(): updates only when localize changes", async () => {
+    const { el, provider } = await mount<TestConsumeLocalizeNoState>(
+      "test-consume-localize-no-state",
+      internationalizationContext,
+      makeI18n(localizeA)
+    );
+    expect(el.localize).toBe(localizeA);
+    expect(el.renderCount).toBe(1);
+
+    provider.setValue(makeI18n(localizeA));
+    await el.updateComplete;
+    expect(el.renderCount).toBe(1);
+
+    provider.setValue(makeI18n(localizeB));
+    await el.updateComplete;
+    expect(el.localize).toBe(localizeB);
+    expect(el.renderCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The `consume*` decorators in `consume-context-entry.ts` (`consumeEntityState`, `consumeEntityStates`, `consumeEntityRegistryEntry`, `consumeLocalize`) pair `@lit/context`'s `@consume({ subscribe: true })` with `@transform` to narrow a whole context down to a single value.

The problem: `@lit/context`'s `ContextConsumer` calls `host.requestUpdate()` **unconditionally** on every provider notification. Since `statesContext` is replaced on every entity state change, every component using these decorators ran an (often empty) update/render cycle on **every unrelated state change** — not just when the value it actually reads changed. `@transform` keeps the value referentially stable so the render is usually a no-op, but the empty cycle still runs.

This replaces the built-in consumer with a small reactive controller that subscribes the same way but leaves update scheduling to the property setter, so an update is requested only when the selected value actually changes (reference equality / `hasChanged` — the same comparison that already gated these properties). Behavior is unchanged for genuine changes; only the redundant render cycles are removed.

Added unit tests asserting each decorator re-renders only when its selected value changes, and not on unrelated context churn. These tests fail against the previous implementation.

## Screenshots

<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: follow-up to the discussion on #52878
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
