### PR TITLE
Add App settings entry to dashboard more menu

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -1,5 +1,6 @@
 import {
   mdiAccount,
+  mdiCellphoneCog,
   mdiCodeBraces,
   mdiCommentProcessingOutline,
   mdiDevices,
@@ -310,6 +311,17 @@ class HUIRoot extends LitElement {
           this.hass.enableShortcuts && !isMobileClient ? "(A)" : undefined,
         visible:
           !this._editMode && this._conversation(this.hass.config.components),
+        overflow: this.narrow,
+      },
+      {
+        icon: mdiCellphoneCog,
+        key: "ui.panel.lovelace.menu.app_configuration",
+        buttonAction: this._showExternalAppConfiguration,
+        overflowAction: this._showExternalAppConfiguration,
+        visible:
+          !this._editMode &&
+          !this.hass.kioskMode &&
+          !!this.hass.auth.external?.config.hasSettingsScreen,
         overflow: this.narrow,
       },
       {
@@ -886,6 +898,10 @@ class HUIRoot extends LitElement {
 
   private _showQuickBar = () => {
     showQuickBar(this, { showHint: this.hass.enableShortcuts });
+  };
+
+  private _showExternalAppConfiguration = () => {
+    this.hass.auth.external!.fireMessage({ type: "config_screen/show" });
   };
 
   private _goBack(): void {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9160,6 +9160,7 @@
           "assist": "Assist",
           "assist_tooltip": "Assist",
           "search_home_assistant": "Search Home Assistant",
+          "app_configuration": "[%key:ui::sidebar::external_app_configuration%]",
           "reload_resources": "Reload resources",
           "exit_edit_mode": "Done",
           "close": "Close",


### PR DESCRIPTION
## Proposed change

Add an "App settings" entry to the dashboard "more" menu. It opens the companion app settings screen, mirroring the existing sidebar entry, and is only shown when the app exposes a settings screen (`hasSettingsScreen`).

## Screenshots
<img width="1206" height="1175" alt="IMG_5144" src="https://github.com/user-attachments/assets/c0d58b64-59c6-4610-bbdb-0f4221aa874d" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
