### PR TITLE
Fix history/logbook entity selection leaking across browser tabs

### DIFF
--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -64,13 +64,17 @@ class HaPanelHistory extends LitElement {
 
   @state() private _endDate: Date;
 
-  @state()
+  @state() private _targetPickerValue: HassServiceTarget = {};
+
+  // Remembers the last user-picked selection as a fallback for visits without
+  // URL params. Kept separate from _targetPickerValue because localStorage is
+  // synced across tabs and would leak one tab's selection into the others.
   @storage({
     key: "historyPickedValue",
-    state: true,
+    state: false,
     subscribe: false,
   })
-  private _targetPickerValue: HassServiceTarget = {};
+  private _storedTargetPickerValue?: HassServiceTarget;
 
   @state() private _isLoading = false;
 
@@ -228,9 +232,11 @@ class HaPanelHistory extends LitElement {
     const queryParams = decodeHistoryLogbookQueryParams(
       extractSearchParamsObject()
     );
-    const targetPickerValue = historyLogbookTargetFromQueryParams(queryParams);
-    if (targetPickerValue) {
-      this._targetPickerValue = targetPickerValue;
+    const initialValue =
+      historyLogbookTargetFromQueryParams(queryParams) ??
+      this._storedTargetPickerValue;
+    if (initialValue) {
+      this._targetPickerValue = initialValue;
     }
     if (queryParams.start_date) {
       this._startDate = queryParams.start_date;
@@ -268,6 +274,7 @@ class HaPanelHistory extends LitElement {
 
   private _removeAll() {
     this._targetPickerValue = {};
+    this._storedTargetPickerValue = this._targetPickerValue;
     this._updatePath();
   }
 
@@ -402,6 +409,7 @@ class HaPanelHistory extends LitElement {
 
   private _targetsChanged(ev) {
     this._targetPickerValue = ev.detail.value || {};
+    this._storedTargetPickerValue = this._targetPickerValue;
     this._updatePath();
   }
 

--- a/src/panels/logbook/ha-panel-logbook.ts
+++ b/src/panels/logbook/ha-panel-logbook.ts
@@ -40,13 +40,17 @@ export class HaPanelLogbook extends LitElement {
   @state()
   private _showBack?: boolean;
 
-  @state()
+  @state() private _targetPickerValue: HassServiceTarget = {};
+
+  // Remembers the last user-picked selection as a fallback for visits without
+  // URL params. Kept separate from _targetPickerValue because localStorage is
+  // synced across tabs and would leak one tab's selection into the others.
   @storage({
     key: "logbookPickedValue",
-    state: true,
+    state: false,
     subscribe: false,
   })
-  private _targetPickerValue: HassServiceTarget = {};
+  private _storedTargetPickerValue?: HassServiceTarget;
 
   public constructor() {
     super();
@@ -176,6 +180,8 @@ export class HaPanelLogbook extends LitElement {
     const targetPickerValue = historyLogbookTargetFromQueryParams(queryParams);
     if (targetPickerValue) {
       this._targetPickerValue = targetPickerValue;
+    } else if (!this.hasUpdated && this._storedTargetPickerValue) {
+      this._targetPickerValue = this._storedTargetPickerValue;
     }
 
     if (queryParams.start_date || queryParams.end_date) {
@@ -208,6 +214,7 @@ export class HaPanelLogbook extends LitElement {
 
   private _targetsChanged(ev) {
     this._targetPickerValue = ev.detail.value || {};
+    this._storedTargetPickerValue = this._targetPickerValue;
     this._updatePath();
   }
 


### PR DESCRIPTION
## Proposed change

With more than one History (or Activity/logbook) tab open in the same browser, updating one tab would make every other tab jump to the same entity selection. Since #52439, each tab persists its URL-derived selection through the `@storage` setter into a shared `localStorage` key, and the storage decorator syncs that value into every other tab even with `subscribe: false` — so one tab's selection overwrote all the others.

This splits the live selection from the remembered preference:

- `_targetPickerValue` is now plain per-tab component state, so tabs no longer share it.
- A separate stored field keeps the last **explicitly picked** selection. It's read once as a fallback when opening the panel without URL parameters, and written only when the user changes the picker or clears it.

The "remember my last selection" behavior is preserved, but opening the panel from a URL (e.g. a dashboard link) no longer clobbers what other tabs are showing. The same fix is applied to the Activity (logbook) panel, which shares this pattern.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #53000
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
