### PR TITLE
Improve/unify icon behavior in entities and helpers tables

### DIFF
--- a/src/components/ha-entity-id-icon.ts
+++ b/src/components/ha-entity-id-icon.ts
@@ -1,0 +1,39 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import "./ha-icon";
+import "./ha-svg-icon";
+import { consumeEntityState } from "../common/decorators/consume-context-entry";
+import { computeDomain } from "../common/entity/compute_domain";
+import "./ha-domain-icon";
+import "./ha-state-icon";
+
+@customElement("ha-entity-id-icon")
+export class HaEntityIdIcon extends LitElement {
+  @state()
+  @consumeEntityState({ entityIdPath: ["entityId"] })
+  private stateObj?: HassEntity;
+
+  @property({ attribute: false }) public entityId!: string;
+
+  @property({ attribute: "state-title", type: Boolean }) public stateTitle =
+    false;
+
+  protected render() {
+    if (this.stateObj) {
+      return html`<ha-state-icon
+        .stateObj=${this.stateObj}
+        .stateTitle=${this.stateTitle}
+      ></ha-state-icon>`;
+    }
+    return html`<ha-domain-icon
+      .domain=${computeDomain(this.entityId)}
+    ></ha-domain-icon>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-entity-id-icon": HaEntityIdIcon;
+  }
+}

--- a/src/components/ha-entity-id-icon.ts
+++ b/src/components/ha-entity-id-icon.ts
@@ -1,8 +1,6 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import { html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import "./ha-icon";
-import "./ha-svg-icon";
 import { consumeEntityState } from "../common/decorators/consume-context-entry";
 import { computeDomain } from "../common/entity/compute_domain";
 import "./ha-domain-icon";

--- a/src/components/ha-state-icon.ts
+++ b/src/components/ha-state-icon.ts
@@ -1,6 +1,7 @@
 import { consume, type ContextType } from "@lit/context";
 import { initialState } from "@lit/task";
 import type { HassEntity } from "home-assistant-js-websocket";
+import type { PropertyValues } from "lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { AsyncValueTask } from "../common/controllers/async-value-task";
@@ -9,6 +10,7 @@ import {
   configContext,
   connectionContext,
   entitiesContext,
+  formattersContext,
 } from "../data/context";
 import {
   DEFAULT_DOMAIN_ICON,
@@ -17,19 +19,21 @@ import {
 } from "../data/icons";
 import "./ha-icon";
 import "./ha-svg-icon";
-import { consumeEntityState } from "../common/decorators/consume-context-entry";
 
 @customElement("ha-state-icon")
 export class HaStateIcon extends LitElement {
   @property({ attribute: false }) public stateObj?: HassEntity;
 
   @state()
-  @consumeEntityState({ entityIdPath: ["entityId"] })
-  private _consumeStateObj?: HassEntity;
+  @consume({ context: formattersContext, subscribe: true })
+  private _formatters!: ContextType<typeof formattersContext>;
 
   @property({ attribute: false }) public entityId?: string;
 
   @property({ attribute: false }) public stateValue?: string;
+
+  @property({ attribute: "state-title", type: Boolean }) public stateTitle =
+    false;
 
   @property() public icon?: string;
 
@@ -45,15 +49,11 @@ export class HaStateIcon extends LitElement {
   @consume({ context: entitiesContext, subscribe: true })
   protected _entities?: ContextType<typeof entitiesContext>;
 
-  private get _stateObj(): HassEntity | undefined {
-    return this.stateObj ?? this._consumeStateObj;
-  }
-
   private get _overrideIcon(): string | undefined {
     return (
       this.icon ||
-      (this._stateObj && this._entities?.[this._stateObj.entity_id]?.icon) ||
-      this._stateObj?.attributes.icon
+      (this.stateObj && this._entities?.[this.stateObj.entity_id]?.icon) ||
+      this.stateObj?.attributes.icon
     );
   }
 
@@ -83,17 +83,30 @@ export class HaStateIcon extends LitElement {
         this._entities,
         this._config,
         this._connection,
-        this._stateObj,
+        this.stateObj,
         this.stateValue,
       ] as const,
   });
+
+  protected willUpdate(changedProps: PropertyValues) {
+    if (
+      changedProps.has("_consumeStateObj") ||
+      changedProps.has("stateObj") ||
+      changedProps.has("_formatters") ||
+      changedProps.has("stateTitle")
+    ) {
+      if (this.stateTitle && this.stateObj) {
+        this.title = this._formatters.formatEntityState(this.stateObj);
+      }
+    }
+  }
 
   protected render() {
     const overrideIcon = this._overrideIcon;
     if (overrideIcon) {
       return html`<ha-icon .icon=${overrideIcon}></ha-icon>`;
     }
-    if (!this._stateObj) {
+    if (!this.stateObj) {
       return nothing;
     }
     if (!this._config || !this._connection || !this._entities) {
@@ -108,7 +121,7 @@ export class HaStateIcon extends LitElement {
   }
 
   private _renderFallback() {
-    const domain = computeStateDomain(this._stateObj!);
+    const domain = computeStateDomain(this.stateObj!);
 
     return html`
       <ha-svg-icon

--- a/src/components/ha-state-icon.ts
+++ b/src/components/ha-state-icon.ts
@@ -90,7 +90,6 @@ export class HaStateIcon extends LitElement {
 
   protected willUpdate(changedProps: PropertyValues) {
     if (
-      changedProps.has("_consumeStateObj") ||
       changedProps.has("stateObj") ||
       changedProps.has("_formatters") ||
       changedProps.has("stateTitle")

--- a/src/components/ha-state-icon.ts
+++ b/src/components/ha-state-icon.ts
@@ -28,8 +28,6 @@ export class HaStateIcon extends LitElement {
   @consume({ context: formattersContext, subscribe: true })
   private _formatters!: ContextType<typeof formattersContext>;
 
-  @property({ attribute: false }) public entityId?: string;
-
   @property({ attribute: false }) public stateValue?: string;
 
   @property({ attribute: "state-title", type: Boolean }) public stateTitle =

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -16,11 +16,9 @@ import {
   mdiToggleSwitch,
   mdiToggleSwitchOffOutline,
 } from "@mdi/js";
-import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
-import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
 import memoize from "memoize-one";
 import { storage } from "../../../common/decorators/storage";
@@ -60,6 +58,7 @@ import "../../../components/ha-check-list-item";
 import "../../../components/ha-dropdown";
 import type { HaDropdownSelectEvent } from "../../../components/ha-dropdown";
 import "../../../components/ha-dropdown-item";
+import "../../../components/ha-entity-id-icon";
 import "../../../components/ha-filter-devices";
 import "../../../components/ha-filter-domains";
 import "../../../components/ha-filter-floor-areas";
@@ -141,7 +140,6 @@ export interface StateEntity extends Omit<
 }
 
 export interface EntityRow extends StateEntity {
-  entity?: HassEntity;
   unavailable: boolean;
   restored: boolean;
   status: string | undefined;
@@ -340,21 +338,13 @@ export class HaConfigEntities extends LitElement {
         template: (entry) =>
           entry.icon
             ? html`<ha-icon .icon=${entry.icon}></ha-icon>`
-            : entry.entity
-              ? html`
-                  <ha-state-icon
-                    title=${ifDefined(
-                      entry.entity
-                        ? this.hass.formatEntityState(entry.entity)
-                        : undefined
-                    )}
-                    slot="item-icon"
-                    .stateObj=${entry.entity}
-                  ></ha-state-icon>
-                `
-              : html`<ha-domain-icon
-                  .domain=${computeDomain(entry.entity_id)}
-                ></ha-domain-icon>`,
+            : html`
+                <ha-entity-id-icon
+                  state-title
+                  slot="item-icon"
+                  .entityId=${entry.entity_id}
+                ></ha-entity-id-icon>
+              `,
       },
       name: {
         main: true,
@@ -711,7 +701,6 @@ export class HaConfigEntities extends LitElement {
 
         result.push({
           ...entry,
-          entity,
           name: entityName || deviceName || entry.entity_id,
           device: deviceName,
           area: areaName,

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -54,7 +54,7 @@ import "../../../components/ha-filter-labels";
 import "../../../components/ha-filter-voice-assistants";
 import "../../../components/ha-icon";
 import "../../../components/ha-icon-overflow-menu";
-import "../../../components/ha-state-icon";
+import "../../../components/ha-entity-id-icon";
 import "../../../components/ha-svg-icon";
 import "../../../components/ha-tooltip";
 import { getSignedPath } from "../../../data/auth";
@@ -355,9 +355,10 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
         moveable: false,
         template: (helper) =>
           helper.entity
-            ? html`<ha-state-icon
+            ? html`<ha-entity-id-icon
                 .entityId=${helper.entity_id}
-              ></ha-state-icon>`
+                state-title
+              ></ha-entity-id-icon>`
             : html`<ha-svg-icon
                 .path=${helper.icon}
                 style="color: var(--error-color)"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Wanted to make a slight adjustment to how I implemented previous PR https://github.com/home-assistant/frontend/pull/52878

I decided making ha-state-icon maintain two parallel paths (icon by stateObj or icon by entityId) was overcomplicated, and instead I will just produce a small wrapper component (ha-entity-id-icon) whose job is to retrieve the stateObj, and then pass that to the original version of ha-state-icon. This keeps ha-state-icon solely responsible for rendering the icon from the stateObj. This also gives a cleaner way to implement a domain-icon fallback when the entityId is not in the state machine, which ha-state-icon could not originally do.

With these changes, we can then also use ha-entity-id-icon in the entities table, allowing us to remove the stateObj from the data table entirely. 

With this change the entities table now has a realtime updating icon and state tooltip at no additional cost, where previously the icon was memoized from stale data, so it would not track the underlying entity, and could reflect a stale state.

The capability of rendering the icon state as a tooltip was removed from the entities table, and added to ha-state-icon as an optional feature. This then allows the helpers table to easily have the same feature, so now helpers and entities table have the same realtime icon and state tooltip.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
