### PR TITLE
Use secondary color for home strategy empty-state icons

### DIFF
--- a/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-area-view-strategy.ts
@@ -419,7 +419,6 @@ export class HomeAreaViewStrategy extends ReactiveElement {
           {
             type: "empty-state",
             icon: area.icon || "mdi:shape-square-rounded-plus",
-            icon_color: "primary",
             content_only: true,
             title: hass.localize(
               "ui.panel.lovelace.strategy.home-area.no_devices_title"

--- a/src/panels/lovelace/strategies/home/home-other-devices-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-other-devices-view-strategy.ts
@@ -151,7 +151,6 @@ export class HomeOtherDevicesViewStrategy extends ReactiveElement {
           {
             type: "empty-state",
             icon: "mdi:check-all",
-            icon_color: "primary",
             content_only: true,
             title: hass.localize(
               "ui.panel.lovelace.strategy.home-other-devices.all_organized_title"

--- a/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
@@ -483,7 +483,6 @@ export class HomeOverviewViewStrategy extends ReactiveElement {
           {
             type: "empty-state",
             icon: "mdi:home-assistant",
-            icon_color: "primary",
             content_only: true,
             title: hass.localize(
               "ui.panel.lovelace.strategy.home.welcome_title"

--- a/src/panels/lovelace/strategies/original-states/original-states-view-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states/original-states-view-strategy.ts
@@ -84,7 +84,6 @@ export class OriginalStatesViewStrategy extends ReactiveElement {
           {
             type: "empty-state",
             icon: "mdi:home-assistant",
-            icon_color: "primary",
             content_only: true,
             title: hass.localize(
               "ui.panel.lovelace.strategy.original-states.empty_state_title"


### PR DESCRIPTION
## Proposed change

The large empty-state icons rendered by the home view strategies (home overview, area, other-devices) and the original-states strategy were configured with `icon_color: "primary"`, painting them in the accent color. At 64px, a colored icon reads as a tappable button — but it is purely decorative and not interactable.

This removes `icon_color: "primary"` from the four strategy configs so the icon falls back to the card's own `--secondary-text-color`, making it read as a muted illustration rather than an interactive control.

Future note: these home dashboard empty states are one of several places in the app that hand-roll the same "big icon + heading + description + action" layout (config pickers for automations/scenes/scripts do too, each with duplicated markup and CSS). We should extract a reusable `ha-empty-state` component and adopt it across empty dashboards, empty settings pages, and empty activity/history pages, so the styling (including this secondary-icon treatment) lives in one place. Out of scope for this PR.

## Screenshots

<!-- TODO: add before/after screenshots of a home dashboard empty state -->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
