### PR TITLE
Limit and avoid duplication when loaded is sent to mobile

### DIFF
--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -135,11 +135,14 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
       this.update = super.update;
       // Apps with a native splash screen keep covering the frontend until
       // frontend/loaded, so the launch screen stays up (invisibly) until the
-      // first panel has rendered and partial-panel-resolver removes it.
-      if (!this.hass.auth.external?.config.hasSplashscreen) {
-        removeLaunchScreen();
+      // first panel has rendered and partial-panel-resolver removes it and
+      // fires frontend/loaded.
+      if (
+        !this.hass.auth.external?.config.hasSplashscreen &&
+        removeLaunchScreen()
+      ) {
+        this.hass.auth.external?.fireMessage({ type: "frontend/loaded" });
       }
-      this.hass.auth.external?.fireMessage({ type: "frontend/loaded" });
     }
     super.update(changedProps);
   }

--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -220,8 +220,13 @@ class PartialPanelResolver extends HassRouterPage {
     ) {
       await this.rebuild();
       await this.pageRendered;
-      removeLaunchScreen(!!this.hass.auth.external?.config.hasSplashscreen);
-      this.hass.auth.external?.fireMessage({ type: "frontend/loaded" });
+      // Only fire frontend/loaded when this call actually removed the launch
+      // screen, so later panel updates do not fire it again.
+      if (
+        removeLaunchScreen(!!this.hass.auth.external?.config.hasSplashscreen)
+      ) {
+        this.hass.auth.external?.fireMessage({ type: "frontend/loaded" });
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Fire `frontend/loaded` on the external bus exactly once, when the launch screen is actually removed.                                                                                                                                                                                                             

Previously the event fired twice: once from `home-assistant.ts` when hass data was ready, and again from `partial-panel-resolver` after the first panel rendered. For apps that declare `hasSplashscreen`, the first event was fired while the launch screen was intentionally still up, so the app would hide its native splash screen and reveal the frontend loading animation underneath instead of a ready dashboard.             
                                                                                                                                                                                         
Both call sites now only fire the event when their `removeLaunchScreen()` call is the one that initiated the removal:                                                                                                                                                                                            
  - Without `hasSplashscreen`: fired once from `home-assistant.ts` when the fade-out starts, as before.                                                                                                                                                                                                            
  - With `hasSplashscreen`: fired once from `partial-panel-resolver` after the first panel has rendered and the launch screen is removed instantly, matching the documented contract in `external_messaging.ts`.                                                                                                   
                                                                                                                                                                                                                                                                                                                   
This also prevents re-firing the event on later panel registry updates that trigger a rebuild.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
