### PR TITLE
Wait for settings overview readiness

### DIFF
--- a/src/layouts/panel-ready.ts
+++ b/src/layouts/panel-ready.ts
@@ -29,6 +29,8 @@ export class ChildPanelReady implements ReactiveController {
 
   private _resolveReady?: () => void;
 
+  private _completing = false;
+
   public ready = new Promise<void>((resolve) => {
     this._resolveReady = resolve;
   });
@@ -43,11 +45,30 @@ export class ChildPanelReady implements ReactiveController {
   }
 
   public hostUpdated() {
-    Promise.allSettled(this._promises).then(() => {
-      this._resolveReady?.();
-      return panelIsReady(this._host);
-    });
+    if (this._completing) {
+      return;
+    }
+    this._completing = true;
     this._host.removeController(this);
+    void this._complete();
+  }
+
+  private async _complete() {
+    // Children created/updated during this render register after the host's
+    // update commits. Wait for that before snapshotting readiness promises.
+    await this._host.updateComplete;
+
+    await this._waitForPromises();
+
+    this._resolveReady?.();
+    await panelIsReady(this._host);
+  }
+
+  private _waitForPromises(): Promise<void> {
+    const count = this._promises.length;
+    return Promise.allSettled(this._promises).then(() =>
+      this._promises.length > count ? this._waitForPromises() : undefined
+    );
   }
 }
 

--- a/src/layouts/panel-ready.ts
+++ b/src/layouts/panel-ready.ts
@@ -43,13 +43,10 @@ export class ChildPanelReady implements ReactiveController {
   }
 
   public hostUpdated() {
-    Promise.all(this._promises).then(
-      () => {
-        this._resolveReady?.();
-        return panelIsReady(this._host);
-      },
-      () => undefined
-    );
+    Promise.allSettled(this._promises).then(() => {
+      this._resolveReady?.();
+      return panelIsReady(this._host);
+    });
     this._host.removeController(this);
   }
 }

--- a/src/layouts/panel-ready.ts
+++ b/src/layouts/panel-ready.ts
@@ -1,3 +1,5 @@
+import { ContextProvider, createContext } from "@lit/context";
+import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { ReactiveElement } from "lit";
 import { fireEvent } from "../common/dom/fire_event";
 
@@ -14,6 +16,43 @@ export const panelIsReady = async (element: HTMLElement) => {
   }
   fireEvent(element, "hass-panel-ready");
 };
+
+export type RegisterChildPanelReady = (ready: Promise<void>) => void;
+
+export const childPanelReadyContext =
+  createContext<RegisterChildPanelReady>("child-panel-ready");
+
+export class ChildPanelReady implements ReactiveController {
+  private _promises: Promise<void>[] = [];
+
+  private _host: ReactiveControllerHost & HTMLElement;
+
+  private _resolveReady?: () => void;
+
+  public ready = new Promise<void>((resolve) => {
+    this._resolveReady = resolve;
+  });
+
+  public constructor(host: ReactiveControllerHost & HTMLElement) {
+    this._host = host;
+    host.addController(this);
+    new ContextProvider(host, {
+      context: childPanelReadyContext,
+      initialValue: (ready) => this._promises.push(ready),
+    });
+  }
+
+  public hostUpdated() {
+    Promise.all(this._promises).then(
+      () => {
+        this._resolveReady?.();
+        return panelIsReady(this._host);
+      },
+      () => undefined
+    );
+    this._host.removeController(this);
+  }
+}
 
 export class PanelReady {
   public ready?: Promise<void>;

--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -158,10 +158,9 @@ class HaConfigDashboard extends SubscribeMixin(LitElement) {
     total: 0,
   };
 
-  private _childPanelReady = new ChildPanelReady(this);
-
-  public get ready(): Promise<void> {
-    return this._childPanelReady.ready;
+  public constructor() {
+    super();
+    new ChildPanelReady(this);
   }
 
   private _pages = memoizeOne(

--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -36,6 +36,7 @@ import { showQuickBar } from "../../../dialogs/quick-bar/show-dialog-quick-bar";
 import { showRestartDialog } from "../../../dialogs/restart/show-dialog-restart";
 import { showShortcutsDialog } from "../../../dialogs/shortcuts/show-shortcuts-dialog";
 import type { PageNavigation } from "../../../layouts/hass-tabs-subpage";
+import { ChildPanelReady } from "../../../layouts/panel-ready";
 import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
@@ -156,6 +157,12 @@ class HaConfigDashboard extends SubscribeMixin(LitElement) {
     issues: [],
     total: 0,
   };
+
+  private _childPanelReady = new ChildPanelReady(this);
+
+  public get ready(): Promise<void> {
+    return this._childPanelReady.ready;
+  }
 
   private _pages = memoizeOne(
     (

--- a/src/panels/config/dashboard/ha-config-navigation.ts
+++ b/src/panels/config/dashboard/ha-config-navigation.ts
@@ -31,18 +31,32 @@ class HaConfigNavigation extends LitElement {
 
   private _childReadyRegistered = false;
 
-  @consume({ context: childPanelReadyContext })
+  @consume({ context: childPanelReadyContext, subscribe: true })
   private _registerChildPanelReady?: RegisterChildPanelReady;
 
   protected override updated(changedProps: Map<PropertyKey, unknown>) {
     super.updated(changedProps);
 
-    if (changedProps.has("pages") || changedProps.has("hass")) {
+    const pagesOrHassChanged =
+      changedProps.has("pages") || changedProps.has("hass");
+
+    if (pagesOrHassChanged) {
       const ready = this._resolveVisiblePages();
-      if (!this._childReadyRegistered) {
-        this._registerChildPanelReady?.(ready);
+      if (!this._childReadyRegistered && this._registerChildPanelReady) {
+        this._registerChildPanelReady(ready);
         this._childReadyRegistered = true;
       }
+      return;
+    }
+
+    if (
+      !this._childReadyRegistered &&
+      this._registerChildPanelReady &&
+      this.pages &&
+      this.hass
+    ) {
+      this._registerChildPanelReady(this._resolveVisiblePages());
+      this._childReadyRegistered = true;
     }
   }
 
@@ -94,9 +108,13 @@ class HaConfigNavigation extends LitElement {
     if (!this._bluetoothEntriesLoaded) {
       this._bluetoothEntriesLoaded = getConfigEntries(this.hass, {
         domain: "bluetooth",
-      }).then((entries) => {
-        this._hasBluetoothConfigEntries = entries.length > 0;
-      });
+      })
+        .then((entries) => {
+          this._hasBluetoothConfigEntries = entries.length > 0;
+        })
+        .catch(() => {
+          this._hasBluetoothConfigEntries = false;
+        });
     }
     return this._bluetoothEntriesLoaded;
   }

--- a/src/panels/config/dashboard/ha-config-navigation.ts
+++ b/src/panels/config/dashboard/ha-config-navigation.ts
@@ -2,6 +2,7 @@ import { consume } from "@lit/context";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
 import { filterNavigationPages } from "../../../common/config/filter_navigation_pages";
 import "../../../components/ha-card";
 import "../../../components/ha-icon-next";
@@ -30,6 +31,14 @@ class HaConfigNavigation extends LitElement {
   private _bluetoothEntriesLoaded?: Promise<void>;
 
   private _childReadyRegistered = false;
+
+  private _filterNavigationPages = memoizeOne(
+    (
+      hass: HomeAssistant,
+      pages: PageNavigation[],
+      hasBluetoothConfigEntries: boolean
+    ) => filterNavigationPages(hass, pages, { hasBluetoothConfigEntries })
+  );
 
   @consume({ context: childPanelReadyContext, subscribe: true })
   private _registerChildPanelReady?: RegisterChildPanelReady;
@@ -124,9 +133,19 @@ class HaConfigNavigation extends LitElement {
       await this._loadBluetoothEntries();
     }
 
-    this._visiblePages = filterNavigationPages(this.hass, this.pages, {
-      hasBluetoothConfigEntries: this._hasBluetoothConfigEntries,
-    });
+    const visiblePages = this._filterNavigationPages(
+      this.hass,
+      this.pages,
+      this._hasBluetoothConfigEntries
+    );
+    const currentVisiblePages = this._visiblePages;
+    if (
+      !currentVisiblePages ||
+      visiblePages.length !== currentVisiblePages.length ||
+      visiblePages.some((page, index) => page !== currentVisiblePages[index])
+    ) {
+      this._visiblePages = visiblePages;
+    }
     await this.updateComplete;
   }
 

--- a/src/panels/config/dashboard/ha-config-navigation.ts
+++ b/src/panels/config/dashboard/ha-config-navigation.ts
@@ -27,12 +27,21 @@ class HaConfigNavigation extends LitElement {
 
   private _hasBluetoothConfigEntries = false;
 
+  private _childReadyRegistered = false;
+
   @consume({ context: childPanelReadyContext })
   private _registerChildPanelReady?: RegisterChildPanelReady;
 
-  public connectedCallback() {
-    super.connectedCallback();
-    this._registerChildPanelReady?.(this._resolveVisiblePages());
+  protected override updated(changedProps: Map<PropertyKey, unknown>) {
+    super.updated(changedProps);
+
+    if (changedProps.has("pages") || changedProps.has("hass")) {
+      const ready = this._resolveVisiblePages();
+      if (!this._childReadyRegistered) {
+        this._registerChildPanelReady?.(ready);
+        this._childReadyRegistered = true;
+      }
+    }
   }
 
   protected render(): TemplateResult {

--- a/src/panels/config/dashboard/ha-config-navigation.ts
+++ b/src/panels/config/dashboard/ha-config-navigation.ts
@@ -1,4 +1,5 @@
-import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
+import { consume } from "@lit/context";
+import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { filterNavigationPages } from "../../../common/config/filter_navigation_pages";
@@ -7,6 +8,10 @@ import "../../../components/ha-icon-next";
 import type { CloudStatus } from "../../../data/cloud";
 import { getConfigEntries } from "../../../data/config_entries";
 import type { PageNavigation } from "../../../layouts/hass-tabs-subpage";
+import {
+  childPanelReadyContext,
+  type RegisterChildPanelReady,
+} from "../../../layouts/panel-ready";
 import type { HomeAssistant } from "../../../types";
 import "../components/ha-config-navigation-list";
 
@@ -18,21 +23,20 @@ class HaConfigNavigation extends LitElement {
 
   @property({ attribute: false }) public pages!: PageNavigation[];
 
-  @state() private _hasBluetoothConfigEntries = false;
+  @state() private _visiblePages?: PageNavigation[];
 
-  protected firstUpdated(changedProps: PropertyValues<this>) {
-    super.firstUpdated(changedProps);
-    getConfigEntries(this.hass, {
-      domain: "bluetooth",
-    }).then((bluetoothEntries) => {
-      this._hasBluetoothConfigEntries = bluetoothEntries.length > 0;
-    });
+  private _hasBluetoothConfigEntries = false;
+
+  @consume({ context: childPanelReadyContext })
+  private _registerChildPanelReady?: RegisterChildPanelReady;
+
+  public connectedCallback() {
+    super.connectedCallback();
+    this._registerChildPanelReady?.(this._resolveVisiblePages());
   }
 
   protected render(): TemplateResult {
-    const pages = filterNavigationPages(this.hass, this.pages, {
-      hasBluetoothConfigEntries: this._hasBluetoothConfigEntries,
-    }).map((page) => ({
+    const pages = (this._visiblePages ?? []).map((page) => ({
       ...page,
       name:
         page.name ||
@@ -73,6 +77,20 @@ class HaConfigNavigation extends LitElement {
         .label=${this.hass.localize("panel.config")}
       ></ha-config-navigation-list>
     `;
+  }
+
+  private async _resolveVisiblePages(): Promise<void> {
+    if (this.pages.some((page) => page.component === "bluetooth")) {
+      const entries = await getConfigEntries(this.hass, {
+        domain: "bluetooth",
+      });
+      this._hasBluetoothConfigEntries = entries.length > 0;
+    }
+
+    this._visiblePages = filterNavigationPages(this.hass, this.pages, {
+      hasBluetoothConfigEntries: this._hasBluetoothConfigEntries,
+    });
+    await this.updateComplete;
   }
 
   static styles: CSSResultGroup = css`

--- a/src/panels/config/dashboard/ha-config-navigation.ts
+++ b/src/panels/config/dashboard/ha-config-navigation.ts
@@ -27,6 +27,8 @@ class HaConfigNavigation extends LitElement {
 
   private _hasBluetoothConfigEntries = false;
 
+  private _bluetoothEntriesLoaded?: Promise<void>;
+
   private _childReadyRegistered = false;
 
   @consume({ context: childPanelReadyContext })
@@ -88,12 +90,20 @@ class HaConfigNavigation extends LitElement {
     `;
   }
 
+  private _loadBluetoothEntries(): Promise<void> {
+    if (!this._bluetoothEntriesLoaded) {
+      this._bluetoothEntriesLoaded = getConfigEntries(this.hass, {
+        domain: "bluetooth",
+      }).then((entries) => {
+        this._hasBluetoothConfigEntries = entries.length > 0;
+      });
+    }
+    return this._bluetoothEntriesLoaded;
+  }
+
   private async _resolveVisiblePages(): Promise<void> {
     if (this.pages.some((page) => page.component === "bluetooth")) {
-      const entries = await getConfigEntries(this.hass, {
-        domain: "bluetooth",
-      });
-      this._hasBluetoothConfigEntries = entries.length > 0;
+      await this._loadBluetoothEntries();
     }
 
     this._visiblePages = filterNavigationPages(this.hass, this.pages, {

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -89,6 +89,7 @@ class HaPanelConfig extends HassRouterPage {
       dashboard: {
         tag: "ha-config-dashboard",
         load: () => import("./dashboard/ha-config-dashboard"),
+        waitForReady: true,
       },
       entities: {
         tag: "ha-config-entities",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Setup settings overview panel to wait for ready before launch screen is removed. Stack on #53351 

The wait here is for protocols, which previously popped in after load but now wait ~150ms reducing pop in

Also sets up a controller for child panels to signal up the chain with a lit context provider.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

https://github.com/user-attachments/assets/7ee4f0b0-f763-496d-90ab-cf3550e287cf

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue or discussion: #53333 #53351 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
