### PR TITLE
Fix tile trend graph rendering blank when shown by a visibility condition

### DIFF
--- a/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
@@ -1,3 +1,4 @@
+import { ResizeController } from "@lit-labs/observers/resize-controller";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
@@ -6,6 +7,7 @@ import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { isNumericFromAttributes } from "../../../common/number/format_number";
 import {
+  type EntityHistoryState,
   limitedHistoryFromStateObj,
   subscribeHistoryStatesTimeWindow,
 } from "../../../data/history";
@@ -56,6 +58,21 @@ class HuiHistoryChartCardFeature
 
   private _interval?: number;
 
+  private _stateHistory?: EntityHistoryState[];
+
+  // Recompute the graph geometry when the feature is resized or revealed
+  // (e.g. by a section/card visibility condition), since the coordinates are
+  // scaled to the element's pixel size and would otherwise stay collapsed to
+  // the size measured while hidden.
+  // @ts-ignore side-effect-only controller, its value is never read
+  private _resizeController = new ResizeController(this, {
+    callback: (entries) => {
+      if (entries[0]?.contentRect.width) {
+        this._calculateCoordinates();
+      }
+    },
+  });
+
   static getStubConfig(): TrendGraphCardFeatureConfig {
     return {
       type: "trend-graph",
@@ -91,26 +108,51 @@ class HuiHistoryChartCardFeature
   }
 
   protected firstUpdated() {
-    this._setLoadingCoordinates();
+    this._calculateCoordinates();
     if (this.isConnected) {
       this._subscribeHistory();
     }
   }
 
-  private _setLoadingCoordinates() {
+  private _calculateCoordinates() {
     const entityId = this.context?.entity_id;
     if (!entityId || !this.hass) {
       return;
     }
-    const stateObj = this.hass.states[entityId];
-    if (!stateObj) {
+    const width = this.clientWidth;
+    const height = this.clientHeight;
+
+    // History not loaded yet: show the loading state based on the current state.
+    if (!this._stateHistory) {
+      const stateObj = this.hass.states[entityId];
+      if (!stateObj) {
+        return;
+      }
+      const { points, yAxisOrigin } = coordinatesMinimalResponseCompressedState(
+        limitedHistoryFromStateObj(stateObj),
+        width,
+        height,
+        10
+      );
+      this._coordinates = points;
+      this._yAxisOrigin = yAxisOrigin;
       return;
     }
+
+    const hourToShow = this._config?.hours_to_show ?? DEFAULT_HOURS_TO_SHOW;
+    const detail = this._config?.detail !== false; // default to true (high detail)
+    // sample to 1 point per hour for low detail or 1 point per 5 pixels for high detail
+    const maxDetails = detail
+      ? Math.max(10, width / 5, hourToShow)
+      : Math.max(10, hourToShow);
+    const useMean = !detail;
     const { points, yAxisOrigin } = coordinatesMinimalResponseCompressedState(
-      limitedHistoryFromStateObj(stateObj),
-      this.clientWidth,
-      this.clientHeight,
-      10
+      this._stateHistory,
+      width,
+      height,
+      maxDetails,
+      undefined,
+      useMean
     );
     this._coordinates = points;
     this._yAxisOrigin = yAxisOrigin;
@@ -190,7 +232,6 @@ class HuiHistoryChartCardFeature
     }
 
     const hourToShow = this._config.hours_to_show ?? DEFAULT_HOURS_TO_SHOW;
-    const detail = this._config.detail !== false; // default to true (high detail)
 
     this._subscribed = subscribeHistoryStatesTimeWindow(
       this.hass!,
@@ -203,23 +244,9 @@ class HuiHistoryChartCardFeature
             history = limitedHistoryFromStateObj(stateObj);
           }
         }
-        // sample to 1 point per hour for low detail or 1 point per 5 pixels for high detail
-        const maxDetails = detail
-          ? Math.max(10, this.clientWidth / 5, hourToShow)
-          : Math.max(10, hourToShow);
-        const useMean = !detail;
-        const { points, yAxisOrigin } =
-          coordinatesMinimalResponseCompressedState(
-            history,
-            this.clientWidth,
-            this.clientHeight,
-            maxDetails,
-            undefined,
-            useMean
-          );
-        this._coordinates = points;
-        this._yAxisOrigin = yAxisOrigin;
+        this._stateHistory = history ?? [];
         this._loading = false;
+        this._calculateCoordinates();
       },
       hourToShow,
       [this.context!.entity_id!]


### PR DESCRIPTION
## Breaking change


## Proposed change

Tile cards with a trend-graph feature rendered blank when they were shown by a dashboard visibility condition (a `conditional` card was unaffected).

The graph scales its line to the element's pixel size, but with a visibility condition the tile is measured while it is still hidden (zero width), so every point collapses to the top-left corner and nothing recomputes it once the tile becomes visible.

This adds a resize observer to the trend-graph feature so it recalculates its coordinates when it gains a real size — when revealed by a visibility condition, or when the window is resized — matching how the weather forecast card features already behave.

## Screenshots

<!-- Before: blank graph (tiny dot top-left) when the section is revealed. After: the graph draws correctly. -->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #53007
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
