### PR TITLE
Round fan speed slider display to whole percentages

### DIFF
--- a/src/components/ha-control-slider.ts
+++ b/src/components/ha-control-slider.ts
@@ -71,6 +71,17 @@ export class HaControlSlider extends LitElement {
   @property({ type: Number })
   public step = 1;
 
+  /**
+   * Round the value shown in the tooltip and announced to assistive
+   * technologies to the nearest integer. The handle still snaps to `step`, so
+   * the number of steps is unchanged. Useful when `step` is fractional but the
+   * value is conceptually a whole number — e.g. a fan whose `percentage_step`
+   * is 100 / speed_count (like ~1.0989 for 91 speeds), which would otherwise
+   * display fractional percentages such as "28.57%".
+   */
+  @property({ type: Boolean, attribute: "round-value" })
+  public roundValue = false;
+
   @property({ type: Number })
   public min = 0;
 
@@ -107,6 +118,11 @@ export class HaControlSlider extends LitElement {
     return Math.round(value / this.step) * this.step;
   }
 
+  private _displayedValue(value: number) {
+    const stepped = this.steppedValue(value);
+    return this.roundValue ? Math.round(stepped) : stepped;
+  }
+
   boundedValue(value: number) {
     return Math.min(Math.max(value, this.min), this.max);
   }
@@ -118,8 +134,8 @@ export class HaControlSlider extends LitElement {
 
   protected updated(changedProps: PropertyValues<this>) {
     super.updated(changedProps);
-    if (changedProps.has("value")) {
-      const valuenow = this.steppedValue(this.value ?? 0);
+    if (changedProps.has("value") || changedProps.has("roundValue")) {
+      const valuenow = this._displayedValue(this.value ?? 0);
       this.setAttribute("aria-valuenow", valuenow.toString());
       this.setAttribute("aria-valuetext", this._formatValue(valuenow));
     }
@@ -312,7 +328,7 @@ export class HaControlSlider extends LitElement {
       this.tooltipMode === "always" ||
       (this.tooltipVisible && this.tooltipMode === "interaction");
 
-    const value = this.steppedValue(this.value ?? 0);
+    const value = this._displayedValue(this.value ?? 0);
 
     return html`
       <span
@@ -330,7 +346,7 @@ export class HaControlSlider extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const valuenow = this.steppedValue(this.value ?? 0);
+    const valuenow = this._displayedValue(this.value ?? 0);
     return html`
       <div
         class="container${classMap({

--- a/src/panels/lovelace/card-features/hui-fan-speed-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-fan-speed-card-feature.ts
@@ -172,6 +172,7 @@ class HuiFanSpeedCardFeature extends LitElement implements LovelaceCardFeature {
         min="0"
         max="100"
         .step=${this._stateObj.attributes.percentage_step ?? 1}
+        round-value
         @value-changed=${this._valueChanged}
         .label=${computeAttributeNameDisplay(
           this._localize,

--- a/src/state-control/fan/ha-state-control-fan-speed.ts
+++ b/src/state-control/fan/ha-state-control-fan-speed.ts
@@ -138,6 +138,7 @@ export class HaStateControlFanSpeed extends LitElement {
         max="100"
         .value=${this.sliderValue}
         .step=${this.stateObj.attributes.percentage_step ?? 1}
+        round-value
         @value-changed=${this._valueChanged}
         .label=${computeAttributeNameDisplay(
           this._i18n.localize,

--- a/test/components/ha-control-slider.test.ts
+++ b/test/components/ha-control-slider.test.ts
@@ -48,3 +48,68 @@ describe("ha-control-slider value mapping", () => {
     expect(el.valueToPercentage(100)).toBe(0);
   });
 });
+
+describe("ha-control-slider display rounding", () => {
+  // A fan with 91 speeds reports percentage_step = 100 / 91 ≈ 1.0989, so a
+  // stepped percentage such as 29 snaps to 26 * step = 28.5714…
+  const FAN_STEP = 100 / 91;
+
+  let sliders: HaControlSlider[] = [];
+
+  const mountSlider = async (
+    props: Partial<HaControlSlider>
+  ): Promise<HaControlSlider> => {
+    const el = createSlider(props);
+    document.body.appendChild(el);
+    sliders.push(el);
+    await el.updateComplete;
+    return el;
+  };
+
+  const ariaValueNow = (el: HaControlSlider) =>
+    el
+      .shadowRoot!.querySelector('[role="slider"]')!
+      .getAttribute("aria-valuenow");
+
+  const tooltipText = (el: HaControlSlider) =>
+    el.shadowRoot!.querySelector(".tooltip")!.textContent!.trim();
+
+  afterEach(() => {
+    sliders.forEach((el) => el.remove());
+    sliders = [];
+  });
+
+  it("shows the fractional stepped value by default", async () => {
+    const el = await mountSlider({ step: FAN_STEP, value: 29 });
+    expect(tooltipText(el)).toBe("28.57");
+    expect(ariaValueNow(el)).toBe(el.steppedValue(29).toString());
+  });
+
+  it("rounds the displayed value to an integer when round-value is set", async () => {
+    const el = await mountSlider({
+      step: FAN_STEP,
+      value: 29,
+      roundValue: true,
+    });
+    expect(tooltipText(el)).toBe("29");
+    expect(ariaValueNow(el)).toBe("29");
+  });
+
+  it("still snaps to the real step grid when rounding the display", async () => {
+    const el = await mountSlider({
+      step: FAN_STEP,
+      value: 29,
+      roundValue: true,
+    });
+    // Only the shown value is rounded; the handle keeps the fractional step, so
+    // the number of speed steps (and keyboard granularity) is preserved.
+    expect(el.steppedValue(29)).toBeCloseTo(28.5714, 3);
+  });
+
+  it("keeps decimal steps intact unless round-value is set", async () => {
+    // A temperature-style slider must keep showing halves.
+    const el = await mountSlider({ step: 0.5, value: 21.5 });
+    expect(tooltipText(el)).toBe("21.5");
+    expect(ariaValueNow(el)).toBe("21.5");
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When a fan reports a non-integer `percentage_step` (for example a fan with 91 speeds, where the step is `100 / 91 ≈ 1.0989`), the speed slider snapped the shown value to that fractional grid and displayed percentages like `28.57%` in the tooltip and to screen readers.

This keeps the slider's real `step` — so it still snaps to the fan's actual speeds and each arrow key moves exactly one speed — and only rounds the value shown in the tooltip and announced via ARIA to a whole number. A new opt-in `round-value` property on `ha-control-slider` does the rounding; it is enabled on the fan speed feature and the more-info fan control. Every other slider is unaffected (e.g. temperature sliders keep showing halves).

Supersedes #52991, which fixed the display by forcing the step to `1`. That removed the speed snapping and made keyboard control move in 1% steps instead of per speed, which is a regression for fans with a small number of speeds.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #28159
- This PR is related to issue or discussion: supersedes #52991
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
