### PR TITLE
Suggest area from device name when adding devices

### DIFF
--- a/src/common/entity/compute_device_area_suggestion.ts
+++ b/src/common/entity/compute_device_area_suggestion.ts
@@ -1,0 +1,85 @@
+import { stripBoundaryLabel } from "../string/strip_boundary_label";
+
+export interface AreaForNameMatch {
+  area_id: string;
+  name: string;
+  aliases?: string[];
+}
+
+export interface DeviceAreaSuggestion {
+  name: string;
+  area?: string;
+}
+
+const areaLabels = (area: AreaForNameMatch): string[] =>
+  [area.name, ...(area.aliases ?? [])].filter(Boolean);
+
+// Longest matching label (name or alias) of a single area, and the device name
+// once that label is stripped off. `null` when the area does not match.
+const matchArea = (
+  name: string,
+  area: AreaForNameMatch
+): { strippedName: string; labelLength: number } | null => {
+  let best: { strippedName: string; labelLength: number } | null = null;
+  for (const label of areaLabels(area)) {
+    const strippedName = stripBoundaryLabel(name, label);
+    if (strippedName === null) {
+      continue;
+    }
+    if (!best || label.length > best.labelLength) {
+      best = { strippedName, labelLength: label.length };
+    }
+  }
+  return best;
+};
+
+// The area with the longest matching label, and the stripped device name.
+const bestAreaMatch = (
+  name: string,
+  areas: AreaForNameMatch[]
+): { areaId: string; strippedName: string; labelLength: number } | null => {
+  let best: {
+    areaId: string;
+    strippedName: string;
+    labelLength: number;
+  } | null = null;
+  for (const area of areas) {
+    const match = matchArea(name, area);
+    if (match && (!best || match.labelLength > best.labelLength)) {
+      best = { areaId: area.area_id, ...match };
+    }
+  }
+  return best;
+};
+
+/**
+ * Suggests a cleaned device name (and an area) when an area name or alias is a
+ * prefix or suffix of the device name.
+ *
+ * - When the device already has an area, only match against that area, so an
+ *   assigned area is never overridden — just the name is cleaned.
+ * - Otherwise pick the area with the longest matching name/alias and suggest it.
+ * - The longest match wins with no fallback: if the name is exactly the area,
+ *   nothing is left to keep and the result is a no-op (`null`).
+ */
+export const computeDeviceAreaSuggestion = (
+  deviceName: string | null | undefined,
+  currentAreaId: string | null | undefined,
+  areas: AreaForNameMatch[]
+): DeviceAreaSuggestion | null => {
+  const name = deviceName?.trim();
+  if (!name) {
+    return null;
+  }
+
+  if (currentAreaId) {
+    const area = areas.find((a) => a.area_id === currentAreaId);
+    const match = area ? matchArea(name, area) : null;
+    return match?.strippedName ? { name: match.strippedName } : null;
+  }
+
+  const match = bestAreaMatch(name, areas);
+  return match?.strippedName
+    ? { name: match.strippedName, area: match.areaId }
+    : null;
+};

--- a/src/common/string/strip_boundary_label.ts
+++ b/src/common/string/strip_boundary_label.ts
@@ -1,0 +1,42 @@
+const SEPARATORS = "\\s\\-_.";
+const LEADING_SEPARATORS = new RegExp(`^[${SEPARATORS}]+`);
+const TRAILING_SEPARATORS = new RegExp(`[${SEPARATORS}]+$`);
+const STARTS_WITH_SEPARATOR = new RegExp(`^[${SEPARATORS}]`);
+const ENDS_WITH_SEPARATOR = new RegExp(`[${SEPARATORS}]$`);
+
+/**
+ * Strips `label` from the start or end of `text` on a word boundary,
+ * case-insensitively, and trims the surrounding separators.
+ *
+ * Returns:
+ * - `""` when `text` equals `label`,
+ * - the trimmed remainder for a prefix or suffix match,
+ * - `null` when `label` is not a word-boundary prefix or suffix of `text`.
+ */
+export const stripBoundaryLabel = (
+  text: string,
+  label: string
+): string | null => {
+  const lowerText = text.toLowerCase();
+  const lowerLabel = label.toLowerCase();
+
+  if (lowerText === lowerLabel) {
+    return "";
+  }
+
+  if (lowerText.startsWith(lowerLabel)) {
+    const rest = text.slice(label.length);
+    if (STARTS_WITH_SEPARATOR.test(rest)) {
+      return rest.replace(LEADING_SEPARATORS, "").trim();
+    }
+  }
+
+  if (lowerText.endsWith(lowerLabel)) {
+    const rest = text.slice(0, text.length - label.length);
+    if (ENDS_WITH_SEPARATOR.test(rest)) {
+      return rest.replace(TRAILING_SEPARATORS, "").trim();
+    }
+  }
+
+  return null;
+};

--- a/src/dialogs/config-flow/step-flow-create-entry.ts
+++ b/src/dialogs/config-flow/step-flow-create-entry.ts
@@ -3,6 +3,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../common/dom/fire_event";
+import { computeDeviceAreaSuggestion } from "../../common/entity/compute_device_area_suggestion";
 import {
   computeDeviceName,
   computeDeviceNameDisplay,
@@ -72,6 +73,10 @@ class StepFlowCreateEntry extends LitElement {
   }
 
   protected willUpdate(changedProps: PropertyValues<this>) {
+    if (changedProps.has("devices")) {
+      this._suggestDeviceUpdates();
+    }
+
     if (!changedProps.has("devices") && !changedProps.has("hass")) {
       return;
     }
@@ -100,6 +105,32 @@ class StepFlowCreateEntry extends LitElement {
       showVoiceAssistantSetupDialog(this, {
         deviceId: this.devices[0].id,
       });
+    }
+  }
+
+  private _suggestDeviceUpdates() {
+    if (!this.hass || !this.devices?.length) {
+      return;
+    }
+    const areas = Object.values(this.hass.areas);
+    const updates = { ...this._deviceUpdate };
+    let changed = false;
+    for (const device of this.devices) {
+      if (device.id in updates || device.name_by_user) {
+        continue;
+      }
+      const suggestion = computeDeviceAreaSuggestion(
+        computeDeviceName(device),
+        device.area_id,
+        areas
+      );
+      if (suggestion) {
+        updates[device.id] = suggestion;
+        changed = true;
+      }
+    }
+    if (changed) {
+      this._deviceUpdate = updates;
     }
   }
 

--- a/test/common/entity/compute_device_area_suggestion.test.ts
+++ b/test/common/entity/compute_device_area_suggestion.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  computeDeviceAreaSuggestion,
+  type AreaForNameMatch,
+} from "../../../src/common/entity/compute_device_area_suggestion";
+
+const AREAS: AreaForNameMatch[] = [
+  { area_id: "living_room", name: "Living Room", aliases: ["Lounge"] },
+  { area_id: "kitchen", name: "Kitchen" },
+  { area_id: "master", name: "Master" },
+  { area_id: "master_bedroom", name: "Master Bedroom" },
+];
+
+describe("computeDeviceAreaSuggestion", () => {
+  describe("device without an area", () => {
+    it("strips a prefix area and suggests it", () => {
+      expect(
+        computeDeviceAreaSuggestion("Living Room Thermostat", null, AREAS)
+      ).toEqual({ name: "Thermostat", area: "living_room" });
+    });
+
+    it("strips a suffix area and suggests it", () => {
+      expect(
+        computeDeviceAreaSuggestion("Thermostat Living Room", null, AREAS)
+      ).toEqual({ name: "Thermostat", area: "living_room" });
+    });
+
+    it("matches an area alias", () => {
+      expect(computeDeviceAreaSuggestion("Lounge Lamp", null, AREAS)).toEqual({
+        name: "Lamp",
+        area: "living_room",
+      });
+    });
+
+    it("prefers the longest matching area name", () => {
+      expect(
+        computeDeviceAreaSuggestion("Master Bedroom Lamp", null, AREAS)
+      ).toEqual({ name: "Lamp", area: "master_bedroom" });
+    });
+
+    it("is a no-op when the name equals an area and does not fall back to a shorter one", () => {
+      expect(
+        computeDeviceAreaSuggestion("Master Bedroom", null, AREAS)
+      ).toBeNull();
+    });
+
+    it("does not match in the middle of a word", () => {
+      expect(
+        computeDeviceAreaSuggestion("Kitchenette Sensor", null, AREAS)
+      ).toBeNull();
+    });
+
+    it("matches case-insensitively and keeps the remainder's casing", () => {
+      expect(
+        computeDeviceAreaSuggestion("living room thermostat", null, AREAS)
+      ).toEqual({ name: "thermostat", area: "living_room" });
+    });
+
+    it("trims residual separators after stripping", () => {
+      expect(
+        computeDeviceAreaSuggestion("Living Room - Thermostat", null, AREAS)
+      ).toEqual({ name: "Thermostat", area: "living_room" });
+    });
+
+    it("does nothing when no area matches", () => {
+      expect(
+        computeDeviceAreaSuggestion("Random Device", null, AREAS)
+      ).toBeNull();
+    });
+  });
+
+  describe("device with an area already set", () => {
+    it("strips the name but keeps the area when it matches", () => {
+      expect(
+        computeDeviceAreaSuggestion("Kitchen Sensor", "kitchen", AREAS)
+      ).toEqual({ name: "Sensor" });
+    });
+
+    it("never overrides the area when the name does not match it", () => {
+      expect(
+        computeDeviceAreaSuggestion("Living Room Sensor", "kitchen", AREAS)
+      ).toBeNull();
+    });
+
+    it("is a no-op when the name equals its own area", () => {
+      expect(
+        computeDeviceAreaSuggestion("Kitchen", "kitchen", AREAS)
+      ).toBeNull();
+    });
+  });
+
+  it("does nothing for an empty name", () => {
+    expect(computeDeviceAreaSuggestion("  ", null, AREAS)).toBeNull();
+    expect(computeDeviceAreaSuggestion(undefined, null, AREAS)).toBeNull();
+  });
+});

--- a/test/common/string/strip_boundary_label.test.ts
+++ b/test/common/string/strip_boundary_label.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+import { stripBoundaryLabel } from "../../../src/common/string/strip_boundary_label";
+
+describe("stripBoundaryLabel", () => {
+  it("returns an empty string when the text equals the label", () => {
+    expect(stripBoundaryLabel("Kitchen", "Kitchen")).toBe("");
+  });
+
+  it("strips a prefix on a word boundary", () => {
+    expect(stripBoundaryLabel("Living Room Thermostat", "Living Room")).toBe(
+      "Thermostat"
+    );
+  });
+
+  it("strips a suffix on a word boundary", () => {
+    expect(stripBoundaryLabel("Thermostat Living Room", "Living Room")).toBe(
+      "Thermostat"
+    );
+  });
+
+  it("is case-insensitive and keeps the remainder's casing", () => {
+    expect(stripBoundaryLabel("living room Thermostat", "Living Room")).toBe(
+      "Thermostat"
+    );
+  });
+
+  it("trims different separators", () => {
+    expect(stripBoundaryLabel("Kitchen - Sensor", "Kitchen")).toBe("Sensor");
+    expect(stripBoundaryLabel("Kitchen_Sensor", "Kitchen")).toBe("Sensor");
+    expect(stripBoundaryLabel("Kitchen.Sensor", "Kitchen")).toBe("Sensor");
+  });
+
+  it("does not match in the middle of a word", () => {
+    expect(stripBoundaryLabel("Kitchenette Sensor", "Kitchen")).toBeNull();
+    expect(stripBoundaryLabel("Sub Kitchenette", "Kitchen")).toBeNull();
+  });
+
+  it("returns null when the label is absent", () => {
+    expect(stripBoundaryLabel("Living Room Sensor", "Kitchen")).toBeNull();
+  });
+
+  it("returns an empty string when only separators are left", () => {
+    expect(stripBoundaryLabel("Kitchen -", "Kitchen")).toBe("");
+  });
+});


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When adding devices through a config flow, if a device's name starts or ends with an existing area name (or alias), that area is now pre-selected and removed from the suggested name (e.g. "Living Room Thermostat" becomes "Thermostat" in the Living Room area). The name and area stay editable, and a device the user already renamed is left untouched.

Currently scoped to the generic config flow device step; it does not cover devices added silently (e.g. by a hub/coordinator in the background).

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53274 
- This PR is related to issue or discussion: https://github.com/home-assistant/core/issues/173125#issuecomment-5059620825
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
