### PR TITLE
Show a warning when deprecated automation options where used and migr…

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -416,12 +416,22 @@ export const saveAutomationConfig = (
   config: AutomationConfig
 ) => hass.callApi<undefined>("POST", `config/automation/config/${id}`, config);
 
+/**
+ * Accumulates whether a deprecated config option was migrated while
+ * normalizing an automation or script config. Used to surface an alert
+ * offering to save the migrated configuration.
+ */
+export interface AutomationMigrationReport {
+  deprecated: boolean;
+}
+
 export const normalizeAutomationConfig = <
   T extends Partial<AutomationConfig> | AutomationConfig,
 >(
-  config: T
+  config: T,
+  report?: AutomationMigrationReport
 ): T => {
-  config = migrateAutomationConfig(config);
+  config = migrateAutomationConfig(config, report);
 
   // Normalize data: ensure triggers, actions and conditions are lists
   // Happens when people copy paste their automations into the config
@@ -438,7 +448,8 @@ export const normalizeAutomationConfig = <
 export const migrateAutomationConfig = <
   T extends Partial<AutomationConfig> | AutomationConfig,
 >(
-  config: T
+  config: T,
+  report?: AutomationMigrationReport
 ) => {
   if ("trigger" in config) {
     if (!("triggers" in config)) {
@@ -460,29 +471,30 @@ export const migrateAutomationConfig = <
   }
 
   if (config.triggers) {
-    config.triggers = migrateAutomationTrigger(config.triggers);
+    config.triggers = migrateAutomationTrigger(config.triggers, report);
   }
 
   if (config.actions) {
-    config.actions = migrateAutomationAction(config.actions);
+    config.actions = migrateAutomationAction(config.actions, report);
   }
 
   return config;
 };
 
 export const migrateAutomationTrigger = (
-  trigger: Trigger | Trigger[]
+  trigger: Trigger | Trigger[],
+  report?: AutomationMigrationReport
 ): Trigger | Trigger[] => {
   if (!trigger) {
     return trigger;
   }
 
   if (Array.isArray(trigger)) {
-    return trigger.map(migrateAutomationTrigger) as Trigger[];
+    return trigger.map((t) => migrateAutomationTrigger(t, report)) as Trigger[];
   }
 
   if ("triggers" in trigger && trigger.triggers) {
-    trigger.triggers = migrateAutomationTrigger(trigger.triggers);
+    trigger.triggers = migrateAutomationTrigger(trigger.triggers, report);
   }
 
   if ("platform" in trigger) {
@@ -495,10 +507,18 @@ export const migrateAutomationTrigger = (
 
   if ("options" in trigger) {
     if (trigger.options && "behavior" in trigger.options) {
+      // Deprecated behavior values renamed in 2026; the backend raises a repair
+      // when they are still used, so flag the migration to offer saving.
       if (trigger.options.behavior === "any") {
         trigger.options.behavior = "each";
+        if (report) {
+          report.deprecated = true;
+        }
       } else if (trigger.options.behavior === "last") {
         trigger.options.behavior = "all";
+        if (report) {
+          report.deprecated = true;
+        }
       }
     }
   }

--- a/src/data/script.ts
+++ b/src/data/script.ts
@@ -22,6 +22,7 @@ import { hasTemplate } from "../common/string/has-template";
 import { createSearchParam } from "../common/url/search-params";
 import type { HomeAssistant } from "../types";
 import type {
+  AutomationMigrationReport,
   Condition,
   ShorthandAndCondition,
   ShorthandNotCondition,
@@ -452,14 +453,15 @@ export const requiredScriptFieldsFilled = (
   requiredScriptFieldsFilledForServices(hass.services, entityId, data);
 
 export const migrateAutomationAction = (
-  action: Action | Action[]
+  action: Action | Action[],
+  report?: AutomationMigrationReport
 ): Action | Action[] => {
   if (!action) {
     return action;
   }
 
   if (Array.isArray(action)) {
-    return action.map(migrateAutomationAction) as Action[];
+    return action.map((a) => migrateAutomationAction(a, report)) as Action[];
   }
 
   if (typeof action === "object" && action !== null && "service" in action) {
@@ -506,7 +508,7 @@ export const migrateAutomationAction = (
   if (typeof action === "object" && action !== null && "sequence" in action) {
     delete (action as SequenceAction).metadata;
     for (const sequenceAction of (action as SequenceAction).sequence) {
-      migrateAutomationAction(sequenceAction);
+      migrateAutomationAction(sequenceAction, report);
     }
   }
 
@@ -514,45 +516,48 @@ export const migrateAutomationAction = (
 
   if (actionType === "parallel") {
     const _action = action as ParallelAction;
-    migrateAutomationAction(_action.parallel);
+    migrateAutomationAction(_action.parallel, report);
   }
 
   if (actionType === "choose") {
     const _action = action as ChooseAction;
     if (Array.isArray(_action.choose)) {
       for (const choice of _action.choose) {
-        migrateAutomationAction(choice.sequence);
+        migrateAutomationAction(choice.sequence, report);
       }
     } else if (_action.choose) {
-      migrateAutomationAction(_action.choose.sequence);
+      migrateAutomationAction(_action.choose.sequence, report);
     }
     if (_action.default) {
-      migrateAutomationAction(_action.default);
+      migrateAutomationAction(_action.default, report);
     }
   }
 
   if (actionType === "repeat") {
     const _action = action as RepeatAction;
-    migrateAutomationAction(_action.repeat.sequence);
+    migrateAutomationAction(_action.repeat.sequence, report);
   }
 
   if (actionType === "if") {
     const _action = action as IfAction;
-    migrateAutomationAction(_action.then);
+    migrateAutomationAction(_action.then, report);
     if (_action.else) {
-      migrateAutomationAction(_action.else);
+      migrateAutomationAction(_action.else, report);
     }
   }
 
   if (actionType === "wait_for_trigger") {
     const _action = action as WaitForTriggerAction;
-    migrateAutomationTrigger(_action.wait_for_trigger);
+    migrateAutomationTrigger(_action.wait_for_trigger, report);
   }
 
   return action;
 };
 
-export const normalizeScriptConfig = (config: ScriptConfig): ScriptConfig => {
+export const normalizeScriptConfig = (
+  config: ScriptConfig,
+  report?: AutomationMigrationReport
+): ScriptConfig => {
   // Normalize data: ensure sequence is a list
   // Happens when people copy paste their scripts into the config
   const value = config.sequence;
@@ -560,7 +565,7 @@ export const normalizeScriptConfig = (config: ScriptConfig): ScriptConfig => {
     config.sequence = [value];
   }
   if (config.sequence) {
-    config.sequence = migrateAutomationAction(config.sequence);
+    config.sequence = migrateAutomationAction(config.sequence, report);
   }
   return config;
 };

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -170,6 +170,32 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
     }
   }
 
+  private _renderDeprecatedMigratedAlert(): TemplateResult | typeof nothing {
+    if (!this.deprecatedConfigMigrated || this.readOnly) {
+      return nothing;
+    }
+    return html`<ha-alert
+      alert-type="warning"
+      .title=${this.hass.localize(
+        "ui.panel.config.automation.editor.deprecated_migrated.title"
+      )}
+    >
+      ${this.hass.localize(
+        "ui.panel.config.automation.editor.deprecated_migrated.description"
+      )}
+      <ha-button
+        appearance="filled"
+        size="s"
+        variant="warning"
+        slot="action"
+        .disabled=${this.saving}
+        @click=${this._handleSaveAutomation}
+      >
+        ${this.hass.localize("ui.common.save")}
+      </ha-button>
+    </ha-alert>`;
+  }
+
   protected render(): TemplateResult | typeof nothing {
     if (!this.config) {
       return this.renderLoading();
@@ -443,6 +469,7 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
                           @editor-save=${this._handleSaveAutomation}
                         >
                           <div class="alert-wrapper" slot="alerts">
+                            ${this._renderDeprecatedMigratedAlert()}
                             ${this.errors || stateObj?.state === UNAVAILABLE
                               ? html`<ha-alert
                                   alert-type="error"
@@ -527,7 +554,8 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
                 </div>
               `
             : this.mode === "yaml"
-              ? html`${stateObj?.state === "off"
+              ? html`${this._renderDeprecatedMigratedAlert()}
+                  ${stateObj?.state === "off"
                     ? html`
                         <ha-alert alert-type="info">
                           ${this.hass.localize(
@@ -1013,6 +1041,7 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
       }
 
       this._markDirtyStateClean();
+      this.deprecatedConfigMigrated = false;
     } catch (errors: any) {
       this.errors = errors.body?.message || errors.error || errors.body;
       showEditorToast(this, {

--- a/src/panels/config/automation/ha-automation-script-editor-mixin.ts
+++ b/src/panels/config/automation/ha-automation-script-editor-mixin.ts
@@ -12,6 +12,7 @@ import { goBack, navigate } from "../../../common/navigate";
 import { afterNextRender } from "../../../common/util/render-status";
 import "../../../components/animation/ha-fade-in";
 import "../../../components/ha-spinner"; // used by renderLoading() provided to both editors
+import type { AutomationMigrationReport } from "../../../data/automation";
 import { fireRelatedContext, fullEntitiesContext } from "../../../data/context";
 import type { EntityRegistryEntry } from "../../../data/entity/entity_registry";
 import {
@@ -79,7 +80,7 @@ export const automationScriptEditorStyles: CSSResult = css`
 
 export interface EditorDomainHooks<TConfig> {
   fetchFileConfig(hass: HomeAssistant, id: string): Promise<TConfig>;
-  normalizeConfig(raw: TConfig): TConfig;
+  normalizeConfig(raw: TConfig, report?: AutomationMigrationReport): TConfig;
   checkValidation(): Promise<void>;
   domain: "automation" | "script";
 }
@@ -115,6 +116,8 @@ export const AutomationScriptEditorMixin = <TConfig extends BaseEditorConfig>(
     @state() protected readOnly = false;
 
     @state() protected saving = false;
+
+    @state() protected deprecatedConfigMigrated = false;
 
     @state() protected validationErrors?: (string | TemplateResult)[];
 
@@ -257,7 +260,12 @@ export const AutomationScriptEditorMixin = <TConfig extends BaseEditorConfig>(
       try {
         const config = await hooks.fetchFileConfig(this.hass, id);
         this.readOnly = false;
-        this.config = hooks.normalizeConfig(config);
+        const report: AutomationMigrationReport = { deprecated: false };
+        this.config = hooks.normalizeConfig(config, report);
+        // The config is loaded as its migrated (clean) version, so it never
+        // looks dirty. Surface an alert offering to save when deprecated
+        // options were migrated.
+        this.deprecatedConfigMigrated = report.deprecated;
         this._initDirtyTracking({ type: "deep" }, this.config);
         hooks.checkValidation();
       } catch (err: any) {

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -130,6 +130,32 @@ export class HaScriptEditor extends SubscribeMixin(
     }
   }
 
+  private _renderDeprecatedMigratedAlert(): TemplateResult | typeof nothing {
+    if (!this.deprecatedConfigMigrated || this.readOnly) {
+      return nothing;
+    }
+    return html`<ha-alert
+      alert-type="warning"
+      .title=${this.hass.localize(
+        "ui.panel.config.script.editor.deprecated_migrated.title"
+      )}
+    >
+      ${this.hass.localize(
+        "ui.panel.config.script.editor.deprecated_migrated.description"
+      )}
+      <ha-button
+        appearance="filled"
+        size="s"
+        variant="warning"
+        slot="action"
+        .disabled=${this.saving}
+        @click=${this._handleSaveScript}
+      >
+        ${this.hass.localize("ui.common.save")}
+      </ha-button>
+    </ha-alert>`;
+  }
+
   protected render(): TemplateResult | typeof nothing {
     if (!this.config) {
       return this.renderLoading();
@@ -398,6 +424,7 @@ export class HaScriptEditor extends SubscribeMixin(
                           @save-script=${this._handleSaveScript}
                         >
                           <div class="alert-wrapper" slot="alerts">
+                            ${this._renderDeprecatedMigratedAlert()}
                             ${this.errors || stateObj?.state === UNAVAILABLE
                               ? html`<ha-alert
                                   alert-type="error"
@@ -462,7 +489,8 @@ export class HaScriptEditor extends SubscribeMixin(
                 </div>
               `
             : this.mode === "yaml"
-              ? html`<ha-yaml-editor
+              ? html`${this._renderDeprecatedMigratedAlert()}
+                  <ha-yaml-editor
                     .defaultValue=${this._preprocessYaml()}
                     .readOnly=${this.readOnly}
                     disable-fullscreen
@@ -934,6 +962,7 @@ export class HaScriptEditor extends SubscribeMixin(
       }
 
       this._markDirtyStateClean();
+      this.deprecatedConfigMigrated = false;
     } catch (errors: any) {
       this.errors = errors.body?.message || errors.error || errors.body;
       showEditorToast(this, {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5040,6 +5040,10 @@
             "disabled": "Automation is disabled",
             "read_only": "This automation cannot be edited from the UI, because it is not stored in the automations.yaml file, or doesn't have an ID.",
             "unavailable": "Automation is unavailable",
+            "deprecated_migrated": {
+              "title": "Deprecated options updated",
+              "description": "This automation used deprecated options that have been automatically updated to their new equivalents. Save the automation to apply the changes."
+            },
             "migrate": "Migrate",
             "duplicate": "[%key:ui::common::duplicate%]",
             "take_control": "Take control",
@@ -6145,6 +6149,10 @@
             "confirm_take_control": "You are viewing a preview of the script config, do you want to take control?",
             "read_only": "This script cannot be edited from the UI, because it is not stored in the ''scripts.yaml'' file.",
             "unavailable": "Script is unavailable",
+            "deprecated_migrated": {
+              "title": "[%key:ui::panel::config::automation::editor::deprecated_migrated::title%]",
+              "description": "This script used deprecated options that have been automatically updated to their new equivalents. Save the script to apply the changes."
+            },
             "migrate": "Migrate",
             "duplicate": "[%key:ui::common::duplicate%]",
             "field": {

--- a/test/data/automation-migration.test.ts
+++ b/test/data/automation-migration.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { AutomationMigrationReport } from "../../src/data/automation";
+import {
+  migrateAutomationConfig,
+  normalizeAutomationConfig,
+} from "../../src/data/automation";
+
+describe("normalizeAutomationConfig deprecated option reporting", () => {
+  it("reports nothing for an already up-to-date config", () => {
+    const report: AutomationMigrationReport = { deprecated: false };
+    normalizeAutomationConfig(
+      {
+        triggers: [{ trigger: "state", entity_id: "light.kitchen" } as any],
+        actions: [],
+      },
+      report
+    );
+    expect(report.deprecated).toBe(false);
+  });
+
+  it("does not flag legacy alias migrations as deprecated", () => {
+    const report: AutomationMigrationReport = { deprecated: false };
+    const config = normalizeAutomationConfig(
+      {
+        trigger: [{ platform: "state", entity_id: "light.kitchen" }],
+        action: [{ service: "light.turn_on" }],
+      } as any,
+      report
+    );
+    // Aliases are normalized...
+    expect(config.triggers).toEqual([
+      { trigger: "state", entity_id: "light.kitchen" },
+    ]);
+    expect(config.actions).toEqual([{ action: "light.turn_on" }]);
+    // ...but they are not deprecated options that raise a repair.
+    expect(report.deprecated).toBe(false);
+  });
+
+  it("migrates and flags the deprecated `any` behavior", () => {
+    const report: AutomationMigrationReport = { deprecated: false };
+    const config = migrateAutomationConfig(
+      {
+        triggers: [
+          {
+            trigger: "state",
+            entity_id: "light.kitchen",
+            options: { behavior: "any" },
+          } as any,
+        ],
+      },
+      report
+    );
+    expect((config.triggers as any)[0].options.behavior).toBe("each");
+    expect(report.deprecated).toBe(true);
+  });
+
+  it("migrates and flags the deprecated `last` behavior", () => {
+    const report: AutomationMigrationReport = { deprecated: false };
+    const config = migrateAutomationConfig(
+      {
+        triggers: [
+          {
+            trigger: "state",
+            entity_id: "light.kitchen",
+            options: { behavior: "last" },
+          } as any,
+        ],
+      },
+      report
+    );
+    expect((config.triggers as any)[0].options.behavior).toBe("all");
+    expect(report.deprecated).toBe(true);
+  });
+
+  it("flags deprecated behavior nested in wait_for_trigger actions", () => {
+    const report: AutomationMigrationReport = { deprecated: false };
+    migrateAutomationConfig(
+      {
+        triggers: [],
+        actions: [
+          {
+            wait_for_trigger: [
+              {
+                trigger: "state",
+                entity_id: "light.kitchen",
+                options: { behavior: "any" },
+              },
+            ],
+          } as any,
+        ],
+      },
+      report
+    );
+    expect(report.deprecated).toBe(true);
+  });
+
+  it("works without a report argument", () => {
+    expect(() =>
+      migrateAutomationConfig({
+        triggers: [
+          {
+            trigger: "state",
+            entity_id: "light.kitchen",
+            options: { behavior: "any" },
+          } as any,
+        ],
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
…ated

## Proposed change

When an automation (or script) is opened, the frontend silently migrates deprecated config options to their new equivalents and loads that migrated version as the clean baseline. As a result, the deprecated values are no longer visible, the editor doesn't mark the config as dirty, and the user gets no opportunity to persist the fix — while the backend keeps raising a repair for the old values.

This adds a warning alert at the top of the automation and script editors when deprecated options were migrated on load, with a **Save** button to write the migrated configuration back. Concretely, this covers the renamed trigger `behavior` values (`any` → `each`, `last` → `all`).

- Threads an optional migration report through the existing `migrate*`/`normalize*` config functions, flagging only genuinely deprecated options (legacy aliases like `platform:`/`service:` are still normalized silently, as before).
- Surfaces the alert in both the GUI and YAML editor modes; it's cleared after a successful save.
- Adds unit tests for the new detection logic.

## Screenshots

<img width="2200" height="590" alt="image" src="https://github.com/user-attachments/assets/9b0eac48-533c-4d5e-9d81-f959e003b8de" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
