### PR TITLE
Migrate entities and glance card state_color to color

### DIFF
--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -6,8 +6,10 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
+import { computeCssColor } from "../../common/color/compute-color";
 import { computeDomain } from "../../common/entity/compute_domain";
 import { computeStateDomain } from "../../common/entity/compute_state_domain";
+import { stateActive } from "../../common/entity/state_active";
 import {
   stateColorBrightness,
   stateColorCss,
@@ -31,6 +33,8 @@ export class StateBadge extends LitElement {
   // false.  When it is undefined, state is still colored for light entities.
   @property({ attribute: false }) public stateColor?: boolean;
 
+  // "state", "none" or a color (theme color name or CSS color). Custom colors
+  // apply when the entity is active. Takes precedence over stateColor.
   @property() public color?: string;
 
   // @todo Consider reworking to eliminate need for attribute since it is manipulated internally
@@ -67,11 +71,17 @@ export class StateBadge extends LitElement {
     }
   }
 
-  private get _stateColor() {
+  private get _color(): string | undefined {
+    if (this.color) {
+      return this.color;
+    }
+    if (this.stateColor !== undefined) {
+      return this.stateColor ? "state" : "none";
+    }
     const domain = this.stateObj
       ? computeStateDomain(this.stateObj)
       : undefined;
-    return this.stateColor ?? domain === "light";
+    return domain === "light" ? "state" : undefined;
   }
 
   protected render() {
@@ -147,10 +157,7 @@ export class StateBadge extends LitElement {
           }
           backgroundImage = `url(${imageUrl})`;
           this.icon = false;
-        } else if (this.color) {
-          // Externally provided overriding color wins over state color
-          iconStyle.color = this.color;
-        } else if (this._stateColor) {
+        } else if (this._color === "state") {
           const color = stateColorCss(stateObj);
           if (color) {
             iconStyle.color = color;
@@ -180,6 +187,12 @@ export class StateBadge extends LitElement {
               delete iconStyle.color;
             }
           }
+        } else if (
+          this._color &&
+          this._color !== "none" &&
+          stateActive(stateObj)
+        ) {
+          iconStyle.color = computeCssColor(this._color);
         }
       } else if (this.overrideImage) {
         backgroundImage = `url(${this._resolveImageUrl(this.overrideImage)})`;

--- a/src/components/entity/state-info.ts
+++ b/src/components/entity/state-info.ts
@@ -1,6 +1,7 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
 import type { HomeAssistant } from "../../types";
 import "../ha-relative-time";
 import "../ha-tooltip";
@@ -25,8 +26,8 @@ class StateInfo extends LitElement {
 
     return html`<state-badge
         .stateObj=${this.stateObj}
-        .stateColor=${true}
-        .color=${this.color}
+        .stateColor=${!this.color}
+        style=${styleMap({ color: this.color })}
       ></state-badge>
       <div class="info">
         <div class="name ${this.inDialog ? "in-dialog" : ""}" .title=${name}>

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -8,11 +8,13 @@ import "../../../components/ha-card";
 import type { HomeAssistant } from "../../../types";
 import { computeCardSize } from "../common/compute-card-size";
 import { findEntities } from "../common/find-entities";
+import { migrateStateColorConfig } from "../common/migrate-state-color-config";
 import { processConfigEntities } from "../common/process-config-entities";
 import "../components/hui-entities-toggle";
 import { createHeaderFooterElement } from "../create-element/create-header-footer-element";
 import { createRowElement } from "../create-element/create-row-element";
 import type {
+  ConditionalRowConfig,
   EntityConfig,
   LovelaceRow,
   LovelaceRowConfig,
@@ -23,7 +25,7 @@ import type {
   LovelaceGridOptions,
   LovelaceHeaderFooter,
 } from "../types";
-import type { EntitiesCardConfig } from "./types";
+import type { EntitiesCardConfig, EntitiesCardEntityConfig } from "./types";
 import { haStyleScrollbar } from "../../../resources/styles";
 
 export const computeShowHeaderToggle = <
@@ -49,30 +51,52 @@ export const computeShowHeaderToggle = <
   return !!config.show_header_toggle;
 };
 
+const migrateEntitiesRowConfig = (
+  rowConf: LovelaceRowConfig | string
+): LovelaceRowConfig | string => {
+  if (typeof rowConf !== "object") {
+    return rowConf;
+  }
+  let newConf = rowConf;
+  if ("format" in newConf) {
+    const { format, ...rest } = newConf;
+    newConf = {
+      ...rest,
+      time_format: (rest as EntityConfig).time_format ?? format,
+    } as LovelaceRowConfig;
+  }
+  if (!("type" in newConf)) {
+    newConf = migrateStateColorConfig(newConf as EntitiesCardEntityConfig);
+  } else if (newConf.type === "conditional") {
+    const row = (newConf as ConditionalRowConfig).row;
+    if (row && typeof row === "object" && !("type" in row)) {
+      const newRow = migrateStateColorConfig(row as EntitiesCardEntityConfig);
+      if (newRow !== row) {
+        newConf = { ...newConf, row: newRow } as ConditionalRowConfig;
+      }
+    }
+  }
+  return newConf;
+};
+
 export const migrateEntitiesCardConfig = (
   config: EntitiesCardConfig
 ): EntitiesCardConfig => {
   let changed = false;
   const newEntities = config.entities?.map((e) => {
-    if (typeof e !== "object") {
-      return e;
+    const newConf = migrateEntitiesRowConfig(e);
+    if (newConf !== e) {
+      changed = true;
     }
-    if (!("format" in e)) {
-      return e;
-    }
-    changed = true;
-    const { format, ...rest } = e;
-    return {
-      ...rest,
-      time_format: (rest as EntityConfig).time_format ?? format,
-    };
+    return newConf;
   });
+  const newConfig = migrateStateColorConfig(config);
   if (!changed) {
-    return config;
+    return newConfig;
   }
   return {
-    ...config,
-    entities: newEntities as (LovelaceRowConfig | string)[],
+    ...newConfig,
+    entities: newEntities,
   };
 };
 
@@ -368,13 +392,13 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   ];
 
   private _renderEntity(entityConf: LovelaceRowConfig): TemplateResult {
+    const cardColor = this._config!.color;
     const element = createRowElement(
       (!("type" in entityConf) || entityConf.type === "conditional") &&
-        "state_color" in this._config!
-        ? ({
-            state_color: this._config.state_color,
-            ...(entityConf as EntityConfig),
-          } as EntityConfig)
+        cardColor !== undefined &&
+        (entityConf as EntitiesCardEntityConfig).color === undefined &&
+        (entityConf as EntitiesCardEntityConfig).state_color === undefined
+        ? ({ ...entityConf, color: cardColor } as EntitiesCardEntityConfig)
         : entityConf.type === "perform-action"
           ? { ...entityConf, type: "call-service" }
           : entityConf

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -26,6 +26,7 @@ import { findEntities } from "../common/find-entities";
 import { handleAction } from "../common/handle-action";
 import { hasAction, hasAnyAction } from "../common/has-action";
 import { hasConfigOrEntitiesChanged } from "../common/has-changed";
+import { migrateStateColorConfig } from "../common/migrate-state-color-config";
 import { processConfigEntities } from "../common/process-config-entities";
 import "../components/hui-timestamp-display";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
@@ -42,21 +43,26 @@ export const migrateGlanceCardConfig = (
     if (typeof e !== "object") {
       return e;
     }
-    if (!("format" in e)) {
-      return e;
+    let newConf = e;
+    if ("format" in e) {
+      const { format, ...rest } = e;
+      newConf = {
+        ...rest,
+        time_format: rest.time_format ?? format,
+      } as GlanceConfigEntity;
     }
-    changed = true;
-    const { format, ...rest } = e;
-    return {
-      ...rest,
-      time_format: rest.time_format ?? format,
-    };
+    newConf = migrateStateColorConfig(newConf);
+    if (newConf !== e) {
+      changed = true;
+    }
+    return newConf;
   });
+  const newConfig = migrateStateColorConfig(config);
   if (!changed) {
-    return config;
+    return newConfig;
   }
   return {
-    ...config,
+    ...newConfig,
     entities: newEntities as (GlanceConfigEntity | string)[],
   };
 };
@@ -111,12 +117,14 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
       show_name: true,
       show_state: true,
       show_icon: true,
-      state_color: true,
+      color: "state",
       ...migratedConfig,
     };
+    const cardColor = this._config.color;
     const entities = processConfigEntities(migratedConfig.entities).map(
       (entityConf) => ({
         hold_action: { action: "more-info" } as MoreInfoActionConfig,
+        color: cardColor,
         ...entityConf,
       })
     );
@@ -318,9 +326,7 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
                   .stateObj=${stateObj}
                   .overrideIcon=${entityConf.icon}
                   .overrideImage=${entityConf.image}
-                  .stateColor=${
-                    entityConf.state_color ?? this._config!.state_color
-                  }
+                  .color=${entityConf.color}
                 ></state-badge>
               `
             : ""

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -113,6 +113,7 @@ export interface EntitiesCardEntityConfig extends EntityConfig {
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
   state_color?: boolean;
+  color?: string;
   show_name?: boolean;
   show_icon?: boolean;
 }
@@ -127,6 +128,7 @@ export interface EntitiesCardConfig extends LovelaceCardConfig {
   header?: LovelaceHeaderFooterConfig;
   footer?: LovelaceHeaderFooterConfig;
   state_color?: boolean;
+  color?: string;
 }
 
 export type AreaCardDisplayType = "compact" | "icon" | "picture" | "camera";
@@ -331,6 +333,7 @@ export interface GlanceConfigEntity extends ConfigEntity {
   image?: string;
   show_state?: boolean;
   state_color?: boolean;
+  color?: string;
   time_format?: TimestampRenderingFormat;
 }
 
@@ -343,6 +346,7 @@ export interface GlanceCardConfig extends LovelaceCardConfig {
   entities: (string | GlanceConfigEntity)[];
   columns?: number;
   state_color?: boolean;
+  color?: string;
 }
 
 export interface HumidifierCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/common/migrate-state-color-config.ts
+++ b/src/panels/lovelace/common/migrate-state-color-config.ts
@@ -1,0 +1,17 @@
+export interface LegacyStateColorConfig {
+  color?: string;
+  state_color?: boolean;
+}
+
+export const migrateStateColorConfig = <T extends LegacyStateColorConfig>(
+  config: T
+): T => {
+  if (config.state_color === undefined) {
+    return config;
+  }
+  const { state_color, ...rest } = config;
+  return {
+    color: state_color ? "state" : "none",
+    ...rest,
+  } as T;
+};

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -86,6 +86,7 @@ export class HuiGenericEntityRow extends LitElement {
           .overrideIcon=${this.config.icon}
           .overrideImage=${this.config.image}
           .stateColor=${this.config.state_color}
+          .color=${this.config.color}
         ></state-badge>
         ${
           !this.hideName

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -24,6 +24,7 @@ import { customType } from "../../../../common/structs/is-custom-type";
 import "../../../../components/ha-card";
 import "../../../../components/ha-formfield";
 import "../../../../components/ha-icon";
+import "../../../../components/ha-selector/ha-selector";
 import "../../../../components/ha-switch";
 import "../../../../components/ha-theme-picker";
 import "../../../../components/input/ha-input";
@@ -181,6 +182,13 @@ const entitiesRowConfigStruct = dynamic<any>((value) => {
   return entitiesConfigStruct;
 });
 
+const COLOR_SELECTOR = {
+  ui_color: {
+    include_state: true,
+    include_none: true,
+  },
+};
+
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
   object({
@@ -190,6 +198,7 @@ const cardConfigStruct = assign(
     icon: optional(string()),
     show_header_toggle: optional(boolean()),
     state_color: optional(boolean()),
+    color: optional(string()),
     entities: array(entitiesRowConfigStruct),
     header: optional(headerFooterConfigStructs),
     footer: optional(headerFooterConfigStructs),
@@ -211,9 +220,14 @@ export class HuiEntitiesCardEditor
 
   public setConfig(config: EntitiesCardConfig): void {
     const migratedConfig = migrateEntitiesCardConfig(config);
-    assert(migratedConfig, cardConfigStruct);
-    this._config = migratedConfig;
-    this._configEntities = processEditorEntities(migratedConfig.entities);
+    if (migratedConfig !== config) {
+      fireEvent(this, "config-changed", { config: migratedConfig });
+      return;
+    }
+
+    assert(config, cardConfigStruct);
+    this._config = config;
+    this._configEntities = processEditorEntities(config.entities);
   }
 
   private _showHeaderToggle = memoizeOne((config: EntitiesCardConfig) => {
@@ -285,17 +299,16 @@ export class HuiEntitiesCardEditor
               @change=${this._valueChanged}
             ></ha-switch>
           </ha-formfield>
-          <ha-formfield
+          <ha-selector
+            .hass=${this.hass}
+            .selector=${COLOR_SELECTOR}
             .label=${this.hass.localize(
-              "ui.panel.lovelace.editor.card.generic.state_color"
+              "ui.panel.lovelace.editor.card.generic.color"
             )}
-          >
-            <ha-switch
-              .checked=${this._config!.state_color}
-              .configValue=${"state_color"}
-              @change=${this._valueChanged}
-            ></ha-switch>
-          </ha-formfield>
+            .value=${this._config!.color}
+            .configValue=${"color"}
+            @value-changed=${this._valueChanged}
+          ></ha-selector>
         </div>
         <hui-header-footer-editor
           .hass=${this.hass}
@@ -331,9 +344,11 @@ export class HuiEntitiesCardEditor
     const configValue =
       target.configValue || this._subElementEditorConfig?.type;
     const value =
-      target.checked !== undefined
-        ? target.checked
-        : target.value || ev.detail.config || ev.detail.value;
+      configValue === "color"
+        ? ev.detail.value
+        : target.checked !== undefined
+          ? target.checked
+          : target.value || ev.detail.config || ev.detail.value;
 
     if (
       (configValue === "title" && target.value === this._title) ||
@@ -359,7 +374,7 @@ export class HuiEntitiesCardEditor
       this._config = { ...this._config!, entities: newConfigEntities };
       this._configEntities = processEditorEntities(this._config!.entities);
     } else if (configValue) {
-      if (value === "") {
+      if (value === "" || value === undefined) {
         this._config = { ...this._config };
         delete this._config[configValue!];
       } else {

--- a/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
@@ -45,6 +45,7 @@ const cardConfigStruct = assign(
     show_state: optional(boolean()),
     show_icon: optional(boolean()),
     state_color: optional(boolean()),
+    color: optional(string()),
     entities: array(entitiesConfigStruct),
   })
 );
@@ -69,7 +70,16 @@ const SCHEMA = [
       { name: "show_state", selector: { boolean: {} } },
     ],
   },
-  { name: "state_color", selector: { boolean: {} } },
+  {
+    name: "color",
+    selector: {
+      ui_color: {
+        default_color: "state",
+        include_state: true,
+        include_none: true,
+      },
+    },
+  },
 ] as const;
 
 @customElement("hui-glance-card-editor")
@@ -87,9 +97,14 @@ export class HuiGlanceCardEditor
 
   public setConfig(config: GlanceCardConfig): void {
     const migratedConfig = migrateGlanceCardConfig(config);
-    assert(migratedConfig, cardConfigStruct);
-    this._config = migratedConfig;
-    this._configEntities = processEditorEntities(migratedConfig.entities);
+    if (migratedConfig !== config) {
+      fireEvent(this, "config-changed", { config: migratedConfig });
+      return;
+    }
+
+    assert(config, cardConfigStruct);
+    this._config = config;
+    this._configEntities = processEditorEntities(config.entities);
   }
 
   private _subForm = memoizeOne((showTimeFormat?: boolean) => ({
@@ -113,6 +128,15 @@ export class HuiGlanceCardEditor
             },
             context: {
               icon_entity: "entity",
+            },
+          },
+          {
+            name: "color",
+            selector: {
+              ui_color: {
+                include_state: true,
+                include_none: true,
+              },
             },
           },
           { name: "show_last_changed", selector: { boolean: {} } },

--- a/src/panels/lovelace/editor/structs/entities-struct.ts
+++ b/src/panels/lovelace/editor/structs/entities-struct.ts
@@ -15,6 +15,7 @@ export const entitiesConfigStruct = union([
     secondary_info: optional(string()),
     time_format: optional(timeFormatConfigStruct),
     state_color: optional(boolean()),
+    color: optional(string()),
     tap_action: optional(actionConfigStruct),
     hold_action: optional(actionConfigStruct),
     double_tap_action: optional(actionConfigStruct),

--- a/src/panels/lovelace/special-rows/hui-conditional-row.ts
+++ b/src/panels/lovelace/special-rows/hui-conditional-row.ts
@@ -1,5 +1,6 @@
 import { customElement } from "lit/decorators";
-import type { EntityCardConfig } from "../cards/types";
+import type { EntitiesCardEntityConfig } from "../cards/types";
+import { migrateStateColorConfig } from "../common/migrate-state-color-config";
 import { HuiConditionalBase } from "../components/hui-conditional-base";
 import { createRowElement } from "../create-element/create-row-element";
 import type {
@@ -23,12 +24,16 @@ class HuiConditionalRow extends HuiConditionalBase implements LovelaceRow {
       throw new Error("No row configured");
     }
 
+    const { color } = migrateStateColorConfig(
+      config as EntitiesCardEntityConfig
+    );
+    const row = config.row as EntitiesCardEntityConfig;
+
     this._element = createRowElement(
-      (config as EntityCardConfig).state_color
-        ? ({
-            state_color: true,
-            ...(config.row as EntityConfig),
-          } as EntityConfig)
+      color !== undefined &&
+        row.color === undefined &&
+        row.state_color === undefined
+        ? ({ ...row, color } as EntityConfig)
         : config.row
     ) as LovelaceRow;
   }

--- a/test/panels/lovelace/cards/migrate-state-color-config.test.ts
+++ b/test/panels/lovelace/cards/migrate-state-color-config.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Hoisted above the imports at runtime: bundler-defined globals the cards'
+// import graphs read at eval (setup.ts already provides __DEMO__/__DEV__).
+vi.hoisted(() => {
+  Object.assign(globalThis, {
+    __STATIC_PATH__: "/",
+    __HASS_URL__: "",
+    __BUILD__: "modern",
+    __VERSION__: "test",
+    __BACKWARDS_COMPAT__: false,
+    __SUPERVISOR__: false,
+    __NAMESPACE__: "frontend",
+  });
+});
+
+const { migrateStateColorConfig } = await import(
+  "../../../../src/panels/lovelace/common/migrate-state-color-config"
+);
+const { migrateEntitiesCardConfig } = await import(
+  "../../../../src/panels/lovelace/cards/hui-entities-card"
+);
+const { migrateGlanceCardConfig } = await import(
+  "../../../../src/panels/lovelace/cards/hui-glance-card"
+);
+
+type EntitiesCardConfig = Parameters<typeof migrateEntitiesCardConfig>[0];
+type GlanceCardConfig = Parameters<typeof migrateGlanceCardConfig>[0];
+
+describe("migrateStateColorConfig", () => {
+  it("converts state_color true to color state", () => {
+    expect(migrateStateColorConfig({ state_color: true })).toEqual({
+      color: "state",
+    });
+  });
+
+  it("converts state_color false to color none", () => {
+    expect(migrateStateColorConfig({ state_color: false })).toEqual({
+      color: "none",
+    });
+  });
+
+  it("keeps an explicit color over state_color", () => {
+    expect(
+      migrateStateColorConfig({ state_color: true, color: "red" })
+    ).toEqual({ color: "red" });
+  });
+
+  it("returns the same object when there is nothing to migrate", () => {
+    const config = { color: "red" };
+    expect(migrateStateColorConfig(config)).toBe(config);
+  });
+});
+
+describe("migrateEntitiesCardConfig", () => {
+  it("migrates card and entity level state_color", () => {
+    expect(
+      migrateEntitiesCardConfig({
+        type: "entities",
+        state_color: true,
+        entities: [
+          "light.bed_light",
+          { entity: "switch.ac", state_color: false },
+          { entity: "sensor.humidity", type: "simple-entity" },
+        ],
+      } as EntitiesCardConfig)
+    ).toEqual({
+      type: "entities",
+      color: "state",
+      entities: [
+        "light.bed_light",
+        { entity: "switch.ac", color: "none" },
+        { entity: "sensor.humidity", type: "simple-entity" },
+      ],
+    });
+  });
+
+  it("migrates conditional row inner rows", () => {
+    expect(
+      migrateEntitiesCardConfig({
+        type: "entities",
+        entities: [
+          {
+            type: "conditional",
+            conditions: [],
+            row: { entity: "light.bed_light", state_color: true },
+          },
+        ],
+      } as unknown as EntitiesCardConfig)
+    ).toEqual({
+      type: "entities",
+      entities: [
+        {
+          type: "conditional",
+          conditions: [],
+          row: { entity: "light.bed_light", color: "state" },
+        },
+      ],
+    });
+  });
+
+  it("returns the same object when there is nothing to migrate", () => {
+    const config = {
+      type: "entities",
+      color: "state",
+      entities: ["light.bed_light", { entity: "switch.ac", color: "none" }],
+    } as EntitiesCardConfig;
+    expect(migrateEntitiesCardConfig(config)).toBe(config);
+  });
+});
+
+describe("migrateGlanceCardConfig", () => {
+  it("migrates card and entity level state_color", () => {
+    expect(
+      migrateGlanceCardConfig({
+        type: "glance",
+        state_color: false,
+        entities: [
+          "light.bed_light",
+          { entity: "switch.ac", state_color: true },
+        ],
+      } as GlanceCardConfig)
+    ).toEqual({
+      type: "glance",
+      color: "none",
+      entities: ["light.bed_light", { entity: "switch.ac", color: "state" }],
+    });
+  });
+
+  it("returns the same object when there is nothing to migrate", () => {
+    const config = {
+      type: "glance",
+      entities: ["light.bed_light"],
+    } as GlanceCardConfig;
+    expect(migrateGlanceCardConfig(config)).toBe(config);
+  });
+});


### PR DESCRIPTION
## Proposed change

Migrates the `entities` and `glance` cards from the boolean `state_color` option to the `color` API (`state`, `none`, or a color) already used by heading badges, badges and the button card. Replaces #52294.

Instead of every card reconciling `color`/`state_color` on its own, `state-badge` is now the single place that resolves the `color` option, and cards just forward it:

- `state-badge` accepts `color: state | none | <color>` (custom colors apply when the entity is active, like badges). The `stateColor` boolean property is kept for existing callers, `color` wins when both are set.
- Card and entity level `state_color` is converted to `color` by the runtime config migration (`state_color: true` → `color: state`, `state_color: false` → `color: none`), shared between `entities` and `glance` through a common helper. Conditional row inner rows are migrated too.
- The card level `color` is applied as a default to rows that don't define their own, so entity level settings keep precedence.
- The editors normalize saved configs on load (same pattern as the button card editor) and replace the `state_color` toggle with the `ui_color` selector. The glance entity sub-editor also gets a per-entity color picker.
- `state-info` now applies its raw CSS color through an inline style, keeping the calendar dialog behavior unchanged.

Existing YAML with `state_color` keeps working unchanged; behavior was verified against the demo for all legacy/new combinations (card default, `state_color: false` on lights, entity overrides, conditional rows, glance defaults).

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #52294
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
