### PR TITLE
Restore initial data argument of the demo registry mocks

### DIFF
--- a/demo/src/stubs/area_registry.ts
+++ b/demo/src/stubs/area_registry.ts
@@ -12,8 +12,21 @@ export interface DemoArea {
 
 let areas: AreaRegistryEntry[] = [];
 
-export const mockAreaRegistry = (hass: MockHomeAssistant) => {
+const setAreas = (hass: MockHomeAssistant, data: AreaRegistryEntry[]) => {
+  areas = data;
+  const areasById: Record<string, AreaRegistryEntry> = {};
+  areas.forEach((area) => {
+    areasById[area.area_id] = area;
+  });
+  hass.updateHass({ areas: areasById });
+};
+
+export const mockAreaRegistry = (
+  hass: MockHomeAssistant,
+  data: AreaRegistryEntry[] = []
+) => {
   hass.mockWS("config/area_registry/list", () => areas);
+  setAreas(hass, data);
 };
 
 /** Set the areas of the currently loaded demo config. */
@@ -21,22 +34,20 @@ export const setDemoAreas = (
   hass: MockHomeAssistant,
   demoAreas: DemoArea[] = []
 ) => {
-  areas = demoAreas.map((area) => ({
-    area_id: area.area_id,
-    name: area.name,
-    floor_id: area.floor_id ?? null,
-    icon: area.icon ?? null,
-    temperature_entity_id: area.temperature_entity_id ?? null,
-    humidity_entity_id: area.humidity_entity_id ?? null,
-    aliases: [],
-    labels: [],
-    picture: null,
-    created_at: 0,
-    modified_at: 0,
-  }));
-  const areasById: Record<string, AreaRegistryEntry> = {};
-  areas.forEach((area) => {
-    areasById[area.area_id] = area;
-  });
-  hass.updateHass({ areas: areasById });
+  setAreas(
+    hass,
+    demoAreas.map((area) => ({
+      area_id: area.area_id,
+      name: area.name,
+      floor_id: area.floor_id ?? null,
+      icon: area.icon ?? null,
+      temperature_entity_id: area.temperature_entity_id ?? null,
+      humidity_entity_id: area.humidity_entity_id ?? null,
+      aliases: [],
+      labels: [],
+      picture: null,
+      created_at: 0,
+      modified_at: 0,
+    }))
+  );
 };

--- a/demo/src/stubs/floor_registry.ts
+++ b/demo/src/stubs/floor_registry.ts
@@ -10,8 +10,21 @@ export interface DemoFloor {
 
 let floors: FloorRegistryEntry[] = [];
 
-export const mockFloorRegistry = (hass: MockHomeAssistant) => {
+const setFloors = (hass: MockHomeAssistant, data: FloorRegistryEntry[]) => {
+  floors = data;
+  const floorsById: Record<string, FloorRegistryEntry> = {};
+  floors.forEach((floor) => {
+    floorsById[floor.floor_id] = floor;
+  });
+  hass.updateHass({ floors: floorsById });
+};
+
+export const mockFloorRegistry = (
+  hass: MockHomeAssistant,
+  data: FloorRegistryEntry[] = []
+) => {
   hass.mockWS("config/floor_registry/list", () => floors);
+  setFloors(hass, data);
 };
 
 /** Set the floors of the currently loaded demo config. */
@@ -19,18 +32,16 @@ export const setDemoFloors = (
   hass: MockHomeAssistant,
   demoFloors: DemoFloor[] = []
 ) => {
-  floors = demoFloors.map((floor) => ({
-    floor_id: floor.floor_id,
-    name: floor.name,
-    level: floor.level ?? null,
-    icon: floor.icon ?? null,
-    aliases: [],
-    created_at: 0,
-    modified_at: 0,
-  }));
-  const floorsById: Record<string, FloorRegistryEntry> = {};
-  floors.forEach((floor) => {
-    floorsById[floor.floor_id] = floor;
-  });
-  hass.updateHass({ floors: floorsById });
+  setFloors(
+    hass,
+    demoFloors.map((floor) => ({
+      floor_id: floor.floor_id,
+      name: floor.name,
+      level: floor.level ?? null,
+      icon: floor.icon ?? null,
+      aliases: [],
+      created_at: 0,
+      modified_at: 0,
+    }))
+  );
 };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

`mockAreaRegistry` and `mockFloorRegistry` lost their initial data argument in #53280, when demo configs gained their own areas and floors. The gallery still passes fixed areas and floors to both mocks (`gallery/src/pages/components/ha-form.ts`, `gallery/src/pages/components/ha-selector.ts`), so `yarn lint:types` currently fails on `dev`:

```
gallery/src/pages/components/ha-form.ts(512,28): error TS2554: Expected 1 arguments, but got 2.
gallery/src/pages/components/ha-selector.ts(534,28): error TS2554: Expected 1 arguments, but got 2.
gallery/src/pages/components/ha-selector.ts(535,29): error TS2554: Expected 1 arguments, but got 2.
```

Both mocks accept initial data again and share the registry update with the demo config setters, so gallery pages get their areas and floors as before.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZ6ydA22VeQndgynH4SxCV

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZ6ydA22VeQndgynH4SxCV)_