### PR TITLE
Improve target picker group header

### DIFF
--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -542,20 +542,14 @@ export class HaServiceControl extends LitElement {
     }
     ${
       serviceData && "target" in serviceData
-        ? html`<ha-settings-row
-            .narrow=${this.narrow || isFullWidthSelector(targetSelector)}
-          >
-            <span slot="heading"
-              >${this.hass.localize("ui.components.service-control.target")}</span
-            >
-            <ha-selector
-              .hass=${this.hass}
-              .selector=${targetSelector}
-              .disabled=${this.disabled}
-              @value-changed=${this._targetChanged}
-              .value=${this._value?.target}
-            ></ha-selector
-          ></ha-settings-row>`
+        ? html`<ha-selector
+            class="target-selector"
+            .hass=${this.hass}
+            .selector=${targetSelector}
+            .disabled=${this.disabled}
+            @value-changed=${this._targetChanged}
+            .value=${this._value?.target}
+          ></ha-selector>`
         : entityId
           ? html`<ha-entity-picker
               .disabled=${this.disabled}
@@ -1058,6 +1052,14 @@ export class HaServiceControl extends LitElement {
     ha-yaml-editor {
       display: block;
       margin: var(--service-control-padding, 0 var(--ha-space-4));
+    }
+    ha-selector.target-selector {
+      display: block;
+      padding: var(--ha-space-2) var(--ha-space-4);
+      border-top: var(
+        --service-control-items-border-top,
+        1px solid var(--divider-color)
+      );
     }
     ha-yaml-editor {
       padding: var(--ha-space-4) 0;

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -1342,7 +1342,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     }
     .item-groups {
       overflow: hidden;
-      border: 2px solid var(--divider-color);
+      border: var(--ha-border-width-sm) solid var(--divider-color);
       border-radius: var(--ha-border-radius-lg);
     }
   `;

--- a/src/components/target-picker/ha-target-picker-item-group.ts
+++ b/src/components/target-picker/ha-target-picker-item-group.ts
@@ -8,6 +8,13 @@ import "../ha-expansion-panel";
 import "../list/ha-list-base";
 import "./ha-target-picker-item-row";
 
+const TYPE_PLURAL: Record<TargetTypeFloorless, string> = {
+  entity: "entities",
+  device: "devices",
+  area: "areas",
+  label: "labels",
+};
+
 @customElement("ha-target-picker-item-group")
 export class HaTargetPickerItemGroup extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -60,11 +67,11 @@ export class HaTargetPickerItemGroup extends LitElement {
     >
       <div slot="header" class="heading">
         ${this.hass.localize(
-          `ui.components.target-picker.selected.${this.type}`,
-          {
-            count,
-          }
+          `ui.components.target-picker.type.${TYPE_PLURAL[this.type]}`
         )}
+        ${
+          this.collapsed ? html`<span class="count">(${count})</span>` : nothing
+        }
       </div>
       <ha-list-base>
         ${Object.entries(this.items).map(([type, items]) =>
@@ -105,6 +112,10 @@ export class HaTargetPickerItemGroup extends LitElement {
       display: flex;
       justify-content: space-between;
       min-height: unset;
+    }
+    .count {
+      color: var(--secondary-text-color);
+      font-weight: var(--ha-font-weight-normal);
     }
   `;
 }

--- a/src/components/target-picker/ha-target-picker-item-group.ts
+++ b/src/components/target-picker/ha-target-picker-item-group.ts
@@ -8,12 +8,12 @@ import "../ha-expansion-panel";
 import "../list/ha-list-base";
 import "./ha-target-picker-item-row";
 
-const TYPE_PLURAL: Record<TargetTypeFloorless, string> = {
+const TYPE_PLURAL = {
   entity: "entities",
   device: "devices",
   area: "areas",
   label: "labels",
-};
+} as const satisfies Record<TargetTypeFloorless, string>;
 
 @customElement("ha-target-picker-item-group")
 export class HaTargetPickerItemGroup extends LitElement {

--- a/src/panels/config/automation/condition/types/ha-automation-condition-platform.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-platform.ts
@@ -218,20 +218,14 @@ export class HaPlatformCondition extends LitElement {
       </div>
       ${
         conditionDesc && "target" in conditionDesc
-          ? html`<ha-settings-row narrow>
-              <span slot="heading"
-                >${this.hass.localize(
-                  "ui.components.service-control.target"
-                )}</span
-              >
-              <ha-selector
-                .hass=${this.hass}
-                .selector=${this._targetSelector(conditionDesc.target)}
-                .disabled=${this.disabled}
-                @value-changed=${this._targetChanged}
-                .value=${this.condition?.target}
-              ></ha-selector
-            ></ha-settings-row>`
+          ? html`<ha-selector
+              class="target-selector"
+              .hass=${this.hass}
+              .selector=${this._targetSelector(conditionDesc.target)}
+              .disabled=${this.disabled}
+              @value-changed=${this._targetChanged}
+              .value=${this.condition?.target}
+            ></ha-selector>`
           : nothing
       }
       ${
@@ -669,6 +663,14 @@ export class HaPlatformCondition extends LitElement {
     ha-yaml-editor {
       display: block;
       margin: 0 var(--ha-space-4);
+    }
+    ha-selector.target-selector {
+      display: block;
+      padding: var(--ha-space-2) var(--ha-space-4);
+      border-top: var(
+        --service-control-items-border-top,
+        1px solid var(--divider-color)
+      );
     }
     ha-yaml-editor {
       padding: var(--ha-space-4) 0;

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
@@ -213,19 +213,14 @@ export class HaPlatformTrigger extends LitElement {
       </div>
       ${
         triggerDesc && "target" in triggerDesc
-          ? html`<ha-settings-row narrow>
-              <span slot="heading"
-                >${this.hass.localize(
-                  "ui.components.service-control.target"
-                )}</span
-              ><ha-selector
-                .hass=${this.hass}
-                .selector=${this._targetSelector(triggerDesc.target)}
-                .disabled=${this.disabled}
-                @value-changed=${this._targetChanged}
-                .value=${this.trigger?.target}
-              ></ha-selector
-            ></ha-settings-row>`
+          ? html`<ha-selector
+              class="target-selector"
+              .hass=${this.hass}
+              .selector=${this._targetSelector(triggerDesc.target)}
+              .disabled=${this.disabled}
+              @value-changed=${this._targetChanged}
+              .value=${this.trigger?.target}
+            ></ha-selector>`
           : nothing
       }
       ${
@@ -547,6 +542,14 @@ export class HaPlatformTrigger extends LitElement {
     ha-yaml-editor {
       display: block;
       margin: 0 var(--ha-space-4);
+    }
+    ha-selector.target-selector {
+      display: block;
+      padding: var(--ha-space-2) var(--ha-space-4);
+      border-top: var(
+        --service-control-items-border-top,
+        1px solid var(--divider-color)
+      );
     }
     ha-yaml-editor {
       padding: var(--ha-space-4) 0;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -796,13 +796,6 @@
         "target_details": "Target details",
         "no_targets": "No targets",
         "no_target_found": "No target found for {term}",
-        "selected": {
-          "entity": "Entities: {count}",
-          "device": "Devices: {count}",
-          "area": "Areas: {count}",
-          "label": "Labels: {count}",
-          "floor": "Floors: {count}"
-        },
         "type": {
           "area": "Area",
           "areas": "Areas",


### PR DESCRIPTION
## Proposed change

- Show group item count only when the group is collapsed, styled as a
  secondary-color "(N)" next to the type label
- Thin the item-groups border to 1px via `--ha-border-width-sm`
- Remove the "Targets" pre-label before the target selector in the
  action, trigger and condition editors, moving its spacing/divider onto
  the selector itself

## Screenshots
<img width="524" height="766" alt="CleanShot 2026-07-23 at 13 09 17" src="https://github.com/user-attachments/assets/27ecfdef-a221-4fe8-9e70-3087e55813c1" />


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr