### PR TITLE
Use supervisor-provided options for string app config fields

### DIFF
--- a/src/panels/config/apps/app-view/config/supervisor-app-config.ts
+++ b/src/panels/config/apps/app-view/config/supervisor-app-config.ts
@@ -181,23 +181,24 @@ class SupervisorAppConfig extends DirtyStateProviderMixin<
       return { select: { options: entry.options, multiple: entry.multiple } };
     }
     if (entry.type === "string") {
-      return entry.multiple
-        ? {
-            select: {
-              options: entry.options ?? [],
-              multiple: true,
-              custom_value: true,
-            },
-          }
-        : {
-            text: {
-              type: entry.format
-                ? entry.format
-                : MASKED_FIELDS.includes(entry.name)
-                  ? "password"
-                  : "text",
-            },
-          };
+      if (entry.multiple) {
+        return {
+          select: {
+            options: entry.options ?? [],
+            multiple: true,
+            custom_value: true,
+          },
+        };
+      }
+      const textType = entry.format
+        ? entry.format
+        : MASKED_FIELDS.includes(entry.name)
+          ? "password"
+          : "text";
+      if (textType === "text" && entry.options?.length) {
+        return { select: { options: entry.options, custom_value: true } };
+      }
+      return { text: { type: textType } };
     }
     if (entry.type === "boolean") {
       return { boolean: {} };

--- a/src/panels/config/apps/app-view/config/supervisor-app-config.ts
+++ b/src/panels/config/apps/app-view/config/supervisor-app-config.ts
@@ -37,6 +37,7 @@ import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import { supervisorAppsStyle } from "../../resources/supervisor-apps-style";
 import { suggestSupervisorAppRestart } from "../dialogs/suggestSupervisorAppRestart";
+import { stringSchemaEntrySelector } from "../util/string-schema-selector";
 
 const SUPPORTED_UI_TYPES = [
   "string",
@@ -52,8 +53,6 @@ const secretTag = defineScalarTag("!secret", {
 });
 
 const ADDON_YAML_SCHEMA = YAML11_SCHEMA.withTags(secretTag);
-
-const MASKED_FIELDS = ["password", "secret", "token"];
 
 @customElement("supervisor-app-config")
 class SupervisorAppConfig extends DirtyStateProviderMixin<
@@ -181,24 +180,7 @@ class SupervisorAppConfig extends DirtyStateProviderMixin<
       return { select: { options: entry.options, multiple: entry.multiple } };
     }
     if (entry.type === "string") {
-      if (entry.multiple) {
-        return {
-          select: {
-            options: entry.options ?? [],
-            multiple: true,
-            custom_value: true,
-          },
-        };
-      }
-      const textType = entry.format
-        ? entry.format
-        : MASKED_FIELDS.includes(entry.name)
-          ? "password"
-          : "text";
-      if (textType === "text" && entry.options?.length) {
-        return { select: { options: entry.options, custom_value: true } };
-      }
-      return { text: { type: textType } };
+      return stringSchemaEntrySelector(entry);
     }
     if (entry.type === "boolean") {
       return { boolean: {} };

--- a/src/panels/config/apps/app-view/config/supervisor-app-config.ts
+++ b/src/panels/config/apps/app-view/config/supervisor-app-config.ts
@@ -182,7 +182,13 @@ class SupervisorAppConfig extends DirtyStateProviderMixin<
     }
     if (entry.type === "string") {
       return entry.multiple
-        ? { select: { options: [], multiple: true, custom_value: true } }
+        ? {
+            select: {
+              options: entry.options ?? [],
+              multiple: true,
+              custom_value: true,
+            },
+          }
         : {
             text: {
               type: entry.format

--- a/src/panels/config/apps/app-view/util/string-schema-selector.ts
+++ b/src/panels/config/apps/app-view/util/string-schema-selector.ts
@@ -1,0 +1,37 @@
+import type { Selector } from "../../../../../data/selector";
+
+export const MASKED_FIELDS = ["password", "secret", "token"];
+
+export interface StringSchemaEntry {
+  name: string;
+  multiple?: boolean;
+  format?: "email" | "password" | "url";
+  options?: string[];
+}
+
+export const stringSchemaEntrySelector = (
+  entry: StringSchemaEntry
+): Selector => {
+  if (entry.multiple) {
+    return {
+      select: {
+        options: entry.options ?? [],
+        multiple: true,
+        custom_value: true,
+      },
+    };
+  }
+  // Single-value fields keep the text selector even when options are
+  // available: the single-value custom_value picker cannot store an empty
+  // string (clearing emits undefined, dropping the key on save), which
+  // would silently change stored-value semantics versus the text field.
+  return {
+    text: {
+      type: entry.format
+        ? entry.format
+        : MASKED_FIELDS.includes(entry.name)
+          ? "password"
+          : "text",
+    },
+  };
+};

--- a/test/panels/config/apps/string-schema-selector.test.ts
+++ b/test/panels/config/apps/string-schema-selector.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { stringSchemaEntrySelector } from "../../../../src/panels/config/apps/app-view/util/string-schema-selector";
+
+describe("stringSchemaEntrySelector", () => {
+  it("renders multi-value fields as a multi-select with supervisor options", () => {
+    expect(
+      stringSchemaEntrySelector({
+        name: "enabled_shares",
+        multiple: true,
+        options: ["addons", "backup", "config"],
+      })
+    ).toEqual({
+      select: {
+        options: ["addons", "backup", "config"],
+        multiple: true,
+        custom_value: true,
+      },
+    });
+  });
+
+  it("renders multi-value fields without options as an empty multi-select", () => {
+    expect(
+      stringSchemaEntrySelector({ name: "veto_files", multiple: true })
+    ).toEqual({
+      select: { options: [], multiple: true, custom_value: true },
+    });
+  });
+
+  it("keeps single-value fields as text even when options are present", () => {
+    expect(
+      stringSchemaEntrySelector({
+        name: "share_on_port",
+        options: ["443", "8443", "10000"],
+      })
+    ).toEqual({ text: { type: "text" } });
+  });
+
+  it("keeps masked fields as password text even when options are present", () => {
+    expect(
+      stringSchemaEntrySelector({ name: "token", options: ["a", "b"] })
+    ).toEqual({ text: { type: "password" } });
+  });
+
+  it("keeps format-typed fields as text even when options are present", () => {
+    expect(
+      stringSchemaEntrySelector({
+        name: "contact",
+        format: "email",
+        options: ["a@b.c"],
+      })
+    ).toEqual({ text: { type: "email" } });
+  });
+
+  it("renders plain single-value fields without options as text", () => {
+    expect(stringSchemaEntrySelector({ name: "workgroup" })).toEqual({
+      text: { type: "text" },
+    });
+  });
+
+  it("renders masked fields without options as password text", () => {
+    expect(stringSchemaEntrySelector({ name: "password" })).toEqual({
+      text: { type: "password" },
+    });
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Multi-value string fields in app configuration always render with an empty
suggestion list, because the selector conversion hard-codes `options: []`. For
users this means fields like the Samba add-on's "Enabled shares" open an empty
dropdown and valid values must be typed from memory.

home-assistant/supervisor#7023 makes Supervisor include `options` on string
schema nodes whose `match()` regex is a simple alternation of literals. This
change passes those through to the select selector so valid values appear as
suggestions. `custom_value` stays enabled, so free-text entry is unaffected and
validation semantics do not change. Single-value string fields deliberately
keep their text selector even when options are present: the single-value
`custom_value` picker cannot store an empty string (clearing emits `undefined`,
which drops the key on save), so converting them would silently change
stored-value semantics. The schema-to-selector mapping for string fields is
extracted into a small util module with unit tests covering each outcome.

This PR functionally depends on home-assistant/supervisor#7023: today's
Supervisor never includes `options` on string schema nodes, so without that PR
this change is a safe no-op (`entry.options` is undefined and behavior is
byte-identical to today). Either merge order is safe, but there is no
user-visible effect until the Supervisor counterpart lands.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

To be added: before (the current empty suggestion list on the Samba add-on's
"Enabled shares" field) and after (requires running this branch against a
Supervisor that includes home-assistant/supervisor#7023).

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51510
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: home-assistant/supervisor#7023

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
