### PR TITLE
Fix required field validation being skipped in the app bundle

### DIFF
--- a/src/common/feature-detect/support-native-element-internals.ts
+++ b/src/common/feature-detect/support-native-element-internals.ts
@@ -1,8 +1,29 @@
+let supported: boolean | undefined;
+
+const detect = (): boolean => {
+  if (
+    !globalThis.ElementInternals ||
+    !globalThis.HTMLElement?.prototype.attachInternals
+  ) {
+    return false;
+  }
+  // Native internals keep their WebIDL brand even when `attachInternals` is
+  // wrapped (e.g. by `@webcomponents/scoped-custom-element-registry`, which
+  // broke the previous `[native code]` source check in the app bundle).
+  // `element-internals-polyfill` swaps in a plain class, which has no brand,
+  // and must not count as native: login on legacy browsers relies on
+  // validation being skipped there (#51338).
+  return (
+    Object.prototype.toString.call(globalThis.ElementInternals.prototype) ===
+    "[object ElementInternals]"
+  );
+};
+
 /**
  * Indicates whether the current browser has native ElementInternals support.
+ * Probed on first use so importing this module has no side effects.
  */
-export const nativeElementInternalsSupported =
-  Boolean(globalThis.ElementInternals) &&
-  globalThis.HTMLElement?.prototype.attachInternals
-    ?.toString()
-    .includes("[native code]");
+export const supportsNativeElementInternals = (): boolean => {
+  supported ??= detect();
+  return supported;
+};

--- a/src/components/input/wa-input-mixin.ts
+++ b/src/components/input/wa-input-mixin.ts
@@ -1,7 +1,7 @@
 import { type LitElement, css } from "lit";
 import { property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
-import { nativeElementInternalsSupported } from "../../common/feature-detect/support-native-element-internals";
+import { supportsNativeElementInternals } from "../../common/feature-detect/support-native-element-internals";
 import type { Constructor } from "../../types";
 
 /**
@@ -198,7 +198,7 @@ export const WaInputMixin = <T extends Constructor<LitElement>>(
     }
 
     public checkValidity(): boolean {
-      return nativeElementInternalsSupported
+      return supportsNativeElementInternals()
         ? (this._formControl?.checkValidity() ?? true)
         : true;
     }

--- a/src/components/input/wa-input-mixin.ts
+++ b/src/components/input/wa-input-mixin.ts
@@ -211,7 +211,7 @@ export const WaInputMixin = <T extends Constructor<LitElement>>(
 
     protected _handleInput(): void {
       this.value = this._formControl?.value ?? undefined;
-      if (this._invalid && this._formControl?.checkValidity()) {
+      if (this._invalid && this.checkValidity()) {
         this._invalid = false;
       }
     }
@@ -222,12 +222,16 @@ export const WaInputMixin = <T extends Constructor<LitElement>>(
 
     protected _handleBlur(): void {
       if (this.autoValidate) {
-        this._invalid = !this._formControl?.checkValidity();
+        this._invalid = !this.checkValidity();
       }
     }
 
     protected _handleInvalid(): void {
-      this._invalid = true;
+      // Polyfilled internals dispatch `invalid` themselves, so only trust the
+      // event when validity comes from the platform (#51338).
+      if (supportsNativeElementInternals()) {
+        this._invalid = true;
+      }
     }
 
     protected _renderLabel = memoizeOne((label: string, required: boolean) => {

--- a/test/common/feature-detect/support-native-element-internals.test.ts
+++ b/test/common/feature-detect/support-native-element-internals.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalAttachInternals = HTMLElement.prototype.attachInternals;
+const originalElementInternals = window.ElementInternals;
+
+// The probe memoizes its result, so re-import the module for each scenario.
+const loadProbe = async () => {
+  vi.resetModules();
+  const mod =
+    await import("../../../src/common/feature-detect/support-native-element-internals");
+  return mod.supportsNativeElementInternals;
+};
+
+describe("supportsNativeElementInternals", () => {
+  afterEach(() => {
+    HTMLElement.prototype.attachInternals = originalAttachInternals;
+    window.ElementInternals = originalElementInternals;
+  });
+
+  it("returns true with native ElementInternals", async () => {
+    const supportsNativeElementInternals = await loadProbe();
+    expect(supportsNativeElementInternals()).toBe(true);
+  });
+
+  it("returns true when attachInternals is wrapped by a delegating function", async () => {
+    // Simulates @webcomponents/scoped-custom-element-registry, which the app
+    // bundle loads. Wrapping used to make detection fail (#53337).
+    HTMLElement.prototype.attachInternals = function (this: HTMLElement) {
+      return originalAttachInternals.call(this);
+    };
+    const supportsNativeElementInternals = await loadProbe();
+    expect(supportsNativeElementInternals()).toBe(true);
+  });
+
+  it("returns false when element-internals-polyfill replaces the global", async () => {
+    // The polyfill swaps in its own class, so the mere presence of
+    // window.ElementInternals says nothing about native support (#51338).
+    class PolyfilledElementInternals {
+      public setFormValue = (): void => undefined;
+
+      public setValidity = (): void => undefined;
+
+      public checkValidity = (): boolean => true;
+
+      public reportValidity = (): boolean => true;
+    }
+    window.ElementInternals =
+      PolyfilledElementInternals as unknown as typeof window.ElementInternals;
+    HTMLElement.prototype.attachInternals = () =>
+      new PolyfilledElementInternals() as unknown as ElementInternals;
+    const supportsNativeElementInternals = await loadProbe();
+    expect(supportsNativeElementInternals()).toBe(false);
+  });
+
+  it("returns false without ElementInternals", async () => {
+    window.ElementInternals =
+      undefined as unknown as typeof window.ElementInternals;
+    const supportsNativeElementInternals = await loadProbe();
+    expect(supportsNativeElementInternals()).toBe(false);
+  });
+
+  it("returns false without attachInternals", async () => {
+    HTMLElement.prototype.attachInternals =
+      undefined as unknown as typeof originalAttachInternals;
+    const supportsNativeElementInternals = await loadProbe();
+    expect(supportsNativeElementInternals()).toBe(false);
+  });
+
+  it("probes on first use rather than on import", async () => {
+    // Imported while support is present, so an eager probe would cache true.
+    const supportsNativeElementInternals = await loadProbe();
+    window.ElementInternals =
+      undefined as unknown as typeof window.ElementInternals;
+    expect(supportsNativeElementInternals()).toBe(false);
+  });
+});

--- a/test/components/input/wa-input-mixin.test.ts
+++ b/test/components/input/wa-input-mixin.test.ts
@@ -1,0 +1,144 @@
+import { LitElement } from "lit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WaInput } from "../../../src/components/input/wa-input-mixin";
+import { WaInputMixin } from "../../../src/components/input/wa-input-mixin";
+
+const supportsNative = vi.hoisted(() => ({ value: true }));
+
+vi.mock(
+  "../../../src/common/feature-detect/support-native-element-internals",
+  () => ({
+    supportsNativeElementInternals: () => supportsNative.value,
+  })
+);
+
+// Subclassing gives legitimate access to the mixin's protected members, which
+// ha-input and ha-textarea reach through their @input/@blur/@wa-invalid bindings.
+class TestInput extends WaInputMixin(LitElement) {
+  public controlValid = true;
+
+  protected get _formControl(): WaInput {
+    return {
+      value: "",
+      select: () => undefined,
+      setSelectionRange: () => undefined,
+      setRangeText: () => undefined,
+      checkValidity: () => this.controlValid,
+      validationMessage: "Please fill out this field.",
+    };
+  }
+
+  public get isInvalid(): boolean {
+    return this._invalid;
+  }
+
+  public set isInvalid(value: boolean) {
+    this._invalid = value;
+  }
+
+  public handleInput(): void {
+    this._handleInput();
+  }
+
+  public handleBlur(): void {
+    this._handleBlur();
+  }
+
+  public handleInvalid(): void {
+    this._handleInvalid();
+  }
+}
+
+customElements.define("test-wa-input-mixin", TestInput);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "test-wa-input-mixin": TestInput;
+  }
+}
+
+const createInput = (props: Partial<TestInput> = {}): TestInput => {
+  const el = document.createElement("test-wa-input-mixin");
+  Object.assign(el, props);
+  return el;
+};
+
+describe("WaInputMixin validity", () => {
+  beforeEach(() => {
+    supportsNative.value = true;
+  });
+
+  describe("with native element internals", () => {
+    it("marks invalid on blur when auto-validate is set", () => {
+      const el = createInput({ autoValidate: true, controlValid: false });
+      el.handleBlur();
+      expect(el.isInvalid).toBe(true);
+    });
+
+    it("keeps valid on blur when the control is valid", () => {
+      const el = createInput({ autoValidate: true, controlValid: true });
+      el.handleBlur();
+      expect(el.isInvalid).toBe(false);
+    });
+
+    it("ignores blur without auto-validate", () => {
+      const el = createInput({ autoValidate: false, controlValid: false });
+      el.handleBlur();
+      expect(el.isInvalid).toBe(false);
+    });
+
+    it("clears invalid on input once the control is valid", () => {
+      const el = createInput({ controlValid: true });
+      el.isInvalid = true;
+      el.handleInput();
+      expect(el.isInvalid).toBe(false);
+    });
+
+    it("keeps invalid on input while the control is invalid", () => {
+      const el = createInput({ controlValid: false });
+      el.isInvalid = true;
+      el.handleInput();
+      expect(el.isInvalid).toBe(true);
+    });
+
+    it("marks invalid on the invalid event", () => {
+      const el = createInput();
+      el.handleInvalid();
+      expect(el.isInvalid).toBe(true);
+    });
+  });
+
+  // Polyfilled internals report validity the app cannot trust, so every path
+  // must agree with checkValidity() and leave the field alone (#51338).
+  describe("without native element internals", () => {
+    beforeEach(() => {
+      supportsNative.value = false;
+    });
+
+    it("does not mark invalid on blur", () => {
+      const el = createInput({ autoValidate: true, controlValid: false });
+      el.handleBlur();
+      expect(el.isInvalid).toBe(false);
+    });
+
+    it("clears invalid on input", () => {
+      const el = createInput({ controlValid: false });
+      el.isInvalid = true;
+      el.handleInput();
+      expect(el.isInvalid).toBe(false);
+    });
+
+    it("ignores the invalid event", () => {
+      const el = createInput();
+      el.handleInvalid();
+      expect(el.isInvalid).toBe(false);
+    });
+
+    it("reports valid so submission is never blocked", () => {
+      const el = createInput({ required: true, controlValid: false });
+      expect(el.checkValidity()).toBe(true);
+      expect(el.reportValidity()).toBe(true);
+      expect(el.isInvalid).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

`required` fields have silently not been enforced anywhere in the app since 2026.4.

Native `ElementInternals` support was detected by checking `attachInternals.toString()` for
`"[native code]"`, but the app entrypoint loads `@webcomponents/scoped-custom-element-registry`,
which replaces that method with a delegating wrapper. The check therefore failed in every modern
browser and `WaInputMixin.checkValidity()` always returned `true`. The login and onboarding
entrypoints do not load the scoped registry, which is why validation still worked there.

This replaces the source-text check with a brand check on the `ElementInternals` interface
prototype, which WebIDL stamps with `@@toStringTag`. Wrapping `attachInternals` leaves that brand
intact, while `element-internals-polyfill` swaps the global for a plain class that has no brand, so
legacy browsers keep skipping validation and the fix from #51373 is preserved. The check is
memoized on first use so importing the module has no side effects.

Following review, the blur and `invalid` paths in the mixin now go through the same guarded
`checkValidity()` too. They previously called the inner control directly, which on a polyfilled
browser reaches the polyfill's `checkValidity()` — and that dispatches an `invalid` event, which
Web Awesome re-emits and the mixin turned into an error state, bypassing the guard entirely. On
browsers with native internals this is a no-op.

For users, empty required fields block submission again and show the browser's validation
message on the field.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Settings → Network → HTTP server, with the required "Server port" field cleared:

| Before | After |
| --- | --- |
| <img width="1000" height="1280" alt="image" src="https://github.com/user-attachments/assets/3f1fec05-99b6-4e4b-9c5b-49eedd8a7fec" /> | <img width="1000" height="1280" alt="image" src="https://github.com/user-attachments/assets/1fc17c7f-e131-4910-902b-e398c352ccf4" /> |

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53337
- This PR is related to issue or discussion: #51338, #51373
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


