### PR TITLE
Add hasLoader external bus config for companion app loaders

### DIFF
--- a/src/external_app/external_messaging.ts
+++ b/src/external_app/external_messaging.ts
@@ -366,6 +366,7 @@ export interface ExternalConfig {
   appVersion?: string;
   hasEntityAddTo?: boolean; // Supports "Add to" from more-info dialog, with action coming from external app
   hasAssistSettings?: boolean; // Shows the "This device" section in voice assistant settings
+  hasLoader?: boolean; // App renders its own loading screen, so the frontend launch screen stays blank
 }
 
 export interface ExternalEntityAddToAction {

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -59,9 +59,6 @@
       #ha-launch-screen.removing {
         opacity: 0;
       }
-      /* Companion apps that render their own loader ask us to keep the launch
-         screen blank, so hide the logo, spinner and badge but keep the
-         background to avoid a flash. */
       #ha-launch-screen.blank > * {
         display: none;
       }

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -59,6 +59,12 @@
       #ha-launch-screen.removing {
         opacity: 0;
       }
+      /* Companion apps that render their own loader ask us to keep the launch
+         screen blank, so hide the logo, spinner and badge but keep the
+         background to avoid a flash. */
+      #ha-launch-screen.blank > * {
+        display: none;
+      }
       #ha-launch-screen svg {
         width: 112px;
         flex-shrink: 0;

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -17,6 +17,8 @@ import QuickBarMixin from "../state/quick-bar-mixin";
 import type { HomeAssistant, Route } from "../types";
 import { storeState } from "../util/ha-pref-storage";
 import {
+  blankLaunchScreen,
+  clearLaunchScreenInfoBox,
   removeLaunchScreen,
   renderLaunchScreenInfoBox,
 } from "../util/launch-screen";
@@ -58,6 +60,8 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
   @state() private _databaseMigration?: boolean;
 
   private _httpPendingDialogOpen = false;
+
+  private _appHandlesLoader = false;
 
   private _panelUrl: string;
 
@@ -306,6 +310,15 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
       const { auth, conn } = result;
       this._checkUpdate(conn);
       this.initializeHass(auth, conn);
+      // When running inside a companion app that renders its own loading
+      // screen, keep the frontend launch screen blank to avoid two competing
+      // loaders. The config is only known after the connection is ready, so
+      // clear any loader that was already rendered.
+      if (this.hass?.auth.external?.config.hasLoader) {
+        this._appHandlesLoader = true;
+        blankLaunchScreen();
+        this._renderInitInfo(false);
+      }
     } catch (_err: any) {
       this._renderInitInfo(true);
     }
@@ -365,6 +378,11 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
   }
 
   private _renderInitInfo(error: boolean) {
+    if (this._appHandlesLoader) {
+      // The companion app displays its own loader; keep ours blank.
+      clearLaunchScreenInfoBox();
+      return;
+    }
     renderLaunchScreenInfoBox(
       html`<ha-init-page
         .error=${error}

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -310,10 +310,6 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
       const { auth, conn } = result;
       this._checkUpdate(conn);
       this.initializeHass(auth, conn);
-      // When running inside a companion app that renders its own loading
-      // screen, keep the frontend launch screen blank to avoid two competing
-      // loaders. The config is only known after the connection is ready, so
-      // clear any loader that was already rendered.
       if (this.hass?.auth.external?.config.hasLoader) {
         this._appHandlesLoader = true;
         blankLaunchScreen();
@@ -379,7 +375,6 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
 
   private _renderInitInfo(error: boolean) {
     if (this._appHandlesLoader) {
-      // The companion app displays its own loader; keep ours blank.
       clearLaunchScreenInfoBox();
       return;
     }

--- a/src/util/launch-screen.ts
+++ b/src/util/launch-screen.ts
@@ -1,5 +1,5 @@
 import type { TemplateResult } from "lit";
-import { render } from "lit";
+import { nothing, render } from "lit";
 import { parseAnimationDuration } from "../common/util/parse-animation-duration";
 import { withViewTransition } from "../common/util/view-transition";
 
@@ -27,9 +27,21 @@ export const removeLaunchScreen = () => {
   });
 };
 
+export const blankLaunchScreen = () => {
+  const launchScreenElement = document.getElementById("ha-launch-screen");
+  launchScreenElement?.classList.add("blank");
+};
+
 export const renderLaunchScreenInfoBox = (content: TemplateResult) => {
   const infoBoxElement = document.getElementById("ha-launch-screen-info-box");
   if (infoBoxElement) {
     render(content, infoBoxElement);
+  }
+};
+
+export const clearLaunchScreenInfoBox = () => {
+  const infoBoxElement = document.getElementById("ha-launch-screen-info-box");
+  if (infoBoxElement) {
+    render(nothing, infoBoxElement);
   }
 };


### PR DESCRIPTION
## Proposed change

Add a new `hasLoader` config flag to the external bus shared with the companion apps (alongside existing flags like `hasAssist`).

When an app reports `hasLoader: true`, the app renders its own loading screen, so the frontend keeps its full-screen launch screen blank (logo, spinner, loading text and badge hidden, background kept) to avoid showing two competing loaders. Behaviour is unchanged for the web frontend and for apps that don't set the flag.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
