### PR TITLE
Fix date range picker presets rendering blank when translations load late

### DIFF
--- a/src/components/date-picker/ha-date-range-picker.ts
+++ b/src/components/date-picker/ha-date-range-picker.ts
@@ -4,7 +4,7 @@ import { mdiCalendar } from "@mdi/js";
 import "cally";
 import { isThisYear } from "date-fns";
 import type { HassConfig } from "home-assistant-js-websocket/dist/types";
-import type { TemplateResult } from "lit";
+import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { tinykeys } from "tinykeys";
@@ -112,17 +112,28 @@ export class HaDateRangePicker extends LitElement {
 
     this._handleResize();
     window.addEventListener("resize", this._handleResize);
+  }
 
-    const rangeKeys = this.extendedPresets
-      ? [...RANGE_KEYS, ...EXTENDED_RANGE_KEYS]
-      : RANGE_KEYS;
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
 
-    this._ranges = {};
-    rangeKeys.forEach((key) => {
-      this._ranges![
-        this._i18n.localize(`ui.components.date-range-picker.ranges.${key}`)
-      ] = calcDateRange(this._i18n.locale, this._hassConfig, key);
-    });
+    if (
+      changedProps.has("_i18n") ||
+      changedProps.has("_hassConfig") ||
+      changedProps.has("extendedPresets")
+    ) {
+      const rangeKeys = this.extendedPresets
+        ? [...RANGE_KEYS, ...EXTENDED_RANGE_KEYS]
+        : RANGE_KEYS;
+
+      const ranges: DateRangePickerRanges = {};
+      rangeKeys.forEach((key) => {
+        ranges[
+          this._i18n.localize(`ui.components.date-range-picker.ranges.${key}`)
+        ] = calcDateRange(this._i18n.locale, this._hassConfig, key);
+      });
+      this._ranges = ranges;
+    }
   }
 
   public open(): void {

--- a/test/components/date-picker/ha-date-range-picker.test.ts
+++ b/test/components/date-picker/ha-date-range-picker.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import "../../../src/components/date-picker/ha-date-range-picker";
+import type { HaDateRangePicker } from "../../../src/components/date-picker/ha-date-range-picker";
+import {
+  DateFormat,
+  FirstWeekday,
+  NumberFormat,
+  TimeFormat,
+  TimeZone,
+} from "../../../src/data/translation";
+import type { LocalizeFunc } from "../../../src/common/translations/localize";
+
+const locale = {
+  language: "en",
+  number_format: NumberFormat.language,
+  time_format: TimeFormat.language,
+  date_format: DateFormat.language,
+  time_zone: TimeZone.local,
+  first_weekday: FirstWeekday.language,
+};
+
+const mockConfig = { time_zone: "Etc/UTC" };
+
+const createI18n = (localize: LocalizeFunc) => ({
+  localize,
+  locale,
+  language: "en",
+});
+
+// Localize behavior before the translation chunk has loaded.
+const emptyLocalize: LocalizeFunc = () => "";
+// Localize behavior once translations are available.
+const loadedLocalize: LocalizeFunc = (key) => String(key).split(".").pop()!;
+
+const createPicker = async (
+  localize: LocalizeFunc,
+  props: Partial<HaDateRangePicker> = {}
+) => {
+  const el = document.createElement(
+    "ha-date-range-picker"
+  ) as HaDateRangePicker;
+  el.minimal = true;
+  Object.assign(el, props);
+  (el as any)._i18n = createI18n(localize);
+  // _hassConfig is wrapped by @transform, whose setter picks `.config` off
+  // the assigned value, so assign the pre-transform shape.
+  (el as any)._hassConfig = { config: mockConfig };
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+};
+
+const rangeKeys = (el: HaDateRangePicker): string[] =>
+  Object.keys((el as any)._ranges ?? {});
+
+describe("ha-date-range-picker preset ranges", () => {
+  beforeAll(() => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }) as any;
+    // jsdom's ElementInternals lacks the validity API used by the
+    // webawesome button that renders inside this component.
+    const internalsProto = window.ElementInternals.prototype as any;
+    internalsProto.setValidity = vi.fn();
+    internalsProto.setFormValue = vi.fn();
+    Object.defineProperty(internalsProto, "validity", {
+      get: () => ({ valid: true }),
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("computes labeled ranges when translations are already loaded", async () => {
+    const el = await createPicker(loadedLocalize);
+    expect(rangeKeys(el)).toEqual(["today", "yesterday", "this_week"]);
+  });
+
+  it("recomputes ranges when localize updates after translations load", async () => {
+    const el = await createPicker(emptyLocalize);
+    // Before translations arrive, every label is "" and entries collapse.
+    expect(rangeKeys(el)).toEqual([""]);
+
+    (el as any)._i18n = createI18n(loadedLocalize);
+    await el.updateComplete;
+    expect(rangeKeys(el)).toEqual(["today", "yesterday", "this_week"]);
+  });
+
+  it("recomputes ranges when the timezone config changes", async () => {
+    const el = await createPicker(loadedLocalize);
+    const before = (el as any)._ranges;
+
+    (el as any)._hassConfig = { config: { time_zone: "America/New_York" } };
+    await el.updateComplete;
+    expect((el as any)._ranges).not.toBe(before);
+    expect(rangeKeys(el)).toEqual(["today", "yesterday", "this_week"]);
+  });
+
+  it("includes the extended presets when enabled", async () => {
+    const el = await createPicker(loadedLocalize, { extendedPresets: true });
+    expect(rangeKeys(el)).toEqual([
+      "today",
+      "yesterday",
+      "this_week",
+      "this_month",
+      "this_year",
+      "now-1h",
+      "now-12h",
+      "now-24h",
+      "now-7d",
+      "now-30d",
+    ]);
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Fixes the date-range picker's preset list ("Today", "Yesterday", "This week", …) intermittently rendering blank, most visibly on the History page.

The presets were computed exactly once, in `connectedCallback()`. If the component connected before the lazy-loaded translation chunk containing `ui.components.date-range-picker.ranges.*` arrived, `localize()` returned an empty string for every key, so all presets collapsed into a single empty-labeled entry — and nothing ever recomputed them. Everything else in the component self-heals because it localizes inside `render()`; only the preset ranges were frozen. Reproduced on Firefox (macOS and Linux); whether the race is hit depends on load timing, so it appears on roughly half of page loads. Navigating away and back "fixed" it because the component reconnected after translations had loaded.

The presets are now computed in `willUpdate()` whenever the internationalization context, the core config, or the `extended-presets` option changes. As a side effect this also fixes two latent bugs: presets not updating when the user changes their language or the instance timezone while the page is open.

Verified A/B against a real instance via `frontend: development_repo:` in Firefox: repeated reloads of /history showed blank presets on roughly half of loads on `dev`, and never with this fix. Unit tests cover the race, the timezone-change recompute, and the extended-presets variant.

Not addressed here (pre-existing design smell): the ranges record is keyed by the localized label itself, which is what allows all entries to collapse when labels collide. A follow-up could key by the range id instead.

## Screenshots
Before:
<img width="939" height="919" alt="Screenshot 2026-07-07 at 21 47 36" src="https://github.com/user-attachments/assets/88388994-c229-4d39-8536-b4b8041e308a" />

After:
<img width="939" height="919" alt="Screenshot 2026-07-07 at 21 47 45" src="https://github.com/user-attachments/assets/e995e818-2058-487f-bf66-354acd591ddc" />



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
