### PR TITLE
Fix tile trend-graph feature not extending unchanging values to now

### DIFF
--- a/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
+++ b/src/panels/lovelace/card-features/hui-trend-graph-card-feature.ts
@@ -34,6 +34,8 @@ export const supportsTrendGraphCardFeature = (
 
 export const DEFAULT_HOURS_TO_SHOW = 24;
 
+const HOUR = 60 * 60 * 1000;
+
 @customElement("hui-trend-graph-card-feature")
 class HuiHistoryChartCardFeature
   extends LitElement
@@ -93,9 +95,13 @@ class HuiHistoryChartCardFeature
 
   public connectedCallback() {
     super.connectedCallback();
-    // redraw the graph every minute to update the time axis
+    // recompute the graph every minute so the x-axis (and the horizontal fill
+    // to now) keeps advancing even while the sensor value stays constant
     clearInterval(this._interval);
-    this._interval = window.setInterval(() => this.requestUpdate(), 1000 * 60);
+    this._interval = window.setInterval(
+      () => this._calculateCoordinates(),
+      1000 * 60
+    );
     if (this.hasUpdated) {
       this._subscribeHistory();
     }
@@ -146,12 +152,18 @@ class HuiHistoryChartCardFeature
       ? Math.max(10, width / 5, hourToShow)
       : Math.max(10, hourToShow);
     const useMean = !detail;
+    // Anchor the x-axis to the full time window so a constant value is drawn as
+    // a horizontal line up to now, instead of ending at the last state change.
+    const now = Date.now();
     const { points, yAxisOrigin } = coordinatesMinimalResponseCompressedState(
       this._stateHistory,
       width,
       height,
       maxDetails,
-      undefined,
+      {
+        minX: now - hourToShow * HOUR,
+        maxX: now,
+      },
       useMean
     );
     this._coordinates = points;


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The tile card's trend-graph feature anchored its x-axis to the last state change instead of the current time. As a result, a sensor that stayed constant was drawn cut off partway across the graph and at the wrong time scale, then jumped when the next update arrived.

It now passes the same `minX`/`maxX` window bounds to the coordinate builder as the sensor card's graph footer (`hui-graph-header-footer`), so an unchanged value is drawn as a horizontal line up to now. The minute redraw also recomputes the coordinates so that fill keeps advancing while the value stays constant.

## Screenshots

<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Same sensor, constant for the last 15h of a 48h window:

| Before | After |
| --- | --- |
| <img width="800" height="220" alt="image" src="https://github.com/user-attachments/assets/f78fffe0-a9f0-45b5-b2b9-dff29639f112" /> | <img width="800" height="220" alt="image" src="https://github.com/user-attachments/assets/910983dc-5f52-4fbc-ac17-0f6ebe863adb" /> |

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53254
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
