### PR TITLE
Recompute sections view column count when the config changes

### DIFF
--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -81,13 +81,13 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
   private _sidebarScrollTop = 0;
 
   private _columnsController = new ResizeController(this, {
-    callback: () => {
-      const totalWidth = this.clientWidth;
-      const container = this.shadowRoot!.querySelector(".container");
+    callback: (entries) => {
+      const totalWidth = entries[0]?.contentRect.width;
 
-      if (!totalWidth || !container) return 1;
+      if (!totalWidth) return 1;
 
       const style = getComputedStyle(this);
+      const container = this.shadowRoot!.querySelector(".container")!;
       const containerStyle = getComputedStyle(container);
 
       const paddingLeft = parsePx(containerStyle.paddingLeft);
@@ -101,8 +101,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
       const columns = Math.floor(
         (totalWidth - padding + columnGap) / (minColumnWidth + columnGap)
       );
-      const maxColumns = this._config?.max_columns ?? DEFAULT_MAX_COLUMNS;
-      return clamp(columns, 1, maxColumns);
+      return Math.max(columns, 1);
     },
   });
 
@@ -147,20 +146,22 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
     );
   }
 
-  willUpdate(changedProperties: PropertyValues): void {
+  willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("sections")) {
       this._computeSectionsCount();
-    }
-    if (changedProperties.has("_config")) {
-      // The view element is reused between views, so the column count has to
-      // be recomputed for the max columns of the new config
-      this._columnsController.handleChanges([]);
     }
     this._updateMaxColumnCount();
   }
 
   private _updateMaxColumnCount(): void {
-    const maxColumnCount = this._columnsController.value ?? 1;
+    // The column count is clamped here instead of in the resize callback, so
+    // that it follows the config of the view the element is currently used for
+    const maxColumns = this._config?.max_columns ?? DEFAULT_MAX_COLUMNS;
+    const maxColumnCount = clamp(
+      this._columnsController.value ?? 1,
+      1,
+      maxColumns
+    );
 
     if (maxColumnCount !== this._maxColumns) {
       this._maxColumns = maxColumnCount;

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -80,20 +80,14 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
 
   private _sidebarScrollTop = 0;
 
-  private _totalWidth = 0;
-
   private _columnsController = new ResizeController(this, {
-    callback: (entries) => {
-      // Without entries we are recomputing for a new config, so reuse the
-      // last observed width
-      const totalWidth = entries[0]?.contentRect.width ?? this._totalWidth;
+    callback: () => {
+      const totalWidth = this.clientWidth;
+      const container = this.shadowRoot!.querySelector(".container");
 
-      if (!totalWidth) return 1;
-
-      this._totalWidth = totalWidth;
+      if (!totalWidth || !container) return 1;
 
       const style = getComputedStyle(this);
-      const container = this.shadowRoot!.querySelector(".container")!;
       const containerStyle = getComputedStyle(container);
 
       const paddingLeft = parsePx(containerStyle.paddingLeft);

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -80,11 +80,17 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
 
   private _sidebarScrollTop = 0;
 
+  private _totalWidth = 0;
+
   private _columnsController = new ResizeController(this, {
     callback: (entries) => {
-      const totalWidth = entries[0]?.contentRect.width;
+      // Without entries we are recomputing for a new config, so reuse the
+      // last observed width
+      const totalWidth = entries[0]?.contentRect.width ?? this._totalWidth;
 
       if (!totalWidth) return 1;
+
+      this._totalWidth = totalWidth;
 
       const style = getComputedStyle(this);
       const container = this.shadowRoot!.querySelector(".container")!;
@@ -147,9 +153,14 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
     );
   }
 
-  willUpdate(changedProperties: PropertyValues<this>): void {
+  willUpdate(changedProperties: PropertyValues): void {
     if (changedProperties.has("sections")) {
       this._computeSectionsCount();
+    }
+    if (changedProperties.has("_config")) {
+      // The view element is reused between views, so the column count has to
+      // be recomputed for the max columns of the new config
+      this._columnsController.handleChanges([]);
     }
     this._updateMaxColumnCount();
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

`hui-view` reuses the layout element when the new view has the same type, so navigating between two sections views only calls `setConfig` on the existing `hui-sections-view`. The column count is cached by a `ResizeController`, which only recomputes when the observer fires. The callback also applied the `max_columns` clamp of the config, so the element kept clamping to the previous view's `max_columns` until the window was resized.

This shows up in my testing with the demo when moving between views with a different `max_columns`. For example, the home page views use `max_columns: 3`, so coming from a view that allows 4 columns renders a 4 column grid on a wide screen, and it only settles into 3 columns after a resize.

The resize callback now returns the column count that fits the width, and the `max_columns` clamp moved to `_updateMaxColumnCount`, which already runs on every update. That way only the width-dependent part is cached, and the config-dependent part follows the view the element is currently used for.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZ6ydA22VeQndgynH4SxCV