### PR TITLE
Share the sankey effective-parent walk across all four cards

### DIFF
--- a/src/panels/lovelace/cards/energy/common/sankey.ts
+++ b/src/panels/lovelace/cards/energy/common/sankey.ts
@@ -194,10 +194,15 @@ export const buildSankeyDeviceNodes = (
   smallConsumersByParent.forEach((allConsumers, parentKey) => {
     // A small consumer whose included_in_stat chain reaches another small
     // consumer is already counted inside that ancestor's value - drop it so
-    // totals don't double-count nested devices.
+    // totals don't double-count nested devices. A rendered ancestor ends the
+    // walk: the consumer links to it and never touches untracked, so it can't
+    // be double-counted through anything further up.
     const consumers = allConsumers.filter((consumer) => {
       let ancestor = consumer.includedInStat;
       for (let hops = 0; ancestor && hops < devices.length; hops++) {
+        if (renderedId(ancestor)) {
+          return true;
+        }
         if (smallConsumerStats.has(ancestor)) {
           return false;
         }

--- a/src/panels/lovelace/cards/energy/common/sankey.ts
+++ b/src/panels/lovelace/cards/energy/common/sankey.ts
@@ -54,9 +54,6 @@ export interface BuildSankeyDeviceNodesOptions {
   getValue: (id: string) => number;
   getLabel: (id: string, name: string | undefined) => string;
   getEntityId: (id: string) => string | undefined;
-  findEffectiveParent: (
-    includedInStat: string | undefined
-  ) => string | undefined;
 }
 
 /**
@@ -86,7 +83,6 @@ export const buildSankeyDeviceNodes = (
     getValue,
     getLabel,
     getEntityId,
-    findEffectiveParent,
   } = options;
 
   const unavailableColor = computedStyle
@@ -100,19 +96,62 @@ export const buildSankeyDeviceNodes = (
   const smallConsumerStats = new Set<string>();
   let untrackedConsumption = initialUntracked;
 
-  // Parent chain in stat_consumption space, used to detect nested small consumers
-  const deviceParents = new Map<string, string | undefined>();
+  // Resolve every device's node id and value once. `included_in_stat` always
+  // names a stat_consumption, so the hierarchy is keyed by that, while the
+  // rendered set holds node ids (stat_consumption or stat_rate, per `getId`).
+  const deviceByStat = new Map<string, DeviceConsumptionEnergyPreference>();
+  const deviceValues = new Map<string, number>();
+  const renderedIds = new Set<string>();
   devices.forEach((device) => {
-    deviceParents.set(device.stat_consumption, device.included_in_stat);
-  });
-
-  devices.forEach((device, idx) => {
+    deviceByStat.set(device.stat_consumption, device);
     const id = getId(device);
     // Falsy check (not `=== undefined`) mirrors the cards' original `!stat_rate` guard.
     if (!id) {
       return;
     }
     const value = getValue(id);
+    deviceValues.set(id, value);
+    if (value >= minThreshold) {
+      renderedIds.add(id);
+    }
+  });
+
+  /** Node id of a device rendered as its own node, else undefined. */
+  const renderedId = (statConsumption: string): string | undefined => {
+    const device = deviceByStat.get(statConsumption);
+    if (!device) {
+      return undefined;
+    }
+    const id = getId(device);
+    return id && renderedIds.has(id) ? id : undefined;
+  };
+
+  // Walk up the included_in_stat chain to the first ancestor that is rendered.
+  // Bounded because a hand-edited config can make included_in_stat cyclic.
+  const findEffectiveParent = (
+    includedInStat: string | undefined
+  ): string | undefined => {
+    let current = includedInStat;
+    for (let hops = 0; current && hops < devices.length; hops++) {
+      const rendered = renderedId(current);
+      if (rendered) {
+        return rendered;
+      }
+      const device = deviceByStat.get(current);
+      if (!device) {
+        return undefined;
+      }
+      current = device.included_in_stat;
+    }
+    return undefined;
+  };
+
+  devices.forEach((device, idx) => {
+    const id = getId(device);
+    if (!id) {
+      return;
+    }
+    const value = deviceValues.get(id)!;
     const effectiveParent = findEffectiveParent(device.included_in_stat);
 
     if (value < minThreshold) {
@@ -162,7 +201,7 @@ export const buildSankeyDeviceNodes = (
         if (smallConsumerStats.has(ancestor)) {
           return false;
         }
-        ancestor = deviceParents.get(ancestor);
+        ancestor = deviceByStat.get(ancestor)?.included_in_stat;
       }
       return true;
     });

--- a/src/panels/lovelace/cards/energy/hui-energy-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sankey-card.ts
@@ -272,35 +272,6 @@ class HuiEnergySankeyCard
         ? calculateStatisticSumGrowth(this._data!.stats[statConsumption]) || 0
         : 0;
 
-    // Set of device stats that will be rendered as their own node
-    const renderedStats = new Set<string>();
-    prefs.device_consumption.forEach((device) => {
-      if (deviceValue(device.stat_consumption) >= minEnergyThreshold) {
-        renderedStats.add(device.stat_consumption);
-      }
-    });
-
-    // Walk up the included_in_stat chain to the first ancestor that is rendered
-    const deviceMap = new Map<string, string | undefined>();
-    prefs.device_consumption.forEach((device) => {
-      deviceMap.set(device.stat_consumption, device.included_in_stat);
-    });
-    const findEffectiveParent = (
-      includedInStat: string | undefined
-    ): string | undefined => {
-      let currentParent = includedInStat;
-      while (currentParent) {
-        if (renderedStats.has(currentParent)) {
-          return currentParent;
-        }
-        if (!deviceMap.has(currentParent)) {
-          return undefined;
-        }
-        currentParent = deviceMap.get(currentParent);
-      }
-      return undefined;
-    };
-
     const deviceLabel = (statConsumption: string, name?: string) =>
       name ||
       getStatisticLabel(
@@ -327,7 +298,6 @@ class HuiEnergySankeyCard
       getValue: deviceValue,
       getLabel: deviceLabel,
       getEntityId: (id) => (isExternalStatistic(id) ? undefined : id),
-      findEffectiveParent,
     });
     links.push(...deviceLinks);
 

--- a/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
@@ -278,54 +278,6 @@ class HuiPowerSankeyCard
       }
     }
 
-    // Build a map of device relationships for hierarchy resolution
-    // Key: stat_consumption (energy), Value: { stat_rate, included_in_stat }
-    const deviceMap = new Map<
-      string,
-      { stat_rate?: string; included_in_stat?: string }
-    >();
-    prefs.device_consumption.forEach((device) => {
-      deviceMap.set(device.stat_consumption, {
-        stat_rate: device.stat_rate,
-        included_in_stat: device.included_in_stat,
-      });
-    });
-
-    // Set of stat_rate entities that will be rendered as nodes
-    const renderedStatRates = new Set<string>();
-    prefs.device_consumption.forEach((device) => {
-      if (device.stat_rate) {
-        const value = this._getCurrentPower(device.stat_rate);
-        if (value >= minPowerThreshold) {
-          renderedStatRates.add(device.stat_rate);
-        }
-      }
-    });
-
-    // Find the effective parent for power hierarchy
-    // Walks up the chain to find an ancestor with stat_rate that will be rendered
-    const findEffectiveParent = (
-      includedInStat: string | undefined
-    ): string | undefined => {
-      let currentParent = includedInStat;
-      while (currentParent) {
-        const parentDevice = deviceMap.get(currentParent);
-        if (!parentDevice) {
-          return undefined;
-        }
-        // If this parent has a stat_rate and will be rendered, use it
-        if (
-          parentDevice.stat_rate &&
-          renderedStatRates.has(parentDevice.stat_rate)
-        ) {
-          return parentDevice.stat_rate;
-        }
-        // Otherwise, continue up the chain
-        currentParent = parentDevice.included_in_stat;
-      }
-      return undefined;
-    };
-
     const {
       deviceNodes,
       parentLinks,
@@ -344,7 +296,6 @@ class HuiPowerSankeyCard
       getValue: (id) => this._getCurrentPower(id),
       getLabel: (id, name) => name || this._getEntityLabel(id),
       getEntityId: (id) => id,
-      findEffectiveParent,
     });
     links.push(...deviceLinks);
 

--- a/src/panels/lovelace/cards/water/hui-water-flow-sankey-card.ts
+++ b/src/panels/lovelace/cards/water/hui-water-flow-sankey-card.ts
@@ -241,48 +241,6 @@ class HuiWaterFlowSankeyCard
       }
     }
 
-    // Build a map of device relationships for hierarchy resolution
-    const deviceMap = new Map<
-      string,
-      { stat_rate?: string; included_in_stat?: string }
-    >();
-    prefs.device_consumption_water.forEach((device) => {
-      deviceMap.set(device.stat_consumption, {
-        stat_rate: device.stat_rate,
-        included_in_stat: device.included_in_stat,
-      });
-    });
-
-    // Set of stat_rate entities that will be rendered as nodes
-    const renderedStatRates = new Set<string>();
-    prefs.device_consumption_water.forEach((device) => {
-      if (device.stat_rate) {
-        const value = this._getCurrentFlowRate(device.stat_rate);
-        if (value >= minFlowThreshold) {
-          renderedStatRates.add(device.stat_rate);
-        }
-      }
-    });
-
-    // Find the effective parent for hierarchy
-    const findEffectiveParent = (
-      includedInStat: string | undefined
-    ): string | undefined => {
-      let currentParent = includedInStat;
-      while (currentParent) {
-        const parentDevice = deviceMap.get(currentParent);
-        if (!parentDevice) return undefined;
-        if (
-          parentDevice.stat_rate &&
-          renderedStatRates.has(parentDevice.stat_rate)
-        ) {
-          return parentDevice.stat_rate;
-        }
-        currentParent = parentDevice.included_in_stat;
-      }
-      return undefined;
-    };
-
     const {
       deviceNodes,
       parentLinks,
@@ -301,7 +259,6 @@ class HuiWaterFlowSankeyCard
       getValue: (id) => this._getCurrentFlowRate(id),
       getLabel: (id, name) => name || this._getEntityLabel(id),
       getEntityId: (id) => id,
-      findEffectiveParent,
     });
     links.push(...deviceLinks);
 

--- a/src/panels/lovelace/cards/water/hui-water-sankey-card.ts
+++ b/src/panels/lovelace/cards/water/hui-water-sankey-card.ts
@@ -215,35 +215,6 @@ class HuiWaterSankeyCard
         ? calculateStatisticSumGrowth(this._data!.stats[statConsumption]) || 0
         : 0;
 
-    // Set of device stats that will be rendered as their own node
-    const renderedStats = new Set<string>();
-    prefs.device_consumption_water.forEach((device) => {
-      if (deviceValue(device.stat_consumption) >= minWaterThreshold) {
-        renderedStats.add(device.stat_consumption);
-      }
-    });
-
-    // Walk up the included_in_stat chain to the first ancestor that is rendered
-    const deviceMap = new Map<string, string | undefined>();
-    prefs.device_consumption_water.forEach((device) => {
-      deviceMap.set(device.stat_consumption, device.included_in_stat);
-    });
-    const findEffectiveParent = (
-      includedInStat: string | undefined
-    ): string | undefined => {
-      let currentParent = includedInStat;
-      while (currentParent) {
-        if (renderedStats.has(currentParent)) {
-          return currentParent;
-        }
-        if (!deviceMap.has(currentParent)) {
-          return undefined;
-        }
-        currentParent = deviceMap.get(currentParent);
-      }
-      return undefined;
-    };
-
     const deviceLabel = (statConsumption: string, name?: string) =>
       name ||
       getStatisticLabel(
@@ -270,7 +241,6 @@ class HuiWaterSankeyCard
       getValue: deviceValue,
       getLabel: deviceLabel,
       getEntityId: (id) => (isExternalStatistic(id) ? undefined : id),
-      findEffectiveParent,
     });
     links.push(...deviceLinks);
 

--- a/test/panels/lovelace/cards/energy/common/sankey.test.ts
+++ b/test/panels/lovelace/cards/energy/common/sankey.test.ts
@@ -382,6 +382,33 @@ describe("buildSankeyDeviceNodes", () => {
     expect(result.untrackedConsumption).toBe(0);
   });
 
+  it("keeps a small device whose chain reaches a small ancestor past a rendered one", () => {
+    // g(small) > a(rendered) > c(small): c hangs off rendered a, so it never
+    // touches untracked and cannot be double-counted through g.
+    const devs = devices(
+      { stat_consumption: "g" },
+      { stat_consumption: "a", included_in_stat: "g" },
+      { stat_consumption: "c", included_in_stat: "a" }
+    );
+    const values = { g: 0.0005, a: 0.5, c: 0.0004 };
+    const result = buildSankeyDeviceNodes(
+      cumulativeOpts({
+        devices: devs,
+        values,
+        initialUntracked: 1,
+      })
+    );
+    expect(result.deviceNodes.map((n) => n.id)).toEqual([
+      "a",
+      "g",
+      "c",
+      "untracked_a",
+    ]);
+    expect(result.parentLinks.c).toBe("a");
+    // only the two top-level values (a and g) come off untracked
+    expect(result.untrackedConsumption).toBeCloseTo(1 - 0.5 - 0.0005, 10);
+  });
+
   it("leaves a cyclic small-device cluster in untracked instead of looping", () => {
     const result = buildSankeyDeviceNodes(
       cumulativeOpts({

--- a/test/panels/lovelace/cards/energy/common/sankey.test.ts
+++ b/test/panels/lovelace/cards/energy/common/sankey.test.ts
@@ -46,7 +46,6 @@ const cumulativeOpts = (
     getValue: (id) => values[id] ?? 0,
     getLabel: (id, name) => name || id,
     getEntityId: (id) => id,
-    findEffectiveParent: () => undefined,
     ...rest,
   };
 };
@@ -168,6 +167,56 @@ describe("buildSankeyDeviceNodes", () => {
     expect(result.untrackedConsumption).toBe(0);
   });
 
+  it("resolves the parent to its node id, not its stat_consumption", () => {
+    // Instantaneous cards key the hierarchy by stat_consumption but render
+    // stat_rate, so the effective parent must come back as the stat_rate.
+    const result = buildSankeyDeviceNodes(
+      cumulativeOpts({
+        devices: devices(
+          { stat_consumption: "p", stat_rate: "sensor.p" },
+          {
+            stat_consumption: "c",
+            stat_rate: "sensor.c",
+            included_in_stat: "p",
+          }
+        ),
+        values: { "sensor.p": 100, "sensor.c": 40 },
+        minThreshold: 1,
+        initialUntracked: 100,
+        getId: (device) => device.stat_rate,
+      })
+    );
+    expect(result.parentLinks["sensor.c"]).toBe("sensor.p");
+    expect(result.links).toContainEqual({
+      source: "sensor.p",
+      target: "sensor.c",
+    });
+    expect(result.untrackedConsumption).toBe(0); // only the top-level parent
+  });
+
+  it("walks through an intermediate device that has no node id", () => {
+    // "middle" has no stat_rate, so the child must attach to the grandparent.
+    const result = buildSankeyDeviceNodes(
+      cumulativeOpts({
+        devices: devices(
+          { stat_consumption: "p", stat_rate: "sensor.p" },
+          { stat_consumption: "middle", included_in_stat: "p" },
+          {
+            stat_consumption: "c",
+            stat_rate: "sensor.c",
+            included_in_stat: "middle",
+          }
+        ),
+        values: { "sensor.p": 100, "sensor.c": 40 },
+        minThreshold: 1,
+        initialUntracked: 100,
+        getId: (device) => device.stat_rate,
+      })
+    );
+    expect(result.parentLinks["sensor.c"]).toBe("sensor.p");
+    expect(result.untrackedConsumption).toBe(0);
+  });
+
   it("adds a per-parent untracked residual above the floor", () => {
     const result = buildSankeyDeviceNodes(
       cumulativeOpts({
@@ -177,7 +226,6 @@ describe("buildSankeyDeviceNodes", () => {
         ),
         values: { parent: 10, child: 4 },
         initialUntracked: 10,
-        findEffectiveParent: (includedInStat) => includedInStat,
       })
     );
     expect(result.parentLinks.child).toBe("parent");
@@ -199,7 +247,6 @@ describe("buildSankeyDeviceNodes", () => {
         values: { parent: 10, child: 9.5 },
         untrackedFloor: 1,
         initialUntracked: 10,
-        findEffectiveParent: (includedInStat) => includedInStat,
       })
     );
     expect(result.deviceNodes.some((n) => n.id.startsWith("untracked_"))).toBe(
@@ -217,7 +264,6 @@ describe("buildSankeyDeviceNodes", () => {
         ),
         values: { parent: 10, s1: 0.003, s2: 0.004 },
         initialUntracked: 10,
-        findEffectiveParent: (includedInStat) => includedInStat,
       })
     );
     const other = result.deviceNodes.find((n) => n.id === "other_parent");
@@ -305,6 +351,35 @@ describe("buildSankeyDeviceNodes", () => {
     );
     expect(result.deviceNodes.map((n) => n.id)).toEqual(["heater_group"]);
     expect(result.untrackedConsumption).toBeCloseTo(10 - 0.008, 10);
+  });
+
+  it("excludes a nested small device from a rendered parent's cluster", () => {
+    // big(rendered) > b(small) > c(small): c is inside b's value, so only b
+    // may be attributed under big.
+    const devs = devices(
+      { stat_consumption: "big" },
+      { stat_consumption: "b", included_in_stat: "big" },
+      { stat_consumption: "c", included_in_stat: "b" }
+    );
+    const values = { big: 10, b: 0.004, c: 0.003 };
+    const result = buildSankeyDeviceNodes(
+      cumulativeOpts({
+        devices: devs,
+        values,
+        initialUntracked: 10,
+      })
+    );
+    // b is the lone survivor, so it is shown directly instead of "Other"
+    expect(result.deviceNodes.map((n) => n.id)).toEqual([
+      "big",
+      "b",
+      "untracked_big",
+    ]);
+    expect(result.parentLinks.b).toBe("big");
+    expect(
+      result.deviceNodes.find((n) => n.id === "untracked_big")?.value
+    ).toBeCloseTo(10 - 0.004, 10);
+    expect(result.untrackedConsumption).toBe(0);
   });
 
   it("leaves a cyclic small-device cluster in untracked instead of looping", () => {


### PR DESCRIPTION
## Proposed change

All four sankey cards carried their own copy of `findEffectiveParent`, the walk up `included_in_stat` to the nearest ancestor that gets rendered as its own node. The two cumulative cards (energy, water) were byte-identical. The two instantaneous ones (power, water flow) differed only in comments and brace style. The pairs differed from each other only in which id space they resolve to — `stat_consumption` vs `stat_rate` — which is what the shared module's `getId` already expresses.

`buildSankeyDeviceNodes` already receives `devices`, `getId`, `getValue` and `minThreshold`, so it has everything the walk needs. This moves it there and drops the `findEffectiveParent` option, removing ~100 lines from the cards.

Three things fall out of it:

- `deviceByStat` replaces each card's `deviceMap` plus the `deviceParents` map added in #53324.
- The walk is a bounded `for` rather than an unbounded `while`, which would hang on a cyclic `included_in_stat`. Cycles are prevented in the config UI but not validated in core, so a hand-edited `.storage` can still produce one.
- `getValue` runs once per device instead of twice. For the cumulative cards that is `calculateStatisticSumGrowth`, which is O(points).

The second commit is a small behaviour fix on top, kept separate so the refactor stays reviewable as behaviour-preserving. The nested-small-consumer filter from #53324 did not stop its walk at rendered ancestors, so a small device under a rendered parent was dropped whenever something further up the chain happened to be small. Such a device links to its rendered parent and never touches untracked, so it cannot be double-counted through that ancestor — dropping it only loses a real device from the graph. Triggering it needs a parent statistic that reads smaller than its child, so a gap or a late start on the parent.

## Screenshots

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: follows up #53324 and #53235
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
