### PR TITLE
Fix flaky demo e2e sidebar helper on narrow viewports

### DIFF
--- a/test/e2e/demo/helpers.ts
+++ b/test/e2e/demo/helpers.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from "@playwright/test";
+import type { HaDrawer } from "../../../src/components/ha-drawer";
 import type { ThemeSettings } from "../../../src/types";
 import { NAVIGATION_TIMEOUT, SHELL_TIMEOUT } from "../helpers";
 
@@ -66,26 +67,34 @@ export async function expectStoredDemoTheme(
 }
 
 export async function openDemoSidebar(page: Page) {
-  const menuButton = page.locator("ha-menu-button");
-  if (await menuButton.isVisible()) {
-    const modalDrawer = page.locator("ha-drawer").locator("wa-drawer");
-    await Promise.all([
-      modalDrawer.evaluate(
-        (element) =>
-          new Promise<void>((resolve) => {
-            element.addEventListener("wa-after-show", () => resolve(), {
-              once: true,
-            });
-          })
-      ),
-      menuButton.click(),
-    ]);
+  const drawer = page.locator("ha-drawer");
+  await expect(drawer).toBeAttached({ timeout: NAVIGATION_TIMEOUT });
+
+  // Pick the layout from ha-drawer, which home-assistant-main sets to "modal"
+  // while committing its very first render (the narrow media query is resolved
+  // synchronously in its constructor). ha-menu-button must not be used for
+  // this: it renders nothing until its Lit contexts resolve, so sampling its
+  // visibility straight after load reports "hidden" on the narrow layout too,
+  // and the drawer would then silently never be opened.
+  const isModal = await drawer.evaluate(
+    (element) => (element as HaDrawer).type === "modal"
+  );
+
+  if (!isModal) {
+    // Wide layout: the sidebar is permanently on screen.
+    await expect(page.locator("ha-sidebar")).toBeVisible({
+      timeout: NAVIGATION_TIMEOUT,
+    });
     return;
   }
 
-  await expect(page.locator("ha-sidebar")).toBeAttached({
-    timeout: NAVIGATION_TIMEOUT,
-  });
+  const menuButton = page.locator("ha-menu-button");
+  await expect(menuButton).toBeVisible({ timeout: SHELL_TIMEOUT });
+  await menuButton.click();
+  // ha-drawer reflects `open` once the app has actually opened the drawer.
+  // The slide-in animation is covered by Playwright's stability check on the
+  // next interaction.
+  await expect(drawer).toHaveAttribute("open", "", { timeout: SHELL_TIMEOUT });
 }
 
 export async function activateDemoSidebarPanel(page: Page, panel: string) {


### PR DESCRIPTION
## Breaking change

<!-- Not a breaking change. -->

## Proposed change

Fixes the `E2E demo (2/2)` failure on `dev`, where "sidebar navigation changes the active panel" fails in the `mobile-chrome` project only, timing out on an attached-but-hidden `#sidebar-panel-map`.

This is a test-only bug. `openDemoSidebar` decided whether the sidebar sits behind a modal drawer by sampling `ha-menu-button` visibility with `isVisible()`, which never waits. `ha-menu-button` renders `nothing` until its `narrowViewportContext` and `uiContext` Lit contexts resolve, so shortly after load it is either not attached yet or attached with a zero-size box. Either way the check reads `false`, the helper takes the wide-layout branch, the drawer is never opened, and its `ha-sidebar` `toBeAttached` fallback passes trivially because the sidebar *is* attached inside the closed drawer. The next assertion then polls a hidden nav item until it times out.

That accounts for the whole signature: mobile-only, because on the wide layout the same misread happens to select the correct branch; and failing identically on retry, because once the wrong branch is taken the state is stable rather than racy.

The layout is now read from `ha-drawer`'s `type`, which `home-assistant-main` sets while committing its first render (`listenMediaQuery` invokes its callback synchronously in the constructor, so `narrow` is already known). The menu button is waited for instead of sampled, and the helper waits for `ha-drawer` to report `open` after the click. That last part also removes a second latent race: the previous `Promise.all` attached the `wa-after-show` listener concurrently with the click, so a fast show could fire before the listener existed and hang until the test timeout.

The app itself is not affected — the Map item is reachable in the mobile sidebar, the menu button just appears a little after the launch screen hides.

### Why it surfaced now

The race pre-dates #53344; that Playwright bump only raised its hit rate. Measured locally against a production `demo/dist`, 30 runs each with the old helper:

| | failures |
| --- | --- |
| Playwright 1.61.1 / Chromium 149 | 2/30 (6.7%) |
| Playwright 1.62.0 / Chromium 151 | 9/30 (30%) |

`test/e2e/app.spec.ts` needs no equivalent change: it asserts `toBeAttached` rather than visibility, and `ensureAppSidebarPanelVisible` already fails safe by opening the sidebar when the link is not visible.

## Screenshots

<!-- No visual changes; test-only. -->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #53344 (the Playwright bump that raised the failure rate)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
