### PR TITLE
Add onboarding survey toast

### DIFF
--- a/src/data/frontend.ts
+++ b/src/data/frontend.ts
@@ -1,6 +1,11 @@
 import type { Connection } from "home-assistant-js-websocket";
 import type { ShortcutItem } from "./home_shortcuts";
 
+export interface SurveyInteraction {
+  date: string;
+  action: "opened" | "dismissed";
+}
+
 export interface CoreFrontendUserData {
   showEntityIdPicker?: boolean;
   default_panel?: string;
@@ -16,6 +21,9 @@ export interface CoreFrontendSystemData {
   default_panel?: string;
   onboarded_version?: string;
   onboarded_date?: string;
+  surveys?: {
+    onboarding?: SurveyInteraction;
+  };
 }
 
 export interface HomeFrontendSystemData {

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -20,6 +20,7 @@ import {
   removeLaunchScreen,
   renderLaunchScreenInfoBox,
 } from "../util/launch-screen";
+import { checkOnboardingSurveyToast } from "../util/onboarding-survey";
 import {
   registerServiceWorker,
   supportsServiceWorker,
@@ -58,6 +59,8 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
   @state() private _databaseMigration?: boolean;
 
   private _httpPendingDialogOpen = false;
+
+  private _onboardingSurveyChecked = false;
 
   private _panelUrl: string;
 
@@ -107,6 +110,17 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
       oldHass?.user !== this.hass.user
     ) {
       this.checkHttpPendingConfig();
+    }
+    if (
+      changedProps.has("hass") &&
+      !this._onboardingSurveyChecked &&
+      this.hass?.user &&
+      this.hass.systemData
+    ) {
+      this._onboardingSurveyChecked = true;
+      if (!__DEMO__) {
+        checkOnboardingSurveyToast(this, this.hass);
+      }
     }
   }
 

--- a/src/managers/notification-manager.ts
+++ b/src/managers/notification-manager.ts
@@ -15,6 +15,7 @@ export interface ShowToastParams {
   message:
     string | { translationKey: LocalizeKeys; args?: Record<string, string> };
   action?: ToastActionParams;
+  dismiss?: () => void;
   duration?: number;
   dismissable?: boolean;
   bottomOffset?: number;
@@ -71,7 +72,10 @@ class NotificationManager extends LitElement {
     this._toast?.show();
   }
 
-  private _toastClosed(_ev: HASSDomEvent<ToastClosedEventDetail>) {
+  private _toastClosed(ev: HASSDomEvent<ToastClosedEventDetail>) {
+    if (ev.detail.reason === "dismiss") {
+      this._parameters?.dismiss?.();
+    }
     this._parameters = undefined;
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2511,7 +2511,11 @@
       "new_version_available": "A new version of the frontend is available.",
       "reload": "Reload",
       "theme_save_failed": "Unable to save theme settings to your user profile.",
-      "theme_preferences_unavailable": "Unable to load user profile theme settings."
+      "theme_preferences_unavailable": "Unable to load user profile theme settings.",
+      "onboarding_survey": {
+        "message": "Hello there! 👋 You've been using Home Assistant for a little while now. We'd love to hear what you think. Just one quick minute!",
+        "action": "Take survey"
+      }
     },
     "sidebar": {
       "external_app_configuration": "App settings",

--- a/src/util/onboarding-survey.ts
+++ b/src/util/onboarding-survey.ts
@@ -1,0 +1,84 @@
+import type { Connection } from "home-assistant-js-websocket";
+import type {
+  CoreFrontendSystemData,
+  SurveyInteraction,
+} from "../data/frontend";
+import { saveFrontendSystemData } from "../data/frontend";
+import type { CurrentUser, HomeAssistant } from "../types";
+import { showToast } from "./toast";
+
+const SURVEY_MIN_AGE = 5 * 24 * 60 * 60 * 1000; // 5 days
+const SURVEY_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 1 month
+
+// Always the production site: the survey is a single page that is not
+// version-specific (the version is passed as a query parameter instead), so
+// beta/dev installs should not be routed to rc./next. like documentationUrl
+// would.
+const SURVEY_URL = "https://www.home-assistant.io/surveys/onboarding";
+
+export const shouldShowOnboardingSurvey = (
+  user: CurrentUser | undefined,
+  systemData: CoreFrontendSystemData | undefined,
+  now: number = Date.now()
+): boolean => {
+  if (!user?.is_owner || !systemData?.onboarded_date) {
+    return false;
+  }
+  if (systemData.surveys?.onboarding) {
+    return false;
+  }
+  const age = now - new Date(systemData.onboarded_date).getTime();
+  // NaN (invalid date) and future dates (clock skew) both fail these checks
+  return age >= SURVEY_MIN_AGE && age <= SURVEY_MAX_AGE;
+};
+
+export const recordOnboardingSurvey = (
+  conn: Connection,
+  systemData: CoreFrontendSystemData,
+  action: SurveyInteraction["action"]
+): Promise<void> =>
+  // saveFrontendSystemData overwrites the whole "core" object, so spread the
+  // existing data to preserve the other fields.
+  saveFrontendSystemData(conn, "core", {
+    ...systemData,
+    surveys: {
+      ...systemData.surveys,
+      onboarding: { date: new Date().toISOString(), action },
+    },
+  });
+
+export const getOnboardingSurveyUrl = (
+  systemData: CoreFrontendSystemData
+): string =>
+  systemData.onboarded_version
+    ? `${SURVEY_URL}?version=${encodeURIComponent(systemData.onboarded_version)}`
+    : SURVEY_URL;
+
+export const checkOnboardingSurveyToast = (
+  el: HTMLElement,
+  hass: HomeAssistant
+) => {
+  if (!shouldShowOnboardingSurvey(hass.user, hass.systemData)) {
+    return;
+  }
+  const record = (action: SurveyInteraction["action"]) =>
+    recordOnboardingSurvey(hass.connection, hass.systemData!, action);
+  showToast(el, {
+    id: "onboarding-survey",
+    message: {
+      translationKey: "ui.notification_toast.onboarding_survey.message",
+    },
+    duration: -1,
+    dismissable: true,
+    action: {
+      text: {
+        translationKey: "ui.notification_toast.onboarding_survey.action",
+      },
+      action: () => {
+        window.open(getOnboardingSurveyUrl(hass.systemData!), "_blank");
+        record("opened");
+      },
+    },
+    dismiss: () => record("dismissed"),
+  });
+};

--- a/test/util/onboarding-survey.test.ts
+++ b/test/util/onboarding-survey.test.ts
@@ -1,0 +1,188 @@
+import type { Connection } from "home-assistant-js-websocket";
+import {
+  afterEach,
+  assert,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { CoreFrontendSystemData } from "../../src/data/frontend";
+import type { CurrentUser } from "../../src/types";
+import {
+  getOnboardingSurveyUrl,
+  recordOnboardingSurvey,
+  shouldShowOnboardingSurvey,
+} from "../../src/util/onboarding-survey";
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = new Date("2026-07-20T12:00:00.000Z").getTime();
+
+const daysAgo = (days: number) => new Date(NOW - days * DAY).toISOString();
+
+const owner = { is_owner: true } as CurrentUser;
+const nonOwner = { is_owner: false } as CurrentUser;
+
+describe("shouldShowOnboardingSurvey", () => {
+  it("returns false without a user", () => {
+    assert.isFalse(
+      shouldShowOnboardingSurvey(undefined, { onboarded_date: daysAgo(6) }, NOW)
+    );
+  });
+
+  it("returns false for a non-owner user", () => {
+    assert.isFalse(
+      shouldShowOnboardingSurvey(nonOwner, { onboarded_date: daysAgo(6) }, NOW)
+    );
+  });
+
+  it("returns false without system data", () => {
+    assert.isFalse(shouldShowOnboardingSurvey(owner, undefined, NOW));
+    assert.isFalse(shouldShowOnboardingSurvey(owner, {}, NOW));
+  });
+
+  it("returns false when onboarded less than 5 days ago", () => {
+    assert.isFalse(
+      shouldShowOnboardingSurvey(owner, { onboarded_date: daysAgo(4) }, NOW)
+    );
+  });
+
+  it("returns false when onboarded more than 30 days ago", () => {
+    assert.isFalse(
+      shouldShowOnboardingSurvey(owner, { onboarded_date: daysAgo(31) }, NOW)
+    );
+  });
+
+  it("returns false for an invalid date", () => {
+    assert.isFalse(
+      shouldShowOnboardingSurvey(owner, { onboarded_date: "not-a-date" }, NOW)
+    );
+  });
+
+  it("returns false for a date in the future", () => {
+    assert.isFalse(
+      shouldShowOnboardingSurvey(owner, { onboarded_date: daysAgo(-1) }, NOW)
+    );
+  });
+
+  it("returns false when already interacted with", () => {
+    assert.isFalse(
+      shouldShowOnboardingSurvey(
+        owner,
+        {
+          onboarded_date: daysAgo(6),
+          surveys: { onboarding: { date: daysAgo(1), action: "dismissed" } },
+        },
+        NOW
+      )
+    );
+    assert.isFalse(
+      shouldShowOnboardingSurvey(
+        owner,
+        {
+          onboarded_date: daysAgo(6),
+          surveys: { onboarding: { date: daysAgo(1), action: "opened" } },
+        },
+        NOW
+      )
+    );
+  });
+
+  it("returns true within the 5-30 day window", () => {
+    assert.isTrue(
+      shouldShowOnboardingSurvey(owner, { onboarded_date: daysAgo(5) }, NOW)
+    );
+    assert.isTrue(
+      shouldShowOnboardingSurvey(owner, { onboarded_date: daysAgo(15) }, NOW)
+    );
+    assert.isTrue(
+      shouldShowOnboardingSurvey(owner, { onboarded_date: daysAgo(30) }, NOW)
+    );
+  });
+
+  it("returns true when surveys exists without the onboarding flag", () => {
+    assert.isTrue(
+      shouldShowOnboardingSurvey(
+        owner,
+        { onboarded_date: daysAgo(6), surveys: {} },
+        NOW
+      )
+    );
+  });
+});
+
+describe("recordOnboardingSurvey", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stores the interaction and preserves existing fields", async () => {
+    const sendMessagePromise = vi.fn().mockResolvedValue(undefined);
+    const conn = { sendMessagePromise } as unknown as Connection;
+    const systemData: CoreFrontendSystemData = {
+      default_panel: "lovelace",
+      onboarded_version: "2026.7.0",
+      onboarded_date: daysAgo(6),
+    };
+
+    await recordOnboardingSurvey(conn, systemData, "dismissed");
+
+    expect(sendMessagePromise).toHaveBeenCalledWith({
+      type: "frontend/set_system_data",
+      key: "core",
+      value: {
+        default_panel: "lovelace",
+        onboarded_version: "2026.7.0",
+        onboarded_date: daysAgo(6),
+        surveys: {
+          onboarding: {
+            date: new Date(NOW).toISOString(),
+            action: "dismissed",
+          },
+        },
+      },
+    });
+  });
+
+  it("merges an existing surveys object", async () => {
+    const sendMessagePromise = vi.fn().mockResolvedValue(undefined);
+    const conn = { sendMessagePromise } as unknown as Connection;
+
+    await recordOnboardingSurvey(conn, { surveys: {} }, "opened");
+
+    expect(sendMessagePromise).toHaveBeenCalledWith({
+      type: "frontend/set_system_data",
+      key: "core",
+      value: {
+        surveys: {
+          onboarding: { date: new Date(NOW).toISOString(), action: "opened" },
+        },
+      },
+    });
+  });
+});
+
+describe("getOnboardingSurveyUrl", () => {
+  it("includes the version param and ignores the onboard date", () => {
+    assert.strictEqual(
+      getOnboardingSurveyUrl({
+        onboarded_version: "2026.7.0",
+        onboarded_date: "2026-07-14T12:00:00.000Z",
+      }),
+      "https://www.home-assistant.io/surveys/onboarding?version=2026.7.0"
+    );
+  });
+
+  it("omits a missing version param", () => {
+    assert.strictEqual(
+      getOnboardingSurveyUrl({}),
+      "https://www.home-assistant.io/surveys/onboarding"
+    );
+  });
+});


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
An in-product survey shown to new users a short period after onboarding, to gather feedback on how setup went and where the early hurdles are. A minimal version first, expanded later.
This PR and  https://github.com/home-assistant/home-assistant.io/pull/46969 implement https://github.com/home-assistant/epics/issues/110

We show a toast with a link to the onboarding survey.
The toast is shown when:
- Current user is the owner, thus the person having done the onboarding.
- The onboarding date is more than 5 days ago, but less than 30 days ago.
- The check if the toast needs to be shown is only done when loading/reloading the page.
- We can only show 1 toast at a time, so if a different toast is pushed, this toast disappears until the user reloads the page.

Extra info:
- The toast does not disappear after a certain time, the user has to dismiss the toast or press Take Survey.
- Both actions make the toast disappear. We store what action the user took locally and don't show the toast anymore.
- We pass on the Home Assistant version used for the onboarding. This adds the ability to automatically add the Home Assistant version to the survey data if the survey provider has this feature.


## Screenshots
<img width="1634" height="1144" alt="survey toast" src="https://github.com/user-attachments/assets/9c1b0656-9713-472f-b45b-3e3d636b1a07" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/epics/issues/110
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
