### PR TITLE
Fix focus loss in text selector with multiple

### DIFF
--- a/src/components/input/ha-input-multi.ts
+++ b/src/components/input/ha-input-multi.ts
@@ -1,10 +1,11 @@
 import { consume, type ContextType } from "@lit/context";
 import { mdiDeleteOutline, mdiDragHorizontalVariant, mdiPlus } from "@mdi/js";
-import type { CSSResultGroup } from "lit";
+import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
 import { fireEvent } from "../../common/dom/fire_event";
+import { uid } from "../../common/util/uid";
 import { internationalizationContext } from "../../data/context";
 import { haStyle } from "../../resources/styles";
 import "../ha-button";
@@ -69,6 +70,25 @@ class HaInputMulti extends LitElement {
 
   @query("ha-input[data-last]") private _lastInput?: HaInput;
 
+  // Stable key per row, kept in sync with `value`. Because items are plain
+  // strings we cannot use a WeakMap (as the object-based sortable lists do),
+  // so we track keys in a parallel array. Keys stay fixed while a row is
+  // edited (preserving input focus) and travel with the row when reordered.
+  @state() private _keys: string[] = [];
+
+  protected willUpdate(changedProps: PropertyValues) {
+    super.willUpdate(changedProps);
+    if (changedProps.has("value") && this._keys.length !== this._items.length) {
+      // Reconcile keys when `value` is (re)set from outside, reusing existing
+      // keys and minting new ones for added rows. Internal add/remove/reorder
+      // keep `_keys` in sync themselves, so this is skipped in those cases.
+      this._keys = Array.from(
+        { length: this._items.length },
+        (_, i) => this._keys[i] ?? uid()
+      );
+    }
+  }
+
   protected render() {
     return html`
       <ha-sortable
@@ -80,7 +100,7 @@ class HaInputMulti extends LitElement {
         <div class="items">
           ${repeat(
             this._items,
-            (item, index) => `${item}-${index}`,
+            (_item, index) => this._keys[index],
             (item, index) => {
               const indexSuffix = `${this.itemIndex ? ` ${index + 1}` : ""}`;
               return html`
@@ -176,6 +196,7 @@ class HaInputMulti extends LitElement {
     if (this.max != null && this._items.length >= this.max) {
       return;
     }
+    this._keys = [...this._keys, uid()];
     const items = [...this._items, ""];
     this._fireChanged(items);
     await this.updateComplete;
@@ -208,11 +229,17 @@ class HaInputMulti extends LitElement {
     const items = [...this._items];
     const [moved] = items.splice(oldIndex, 1);
     items.splice(newIndex, 0, moved);
+    // Move the row's key with it so its DOM (and identity) is preserved.
+    const keys = [...this._keys];
+    const [movedKey] = keys.splice(oldIndex, 1);
+    keys.splice(newIndex, 0, movedKey);
+    this._keys = keys;
     this._fireChanged(items);
   }
 
   private async _removeItem(ev: Event) {
     const index = (ev.target as any).index;
+    this._keys = this._keys.filter((_, i) => i !== index);
     const items = [...this._items];
     items.splice(index, 1);
     this._fireChanged(items);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

A text selector configured to allow multiple values lost focus after every
keystroke, making it impossible to type normally in its input fields.

Each row in the multi-value input now has a stable identity that stays with the
row as you type, add, remove, or reorder entries. As a result the field keeps
focus while you type, and rows keep their identity when reordered.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52918
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
