### PR TITLE
Fix network error briefly shown on landing page when Core comes up

### DIFF
--- a/landing-page/src/ha-landing-page.ts
+++ b/landing-page/src/ha-landing-page.ts
@@ -182,12 +182,10 @@ class HaLandingPage extends LandingPageBaseElement {
       this._networkInfoError = false;
       this._coreStatusChecked = false;
     } catch (err: any) {
-      if (!this._coreStatusChecked) {
-        // wait before show errors, because we assume that core is starting
-        this._coreCheckActive = true;
-        this._scheduleTurnOffCoreCheck();
+      if (await this._checkCoreAvailability()) {
+        // core is available, page reload in progress -> don't show an error
+        return;
       }
-      await this._checkCoreAvailability();
 
       // assume supervisor update if ping fails -> don't show an error
       if (!this._coreCheckActive && err.message !== "ping-failed") {
@@ -217,7 +215,10 @@ class HaLandingPage extends LandingPageBaseElement {
         this._progress = -1;
       }
     } catch (err: any) {
-      await this._checkCoreAvailability();
+      if (await this._checkCoreAvailability()) {
+        // core is available, page reload in progress -> stop polling
+        return;
+      }
 
       if (!this._coreCheckActive) {
         this._progress = -1;
@@ -229,16 +230,22 @@ class HaLandingPage extends LandingPageBaseElement {
     this._scheduleFetchSupervisorJobsInfo();
   }
 
-  private async _checkCoreAvailability() {
+  private async _checkCoreAvailability(): Promise<boolean> {
     try {
       const response = await fetch("/manifest.json");
-      if (response.ok) {
-        location.reload();
-      } else {
+      if (!response.ok) {
         throw new Error("Failed to fetch manifest");
       }
+      location.reload();
+      return true;
     } catch (_err) {
-      this._coreStatusChecked = true;
+      if (!this._coreStatusChecked) {
+        // wait before showing errors, because we assume that core is starting
+        this._coreStatusChecked = true;
+        this._coreCheckActive = true;
+        this._scheduleTurnOffCoreCheck();
+      }
+      return false;
     }
   }
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When Home Assistant Core comes up and the landing page backend is torn down, the landing page sometimes briefly showed "Cannot get network information" before reloading into onboarding, even though there is no network problem. Two issues caused this:

- `location.reload()` does not stop script execution, so the error state was still set after the reload was triggered, and the error alert rendered until the browser actually navigated. Both pollers now return early when a reload is in progress.
- During the teardown gap where neither the Supervisor API nor Core responds yet, the jobs info poller set `_coreStatusChecked` without arming the 60 second grace period, so the network info poller skipped arming it as well and showed the error immediately instead of waiting. The grace period is now armed in `_checkCoreAvailability` so both pollers share it consistently.

The behavior for genuinely broken setups is unchanged: if the backend stays unreachable for longer than 60 seconds, the error is still shown.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)