### PR TITLE
Wait for initial panel readiness

### DIFF
--- a/src/layouts/hass-router-page.ts
+++ b/src/layouts/hass-router-page.ts
@@ -5,6 +5,7 @@ import memoizeOne from "memoize-one";
 import { navigate } from "../common/navigate";
 import { computeRouteTail } from "../common/url/route";
 import type { Route } from "../types";
+import { PanelReady } from "./panel-ready";
 
 const extractPage = (path: string, defaultPage: string) => {
   if (path === "") {
@@ -22,6 +23,7 @@ export interface RouteOptions {
   // Function to load the page.
   load?: () => Promise<unknown>;
   cache?: boolean;
+  waitForReady?: boolean;
 }
 
 export interface RouterOptions {
@@ -52,6 +54,8 @@ export class HassRouterPage extends ReactiveElement {
   protected _currentPage = "";
 
   private _currentLoadProm?: Promise<void>;
+
+  private _panelReady = new PanelReady();
 
   private _cache = {};
 
@@ -180,6 +184,10 @@ export class HassRouterPage extends ReactiveElement {
     // If we don't show loading screen, just show the panel.
     // It will be automatically upgraded when loading done.
     if (!routerOptions.showLoading) {
+      const loadComplete = () => {
+        this._currentLoadProm = undefined;
+      };
+      this._currentLoadProm = loadProm.then(loadComplete, loadComplete);
       this._createPanel(routerOptions, newPage, routeOptions);
       return;
     }
@@ -287,7 +295,21 @@ export class HassRouterPage extends ReactiveElement {
    * Promise that resolves when the page has rendered.
    */
   protected get pageRendered(): Promise<void> {
-    return this.updateComplete.then(() => this._currentLoadProm);
+    return this.updateComplete
+      .then(() => this._currentLoadProm)
+      .then(() => {
+        const page = this.lastElementChild as Partial<HassRouterPage> | null;
+        return Promise.all([this._panelReady.ready, page?.panelReady]).then(
+          () => undefined
+        );
+      });
+  }
+
+  /**
+   * Promise that resolves when the current page is ready to be shown.
+   */
+  public get panelReady(): Promise<void> {
+    return this.pageRendered;
   }
 
   protected createElement(tag: string) {
@@ -312,6 +334,7 @@ export class HassRouterPage extends ReactiveElement {
     }
 
     const panelEl = this._cache[page] || this.createElement(routeOptions.tag);
+    this._panelReady.track(panelEl, routeOptions.waitForReady);
     this.updatePageEl(panelEl);
     this.appendChild(panelEl);
 

--- a/src/layouts/hass-router-page.ts
+++ b/src/layouts/hass-router-page.ts
@@ -298,18 +298,12 @@ export class HassRouterPage extends ReactiveElement {
     return this.updateComplete
       .then(() => this._currentLoadProm)
       .then(() => {
-        const page = this.lastElementChild as Partial<HassRouterPage> | null;
-        return Promise.all([this._panelReady.ready, page?.panelReady]).then(
-          () => undefined
-        );
+        const page = this.lastElementChild;
+        return Promise.all([
+          this._panelReady.ready,
+          page instanceof HassRouterPage ? page.pageRendered : undefined,
+        ]).then(() => undefined);
       });
-  }
-
-  /**
-   * Promise that resolves when the current page is ready to be shown.
-   */
-  public get panelReady(): Promise<void> {
-    return this.pageRendered;
   }
 
   protected createElement(tag: string) {

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -17,10 +17,7 @@ import { HassElement } from "../state/hass-element";
 import QuickBarMixin from "../state/quick-bar-mixin";
 import type { HomeAssistant, Route } from "../types";
 import { storeState } from "../util/ha-pref-storage";
-import {
-  removeLaunchScreen,
-  renderLaunchScreenContent,
-} from "../util/launch-screen";
+import { renderLaunchScreenContent } from "../util/launch-screen";
 import { checkOnboardingSurveyToast } from "../util/onboarding-survey";
 import {
   registerServiceWorker,
@@ -136,16 +133,9 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
     ) {
       this.render = this.renderHass;
       this.update = super.update;
-      // Apps with a native splash screen keep covering the frontend until
-      // frontend/loaded, so the launch screen stays up (invisibly) until the
-      // first panel has rendered and partial-panel-resolver removes it and
-      // fires frontend/loaded.
-      if (
-        !this.hass.auth.external?.config.hasSplashscreen &&
-        removeLaunchScreen()
-      ) {
-        this.hass.auth.external?.fireMessage({ type: "frontend/loaded" });
-      }
+      // partial-panel-resolver removes the launch screen after the first panel
+      // is ready. Native apps request instant removal because their own splash
+      // screen covers the frontend until frontend/loaded is sent.
     }
     super.update(changedProps);
   }

--- a/src/layouts/panel-ready.ts
+++ b/src/layouts/panel-ready.ts
@@ -1,0 +1,30 @@
+import { ReactiveElement } from "lit";
+import { fireEvent } from "../common/dom/fire_event";
+
+declare global {
+  interface HASSDomEvents {
+    "hass-panel-ready": undefined;
+  }
+}
+
+export const panelIsReady = async (element: HTMLElement) => {
+  if (element instanceof ReactiveElement) {
+    // Ensure pending Lit changes are rendered before revealing the panel.
+    await element.updateComplete;
+  }
+  fireEvent(element, "hass-panel-ready");
+};
+
+export class PanelReady {
+  public ready?: Promise<void>;
+
+  public track(element: HTMLElement, waitForReady = false) {
+    this.ready = waitForReady
+      ? new Promise((resolve) => {
+          element.addEventListener("hass-panel-ready", () => resolve(), {
+            once: true,
+          });
+        })
+      : undefined;
+  }
+}

--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -8,6 +8,7 @@ import type { PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { deepActiveElement } from "../common/dom/deep-active-element";
 import { deepEqual } from "../common/util/deep-equal";
+import { promiseTimeout } from "../common/util/promise-timeout";
 import { narrowViewportContext } from "../data/context";
 import { getDefaultPanel } from "../data/panel";
 import type { CustomPanelInfo } from "../data/panel_custom";
@@ -17,6 +18,7 @@ import type { RouteOptions, RouterOptions } from "./hass-router-page";
 import { HassRouterPage } from "./hass-router-page";
 
 const CACHE_URL_PATHS = ["lovelace", "home", "config"];
+const PANEL_READY_TIMEOUT = 2000;
 const COMPONENTS = {
   app: () => import("../panels/app/ha-panel-app"),
   energy: () => import("../panels/energy/ha-panel-energy"),
@@ -219,9 +221,12 @@ class PartialPanelResolver extends HassRouterPage {
       )
     ) {
       await this.rebuild();
-      await this.pageRendered;
+      await promiseTimeout(PANEL_READY_TIMEOUT, this.pageRendered).catch(
+        () => undefined
+      );
       // Only fire frontend/loaded when this call actually removed the launch
-      // screen, so later panel updates do not fire it again.
+      // screen, so later panel updates do not fire it again. Native apps remove
+      // it instantly because their own splash screen is still visible.
       if (
         removeLaunchScreen(!!this.hass.auth.external?.config.hasSplashscreen)
       ) {

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -82,6 +82,7 @@ class HaPanelConfig extends HassRouterPage {
       info: {
         tag: "ha-config-info",
         load: () => import("./info/ha-config-info"),
+        waitForReady: true,
       },
       // customize was removed in 2021.12, fallback to dashboard
       customize: "dashboard",

--- a/src/panels/config/info/ha-config-info.ts
+++ b/src/panels/config/info/ha-config-info.ts
@@ -24,6 +24,7 @@ import { fetchHassioInfo } from "../../../data/hassio/supervisor";
 import { subscribeSystemHealthInfo } from "../../../data/system_health";
 import { showShortcutsDialog } from "../../../dialogs/shortcuts/show-shortcuts-dialog";
 import "../../../layouts/hass-subpage";
+import { panelIsReady } from "../../../layouts/panel-ready";
 import { mdiHomeAssistant } from "../../../resources/home-assistant-logo-svg";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant, Route } from "../../../types";
@@ -289,6 +290,7 @@ class HaConfigInfo extends LitElement {
       if (info?.homeassistant) {
         this._installationMethod = info.homeassistant.info.installation_type;
         unsubSystemHealth.then((unsub) => unsub());
+        panelIsReady(this);
       }
     });
   }

--- a/test/layouts/hass-router-page.test.ts
+++ b/test/layouts/hass-router-page.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ReactiveElement } from "lit";
+import { state } from "lit/decorators";
+import type { RouterOptions } from "../../src/layouts/hass-router-page";
+import { HassRouterPage } from "../../src/layouts/hass-router-page";
+import { panelIsReady } from "../../src/layouts/panel-ready";
+
+class TestRouter extends HassRouterPage {
+  protected routerOptions: RouterOptions = {
+    routes: {
+      immediate: { tag: "test-immediate-panel" },
+      deferred: { tag: "test-deferred-panel", waitForReady: true },
+      loaded: {
+        tag: "test-loaded-panel",
+        load: () => loadedPanelImport,
+        waitForReady: true,
+      },
+    },
+  };
+}
+
+class ImmediatePanel extends HTMLElement {}
+
+class DeferredPanel extends ReactiveElement {
+  @state() public loaded = false;
+}
+
+let resolveLoadedPanelImport: () => void;
+const loadedPanelImport = new Promise<void>((resolve) => {
+  resolveLoadedPanelImport = resolve;
+});
+
+class LoadedPanel extends HTMLElement {}
+
+customElements.define("test-router", TestRouter);
+customElements.define("test-immediate-panel", ImmediatePanel);
+customElements.define("test-deferred-panel", DeferredPanel);
+
+let router: TestRouter | undefined;
+
+const mountRouter = async (path: string) => {
+  router = document.createElement("test-router") as TestRouter;
+  router.route = { prefix: "", path };
+  document.body.append(router);
+  await router.updateComplete;
+  return router;
+};
+
+afterEach(() => {
+  router?.remove();
+  router = undefined;
+});
+
+describe("HassRouterPage panel readiness", () => {
+  it("resolves when a routed panel has no readiness promise", async () => {
+    const element = await mountRouter("/immediate");
+
+    await expect(element.panelReady).resolves.toBeUndefined();
+  });
+
+  it("waits for the routed panel readiness promise", async () => {
+    const element = await mountRouter("/deferred");
+    let ready = false;
+    element.panelReady.then(() => {
+      ready = true;
+    });
+
+    await Promise.resolve();
+    expect(ready).toBe(false);
+
+    const panel = element.lastElementChild as DeferredPanel;
+    panel.loaded = true;
+    panelIsReady(panel);
+    await Promise.resolve();
+    expect(ready).toBe(false);
+
+    await expect(element.panelReady).resolves.toBeUndefined();
+    expect(panel.loaded).toBe(true);
+  });
+
+  it("waits for a dynamically loaded panel before reading its readiness", async () => {
+    const element = await mountRouter("/loaded");
+    let ready = false;
+    element.panelReady.then(() => {
+      ready = true;
+    });
+
+    resolveLoadedPanelImport();
+    customElements.define("test-loaded-panel", LoadedPanel);
+    await vi.waitFor(() => {
+      expect(element.lastElementChild).toBeInstanceOf(LoadedPanel);
+    });
+    expect(ready).toBe(false);
+
+    panelIsReady(element.lastElementChild as HTMLElement);
+    await expect(element.panelReady).resolves.toBeUndefined();
+  });
+});
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "test-router": TestRouter;
+    "test-immediate-panel": ImmediatePanel;
+    "test-deferred-panel": DeferredPanel;
+    "test-loaded-panel": LoadedPanel;
+  }
+}

--- a/test/layouts/hass-router-page.test.ts
+++ b/test/layouts/hass-router-page.test.ts
@@ -17,6 +17,10 @@ class TestRouter extends HassRouterPage {
       },
     },
   };
+
+  public get rendered() {
+    return this.pageRendered;
+  }
 }
 
 class ImmediatePanel extends HTMLElement {}
@@ -55,13 +59,13 @@ describe("HassRouterPage panel readiness", () => {
   it("resolves when a routed panel has no readiness promise", async () => {
     const element = await mountRouter("/immediate");
 
-    await expect(element.panelReady).resolves.toBeUndefined();
+    await expect(element.rendered).resolves.toBeUndefined();
   });
 
   it("waits for the routed panel readiness promise", async () => {
     const element = await mountRouter("/deferred");
     let ready = false;
-    element.panelReady.then(() => {
+    element.rendered.then(() => {
       ready = true;
     });
 
@@ -74,14 +78,14 @@ describe("HassRouterPage panel readiness", () => {
     await Promise.resolve();
     expect(ready).toBe(false);
 
-    await expect(element.panelReady).resolves.toBeUndefined();
+    await expect(element.rendered).resolves.toBeUndefined();
     expect(panel.loaded).toBe(true);
   });
 
   it("waits for a dynamically loaded panel before reading its readiness", async () => {
     const element = await mountRouter("/loaded");
     let ready = false;
-    element.panelReady.then(() => {
+    element.rendered.then(() => {
       ready = true;
     });
 
@@ -93,7 +97,7 @@ describe("HassRouterPage panel readiness", () => {
     expect(ready).toBe(false);
 
     panelIsReady(element.lastElementChild as HTMLElement);
-    await expect(element.panelReady).resolves.toBeUndefined();
+    await expect(element.rendered).resolves.toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Setup an opt-in readyness event. If a panel has `waitForReady` enabled, it will wait for the `hass-panel-ready` event.

First usage on info page, this helps the ~100ms render pop in for the system info side. It's called at the end of data sets, then internally waits for `updateComplete` so the page is rendered. Was going to do this for the settings overview page which has a bunch of dynamically rendered protocols, but that needs a little more work, maybe something to unify the loaders to reduce rerenders for every loaded item.

Also have a 2000ms timeout, hopefully this never gets hit, but ensures not to lock on launch

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Using fast 4g in devtools, also excuse linux animation jankyness 

<details>
<summary>Original</summary>

https://github.com/user-attachments/assets/0272526d-43ea-4bf5-a955-7316f8a66881

</details>

New

https://github.com/user-attachments/assets/400f8056-d27b-4ed6-a78d-1e3e1ba95ede


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue or discussion: #53333 
  - Initial part of this, dashboards are the big target, but making this avaliable for all panels now

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
