### PR TITLE
Use toggle_cover_tilt when toggling tilt-only covers

### DIFF
--- a/src/common/entity/can_toggle_state.ts
+++ b/src/common/entity/can_toggle_state.ts
@@ -1,4 +1,6 @@
 import type { HassEntity } from "home-assistant-js-websocket";
+import { isTiltOnly } from "../../data/cover";
+import { CoverEntityFeature } from "../../data/feature/cover_entity_feature";
 import type { HomeAssistant } from "../../types";
 import { canToggleDomain } from "./can_toggle_domain";
 import { computeStateDomain } from "./compute_state_domain";
@@ -24,6 +26,13 @@ export const canToggleState = (hass: HomeAssistant, stateObj: HassEntity) => {
     }
 
     return false;
+  }
+
+  // Tilt-only covers toggle via toggle_cover_tilt, which requires both tilt features
+  if (domain === "cover" && isTiltOnly(stateObj)) {
+    return [CoverEntityFeature.OPEN_TILT, CoverEntityFeature.CLOSE_TILT].every(
+      (f) => supportsFeature(stateObj, f)
+    );
   }
 
   if (

--- a/src/common/entity/get_toggle_action.ts
+++ b/src/common/entity/get_toggle_action.ts
@@ -1,5 +1,6 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import { isTiltOnly } from "../../data/cover";
+import { UNAVAILABLE, UNKNOWN } from "../../data/entity/entity";
 import { CameraEntityFeature } from "../../data/feature/camera_entity_feature";
 import { ClimateEntityFeature } from "../../data/feature/climate_entity_feature";
 import { CoverEntityFeature } from "../../data/feature/cover_entity_feature";
@@ -70,10 +71,14 @@ export const getToggleAction = (
   onOff: boolean,
   stateObj?: HassEntity
 ): string => {
-  // Tilt-only covers don't support open_cover/close_cover. Let core pick the
-  // direction from the tilt position, as the state may be unknown.
+  // Tilt-only covers don't support open_cover/close_cover. When the cover
+  // reports no state to derive a direction from, let core pick one from the
+  // tilt position.
   if (domain === "cover" && stateObj && isTiltOnly(stateObj)) {
-    return "toggle_cover_tilt";
+    if (stateObj.state === UNKNOWN || stateObj.state === UNAVAILABLE) {
+      return "toggle_cover_tilt";
+    }
+    return onOff ? "open_cover_tilt" : "close_cover_tilt";
   }
   return (
     SPECIAL_TOGGLE_ACTIONS[domain]?.[onOff ? "on" : "off"] ||

--- a/src/common/entity/get_toggle_action.ts
+++ b/src/common/entity/get_toggle_action.ts
@@ -1,6 +1,5 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import { isTiltOnly } from "../../data/cover";
-import { UNAVAILABLE, UNKNOWN } from "../../data/entity/entity";
 import { CameraEntityFeature } from "../../data/feature/camera_entity_feature";
 import { ClimateEntityFeature } from "../../data/feature/climate_entity_feature";
 import { CoverEntityFeature } from "../../data/feature/cover_entity_feature";
@@ -71,13 +70,8 @@ export const getToggleAction = (
   onOff: boolean,
   stateObj?: HassEntity
 ): string => {
-  // Tilt-only covers don't support open_cover/close_cover. When the cover
-  // reports no state to derive a direction from, let core pick one from the
-  // tilt position.
+  // Tilt-only covers don't support open_cover/close_cover
   if (domain === "cover" && stateObj && isTiltOnly(stateObj)) {
-    if (stateObj.state === UNKNOWN || stateObj.state === UNAVAILABLE) {
-      return "toggle_cover_tilt";
-    }
     return onOff ? "open_cover_tilt" : "close_cover_tilt";
   }
   return (

--- a/src/common/entity/get_toggle_action.ts
+++ b/src/common/entity/get_toggle_action.ts
@@ -1,3 +1,5 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { isTiltOnly } from "../../data/cover";
 import { CameraEntityFeature } from "../../data/feature/camera_entity_feature";
 import { ClimateEntityFeature } from "../../data/feature/climate_entity_feature";
 import { CoverEntityFeature } from "../../data/feature/cover_entity_feature";
@@ -63,7 +65,16 @@ export const SPECIAL_TOGGLE_ACTIONS: Record<string, SpecialToggleAction> = {
 
 // This function assumes that the passed domain can toggle, it may otherwise
 // return a service that does not exist.
-export const getToggleAction = (domain: string, onOff: boolean): string => {
+export const getToggleAction = (
+  domain: string,
+  onOff: boolean,
+  stateObj?: HassEntity
+): string => {
+  // Tilt-only covers don't support open_cover/close_cover. Let core pick the
+  // direction from the tilt position, as the state may be unknown.
+  if (domain === "cover" && stateObj && isTiltOnly(stateObj)) {
+    return "toggle_cover_tilt";
+  }
   return (
     SPECIAL_TOGGLE_ACTIONS[domain]?.[onOff ? "on" : "off"] ||
     SPECIAL_TOGGLE_ACTIONS[domain]?.["on"] ||

--- a/src/common/entity/group_entities.ts
+++ b/src/common/entity/group_entities.ts
@@ -1,8 +1,21 @@
 import type { HassEntity } from "home-assistant-js-websocket";
+import { isTiltOnly } from "../../data/cover";
 import { UNAVAILABLE, UNKNOWN } from "../../data/entity/entity";
+import { CoverEntityFeature } from "../../data/feature/cover_entity_feature";
 import type { HomeAssistant } from "../../types";
 import { computeStateDomain } from "./compute_state_domain";
 import { getToggleAction } from "./get_toggle_action";
+import { supportsFeature } from "./supports-feature";
+
+// Tilt-only covers can only stop their tilt, and may not support it at all
+const getStopAction = (stateObj: HassEntity): string | undefined => {
+  if (!isTiltOnly(stateObj)) {
+    return "stop_cover";
+  }
+  return supportsFeature(stateObj, CoverEntityFeature.STOP_TILT)
+    ? "stop_cover_tilt"
+    : undefined;
+};
 
 export const computeGroupEntitiesState = (states: HassEntity[]): string => {
   if (!states.length) {
@@ -58,17 +71,29 @@ export const toggleGroupEntities = (
 
   const isOn = state === "on" || state === "open";
 
-  let service = getToggleAction(domain, !isOn);
-  if (domain === "cover") {
-    if (state === "opening" || state === "closing") {
-      // If the cover is opening or closing, we toggle it to stop it
-      service = "stop_cover";
+  // If the cover is opening or closing, we toggle it to stop it
+  const stopping =
+    domain === "cover" && (state === "opening" || state === "closing");
+
+  // The service can differ per entity, e.g. for tilt-only covers,
+  // so group the entities by the service they need
+  const entityIdsByService: Record<string, string[]> = {};
+  states.forEach((stateObj) => {
+    const service = stopping
+      ? getStopAction(stateObj)
+      : getToggleAction(domain, !isOn, stateObj);
+    if (!service) {
+      return;
     }
-  }
+    if (!(service in entityIdsByService)) {
+      entityIdsByService[service] = [];
+    }
+    entityIdsByService[service].push(stateObj.entity_id);
+  });
 
-  const entitiesIds = states.map((stateObj) => stateObj.entity_id);
-
-  hass.callService(domain, service, {
-    entity_id: entitiesIds,
+  Object.entries(entityIdsByService).forEach(([service, entityIds]) => {
+    hass.callService(domain, service, {
+      entity_id: entityIds,
+    });
   });
 };

--- a/src/components/entity/ha-entity-toggle.ts
+++ b/src/components/entity/ha-entity-toggle.ts
@@ -128,7 +128,7 @@ export class HaEntityToggle extends LitElement {
 
     const serviceDomain =
       stateDomain === "group" ? "homeassistant" : stateDomain;
-    const service = getToggleAction(stateDomain, turnOn);
+    const service = getToggleAction(stateDomain, turnOn, this.stateObj);
 
     const currentState = this.stateObj;
 

--- a/src/panels/lovelace/common/entity/toggle-entity.ts
+++ b/src/panels/lovelace/common/entity/toggle-entity.ts
@@ -1,4 +1,7 @@
 import { STATES_OFF } from "../../../../common/const";
+import { computeDomain } from "../../../../common/entity/compute_domain";
+import { isTiltOnly } from "../../../../data/cover";
+import { UNAVAILABLE, UNKNOWN } from "../../../../data/entity/entity";
 import type { HomeAssistant, ServiceCallResponse } from "../../../../types";
 import { turnOnOffEntity } from "./turn-on-off-entity";
 
@@ -6,6 +9,20 @@ export const toggleEntity = (
   hass: HomeAssistant,
   entityId: string
 ): Promise<ServiceCallResponse> => {
-  const turnOn = STATES_OFF.includes(hass.states[entityId].state);
+  const stateObj = hass.states[entityId];
+
+  // Tilt-only covers may not report a state to pick a direction from,
+  // let core pick one based on the tilt position instead.
+  if (
+    computeDomain(entityId) === "cover" &&
+    isTiltOnly(stateObj) &&
+    (stateObj.state === UNKNOWN || stateObj.state === UNAVAILABLE)
+  ) {
+    return hass.callService("cover", "toggle_cover_tilt", {
+      entity_id: entityId,
+    });
+  }
+
+  const turnOn = STATES_OFF.includes(stateObj.state);
   return turnOnOffEntity(hass, entityId, turnOn);
 };

--- a/src/panels/lovelace/common/entity/toggle-entity.ts
+++ b/src/panels/lovelace/common/entity/toggle-entity.ts
@@ -1,7 +1,7 @@
 import { STATES_OFF } from "../../../../common/const";
 import { computeDomain } from "../../../../common/entity/compute_domain";
 import { isTiltOnly } from "../../../../data/cover";
-import { UNAVAILABLE, UNKNOWN } from "../../../../data/entity/entity";
+import { UNKNOWN } from "../../../../data/entity/entity";
 import type { HomeAssistant, ServiceCallResponse } from "../../../../types";
 import { turnOnOffEntity } from "./turn-on-off-entity";
 
@@ -16,7 +16,7 @@ export const toggleEntity = (
   if (
     computeDomain(entityId) === "cover" &&
     isTiltOnly(stateObj) &&
-    (stateObj.state === UNKNOWN || stateObj.state === UNAVAILABLE)
+    stateObj.state === UNKNOWN
   ) {
     return hass.callService("cover", "toggle_cover_tilt", {
       entity_id: entityId,

--- a/src/panels/lovelace/common/entity/turn-on-off-entities.ts
+++ b/src/panels/lovelace/common/entity/turn-on-off-entities.ts
@@ -8,27 +8,31 @@ export const turnOnOffEntities = (
   entityIds: string[],
   turnOn = true
 ): void => {
-  const domainsToCall = {};
+  const callsToMake: Record<
+    string,
+    { domain: string; service: string; entityIds: string[] }
+  > = {};
   entityIds.forEach((entityId) => {
-    if (STATES_OFF.includes(hass.states[entityId].state) === turnOn) {
+    const stateObj = hass.states[entityId];
+    if (STATES_OFF.includes(stateObj.state) === turnOn) {
       const stateDomain = computeDomain(entityId);
       // Entities with non-standard toggle action need separate calls
-      const serviceDomain =
+      const domain =
         getToggleAction(stateDomain, true) !== "turn_on"
           ? stateDomain
           : "homeassistant";
+      // The service can differ per entity, e.g. for tilt-only covers
+      const service = getToggleAction(domain, turnOn, stateObj);
 
-      if (!(serviceDomain in domainsToCall)) {
-        domainsToCall[serviceDomain] = [];
+      const key = `${domain}.${service}`;
+      if (!(key in callsToMake)) {
+        callsToMake[key] = { domain, service, entityIds: [] };
       }
-      domainsToCall[serviceDomain].push(entityId);
+      callsToMake[key].entityIds.push(entityId);
     }
   });
 
-  Object.keys(domainsToCall).forEach((domain) => {
-    const service = getToggleAction(domain, turnOn);
-
-    const entities = domainsToCall[domain];
-    hass.callService(domain, service, { entity_id: entities });
+  Object.values(callsToMake).forEach(({ domain, service, entityIds: ids }) => {
+    hass.callService(domain, service, { entity_id: ids });
   });
 };

--- a/src/panels/lovelace/common/entity/turn-on-off-entity.ts
+++ b/src/panels/lovelace/common/entity/turn-on-off-entity.ts
@@ -10,7 +10,7 @@ export const turnOnOffEntity = (
   const stateDomain = computeDomain(entityId);
   const serviceDomain = stateDomain === "group" ? "homeassistant" : stateDomain;
 
-  const service = getToggleAction(stateDomain, turnOn);
+  const service = getToggleAction(stateDomain, turnOn, hass.states[entityId]);
 
   return hass.callService(serviceDomain, service, { entity_id: entityId });
 };

--- a/test/common/entity/can_toggle_state.test.ts
+++ b/test/common/entity/can_toggle_state.test.ts
@@ -2,6 +2,7 @@ import { assert, describe, it } from "vitest";
 
 import { canToggleState } from "../../../src/common/entity/can_toggle_state";
 import { ClimateEntityFeature } from "../../../src/data/climate";
+import { CoverEntityFeature } from "../../../src/data/feature/cover_entity_feature";
 
 describe("canToggleState", () => {
   const hass: any = {
@@ -61,6 +62,39 @@ describe("canToggleState", () => {
       entity_id: "climate.bla",
       attributes: {
         supported_features: 0,
+      },
+    };
+    assert.isFalse(canToggleState(hass, stateObj));
+  });
+
+  it("Detects cover with toggle", () => {
+    const stateObj: any = {
+      entity_id: "cover.bla",
+      attributes: {
+        supported_features: CoverEntityFeature.OPEN + CoverEntityFeature.CLOSE,
+      },
+    };
+    assert.isTrue(canToggleState(hass, stateObj));
+  });
+
+  it("Detects tilt-only cover with toggle", () => {
+    const stateObj: any = {
+      entity_id: "cover.bla",
+      attributes: {
+        supported_features:
+          CoverEntityFeature.OPEN_TILT +
+          CoverEntityFeature.CLOSE_TILT +
+          CoverEntityFeature.SET_TILT_POSITION,
+      },
+    };
+    assert.isTrue(canToggleState(hass, stateObj));
+  });
+
+  it("Detects tilt-only cover without toggle", () => {
+    const stateObj: any = {
+      entity_id: "cover.bla",
+      attributes: {
+        supported_features: CoverEntityFeature.STOP_TILT,
       },
     };
     assert.isFalse(canToggleState(hass, stateObj));

--- a/test/common/entity/get_toggle_action.test.ts
+++ b/test/common/entity/get_toggle_action.test.ts
@@ -32,9 +32,31 @@ describe("getToggleAction", () => {
     );
   });
 
-  it("Uses toggle_cover_tilt for tilt-only covers", () => {
+  it("Uses tilt services for tilt-only covers with a known state", () => {
     const stateObj: any = {
       entity_id: "cover.bla",
+      state: "open",
+      attributes: {
+        supported_features:
+          CoverEntityFeature.OPEN_TILT +
+          CoverEntityFeature.CLOSE_TILT +
+          CoverEntityFeature.SET_TILT_POSITION,
+      },
+    };
+    assert.strictEqual(
+      getToggleAction("cover", true, stateObj),
+      "open_cover_tilt"
+    );
+    assert.strictEqual(
+      getToggleAction("cover", false, stateObj),
+      "close_cover_tilt"
+    );
+  });
+
+  it("Uses toggle_cover_tilt for tilt-only covers with an unknown state", () => {
+    const stateObj: any = {
+      entity_id: "cover.bla",
+      state: "unknown",
       attributes: {
         supported_features:
           CoverEntityFeature.OPEN_TILT +

--- a/test/common/entity/get_toggle_action.test.ts
+++ b/test/common/entity/get_toggle_action.test.ts
@@ -1,0 +1,54 @@
+import { assert, describe, it } from "vitest";
+
+import { getToggleAction } from "../../../src/common/entity/get_toggle_action";
+import { CoverEntityFeature } from "../../../src/data/feature/cover_entity_feature";
+
+describe("getToggleAction", () => {
+  it("Uses turn_on/turn_off for default domains", () => {
+    assert.strictEqual(getToggleAction("light", true), "turn_on");
+    assert.strictEqual(getToggleAction("light", false), "turn_off");
+  });
+
+  it("Uses open_cover/close_cover for covers without a state object", () => {
+    assert.strictEqual(getToggleAction("cover", true), "open_cover");
+    assert.strictEqual(getToggleAction("cover", false), "close_cover");
+  });
+
+  it("Uses open_cover/close_cover for covers supporting open/close", () => {
+    const stateObj: any = {
+      entity_id: "cover.bla",
+      attributes: {
+        supported_features:
+          CoverEntityFeature.OPEN +
+          CoverEntityFeature.CLOSE +
+          CoverEntityFeature.OPEN_TILT +
+          CoverEntityFeature.CLOSE_TILT,
+      },
+    };
+    assert.strictEqual(getToggleAction("cover", true, stateObj), "open_cover");
+    assert.strictEqual(
+      getToggleAction("cover", false, stateObj),
+      "close_cover"
+    );
+  });
+
+  it("Uses toggle_cover_tilt for tilt-only covers", () => {
+    const stateObj: any = {
+      entity_id: "cover.bla",
+      attributes: {
+        supported_features:
+          CoverEntityFeature.OPEN_TILT +
+          CoverEntityFeature.CLOSE_TILT +
+          CoverEntityFeature.SET_TILT_POSITION,
+      },
+    };
+    assert.strictEqual(
+      getToggleAction("cover", true, stateObj),
+      "toggle_cover_tilt"
+    );
+    assert.strictEqual(
+      getToggleAction("cover", false, stateObj),
+      "toggle_cover_tilt"
+    );
+  });
+});

--- a/test/common/entity/get_toggle_action.test.ts
+++ b/test/common/entity/get_toggle_action.test.ts
@@ -32,7 +32,7 @@ describe("getToggleAction", () => {
     );
   });
 
-  it("Uses tilt services for tilt-only covers with a known state", () => {
+  it("Uses tilt services for tilt-only covers", () => {
     const stateObj: any = {
       entity_id: "cover.bla",
       state: "open",
@@ -50,27 +50,6 @@ describe("getToggleAction", () => {
     assert.strictEqual(
       getToggleAction("cover", false, stateObj),
       "close_cover_tilt"
-    );
-  });
-
-  it("Uses toggle_cover_tilt for tilt-only covers with an unknown state", () => {
-    const stateObj: any = {
-      entity_id: "cover.bla",
-      state: "unknown",
-      attributes: {
-        supported_features:
-          CoverEntityFeature.OPEN_TILT +
-          CoverEntityFeature.CLOSE_TILT +
-          CoverEntityFeature.SET_TILT_POSITION,
-      },
-    };
-    assert.strictEqual(
-      getToggleAction("cover", true, stateObj),
-      "toggle_cover_tilt"
-    );
-    assert.strictEqual(
-      getToggleAction("cover", false, stateObj),
-      "toggle_cover_tilt"
     );
   });
 });

--- a/test/common/entity/group_entities.test.ts
+++ b/test/common/entity/group_entities.test.ts
@@ -1,0 +1,101 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { describe, expect, it, vi } from "vitest";
+import { toggleGroupEntities } from "../../../src/common/entity/group_entities";
+import { CoverEntityFeature } from "../../../src/data/feature/cover_entity_feature";
+import type { HomeAssistant } from "../../../src/types";
+
+const cover = (
+  entityId: string,
+  state: string,
+  supportedFeatures: number
+): HassEntity =>
+  ({
+    entity_id: entityId,
+    state,
+    attributes: { supported_features: supportedFeatures },
+  }) as HassEntity;
+
+const TILT_ONLY =
+  CoverEntityFeature.OPEN_TILT +
+  CoverEntityFeature.CLOSE_TILT +
+  CoverEntityFeature.STOP_TILT;
+const OPEN_CLOSE = CoverEntityFeature.OPEN + CoverEntityFeature.CLOSE;
+
+const mockHass = () => {
+  const callService = vi.fn();
+  return { hass: { callService } as unknown as HomeAssistant, callService };
+};
+
+describe("toggleGroupEntities", () => {
+  it("Uses tilt services for a group of tilt-only covers", () => {
+    const { hass, callService } = mockHass();
+    toggleGroupEntities(hass, [cover("cover.tilt", "closed", TILT_ONLY)]);
+
+    expect(callService).toHaveBeenCalledOnce();
+    expect(callService).toHaveBeenCalledWith("cover", "open_cover_tilt", {
+      entity_id: ["cover.tilt"],
+    });
+  });
+
+  it("Splits the call when a group mixes tilt-only and regular covers", () => {
+    const { hass, callService } = mockHass();
+    toggleGroupEntities(hass, [
+      cover("cover.regular", "closed", OPEN_CLOSE),
+      cover("cover.tilt", "closed", TILT_ONLY),
+    ]);
+
+    expect(callService).toHaveBeenCalledTimes(2);
+    expect(callService).toHaveBeenCalledWith("cover", "open_cover", {
+      entity_id: ["cover.regular"],
+    });
+    expect(callService).toHaveBeenCalledWith("cover", "open_cover_tilt", {
+      entity_id: ["cover.tilt"],
+    });
+  });
+
+  it("Stops the tilt of tilt-only covers", () => {
+    const { hass, callService } = mockHass();
+    toggleGroupEntities(hass, [
+      cover("cover.regular", "opening", OPEN_CLOSE),
+      cover("cover.tilt", "closed", TILT_ONLY),
+    ]);
+
+    expect(callService).toHaveBeenCalledTimes(2);
+    expect(callService).toHaveBeenCalledWith("cover", "stop_cover", {
+      entity_id: ["cover.regular"],
+    });
+    expect(callService).toHaveBeenCalledWith("cover", "stop_cover_tilt", {
+      entity_id: ["cover.tilt"],
+    });
+  });
+
+  it("Skips tilt-only covers that can't stop", () => {
+    const { hass, callService } = mockHass();
+    toggleGroupEntities(hass, [
+      cover("cover.regular", "opening", OPEN_CLOSE),
+      cover(
+        "cover.tilt",
+        "closed",
+        CoverEntityFeature.OPEN_TILT + CoverEntityFeature.CLOSE_TILT
+      ),
+    ]);
+
+    expect(callService).toHaveBeenCalledOnce();
+    expect(callService).toHaveBeenCalledWith("cover", "stop_cover", {
+      entity_id: ["cover.regular"],
+    });
+  });
+
+  it("Uses a single call for a group of regular covers", () => {
+    const { hass, callService } = mockHass();
+    toggleGroupEntities(hass, [
+      cover("cover.one", "open", OPEN_CLOSE),
+      cover("cover.two", "open", OPEN_CLOSE),
+    ]);
+
+    expect(callService).toHaveBeenCalledOnce();
+    expect(callService).toHaveBeenCalledWith("cover", "close_cover", {
+      entity_id: ["cover.one", "cover.two"],
+    });
+  });
+});

--- a/test/panels/lovelace/common/entity/toggle-entity.test.ts
+++ b/test/panels/lovelace/common/entity/toggle-entity.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { CoverEntityFeature } from "../../../../../src/data/feature/cover_entity_feature";
+import { toggleEntity } from "../../../../../src/panels/lovelace/common/entity/toggle-entity";
+import type { HomeAssistant } from "../../../../../src/types";
+
+const TILT_ONLY = CoverEntityFeature.OPEN_TILT + CoverEntityFeature.CLOSE_TILT;
+
+const mockHass = (state: string, supportedFeatures = TILT_ONLY) => {
+  const callService = vi.fn();
+  return {
+    hass: {
+      states: {
+        "cover.tilt": {
+          entity_id: "cover.tilt",
+          state,
+          attributes: { supported_features: supportedFeatures },
+        },
+      },
+      callService,
+    } as unknown as HomeAssistant,
+    callService,
+  };
+};
+
+describe("toggleEntity", () => {
+  it("Opens the tilt of a closed tilt-only cover", () => {
+    const { hass, callService } = mockHass("closed");
+    toggleEntity(hass, "cover.tilt");
+
+    expect(callService).toHaveBeenCalledWith("cover", "open_cover_tilt", {
+      entity_id: "cover.tilt",
+    });
+  });
+
+  it("Closes the tilt of an open tilt-only cover", () => {
+    const { hass, callService } = mockHass("open");
+    toggleEntity(hass, "cover.tilt");
+
+    expect(callService).toHaveBeenCalledWith("cover", "close_cover_tilt", {
+      entity_id: "cover.tilt",
+    });
+  });
+
+  it("Lets core pick the direction when the tilt-only cover state is unknown", () => {
+    const { hass, callService } = mockHass("unknown");
+    toggleEntity(hass, "cover.tilt");
+
+    expect(callService).toHaveBeenCalledWith("cover", "toggle_cover_tilt", {
+      entity_id: "cover.tilt",
+    });
+  });
+
+  it("Uses open/close for covers supporting it", () => {
+    const { hass, callService } = mockHass(
+      "closed",
+      CoverEntityFeature.OPEN + CoverEntityFeature.CLOSE
+    );
+    toggleEntity(hass, "cover.tilt");
+
+    expect(callService).toHaveBeenCalledWith("cover", "open_cover", {
+      entity_id: "cover.tilt",
+    });
+  });
+});

--- a/test/panels/lovelace/common/entity/turn-on-off-entities.test.ts
+++ b/test/panels/lovelace/common/entity/turn-on-off-entities.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { CoverEntityFeature } from "../../../../../src/data/feature/cover_entity_feature";
+import { turnOnOffEntities } from "../../../../../src/panels/lovelace/common/entity/turn-on-off-entities";
+import type { HomeAssistant } from "../../../../../src/types";
+
+const TILT_ONLY = CoverEntityFeature.OPEN_TILT + CoverEntityFeature.CLOSE_TILT;
+const OPEN_CLOSE = CoverEntityFeature.OPEN + CoverEntityFeature.CLOSE;
+
+const mockHass = (states: Record<string, any>) => {
+  const callService = vi.fn();
+  return {
+    hass: { states, callService } as unknown as HomeAssistant,
+    callService,
+  };
+};
+
+describe("turnOnOffEntities", () => {
+  it("Batches standard domains into a single homeassistant call", () => {
+    const { hass, callService } = mockHass({
+      "light.one": { entity_id: "light.one", state: "off", attributes: {} },
+      "switch.two": { entity_id: "switch.two", state: "off", attributes: {} },
+    });
+    turnOnOffEntities(hass, ["light.one", "switch.two"], true);
+
+    expect(callService).toHaveBeenCalledOnce();
+    expect(callService).toHaveBeenCalledWith("homeassistant", "turn_on", {
+      entity_id: ["light.one", "switch.two"],
+    });
+  });
+
+  it("Uses tilt services for tilt-only covers", () => {
+    const { hass, callService } = mockHass({
+      "cover.tilt": {
+        entity_id: "cover.tilt",
+        state: "closed",
+        attributes: { supported_features: TILT_ONLY },
+      },
+    });
+    turnOnOffEntities(hass, ["cover.tilt"], true);
+
+    expect(callService).toHaveBeenCalledOnce();
+    expect(callService).toHaveBeenCalledWith("cover", "open_cover_tilt", {
+      entity_id: ["cover.tilt"],
+    });
+  });
+
+  it("Splits the call when covers need different services", () => {
+    const { hass, callService } = mockHass({
+      "cover.regular": {
+        entity_id: "cover.regular",
+        state: "closed",
+        attributes: { supported_features: OPEN_CLOSE },
+      },
+      "cover.tilt": {
+        entity_id: "cover.tilt",
+        state: "closed",
+        attributes: { supported_features: TILT_ONLY },
+      },
+    });
+    turnOnOffEntities(hass, ["cover.regular", "cover.tilt"], true);
+
+    expect(callService).toHaveBeenCalledTimes(2);
+    expect(callService).toHaveBeenCalledWith("cover", "open_cover", {
+      entity_id: ["cover.regular"],
+    });
+    expect(callService).toHaveBeenCalledWith("cover", "open_cover_tilt", {
+      entity_id: ["cover.tilt"],
+    });
+  });
+
+  it("Skips entities already in the requested state", () => {
+    const { hass, callService } = mockHass({
+      "light.on": { entity_id: "light.on", state: "on", attributes: {} },
+      "light.off": { entity_id: "light.off", state: "off", attributes: {} },
+    });
+    turnOnOffEntities(hass, ["light.on", "light.off"], true);
+
+    expect(callService).toHaveBeenCalledOnce();
+    expect(callService).toHaveBeenCalledWith("homeassistant", "turn_on", {
+      entity_id: ["light.off"],
+    });
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Toggling a tilt-only cover (e.g. a tile card with `tap_action: toggle`) called `cover.open_cover`/`cover.close_cover`, which core rejects with "Entity … does not support action …".

`getToggleAction` now returns `open_cover_tilt`/`close_cover_tilt` for tilt-only covers, so a toggle still negates the state shown on the card — consistent with how every other domain is toggled here.

`toggle_cover_tilt` is only used in the one case where no direction can be derived: `toggleEntity` on a cover that reports `unknown`. There the state-based direction would always resolve to "close", so tapping an already-closed tilt would do nothing; core picks the direction from the tilt position instead.

This applies to the group paths too, so it also works from the area card controls and the entities card header toggle. Both call one service per domain, so entities are now grouped by the service they need — a group mixing tilt-only and regular covers gets one call each instead of a single unsupported one. Same for stopping a moving group: tilt-only covers get `stop_cover_tilt`, or are skipped when they don't support it.

Since toggle now works for tilt-only covers, `canToggleState` allows them again, so the action editor offers "Toggle" for them once more (relaxes the #53210 filter).

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53199
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr




