### PR TITLE
Abbreviate sections in automation add search dialog

### DIFF
--- a/src/panels/config/automation/add-automation-element/ha-automation-add-search.ts
+++ b/src/panels/config/automation/add-automation-element/ha-automation-add-search.ts
@@ -804,7 +804,7 @@ export class HaAutomationAddSearch extends LitElement {
           const typeKey = section.type === "item" ? type : section.type;
           resultItems.push({
             primary: "",
-            id: `search-more-${type}`,
+            id: `search-more-${section.type}`,
             type: "more",
             section: section.type,
             label: localize(

--- a/src/panels/config/automation/add-automation-element/ha-automation-add-search.ts
+++ b/src/panels/config/automation/add-automation-element/ha-automation-add-search.ts
@@ -1,7 +1,7 @@
 import type { LitVirtualizer } from "@lit-labs/virtualizer";
 import { consume } from "@lit/context";
 import "@material/mwc-list/mwc-list";
-import { mdiPlus, mdiTextureBox } from "@mdi/js";
+import { mdiPlus, mdiTextureBox, mdiUnfoldMoreHorizontal } from "@mdi/js";
 import Fuse from "fuse.js";
 import { css, html, LitElement, nothing, type PropertyValues } from "lit";
 import {
@@ -98,7 +98,15 @@ export const ITEM_SEARCH_KEYS: FuseWeightedKey[] = [
   },
 ];
 
+const MAX_SEARCH_ITEMS_PER_SECTION = 5;
+
 type SearchSection = "item" | "block" | "entity" | "device" | "area" | "label";
+
+interface SearchMoreComboBoxItem {
+  type: "more";
+  section: "entity" | "device" | "item";
+  label: string;
+}
 
 @customElement("ha-automation-add-search")
 export class HaAutomationAddSearch extends LitElement {
@@ -288,7 +296,8 @@ export class HaAutomationAddSearch extends LitElement {
       | (FloorComboBoxItem & { last?: boolean | undefined })
       | EntityComboBoxItem
       | DevicePickerItem
-      | AutomationItemComboBoxItem,
+      | AutomationItemComboBoxItem
+      | SearchMoreComboBoxItem,
     index: number
   ) => {
     if (!item) {
@@ -297,6 +306,24 @@ export class HaAutomationAddSearch extends LitElement {
 
     if (typeof item === "string") {
       return html`<ha-section-title>${item}</ha-section-title>`;
+    }
+
+    if ("type" in item && item.type === "more") {
+      return html`<ha-combo-box-item
+        id=${`search-list-item-${index}`}
+        type="button"
+        tabindex="-1"
+        .section-id=${item.section}
+        .value=${`more-${item.section}`}
+        @click=${this._toggleSection}
+      >
+        <ha-svg-icon
+          slot="start"
+          .path=${mdiUnfoldMoreHorizontal}
+        ></ha-svg-icon>
+        <span slot="headline"></span>
+        <span slot="supporting-text">${item.label}</span></ha-combo-box-item
+      ></ha-combo-box-item>`;
     }
 
     const type = ["trigger", "condition", "action", "block"].includes(
@@ -512,10 +539,17 @@ export class HaAutomationAddSearch extends LitElement {
       selectedSection?: SearchSection,
       relatedIdSets?: RelatedIdSets
     ) => {
-      const resultItems: (
-        string | FloorComboBoxItem | EntityComboBoxItem | PickerComboBoxItem
-      )[] = [];
-
+      type ResultItem =
+        | string
+        | FloorComboBoxItem
+        | EntityComboBoxItem
+        | PickerComboBoxItem
+        | SearchMoreComboBoxItem;
+      const resultSections: {
+        title: string;
+        type: string;
+        items: ResultItem[];
+      }[] = [];
       if (!selectedSection || selectedSection === "item") {
         let items = this._convertItemsToComboBoxItems(automationItems, type);
         if (searchTerm) {
@@ -526,15 +560,13 @@ export class HaAutomationAddSearch extends LitElement {
             ITEM_SEARCH_KEYS
           ) as AutomationItemComboBoxItem[];
         }
-
-        if (!selectedSection && items.length) {
-          // show group title
-          resultItems.push(
-            localize(`ui.panel.config.automation.editor.${type}s.name`)
-          );
+        if (items.length) {
+          resultSections.push({
+            title: localize(`ui.panel.config.automation.editor.${type}s.name`),
+            type: "item",
+            items: items,
+          });
         }
-
-        resultItems.push(...items);
       }
 
       if (
@@ -564,13 +596,13 @@ export class HaAutomationAddSearch extends LitElement {
           ) as AutomationItemComboBoxItem[];
         }
 
-        if (!selectedSection && blocks.length) {
-          // show group title
-          resultItems.push(
-            localize("ui.panel.config.automation.editor.blocks")
-          );
+        if (blocks.length) {
+          resultSections.push({
+            title: localize("ui.panel.config.automation.editor.blocks"),
+            type: "block",
+            items: blocks,
+          });
         }
-        resultItems.push(...blocks);
       }
 
       if (!selectedSection || selectedSection === "entity") {
@@ -601,14 +633,13 @@ export class HaAutomationAddSearch extends LitElement {
           entityItems = sortRelatedFirst(entityItems) as EntityComboBoxItem[];
         }
 
-        if (!selectedSection && entityItems.length) {
-          // show group title
-          resultItems.push(
-            localize("ui.components.target-picker.type.entities")
-          );
+        if (entityItems.length) {
+          resultSections.push({
+            title: localize("ui.components.target-picker.type.entities"),
+            type: "entity",
+            items: entityItems,
+          });
         }
-
-        resultItems.push(...entityItems);
       }
 
       if (!selectedSection || selectedSection === "device") {
@@ -640,14 +671,13 @@ export class HaAutomationAddSearch extends LitElement {
           deviceItems = sortRelatedFirst(deviceItems);
         }
 
-        if (!selectedSection && deviceItems.length) {
-          // show group title
-          resultItems.push(
-            localize("ui.components.target-picker.type.devices")
-          );
+        if (deviceItems.length) {
+          resultSections.push({
+            title: localize("ui.components.target-picker.type.devices"),
+            type: "device",
+            items: deviceItems,
+          });
         }
-
-        resultItems.push(...deviceItems);
       }
 
       if (!selectedSection || selectedSection === "area") {
@@ -697,15 +727,9 @@ export class HaAutomationAddSearch extends LitElement {
           ) as FloorComboBoxItem[];
         }
 
-        if (!selectedSection && areasAndFloors.length) {
-          // show group title
-          resultItems.push(localize("ui.components.target-picker.type.areas"));
-        }
-
-        resultItems.push(
-          ...areasAndFloors.map((item, index) => {
+        if (areasAndFloors.length) {
+          const areaItems = areasAndFloors.map((item, index) => {
             const nextItem = areasAndFloors[index + 1];
-
             if (
               !nextItem ||
               (item.type === "area" && nextItem.type === "floor")
@@ -715,10 +739,15 @@ export class HaAutomationAddSearch extends LitElement {
                 last: true,
               };
             }
-
             return item;
-          })
-        );
+          });
+
+          resultSections.push({
+            title: localize("ui.components.target-picker.type.areas"),
+            type: "area",
+            items: areaItems,
+          });
+        }
       }
 
       if (!selectedSection || selectedSection === "label") {
@@ -746,13 +775,45 @@ export class HaAutomationAddSearch extends LitElement {
           );
         }
 
-        if (!selectedSection && labels.length) {
-          // show group title
-          resultItems.push(localize("ui.components.target-picker.type.labels"));
+        if (labels.length) {
+          resultSections.push({
+            title: localize("ui.components.target-picker.type.labels"),
+            type: "device",
+            items: labels,
+          });
         }
-
-        resultItems.push(...labels);
       }
+
+      const resultItems: ResultItem[] = [];
+      resultSections.forEach((section, index) => {
+        if (selectedSection) {
+          resultItems.push(...section.items);
+          return;
+        }
+        resultItems.push(section.title);
+        if (
+          index !== resultSections.length - 1 &&
+          (section.type === "item" ||
+            section.type === "entity" ||
+            section.type === "device") &&
+          section.items.length > MAX_SEARCH_ITEMS_PER_SECTION
+        ) {
+          resultItems.push(
+            ...section.items.slice(0, MAX_SEARCH_ITEMS_PER_SECTION)
+          );
+          const typeKey = section.type === "item" ? type : section.type;
+          resultItems.push({
+            type: "more",
+            section: section.type,
+            label: localize(
+              `ui.panel.config.automation.editor.show_more_search.${typeKey}`,
+              { count: section.items.length - MAX_SEARCH_ITEMS_PER_SECTION }
+            ),
+          });
+        } else {
+          resultItems.push(...section.items);
+        }
+      });
 
       return resultItems;
     }
@@ -790,18 +851,22 @@ export class HaAutomationAddSearch extends LitElement {
     );
   }
 
-  private _toggleSection(ev: Event) {
+  private _toggleSection = (ev: Event) => {
     ev.stopPropagation();
     // this._resetSelectedItem();
     this._searchSectionTitle = undefined;
-    const section = (ev.target as HTMLElement)["section-id"] as string;
+    const section = (ev.currentTarget as HTMLElement)["section-id"] as string;
     if (!section) {
       return;
     }
-    if (this._selectedSearchSection === section) {
+    this._toggleSectionType(section);
+  };
+
+  private _toggleSectionType(type: string) {
+    if (this._selectedSearchSection === type) {
       this._selectedSearchSection = undefined;
     } else {
-      this._selectedSearchSection = section as SearchSection;
+      this._selectedSearchSection = type as SearchSection;
     }
 
     // Reset scroll position when filter changes
@@ -1019,9 +1084,13 @@ export class HaAutomationAddSearch extends LitElement {
 
     const item = this._virtualizerElement?.items[
       this._selectedSearchItemIndex
-    ] as PickerComboBoxItem;
+    ] as PickerComboBoxItem | SearchMoreComboBoxItem;
     if (item) {
-      this._selectSearchItem(item);
+      if ("type" in item && item.type === "more") {
+        this._toggleSectionType((item as SearchMoreComboBoxItem).section);
+      } else {
+        this._selectSearchItem(item as PickerComboBoxItem);
+      }
     }
   };
 

--- a/src/panels/config/automation/add-automation-element/ha-automation-add-search.ts
+++ b/src/panels/config/automation/add-automation-element/ha-automation-add-search.ts
@@ -102,7 +102,7 @@ const MAX_SEARCH_ITEMS_PER_SECTION = 5;
 
 type SearchSection = "item" | "block" | "entity" | "device" | "area" | "label";
 
-interface SearchMoreComboBoxItem {
+interface SearchMoreComboBoxItem extends PickerComboBoxItem {
   type: "more";
   section: "entity" | "device" | "item";
   label: string;
@@ -322,8 +322,8 @@ export class HaAutomationAddSearch extends LitElement {
           .path=${mdiUnfoldMoreHorizontal}
         ></ha-svg-icon>
         <span slot="headline"></span>
-        <span slot="supporting-text">${item.label}</span></ha-combo-box-item
-      ></ha-combo-box-item>`;
+        <span slot="supporting-text">${item.label}</span>
+      </ha-combo-box-item>`;
     }
 
     const type = ["trigger", "condition", "action", "block"].includes(
@@ -778,7 +778,7 @@ export class HaAutomationAddSearch extends LitElement {
         if (labels.length) {
           resultSections.push({
             title: localize("ui.components.target-picker.type.labels"),
-            type: "device",
+            type: "label",
             items: labels,
           });
         }
@@ -796,13 +796,15 @@ export class HaAutomationAddSearch extends LitElement {
           (section.type === "item" ||
             section.type === "entity" ||
             section.type === "device") &&
-          section.items.length > MAX_SEARCH_ITEMS_PER_SECTION
+          section.items.length > MAX_SEARCH_ITEMS_PER_SECTION + 1
         ) {
           resultItems.push(
             ...section.items.slice(0, MAX_SEARCH_ITEMS_PER_SECTION)
           );
           const typeKey = section.type === "item" ? type : section.type;
           resultItems.push({
+            primary: "",
+            id: `search-more-${type}`,
             type: "more",
             section: section.type,
             label: localize(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5177,6 +5177,13 @@
               "area": "No areas or floors found for {term}",
               "label": "No labels found for {term}"
             },
+            "show_more_search": {
+              "trigger": "{count} more triggers...",
+              "condition": "{count} more conditions...",
+              "action": "{count} more actions...",
+              "entity": "{count} more entities...",
+              "device": "{count} more devices..."
+            },
             "load_target_items_failed": "Failed to load target items for",
             "other_areas": "Other areas",
             "services": "Services",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
In the automation-add-search dialog, initially cap the amount of items displayed from each result type when no type is selected. 

This solves a problem when user performs a search for an item like "or" in the search box. Because each type of section is searched individually and sorted individually, a very high match like "Or" block may be buried 20 pages down below hundreds of domain-based conditions that are weak matches, it's not obvious to find it all.

In this PR, when an item is searched, we will show only the top few matches from each group when there is another group below, so that it's much easier to see that there are multiple result types, and to quickly scan the top results from each group. A link is available to expand the rest of the matches from the group. 

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
https://github.com/user-attachments/assets/8a512c61-7483-4212-88af-b51d7641e4ce


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/issues/53042
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
