### PR TITLE
Limit clock card date picker to one value per group

### DIFF
--- a/src/components/ha-clock-date-format-picker.ts
+++ b/src/components/ha-clock-date-format-picker.ts
@@ -75,25 +75,28 @@ interface ClockDatePartSectionData {
 
 /**
  * Filters out sections whose group already has a value in `value`, so only
- * one non-separator value per group can be selected in the picker. The item
- * at `excludeIndex` (the one being edited) is ignored so its own group stays
- * selectable. The separator group is always kept.
+ * one non-separator value per group can be selected in the picker. The whole
+ * group of the item at `excludeIndex` (the one being edited) stays
+ * selectable, even if that group has more than one value in `value` (e.g. a
+ * pre-existing config authored outside the picker via YAML).
+ * The separator group is always kept.
  */
 export const getAvailableClockDatePartSections = (
   sections: ClockDatePartSectionData[],
   value: string[],
   excludeIndex?: number
 ): ClockDatePartSectionData[] => {
+  const editedItem = excludeIndex != null ? value[excludeIndex] : undefined;
+  const editedSection = editedItem
+    ? getClockDatePartSection(editedItem as ClockCardDatePart)
+    : undefined;
+
   const usedSections = new Set<ClockDatePartSection>();
 
-  value.forEach((item, idx) => {
-    if (idx === excludeIndex) {
-      return;
-    }
-
+  value.forEach((item) => {
     const section = getClockDatePartSection(item as ClockCardDatePart);
 
-    if (section !== "separator") {
+    if (section !== "separator" && section !== editedSection) {
       usedSections.add(section);
     }
   });

--- a/src/components/ha-clock-date-format-picker.ts
+++ b/src/components/ha-clock-date-format-picker.ts
@@ -73,6 +73,37 @@ interface ClockDatePartSectionData {
   items: PickerComboBoxItem[];
 }
 
+/**
+ * Filters out sections whose group already has a value in `value`, so only
+ * one non-separator value per group can be selected in the picker. The item
+ * at `excludeIndex` (the one being edited) is ignored so its own group stays
+ * selectable. The separator group is always kept.
+ */
+export const getAvailableClockDatePartSections = (
+  sections: ClockDatePartSectionData[],
+  value: string[],
+  excludeIndex?: number
+): ClockDatePartSectionData[] => {
+  const usedSections = new Set<ClockDatePartSection>();
+
+  value.forEach((item, idx) => {
+    if (idx === excludeIndex) {
+      return;
+    }
+
+    const section = getClockDatePartSection(item as ClockCardDatePart);
+
+    if (section !== "separator") {
+      usedSections.add(section);
+    }
+  });
+
+  return sections.filter(
+    (sectionData) =>
+      sectionData.id === "separator" || !usedSections.has(sectionData.id)
+  );
+};
+
 interface ClockDatePartValueItem {
   key: string;
   item: string;
@@ -103,12 +134,17 @@ export class HaClockDateFormatPicker extends LitElement {
 
   @query("ha-generic-picker", true) private _picker?: HaGenericPicker;
 
-  private _editIndex?: number;
+  @state() private _editIndex?: number;
 
   protected render() {
     const value = this._value;
     const valueItems = this._getValueItems(value);
     const sections = this._buildSections();
+    const pickerSections = getAvailableClockDatePartSections(
+      sections,
+      value,
+      this._editIndex
+    );
 
     return html`
       ${this.label ? html`<label>${this.label}</label>` : nothing}
@@ -117,8 +153,8 @@ export class HaClockDateFormatPicker extends LitElement {
         .disabled=${this.disabled}
         .required=${this.required && !value.length}
         .value=${this._getPickerValue()}
-        .sections=${this._getSectionHeaders(sections)}
-        .getItems=${this._getItems(sections)}
+        .sections=${this._getSectionHeaders(pickerSections)}
+        .getItems=${this._getItems(pickerSections)}
         @value-changed=${this._pickerValueChanged}
       >
         <div slot="field" class="container">

--- a/test/components/ha-clock-date-format-picker.test.ts
+++ b/test/components/ha-clock-date-format-picker.test.ts
@@ -57,6 +57,27 @@ describe("getAvailableClockDatePartSections", () => {
     ]);
   });
 
+  it("keeps the edited item's group visible even when a duplicate of that group exists elsewhere", () => {
+    const value = ["day-numeric", "day-2-digit", "month-long"];
+    const result = getAvailableClockDatePartSections(ALL_SECTIONS, value, 0);
+    expect(result.map((sectionData) => sectionData.id)).toEqual([
+      "day",
+      "year",
+      "weekday",
+      "separator",
+    ]);
+  });
+
+  it("does not crash and keeps normal filtering when excludeIndex is out of range", () => {
+    const value = ["day-numeric", "month-long"];
+    const result = getAvailableClockDatePartSections(ALL_SECTIONS, value, 5);
+    expect(result.map((sectionData) => sectionData.id)).toEqual([
+      "year",
+      "weekday",
+      "separator",
+    ]);
+  });
+
   it("never hides the separator section, even with multiple separators used", () => {
     const value = [
       "separator-dash",

--- a/test/components/ha-clock-date-format-picker.test.ts
+++ b/test/components/ha-clock-date-format-picker.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { getAvailableClockDatePartSections } from "../../src/components/ha-clock-date-format-picker";
+
+type TestSection = "weekday" | "day" | "month" | "year" | "separator";
+
+const section = (id: TestSection, itemIds: string[]) => ({
+  id,
+  title: id,
+  items: itemIds.map((itemId) => ({ id: itemId, primary: itemId })),
+});
+
+const ALL_SECTIONS = [
+  section("day", ["day-numeric", "day-2-digit"]),
+  section("month", ["month-numeric", "month-short", "month-long"]),
+  section("year", ["year-numeric", "year-2-digit"]),
+  section("weekday", ["weekday-short", "weekday-long"]),
+  section("separator", [
+    "separator-dash",
+    "separator-slash",
+    "separator-dot",
+    "separator-new-line",
+  ]),
+];
+
+describe("getAvailableClockDatePartSections", () => {
+  it("returns every section when no value is set", () => {
+    const result = getAvailableClockDatePartSections(ALL_SECTIONS, []);
+    expect(result.map((sectionData) => sectionData.id)).toEqual([
+      "day",
+      "month",
+      "year",
+      "weekday",
+      "separator",
+    ]);
+  });
+
+  it("hides a group's section once a value from that group is used", () => {
+    const result = getAvailableClockDatePartSections(ALL_SECTIONS, [
+      "day-numeric",
+    ]);
+    expect(result.map((sectionData) => sectionData.id)).toEqual([
+      "month",
+      "year",
+      "weekday",
+      "separator",
+    ]);
+  });
+
+  it("keeps the edited item's own group visible via excludeIndex", () => {
+    const value = ["day-numeric", "month-short"];
+    const result = getAvailableClockDatePartSections(ALL_SECTIONS, value, 0);
+    expect(result.map((sectionData) => sectionData.id)).toEqual([
+      "day",
+      "year",
+      "weekday",
+      "separator",
+    ]);
+  });
+
+  it("never hides the separator section, even with multiple separators used", () => {
+    const value = [
+      "separator-dash",
+      "separator-slash",
+      "separator-dot",
+      "separator-new-line",
+    ];
+    const result = getAvailableClockDatePartSections(ALL_SECTIONS, value);
+    expect(result.map((sectionData) => sectionData.id)).toEqual([
+      "day",
+      "month",
+      "year",
+      "weekday",
+      "separator",
+    ]);
+  });
+
+  it("treats an unrecognized token as a separator and does not hide any group", () => {
+    const result = getAvailableClockDatePartSections(ALL_SECTIONS, [
+      "not-a-real-part",
+    ]);
+    expect(result.map((sectionData) => sectionData.id)).toEqual([
+      "day",
+      "month",
+      "year",
+      "weekday",
+      "separator",
+    ]);
+  });
+});


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The clock card's date format picker let you select several values from the same group (e.g. two `day` tokens), which, IMO, doesn't make sense when building a date, the picker had no restriction preventing it. This PR adds that restriction: only one value per group is now allowed, except for the separator group. A group's section is hidden once it has a value, except for the item currently being edited. Separators are unaffected and can still be repeated.

## Screenshots

<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
