### PR TITLE
Clarify E2E report failures

### DIFF
--- a/test/e2e/app.spec.ts
+++ b/test/e2e/app.spec.ts
@@ -205,6 +205,10 @@ test.describe("App shell", () => {
 // ---------------------------------------------------------------------------
 
 test.describe("Panel navigation", () => {
+  test("intentionally fails to exercise report output", () => {
+    expect(true).toBe(false);
+  });
+
   test("navigates to lovelace dashboard", async ({ page }) => {
     await goToPanel(page, "/lovelace");
     await expect(

--- a/test/e2e/app.spec.ts
+++ b/test/e2e/app.spec.ts
@@ -205,10 +205,6 @@ test.describe("App shell", () => {
 // ---------------------------------------------------------------------------
 
 test.describe("Panel navigation", () => {
-  test("intentionally fails to exercise report output", () => {
-    expect(true).toBe(false);
-  });
-
   test("navigates to lovelace dashboard", async ({ page }) => {
     await goToPanel(page, "/lovelace");
     await expect(

--- a/test/e2e/post-report-comment.mjs
+++ b/test/e2e/post-report-comment.mjs
@@ -40,7 +40,7 @@ const collectFailures = (report) => {
 
         const title = [...here, spec.title].join(" › ");
         failures.push({
-          title: test.projectName ? `[${test.projectName}] ${title}` : title,
+          title: test.projectName ? `\`${test.projectName}\` ${title}` : title,
           location: `${spec.file ?? suite.file ?? ""}:${spec.line ?? ""}`,
           attempts,
         });

--- a/test/e2e/post-report-comment.mjs
+++ b/test/e2e/post-report-comment.mjs
@@ -27,19 +27,24 @@ const collectFailures = (report) => {
     const here = suite.title ? [...titlePath, suite.title] : titlePath;
     for (const spec of suite.specs ?? []) {
       if (spec.ok) continue;
-      const errors = [];
       for (const test of spec.tests ?? []) {
-        for (const result of test.results ?? []) {
+        const attempts = [];
+        for (const [index, result] of (test.results ?? []).entries()) {
+          const errors = [];
           for (const err of result.errors ?? []) {
             if (err.message) errors.push(stripAnsi(err.message));
           }
+          if (errors.length) attempts.push({ index: index + 1, errors });
         }
+        if (!attempts.length) continue;
+
+        const title = [...here, spec.title].join(" › ");
+        failures.push({
+          title: test.projectName ? `[${test.projectName}] ${title}` : title,
+          location: `${spec.file ?? suite.file ?? ""}:${spec.line ?? ""}`,
+          attempts,
+        });
       }
-      failures.push({
-        title: [...here, spec.title].join(" › "),
-        location: `${spec.file ?? suite.file ?? ""}:${spec.line ?? ""}`,
-        errors,
-      });
     }
     for (const child of suite.suites ?? []) walk(child, here);
   };
@@ -50,7 +55,12 @@ const collectFailures = (report) => {
 
 const formatFailure = (failure) => {
   const output =
-    failure.errors.join("\n\n").trim() || "(no error output captured)";
+    failure.attempts
+      .map(({ index, errors }) =>
+        [`Attempt ${index}`, "", errors.join("\n\n")].join("\n")
+      )
+      .join("\n\n")
+      .trim() || "(no error output captured)";
   return [
     `<details><summary>❌ ${failure.title} <code>${failure.location}</code></summary>`,
     "",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
https://github.com/home-assistant/frontend/pull/53045#issuecomment-4913594314 discovered an issue with the comments looking like they printed the same error twice, when it was actually the mobile and desktop suites failing.

- Failure entries are now emitted per Playwright project/test entry.
- Headings include projectName when present, like [chromium] .... (https://github.com/home-assistant/frontend/pull/53052#issuecomment-4913879683 with one addition of `[chromium`)
- Retry output is grouped as Attempt 1, Attempt 2, etc., instead of repeated unlabeled errors.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
