### PR TITLE
Revert "Add App settings entry to dashboard more menu"

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -1,6 +1,5 @@
 import {
   mdiAccount,
-  mdiCellphoneCog,
   mdiCodeBraces,
   mdiCommentProcessingOutline,
   mdiDevices,
@@ -311,17 +310,6 @@ class HUIRoot extends LitElement {
           this.hass.enableShortcuts && !isMobileClient ? "(A)" : undefined,
         visible:
           !this._editMode && this._conversation(this.hass.config.components),
-        overflow: this.narrow,
-      },
-      {
-        icon: mdiCellphoneCog,
-        key: "ui.panel.lovelace.menu.app_configuration",
-        buttonAction: this._showExternalAppConfiguration,
-        overflowAction: this._showExternalAppConfiguration,
-        visible:
-          !this._editMode &&
-          !this.hass.kioskMode &&
-          !!this.hass.auth.external?.config.hasSettingsScreen,
         overflow: this.narrow,
       },
       {
@@ -898,10 +886,6 @@ class HUIRoot extends LitElement {
 
   private _showQuickBar = () => {
     showQuickBar(this, { showHint: this.hass.enableShortcuts });
-  };
-
-  private _showExternalAppConfiguration = () => {
-    this.hass.auth.external!.fireMessage({ type: "config_screen/show" });
   };
 
   private _goBack(): void {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9160,7 +9160,6 @@
           "assist": "Assist",
           "assist_tooltip": "Assist",
           "search_home_assistant": "Search Home Assistant",
-          "app_configuration": "[%key:ui::sidebar::external_app_configuration%]",
           "reload_resources": "Reload resources",
           "exit_edit_mode": "Done",
           "close": "Close",


### PR DESCRIPTION
Reverts home-assistant/frontend#53130

Original PR was intended to have “need UX” label but I forgot, so reverting it for now 