### PR TITLE
Fix inverted and missing feature checks in lock and lawn mower

### DIFF
--- a/src/dialogs/more-info/controls/more-info-lawn_mower.ts
+++ b/src/dialogs/more-info/controls/more-info-lawn_mower.ts
@@ -78,18 +78,21 @@ class MoreInfoLawnMower extends LitElement {
     );
   }
 
-  private get _startPauseIcon(): string {
-    if (!this.stateObj) return mdiPlay;
-    return isMowing(this.stateObj) &&
+  private get _showPause(): boolean {
+    if (!this.stateObj) return false;
+    return (
+      isMowing(this.stateObj) &&
       supportsFeature(this.stateObj, LawnMowerEntityFeature.PAUSE)
-      ? mdiPause
-      : mdiPlay;
+    );
+  }
+
+  private get _startPauseIcon(): string {
+    return this._showPause ? mdiPause : mdiPlay;
   }
 
   private get _startPauseLabel(): string {
     if (!this.stateObj) return "";
-    return isMowing(this.stateObj) &&
-      supportsFeature(this.stateObj, LawnMowerEntityFeature.PAUSE)
+    return this._showPause
       ? this._i18n.localize("ui.dialogs.more_info_control.lawn_mower.pause")
       : this._i18n.localize(
           "ui.dialogs.more_info_control.lawn_mower.start_mowing"
@@ -99,8 +102,11 @@ class MoreInfoLawnMower extends LitElement {
   private get _startPauseDisabled(): boolean {
     if (!this.stateObj) return true;
     if (this.stateObj.state === UNAVAILABLE) return true;
-    if (isMowing(this.stateObj)) return false;
-    return !canStartMowing(this.stateObj);
+    if (this._showPause) return false;
+    return (
+      !supportsFeature(this.stateObj, LawnMowerEntityFeature.START_MOWING) ||
+      !canStartMowing(this.stateObj)
+    );
   }
 
   private _renderBattery() {
@@ -156,7 +162,7 @@ class MoreInfoLawnMower extends LitElement {
   private _handleStartPause() {
     if (!this.stateObj) return;
     forwardHaptic(this, "light");
-    if (isMowing(this.stateObj)) {
+    if (this._showPause) {
       this._api.callService("lawn_mower", "pause", {
         entity_id: this.stateObj.entity_id,
       });

--- a/src/panels/lovelace/card-features/hui-lawn-mower-commands-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-lawn-mower-commands-card-feature.ts
@@ -16,7 +16,11 @@ import "../../../components/ha-svg-icon";
 import { apiContext } from "../../../data/context";
 import { UNAVAILABLE } from "../../../data/entity/entity";
 import type { LawnMowerEntity } from "../../../data/lawn_mower";
-import { LawnMowerEntityFeature, canDock } from "../../../data/lawn_mower";
+import {
+  LawnMowerEntityFeature,
+  canDock,
+  canStartMowing,
+} from "../../../data/lawn_mower";
 import type { HomeAssistant, HomeAssistantApi } from "../../../types";
 import type { LovelaceCardFeature, LovelaceCardFeatureEditor } from "../types";
 import { cardFeatureStyles } from "./common/card-feature-styles";
@@ -72,6 +76,9 @@ export const LAWN_MOWER_COMMANDS_BUTTONS: Record<
           translationKey: "start",
           icon: mdiPlay,
           serviceName: "start_mowing",
+          disabled:
+            !supportsFeature(stateObj, LawnMowerEntityFeature.START_MOWING) ||
+            !canStartMowing(stateObj),
         };
   },
   dock: (stateObj) => ({

--- a/src/state-summary/state-card-lock.ts
+++ b/src/state-summary/state-card-lock.ts
@@ -29,7 +29,7 @@ class StateCardLock extends LitElement {
           .inDialog=${this.inDialog}
         ></state-info>
         ${
-          !supportsOpen
+          supportsOpen
             ? html`<ha-button
                 appearance="plain"
                 size="s"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Three feature checks that let the UI dispatch services core rejects.

**Lock** : `state-card-lock` renders the open button when the lock does *not* support `LockEntityFeature.OPEN`. Supporting locks get no button, non-supporting ones get a button that calls `lock.open` and raises. The Polymer original used `hidden$="[[!supportsOpen]]"`, a hide condition, and the negation was carried over verbatim when it became a show condition in #18257. The two other buttons in the same file were inverted correctly.

**Lawn mower** : `more-info-lawn_mower` guards the icon and label on `PAUSE`, but `_handleStartPause` branches on `isMowing()` alone, so a START_MOWING-only mower shows "Start mowing" while mowing and calls `lawn_mower.pause`. Extracted a `_showPause` getter used by the icon, label, service branch and disabled state. `_startPauseDisabled` also never checked `START_MOWING`, so a PAUSE-only mower rendered an enabled button calling `lawn_mower.start_mowing`. Same gap on the start branch of `LAWN_MOWER_COMMANDS_BUTTONS`.

Core gates all of these: `lock.open` on `LockEntityFeature.OPEN`, `lawn_mower.start_mowing` on `START_MOWING`, `lawn_mower.pause` on `PAUSE`.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
