### PR TITLE
Use more user-friendly 'Fit mode' options in Picture entity card

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9782,9 +9782,9 @@
               "entity": "Entity",
               "fit_mode": "Fit mode",
               "fit_mode_options": {
-                "contain": "Contain",
-                "cover": "Cover",
-                "fill": "Fill"
+                "contain": "Scaled (Contain)",
+                "cover": "Cropped (Cover)",
+                "fill": "Stretched (Fill)"
               },
               "hold_action": "Hold behavior",
               "hours_to_show": "Hours to show",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

For images or video feeds the Picture entity card offers the three fit modes

<img width="402" height="311" alt="image" src="https://github.com/user-attachments/assets/e6452b5f-63bd-4184-aad3-8035a8612c7d" />


which may be clear for HTML devs but certainly not for the average user.

And this becomes even worse in translations - we just got a user to completely alter the German wording in Lokalise because of that, something that should be avoided by clarifying in English instead.

Therefore this PR replaces the options with a wording that is easy to translate, while keeping the CSS properties in brackets:
- Cropped (Cover)
- Scaled (Contain)
- Stretched (Fill)

As indicated by capitalization within the brackets the English words can be kept in translations.
Google Translate understands this correctly:

<img width="1180" height="392" alt="image" src="https://github.com/user-attachments/assets/0fa60db7-0eab-48bc-977d-3d6dae9a232b" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
