### PR TITLE
Link the config pane help icon to the dedicated docs page

### DIFF
--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -525,10 +525,10 @@ export class HaServiceControl extends LitElement {
                 this._manifest
                   ? html` <a
                       href=${
-                        this._manifest.is_built_in
+                        this._manifest.is_built_in && this._value?.action
                           ? documentationUrl(
                               this.hass,
-                              `/integrations/${this._manifest.domain}`
+                              `/actions/${this._value.action}`
                             )
                           : this._manifest.documentation
                       }

--- a/src/panels/config/automation/condition/types/ha-automation-condition-platform.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-platform.ts
@@ -195,7 +195,7 @@ export class HaPlatformCondition extends LitElement {
                   this._manifest.is_built_in
                     ? documentationUrl(
                         this.hass,
-                        `/integrations/${this._manifest.domain}`
+                        `/conditions/${this.condition.condition}`
                       )
                     : this._manifest.documentation
                 }

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
@@ -190,7 +190,7 @@ export class HaPlatformTrigger extends LitElement {
                   this._manifest.is_built_in
                     ? documentationUrl(
                         this.hass,
-                        `/integrations/${this._manifest.domain}`
+                        `/triggers/${this.trigger.trigger}`
                       )
                     : this._manifest.documentation
                 }


### PR DESCRIPTION
## Proposed change

When configuring a trigger, condition, or action in the automation editor (and in Developer Tools), the small help icon in the options pane linked to the integration page (`/integrations/<domain>`). For built-in items it now links to the dedicated documentation page for that specific trigger, condition, or action, for example `/triggers/air_quality.co2_changed`, `/conditions/...`, or `/actions/light.turn_on`.

Custom integrations are unchanged and keep linking to their own documentation URL.


https://github.com/user-attachments/assets/8a133520-2146-4386-ac83-8d6a50029f2b



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
