### PR TITLE
No need to show rename when alias is already provided

### DIFF
--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -1011,7 +1011,7 @@ export class HaAutomationEditor extends AutomationScriptEditorMixin<AutomationCo
     this._manualEditor?.resetPastedConfig();
 
     const id = this.automationId || String(Date.now());
-    if (!this.automationId) {
+    if (!this.automationId && !this.config?.alias) {
       const saved = await this._promptAutomationAlias();
       if (!saved) {
         return;

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -918,7 +918,7 @@ export class HaScriptEditor extends SubscribeMixin(
 
     this._manualEditor?.resetPastedConfig();
 
-    if (!this.scriptId) {
+    if (!this.scriptId && !this.config?.alias) {
       const saved = await this._promptScriptAlias();
       if (!saved) {
         return;

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -924,6 +924,14 @@ export class HaScriptEditor extends SubscribeMixin(
         return;
       }
       this.currentEntityId = this._computeEntityIdFromAlias(this.config!.alias);
+    if (!this.scriptId) {
+      if (!this.config?.alias) {
+        const saved = await this._promptScriptAlias();
+        if (!saved) {
+          return;
+        }
+      }
+      this.currentEntityId = this._computeEntityIdFromAlias(this.config!.alias);
     }
     const id = this.scriptId || this.currentEntityId || Date.now();
 

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -918,12 +918,6 @@ export class HaScriptEditor extends SubscribeMixin(
 
     this._manualEditor?.resetPastedConfig();
 
-    if (!this.scriptId && !this.config?.alias) {
-      const saved = await this._promptScriptAlias();
-      if (!saved) {
-        return;
-      }
-      this.currentEntityId = this._computeEntityIdFromAlias(this.config!.alias);
     if (!this.scriptId) {
       if (!this.config?.alias) {
         const saved = await this._promptScriptAlias();


### PR DESCRIPTION
## Proposed change
Fixes https://github.com/home-assistant/frontend/issues/52987
Fixes https://github.com/home-assistant/frontend/issues/52985

The rename dialog has dirty state right now and when you've already provided an alias (as name) it will be passed in. 
When you're creating a new automation (or script) it will show the dialog always, forcing you to take a new name. 

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
