### PR TITLE
Show dedicated icons for Cloud and Cast in Actvity and add tooltip

### DIFF
--- a/src/panels/logbook/ha-logbook-entry.ts
+++ b/src/panels/logbook/ha-logbook-entry.ts
@@ -1,4 +1,4 @@
-import { mdiPuzzle, mdiRobot, mdiScriptText } from "@mdi/js";
+import { mdiCast, mdiCloud, mdiPuzzle, mdiRobot, mdiScriptText } from "@mdi/js";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
@@ -17,6 +17,7 @@ import "../../components/ha-relative-time";
 import "../../components/ha-domain-icon";
 import "../../components/ha-state-icon";
 import "../../components/ha-svg-icon";
+import "../../components/ha-tooltip";
 import "../../components/user/ha-user-badge";
 import { UNAVAILABLE } from "../../data/entity/entity";
 import type { LogbookEntry } from "../../data/logbook";
@@ -47,6 +48,12 @@ interface LogbookRenderItem extends LogbookItem {
   renderedValue: TemplateResult | string;
 }
 
+// Names are the fixed system user names set by core (cloud/cast integrations).
+const SYSTEM_USER_ICONS: Record<string, string> = {
+  "Home Assistant Cloud": mdiCloud,
+  "Home Assistant Cast": mdiCast,
+};
+
 @customElement("ha-logbook-entry")
 class HaLogbookEntry extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -55,6 +62,8 @@ class HaLogbookEntry extends LitElement {
 
   @property({ attribute: false }) public userIdToName: Record<string, string> =
     {};
+
+  @property({ attribute: false }) public systemUserIds = new Set<string>();
 
   @property({ attribute: false }) public traceContexts: TraceContexts = {};
 
@@ -87,6 +96,7 @@ class HaLogbookEntry extends LitElement {
     const item = computeLogbookItem(this.hass, entry, {
       nameDetail: this.nameDetail,
       userIdToName: this.userIdToName,
+      systemUserIds: this.systemUserIds,
     });
 
     const traceContext =
@@ -208,9 +218,10 @@ class HaLogbookEntry extends LitElement {
   ) {
     return html`<span class="trailing">
       ${cause
-        ? html`<span class="cause-badge" title=${cause.name}
-            >${this._renderCauseIcon(cause)}</span
-          >`
+        ? html`<ha-tooltip for="cause-badge">${cause.name}</ha-tooltip>
+            <span class="cause-badge" id="cause-badge"
+              >${this._renderCauseIcon(cause)}</span
+            >`
         : nothing}
       ${traceLink ? this._renderTraceLink(traceLink) : nothing}
       ${this._renderTimeChip(renderedTime)}
@@ -443,6 +454,15 @@ class HaLogbookEntry extends LitElement {
 
   private _renderCauseIcon(cause: LogbookCause) {
     if (cause.type === "user") {
+      const systemIcon = cause.systemUser
+        ? SYSTEM_USER_ICONS[cause.name]
+        : undefined;
+      if (systemIcon) {
+        return html`<ha-svg-icon
+          class="cause-icon"
+          .path=${systemIcon}
+        ></ha-svg-icon>`;
+      }
       return html`<ha-user-badge
         class="cause-icon cause-avatar"
         .user=${{ id: cause.userId!, name: cause.name } as User}

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -30,6 +30,8 @@ class HaLogbookRenderer extends LitElement {
   @property({ attribute: false }) public userIdToName: Record<string, string> =
     {};
 
+  @property({ attribute: false }) public systemUserIds = new Set<string>();
+
   @property({ attribute: false }) public traceContexts: TraceContexts = {};
 
   @property({ attribute: false }) public entries: LogbookEntry[] = [];
@@ -134,6 +136,7 @@ class HaLogbookRenderer extends LitElement {
           .hass=${this.hass}
           .item=${item}
           .userIdToName=${this.userIdToName}
+          .systemUserIds=${this.systemUserIds}
           .traceContexts=${this.traceContexts}
           .narrow=${this.narrow}
           .noIcon=${this.noIcon}

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -81,6 +81,8 @@ export class HaLogbook extends LitElement {
 
   @state() private _userIdToName = {};
 
+  @state() private _systemUserIds = new Set<string>();
+
   @state() private _error?: string;
 
   private _unsubLogbook?: Promise<UnsubscribeFunc>;
@@ -135,6 +137,7 @@ export class HaLogbook extends LitElement {
         .entries=${this._logbookEntries}
         .traceContexts=${this._traceContexts}
         .userIdToName=${this._userIdToName}
+        .systemUserIds=${this._systemUserIds}
         @hass-logbook-live=${this._handleLogbookLive}
       ></ha-logbook-renderer>
     `;
@@ -415,6 +418,7 @@ export class HaLogbook extends LitElement {
 
   private _updateUsers = throttle(async () => {
     const userIdToName = {};
+    const systemUserIds = new Set<string>();
 
     // Start loading users
     const userProm = this.hass.user?.is_admin && fetchUsers(this.hass);
@@ -437,10 +441,14 @@ export class HaLogbook extends LitElement {
         if (!(user.id in userIdToName)) {
           userIdToName[user.id] = user.name;
         }
+        if (user.system_generated) {
+          systemUserIds.add(user.id);
+        }
       }
     }
 
     this._userIdToName = userIdToName;
+    this._systemUserIds = systemUserIds;
   }, 60000);
 
   static get styles() {

--- a/src/panels/logbook/logbook-entry-model.ts
+++ b/src/panels/logbook/logbook-entry-model.ts
@@ -126,6 +126,7 @@ export interface LogbookCause {
   type: LogbookCauseType;
   name: string;
   userId?: string;
+  systemUser?: boolean;
   entityId?: string;
   brandDomain?: string;
 }
@@ -133,13 +134,19 @@ export interface LogbookCause {
 export const computeLogbookCause = (
   hass: HomeAssistant,
   item: LogbookEntry,
-  userIdToName: Record<string, string>
+  userIdToName: Record<string, string>,
+  systemUserIds?: Set<string>
 ): LogbookCause | undefined => {
   const userName = item.context_user_id
     ? userIdToName[item.context_user_id]
     : undefined;
   if (userName) {
-    return { type: "user", name: userName, userId: item.context_user_id };
+    return {
+      type: "user",
+      name: userName,
+      userId: item.context_user_id,
+      systemUser: systemUserIds?.has(item.context_user_id!),
+    };
   }
 
   if (
@@ -312,6 +319,7 @@ export interface LogbookItem {
 export interface BuildLogbookItemOptions {
   nameDetail?: LogbookNameDetail;
   userIdToName?: Record<string, string>;
+  systemUserIds?: Set<string>;
 }
 
 export const computeLogbookItem = (
@@ -341,7 +349,12 @@ export const computeLogbookItem = (
     name: display?.primary ?? entry.name,
     context: display?.secondary,
     value: computeLogbookValue(hass, entry, domain, historicStateObj),
-    cause: computeLogbookCause(hass, entry, opts.userIdToName ?? {}),
+    cause: computeLogbookCause(
+      hass,
+      entry,
+      opts.userIdToName ?? {},
+      opts.systemUserIds
+    ),
     when: entry.when * 1000,
   };
 };

--- a/test/panels/logbook/logbook-entry-model.test.ts
+++ b/test/panels/logbook/logbook-entry-model.test.ts
@@ -222,6 +222,31 @@ describe("computeLogbookCause", () => {
     );
     expect(cause?.type).toBe("scheduled");
   });
+
+  it("flags a system user when its id is in the system set", () => {
+    const hass = baseHass({ localize: localizeStub() });
+    const cause = computeLogbookCause(
+      hass,
+      entry({ context_user_id: "cloud_user" }),
+      { cloud_user: "Home Assistant Cloud" },
+      new Set(["cloud_user"])
+    );
+    expect(cause?.type).toBe("user");
+    expect(cause?.name).toBe("Home Assistant Cloud");
+    expect(cause?.systemUser).toBe(true);
+  });
+
+  it("does not flag a regular user as a system user", () => {
+    const hass = baseHass({ localize: localizeStub() });
+    const cause = computeLogbookCause(
+      hass,
+      entry({ context_user_id: "person_1" }),
+      { person_1: "Paul" },
+      new Set(["cloud_user"])
+    );
+    expect(cause?.type).toBe("user");
+    expect(cause?.systemUser).toBe(false);
+  });
 });
 
 describe("computeLogbookGlyph", () => {


### PR DESCRIPTION
## Proposed change

Two improvements to how the Activity card shows what caused a change:

- The Home Assistant Cloud and Cast system users showed initials ("HAC"), which was easy to mistake for HACS. They now use a cloud and cast icon.
- Cause icons now show a tooltip with the full name on hover, so any cause (automation, script, user, or integration) is identifiable at a glance, not just by its icon.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
