### PR TITLE
Fix gallery type errors by letting registry mocks take the demo area and floor shapes

### DIFF
--- a/demo/src/stubs/area_registry.ts
+++ b/demo/src/stubs/area_registry.ts
@@ -12,8 +12,12 @@ export interface DemoArea {
 
 let areas: AreaRegistryEntry[] = [];
 
-export const mockAreaRegistry = (hass: MockHomeAssistant) => {
+export const mockAreaRegistry = (
+  hass: MockHomeAssistant,
+  data: DemoArea[] = []
+) => {
   hass.mockWS("config/area_registry/list", () => areas);
+  setDemoAreas(hass, data);
 };
 
 /** Set the areas of the currently loaded demo config. */

--- a/demo/src/stubs/floor_registry.ts
+++ b/demo/src/stubs/floor_registry.ts
@@ -10,8 +10,12 @@ export interface DemoFloor {
 
 let floors: FloorRegistryEntry[] = [];
 
-export const mockFloorRegistry = (hass: MockHomeAssistant) => {
+export const mockFloorRegistry = (
+  hass: MockHomeAssistant,
+  data: DemoFloor[] = []
+) => {
   hass.mockWS("config/floor_registry/list", () => floors);
+  setDemoFloors(hass, data);
 };
 
 /** Set the floors of the currently loaded demo config. */

--- a/gallery/src/pages/components/ha-form.ts
+++ b/gallery/src/pages/components/ha-form.ts
@@ -2,7 +2,10 @@
 import type { TemplateResult } from "lit";
 import { html, LitElement } from "lit";
 import { customElement, state } from "lit/decorators";
-import { mockAreaRegistry } from "../../../../demo/src/stubs/area_registry";
+import {
+  mockAreaRegistry,
+  type DemoArea,
+} from "../../../../demo/src/stubs/area_registry";
 import { mockConfigEntries } from "../../../../demo/src/stubs/config_entries";
 import { mockDeviceRegistry } from "../../../../demo/src/stubs/device_registry";
 import { mockEntityRegistry } from "../../../../demo/src/stubs/entity_registry";
@@ -10,7 +13,6 @@ import { mockHassioSupervisor } from "../../../../demo/src/stubs/hassio_supervis
 import { computeInitialHaFormData } from "../../../../src/components/ha-form/compute-initial-ha-form-data";
 import "../../../../src/components/ha-form/ha-form";
 import type { HaFormSchema } from "../../../../src/components/ha-form/types";
-import type { AreaRegistryEntry } from "../../../../src/data/area/area_registry";
 import type { DeviceRegistryEntry } from "../../../../src/data/device/device_registry";
 import { provideHass } from "../../../../src/fake_data/provide_hass";
 import type { HomeAssistant } from "../../../../src/types";
@@ -136,45 +138,20 @@ const DEVICES: DeviceRegistryEntry[] = [
   },
 ];
 
-const AREAS: AreaRegistryEntry[] = [
+const AREAS: DemoArea[] = [
   {
     area_id: "backyard",
-    floor_id: null,
     name: "Backyard",
-    icon: null,
-    picture: null,
-    aliases: [],
-    labels: [],
-    temperature_entity_id: null,
-    humidity_entity_id: null,
-    created_at: 0,
-    modified_at: 0,
   },
   {
     area_id: "bedroom",
-    floor_id: null,
     name: "Bedroom",
     icon: "mdi:bed",
-    picture: null,
-    aliases: [],
-    labels: [],
-    temperature_entity_id: null,
-    humidity_entity_id: null,
-    created_at: 0,
-    modified_at: 0,
   },
   {
     area_id: "livingroom",
-    floor_id: null,
     name: "Livingroom",
     icon: "mdi:sofa",
-    picture: null,
-    aliases: [],
-    labels: [],
-    temperature_entity_id: null,
-    humidity_entity_id: null,
-    created_at: 0,
-    modified_at: 0,
   },
 ];
 

--- a/gallery/src/pages/components/ha-selector.ts
+++ b/gallery/src/pages/components/ha-selector.ts
@@ -1,21 +1,25 @@
 import type { TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, state } from "lit/decorators";
-import { mockAreaRegistry } from "../../../../demo/src/stubs/area_registry";
+import {
+  mockAreaRegistry,
+  type DemoArea,
+} from "../../../../demo/src/stubs/area_registry";
 import { mockConfigEntries } from "../../../../demo/src/stubs/config_entries";
 import { mockDeviceRegistry } from "../../../../demo/src/stubs/device_registry";
 import { mockEntityRegistry } from "../../../../demo/src/stubs/entity_registry";
-import { mockFloorRegistry } from "../../../../demo/src/stubs/floor_registry";
+import {
+  mockFloorRegistry,
+  type DemoFloor,
+} from "../../../../demo/src/stubs/floor_registry";
 import { mockHassioSupervisor } from "../../../../demo/src/stubs/hassio_supervisor";
 import { mockLabelRegistry } from "../../../../demo/src/stubs/label_registry";
 import type { HASSDomEvent } from "../../../../src/common/dom/fire_event";
 import "../../../../src/components/ha-formfield";
 import "../../../../src/components/ha-selector/ha-selector";
 import "../../../../src/components/ha-settings-row";
-import type { AreaRegistryEntry } from "../../../../src/data/area/area_registry";
 import type { BlueprintInput } from "../../../../src/data/blueprint";
 import type { DeviceRegistryEntry } from "../../../../src/data/device/device_registry";
-import type { FloorRegistryEntry } from "../../../../src/data/floor_registry";
 import type { LabelRegistryEntry } from "../../../../src/data/label/label_registry";
 import {
   showDialog,
@@ -147,75 +151,43 @@ const DEVICES: DeviceRegistryEntry[] = [
   },
 ];
 
-const AREAS: AreaRegistryEntry[] = [
+const AREAS: DemoArea[] = [
   {
     area_id: "backyard",
     floor_id: "ground",
     name: "Backyard",
-    icon: null,
-    picture: null,
-    aliases: [],
-    labels: [],
-    temperature_entity_id: null,
-    humidity_entity_id: null,
-    created_at: 0,
-    modified_at: 0,
   },
   {
     area_id: "bedroom",
     floor_id: "first",
     name: "Bedroom",
     icon: "mdi:bed",
-    picture: null,
-    aliases: [],
-    labels: [],
-    temperature_entity_id: null,
-    humidity_entity_id: null,
-    created_at: 0,
-    modified_at: 0,
   },
   {
     area_id: "livingroom",
     floor_id: "ground",
     name: "Livingroom",
     icon: "mdi:sofa",
-    picture: null,
-    aliases: [],
-    labels: [],
-    temperature_entity_id: null,
-    humidity_entity_id: null,
-    created_at: 0,
-    modified_at: 0,
   },
 ];
 
-const FLOORS: FloorRegistryEntry[] = [
+const FLOORS: DemoFloor[] = [
   {
     floor_id: "ground",
     name: "Ground floor",
     level: 0,
-    icon: null,
-    aliases: [],
-    created_at: 0,
-    modified_at: 0,
   },
   {
     floor_id: "first",
     name: "First floor",
     level: 1,
     icon: "mdi:numeric-1",
-    aliases: [],
-    created_at: 0,
-    modified_at: 0,
   },
   {
     floor_id: "second",
     name: "Second floor",
     level: 2,
     icon: "mdi:numeric-2",
-    aliases: [],
-    created_at: 0,
-    modified_at: 0,
   },
 ];
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Fix three TypeScript errors on `dev`.

**Cause:** "Let demo configs provide areas and floors" (https://github.com/home-assistant/frontend/pull/53280, merged as 3284633). That PR made areas and floors demo-config-owned, so `mockAreaRegistry` and `mockFloorRegistry` lost their data parameter. Two gallery pages still pass fixtures to them, so `yarn lint:types` fails on `dev` today:

```
gallery/src/pages/components/ha-form.ts(512,28): error TS2554: Expected 1 arguments, but got 2.
gallery/src/pages/components/ha-selector.ts(534,28): error TS2554: Expected 1 arguments, but got 2.
gallery/src/pages/components/ha-selector.ts(535,29): error TS2554: Expected 1 arguments, but got 2.
```

Note that `gallery/script/build_gallery` still succeeds — rspack transpiles without typechecking, so the gallery build is not what catches this. The failing check is `yarn lint:types` in the "Lint and check format" job. See the Additional information section for why that job went green on #53280.

The gallery never needed full registry entries — it only sets `area_id`, `name`, `floor_id`, `icon` and `level`, and the rest was null and empty-array filler required by `AreaRegistryEntry` / `FloorRegistryEntry`. #53280 introduced `DemoArea` and `DemoFloor` precisely to drop that filler, so rather than restoring the old verbose parameter types, the mocks now take those demo shapes and seed the registry through `setDemoAreas` / `setDemoFloors`:

```ts
export const mockAreaRegistry = (
  hass: MockHomeAssistant,
  data: DemoArea[] = []
) => {
  hass.mockWS("config/area_registry/list", () => areas);
  setDemoAreas(hass, data);
};
```

`setDemoAreas` / `setDemoFloors` stay the single place that expands a demo shape into a real registry entry. The `(hass, data)` signature also matches `mockDeviceRegistry`, `mockEntityRegistry` and `mockLabelRegistry`, so the gallery keeps one call per registry.

The gallery fixtures then shed the filler: each area drops from 12 lines to 3-5, and the `AreaRegistryEntry` / `FloorRegistryEntry` imports go away. Net 25 insertions against 68 deletions.

One behavior note: a bare `mockAreaRegistry(hass)` now also calls `setDemoAreas(hass, [])`, which fires `updateHass({ areas: {} })`. `provideHass` already initializes `areas: {}` and `floors: {}`, so this is a no-op in practice, but it is a write that did not happen before — it affects `demo/src/ha-demo.ts` and `test/e2e/app/src/ha-test.ts`.

Verified with `yarn lint:types` from a cold cache, ESLint, Prettier, lit-analyzer and `gallery/script/build_gallery`. Also loaded the built gallery in Chromium and confirmed the area picker still renders Backyard / Ground floor, Bedroom / First floor with `mdi:bed`, and Livingroom / Ground floor with `mdi:sofa`, so icons and floor associations resolve exactly as before.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

No visual changes — the gallery renders the same areas and floors as before the break.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: fixes the type errors introduced by https://github.com/home-assistant/frontend/pull/53280, and supersedes the stub fix in https://github.com/home-assistant/frontend/pull/53299
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

**Why CI did not catch this on #53280** (worth a separate look, not addressed here): the `lint` job caches `node_modules/.cache/typescript` with `key: lint-${{ github.sha }}` and `restore-keys: lint-`, and `tsconfig.json` sets `"incremental": true`. On #53280 the job logged `Cache restored from key: lint-9d96d0b...` — the PR's own base commit — and `yarn lint:types` then finished in 4.3 seconds without output.

This reproduces locally. Starting from a `.tsbuildinfo` built at `3284633^` and then applying #53280's files:

| run | time | result |
| --- | --- | --- |
| warm cache (what CI did) | 7.0s | 0 errors |
| cold cache | 18.8s | the 3 errors above |

Only `demo/src/stubs/*.ts` changed in #53280; the gallery files that call them did not. With `noEmit` plus `incremental`, tsc did not re-check those dependents, so the signature change went unnoticed. Dropping `node_modules/.cache/typescript` from that cache (keeping the content-hashed ESLint and Prettier caches) would close the hole for roughly 12 extra seconds per run.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
