### PR TITLE
Add SSH authorized keys configuration for Home Assistant OS

### DIFF
--- a/src/data/hassio/host.ts
+++ b/src/data/hassio/host.ts
@@ -158,6 +158,26 @@ export const changeHostOptions = async (hass: HomeAssistant, options: any) => {
   );
 };
 
+export const setOSSSHAuthorizedKeys = async (
+  hass: HomeAssistant,
+  keys: string[]
+) => {
+  if (atLeastVersion(hass.config.version, 2021, 2, 4)) {
+    return hass.callWS({
+      type: "supervisor/api",
+      endpoint: "/os/ssh/authorized_keys",
+      method: "post",
+      data: { keys },
+    });
+  }
+
+  return hass.callApi<HassioResponse<void>>(
+    "POST",
+    "hassio/os/ssh/authorized_keys",
+    { keys }
+  );
+};
+
 export const moveDatadisk = async (hass: HomeAssistant, device: string) => {
   if (atLeastVersion(hass.config.version, 2021, 2, 4)) {
     return hass.callWS({

--- a/src/panels/config/hardware/dialog-ssh-authorized-keys.ts
+++ b/src/panels/config/hardware/dialog-ssh-authorized-keys.ts
@@ -1,0 +1,173 @@
+import type { CSSResultGroup } from "lit";
+import { css, html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../../common/dom/fire_event";
+import "../../../components/ha-alert";
+import "../../../components/ha-button";
+import "../../../components/ha-dialog";
+import "../../../components/ha-dialog-footer";
+import "../../../components/ha-textarea";
+import type { HaTextArea } from "../../../components/ha-textarea";
+import { extractApiErrorMessage } from "../../../data/hassio/common";
+import { setOSSSHAuthorizedKeys } from "../../../data/hassio/host";
+import {
+  showAlertDialog,
+  showConfirmationDialog,
+} from "../../../dialogs/generic/show-dialog-box";
+import { DirtyStateProviderMixin } from "../../../mixins/dirty-state-provider-mixin";
+import { haStyle, haStyleDialog } from "../../../resources/styles";
+import type { HomeAssistant } from "../../../types";
+
+interface SSHAuthorizedKeysFormState {
+  keys: string;
+}
+
+@customElement("dialog-ssh-authorized-keys")
+class DialogSSHAuthorizedKeys extends DirtyStateProviderMixin<SSHAuthorizedKeysFormState>()(
+  LitElement
+) {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _open = false;
+
+  @state() private _keys = "";
+
+  @state() private _saving = false;
+
+  public showDialog(): void {
+    this._open = true;
+    this._keys = "";
+    this._initDirtyTracking({ type: "shallow" }, { keys: this._keys });
+  }
+
+  public closeDialog(): void {
+    this._open = false;
+  }
+
+  private _dialogClosed(): void {
+    this._keys = "";
+    this._saving = false;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render() {
+    return html`
+      <ha-dialog
+        .open=${this._open}
+        header-title=${this.hass.localize(
+          "ui.panel.config.hardware.ssh_authorized_keys.dialog_title"
+        )}
+        .preventScrimClose=${this.isDirtyState}
+        @closed=${this._dialogClosed}
+      >
+        <p>
+          ${this.hass.localize(
+            "ui.panel.config.hardware.ssh_authorized_keys.dialog_description"
+          )}
+        </p>
+        <ha-alert alert-type="warning">
+          ${this.hass.localize(
+            "ui.panel.config.hardware.ssh_authorized_keys.replace_warning"
+          )}
+        </ha-alert>
+        <ha-textarea
+          autofocus
+          rows="5"
+          .label=${this.hass.localize(
+            "ui.panel.config.hardware.ssh_authorized_keys.keys_label"
+          )}
+          placeholder="ssh-ed25519 AAAA…"
+          .value=${this._keys}
+          .disabled=${this._saving}
+          @input=${this._keysChanged}
+        ></ha-textarea>
+        <ha-dialog-footer slot="footer">
+          <ha-button
+            slot="secondaryAction"
+            appearance="plain"
+            .disabled=${this._saving}
+            @click=${this.closeDialog}
+          >
+            ${this.hass.localize("ui.common.cancel")}
+          </ha-button>
+          <ha-button
+            slot="primaryAction"
+            .loading=${this._saving}
+            @click=${this._save}
+          >
+            ${this.hass.localize("ui.common.save")}
+          </ha-button>
+        </ha-dialog-footer>
+      </ha-dialog>
+    `;
+  }
+
+  private _keysChanged(ev: InputEvent): void {
+    this._keys = (ev.target as HaTextArea).value || "";
+    this._updateDirtyState({ keys: this._keys });
+  }
+
+  private async _save(): Promise<void> {
+    const keys = this._keys
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line);
+
+    if (!keys.length) {
+      const confirmed = await showConfirmationDialog(this, {
+        title: this.hass.localize(
+          "ui.panel.config.hardware.ssh_authorized_keys.delete_all_title"
+        ),
+        text: this.hass.localize(
+          "ui.panel.config.hardware.ssh_authorized_keys.delete_all_text"
+        ),
+        confirmText: this.hass.localize("ui.common.delete"),
+        dismissText: this.hass.localize("ui.common.cancel"),
+        destructive: true,
+      });
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    this._saving = true;
+    try {
+      await setOSSSHAuthorizedKeys(this.hass, keys);
+      this.closeDialog();
+    } catch (err: any) {
+      showAlertDialog(this, {
+        title: this.hass.localize(
+          "ui.panel.config.hardware.ssh_authorized_keys.failed_to_save"
+        ),
+        text: extractApiErrorMessage(err),
+      });
+    } finally {
+      this._saving = false;
+    }
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      haStyleDialog,
+      css`
+        p {
+          margin-top: 0;
+        }
+        ha-alert {
+          display: block;
+          margin-bottom: 16px;
+        }
+        ha-textarea {
+          width: 100%;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-ssh-authorized-keys": DialogSSHAuthorizedKeys;
+  }
+}

--- a/src/panels/config/hardware/ha-config-hardware-overview.ts
+++ b/src/panels/config/hardware/ha-config-hardware-overview.ts
@@ -25,8 +25,14 @@ import type {
 } from "../../../data/hardware";
 import { BOARD_NAMES } from "../../../data/hardware";
 import { extractApiErrorMessage } from "../../../data/hassio/common";
-import type { HassioHassOSInfo } from "../../../data/hassio/host";
-import { fetchHassioHassOsInfo } from "../../../data/hassio/host";
+import type {
+  HassioHassOSInfo,
+  HassioHostInfo,
+} from "../../../data/hassio/host";
+import {
+  fetchHassioHassOsInfo,
+  fetchHassioHostInfo,
+} from "../../../data/hassio/host";
 import { scanUSBDevices } from "../../../data/usb";
 import { showOptionsFlowDialog } from "../../../dialogs/config-flow/show-dialog-options-flow";
 import { showRestartDialog } from "../../../dialogs/restart/show-dialog-restart";
@@ -38,6 +44,7 @@ import { DefaultPrimaryColor } from "../../../resources/theme/color/color.global
 import type { HomeAssistant, Route } from "../../../types";
 import { hardwareBrandsUrl } from "../../../util/brands-url";
 import { hardwareTabs } from "./ha-config-hardware";
+import { showSSHAuthorizedKeysDialog } from "./show-dialog-ssh-authorized-keys";
 
 const DATASAMPLES = 60;
 
@@ -63,6 +70,8 @@ class HaConfigHardwareOverview extends SubscribeMixin(LitElement) {
   @state() private _error?: string;
 
   @state() private _OSData?: HassioHassOSInfo;
+
+  @state() private _hostInfo?: HassioHostInfo;
 
   @state() private _hardwareInfo?: HardwareInfo;
 
@@ -326,6 +335,28 @@ class HaConfigHardwareOverview extends SubscribeMixin(LitElement) {
                         : nothing
                     }
                     ${
+                      this._hostInfo?.features.includes("haos")
+                        ? html`
+                            <ha-md-list-item
+                              type="button"
+                              @click=${this._showSSHAuthorizedKeysDialog}
+                            >
+                              <span
+                                >${this.hass.localize(
+                                  "ui.panel.config.hardware.ssh_authorized_keys.title"
+                                )}</span
+                              >
+                              <span slot="supporting-text"
+                                >${this.hass.localize(
+                                  "ui.panel.config.hardware.ssh_authorized_keys.description"
+                                )}</span
+                              >
+                              <ha-icon-next slot="end"></ha-icon-next>
+                            </ha-md-list-item>
+                          `
+                        : nothing
+                    }
+                    ${
                       boardConfigEntries.length
                         ? html`<div class="card-actions">
                             <ha-button
@@ -471,6 +502,10 @@ class HaConfigHardwareOverview extends SubscribeMixin(LitElement) {
       if (isHassioLoaded && !this._hardwareInfo?.hardware.length) {
         this._OSData = await fetchHassioHassOsInfo(this.hass);
       }
+
+      if (isHassioLoaded) {
+        this._hostInfo = await fetchHassioHostInfo(this.hass);
+      }
     } catch (err: any) {
       this._error = extractApiErrorMessage(err);
     }
@@ -486,6 +521,10 @@ class HaConfigHardwareOverview extends SubscribeMixin(LitElement) {
 
   private async _showRestartDialog() {
     showRestartDialog(this);
+  }
+
+  private _showSSHAuthorizedKeysDialog() {
+    showSSHAuthorizedKeysDialog(this);
   }
 
   private _getChartData = memoizeOne(

--- a/src/panels/config/hardware/show-dialog-ssh-authorized-keys.ts
+++ b/src/panels/config/hardware/show-dialog-ssh-authorized-keys.ts
@@ -1,0 +1,9 @@
+import { fireEvent } from "../../../common/dom/fire_event";
+
+export const showSSHAuthorizedKeysDialog = (element: HTMLElement): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-ssh-authorized-keys",
+    dialogImport: () => import("./dialog-ssh-authorized-keys"),
+    dialogParams: {},
+  });
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4465,7 +4465,18 @@
           "configure": "Configure",
           "documentation_description": "Find extra information about your device",
           "restart_homeassistant": "[%key:ui::panel::config::system_dashboard::restart_homeassistant%]",
-          "loading_system_data": "Loading processor and memory data..."
+          "loading_system_data": "Loading processor and memory data...",
+          "ssh_authorized_keys": {
+            "title": "SSH access",
+            "description": "Set authorized keys for SSH access to the operating system",
+            "dialog_title": "SSH authorized keys",
+            "dialog_description": "Set the SSH public keys that are authorized to access the Home Assistant Operating System developer SSH service on port 22222. Enter one public key per line.",
+            "replace_warning": "Saving replaces all previously configured authorized keys. Existing keys cannot be shown here.",
+            "keys_label": "Authorized keys",
+            "delete_all_title": "Delete all authorized keys?",
+            "delete_all_text": "You didn't enter any keys. Saving deletes all SSH authorized keys and disables SSH access to the operating system.",
+            "failed_to_save": "Failed to save SSH authorized keys"
+          }
         },
         "info": {
           "caption": "About",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Allow configuring the SSH authorized keys of the Home Assistant Operating System developer SSH service (port 22222) from the UI, so users no longer need a USB drive with a `CONFIG/authorized_keys` file to enable host SSH access.

- Adds an "SSH access" entry to the board card on **Settings > System > Hardware**, shown only when the host reports the `haos` feature.
- The entry opens a dialog with a textarea (one public key per line) that saves via a new `POST /os/ssh/authorized_keys` Supervisor endpoint with body `{"keys": ["ssh-ed25519 AAAA…", …]}`, replacing all previously configured keys.
- Since the keys cannot be read back (os-agent only supports add/clear), the dialog starts empty, warns that saving replaces all existing keys, and asks for confirmation before saving an empty list (which deletes all keys and disables SSH access).

**This PR requires Supervisor backend work before it can be merged.** The os-agent already exposes `AddSSHAuthKey`/`ClearSSHAuthKeys` on the `io.hass.os` System D-Bus object, but the Supervisor neither wraps them in `supervisor/dbus/agent/system.py` nor exposes a REST endpoint. The expected contract implemented here: `POST /os/ssh/authorized_keys` with `{"keys": [...]}` clears existing keys and adds the given ones; an empty list just clears.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: https://github.com/home-assistant/supervisor/pull/7039

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)