### PR TITLE
Sync entity constants with core

### DIFF
--- a/src/common/entity/get_states.ts
+++ b/src/common/entity/get_states.ts
@@ -89,7 +89,7 @@ const FIXED_DOMAIN_ATTRIBUTE_STATES = {
     device_class: [
       "battery",
       "battery_charging",
-      "co",
+      "carbon_monoxide",
       "cold",
       "connectivity",
       "door",
@@ -227,7 +227,12 @@ const FIXED_DOMAIN_ATTRIBUTE_STATES = {
       "voltage",
       "volume_flow_rate",
     ],
-    state_class: ["measurement", "total", "total_increasing"],
+    state_class: [
+      "measurement",
+      "measurement_angle",
+      "total",
+      "total_increasing",
+    ],
   },
   switch: {
     device_class: ["outlet", "switch"],

--- a/src/components/entity/ha-entity-state-content-picker.ts
+++ b/src/components/entity/ha-entity-state-content-picker.ts
@@ -33,7 +33,6 @@ const HIDDEN_ATTRIBUTES = [
   "battery_level",
   "code_arm_required",
   "code_format",
-  "color_modes",
   "device_class",
   "editable",
   "effect_list",

--- a/src/data/entity/entity_attributes.ts
+++ b/src/data/entity/entity_attributes.ts
@@ -127,7 +127,6 @@ export const NON_NUMERIC_ATTRIBUTES = [
   "away_mode",
   "changed_by",
   "code_format",
-  "color_modes",
   "current_activity",
   "device_class",
   "editable",
@@ -177,6 +176,7 @@ export const NON_NUMERIC_ATTRIBUTES = [
   "source_type",
   "source",
   "state_class",
+  "supported_color_modes",
   "supported_features",
   "swing_mode",
   "swing_mode",
@@ -190,7 +190,6 @@ export const NON_NUMERIC_ATTRIBUTES = [
 export const STATE_CONDITION_HIDDEN_ATTRIBUTES = [
   "access_token",
   "available_modes",
-  "color_modes",
   "editable",
   "effect_list",
   "entity_picture",
@@ -207,6 +206,7 @@ export const STATE_CONDITION_HIDDEN_ATTRIBUTES = [
   "sound_mode_list",
   "source_list",
   "state_class",
+  "supported_color_modes",
   "swing_modes",
   "token",
 ];

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -149,6 +149,7 @@ export const weatherAttrIcons = {
   humidity: mdiWaterPercent,
   wind_bearing: mdiWeatherWindy,
   wind_speed: mdiWeatherWindy,
+  wind_gust_speed: mdiWeatherWindy,
   pressure: mdiGauge,
   temperature: mdiThermometer,
   uv_index: mdiSunWireless,
@@ -268,6 +269,7 @@ export const getWeatherUnit = (
       return (
         stateObj.attributes.temperature_unit || config.unit_system.temperature
       );
+    case "wind_gust_speed":
     case "wind_speed":
       return stateObj.attributes.wind_speed_unit || `${lengthUnit}/h`;
     case "cloud_coverage":

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
@@ -30,7 +30,6 @@ const SCHEMA = [
           "code_arm_required",
           "code_format",
           "color_mode",
-          "color_modes",
           "current_activity",
           "device_class",
           "editable",

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
@@ -80,7 +80,6 @@ export class HaStateTrigger extends LitElement implements TriggerElement {
                 "available_modes",
                 "code_arm_required",
                 "code_format",
-                "color_modes",
                 "device_class",
                 "editable",
                 "effect_list",

--- a/src/panels/lovelace/card-suggestions/hui-statistics-graph-card-suggestions.ts
+++ b/src/panels/lovelace/card-suggestions/hui-statistics-graph-card-suggestions.ts
@@ -36,6 +36,30 @@ const MEASUREMENT_VARIANTS: Variant[] = [
   },
 ];
 
+const MEASUREMENT_ANGLE_VARIANTS: Variant[] = [
+  {
+    labelKey: "last_24h",
+    days_to_show: 1,
+    period: "hour",
+    chart_type: "line",
+    stat_types: ["mean"],
+  },
+  {
+    labelKey: "last_7d",
+    days_to_show: 7,
+    period: "day",
+    chart_type: "line",
+    stat_types: ["mean"],
+  },
+  {
+    labelKey: "last_30d",
+    days_to_show: 30,
+    period: "day",
+    chart_type: "line",
+    stat_types: ["mean"],
+  },
+];
+
 const TOTAL_VARIANTS: Variant[] = [
   {
     labelKey: "last_7d",
@@ -60,6 +84,13 @@ const TOTAL_VARIANTS: Variant[] = [
   },
 ];
 
+const VARIANTS_BY_STATE_CLASS: Record<string, Variant[]> = {
+  measurement: MEASUREMENT_VARIANTS,
+  measurement_angle: MEASUREMENT_ANGLE_VARIANTS,
+  total: TOTAL_VARIANTS,
+  total_increasing: TOTAL_VARIANTS,
+};
+
 export const statisticsGraphCardSuggestions: CardSuggestionProvider<StatisticsGraphCardConfig> =
   {
     getEntitySuggestion(hass, entityId) {
@@ -67,8 +98,8 @@ export const statisticsGraphCardSuggestions: CardSuggestionProvider<StatisticsGr
       const stateObj = hass.states[entityId];
       const stateClass = stateObj?.attributes.state_class;
       if (!stateClass) return null;
-      const variants =
-        stateClass === "measurement" ? MEASUREMENT_VARIANTS : TOTAL_VARIANTS;
+      const variants = VARIANTS_BY_STATE_CLASS[stateClass];
+      if (!variants) return null;
       const suggestions: CardSuggestion<StatisticsGraphCardConfig>[] =
         variants.map((v) => ({
           label: hass.localize(`${LABEL_PREFIX}${v.labelKey}` as any),

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -348,6 +348,7 @@
           "temperature": "Temperature",
           "visibility": "Visibility",
           "wind_speed": "Wind speed",
+          "wind_gust_speed": "Wind gust speed",
           "precipitation": "Precipitation"
         },
         "cardinal_direction": {

--- a/test/common/entity/get_states.test.ts
+++ b/test/common/entity/get_states.test.ts
@@ -132,7 +132,7 @@ describe("getStates", () => {
         expect.arrayContaining([
           "battery",
           "battery_charging",
-          "co",
+          "carbon_monoxide",
           "cold",
           "connectivity",
           "door",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Constants that drifted from core. Each one is a value the frontend spells differently from the backend, so the option is unreachable or the attribute is misclassified.

**`binary_sensor` device class** : we list `"co"`, core's `BinarySensorDeviceClass.CO` is `"carbon_monoxide"`. The picker option has no translation key and no entity can ever match it, while the real device class is unpickable. Test updated, it asserted the old value.

**`color_modes` does not exist** : the real attribute is `supported_color_modes`. Because the wrong name sat in `NON_NUMERIC_ATTRIBUTES` and `STATE_CONDITION_HIDDEN_ATTRIBUTES`, the actual list attribute was offered as a *numeric* attribute in numeric state conditions and gauge cards, and was not hidden from the state condition picker. Three files also carried a now-dead `"color_modes"` entry alongside the correct one.

**`measurement_angle` state class** : missing from the `sensor` `state_class` list, so it was unpickable. The statistics graph suggestions had the same blind spot: they only special-cased `measurement`, so a `wind_direction` sensor fell through to the total variants and got three suggested cards that all render empty. Core records only a circular `mean` for `MEASUREMENT_ANGLE`, never `sum`, and not `min`/`max` either.

```python
# homeassistant/components/sensor/recorder.py
SensorStateClass.MEASUREMENT: _StatisticsConfig({"mean", "min", "max"}, StatisticMeanType.ARITHMETIC),
SensorStateClass.MEASUREMENT_ANGLE: _StatisticsConfig({"mean"}, StatisticMeanType.CIRCULAR),
SensorStateClass.TOTAL: _StatisticsConfig({"sum"}),
SensorStateClass.TOTAL_INCREASING: _StatisticsConfig({"sum"}),
```

Worth a look in review: the suggestions now use a lookup keyed by state class instead of an if/else chain, which changes the default. An unrecognised state class yields no suggestions instead of falling through to the change based ones. All four members of `SensorStateClass` are covered so nothing loses suggestions today, and it means the next state class core adds fails closed rather than silently proposing charts that render empty, which is how this bug appeared in the first place.

**`wind_gust_speed` unit** — no case in `getWeatherUnit`, so it fell through to `config.unit_system["wind_gust_speed"]` and returned `""`. Core converts it with the same unit as `wind_speed`. Landed with its icon and translation key, since `secondary_info_attribute` is typed on the keys of `ui.card.weather.attributes`.

Values checked against `homeassistant/components/{binary_sensor,light,sensor,weather}` on dev.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
