### PR TITLE
Fix mocked entity states and demo config switching

### DIFF
--- a/demo/src/configs/demo-configs.ts
+++ b/demo/src/configs/demo-configs.ts
@@ -43,6 +43,13 @@ export const setDemoConfig = async (
   setDemoAreas(hass, config.areas);
   hass.addEntities(config.entities(hass.localize), true);
   hass.addEntities(energyEntities());
+
+  // Let the new registries and entities reach the dashboard before saving the
+  // config, so dashboard strategies generate against them
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
   lovelace.saveConfig(config.lovelace(hass.localize));
   applyDemoTheme(hass, config.theme);
 };

--- a/demo/src/stubs/entities.ts
+++ b/demo/src/stubs/entities.ts
@@ -85,7 +85,7 @@ export const energyEntities = () =>
       },
     },
     "sensor.energy_consumption_tarif_1": {
-      entity_id: "sensor.energy_consumption_tarif_1	",
+      entity_id: "sensor.energy_consumption_tarif_1",
       state: "88.6",
       attributes: {
         last_reset: "1970-01-01T00:00:00:00+00",

--- a/src/fake_data/entities/base-entity.ts
+++ b/src/fake_data/entities/base-entity.ts
@@ -130,6 +130,8 @@ export class MockBaseEntity {
       "entity_picture",
       "assumed_state",
       "device_class",
+      "state_class",
+      "unit_of_measurement",
       "supported_features",
     ]) {
       if (key in attrs) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Three small demo and mock fixes, split out of the upcoming home page demo:

- Mocked entities dropped `unit_of_measurement` and `state_class` when writing to the state machine, even though both are part of their capability attributes. Demo sensors therefore rendered without a unit, and the mocked history stream (which branches on the unit) returned a single state for them, leaving trend graphs empty.
- The energy consumption sensor entity id in the demo has a stray tab, which fails entity id validation in cards that render it.
- Switching demos saved the new dashboard config before the new registries and entities reached the dashboard, so dashboard strategies generated against the previous demo's data.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Not sure how long it has been broken (too lazy to ask AI), but currently all history in demo is broken.

Before this PR from https://demo.home-assistant.io: 
<img width="212" height="132" alt="image" src="https://github.com/user-attachments/assets/ab08c994-9d38-4ce3-b427-95ca72e1171f" />

After:
<img width="167" height="129" alt="image" src="https://github.com/user-attachments/assets/2723b9f9-c3a3-4844-a495-dcacdf62fbeb" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZ6ydA22VeQndgynH4SxCV

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZ6ydA22VeQndgynH4SxCV)_