### PR TITLE
Fix supervisor_add_addon_repository not opening add repository dialog

### DIFF
--- a/src/panels/config/apps/ha-config-apps-available.ts
+++ b/src/panels/config/apps/ha-config-apps-available.ts
@@ -87,17 +87,16 @@ export class HaConfigAppsAvailable extends LitElement {
     );
   }
 
-  protected firstUpdated(changedProps: PropertyValues<this>) {
+  protected async firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     const repositoryUrl = extractSearchParam("repository_url");
     if (repositoryUrl) {
-      navigate("/config/apps/available", { replace: true });
+      await navigate("/config/apps/available", { replace: true });
     }
-    this._loadData().then(() => {
-      if (repositoryUrl) {
-        this._addRepository(repositoryUrl);
-      }
-    });
+    await this._loadData();
+    if (repositoryUrl) {
+      this._addRepository(repositoryUrl);
+    }
     this.addEventListener("hass-api-called", (ev) => this._apiCalled(ev));
   }
 
@@ -250,7 +249,6 @@ export class HaConfigAppsAvailable extends LitElement {
     ) {
       return;
     }
-
     if (
       !(await showConfirmationDialog(this, {
         title: this.hass.localize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

None

## Proposed change

When using the `supervisor_add_addon_repository` redirect from My Home Assistant, the add repository confirmation dialog no longer appears.

The `firstUpdated` handler in `ha-config-apps-available` previously called `navigate()` without awaiting it, then used a `.then()` callback on `_loadData()` to call `_addRepository()`. These steps triggering simultaneously allowed the `location-changed` event to fire and potential state changes to race with data loading, causing the dialog to never be shown.

This change makes `firstUpdated` async, properly await both `navigate()` and `_loadData()` before calling `_addRepository()`, following the same pattern already used in `ha-config-app-dashboard.ts`.

This could be considered a hotfix suitable for inclusion with the next patch release, as it affects a user-facing workflow (adding third-party addon repositories via My Home Assistant).


## Screenshots

No visual changes.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/my.home-assistant.io/issues/698
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
