### PR TITLE
Fix fan speed slider displaying decimals instead of whole numbers

### DIFF
--- a/src/panels/lovelace/card-features/hui-fan-speed-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-fan-speed-card-feature.ts
@@ -171,7 +171,7 @@ class HuiFanSpeedCardFeature extends LitElement implements LovelaceCardFeature {
         .value=${value}
         min="0"
         max="100"
-        .step=${this._stateObj.attributes.percentage_step ?? 1}
+        .step=${1}
         @value-changed=${this._valueChanged}
         .label=${computeAttributeNameDisplay(
           this._localize,

--- a/src/state-control/fan/ha-state-control-fan-speed.ts
+++ b/src/state-control/fan/ha-state-control-fan-speed.ts
@@ -137,7 +137,7 @@ export class HaStateControlFanSpeed extends LitElement {
         min="0"
         max="100"
         .value=${this.sliderValue}
-        .step=${this.stateObj.attributes.percentage_step ?? 1}
+        .step=${1}
         @value-changed=${this._valueChanged}
         .label=${computeAttributeNameDisplay(
           this._i18n.localize,


### PR DESCRIPTION
Fixes #28159. The fan speed slider step was set to the entity's percentage_step attribute (e.g. 1.099), which caused steppedValue() to produce non-integer display values like 28.57% instead of 29%.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

None

## Proposed change

The tile card fan speed slider displays decimal values (like `28.57%`) instead of whole numbers when the fan entity has a non-integer `percentage_step` (for example, `1.099` from a fan with 91 speed levels).

The fix changes the slider step from the entity's `percentage_step` attribute to `1`, so the slider snaps to integer percentages (0-100) which display as whole numbers. The back-end still maps these integer percentages to the correct fan speed levels, so fan behavior is unchanged.

This update aligns with behavior of other components that rely on the `ha-control-slider`. The back-end already converts input in `set_percentage` to integers. This front-end change now matches actual back-end behavior.

The proposed change only impacts Tile cards with fan-speed configured, where the speed count of the entity is greater than 3. Fans with speed counts of 3 or less display buttons instead of a slider.


## Screenshots

Sliders show no decimal increments when `percentage_step` attribute is an arbitrarily long float: `1.098901098901099`.

<img width="353" height="396" alt="popoutslider" src="https://github.com/user-attachments/assets/50a8ce4f-a296-4517-bcfd-0f287aae075b" />
<img width="342" height="173" alt="inlineslider" src="https://github.com/user-attachments/assets/0df2af3b-796c-4e90-9dc0-e1c20c3306b5" />


## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/28159
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
