### PR TITLE
Allow dismissing clean data entry flows

### DIFF
--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -17,6 +17,7 @@ import {
   subscribeDataEntryFlowProgressed,
 } from "../../data/data_entry_flow";
 import type { DeviceRegistryEntry } from "../../data/device/device_registry";
+import { DirtyStateProviderMixin } from "../../mixins/dirty-state-provider-mixin";
 import { haStyleDialog } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import { documentationUrl } from "../../util/documentation-url";
@@ -74,7 +75,10 @@ declare global {
 }
 
 @customElement("dialog-data-entry-flow")
-class DataEntryFlowDialog extends LitElement {
+class DataEntryFlowDialog extends DirtyStateProviderMixin<
+  Record<string, unknown>,
+  "form"
+>()(LitElement) {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @state() private _params?: DataEntryFlowDialogParams;
@@ -99,6 +103,8 @@ class DataEntryFlowDialog extends LitElement {
 
   @state() private _createEntryHasPendingUpdates = false;
 
+  @state() private _flowHasProgressed = false;
+
   private _formStepRef = createRef<FormStepElement>();
 
   private _abortStepRef = createRef<AbortStepElement>();
@@ -108,6 +114,8 @@ class DataEntryFlowDialog extends LitElement {
   private _unsubDataEntryFlowProgress?: UnsubscribeFunc;
 
   public async showDialog(params: DataEntryFlowDialogParams): Promise<void> {
+    this._initDirtyTracking({ type: "deep" });
+    this._flowHasProgressed = Boolean(params.continueFlowId);
     this._params = params;
     this._instance = instance++;
     this._open = true;
@@ -175,7 +183,7 @@ class DataEntryFlowDialog extends LitElement {
       return;
     }
 
-    this._processStep(step);
+    this._processStep(step, this._flowHasProgressed);
     this._loading = undefined;
   }
 
@@ -213,6 +221,7 @@ class DataEntryFlowDialog extends LitElement {
 
     this._loading = undefined;
     this._step = undefined;
+    this._flowHasProgressed = false;
     this._params = undefined;
     this._handler = undefined;
     if (this._unsubDataEntryFlowProgress) {
@@ -334,7 +343,7 @@ class DataEntryFlowDialog extends LitElement {
     return html`
       <ha-dialog
         .open=${this._open}
-        prevent-scrim-close
+        .preventScrimClose=${this._preventScrimClose}
         @after-show=${this._focusFormStep}
         @closed=${this._dialogClosed}
       >
@@ -484,6 +493,18 @@ class DataEntryFlowDialog extends LitElement {
     `;
   }
 
+  private get _preventScrimClose(): boolean {
+    return (
+      this.isDirtyState ||
+      this._flowHasProgressed ||
+      this._loading !== undefined ||
+      this._formStepLoading ||
+      this._createEntryHasPendingUpdates ||
+      this._step?.type === "external" ||
+      this._step?.type === "progress"
+    );
+  }
+
   private _renderFooter() {
     if (!this._step || this._loading) {
       return nothing;
@@ -588,13 +609,15 @@ class DataEntryFlowDialog extends LitElement {
   }
 
   private async _processStep(
-    step: DataEntryFlowStep | undefined | Promise<DataEntryFlowStep>
+    step: DataEntryFlowStep | undefined | Promise<DataEntryFlowStep>,
+    flowHasProgressed = true
   ): Promise<void> {
     if (step === undefined) {
       this.closeDialog();
       return;
     }
 
+    this._flowHasProgressed ||= flowHasProgressed;
     const delayedLoading = setTimeout(() => {
       // only show loading for slow steps to avoid flickering
       this._loading = "loading_step";
@@ -615,11 +638,11 @@ class DataEntryFlowDialog extends LitElement {
       clearTimeout(delayedLoading);
       this._loading = undefined;
     }
-
     this._step = undefined;
     this._formStepLoading = false;
     this._createEntryHasPendingUpdates = false;
     await this.updateComplete;
+    this._initDirtyTracking({ type: "deep" });
     this._step = _step;
     if (
       (_step.type === "create_entry" || _step.type === "abort") &&

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -1,3 +1,4 @@
+import { consume } from "@lit/context";
 import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
@@ -16,6 +17,10 @@ import type {
 import "../../components/ha-markdown";
 import "../../components/ha-spinner";
 import { autocompleteLoginFields } from "../../data/auth";
+import {
+  dirtyStateContext,
+  type DirtyStateContext,
+} from "../../data/context/dirty-state";
 import type { DataEntryFlowStepForm } from "../../data/data_entry_flow";
 import { previewModule } from "../../data/preview";
 import { haStyle } from "../../resources/styles";
@@ -48,6 +53,10 @@ class StepFlowForm extends LitElement {
   @state() private _submitErrors?: Record<string, string>;
 
   @state() private _errorMsg?: string;
+
+  @consume({ context: dirtyStateContext, subscribe: true })
+  @state()
+  private _dirtyState?: DirtyStateContext<Record<string, unknown>, "form">;
 
   private _errors?: Record<string, string>;
 
@@ -150,6 +159,7 @@ class StepFlowForm extends LitElement {
   protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     this.addEventListener("keydown", this._handleKeyDown);
+    this._dirtyState?.setState(this._stepDataProcessed, "form");
   }
 
   protected updated(changedProps: PropertyValues): void {
@@ -303,6 +313,7 @@ class StepFlowForm extends LitElement {
     ev: ValueChangedEvent<Record<string, unknown>>
   ): void {
     this._stepData = ev.detail.value;
+    this._dirtyState?.setState(this._stepData, "form");
   }
 
   private _labelCallback = (field: HaFormSchema, _data, options): string =>

--- a/test/dialogs/config-flow/dialog-data-entry-flow.test.ts
+++ b/test/dialogs/config-flow/dialog-data-entry-flow.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HaDialog } from "../../../src/components/ha-dialog";
+import type {
+  DataEntryFlowStep,
+  DataEntryFlowStepForm,
+  DataEntryFlowStepMenu,
+} from "../../../src/data/data_entry_flow";
+import "../../../src/dialogs/config-flow/dialog-data-entry-flow";
+import type { FlowConfig } from "../../../src/dialogs/config-flow/show-dialog-data-entry-flow";
+import type { HomeAssistant } from "../../../src/types";
+
+vi.mock("../../../src/data/auth", () => ({
+  autocompleteLoginFields: (schema: unknown) => schema,
+}));
+
+vi.mock("../../../src/components/ha-dialog", () => {
+  customElements.define("ha-dialog", class extends HTMLElement {});
+  return {};
+});
+
+vi.mock("../../../src/components/ha-button", () => {
+  customElements.define("ha-button", class extends HTMLElement {});
+  return {};
+});
+
+vi.mock("../../../src/components/ha-dialog-footer", () => {
+  customElements.define("ha-dialog-footer", class extends HTMLElement {});
+  return {};
+});
+
+vi.mock("../../../src/components/ha-icon-button", () => {
+  customElements.define("ha-icon-button", class extends HTMLElement {});
+  return {};
+});
+
+vi.mock("../../../src/components/ha-form/ha-form", () => {
+  customElements.define("ha-form", class extends HTMLElement {});
+  return {};
+});
+
+vi.mock("../../../src/components/ha-list-item", () => {
+  customElements.define("ha-list-item", class extends HTMLElement {});
+  return {};
+});
+
+const formStep: DataEntryFlowStepForm = {
+  type: "form",
+  flow_id: "test-flow",
+  handler: "test",
+  step_id: "user",
+  data_schema: [
+    {
+      name: "name",
+      required: true,
+      selector: { text: {} },
+    },
+  ],
+  errors: {},
+  last_step: true,
+};
+
+const menuStep: DataEntryFlowStepMenu = {
+  type: "menu",
+  flow_id: "test-flow",
+  handler: "test",
+  step_id: "user",
+  menu_options: ["next"],
+};
+
+const flowConfig: FlowConfig = {
+  flowType: "config_flow",
+  showDevices: false,
+  createFlow: vi.fn().mockResolvedValue(formStep),
+  fetchFlow: vi.fn().mockResolvedValue(formStep),
+  handleFlowStep: vi.fn().mockResolvedValue(formStep),
+  deleteFlow: vi.fn().mockResolvedValue(undefined),
+  renderAbortDescription: () => "",
+  renderShowFormStepHeader: () => "Test flow",
+  renderShowFormStepDescription: () => "",
+  renderShowFormStepFieldLabel: () => "Name",
+  renderShowFormStepFieldHelper: () => "",
+  renderShowFormStepFieldError: () => "",
+  renderShowFormStepFieldLocalizeValue: (_, __, key) => key,
+  renderShowFormStepSubmitButton: () => "Submit",
+  renderExternalStepHeader: () => "",
+  renderExternalStepDescription: () => "",
+  renderCreateEntryDescription: () => "",
+  renderShowFormProgressHeader: () => "",
+  renderShowFormProgressDescription: () => "",
+  renderMenuHeader: () => "",
+  renderMenuDescription: () => "",
+  renderMenuOption: (_, __, option) => option,
+  renderMenuOptionDescription: () => "",
+  renderLoadingDescription: () => "",
+};
+
+const hass = {
+  localize: (key: string) => key,
+  devices: {},
+} as HomeAssistant;
+
+const nextTask = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+const openDialog = async (initialStep: DataEntryFlowStep = formStep) => {
+  vi.mocked(flowConfig.createFlow).mockResolvedValueOnce(initialStep);
+  const dialog = document.createElement("dialog-data-entry-flow");
+  dialog.hass = hass;
+  document.body.append(dialog);
+  await dialog.showDialog({
+    startFlowHandler: "test",
+    flowConfig,
+  });
+  await nextTask();
+  await dialog.updateComplete;
+  return dialog;
+};
+
+const innerDialog = (dialog: HTMLElementTagNameMap["dialog-data-entry-flow"]) =>
+  dialog.shadowRoot!.querySelector("ha-dialog") as HaDialog;
+
+describe("dialog-data-entry-flow dismissal", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.clearAllMocks();
+  });
+
+  it("allows clean forms to be dismissed", async () => {
+    const dialog = await openDialog();
+
+    expect(innerDialog(dialog).preventScrimClose).toBe(false);
+  });
+
+  it("prevents dismissal after form values change", async () => {
+    const dialog = await openDialog();
+    const step = dialog.shadowRoot!.querySelector("step-flow-form")!;
+    await step.updateComplete;
+    const form = step.shadowRoot!.querySelector("ha-form")!;
+
+    form.dispatchEvent(
+      new CustomEvent("value-changed", {
+        detail: { value: { name: "New list" } },
+      })
+    );
+    await nextTask();
+    await dialog.updateComplete;
+
+    expect(innerDialog(dialog).preventScrimClose).toBe(true);
+  });
+
+  it("prevents dismissal after advancing to a clean form step", async () => {
+    const dialog = await openDialog();
+
+    dialog.dispatchEvent(
+      new CustomEvent("flow-update", {
+        detail: {
+          step: {
+            ...formStep,
+            step_id: "second",
+          },
+        },
+      })
+    );
+    await nextTask();
+    await dialog.updateComplete;
+
+    const step = dialog.shadowRoot!.querySelector("step-flow-form")!;
+    await step.updateComplete;
+
+    expect(innerDialog(dialog).preventScrimClose).toBe(true);
+  });
+
+  it("prevents dismissal while advancing from a menu step", async () => {
+    vi.mocked(flowConfig.handleFlowStep).mockReturnValueOnce(
+      Promise.race<DataEntryFlowStep>([])
+    );
+    const dialog = await openDialog(menuStep);
+    const step = dialog.shadowRoot!.querySelector("step-flow-menu")!;
+    await step.updateComplete;
+
+    step.shadowRoot!.querySelector<HTMLElement>("ha-list-item")!.click();
+    await dialog.updateComplete;
+
+    expect(innerDialog(dialog).preventScrimClose).toBe(true);
+  });
+
+  it("prevents dismissal while a form is submitting", async () => {
+    const dialog = await openDialog();
+    const step = dialog.shadowRoot!.querySelector("step-flow-form")!;
+
+    step.dispatchEvent(
+      new CustomEvent("flow-step-footer-state-changed", {
+        detail: { loading: true },
+      })
+    );
+    await dialog.updateComplete;
+
+    expect(innerDialog(dialog).preventScrimClose).toBe(true);
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Data entry flow dialogs currently require the explicit close button even when the user has not entered anything. This allows untouched initial form and menu steps to be dismissed with Escape or by clicking outside the dialog.

Dismissal remains blocked after a form changes, after a flow advances or resumes, and while a flow is loading or submitting, so users cannot accidentally lose work. The behavior applies to shared config flows such as repair and To-do dialogs rather than adding flow-specific exceptions.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if your PR has no visual changes.
-->

No visual styling changes.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53080
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to backend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr