### PR TITLE
Fix energy usage graph stacking order for grid + solar without battery

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -59,6 +59,11 @@ const stackOrder = {
   to_grid: 2,
   used_solar: 3,
   used_battery: 4,
+  // Grid consumption must stay on top of the positive stack, with solar and
+  // battery self-consumption below it. Give it an explicit order so it no
+  // longer depends on the dataset count / insertion order (see #53197).
+  from_grid: 5,
+  used_grid: 5,
 };
 
 @customElement("hui-energy-usage-graph-card")

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -59,9 +59,6 @@ const stackOrder = {
   to_grid: 2,
   used_solar: 3,
   used_battery: 4,
-  // Grid consumption must stay on top of the positive stack, with solar and
-  // battery self-consumption below it. Give it an explicit order so it no
-  // longer depends on the dataset count / insertion order (see #53197).
   from_grid: 5,
   used_grid: 5,
 };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Regression from #52541: `from_grid` and `used_grid` were missing from the explicit
`stackOrder` map in the energy usage graph, so they fell back to
`Object.keys(combinedData).length`. For a grid + solar setup without a configured
battery that fallback collides with `used_solar`, and consumed solar ends up stacked
above grid consumption.

Give `from_grid`/`used_grid` an explicit order so grid consumption stays on top of the
positive stack and self-consumed solar stays at the bottom, independent of how many
datasets are present. Battery setups are unaffected.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Grid + solar, no battery:

Before:
<img width="796" height="560" alt="image" src="https://github.com/user-attachments/assets/50987297-3e20-4641-8a68-262beb5a15e9" />

After:
<img width="796" height="560" alt="image" src="https://github.com/user-attachments/assets/48f35a07-e959-4c3d-9aeb-620f930d8244" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53197
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
