### PR TITLE
Allow opening a specific demo via URL and document demo navigation for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 You are helping develop the Home Assistant frontend. This repository is a TypeScript application built from Lit-based Web Components for the Home Assistant web UI.
 
+For the standalone demo — including how to open a specific demo configuration or page via URL — read `demo/AGENTS.md`.
+
 ## Essential Commands
 
 ```bash

--- a/demo/AGENTS.md
+++ b/demo/AGENTS.md
@@ -1,0 +1,46 @@
+# Demo Agent Instructions
+
+This file applies to all files under `demo/`. Follow the root `AGENTS.md` for repository-wide standards.
+
+The demo is the full Home Assistant frontend running against a mocked backend (published at https://demo.home-assistant.io). It needs no Home Assistant server, which makes it the easiest way to load the real UI in a browser, for example to take screenshots.
+
+## Running the demo
+
+Run from the repository root:
+
+```bash
+yarn dev:demo               # dev server on http://localhost:8090
+yarn dev:demo --background  # detached; also supports --status/--stop/--logs
+```
+
+## Opening a specific demo
+
+The demo contains multiple demo configurations. Select one directly with the `demo` query parameter, e.g. `http://localhost:8090/?demo=<slug>`. The valid slugs are listed in `demoConfigSlugs` in `src/configs/demo-configs.ts`, in the same order as the demo configurations, so "the second demo" means the second slug in that list. An unknown slug falls back to the default (the first entry).
+
+## Opening a specific page
+
+The demo build uses hash-based routing: the frontend path goes in the URL hash, and the `demo` query parameter goes before the `#`. The URL format is:
+
+```
+http://localhost:8090/?demo=<slug>#/<path>
+```
+
+Useful paths:
+
+- `/lovelace/0` — the selected demo's dashboard (also the default when no hash is given)
+- `/energy` — energy dashboard. Its tabs are views: `/energy/overview` (Summary), `/energy/electricity`, `/energy/gas`, `/energy/water`, `/energy/now`
+- `/map`, `/history`, `/todo`, `/config` — other sidebar panels
+
+Example — the water tab of the energy dashboard of the second demo:
+
+```
+http://localhost:8090/?demo=<second slug>#/energy/water
+```
+
+## Structure
+
+- `src/ha-demo.ts`: Root element; sets up all backend mocks.
+- `src/configs/<slug>/`: One directory per demo configuration (entities, dashboard, theme).
+- `src/configs/demo-configs.ts`: Registry of demo configurations and URL slug handling.
+- `src/stubs/`: Mocked WebSocket/REST APIs.
+- `script/develop_demo`, `script/build_demo`: Dev server and static build wrappers.

--- a/demo/AGENTS.md
+++ b/demo/AGENTS.md
@@ -15,7 +15,7 @@ yarn dev:demo --background  # detached; also supports --status/--stop/--logs
 
 ## Opening a specific demo
 
-The demo contains multiple demo configurations. Select one directly with the `demo` query parameter, e.g. `http://localhost:8090/?demo=<slug>`. The valid slugs are listed in `demoConfigSlugs` in `src/configs/demo-configs.ts`, in the same order as the demo configurations, so "the second demo" means the second slug in that list. An unknown slug falls back to the default (the first entry).
+The demo contains multiple demo configurations. Select one directly with the `demo` query parameter, e.g. `http://localhost:8090/?demo=<slug>`. The valid slugs are defined in `demoConfigs` in `src/configs/demo-configs.ts`, so "the second demo" means the slug of the second entry in that list. An unknown slug falls back to the default (the first entry).
 
 ## Opening a specific page
 

--- a/demo/CLAUDE.md
+++ b/demo/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/demo/src/configs/demo-configs.ts
+++ b/demo/src/configs/demo-configs.ts
@@ -12,27 +12,38 @@ export const applyDemoTheme = (hass: MockHomeAssistant, theme: DemoTheme) => {
   hass.mockTheme(null, getDemoTheme(theme));
 };
 
-export const demoConfigs: (() => Promise<DemoConfig>)[] = [
-  () => import("./sections").then((mod) => mod.demoSections),
-  () => import("./arsaboo").then((mod) => mod.demoArsaboo),
-  () => import("./teachingbirds").then((mod) => mod.demoTeachingbirds),
-  () => import("./kernehed").then((mod) => mod.demoKernehed),
-  () => import("./jimpower").then((mod) => mod.demoJimpower),
-];
-
-// URL slugs matching the order of demoConfigs, so a specific demo can be
-// opened directly via e.g. /?demo=arsaboo
-const demoConfigSlugs = [
-  "sections",
-  "arsaboo",
-  "teachingbirds",
-  "kernehed",
-  "jimpower",
+// The slug allows opening a demo directly via e.g. /?demo=arsaboo
+export const demoConfigs: {
+  slug: string;
+  load: () => Promise<DemoConfig>;
+}[] = [
+  {
+    slug: "sections",
+    load: () => import("./sections").then((mod) => mod.demoSections),
+  },
+  {
+    slug: "arsaboo",
+    load: () => import("./arsaboo").then((mod) => mod.demoArsaboo),
+  },
+  {
+    slug: "teachingbirds",
+    load: () => import("./teachingbirds").then((mod) => mod.demoTeachingbirds),
+  },
+  {
+    slug: "kernehed",
+    load: () => import("./kernehed").then((mod) => mod.demoKernehed),
+  },
+  {
+    slug: "jimpower",
+    load: () => import("./jimpower").then((mod) => mod.demoJimpower),
+  },
 ];
 
 const initialDemoConfigIndex = () => {
   const slug = new URLSearchParams(window.location.search).get("demo");
-  const index = slug ? demoConfigSlugs.indexOf(slug.toLowerCase()) : -1;
+  const index = slug
+    ? demoConfigs.findIndex((conf) => conf.slug === slug.toLowerCase())
+    : -1;
   return index === -1 ? 0 : index;
 };
 
@@ -40,14 +51,14 @@ const initialDemoConfigIndex = () => {
 export let selectedDemoConfigIndex = initialDemoConfigIndex();
 // eslint-disable-next-line import-x/no-mutable-exports
 export let selectedDemoConfig: Promise<DemoConfig> =
-  demoConfigs[selectedDemoConfigIndex]();
+  demoConfigs[selectedDemoConfigIndex].load();
 
 export const setDemoConfig = async (
   hass: MockHomeAssistant,
   lovelace: Lovelace,
   index: number
 ) => {
-  const confProm = demoConfigs[index]();
+  const confProm = demoConfigs[index].load();
   const config = await confProm;
 
   selectedDemoConfigIndex = index;

--- a/demo/src/configs/demo-configs.ts
+++ b/demo/src/configs/demo-configs.ts
@@ -21,11 +21,11 @@ export const demoConfigs: Record<string, () => Promise<DemoConfig>> = {
   jimpower: () => import("./jimpower").then((mod) => mod.demoJimpower),
 };
 
+export const demos = Object.keys(demoConfigs);
+
 const initialDemoConfigIndex = () => {
   const slug = new URLSearchParams(window.location.search).get("demo");
-  const index = slug
-    ? Object.keys(demoConfigs).indexOf(slug.toLowerCase())
-    : -1;
+  const index = slug ? demos.indexOf(slug.toLowerCase()) : -1;
   return index === -1 ? 0 : index;
 };
 
@@ -33,18 +33,18 @@ const initialDemoConfigIndex = () => {
 export let selectedDemoConfigIndex = initialDemoConfigIndex();
 // eslint-disable-next-line import-x/no-mutable-exports
 export let selectedDemoConfig: Promise<DemoConfig> =
-  Object.values(demoConfigs)[selectedDemoConfigIndex]();
+  demoConfigs[demos[selectedDemoConfigIndex]]();
 
 export const setDemoConfig = async (
   hass: MockHomeAssistant,
   lovelace: Lovelace,
   index: number
 ) => {
-  const confProm = Object.values(demoConfigs)[index]();
-  const config = await confProm;
-
+  selectedDemoConfig = demoConfigs[demos[index]]();
+  const config = await selectedDemoConfig;
+  // Only after a successful load, so the set-demo-config error handler can
+  // restore the previous demo from this index.
   selectedDemoConfigIndex = index;
-  selectedDemoConfig = confProm;
 
   hass.addEntities(config.entities(hass.localize), true);
   hass.addEntities(energyEntities());

--- a/demo/src/configs/demo-configs.ts
+++ b/demo/src/configs/demo-configs.ts
@@ -24,9 +24,7 @@ export const demoConfigs: Record<string, () => Promise<DemoConfig>> = {
 export const demos = Object.keys(demoConfigs);
 
 const initialDemo = () => {
-  const slug = new URLSearchParams(window.location.search)
-    .get("demo")
-    ?.toLowerCase();
+  const slug = new URLSearchParams(window.location.search).get("demo");
   return slug && demos.includes(slug) ? slug : demos[0];
 };
 
@@ -41,11 +39,11 @@ export const setDemoConfig = async (
   lovelace: Lovelace,
   demo: string
 ) => {
-  selectedDemoConfig = demoConfigs[demo]();
-  const config = await selectedDemoConfig;
-  // Only after a successful load, so the set-demo-config error handler can
-  // restore the previous demo.
+  const confProm = demoConfigs[demo]();
+  const config = await confProm;
+
   selectedDemo = demo;
+  selectedDemoConfig = confProm;
 
   hass.addEntities(config.entities(hass.localize), true);
   hass.addEntities(energyEntities());

--- a/demo/src/configs/demo-configs.ts
+++ b/demo/src/configs/demo-configs.ts
@@ -23,28 +23,29 @@ export const demoConfigs: Record<string, () => Promise<DemoConfig>> = {
 
 export const demos = Object.keys(demoConfigs);
 
-const initialDemoConfigIndex = () => {
-  const slug = new URLSearchParams(window.location.search).get("demo");
-  const index = slug ? demos.indexOf(slug.toLowerCase()) : -1;
-  return index === -1 ? 0 : index;
+const initialDemo = () => {
+  const slug = new URLSearchParams(window.location.search)
+    .get("demo")
+    ?.toLowerCase();
+  return slug && demos.includes(slug) ? slug : demos[0];
 };
 
 // eslint-disable-next-line import-x/no-mutable-exports
-export let selectedDemoConfigIndex = initialDemoConfigIndex();
+export let selectedDemo = initialDemo();
 // eslint-disable-next-line import-x/no-mutable-exports
 export let selectedDemoConfig: Promise<DemoConfig> =
-  demoConfigs[demos[selectedDemoConfigIndex]]();
+  demoConfigs[selectedDemo]();
 
 export const setDemoConfig = async (
   hass: MockHomeAssistant,
   lovelace: Lovelace,
-  index: number
+  demo: string
 ) => {
-  selectedDemoConfig = demoConfigs[demos[index]]();
+  selectedDemoConfig = demoConfigs[demo]();
   const config = await selectedDemoConfig;
   // Only after a successful load, so the set-demo-config error handler can
-  // restore the previous demo from this index.
-  selectedDemoConfigIndex = index;
+  // restore the previous demo.
+  selectedDemo = demo;
 
   hass.addEntities(config.entities(hass.localize), true);
   hass.addEntities(energyEntities());

--- a/demo/src/configs/demo-configs.ts
+++ b/demo/src/configs/demo-configs.ts
@@ -20,8 +20,24 @@ export const demoConfigs: (() => Promise<DemoConfig>)[] = [
   () => import("./jimpower").then((mod) => mod.demoJimpower),
 ];
 
+// URL slugs matching the order of demoConfigs, so a specific demo can be
+// opened directly via e.g. /?demo=arsaboo
+const demoConfigSlugs = [
+  "sections",
+  "arsaboo",
+  "teachingbirds",
+  "kernehed",
+  "jimpower",
+];
+
+const initialDemoConfigIndex = () => {
+  const slug = new URLSearchParams(window.location.search).get("demo");
+  const index = slug ? demoConfigSlugs.indexOf(slug.toLowerCase()) : -1;
+  return index === -1 ? 0 : index;
+};
+
 // eslint-disable-next-line import-x/no-mutable-exports
-export let selectedDemoConfigIndex = 0;
+export let selectedDemoConfigIndex = initialDemoConfigIndex();
 // eslint-disable-next-line import-x/no-mutable-exports
 export let selectedDemoConfig: Promise<DemoConfig> =
   demoConfigs[selectedDemoConfigIndex]();

--- a/demo/src/configs/demo-configs.ts
+++ b/demo/src/configs/demo-configs.ts
@@ -12,37 +12,19 @@ export const applyDemoTheme = (hass: MockHomeAssistant, theme: DemoTheme) => {
   hass.mockTheme(null, getDemoTheme(theme));
 };
 
-// The slug allows opening a demo directly via e.g. /?demo=arsaboo
-export const demoConfigs: {
-  slug: string;
-  load: () => Promise<DemoConfig>;
-}[] = [
-  {
-    slug: "sections",
-    load: () => import("./sections").then((mod) => mod.demoSections),
-  },
-  {
-    slug: "arsaboo",
-    load: () => import("./arsaboo").then((mod) => mod.demoArsaboo),
-  },
-  {
-    slug: "teachingbirds",
-    load: () => import("./teachingbirds").then((mod) => mod.demoTeachingbirds),
-  },
-  {
-    slug: "kernehed",
-    load: () => import("./kernehed").then((mod) => mod.demoKernehed),
-  },
-  {
-    slug: "jimpower",
-    load: () => import("./jimpower").then((mod) => mod.demoJimpower),
-  },
-];
+export const demoConfigs: Record<string, () => Promise<DemoConfig>> = {
+  sections: () => import("./sections").then((mod) => mod.demoSections),
+  arsaboo: () => import("./arsaboo").then((mod) => mod.demoArsaboo),
+  teachingbirds: () =>
+    import("./teachingbirds").then((mod) => mod.demoTeachingbirds),
+  kernehed: () => import("./kernehed").then((mod) => mod.demoKernehed),
+  jimpower: () => import("./jimpower").then((mod) => mod.demoJimpower),
+};
 
 const initialDemoConfigIndex = () => {
   const slug = new URLSearchParams(window.location.search).get("demo");
   const index = slug
-    ? demoConfigs.findIndex((conf) => conf.slug === slug.toLowerCase())
+    ? Object.keys(demoConfigs).indexOf(slug.toLowerCase())
     : -1;
   return index === -1 ? 0 : index;
 };
@@ -51,14 +33,14 @@ const initialDemoConfigIndex = () => {
 export let selectedDemoConfigIndex = initialDemoConfigIndex();
 // eslint-disable-next-line import-x/no-mutable-exports
 export let selectedDemoConfig: Promise<DemoConfig> =
-  demoConfigs[selectedDemoConfigIndex].load();
+  Object.values(demoConfigs)[selectedDemoConfigIndex]();
 
 export const setDemoConfig = async (
   hass: MockHomeAssistant,
   lovelace: Lovelace,
   index: number
 ) => {
-  const confProm = demoConfigs[index].load();
+  const confProm = Object.values(demoConfigs)[index]();
   const config = await confProm;
 
   selectedDemoConfigIndex = index;

--- a/demo/src/custom-cards/ha-demo-card.ts
+++ b/demo/src/custom-cards/ha-demo-card.ts
@@ -13,7 +13,7 @@ import type {
   LovelaceCard,
 } from "../../../src/panels/lovelace/types";
 import {
-  demoConfigs,
+  demos,
   selectedDemoConfig,
   selectedDemoConfigIndex,
 } from "../configs/demo-configs";
@@ -113,7 +113,7 @@ export class HADemoCard extends LitElement implements LovelaceCard {
 
   private _nextConfig() {
     this._updateConfig(
-      selectedDemoConfigIndex < Object.keys(demoConfigs).length - 1
+      selectedDemoConfigIndex < demos.length - 1
         ? selectedDemoConfigIndex + 1
         : 0
     );

--- a/demo/src/custom-cards/ha-demo-card.ts
+++ b/demo/src/custom-cards/ha-demo-card.ts
@@ -113,7 +113,7 @@ export class HADemoCard extends LitElement implements LovelaceCard {
 
   private _nextConfig() {
     this._updateConfig(
-      selectedDemoConfigIndex < demoConfigs.length - 1
+      selectedDemoConfigIndex < Object.keys(demoConfigs).length - 1
         ? selectedDemoConfigIndex + 1
         : 0
     );

--- a/demo/src/custom-cards/ha-demo-card.ts
+++ b/demo/src/custom-cards/ha-demo-card.ts
@@ -14,8 +14,8 @@ import type {
 } from "../../../src/panels/lovelace/types";
 import {
   demos,
+  selectedDemo,
   selectedDemoConfig,
-  selectedDemoConfigIndex,
 } from "../configs/demo-configs";
 
 @customElement("ha-demo-card")
@@ -112,16 +112,12 @@ export class HADemoCard extends LitElement implements LovelaceCard {
   }
 
   private _nextConfig() {
-    this._updateConfig(
-      selectedDemoConfigIndex < demos.length - 1
-        ? selectedDemoConfigIndex + 1
-        : 0
-    );
+    this._updateConfig(demos[(demos.indexOf(selectedDemo) + 1) % demos.length]);
   }
 
-  private async _updateConfig(index: number) {
+  private async _updateConfig(demo: string) {
     this._switching = true;
-    fireEvent(this, "set-demo-config" as any, { index });
+    fireEvent(this, "set-demo-config" as any, { demo });
   }
 
   static get styles(): CSSResultGroup {

--- a/demo/src/stubs/lovelace.ts
+++ b/demo/src/stubs/lovelace.ts
@@ -2,8 +2,8 @@ import type { LocalizeFunc } from "../../../src/common/translations/localize";
 import type { LovelaceInfo } from "../../../src/data/lovelace/resource";
 import type { MockHomeAssistant } from "../../../src/fake_data/provide_hass";
 import {
+  selectedDemo,
   selectedDemoConfig,
-  selectedDemoConfigIndex,
   setDemoConfig,
 } from "../configs/demo-configs";
 import "../custom-cards/cast-demo-row";
@@ -45,11 +45,11 @@ customElements.whenDefined("hui-root").then(() => {
   HUIRoot.prototype.firstUpdated = function (changedProperties) {
     oldFirstUpdated.call(this, changedProperties);
     this.addEventListener("set-demo-config", async (ev) => {
-      const index = (ev as CustomEvent).detail.index;
+      const demo = (ev as CustomEvent).detail.demo;
       try {
-        await setDemoConfig(this.hass, this.lovelace!, index);
+        await setDemoConfig(this.hass, this.lovelace!, demo);
       } catch (_err: any) {
-        setDemoConfig(this.hass, this.lovelace!, selectedDemoConfigIndex);
+        setDemoConfig(this.hass, this.lovelace!, selectedDemo);
         alert("Failed to switch config :-(");
       }
     });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Allow opening a specific demo configuration in the standalone demo by URL: `/?demo=<slug>` (e.g. `https://demo.home-assistant.io/?demo=arsaboo`) selects the demo directly instead of always starting on the default one. Slugs are defined in `demoConfigSlugs` in `demo/src/configs/demo-configs.ts`, ordered to match `demoConfigs`; an unknown slug falls back to the default. Combined with the demo's hash-based routing this makes any demo page directly addressable, e.g. `/?demo=arsaboo#/energy/water` for the water tab of the energy dashboard.

The main motivation is coding agents: a new `demo/AGENTS.md` (with a `demo/CLAUDE.md` symlink, following the repository convention) documents how to run the demo and the URL scheme, so an agent asked to e.g. "take a screenshot of the water tab of the energy dashboard of the second demo" can construct the right URL without spelunking. The root `AGENTS.md` links to it. The guide deliberately avoids listing the current slugs and points at `demoConfigSlugs` as the source of truth so it cannot go stale.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3oj5uaCRRaoXRd5iEffhi

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3oj5uaCRRaoXRd5iEffhi)_