### PR TITLE
Fix My redirect for AI tasks to /config/ai-tasks

### DIFF
--- a/src/panels/my/ha-panel-my.ts
+++ b/src/panels/my/ha-panel-my.ts
@@ -165,7 +165,7 @@ export const getMyRedirects = (): Redirects => ({
     redirect: "/config/bluetooth/visualization",
   },
   config_ai_task: {
-    redirect: "/config/general/#ai-task",
+    redirect: "/config/ai-tasks",
   },
   config_bluetooth: {
     component: "bluetooth",


### PR DESCRIPTION
## Breaking change


## Proposed change

The My Home Assistant redirect for AI tasks (`config_ai_task`) pointed to `/config/general/#ai-task`, but AI tasks was moved into its own panel at `/config/ai-tasks`. The old anchor no longer exists, so the link landed on a broken page.

This updates the redirect target to `/config/ai-tasks`. As a result, the "AI Preferences" My link now opens the correct page, and pressing `m` on the AI tasks page generates a valid My link instead of showing "No matching My link found".

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #53009
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
