### PR TITLE
Rename ha-form conditional field to `visible` and skip it in config flow submission

### DIFF
--- a/src/components/ha-form/conditions.ts
+++ b/src/components/ha-form/conditions.ts
@@ -71,3 +71,26 @@ export const isFieldHidden = (
   const conditions = Array.isArray(hidden) ? hidden : [hidden];
   return conditions.every((condition) => evaluateCondition(condition, data));
 };
+
+// A hidden field holds no value, so it reads as absent to the conditions of the
+// other fields. Visibility is resolved until it is stable.
+export const getHiddenFields = (
+  schema: readonly HaFormSchema[],
+  data: HaFormDataContainer | undefined
+): Set<string> => {
+  const hidden = new Set<string>();
+  const evalData: HaFormDataContainer = { ...(data ?? {}) };
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const field of schema) {
+      if (hidden.has(field.name) || !isFieldHidden(field, evalData)) {
+        continue;
+      }
+      hidden.add(field.name);
+      delete evalData[field.name];
+      changed = true;
+    }
+  }
+  return hidden;
+};

--- a/src/components/ha-form/conditions.ts
+++ b/src/components/ha-form/conditions.ts
@@ -57,23 +57,23 @@ export const evaluateCondition = (
   return matchFieldCondition(condition, data);
 };
 
-export const isFieldHidden = (
+export const isFieldVisible = (
   schema: HaFormSchema,
   data: HaFormDataContainer | undefined
 ): boolean => {
-  const { hidden } = schema as HaFormBaseSchema;
-  if (!hidden) {
-    return false;
-  }
-  if (hidden === true) {
+  const { visible } = schema as HaFormBaseSchema;
+  if (visible === undefined || visible === true) {
     return true;
   }
-  const conditions = Array.isArray(hidden) ? hidden : [hidden];
+  if (visible === false) {
+    return false;
+  }
+  const conditions = Array.isArray(visible) ? visible : [visible];
   return conditions.every((condition) => evaluateCondition(condition, data));
 };
 
-// A hidden field holds no value, so it reads as absent to the conditions of the
-// other fields. Visibility is resolved until it is stable.
+// Hiding a field drops its value, which can flip another field's condition, so
+// resolve the set to a fixpoint.
 export const getHiddenFields = (
   schema: readonly HaFormSchema[],
   data: HaFormDataContainer | undefined
@@ -84,7 +84,7 @@ export const getHiddenFields = (
   while (changed) {
     changed = false;
     for (const field of schema) {
-      if (hidden.has(field.name) || !isFieldHidden(field, evalData)) {
+      if (hidden.has(field.name) || isFieldVisible(field, evalData)) {
         continue;
       }
       hidden.add(field.name);

--- a/src/components/ha-form/ha-form-grid.ts
+++ b/src/components/ha-form/ha-form-grid.ts
@@ -2,7 +2,7 @@ import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, queryAll } from "lit/decorators";
 import type { HomeAssistant } from "../../types";
-import { isFieldHidden } from "./conditions";
+import { getHiddenFields } from "./conditions";
 import "./ha-form";
 import type { HaForm } from "./ha-form";
 import type {
@@ -68,9 +68,11 @@ export class HaFormGrid extends LitElement implements HaFormElement {
   }
 
   protected render(): TemplateResult {
+    const hiddenFields = getHiddenFields(this.schema.schema, this.data);
+
     return html`
       ${this.schema.schema
-        .filter((item) => !isFieldHidden(item, this.data))
+        .filter((item) => !hiddenFields.has(item.name))
         .map(
           (item) => html`
             <ha-form

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -6,7 +6,7 @@ import { fireEvent } from "../../common/dom/fire_event";
 import type { HomeAssistant } from "../../types";
 import "../ha-alert";
 import "../ha-selector/ha-selector";
-import { isFieldHidden } from "./conditions";
+import { getHiddenFields } from "./conditions";
 import type { HaFormDataContainer, HaFormElement, HaFormSchema } from "./types";
 
 const LOAD_ELEMENTS = {
@@ -99,8 +99,9 @@ export class HaForm extends LitElement implements HaFormElement {
     let isValid = true;
     let firstInvalidElement: HTMLElement | undefined;
 
+    const hiddenFields = getHiddenFields(this.schema, this.data);
     const visibleSchema = this.schema.filter(
-      (item) => !isFieldHidden(item, this.data)
+      (item) => !hiddenFields.has(item.name)
     );
 
     visibleSchema.forEach((item, index) => {
@@ -157,6 +158,8 @@ export class HaForm extends LitElement implements HaFormElement {
   }
 
   protected render(): TemplateResult {
+    const renderHiddenFields = getHiddenFields(this.schema, this.data);
+
     return html`
       <div class="root" part="root">
         ${
@@ -169,7 +172,7 @@ export class HaForm extends LitElement implements HaFormElement {
             : ""
         }
         ${this.schema.map((item) => {
-          if (isFieldHidden(item, this.data)) {
+          if (renderHiddenFields.has(item.name)) {
             return nothing;
           }
 

--- a/src/components/ha-form/types.ts
+++ b/src/components/ha-form/types.ts
@@ -22,9 +22,9 @@ export interface HaFormBaseSchema {
   default?: HaFormData;
   required?: boolean;
   disabled?: boolean;
-  // Field is hidden while the condition holds. Serializable so it can be
-  // shared with the backend and other renderers.
-  hidden?: boolean | HaFormCondition | HaFormCondition[];
+  // Field is visible while the condition holds (visible by default).
+  // Serializable so it can be shared with the backend and other renderers.
+  visible?: boolean | HaFormCondition | HaFormCondition[];
   description?: {
     suffix?: string;
     // This value will be set initially when form is loaded

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -9,7 +9,7 @@ import { fireEvent } from "../../common/dom/fire_event";
 import { isNavigationClick } from "../../common/dom/is-navigation-click";
 import "../../components/ha-alert";
 import { computeInitialHaFormData } from "../../components/ha-form/compute-initial-ha-form-data";
-import { isFieldHidden } from "../../components/ha-form/conditions";
+import { getHiddenFields } from "../../components/ha-form/conditions";
 import "../../components/ha-form/ha-form";
 import type {
   HaFormSchema,
@@ -227,15 +227,17 @@ class StepFlowForm extends LitElement {
     const checkAllRequiredFields = (
       schema: readonly HaFormSchema[],
       data: Record<string, any>
-    ) =>
-      schema.every(
+    ) => {
+      const hidden = getHiddenFields(schema, data);
+      return schema.every(
         (field) =>
-          isFieldHidden(field, data) ||
+          hidden.has(field.name) ||
           ((!field.required || !["", undefined].includes(data[field.name])) &&
             (field.type !== "expandable" ||
               (!field.required && data[field.name] === undefined) ||
               checkAllRequiredFields(field.schema, data[field.name])))
       );
+    };
 
     const allRequiredInfoFilledIn =
       stepData === undefined
@@ -257,15 +259,17 @@ class StepFlowForm extends LitElement {
 
     const flowId = this.step.flow_id;
 
+    const hiddenFields = getHiddenFields(this.step.data_schema, stepData);
+
     const toSendData: Record<string, unknown> = {};
     Object.keys(stepData).forEach((key) => {
-      const value = stepData[key];
-      const isEmpty = [undefined, ""].includes(value);
-      const field = this.step.data_schema?.find((f) => f.name === key);
-      if (field && isFieldHidden(field, stepData)) {
+      if (hiddenFields.has(key)) {
         // Hidden fields are not part of the submitted config
         return;
       }
+      const value = stepData[key];
+      const isEmpty = [undefined, ""].includes(value);
+      const field = this.step.data_schema?.find((f) => f.name === key);
       const selector = (field as HaFormSelector)?.selector ?? {};
       const read_only = (
         Object.values(selector)[0] as { read_only?: boolean } | null | undefined

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -9,6 +9,7 @@ import { fireEvent } from "../../common/dom/fire_event";
 import { isNavigationClick } from "../../common/dom/is-navigation-click";
 import "../../components/ha-alert";
 import { computeInitialHaFormData } from "../../components/ha-form/compute-initial-ha-form-data";
+import { isFieldHidden } from "../../components/ha-form/conditions";
 import "../../components/ha-form/ha-form";
 import type {
   HaFormSchema,
@@ -229,10 +230,11 @@ class StepFlowForm extends LitElement {
     ) =>
       schema.every(
         (field) =>
-          (!field.required || !["", undefined].includes(data[field.name])) &&
-          (field.type !== "expandable" ||
-            (!field.required && data[field.name] === undefined) ||
-            checkAllRequiredFields(field.schema, data[field.name]))
+          isFieldHidden(field, data) ||
+          ((!field.required || !["", undefined].includes(data[field.name])) &&
+            (field.type !== "expandable" ||
+              (!field.required && data[field.name] === undefined) ||
+              checkAllRequiredFields(field.schema, data[field.name])))
       );
 
     const allRequiredInfoFilledIn =
@@ -260,6 +262,10 @@ class StepFlowForm extends LitElement {
       const value = stepData[key];
       const isEmpty = [undefined, ""].includes(value);
       const field = this.step.data_schema?.find((f) => f.name === key);
+      if (field && isFieldHidden(field, stepData)) {
+        // Hidden fields are not part of the submitted config
+        return;
+      }
       const selector = (field as HaFormSelector)?.selector ?? {};
       const read_only = (
         Object.values(selector)[0] as { read_only?: boolean } | null | undefined

--- a/src/panels/lovelace/editor/config-elements/hui-clock-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-clock-card-editor.ts
@@ -113,9 +113,8 @@ export class HuiClockCardEditor
         },
         {
           name: "time_format",
-          hidden: {
+          visible: {
             field: "clock_style",
-            operator: "not_eq",
             value: "digital",
           },
           selector: {
@@ -132,7 +131,7 @@ export class HuiClockCardEditor
         },
         {
           name: "border",
-          hidden: { field: "clock_style", operator: "not_eq", value: "analog" },
+          visible: { field: "clock_style", value: "analog" },
           description: {
             suffix: localize(
               `ui.panel.lovelace.editor.card.clock.border.description`
@@ -145,7 +144,7 @@ export class HuiClockCardEditor
         },
         {
           name: "ticks",
-          hidden: { field: "clock_style", operator: "not_eq", value: "analog" },
+          visible: { field: "clock_style", value: "analog" },
           description: {
             suffix: localize(
               `ui.panel.lovelace.editor.card.clock.ticks.description`
@@ -169,13 +168,10 @@ export class HuiClockCardEditor
         },
         {
           name: "seconds_motion",
-          hidden: {
-            condition: "or",
-            conditions: [
-              { field: "clock_style", operator: "not_eq", value: "analog" },
-              { field: "show_seconds", operator: "not_eq", value: true },
-            ],
-          },
+          visible: [
+            { field: "clock_style", value: "analog" },
+            { field: "show_seconds", value: true },
+          ],
           description: {
             suffix: localize(
               `ui.panel.lovelace.editor.card.clock.seconds_motion.description`
@@ -199,13 +195,10 @@ export class HuiClockCardEditor
         },
         {
           name: "face_style",
-          hidden: {
-            condition: "or",
-            conditions: [
-              { field: "clock_style", operator: "not_eq", value: "analog" },
-              { field: "ticks", value: "none" },
-            ],
-          },
+          visible: [
+            { field: "clock_style", value: "analog" },
+            { field: "ticks", operator: "not_eq", value: "none" },
+          ],
           description: {
             suffix: localize(
               `ui.panel.lovelace.editor.card.clock.face_style.description`

--- a/src/panels/lovelace/editor/config-elements/hui-history-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-history-graph-card-editor.ts
@@ -102,11 +102,11 @@ const SCHEMA = [
   {
     name: "fit_y_data",
     required: false,
-    hidden: {
-      condition: "and",
+    visible: {
+      condition: "or",
       conditions: [
-        { field: "min_y_axis", operator: "not_exists" },
-        { field: "max_y_axis", operator: "not_exists" },
+        { field: "min_y_axis", operator: "exists" },
+        { field: "max_y_axis", operator: "exists" },
       ],
     },
     selector: { boolean: {} },

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -145,7 +145,7 @@ export class HuiTileCardEditor
             },
             {
               name: "state_content",
-              hidden: { field: "hide_state", value: true },
+              visible: { field: "hide_state", operator: "not_eq", value: true },
               selector: {
                 ui_state_content: {
                   allow_context: true,
@@ -157,7 +157,7 @@ export class HuiTileCardEditor
             },
             {
               name: "time_format",
-              hidden: !showTimeFormat,
+              visible: showTimeFormat,
               selector: {
                 ui_time_format: {},
               },

--- a/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
+++ b/src/panels/lovelace/editor/section-editor/hui-section-settings-editor.ts
@@ -56,7 +56,7 @@ export class HuiDialogEditSection extends LitElement {
           type: "expandable",
           flatten: true,
           expanded: true,
-          hidden: { field: "background_enabled", value: false },
+          visible: { field: "background_enabled", value: true },
           iconPath: mdiPalette,
           schema: [
             {

--- a/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
@@ -93,9 +93,8 @@ export class HuiViewEditor extends LitElement {
           type: "expandable",
           flatten: true,
           expanded: true,
-          hidden: {
+          visible: {
             field: "type",
-            operator: "not_eq",
             value: SECTIONS_VIEW_LAYOUT,
           },
           schema: [

--- a/test/components/ha-form/ha-form-conditions.test.ts
+++ b/test/components/ha-form/ha-form-conditions.test.ts
@@ -2,43 +2,43 @@ import { describe, expect, it } from "vitest";
 
 import {
   getHiddenFields,
-  isFieldHidden,
+  isFieldVisible,
 } from "../../../src/components/ha-form/conditions";
 import type { HaFormSchema } from "../../../src/components/ha-form/types";
 
-const field = (hidden: HaFormSchema["hidden"]): HaFormSchema =>
-  ({ name: "field", selector: { text: {} }, hidden }) as HaFormSchema;
+const field = (visible: HaFormSchema["visible"]): HaFormSchema =>
+  ({ name: "field", selector: { text: {} }, visible }) as HaFormSchema;
 
-describe("isFieldHidden", () => {
-  it("shows a field without a hidden condition", () => {
-    expect(isFieldHidden(field(undefined), { a: 1 })).toBe(false);
+describe("isFieldVisible", () => {
+  it("shows a field without a visible condition", () => {
+    expect(isFieldVisible(field(undefined), { a: 1 })).toBe(true);
   });
 
-  it("honors a boolean hidden", () => {
-    expect(isFieldHidden(field(true), {})).toBe(true);
-    expect(isFieldHidden(field(false), {})).toBe(false);
+  it("honors a boolean visible", () => {
+    expect(isFieldVisible(field(true), {})).toBe(true);
+    expect(isFieldVisible(field(false), {})).toBe(false);
   });
 
   describe("operators", () => {
     it("eq (default) matches equal values", () => {
-      expect(isFieldHidden(field({ field: "a", value: 1 }), { a: 1 })).toBe(
+      expect(isFieldVisible(field({ field: "a", value: 1 }), { a: 1 })).toBe(
         true
       );
-      expect(isFieldHidden(field({ field: "a", value: 1 }), { a: 2 })).toBe(
+      expect(isFieldVisible(field({ field: "a", value: 1 }), { a: 2 })).toBe(
         false
       );
     });
 
     it("not_eq matches different values", () => {
       const schema = field({ field: "a", operator: "not_eq", value: 1 });
-      expect(isFieldHidden(schema, { a: 2 })).toBe(true);
-      expect(isFieldHidden(schema, { a: 1 })).toBe(false);
+      expect(isFieldVisible(schema, { a: 2 })).toBe(true);
+      expect(isFieldVisible(schema, { a: 1 })).toBe(false);
     });
 
     it("in matches membership", () => {
       const schema = field({ field: "a", operator: "in", value: ["x", "y"] });
-      expect(isFieldHidden(schema, { a: "y" })).toBe(true);
-      expect(isFieldHidden(schema, { a: "z" })).toBe(false);
+      expect(isFieldVisible(schema, { a: "y" })).toBe(true);
+      expect(isFieldVisible(schema, { a: "z" })).toBe(false);
     });
 
     it("not_in matches non-membership", () => {
@@ -47,22 +47,22 @@ describe("isFieldHidden", () => {
         operator: "not_in",
         value: ["x", "y"],
       });
-      expect(isFieldHidden(schema, { a: "z" })).toBe(true);
-      expect(isFieldHidden(schema, { a: "x" })).toBe(false);
+      expect(isFieldVisible(schema, { a: "z" })).toBe(true);
+      expect(isFieldVisible(schema, { a: "x" })).toBe(false);
     });
 
     it("exists matches a defined non-empty value", () => {
       const schema = field({ field: "a", operator: "exists" });
-      expect(isFieldHidden(schema, { a: "x" })).toBe(true);
-      expect(isFieldHidden(schema, { a: "" })).toBe(false);
-      expect(isFieldHidden(schema, {})).toBe(false);
+      expect(isFieldVisible(schema, { a: "x" })).toBe(true);
+      expect(isFieldVisible(schema, { a: "" })).toBe(false);
+      expect(isFieldVisible(schema, {})).toBe(false);
     });
 
     it("not_exists matches a missing or empty value", () => {
       const schema = field({ field: "a", operator: "not_exists" });
-      expect(isFieldHidden(schema, {})).toBe(true);
-      expect(isFieldHidden(schema, { a: null } as any)).toBe(true);
-      expect(isFieldHidden(schema, { a: "x" })).toBe(false);
+      expect(isFieldVisible(schema, {})).toBe(true);
+      expect(isFieldVisible(schema, { a: null } as any)).toBe(true);
+      expect(isFieldVisible(schema, { a: "x" })).toBe(false);
     });
   });
 
@@ -75,8 +75,8 @@ describe("isFieldHidden", () => {
           { field: "b", value: 2 },
         ],
       });
-      expect(isFieldHidden(schema, { a: 1, b: 2 })).toBe(true);
-      expect(isFieldHidden(schema, { a: 1, b: 9 })).toBe(false);
+      expect(isFieldVisible(schema, { a: 1, b: 2 })).toBe(true);
+      expect(isFieldVisible(schema, { a: 1, b: 9 })).toBe(false);
     });
 
     it("or requires any condition", () => {
@@ -87,8 +87,8 @@ describe("isFieldHidden", () => {
           { field: "b", value: 2 },
         ],
       });
-      expect(isFieldHidden(schema, { a: 9, b: 2 })).toBe(true);
-      expect(isFieldHidden(schema, { a: 9, b: 9 })).toBe(false);
+      expect(isFieldVisible(schema, { a: 9, b: 2 })).toBe(true);
+      expect(isFieldVisible(schema, { a: 9, b: 9 })).toBe(false);
     });
 
     it("not negates its conditions", () => {
@@ -96,8 +96,8 @@ describe("isFieldHidden", () => {
         condition: "not",
         conditions: [{ field: "a", value: 1 }],
       });
-      expect(isFieldHidden(schema, { a: 2 })).toBe(true);
-      expect(isFieldHidden(schema, { a: 1 })).toBe(false);
+      expect(isFieldVisible(schema, { a: 2 })).toBe(true);
+      expect(isFieldVisible(schema, { a: 1 })).toBe(false);
     });
 
     it("nests combinators", () => {
@@ -114,9 +114,9 @@ describe("isFieldHidden", () => {
           },
         ],
       });
-      expect(isFieldHidden(schema, { a: 1, b: 9, c: 3 })).toBe(true);
-      expect(isFieldHidden(schema, { a: 1, b: 9, c: 9 })).toBe(false);
-      expect(isFieldHidden(schema, { a: 9, b: 2, c: 3 })).toBe(false);
+      expect(isFieldVisible(schema, { a: 1, b: 9, c: 3 })).toBe(true);
+      expect(isFieldVisible(schema, { a: 1, b: 9, c: 9 })).toBe(false);
+      expect(isFieldVisible(schema, { a: 9, b: 2, c: 3 })).toBe(false);
     });
   });
 
@@ -125,25 +125,28 @@ describe("isFieldHidden", () => {
       { field: "a", value: 1 },
       { field: "b", value: 2 },
     ]);
-    expect(isFieldHidden(schema, { a: 1, b: 2 })).toBe(true);
-    expect(isFieldHidden(schema, { a: 1, b: 9 })).toBe(false);
+    expect(isFieldVisible(schema, { a: 1, b: 2 })).toBe(true);
+    expect(isFieldVisible(schema, { a: 1, b: 9 })).toBe(false);
   });
 
   it("handles missing data", () => {
-    expect(isFieldHidden(field({ field: "a", value: 1 }), undefined)).toBe(
+    expect(isFieldVisible(field({ field: "a", value: 1 }), undefined)).toBe(
       false
     );
   });
 });
 
 describe("getHiddenFields", () => {
-  const named = (name: string, hidden?: HaFormSchema["hidden"]): HaFormSchema =>
-    ({ name, selector: { text: {} }, hidden }) as HaFormSchema;
+  const named = (
+    name: string,
+    visible?: HaFormSchema["visible"]
+  ): HaFormSchema =>
+    ({ name, selector: { text: {} }, visible }) as HaFormSchema;
 
-  it("collects the fields whose condition matches", () => {
+  it("collects the fields that are not visible", () => {
     const schema = [
       named("mode"),
-      named("token", { field: "mode", value: "simple" }),
+      named("token", { field: "mode", value: "advanced" }),
     ];
     expect([...getHiddenFields(schema, { mode: "simple" })]).toEqual(["token"]);
     expect([...getHiddenFields(schema, { mode: "advanced" })]).toEqual([]);
@@ -153,8 +156,8 @@ describe("getHiddenFields", () => {
     // "token" is hidden, so its value must not satisfy the condition on "extra"
     const schema = [
       named("mode"),
-      named("token", { field: "mode", value: "simple" }),
-      named("extra", { field: "token", operator: "not_exists" }),
+      named("token", { field: "mode", value: "advanced" }),
+      named("extra", { field: "token", operator: "exists" }),
     ];
     expect([
       ...getHiddenFields(schema, { mode: "simple", token: "stale" }),

--- a/test/components/ha-form/ha-form-hidden.test.ts
+++ b/test/components/ha-form/ha-form-hidden.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { isFieldHidden } from "../../../src/components/ha-form/conditions";
+import {
+  getHiddenFields,
+  isFieldHidden,
+} from "../../../src/components/ha-form/conditions";
 import type { HaFormSchema } from "../../../src/components/ha-form/types";
 
 const field = (hidden: HaFormSchema["hidden"]): HaFormSchema =>
@@ -130,5 +133,34 @@ describe("isFieldHidden", () => {
     expect(isFieldHidden(field({ field: "a", value: 1 }), undefined)).toBe(
       false
     );
+  });
+});
+
+describe("getHiddenFields", () => {
+  const named = (name: string, hidden?: HaFormSchema["hidden"]): HaFormSchema =>
+    ({ name, selector: { text: {} }, hidden }) as HaFormSchema;
+
+  it("collects the fields whose condition matches", () => {
+    const schema = [
+      named("mode"),
+      named("token", { field: "mode", value: "simple" }),
+    ];
+    expect([...getHiddenFields(schema, { mode: "simple" })]).toEqual(["token"]);
+    expect([...getHiddenFields(schema, { mode: "advanced" })]).toEqual([]);
+  });
+
+  it("treats a hidden field as absent to the other conditions", () => {
+    // "token" is hidden, so its value must not satisfy the condition on "extra"
+    const schema = [
+      named("mode"),
+      named("token", { field: "mode", value: "simple" }),
+      named("extra", { field: "token", operator: "not_exists" }),
+    ];
+    expect([
+      ...getHiddenFields(schema, { mode: "simple", token: "stale" }),
+    ]).toEqual(["token", "extra"]);
+    expect([
+      ...getHiddenFields(schema, { mode: "advanced", token: "kept" }),
+    ]).toEqual([]);
   });
 });


### PR DESCRIPTION
## Proposed change

Builds on the conditional field visibility added in #53165.

- Rename the `ha-form` field property `hidden` to `visible`, flipping to positive polarity: a field is shown while its condition holds, instead of hidden while it holds. Conditions almost always expressed "show when X", which forced negated operators everywhere; the positive form removes them and reads better in config flows and blueprints.
- Skip fields that resolve to hidden when submitting a config or options flow, so a conditionally hidden field no longer counts as required or leaks its value into the saved config.
- Resolve visibility to a fixpoint, since hiding a field drops its value and can hide another field whose condition depends on it.

It takes effect once the backend emits `visible` conditions in a flow's schema.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #53165
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: https://github.com/home-assistant/core/pull/176703

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
