### PR TITLE
Make config dashboard responsive on wide screens

### DIFF
--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -334,25 +334,27 @@ class HaConfigDashboard extends SubscribeMixin(LitElement) {
                 </div>`
               : ""
           }
-          ${this._pages(
-            this.cloudStatus,
-            isComponentLoaded(this.hass.config, "cloud"),
-            this.hass.auth.external?.config.hasSettingsScreen,
-            this.hass.userData?.apps_info_dismissed,
-            isComponentLoaded(this.hass.config, "hassio")
-          ).map((categoryPages) =>
-            categoryPages.length === 0
-              ? nothing
-              : html`
-                  <ha-card outlined>
-                    <ha-config-navigation
-                      .hass=${this.hass}
-                      .narrow=${this.narrow}
-                      .pages=${categoryPages}
-                    ></ha-config-navigation>
-                  </ha-card>
-                `
-          )}
+          <div class="cards">
+            ${this._pages(
+              this.cloudStatus,
+              isComponentLoaded(this.hass.config, "cloud"),
+              this.hass.auth.external?.config.hasSettingsScreen,
+              this.hass.userData?.apps_info_dismissed,
+              isComponentLoaded(this.hass.config, "hassio")
+            ).map((categoryPages) =>
+              categoryPages.length === 0
+                ? nothing
+                : html`
+                    <ha-card outlined>
+                      <ha-config-navigation
+                        .hass=${this.hass}
+                        .narrow=${this.narrow}
+                        .pages=${categoryPages}
+                      ></ha-config-navigation>
+                    </ha-card>
+                  `
+            )}
+          </div>
           <ha-tip>${this._tip}</ha-tip>
         </ha-config-section>
       </ha-top-app-bar-fixed>
@@ -414,7 +416,20 @@ class HaConfigDashboard extends SubscribeMixin(LitElement) {
         ha-config-section {
           margin: auto;
           margin-top: -32px;
-          max-width: 600px;
+          max-width: 1040px;
+          padding: 0 var(--ha-space-4);
+          box-sizing: border-box;
+        }
+
+        .cards {
+          columns: 400px 2;
+          column-gap: var(--ha-space-4);
+          margin-bottom: calc(-1 * var(--ha-space-4));
+        }
+
+        .cards > * {
+          break-inside: avoid;
+          margin-bottom: var(--ha-space-4);
         }
 
         ha-card {
@@ -427,9 +442,13 @@ class HaConfigDashboard extends SubscribeMixin(LitElement) {
         }
 
         .dashboard-alerts {
-          display: flex;
-          flex-direction: column;
+          display: grid;
+          grid-template-columns: repeat(
+            auto-fit,
+            minmax(min(400px, 100%), 1fr)
+          );
           gap: var(--ha-space-4);
+          align-items: start;
         }
 
         .dashboard-alert-title {
@@ -457,6 +476,7 @@ class HaConfigDashboard extends SubscribeMixin(LitElement) {
           }
           ha-config-section {
             margin-top: -42px;
+            padding: 0;
           }
         }
 


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
nope

## Proposed change
The settings dashboard was a single column capped at 600px, leaving large empty margins on wide screens. Widen the page to 1040px and flow the category cards into balanced masonry columns, collapsing to a single column on narrow screens. Lay out the repairs/updates alert cards side by side on wide screens too. The mobile edge-to-edge design is preserved.


## Screenshots
before: 
<img width="3340" height="1808" alt="Screenshot From 2026-07-10 19-12-02" src="https://github.com/user-attachments/assets/1139b124-b359-4b30-8ffd-1332d4df215b" />

after: 
<img width="2738" height="1734" alt="image" src="https://github.com/user-attachments/assets/d5b808e2-292b-422c-9279-304fdbc8a784" />

smaller screen: (same as before)
<img width="2016" height="1714" alt="Screenshot From 2026-07-10 19-12-46" src="https://github.com/user-attachments/assets/227abb82-5513-4ea3-9fd2-430af99841d0" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code/UI quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
