### PR TITLE
Add conditional field visibility to ha-form

### DIFF
--- a/src/components/ha-form/conditions.ts
+++ b/src/components/ha-form/conditions.ts
@@ -1,0 +1,73 @@
+import type {
+  HaFormBaseSchema,
+  HaFormCondition,
+  HaFormDataContainer,
+  HaFormFieldCondition,
+  HaFormSchema,
+} from "./types";
+
+const isEmpty = (value: unknown): boolean =>
+  value === undefined || value === null || value === "";
+
+const matchFieldCondition = (
+  condition: HaFormFieldCondition,
+  data: HaFormDataContainer | undefined
+): boolean => {
+  const actual = data?.[condition.field];
+  switch (condition.operator ?? "eq") {
+    case "eq":
+      return actual === condition.value;
+    case "not_eq":
+      return actual !== condition.value;
+    case "in":
+      return (
+        Array.isArray(condition.value) &&
+        condition.value.includes(actual as any)
+      );
+    case "not_in":
+      return (
+        Array.isArray(condition.value) &&
+        !condition.value.includes(actual as any)
+      );
+    case "exists":
+      return !isEmpty(actual);
+    case "not_exists":
+      return isEmpty(actual);
+    default:
+      return false;
+  }
+};
+
+export const evaluateCondition = (
+  condition: HaFormCondition,
+  data: HaFormDataContainer | undefined
+): boolean => {
+  if ("condition" in condition) {
+    switch (condition.condition) {
+      case "and":
+        return condition.conditions.every((c) => evaluateCondition(c, data));
+      case "or":
+        return condition.conditions.some((c) => evaluateCondition(c, data));
+      case "not":
+        return !condition.conditions.some((c) => evaluateCondition(c, data));
+      default:
+        return false;
+    }
+  }
+  return matchFieldCondition(condition, data);
+};
+
+export const isFieldHidden = (
+  schema: HaFormSchema,
+  data: HaFormDataContainer | undefined
+): boolean => {
+  const { hidden } = schema as HaFormBaseSchema;
+  if (!hidden) {
+    return false;
+  }
+  if (hidden === true) {
+    return true;
+  }
+  const conditions = Array.isArray(hidden) ? hidden : [hidden];
+  return conditions.every((condition) => evaluateCondition(condition, data));
+};

--- a/src/components/ha-form/ha-form-grid.ts
+++ b/src/components/ha-form/ha-form-grid.ts
@@ -2,6 +2,7 @@ import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, queryAll } from "lit/decorators";
 import type { HomeAssistant } from "../../types";
+import { isFieldHidden } from "./conditions";
 import "./ha-form";
 import type { HaForm } from "./ha-form";
 import type {
@@ -68,19 +69,21 @@ export class HaFormGrid extends LitElement implements HaFormElement {
 
   protected render(): TemplateResult {
     return html`
-      ${this.schema.schema.map(
-        (item) => html`
-          <ha-form
-            .hass=${this.hass}
-            .data=${this.data}
-            .schema=${[item]}
-            .disabled=${this.disabled}
-            .computeLabel=${this.computeLabel}
-            .computeHelper=${this.computeHelper}
-            .localizeValue=${this.localizeValue}
-          ></ha-form>
-        `
-      )}
+      ${this.schema.schema
+        .filter((item) => !isFieldHidden(item, this.data))
+        .map(
+          (item) => html`
+            <ha-form
+              .hass=${this.hass}
+              .data=${this.data}
+              .schema=${[item]}
+              .disabled=${this.disabled}
+              .computeLabel=${this.computeLabel}
+              .computeHelper=${this.computeHelper}
+              .localizeValue=${this.localizeValue}
+            ></ha-form>
+          `
+        )}
     `;
   }
 

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -1,11 +1,12 @@
 import type { PropertyValues, TemplateResult } from "lit";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import { dynamicElement } from "../../common/dom/dynamic-element-directive";
 import { fireEvent } from "../../common/dom/fire_event";
 import type { HomeAssistant } from "../../types";
 import "../ha-alert";
 import "../ha-selector/ha-selector";
+import { isFieldHidden } from "./conditions";
 import type { HaFormDataContainer, HaFormElement, HaFormSchema } from "./types";
 
 const LOAD_ELEMENTS = {
@@ -98,7 +99,11 @@ export class HaForm extends LitElement implements HaFormElement {
     let isValid = true;
     let firstInvalidElement: HTMLElement | undefined;
 
-    this.schema.forEach((item, index) => {
+    const visibleSchema = this.schema.filter(
+      (item) => !isFieldHidden(item, this.data)
+    );
+
+    visibleSchema.forEach((item, index) => {
       const element = elements[index];
       if (!element) {
         return;
@@ -164,6 +169,10 @@ export class HaForm extends LitElement implements HaFormElement {
             : ""
         }
         ${this.schema.map((item) => {
+          if (isFieldHidden(item, this.data)) {
+            return nothing;
+          }
+
           const error = getError(this.error, item);
           const warning = getWarning(this.warning, item);
 

--- a/src/components/ha-form/types.ts
+++ b/src/components/ha-form/types.ts
@@ -22,6 +22,9 @@ export interface HaFormBaseSchema {
   default?: HaFormData;
   required?: boolean;
   disabled?: boolean;
+  // Field is hidden while the condition holds. Serializable so it can be
+  // shared with the backend and other renderers.
+  hidden?: boolean | HaFormCondition | HaFormCondition[];
   description?: {
     suffix?: string;
     // This value will be set initially when form is loaded
@@ -29,6 +32,36 @@ export interface HaFormBaseSchema {
   };
   context?: Record<string, string>;
 }
+
+export type HaFormConditionOperator =
+  "eq" | "not_eq" | "in" | "not_in" | "exists" | "not_exists";
+
+export interface HaFormFieldCondition {
+  field: string;
+  operator?: HaFormConditionOperator;
+  value?: HaFormData | readonly HaFormData[];
+}
+
+export interface HaFormAndCondition {
+  condition: "and";
+  conditions: readonly HaFormCondition[];
+}
+
+export interface HaFormOrCondition {
+  condition: "or";
+  conditions: readonly HaFormCondition[];
+}
+
+export interface HaFormNotCondition {
+  condition: "not";
+  conditions: readonly HaFormCondition[];
+}
+
+export type HaFormCondition =
+  | HaFormFieldCondition
+  | HaFormAndCondition
+  | HaFormOrCondition
+  | HaFormNotCondition;
 
 export interface HaFormGridSchema extends HaFormBaseSchema {
   type: "grid";

--- a/src/panels/lovelace/editor/config-elements/hui-history-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-history-graph-card-editor.ts
@@ -54,6 +54,65 @@ const cardConfigStruct = assign(
   })
 );
 
+const SCHEMA = [
+  { name: "title", selector: { text: {} } },
+  {
+    name: "",
+    type: "grid",
+    schema: [
+      {
+        name: "hours_to_show",
+        default: DEFAULT_HOURS_TO_SHOW,
+        selector: { number: { min: 0, step: "any", mode: "box" } },
+      },
+      {
+        name: "show_names",
+        default: true,
+        required: false,
+        selector: { boolean: {} },
+      },
+      {
+        name: "logarithmic_scale",
+        required: false,
+        selector: { boolean: {} },
+      },
+      {
+        name: "expand_legend",
+        required: false,
+        selector: { boolean: {} },
+      },
+    ],
+  },
+  {
+    name: "",
+    type: "grid",
+    schema: [
+      {
+        name: "min_y_axis",
+        required: false,
+        selector: { number: { mode: "box", step: "any" } },
+      },
+      {
+        name: "max_y_axis",
+        required: false,
+        selector: { number: { mode: "box", step: "any" } },
+      },
+    ],
+  },
+  {
+    name: "fit_y_data",
+    required: false,
+    hidden: {
+      condition: "and",
+      conditions: [
+        { field: "min_y_axis", operator: "not_exists" },
+        { field: "max_y_axis", operator: "not_exists" },
+      ],
+    },
+    selector: { boolean: {} },
+  },
+] as const satisfies readonly HaFormSchema[];
+
 @customElement("hui-history-graph-card-editor")
 export class HuiHistoryGraphCardEditor
   extends LitElement
@@ -69,65 +128,6 @@ export class HuiHistoryGraphCardEditor
     assert(config, cardConfigStruct);
     this._config = config;
   }
-
-  private _schema = memoizeOne(
-    (showFitOption: boolean) =>
-      [
-        { name: "title", selector: { text: {} } },
-        {
-          name: "",
-          type: "grid",
-          schema: [
-            {
-              name: "hours_to_show",
-              default: DEFAULT_HOURS_TO_SHOW,
-              selector: { number: { min: 0, step: "any", mode: "box" } },
-            },
-            {
-              name: "show_names",
-              default: true,
-              required: false,
-              selector: { boolean: {} },
-            },
-            {
-              name: "logarithmic_scale",
-              required: false,
-              selector: { boolean: {} },
-            },
-            {
-              name: "expand_legend",
-              required: false,
-              selector: { boolean: {} },
-            },
-          ],
-        },
-        {
-          name: "",
-          type: "grid",
-          schema: [
-            {
-              name: "min_y_axis",
-              required: false,
-              selector: { number: { mode: "box", step: "any" } },
-            },
-            {
-              name: "max_y_axis",
-              required: false,
-              selector: { number: { mode: "box", step: "any" } },
-            },
-          ],
-        },
-        ...(showFitOption
-          ? [
-              {
-                name: "fit_y_data",
-                required: false,
-                selector: { boolean: {} },
-              },
-            ]
-          : []),
-      ] as const
-  );
 
   private _subForm = memoizeOne((localize: LocalizeFunc, entityId: string) => ({
     schema: [
@@ -176,11 +176,6 @@ export class HuiHistoryGraphCardEditor
       `;
     }
 
-    const schema = this._schema(
-      this._config!.min_y_axis !== undefined ||
-        this._config!.max_y_axis !== undefined
-    );
-
     const configEntities = this._config.entities
       ? (processEditorEntities(this._config.entities) as GraphEntityConfig[])
       : [];
@@ -188,7 +183,7 @@ export class HuiHistoryGraphCardEditor
       <ha-form
         .hass=${this.hass}
         .data=${this._config}
-        .schema=${schema}
+        .schema=${SCHEMA}
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
       ></ha-form>
@@ -283,9 +278,7 @@ export class HuiHistoryGraphCardEditor
     ) as HistoryGraphCardConfig;
   }
 
-  private _computeLabelCallback = (
-    schema: SchemaUnion<ReturnType<typeof this._schema>>
-  ) => {
+  private _computeLabelCallback = (schema: SchemaUnion<typeof SCHEMA>) => {
     switch (schema.name) {
       case "show_names":
       case "logarithmic_scale":

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -92,7 +92,6 @@ export class HuiTileCardEditor
     (
       localize: LocalizeFunc,
       entityId: string | undefined,
-      hideState: boolean,
       showTimeFormat: boolean
     ) =>
       [
@@ -144,31 +143,25 @@ export class HuiTileCardEditor
                 },
               ],
             },
-            ...(!hideState
-              ? ([
-                  {
-                    name: "state_content",
-                    selector: {
-                      ui_state_content: {
-                        allow_context: true,
-                      },
-                    },
-                    context: {
-                      filter_entity: "entity",
-                    },
-                  },
-                ] as const satisfies readonly HaFormSchema[])
-              : []),
-            ...(showTimeFormat
-              ? ([
-                  {
-                    name: "time_format",
-                    selector: {
-                      ui_time_format: {},
-                    },
-                  },
-                ] as const satisfies readonly HaFormSchema[])
-              : []),
+            {
+              name: "state_content",
+              hidden: { field: "hide_state", value: true },
+              selector: {
+                ui_state_content: {
+                  allow_context: true,
+                },
+              },
+              context: {
+                filter_entity: "entity",
+              },
+            },
+            {
+              name: "time_format",
+              hidden: !showTimeFormat,
+              selector: {
+                ui_time_format: {},
+              },
+            },
             {
               name: "content_layout",
               required: true,
@@ -293,12 +286,7 @@ export class HuiTileCardEditor
         this._config.state_content
       );
 
-    const schema = this._schema(
-      this.hass.localize,
-      entityId,
-      this._config.hide_state ?? false,
-      showTimeFormat
-    );
+    const schema = this._schema(this.hass.localize, entityId, showTimeFormat);
 
     const vertical = this._config.vertical ?? false;
 

--- a/test/components/ha-form/ha-form-hidden.test.ts
+++ b/test/components/ha-form/ha-form-hidden.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import { isFieldHidden } from "../../../src/components/ha-form/conditions";
+import type { HaFormSchema } from "../../../src/components/ha-form/types";
+
+const field = (hidden: HaFormSchema["hidden"]): HaFormSchema =>
+  ({ name: "field", selector: { text: {} }, hidden }) as HaFormSchema;
+
+describe("isFieldHidden", () => {
+  it("shows a field without a hidden condition", () => {
+    expect(isFieldHidden(field(undefined), { a: 1 })).toBe(false);
+  });
+
+  it("honors a boolean hidden", () => {
+    expect(isFieldHidden(field(true), {})).toBe(true);
+    expect(isFieldHidden(field(false), {})).toBe(false);
+  });
+
+  describe("operators", () => {
+    it("eq (default) matches equal values", () => {
+      expect(isFieldHidden(field({ field: "a", value: 1 }), { a: 1 })).toBe(
+        true
+      );
+      expect(isFieldHidden(field({ field: "a", value: 1 }), { a: 2 })).toBe(
+        false
+      );
+    });
+
+    it("not_eq matches different values", () => {
+      const schema = field({ field: "a", operator: "not_eq", value: 1 });
+      expect(isFieldHidden(schema, { a: 2 })).toBe(true);
+      expect(isFieldHidden(schema, { a: 1 })).toBe(false);
+    });
+
+    it("in matches membership", () => {
+      const schema = field({ field: "a", operator: "in", value: ["x", "y"] });
+      expect(isFieldHidden(schema, { a: "y" })).toBe(true);
+      expect(isFieldHidden(schema, { a: "z" })).toBe(false);
+    });
+
+    it("not_in matches non-membership", () => {
+      const schema = field({
+        field: "a",
+        operator: "not_in",
+        value: ["x", "y"],
+      });
+      expect(isFieldHidden(schema, { a: "z" })).toBe(true);
+      expect(isFieldHidden(schema, { a: "x" })).toBe(false);
+    });
+
+    it("exists matches a defined non-empty value", () => {
+      const schema = field({ field: "a", operator: "exists" });
+      expect(isFieldHidden(schema, { a: "x" })).toBe(true);
+      expect(isFieldHidden(schema, { a: "" })).toBe(false);
+      expect(isFieldHidden(schema, {})).toBe(false);
+    });
+
+    it("not_exists matches a missing or empty value", () => {
+      const schema = field({ field: "a", operator: "not_exists" });
+      expect(isFieldHidden(schema, {})).toBe(true);
+      expect(isFieldHidden(schema, { a: null } as any)).toBe(true);
+      expect(isFieldHidden(schema, { a: "x" })).toBe(false);
+    });
+  });
+
+  describe("combinators", () => {
+    it("and requires every condition", () => {
+      const schema = field({
+        condition: "and",
+        conditions: [
+          { field: "a", value: 1 },
+          { field: "b", value: 2 },
+        ],
+      });
+      expect(isFieldHidden(schema, { a: 1, b: 2 })).toBe(true);
+      expect(isFieldHidden(schema, { a: 1, b: 9 })).toBe(false);
+    });
+
+    it("or requires any condition", () => {
+      const schema = field({
+        condition: "or",
+        conditions: [
+          { field: "a", value: 1 },
+          { field: "b", value: 2 },
+        ],
+      });
+      expect(isFieldHidden(schema, { a: 9, b: 2 })).toBe(true);
+      expect(isFieldHidden(schema, { a: 9, b: 9 })).toBe(false);
+    });
+
+    it("not negates its conditions", () => {
+      const schema = field({
+        condition: "not",
+        conditions: [{ field: "a", value: 1 }],
+      });
+      expect(isFieldHidden(schema, { a: 2 })).toBe(true);
+      expect(isFieldHidden(schema, { a: 1 })).toBe(false);
+    });
+
+    it("nests combinators", () => {
+      const schema = field({
+        condition: "and",
+        conditions: [
+          { field: "a", value: 1 },
+          {
+            condition: "or",
+            conditions: [
+              { field: "b", value: 2 },
+              { field: "c", value: 3 },
+            ],
+          },
+        ],
+      });
+      expect(isFieldHidden(schema, { a: 1, b: 9, c: 3 })).toBe(true);
+      expect(isFieldHidden(schema, { a: 1, b: 9, c: 9 })).toBe(false);
+      expect(isFieldHidden(schema, { a: 9, b: 2, c: 3 })).toBe(false);
+    });
+  });
+
+  it("treats an array of conditions as AND", () => {
+    const schema = field([
+      { field: "a", value: 1 },
+      { field: "b", value: 2 },
+    ]);
+    expect(isFieldHidden(schema, { a: 1, b: 2 })).toBe(true);
+    expect(isFieldHidden(schema, { a: 1, b: 9 })).toBe(false);
+  });
+
+  it("handles missing data", () => {
+    expect(isFieldHidden(field({ field: "a", value: 1 }), undefined)).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add a declarative `hidden` option to `ha-form` schemas so a field can be shown or hidden based on other field values, instead of editors rebuilding their schema. Hidden fields keep their position in the form and the condition is serializable so it can be reused across editors and, later, backend-driven forms.

The condition supports `eq`/`not_eq`/`in`/`not_in`/`exists`/`not_exists` operators and `and`/`or`/`not` combinators. The tile and history-graph card editors adopt it as a first migration; history-graph's schema is now fully static.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
