### PR TITLE
Fix excessive y-axis decimals on near-flat energy charts

### DIFF
--- a/src/components/chart/y-axis-fraction-digits.ts
+++ b/src/components/chart/y-axis-fraction-digits.ts
@@ -1,12 +1,27 @@
+// A range smaller than this fraction of the axis magnitude is floating-point
+// noise (e.g. from summed statistics), not real precision.
+const NEGLIGIBLE_RANGE_RATIO = 1e-10;
+
 // Derive the number of decimal digits to use for Y-axis labels from the
 // observed data range. We mirror how ECharts sizes its ticks: it splits the
 // range into ~5 intervals (its default `splitNumber`) and rounds that raw
 // interval to a "nice" 1/2/3/5×10ⁿ value, then reports the decimals that nice
 // interval needs. This matches the precision ECharts actually renders, so
 // labels are neither truncated to identical values nor padded with extra zeros.
-export function computeYAxisFractionDigits(min: number, max: number): number {
-  const range = max - min;
+export function computeYAxisFractionDigits(
+  min: number,
+  max: number,
+  // Bar axes render from 0, so union the extent with 0 to match.
+  includeZero = false
+): number {
+  const lo = includeZero ? Math.min(min, 0) : min;
+  const hi = includeZero ? Math.max(max, 0) : max;
+  const range = hi - lo;
   if (!Number.isFinite(range) || range <= 0) return 1;
+  // A near-zero range is fp noise; deriving digits from it would pad the labels
+  // with a tail of zeros (e.g. "0.20000000000000"), so treat it as flat.
+  const magnitude = Math.max(Math.abs(lo), Math.abs(hi));
+  if (range <= magnitude * NEGLIGIBLE_RANGE_RATIO) return 1;
   const rawInterval = range / 5;
   const exponent = Math.floor(Math.log10(rawInterval));
   const mantissa = rawInterval / 10 ** exponent; // in [1, 10)
@@ -38,9 +53,7 @@ const resolveYAxisBound = (
 export function createYAxisPrecisionBounds(options: {
   min?: YAxisBound;
   max?: YAxisBound;
-  // Axes without `scale: true` (e.g. bar charts) stay anchored at 0, so the
-  // rendered ticks span from 0 even when the data does not. Union the extent
-  // with 0 to match the labels ECharts actually draws.
+  // Set for bar axes anchored at 0, so precision reflects the 0-based range.
   includeZero?: boolean;
   onFractionDigits: (digits: number) => void;
 }): {
@@ -52,13 +65,11 @@ export function createYAxisPrecisionBounds(options: {
     min: (values) => {
       const resolvedMin = resolveYAxisBound(min, values);
       const resolvedMax = resolveYAxisBound(max, values);
-      let extentMin = resolvedMin ?? values.min;
-      let extentMax = resolvedMax ?? values.max;
-      if (includeZero) {
-        extentMin = Math.min(extentMin, 0);
-        extentMax = Math.max(extentMax, 0);
-      }
-      onFractionDigits(computeYAxisFractionDigits(extentMin, extentMax));
+      const extentMin = resolvedMin ?? values.min;
+      const extentMax = resolvedMax ?? values.max;
+      onFractionDigits(
+        computeYAxisFractionDigits(extentMin, extentMax, includeZero)
+      );
       return resolvedMin;
     },
     max: (values) => resolveYAxisBound(max, values),

--- a/src/panels/lovelace/cards/energy/energy-devices-detail-graph-data.ts
+++ b/src/panels/lovelace/cards/energy/energy-devices-detail-graph-data.ts
@@ -521,7 +521,7 @@ export function generateEnergyDevicesDetailGraphData(
     true,
     generateFillBuckets(datasets, start, end, getSuggestedPeriod(start, end))
   );
-  const yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax);
+  const yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax, true);
 
   return {
     chartData: datasets,

--- a/src/panels/lovelace/cards/energy/energy-gas-graph-data.ts
+++ b/src/panels/lovelace/cards/energy/energy-gas-graph-data.ts
@@ -119,7 +119,7 @@ export function generateEnergyGasGraphData(
     true,
     generateFillBuckets(datasets, start, end, period)
   );
-  const yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax);
+  const yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax, true);
   const chartData = datasets;
   const total = processTotal(energyData.stats, gasSources);
 

--- a/src/panels/lovelace/cards/energy/energy-solar-graph-data.ts
+++ b/src/panels/lovelace/cards/energy/energy-solar-graph-data.ts
@@ -146,7 +146,7 @@ export function generateEnergySolarGraphData(
     end,
     compareStart,
     compareEnd,
-    yAxisFractionDigits: computeYAxisFractionDigits(yMin, yMax),
+    yAxisFractionDigits: computeYAxisFractionDigits(yMin, yMax, true),
   };
 }
 

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -461,7 +461,7 @@ export class HuiEnergyUsageGraphCard
         getSuggestedPeriod(this._start, this._end)
       )
     );
-    this._yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax);
+    this._yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax, true);
     this._chartData = datasets;
     this._legendData = this._getLegendData(datasets);
     this._total = this._processTotal(consumption);

--- a/src/panels/lovelace/cards/energy/hui-energy-water-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-water-graph-card.ts
@@ -274,7 +274,7 @@ export class HuiEnergyWaterGraphCard
         getSuggestedPeriod(this._start, this._end)
       )
     );
-    this._yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax);
+    this._yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax, true);
     this._chartData = datasets;
     this._total = this._processTotal(energyData.stats, waterSources);
   }

--- a/src/panels/lovelace/cards/energy/power-sources-graph-data.ts
+++ b/src/panels/lovelace/cards/energy/power-sources-graph-data.ts
@@ -261,7 +261,7 @@ export function generatePowerSourcesGraphData(
   const end = energyData.end || endOfToday();
 
   const chartData = fillLineGaps(datasets);
-  const yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax);
+  const yAxisFractionDigits = computeYAxisFractionDigits(yMin, yMax, true);
 
   const usageData: NonNullable<LineSeriesOption["data"]> = [];
   // fillLineGaps ensures all datasets share the same x values, so iterate the

--- a/test/components/chart/y-axis-fraction-digits.test.ts
+++ b/test/components/chart/y-axis-fraction-digits.test.ts
@@ -43,6 +43,23 @@ describe("computeYAxisFractionDigits", () => {
     expect(computeYAxisFractionDigits(1.5, 1.5)).toBe(1);
   });
 
+  it("treats a floating-point-noise range as flat (issue #53180)", () => {
+    expect(computeYAxisFractionDigits(0.3, 0.3 + 1e-16)).toBe(1);
+    expect(computeYAxisFractionDigits(0.2, 0.20000000000004547)).toBe(1);
+    expect(computeYAxisFractionDigits(1_000_000, 1_000_000.00001)).toBe(1);
+  });
+
+  it("keeps precision for a genuinely narrow, non-noise range", () => {
+    expect(computeYAxisFractionDigits(1e-6, 3e-6)).toBe(7);
+  });
+
+  it("unions the extent with zero for anchored (bar) axes", () => {
+    expect(computeYAxisFractionDigits(0.3, 0.3, true)).toBe(2);
+    expect(
+      computeYAxisFractionDigits(0.29999999999999993, 0.3000000000000001, true)
+    ).toBe(2);
+  });
+
   it("falls back to one decimal when range is non-finite", () => {
     expect(computeYAxisFractionDigits(Infinity, -Infinity)).toBe(1);
     expect(computeYAxisFractionDigits(NaN, 1)).toBe(1);
@@ -111,5 +128,13 @@ describe("createYAxisPrecisionBounds", () => {
     // Small visible max close to zero -> more decimals
     min({ min: 0.02, max: 0.05 });
     expect(onFractionDigits).toHaveBeenLastCalledWith(2);
+  });
+
+  it("does not over-pad when the visible extent collapses to noise", () => {
+    const onFractionDigits = vi.fn();
+    const { min } = createYAxisPrecisionBounds({ onFractionDigits });
+
+    min({ min: 0.3, max: 0.3 + 1e-15 });
+    expect(onFractionDigits).toHaveBeenLastCalledWith(1);
   });
 });


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

`computeYAxisFractionDigits` derived chart Y-axis label precision from the data
range with only a `range <= 0` guard. When summed/stacked statistics leave
values that should be equal differing by a floating-point sliver, the range is
tiny-but-positive and the function returned 13–17 decimals, padding round tick
labels with a long tail of zeros (e.g. `0.20000000000000`) across the energy
graph cards.

This treats a range that is negligible relative to the axis magnitude as flat,
and unions bar chart precision seed with 0 so it matches the 0-based (bar)
axis that is actually rendered.

## Screenshots

<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Before:
<img width="1240" height="564" alt="image" src="https://github.com/user-attachments/assets/1cdad08a-df75-4f5e-88e9-4de7fa59cf2e" />

After:
<img width="940" height="564" alt="image" src="https://github.com/user-attachments/assets/00ffb3e5-d9db-4c1b-ac0c-d7092e8eba2d" />



## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53180
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
