### PR TITLE
Fix unhandled error when the Cast SDK fails to load

### DIFF
--- a/demo/src/custom-cards/cast-demo-row.ts
+++ b/demo/src/custom-cards/cast-demo-row.ts
@@ -41,25 +41,30 @@ class CastDemoRow extends LitElement implements LovelaceRow {
   protected firstUpdated(changedProps: PropertyValues<this>) {
     super.firstUpdated(changedProps);
     import("../../../src/cast/cast_manager").then(({ getCastManager }) =>
-      getCastManager().then((mgr) => {
-        this._castManager = mgr;
-        mgr.addEventListener("state-changed", () => {
-          this.requestUpdate();
-        });
-        mgr.castContext.addEventListener(
-          cast.framework.CastContextEventType.SESSION_STATE_CHANGED,
-          (ev) => {
-            // On Android, opening a new session always results in SESSION_RESUMED.
-            // So treat both as the same.
-            if (
-              ev.sessionState === "SESSION_STARTED" ||
-              ev.sessionState === "SESSION_RESUMED"
-            ) {
-              castSendShowDemo(mgr);
+      getCastManager().then(
+        (mgr) => {
+          this._castManager = mgr;
+          mgr.addEventListener("state-changed", () => {
+            this.requestUpdate();
+          });
+          mgr.castContext.addEventListener(
+            cast.framework.CastContextEventType.SESSION_STATE_CHANGED,
+            (ev) => {
+              // On Android, opening a new session always results in SESSION_RESUMED.
+              // So treat both as the same.
+              if (
+                ev.sessionState === "SESSION_STARTED" ||
+                ev.sessionState === "SESSION_RESUMED"
+              ) {
+                castSendShowDemo(mgr);
+              }
             }
-          }
-        );
-      })
+          );
+        },
+        () => {
+          this._castManager = null;
+        }
+      )
     );
   }
 

--- a/src/cast/cast_framework.ts
+++ b/src/cast/cast_framework.ts
@@ -17,7 +17,6 @@ export const castApiAvailable = () => {
     el.id = "cast";
     document.body.append(el);
 
-    // Resolve as unavailable when the SDK cannot be loaded (e.g. offline).
     loadJS(
       "https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
     ).catch(() => resolve(false));

--- a/src/cast/cast_framework.ts
+++ b/src/cast/cast_framework.ts
@@ -3,11 +3,7 @@ import { loadJS } from "../common/dom/load_resource";
 let loadedPromise: Promise<boolean> | undefined;
 
 export const castApiAvailable = () => {
-  if (loadedPromise) {
-    return loadedPromise;
-  }
-
-  loadedPromise = new Promise((resolve) => {
+  loadedPromise ??= new Promise((resolve) => {
     (window as any).__onGCastApiAvailable = resolve;
 
     // Any element with a specific ID will get set as a JS variable on window

--- a/src/cast/cast_framework.ts
+++ b/src/cast/cast_framework.ts
@@ -9,16 +9,18 @@ export const castApiAvailable = () => {
 
   loadedPromise = new Promise((resolve) => {
     (window as any).__onGCastApiAvailable = resolve;
-  });
-  // Any element with a specific ID will get set as a JS variable on window
-  // This will override the cast SDK if the iconset is loaded afterwards.
-  // Conflicting IDs will no longer mess with window, so we'll just append one.
-  const el = document.createElement("div");
-  el.id = "cast";
-  document.body.append(el);
 
-  loadJS(
-    "https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
-  );
+    // Any element with a specific ID will get set as a JS variable on window
+    // This will override the cast SDK if the iconset is loaded afterwards.
+    // Conflicting IDs will no longer mess with window, so we'll just append one.
+    const el = document.createElement("div");
+    el.id = "cast";
+    document.body.append(el);
+
+    // Resolve as unavailable when the SDK cannot be loaded (e.g. offline).
+    loadJS(
+      "https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
+    ).catch(() => resolve(false));
+  });
   return loadedPromise;
 };

--- a/src/cast/cast_framework.ts
+++ b/src/cast/cast_framework.ts
@@ -3,7 +3,11 @@ import { loadJS } from "../common/dom/load_resource";
 let loadedPromise: Promise<boolean> | undefined;
 
 export const castApiAvailable = () => {
-  loadedPromise ??= new Promise((resolve) => {
+  if (loadedPromise) {
+    return loadedPromise;
+  }
+
+  loadedPromise = new Promise((resolve) => {
     (window as any).__onGCastApiAvailable = resolve;
 
     // Any element with a specific ID will get set as a JS variable on window


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

`castApiAvailable()` ignores the rejection of the `loadJS()` promise, so when the Cast SDK script (`cast_sender.js`) fails to load — offline environment, ad-blocker, or a firewalled network that blocks gstatic.com — an unhandled promise rejection is thrown. In dev builds this also triggers the dev server error overlay, covering the whole page.

This PR resolves the Cast API promise as unavailable (`false`) when the script fails to load, which the existing `getCastManager()` code already handles by rejecting with "No Cast API available". The demo's `cast-demo-row` was missing a rejection handler for that path (unlike `hui-cast-row`, which has one), so one is added there too; the row hides itself, same as when the Cast API reports unavailable.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3oj5uaCRRaoXRd5iEffhi

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3oj5uaCRRaoXRd5iEffhi)_