### PR TITLE
Respect prefers-reduced-motion on the launch screen

### DIFF
--- a/demo/src/html/index.html.template
+++ b/demo/src/html/index.html.template
@@ -44,9 +44,16 @@
         font-weight: 400;
         font-style: normal;
       }
+      /* Mirrors core.globals.ts, which only lands once the app bundle has loaded */
       html {
         background-color: var(--primary-background-color, #fafafa);
         color: var(--primary-text-color, #212121);
+        --ha-animation-duration-normal: 250ms;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        html {
+          --ha-animation-duration-normal: 1ms;
+        }
       }
       @media (prefers-color-scheme: dark) {
         html {

--- a/demo/src/html/index.html.template
+++ b/demo/src/html/index.html.template
@@ -44,7 +44,6 @@
         font-weight: 400;
         font-style: normal;
       }
-      /* Mirrors core.globals.ts, which only lands once the app bundle has loaded */
       html {
         background-color: var(--primary-background-color, #fafafa);
         color: var(--primary-text-color, #212121);

--- a/public/static/images/home-assistant-logo-loading.svg
+++ b/public/static/images/home-assistant-logo-loading.svg
@@ -20,6 +20,9 @@
       46.153846% { transform: translate(70px, 37.6348px) scale(1.2); animation-timing-function: cubic-bezier(.39, .575, .565, 1); }
       69.230769%, 100% { transform: translate(70px, 37.6348px) scale(1); }
     }
+    @media (prefers-reduced-motion: reduce) {
+      .dot-left, .dot-right, .dot-top { animation: none; }
+    }
   </style>
   <g transform="matrix(.938408 0 0 .93841 -5.688557 -13.572944)">
     <path fill="#18bcf2" d="M73.5367 13.0937 106.463 46.0524v.0033C108.41 48.0043 110 51.848 110 54.6007v30.0292c0 2.7527-2.25 5.0049-5 5.0049l-70-.0034c-2.75 0-5-2.2522-5-5.0048V54.5974c0-2.7527 1.5933-6.5998 3.5367-8.545l32.93-32.9587c1.9433-1.9452 5.1266-1.9452 7.07 0Z" transform="matrix(1.598452 0 0 1.598452 -41.89164 -.937304)"/>

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -28,6 +28,15 @@
         font-weight: 400;
         font-style: normal;
       }
+      /* Mirrors core.globals.ts, which only lands once the app bundle has loaded */
+      html {
+        --ha-animation-duration-normal: 250ms;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        html {
+          --ha-animation-duration-normal: 1ms;
+        }
+      }
       @keyframes fade-out {
         from {
           opacity: 1;

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -28,7 +28,6 @@
         font-weight: 400;
         font-style: normal;
       }
-      /* Mirrors core.globals.ts, which only lands once the app bundle has loaded */
       html {
         --ha-animation-duration-normal: 250ms;
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Follow-up to #53328: the new launch screen keeps animating under a reduced motion preference.

- The pulsing dots in the loading logomark are guarded inside the SVG. The logomark is loaded via `<img>`, so page CSS can't reach it and the media query has to live in the file itself.
- The launch screen's fades, the view transition and the removal timeout all reference `--ha-animation-duration-normal`, but `core.globals.ts` only applies once the app bundle has loaded — until then the `250ms` literal fallback is what actually takes effect. Defining the token in the launch screen styles makes all of them collapse to `1ms`, matching what `core.globals.ts` already does everywhere else.

Worth noting for reviewers: DevTools' "Emulate `prefers-reduced-motion`" only overrides the top-level document, not the separate document an SVG-as-`<img>` renders in, so the logomark still looks like it's animating under emulation. Testing needs the real OS/browser setting (or `--force-prefers-reduced-motion`). Verified static in Chrome and Firefox with a real browser-level setting.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #53328
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
