### PR TITLE
Fix double bar in energy devices detail graph at start of day

### DIFF
--- a/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
+++ b/src/panels/lovelace/cards/energy/common/energy-chart-options.ts
@@ -369,6 +369,22 @@ export function computeStatMidpoint(
   return (start + end) / 2;
 }
 
+const PERIOD_MS: Record<string, number> = {
+  "5minute": 5 * 60 * 1000,
+  hour: 60 * 60 * 1000,
+};
+
+/**
+ * Offset from a period's start to its midpoint, for centering sub-daily bars
+ * (and forecast lines) between axis ticks — 0 for daily+ periods, which sit at
+ * the start. Derived from the period, not from the data, so the first/only
+ * bucket centers identically to every other bucket. (Previously estimated from
+ * the gap between the first two entries, which collapsed to 0 with one bucket.)
+ */
+export function getPeriodMidpointOffset(period: string): number {
+  return (PERIOD_MS[period] ?? 0) / 2;
+}
+
 export interface UntrackedSplit {
   /** Untracked consumption per timestamp, clamped to >= 0. */
   positive: Record<number, number>;

--- a/src/panels/lovelace/cards/energy/energy-devices-detail-graph-data.ts
+++ b/src/panels/lovelace/cards/energy/energy-devices-detail-graph-data.ts
@@ -24,6 +24,7 @@ import {
   type EnergyDataPoint,
   fillDataGapsAndRoundCaps,
   getCompareTransform,
+  getPeriodMidpointOffset,
   splitUntrackedConsumption,
 } from "./common/energy-chart-options";
 import { getEnergyColor } from "./common/color";
@@ -237,12 +238,15 @@ function processUntracked(
   const sortedTimes = Object.keys(consumptionData.used_total).sort(
     (a, b) => Number(a) - Number(b)
   );
-  // Only start timestamps available here, so estimate midpoint from the gap
-  // between the first two entries. Assumes uniform period spacing.
+  // Only start timestamps available here, so center sub-daily bars using the
+  // gap between the first two entries. With a lone first-of-day bucket there is
+  // no gap to measure, so fall back to the nominal period midpoint — which
+  // matches the device bars' computeStatMidpoint instead of collapsing to the
+  // period start and splitting into a second stack.
   const periodOffset =
     (period === "hour" || period === "5minute") && sortedTimes.length >= 2
       ? (Number(sortedTimes[1]) - Number(sortedTimes[0])) / 2
-      : 0;
+      : getPeriodMidpointOffset(period);
   sortedTimes.forEach((time) => {
     const ts = Number(time);
     const x = compare

--- a/src/panels/lovelace/cards/energy/energy-solar-graph-data.ts
+++ b/src/panels/lovelace/cards/energy/energy-solar-graph-data.ts
@@ -14,6 +14,7 @@ import {
   type EnergyDataPoint,
   fillDataGapsAndRoundCaps,
   getCompareTransform,
+  getPeriodMidpointOffset,
 } from "./common/energy-chart-options";
 
 export interface EnergySolarGraphDataParams {
@@ -323,7 +324,8 @@ function processForecast(
         const solarForecastData: LineSeriesOption["data"] = [];
         // Only center forecast points for sub-daily periods to align with bars.
         // Only start timestamps available, so estimate midpoint from the gap
-        // between the first two entries. Assumes uniform spacing.
+        // between the first two entries; with a lone first bucket there is no
+        // gap to measure, so fall back to the nominal period midpoint.
         let forecastOffset = 0;
         if (period === "hour" || period === "5minute") {
           const forecastTimes = Object.keys(forecastsData)
@@ -332,7 +334,7 @@ function processForecast(
           forecastOffset =
             forecastTimes.length >= 2
               ? (forecastTimes[1] - forecastTimes[0]) / 2
-              : 0;
+              : getPeriodMidpointOffset(period);
         }
         for (const [time, value] of Object.entries(forecastsData)) {
           const kWh = value / 1000;

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -39,6 +39,7 @@ import {
   fillDataGapsAndRoundCaps,
   getCommonOptions,
   getCompareTransform,
+  getPeriodMidpointOffset,
 } from "./common/energy-chart-options";
 import type { HaECOption } from "../../../../resources/echarts/echarts";
 import type { CustomLegendOption } from "../../../../components/chart/ha-chart-base";
@@ -595,14 +596,15 @@ export class HuiEnergyUsageGraphCard
 
     const uniqueKeys = summedData.timestamps;
 
-    // Only center bars for sub-daily periods (hour/5min).
-    // Only start timestamps available here, so estimate midpoint from the gap
-    // between the first two entries. Assumes uniform period spacing.
+    // Only center bars for sub-daily periods (hour/5min). Only start timestamps
+    // available here, so estimate midpoint from the gap between the first two
+    // entries; with a lone first-of-day bucket there is no gap to measure, so
+    // fall back to the nominal period midpoint so the bar stays centered.
     const period = getSuggestedPeriod(this._start, this._end);
     const periodOffset =
       (period === "hour" || period === "5minute") && uniqueKeys.length >= 2
         ? (uniqueKeys[1] - uniqueKeys[0]) / 2
-        : 0;
+        : getPeriodMidpointOffset(period);
 
     const compareTransform = getCompareTransform(
       this._start,

--- a/test/fixtures/energy.ts
+++ b/test/fixtures/energy.ts
@@ -89,6 +89,8 @@ export interface EnergyDataOptions {
   period?: "5minute" | "hour" | "day";
   compare?: boolean;
   prefs?: EnergyPreferences;
+  /** Probability a period is missing (creates gaps); 0 for a dense dataset. */
+  gapChance?: number;
 }
 
 const statisticIdsForPrefs = (prefs: EnergyPreferences): string[] => {
@@ -115,7 +117,7 @@ export const generateEnergyData = (
   seed: number,
   options: EnergyDataOptions
 ): EnergyData => {
-  const { days, period = "hour", compare = false } = options;
+  const { days, period = "hour", compare = false, gapChance } = options;
   const prefs = options.prefs ?? generateEnergyPreferences();
   const ids = statisticIdsForPrefs(prefs);
   const dayMs = 24 * 60 * 60 * 1000;
@@ -124,6 +126,7 @@ export const generateEnergyData = (
     ids,
     period,
     days,
+    gapChance,
     sumStatistics: true,
   });
   const statsCompare = compare
@@ -132,6 +135,7 @@ export const generateEnergyData = (
         period,
         days,
         startMs: FIXED_EPOCH_MS - days * dayMs,
+        gapChance,
         sumStatistics: true,
       })
     : ({} as EnergyData["statsCompare"]);

--- a/test/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-data.test.ts
+++ b/test/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-data.test.ts
@@ -164,6 +164,57 @@ describe("generateEnergyDevicesDetailGraphData", () => {
     ).toMatchSnapshot();
   });
 
+  // Regression test for #52937: at the start of the day only the first hour
+  // has data. The untracked/over-reported bars must center on the same period
+  // midpoint as the device bars so they stack as one bar instead of splitting
+  // into a second stack at the period start.
+  it("stacks untracked bars on the device bars for a lone first-of-day bucket", () => {
+    // Full-day range (so getSuggestedPeriod stays "hour") but keep only the
+    // first hourly bucket in every stat. gapChance: 0 makes the bucket dense.
+    const full = generateEnergyData(1, {
+      days: 1,
+      period: "hour",
+      gapChance: 0,
+      prefs: buildPrefs(false),
+    });
+    const firstStart = full.start.getTime();
+    const energyData = {
+      ...full,
+      stats: Object.fromEntries(
+        Object.entries(full.stats).map(
+          ([id, values]) =>
+            [id, values.filter((s) => s.start === firstStart)] as const
+        )
+      ),
+    };
+
+    const result = generateEnergyDevicesDetailGraphData({
+      ...baseParams,
+      energyData,
+    });
+
+    // Collect the display x of every bar across all series.
+    const xs = new Set<number>();
+    let nonEmptySeries = 0;
+    for (const series of result.chartData) {
+      const points = series.data ?? [];
+      if (points.length) {
+        nonEmptySeries++;
+      }
+      for (const point of points as any[]) {
+        const x = Array.isArray(point) ? point[0] : point?.value?.[0];
+        if (x != null) {
+          xs.add(Number(x));
+        }
+      }
+    }
+
+    // Device bars + at least one untracked series are present...
+    assert.isAtLeast(nonEmptySeries, 2);
+    // ...and they all share a single x, so they render as one full stack.
+    assert.equal(xs.size, 1);
+  });
+
   // The seeded fixtures above all happen to produce fully-negative untracked
   // (devices reference the source stats, so they consume all of used_total).
   // These two cases pin the branches those snapshots can't reach.


### PR DESCRIPTION
## Breaking change

## Proposed change

When only the first hour of the day has data, the individual devices detail graph showed a broken-looking double bar: the untracked and over-reported consumption bars split off into a separate stack from the device bars instead of stacking on top of them.

For sub-daily periods the bars are centered between axis ticks. The device bars are centered on the true period midpoint, but the untracked bars estimated their centering offset from the gap between the first two data points — and with only one bucket of data there is no gap to measure, so the offset collapsed to zero and the untracked bars landed at the period start.

The offset now falls back to the nominal period midpoint when there is only a single bucket, so the bars line up and render as one full stack. The same fragile estimate existed in the solar graph (forecast line) and the energy usage graph, so the fix is applied consistently there too via a shared helper. A regression test reproduces the start-of-day scenario.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #52937
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
