### PR TITLE
Unify number slider threshold across rows and state cards

### DIFF
--- a/src/data/number.ts
+++ b/src/data/number.ts
@@ -1,8 +1,22 @@
+import type { HassEntity } from "home-assistant-js-websocket";
 import type { HomeAssistant } from "../types";
 
 export interface NumberDeviceClassUnits {
   units: string[];
 }
+
+const AUTO_MODE_MAX_STEPS = 256;
+
+export const showNumberSlider = (stateObj: HassEntity): boolean => {
+  const { mode, min, max, step } = stateObj.attributes;
+  if (mode === "slider") {
+    return true;
+  }
+  return (
+    mode === "auto" &&
+    (Number(max) - Number(min)) / Number(step) <= AUTO_MODE_MAX_STEPS
+  );
+};
 
 export const getNumberDeviceClassConvertibleUnits = (
   hass: HomeAssistant,

--- a/src/dialogs/config-flow/previews/entity-preview-row.ts
+++ b/src/dialogs/config-flow/previews/entity-preview-row.ts
@@ -21,6 +21,7 @@ import { isTiltOnly } from "../../../data/cover";
 import { UNAVAILABLE, UNKNOWN } from "../../../data/entity/entity";
 import type { ImageEntity } from "../../../data/image";
 import { computeImageUrl } from "../../../data/image";
+import { showNumberSlider } from "../../../data/number";
 import "../../../panels/lovelace/components/hui-timestamp-display";
 import type { HomeAssistant } from "../../../types";
 import {
@@ -249,15 +250,9 @@ class EntityPreviewRow extends LitElement {
     }
 
     if (domain === "number") {
-      const showNumberSlider =
-        stateObj.attributes.mode === "slider" ||
-        (stateObj.attributes.mode === "auto" &&
-          (Number(stateObj.attributes.max) - Number(stateObj.attributes.min)) /
-            Number(stateObj.attributes.step) <=
-            256);
       return html`
         ${
-          showNumberSlider
+          showNumberSlider(stateObj)
             ? html`
                 <div class="numberflex">
                   <ha-slider

--- a/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
@@ -7,6 +7,7 @@ import "../../../components/input/ha-input";
 import type { HaInput } from "../../../components/input/ha-input";
 import { UNAVAILABLE, UNKNOWN } from "../../../data/entity/entity";
 import { setValue } from "../../../data/input_text";
+import { showNumberSlider } from "../../../data/number";
 import type { HomeAssistant } from "../../../types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
@@ -75,12 +76,7 @@ class HuiNumberEntityRow extends LitElement implements LovelaceRow {
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         ${
-          stateObj.attributes.mode === "slider" ||
-          (stateObj.attributes.mode === "auto" &&
-            (Number(stateObj.attributes.max) -
-              Number(stateObj.attributes.min)) /
-              Number(stateObj.attributes.step) <=
-              256)
+          showNumberSlider(stateObj)
             ? html`
                 <div class="flex">
                   <ha-slider

--- a/src/state-summary/state-card-number.ts
+++ b/src/state-summary/state-card-number.ts
@@ -7,6 +7,7 @@ import "../components/entity/state-info";
 import "../components/ha-slider";
 import "../components/input/ha-input";
 import { UNAVAILABLE } from "../data/entity/entity";
+import { showNumberSlider } from "../data/number";
 import { haStyle } from "../resources/styles";
 import type { HomeAssistant } from "../types";
 
@@ -46,8 +47,6 @@ class StateCardNumber extends LitElement {
   }
 
   protected render() {
-    const range = this.stateObj.attributes.max - this.stateObj.attributes.min;
-
     return html`
       <state-info
         .hass=${this.hass}
@@ -55,8 +54,7 @@ class StateCardNumber extends LitElement {
         .inDialog=${this.inDialog}
       ></state-info>
       ${
-        this.stateObj.attributes.mode === "slider" ||
-        (this.stateObj.attributes.mode === "auto" && range <= 256)
+        showNumberSlider(this.stateObj)
           ? html`
               <div class="flex">
                 <ha-slider

--- a/test/data/number.test.ts
+++ b/test/data/number.test.ts
@@ -1,0 +1,52 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { describe, expect, it } from "vitest";
+import { showNumberSlider } from "../../src/data/number";
+
+const makeStateObj = (attributes: Record<string, unknown>): HassEntity => ({
+  entity_id: "number.test",
+  state: "0",
+  last_changed: "2024-01-01T00:00:00Z",
+  last_updated: "2024-01-01T00:00:00Z",
+  attributes: { min: 0, max: 100, step: 1, ...attributes },
+  context: { id: "test", parent_id: null, user_id: null },
+});
+
+describe("showNumberSlider", () => {
+  it("shows a slider in slider mode regardless of step count", () => {
+    expect(
+      showNumberSlider(
+        makeStateObj({ mode: "slider", min: 0, max: 100000, step: 1 })
+      )
+    ).toBe(true);
+  });
+
+  it("shows a slider in auto mode when the step count is at or below the threshold", () => {
+    expect(
+      showNumberSlider(
+        makeStateObj({ mode: "auto", min: 0, max: 256, step: 1 })
+      )
+    ).toBe(true);
+    expect(
+      showNumberSlider(
+        makeStateObj({ mode: "auto", min: 0, max: 1000, step: 10 })
+      )
+    ).toBe(true);
+  });
+
+  it("shows a box in auto mode when the step count is above the threshold", () => {
+    expect(
+      showNumberSlider(
+        makeStateObj({ mode: "auto", min: 0, max: 257, step: 1 })
+      )
+    ).toBe(false);
+    expect(
+      showNumberSlider(
+        makeStateObj({ mode: "auto", min: 0, max: 100, step: 0.1 })
+      )
+    ).toBe(false);
+  });
+
+  it("shows a box for box mode", () => {
+    expect(showNumberSlider(makeStateObj({ mode: "box" }))).toBe(false);
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Three places decide whether a `number` entity in `auto` mode shows a slider or a text box, and they disagreed: `state-card-number` compared `max - min` against 256, while the two entity rows compared `(max - min) / step`.

Extracted the check into a shared `showNumberSlider` helper in `src/data/number.ts` and used it at all three sites.

This aligns the state card with the rows. A `number` whose range is above 256 but whose step count is not (e.g. min 0, max 1000, step 10, so 100 steps) now shows a slider in the state card too, matching what the row and the config flow preview already did.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
