### PR TITLE
Add activity detail dialog

### DIFF
--- a/src/common/datetime/format_time.ts
+++ b/src/common/datetime/format_time.ts
@@ -39,6 +39,25 @@ const formatTimeWithSecondsMem = memoizeOne(
     })
 );
 
+// 9:15:24.123 PM || 21:15:24,123
+export const formatTimeWithMilliseconds = (
+  dateObj: Date,
+  locale: FrontendLocaleData,
+  config: HassConfig
+) => formatTimeWithMillisecondsMem(locale, config.time_zone).format(dateObj);
+
+const formatTimeWithMillisecondsMem = memoizeOne(
+  (locale: FrontendLocaleData, serverTimeZone: string) =>
+    new Intl.DateTimeFormat(locale.language, {
+      hour: useAmPm(locale) ? "numeric" : "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      fractionalSecondDigits: 3,
+      hourCycle: useAmPm(locale) ? "h12" : "h23",
+      timeZone: resolveTimeZone(locale.time_zone, serverTimeZone),
+    })
+);
+
 // Tuesday 7:00 PM || Tuesday 19:00
 export const formatTimeWeekday = (
   dateObj: Date,

--- a/src/components/trace/ha-trace-logbook.ts
+++ b/src/components/trace/ha-trace-logbook.ts
@@ -29,6 +29,7 @@ export class HaTraceLogbook extends LitElement {
             .hass=${this.hass}
             .entries=${this.logbookEntries}
             .narrow=${this.narrow}
+            no-row-click
           ></ha-logbook-renderer>
           <hat-logbook-note .domain=${this.trace.domain}></hat-logbook-note>
         `

--- a/src/components/trace/ha-trace-logbook.ts
+++ b/src/components/trace/ha-trace-logbook.ts
@@ -29,7 +29,7 @@ export class HaTraceLogbook extends LitElement {
             .hass=${this.hass}
             .entries=${this.logbookEntries}
             .narrow=${this.narrow}
-            no-row-click
+            no-detail
           ></ha-logbook-renderer>
           <hat-logbook-note .domain=${this.trace.domain}></hat-logbook-note>
         `

--- a/src/components/trace/ha-trace-path-details.ts
+++ b/src/components/trace/ha-trace-path-details.ts
@@ -437,7 +437,7 @@ export class HaTracePathDetails extends LitElement {
             .hass=${this.hass}
             .entries=${entries}
             .narrow=${this.narrow}
-            no-row-click
+            no-detail
           ></ha-logbook-renderer>
           <hat-logbook-note .domain=${this.trace.domain}></hat-logbook-note>
         `

--- a/src/components/trace/ha-trace-path-details.ts
+++ b/src/components/trace/ha-trace-path-details.ts
@@ -437,6 +437,7 @@ export class HaTracePathDetails extends LitElement {
             .hass=${this.hass}
             .entries=${entries}
             .narrow=${this.narrow}
+            no-row-click
           ></ha-logbook-renderer>
           <hat-logbook-note .domain=${this.trace.domain}></hat-logbook-note>
         `

--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -76,16 +76,7 @@ export const getLogbookDataForContext = async (
 ): Promise<LogbookEntry[]> =>
   getLogbookDataFromServer(hass, startDate, undefined, undefined, contextId);
 
-export const getLogbookEvents = (
-  hass: HomeAssistant,
-  startDate: string,
-  endDate?: string,
-  entityIds?: string[],
-  contextId?: string
-): Promise<LogbookEntry[]> =>
-  getLogbookDataFromServer(hass, startDate, endDate, entityIds, contextId);
-
-const getLogbookDataFromServer = (
+export const getLogbookDataFromServer = (
   hass: HomeAssistant,
   startDate: string,
   endDate?: string,

--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -76,6 +76,15 @@ export const getLogbookDataForContext = async (
 ): Promise<LogbookEntry[]> =>
   getLogbookDataFromServer(hass, startDate, undefined, undefined, contextId);
 
+export const getLogbookEvents = (
+  hass: HomeAssistant,
+  startDate: string,
+  endDate?: string,
+  entityIds?: string[],
+  contextId?: string
+): Promise<LogbookEntry[]> =>
+  getLogbookDataFromServer(hass, startDate, endDate, entityIds, contextId);
+
 const getLogbookDataFromServer = (
   hass: HomeAssistant,
   startDate: string,

--- a/src/panels/logbook/dialog-logbook-detail.ts
+++ b/src/panels/logbook/dialog-logbook-detail.ts
@@ -1,0 +1,384 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import type { CSSResultGroup } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { isComponentLoaded } from "../../common/config/is_component_loaded";
+import { formatDateTimeWithSeconds } from "../../common/datetime/format_date_time";
+import { fireEvent } from "../../common/dom/fire_event";
+import type { LocalizeKeys } from "../../common/translations/localize";
+import { computeRTL } from "../../common/util/compute_rtl";
+import "../../components/ha-adaptive-dialog";
+import "../../components/ha-alert";
+import "../../components/ha-relative-time";
+import "../../components/ha-spinner";
+import type { LogbookEntry } from "../../data/logbook";
+import type { HassDialog } from "../../dialogs/make-dialog-manager";
+import {
+  buttonLinkStyle,
+  haStyle,
+  haStyleDialog,
+} from "../../resources/styles";
+import type { HomeAssistant } from "../../types";
+import "./ha-logbook-chain";
+import type { LogbookChain } from "./logbook-chain-resolver";
+import { resolveLogbookChain } from "./logbook-chain-resolver";
+import type { LogbookItem } from "./logbook-entry-model";
+import { computeLogbookItem } from "./logbook-entry-model";
+import type { LogbookDetailDialogParams } from "./show-dialog-logbook-detail";
+
+@customElement("dialog-logbook-detail")
+class DialogLogbookDetail
+  extends LitElement
+  implements HassDialog<LogbookDetailDialogParams>
+{
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _params?: LogbookDetailDialogParams;
+
+  @state() private _open = false;
+
+  @state() private _chain?: LogbookChain;
+
+  @state() private _error = false;
+
+  public showDialog(params: LogbookDetailDialogParams): void {
+    this._params = params;
+    this._open = true;
+    this._chain = undefined;
+    this._error = false;
+    if (
+      params.entry.context_event_type === "call_service" &&
+      params.entry.context_domain
+    ) {
+      this.hass.loadBackendTranslation("services", params.entry.context_domain);
+    }
+    this._loadChain();
+  }
+
+  public closeDialog(): boolean {
+    this._open = false;
+    return true;
+  }
+
+  private _dialogClosed(): void {
+    this._params = undefined;
+    this._chain = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  private async _loadChain() {
+    const { entry, userIdToName, systemUserIds } = this._params!;
+    const options = { userIdToName, systemUserIds };
+    const resolveWithoutFetch = () =>
+      resolveLogbookChain(this.hass, entry, options, async () => []);
+    try {
+      const chain = isComponentLoaded(this.hass.config, "logbook")
+        ? await resolveLogbookChain(this.hass, entry, options)
+        : await resolveWithoutFetch();
+      if (this._params?.entry !== entry) {
+        return;
+      }
+      this._chain = chain;
+    } catch {
+      if (this._params?.entry !== entry) {
+        return;
+      }
+      this._error = true;
+      this._chain = await resolveWithoutFetch();
+    }
+  }
+
+  protected render() {
+    if (!this._params) {
+      return nothing;
+    }
+
+    const { entry } = this._params;
+    const item = computeLogbookItem(this.hass, entry);
+
+    return html`
+      <ha-adaptive-dialog
+        .open=${this._open}
+        header-title=${this.hass.localize("ui.dialogs.logbook_detail.title")}
+        @closed=${this._dialogClosed}
+        @hass-more-info=${this._moreInfoOpened}
+      >
+        <div class="content">
+          ${this._renderFacts(item, entry)} ${this._renderWhatHappened(entry)}
+        </div>
+      </ha-adaptive-dialog>
+    `;
+  }
+
+  private _renderFacts(item: LogbookItem, entry: LogbookEntry) {
+    const stateObj = entry.entity_id
+      ? this.hass.states[entry.entity_id]
+      : undefined;
+    const transition = this._transitionValues(item, entry, stateObj);
+    const when = new Date(item.when);
+    const subjectKey =
+      item.category === "entity"
+        ? "entity"
+        : item.category === "automation"
+          ? entry.domain === "script"
+            ? "script"
+            : "automation"
+          : "integration";
+
+    return html`
+      <div class="box">
+        <div class="row">
+          <span class="label">
+            ${this.hass.localize(
+              `ui.dialogs.logbook_detail.${subjectKey}` as LocalizeKeys
+            )}
+          </span>
+          <span class="value">
+            ${this._renderName(item.name, entry.entity_id)}
+            ${
+              item.context
+                ? html`<span class="sub">${item.context}</span>`
+                : nothing
+            }
+          </span>
+        </div>
+        ${
+          transition
+            ? html`
+                <div class="row">
+                  <span class="label">
+                    ${this.hass.localize("ui.dialogs.logbook_detail.state")}
+                  </span>
+                  <span class="value">
+                    ${
+                      transition.oldState
+                        ? html`<span class="old-state"
+                              >${transition.oldState}</span
+                            ><span class="arrow">${this._arrow()}</span>`
+                        : nothing
+                    }<span class="new-state">${transition.newState}</span>
+                  </span>
+                </div>
+              `
+            : item.value
+              ? html`
+                  <div class="row">
+                    <span class="label">
+                      ${this.hass.localize("ui.dialogs.logbook_detail.event")}
+                    </span>
+                    <span class="value">${item.value.text}</span>
+                  </div>
+                `
+              : nothing
+        }
+        <div class="row">
+          <span class="label">
+            ${this.hass.localize("ui.dialogs.logbook_detail.time")}
+          </span>
+          <span class="value time-value">
+            ${formatDateTimeWithSeconds(
+              when,
+              this.hass.locale,
+              this.hass.config
+            )}
+            <span class="sub">
+              <ha-relative-time .datetime=${when} capitalize></ha-relative-time>
+            </span>
+          </span>
+        </div>
+      </div>
+    `;
+  }
+
+  private _renderWhatHappened(entry: LogbookEntry) {
+    return html`
+      <div class="section">
+        <h3 class="section-title">
+          ${this.hass.localize("ui.dialogs.logbook_detail.what_happened")}
+        </h3>
+        ${
+          this._error
+            ? html`<ha-alert alert-type="warning">
+                ${this.hass.localize("ui.components.logbook.retrieval_error")}
+              </ha-alert>`
+            : nothing
+        }
+        ${
+          this._chain === undefined
+            ? html`<div class="loading"><ha-spinner></ha-spinner></div>`
+            : html`<ha-logbook-chain
+                .hass=${this.hass}
+                .chain=${this._chain}
+                .subject=${entry}
+                .traceContexts=${this._params?.traceContexts ?? {}}
+              ></ha-logbook-chain>`
+        }
+      </div>
+    `;
+  }
+
+  private _renderName(name: string | undefined, entityId?: string) {
+    if (entityId && entityId in this.hass.states) {
+      return html`<button
+        class="link name"
+        .entityId=${entityId}
+        @click=${this._entityClicked}
+      >
+        ${name}
+      </button>`;
+    }
+    return html`<span class="name">${name}</span>`;
+  }
+
+  private _arrow() {
+    return computeRTL(
+      this.hass.language,
+      this.hass.translationMetadata.translations
+    )
+      ? "←"
+      : "→";
+  }
+
+  private _transitionValues(
+    item: LogbookItem,
+    entry: LogbookEntry,
+    stateObj?: HassEntity
+  ): { oldState?: string; newState: string } | undefined {
+    if (item.category !== "entity" || entry.state === undefined) {
+      return undefined;
+    }
+    const newState = stateObj
+      ? this.hass.formatEntityState(stateObj, entry.state)
+      : entry.state;
+    const previousState = this._params?.previousState;
+    const oldState =
+      previousState !== undefined && previousState !== entry.state
+        ? stateObj
+          ? this.hass.formatEntityState(stateObj, previousState)
+          : previousState
+        : undefined;
+    return { oldState, newState };
+  }
+
+  private _entityClicked(ev: Event) {
+    const entityId = (ev.currentTarget as HTMLElement & { entityId?: string })
+      .entityId;
+    if (!entityId) {
+      return;
+    }
+    this.closeDialog();
+    fireEvent(this, "hass-more-info", { entityId });
+  }
+
+  private _moreInfoOpened() {
+    this.closeDialog();
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      haStyleDialog,
+      buttonLinkStyle,
+      css`
+        .content {
+          display: flex;
+          flex-direction: column;
+          gap: var(--ha-space-4);
+        }
+
+        .box {
+          border: 1px solid var(--divider-color);
+          border-radius: var(
+            --ha-card-border-radius,
+            var(--ha-border-radius-lg)
+          );
+          overflow: hidden;
+        }
+
+        .box > .row + .row {
+          border-top: 1px solid var(--divider-color);
+        }
+
+        .row {
+          display: flex;
+          align-items: center;
+          gap: var(--ha-space-4);
+          min-height: 48px;
+          padding: var(--ha-space-2) var(--ha-space-4);
+          box-sizing: border-box;
+        }
+
+        .row .label {
+          color: var(--secondary-text-color);
+          flex-shrink: 0;
+        }
+
+        .row .value {
+          flex: 1;
+          min-width: 0;
+          text-align: end;
+          overflow-wrap: anywhere;
+        }
+
+        .value .name {
+          font-weight: var(--ha-font-weight-medium);
+        }
+
+        button.link.name {
+          color: var(--primary-text-color);
+          text-align: inherit;
+          text-decoration: none;
+        }
+
+        button.link.name:hover {
+          text-decoration: underline;
+        }
+
+        .sub {
+          display: block;
+          color: var(--secondary-text-color);
+          font-size: var(--ha-font-size-s);
+        }
+
+        .old-state {
+          color: var(--secondary-text-color);
+        }
+
+        .arrow {
+          color: var(--disabled-color);
+          padding: 0 4px;
+        }
+
+        .new-state {
+          font-weight: var(--ha-font-weight-medium);
+        }
+
+        .time-value {
+          font-variant-numeric: tabular-nums;
+        }
+
+        ha-relative-time {
+          display: contents;
+        }
+
+        .section-title {
+          margin: 0 0 var(--ha-space-2);
+          font-size: var(--ha-font-size-m);
+          font-weight: var(--ha-font-weight-medium);
+        }
+
+        .loading {
+          display: flex;
+          justify-content: center;
+          padding: var(--ha-space-4);
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-logbook-detail": DialogLogbookDetail;
+  }
+}

--- a/src/panels/logbook/dialog-logbook-detail.ts
+++ b/src/panels/logbook/dialog-logbook-detail.ts
@@ -11,6 +11,7 @@ import "../../components/ha-adaptive-dialog";
 import "../../components/ha-alert";
 import "../../components/ha-relative-time";
 import "../../components/ha-spinner";
+import { fetchDateWS } from "../../data/history";
 import type { LogbookEntry } from "../../data/logbook";
 import type { HassDialog } from "../../dialogs/make-dialog-manager";
 import {
@@ -44,12 +45,15 @@ class DialogLogbookDetail
 
   @state() private _chain?: LogbookChain;
 
+  @state() private _previousState?: string;
+
   @state() private _error = false;
 
   public showDialog(params: LogbookDetailDialogParams): void {
     this._params = params;
     this._open = true;
     this._chain = undefined;
+    this._previousState = undefined;
     this._error = false;
     if (
       params.entry.context_event_type === "call_service" &&
@@ -57,7 +61,7 @@ class DialogLogbookDetail
     ) {
       this.hass.loadBackendTranslation("services", params.entry.context_domain);
     }
-    this._loadChain();
+    this._loadDetails();
   }
 
   public closeDialog(): boolean {
@@ -71,26 +75,61 @@ class DialogLogbookDetail
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
-  private async _loadChain() {
-    const { entry, userIdToName, systemUserIds } = this._params!;
-    const options = { userIdToName, systemUserIds };
-    const resolveWithoutFetch = () =>
-      resolveLogbookChain(this.hass, entry, options, async () => []);
-    let chain: LogbookChain;
-    let errored = false;
-    try {
-      chain = isComponentLoaded(this.hass.config, "logbook")
-        ? await resolveLogbookChain(this.hass, entry, options)
-        : await resolveWithoutFetch();
-    } catch {
-      errored = true;
-      chain = await resolveWithoutFetch();
-    }
+  // Both fetches resolve into a single render so the dialog reflows once.
+  private async _loadDetails() {
+    const { entry } = this._params!;
+    const [{ chain, errored }, previousState] = await Promise.all([
+      this._fetchChain(entry),
+      this._fetchPreviousState(entry),
+    ]);
     if (this._params?.entry !== entry) {
       return;
     }
     this._error = errored;
     this._chain = chain;
+    this._previousState = previousState;
+  }
+
+  private async _fetchChain(
+    entry: LogbookEntry
+  ): Promise<{ chain: LogbookChain; errored: boolean }> {
+    const { userIdToName, systemUserIds } = this._params!;
+    const options = { userIdToName, systemUserIds };
+    const resolveWithoutFetch = () =>
+      resolveLogbookChain(this.hass, entry, options, async () => []);
+    try {
+      const chain = isComponentLoaded(this.hass.config, "logbook")
+        ? await resolveLogbookChain(this.hass, entry, options)
+        : await resolveWithoutFetch();
+      return { chain, errored: false };
+    } catch {
+      return { chain: await resolveWithoutFetch(), errored: true };
+    }
+  }
+
+  // The feed the row was clicked in can be filtered or partially loaded, so
+  // the state active just before the entry is resolved from history instead.
+  private async _fetchPreviousState(
+    entry: LogbookEntry
+  ): Promise<string | undefined> {
+    if (
+      !entry.entity_id ||
+      entry.state === undefined ||
+      !isComponentLoaded(this.hass.config, "history")
+    ) {
+      return undefined;
+    }
+    const end = new Date(entry.when * 1000);
+    const start = new Date(end.getTime() - 1);
+    try {
+      const states = await fetchDateWS(this.hass, start, end, [
+        entry.entity_id,
+      ]);
+      return states[entry.entity_id]?.[0]?.s;
+    } catch {
+      // The row is still useful without an old state.
+      return undefined;
+    }
   }
 
   protected render() {
@@ -210,16 +249,18 @@ class DialogLogbookDetail
               </ha-alert>`
             : nothing
         }
-        ${
-          this._chain === undefined
-            ? html`<div class="loading"><ha-spinner></ha-spinner></div>`
-            : html`<ha-logbook-chain
-                .hass=${this.hass}
-                .chain=${this._chain}
-                .subject=${entry}
-                .traceContexts=${this._params?.traceContexts ?? {}}
-              ></ha-logbook-chain>`
-        }
+        <div class="chain-area">
+          ${
+            this._chain === undefined
+              ? html`<div class="loading"><ha-spinner></ha-spinner></div>`
+              : html`<ha-logbook-chain
+                  .hass=${this.hass}
+                  .chain=${this._chain}
+                  .subject=${entry}
+                  .traceContexts=${this._params?.traceContexts ?? {}}
+                ></ha-logbook-chain>`
+          }
+        </div>
       </div>
     `;
   }
@@ -237,7 +278,7 @@ class DialogLogbookDetail
     const newState = stateObj
       ? this.hass.formatEntityState(stateObj, entry.state)
       : entry.state;
-    const previousState = this._params?.previousState;
+    const previousState = this._previousState;
     const oldState =
       previousState !== undefined && previousState !== entry.state
         ? stateObj
@@ -335,10 +376,17 @@ class DialogLogbookDetail
           font-weight: var(--ha-font-weight-medium);
         }
 
+        /* Reserved at two chain rows, the typical chain height, so the swap
+           from spinner to content barely moves the dialog. */
+        .chain-area {
+          display: grid;
+          min-height: 114px;
+        }
+
         .loading {
           display: flex;
+          align-items: center;
           justify-content: center;
-          padding: var(--ha-space-4);
         }
       `,
     ];

--- a/src/panels/logbook/dialog-logbook-detail.ts
+++ b/src/panels/logbook/dialog-logbook-detail.ts
@@ -2,11 +2,11 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import { formatDateTimeWithSeconds } from "../../common/datetime/format_date_time";
 import { fireEvent } from "../../common/dom/fire_event";
 import type { LocalizeKeys } from "../../common/translations/localize";
-import { computeRTL } from "../../common/util/compute_rtl";
 import "../../components/ha-adaptive-dialog";
 import "../../components/ha-alert";
 import "../../components/ha-relative-time";
@@ -24,6 +24,11 @@ import type { LogbookChain } from "./logbook-chain-resolver";
 import { resolveLogbookChain } from "./logbook-chain-resolver";
 import type { LogbookItem } from "./logbook-entry-model";
 import { computeLogbookItem } from "./logbook-entry-model";
+import {
+  entityNameButtonStyle,
+  renderEntityName,
+  transitionArrow,
+} from "./logbook-entry-templates";
 import type { LogbookDetailDialogParams } from "./show-dialog-logbook-detail";
 
 @customElement("dialog-logbook-detail")
@@ -71,21 +76,21 @@ class DialogLogbookDetail
     const options = { userIdToName, systemUserIds };
     const resolveWithoutFetch = () =>
       resolveLogbookChain(this.hass, entry, options, async () => []);
+    let chain: LogbookChain;
+    let errored = false;
     try {
-      const chain = isComponentLoaded(this.hass.config, "logbook")
+      chain = isComponentLoaded(this.hass.config, "logbook")
         ? await resolveLogbookChain(this.hass, entry, options)
         : await resolveWithoutFetch();
-      if (this._params?.entry !== entry) {
-        return;
-      }
-      this._chain = chain;
     } catch {
-      if (this._params?.entry !== entry) {
-        return;
-      }
-      this._error = true;
-      this._chain = await resolveWithoutFetch();
+      errored = true;
+      chain = await resolveWithoutFetch();
     }
+    if (this._params?.entry !== entry) {
+      return;
+    }
+    this._error = errored;
+    this._chain = chain;
   }
 
   protected render() {
@@ -115,7 +120,7 @@ class DialogLogbookDetail
       ? this.hass.states[entry.entity_id]
       : undefined;
     const transition = this._transitionValues(item, entry, stateObj);
-    const when = new Date(item.when);
+    const when = this._entryDate(item.when);
     const subjectKey =
       item.category === "entity"
         ? "entity"
@@ -134,7 +139,7 @@ class DialogLogbookDetail
             )}
           </span>
           <span class="value">
-            ${this._renderName(item.name, entry.entity_id)}
+            ${renderEntityName(this.hass, item.name, entry.entity_id)}
             ${
               item.context
                 ? html`<span class="sub">${item.context}</span>`
@@ -154,7 +159,9 @@ class DialogLogbookDetail
                       transition.oldState
                         ? html`<span class="old-state"
                               >${transition.oldState}</span
-                            ><span class="arrow">${this._arrow()}</span>`
+                            ><span class="arrow"
+                              >${transitionArrow(this.hass)}</span
+                            >`
                         : nothing
                     }<span class="new-state">${transition.newState}</span>
                   </span>
@@ -217,27 +224,7 @@ class DialogLogbookDetail
     `;
   }
 
-  private _renderName(name: string | undefined, entityId?: string) {
-    if (entityId && entityId in this.hass.states) {
-      return html`<button
-        class="link name"
-        .entityId=${entityId}
-        @click=${this._entityClicked}
-      >
-        ${name}
-      </button>`;
-    }
-    return html`<span class="name">${name}</span>`;
-  }
-
-  private _arrow() {
-    return computeRTL(
-      this.hass.language,
-      this.hass.translationMetadata.translations
-    )
-      ? "←"
-      : "→";
-  }
+  private _entryDate = memoizeOne((when: number) => new Date(when));
 
   private _transitionValues(
     item: LogbookItem,
@@ -260,16 +247,6 @@ class DialogLogbookDetail
     return { oldState, newState };
   }
 
-  private _entityClicked(ev: Event) {
-    const entityId = (ev.currentTarget as HTMLElement & { entityId?: string })
-      .entityId;
-    if (!entityId) {
-      return;
-    }
-    this.closeDialog();
-    fireEvent(this, "hass-more-info", { entityId });
-  }
-
   private _moreInfoOpened() {
     this.closeDialog();
   }
@@ -279,6 +256,7 @@ class DialogLogbookDetail
       haStyle,
       haStyleDialog,
       buttonLinkStyle,
+      entityNameButtonStyle,
       css`
         .content {
           display: flex;
@@ -322,16 +300,6 @@ class DialogLogbookDetail
 
         .value .name {
           font-weight: var(--ha-font-weight-medium);
-        }
-
-        button.link.name {
-          color: var(--primary-text-color);
-          text-align: inherit;
-          text-decoration: none;
-        }
-
-        button.link.name:hover {
-          text-decoration: underline;
         }
 
         .sub {

--- a/src/panels/logbook/dialog-logbook-detail.ts
+++ b/src/panels/logbook/dialog-logbook-detail.ts
@@ -13,6 +13,10 @@ import "../../components/ha-icon";
 import "../../components/ha-icon-next";
 import "../../components/ha-relative-time";
 import "../../components/ha-spinner";
+import "../../components/item/ha-list-item-base";
+import "../../components/item/ha-list-item-button";
+import "../../components/item/ha-list-item-value";
+import "../../components/list/ha-grouped-list";
 import { fetchDateWS } from "../../data/history";
 import type { LogbookEntry } from "../../data/logbook";
 import type { HassDialog } from "../../dialogs/make-dialog-manager";
@@ -156,83 +160,79 @@ class DialogLogbookDetail
     const when = this._entryDate(item.when);
 
     return html`
-      <div class="box">
+      <ha-grouped-list>
         ${this._renderSubjectRow(item, entry)}
         ${
           transition
             ? html`
-                <div class="row">
-                  <span class="label">
-                    ${this.hass.localize("ui.dialogs.logbook_detail.state")}
-                  </span>
-                  <span class="value">
-                    ${
-                      transition.oldState
-                        ? html`<span class="old-state"
-                              >${transition.oldState}</span
-                            ><span class="arrow"
-                              >${transitionArrow(this.hass)}</span
-                            >`
-                        : nothing
-                    }<span class="new-state">${transition.newState}</span>
-                  </span>
-                </div>
+                <ha-list-item-value
+                  .label=${this.hass.localize(
+                    "ui.dialogs.logbook_detail.state"
+                  )}
+                >
+                  ${
+                    transition.oldState
+                      ? html`<span class="old-state"
+                            >${transition.oldState}</span
+                          ><span class="arrow"
+                            >${transitionArrow(this.hass)}</span
+                          >`
+                      : nothing
+                  }<span class="new-state">${transition.newState}</span>
+                </ha-list-item-value>
               `
             : item.value
               ? html`
-                  <div class="row">
-                    <span class="label">
-                      ${this.hass.localize("ui.dialogs.logbook_detail.event")}
-                    </span>
-                    <span class="value">${item.value.text}</span>
-                  </div>
+                  <ha-list-item-value
+                    .label=${this.hass.localize(
+                      "ui.dialogs.logbook_detail.event"
+                    )}
+                  >
+                    ${item.value.text}
+                  </ha-list-item-value>
                 `
               : nothing
         }
-        <div class="row">
-          <span class="label">
-            ${this.hass.localize("ui.dialogs.logbook_detail.time")}
+        <ha-list-item-value
+          class="time-value"
+          .label=${this.hass.localize("ui.dialogs.logbook_detail.time")}
+        >
+          ${formatDateTimeWithSeconds(when, this.hass.locale, this.hass.config)}
+          <span class="sub">
+            <ha-relative-time .datetime=${when} capitalize></ha-relative-time>
           </span>
-          <span class="value time-value">
-            ${formatDateTimeWithSeconds(
-              when,
-              this.hass.locale,
-              this.hass.config
-            )}
-            <span class="sub">
-              <ha-relative-time .datetime=${when} capitalize></ha-relative-time>
-            </span>
-          </span>
-        </div>
-      </div>
+        </ha-list-item-value>
+      </ha-grouped-list>
     `;
   }
 
   // Mirrors the target picker: icon, name, area ▸ device.
   private _renderSubjectRow(item: LogbookItem, entry: LogbookEntry) {
-    const content = html`
-      <span class="subject-icon">
-        ${this._renderSubjectIcon(item, entry)}
-      </span>
-      <span class="subject-name">
-        <span class="name">${item.name}</span>
-        ${item.context ? html`<span class="sub">${item.context}</span>` : nothing}
-      </span>
-    `;
+    const icon = html`<span class="subject-icon" slot="start">
+      ${this._renderSubjectIcon(item, entry)}
+    </span>`;
 
     if (!entry.entity_id || !(entry.entity_id in this.hass.states)) {
-      return html`<div class="row subject">${content}</div>`;
+      return html`
+        <ha-list-item-base
+          .headline=${item.name}
+          .supportingText=${item.context}
+        >
+          ${icon}
+        </ha-list-item-base>
+      `;
     }
 
     return html`
-      <button
-        class="row subject clickable"
+      <ha-list-item-button
+        .headline=${item.name}
+        .supportingText=${item.context}
         .entityId=${entry.entity_id}
         @click=${this._entityClicked}
       >
-        ${content}
-        <ha-icon-next class="chevron"></ha-icon-next>
-      </button>
+        ${icon}
+        <ha-icon-next slot="end"></ha-icon-next>
+      </ha-list-item-button>
     `;
   }
 
@@ -255,17 +255,16 @@ class DialogLogbookDetail
 
   private _renderWhatHappened(entry: LogbookEntry) {
     return html`
-      <div class="section">
-        <h3 class="section-title">
-          ${this.hass.localize("ui.dialogs.logbook_detail.what_happened")}
-        </h3>
-        ${
-          this._error
-            ? html`<ha-alert alert-type="warning">
-                ${this.hass.localize("ui.components.logbook.retrieval_error")}
-              </ha-alert>`
-            : nothing
-        }
+      ${
+        this._error
+          ? html`<ha-alert alert-type="warning">
+              ${this.hass.localize("ui.components.logbook.retrieval_error")}
+            </ha-alert>`
+          : nothing
+      }
+      <ha-grouped-list
+        .header=${this.hass.localize("ui.dialogs.logbook_detail.what_happened")}
+      >
         <div class="chain-area">
           ${
             this._chain === undefined
@@ -278,7 +277,7 @@ class DialogLogbookDetail
                 ></ha-logbook-chain>`
           }
         </div>
-      </div>
+      </ha-grouped-list>
     `;
   }
 
@@ -320,64 +319,22 @@ class DialogLogbookDetail
           gap: var(--ha-space-4);
         }
 
-        .box {
-          border: 1px solid var(--divider-color);
-          border-radius: var(
-            --ha-card-border-radius,
-            var(--ha-border-radius-lg)
-          );
-          overflow: hidden;
+        ha-list-item-button,
+        ha-list-item-base {
+          --ha-row-item-gap: var(--ha-space-3);
+          --ha-row-item-min-height: 56px;
         }
 
-        .box > .row + .row {
-          border-top: 1px solid var(--divider-color);
-        }
-
-        .row {
-          display: flex;
-          align-items: center;
-          gap: var(--ha-space-4);
-          min-height: 48px;
-          padding: var(--ha-space-2) var(--ha-space-4);
-          box-sizing: border-box;
-        }
-
-        .row .label {
-          color: var(--secondary-text-color);
-          flex-shrink: 0;
-        }
-
-        .row .value {
-          flex: 1;
-          min-width: 0;
-          text-align: end;
-          overflow-wrap: anywhere;
-        }
-
-        .row.subject {
-          gap: var(--ha-space-3);
-          min-height: 56px;
-          width: 100%;
-          text-align: start;
-        }
-
-        button.row.subject {
-          border: none;
-          background: none;
-          color: inherit;
-          font: inherit;
-          cursor: pointer;
-        }
-
-        button.row.subject:hover {
-          background-color: rgba(var(--rgb-primary-text-color), 0.04);
+        /* Match the weight the chain gives its own row names. */
+        ha-list-item-button::part(headline),
+        ha-list-item-base::part(headline) {
+          font-weight: var(--ha-font-weight-medium);
         }
 
         .subject-icon {
           display: flex;
           align-items: center;
           justify-content: center;
-          flex-shrink: 0;
           width: 32px;
           color: var(--secondary-text-color);
           --state-icon-color: var(--secondary-text-color);
@@ -389,21 +346,7 @@ class DialogLogbookDetail
           margin: 0;
         }
 
-        .subject-name {
-          flex: 1;
-          min-width: 0;
-        }
-
-        .subject-name .name {
-          display: block;
-          font-weight: var(--ha-font-weight-medium);
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-        }
-
-        .chevron {
-          flex-shrink: 0;
+        ha-icon-next {
           color: var(--secondary-text-color);
         }
 
@@ -434,26 +377,21 @@ class DialogLogbookDetail
           display: contents;
         }
 
-        .section-title {
-          margin: 0 0 var(--ha-space-2);
-          font-size: var(--ha-font-size-m);
-          font-weight: var(--ha-font-weight-medium);
-        }
-
-        /* Reserved at two chain rows, the typical chain height, so the swap
-           from spinner to content barely moves the dialog. minmax(0, 1fr)
-           lets the chain shrink: a grid item defaults to its min-content
-           width, which a long automation name blows past. */
+        /* minmax(0, 1fr) lets the chain shrink: a grid item defaults to its
+           min-content width, which a long automation name blows past. */
         .chain-area {
           display: grid;
           grid-template-columns: minmax(0, 1fr);
-          min-height: 114px;
         }
 
+        /* Held at two chain rows, the typical chain height, so the swap from
+           spinner to content barely moves the dialog. The resolved content
+           sizes itself — a lone "no cause" line must not sit in a tall box. */
         .loading {
           display: flex;
           align-items: center;
           justify-content: center;
+          min-height: 114px;
         }
       `,
     ];

--- a/src/panels/logbook/dialog-logbook-detail.ts
+++ b/src/panels/logbook/dialog-logbook-detail.ts
@@ -1,3 +1,4 @@
+import { mdiPuzzle } from "@mdi/js";
 import type { HassEntity } from "home-assistant-js-websocket";
 import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
@@ -6,30 +7,23 @@ import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import { formatDateTimeWithSeconds } from "../../common/datetime/format_date_time";
 import { fireEvent } from "../../common/dom/fire_event";
-import type { LocalizeKeys } from "../../common/translations/localize";
 import "../../components/ha-adaptive-dialog";
 import "../../components/ha-alert";
+import "../../components/ha-icon";
+import "../../components/ha-icon-next";
 import "../../components/ha-relative-time";
 import "../../components/ha-spinner";
 import { fetchDateWS } from "../../data/history";
 import type { LogbookEntry } from "../../data/logbook";
 import type { HassDialog } from "../../dialogs/make-dialog-manager";
-import {
-  buttonLinkStyle,
-  haStyle,
-  haStyleDialog,
-} from "../../resources/styles";
+import { haStyle, haStyleDialog } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import "./ha-logbook-chain";
 import type { LogbookChain } from "./logbook-chain-resolver";
 import { resolveLogbookChain } from "./logbook-chain-resolver";
 import type { LogbookItem } from "./logbook-entry-model";
 import { computeLogbookItem } from "./logbook-entry-model";
-import {
-  entityNameButtonStyle,
-  renderEntityName,
-  transitionArrow,
-} from "./logbook-entry-templates";
+import { renderLogbookGlyph, transitionArrow } from "./logbook-entry-templates";
 import type { LogbookDetailDialogParams } from "./show-dialog-logbook-detail";
 
 @customElement("dialog-logbook-detail")
@@ -160,32 +154,10 @@ class DialogLogbookDetail
       : undefined;
     const transition = this._transitionValues(item, entry, stateObj);
     const when = this._entryDate(item.when);
-    const subjectKey =
-      item.category === "entity"
-        ? "entity"
-        : item.category === "automation"
-          ? entry.domain === "script"
-            ? "script"
-            : "automation"
-          : "integration";
 
     return html`
       <div class="box">
-        <div class="row">
-          <span class="label">
-            ${this.hass.localize(
-              `ui.dialogs.logbook_detail.${subjectKey}` as LocalizeKeys
-            )}
-          </span>
-          <span class="value">
-            ${renderEntityName(this.hass, item.name, entry.entity_id)}
-            ${
-              item.context
-                ? html`<span class="sub">${item.context}</span>`
-                : nothing
-            }
-          </span>
-        </div>
+        ${this._renderSubjectRow(item, entry)}
         ${
           transition
             ? html`
@@ -234,6 +206,51 @@ class DialogLogbookDetail
         </div>
       </div>
     `;
+  }
+
+  // Mirrors the target picker: icon, name, area ▸ device.
+  private _renderSubjectRow(item: LogbookItem, entry: LogbookEntry) {
+    const content = html`
+      <span class="subject-icon">
+        ${this._renderSubjectIcon(item, entry)}
+      </span>
+      <span class="subject-name">
+        <span class="name">${item.name}</span>
+        ${item.context ? html`<span class="sub">${item.context}</span>` : nothing}
+      </span>
+    `;
+
+    if (!entry.entity_id || !(entry.entity_id in this.hass.states)) {
+      return html`<div class="row subject">${content}</div>`;
+    }
+
+    return html`
+      <button
+        class="row subject clickable"
+        .entityId=${entry.entity_id}
+        @click=${this._entityClicked}
+      >
+        ${content}
+        <ha-icon-next class="chevron"></ha-icon-next>
+      </button>
+    `;
+  }
+
+  // The feed draws brand rows as a brands image, which stays blank for the
+  // integrations that have none. An integration domain resolves to no domain
+  // icon either, so fall back to the chain's own integration glyph.
+  private _renderSubjectIcon(item: LogbookItem, entry: LogbookEntry) {
+    if (item.glyph.type !== "brand") {
+      return renderLogbookGlyph(this.hass, entry, item.glyph);
+    }
+    return item.glyph.icon
+      ? html`<ha-icon .icon=${item.glyph.icon}></ha-icon>`
+      : html`<ha-svg-icon .path=${mdiPuzzle}></ha-svg-icon>`;
+  }
+
+  private _entityClicked(ev: Event) {
+    const target = ev.currentTarget as HTMLElement & { entityId: string };
+    fireEvent(target, "hass-more-info", { entityId: target.entityId });
   }
 
   private _renderWhatHappened(entry: LogbookEntry) {
@@ -296,8 +313,6 @@ class DialogLogbookDetail
     return [
       haStyle,
       haStyleDialog,
-      buttonLinkStyle,
-      entityNameButtonStyle,
       css`
         .content {
           display: flex;
@@ -339,8 +354,57 @@ class DialogLogbookDetail
           overflow-wrap: anywhere;
         }
 
-        .value .name {
+        .row.subject {
+          gap: var(--ha-space-3);
+          min-height: 56px;
+          width: 100%;
+          text-align: start;
+        }
+
+        button.row.subject {
+          border: none;
+          background: none;
+          color: inherit;
+          font: inherit;
+          cursor: pointer;
+        }
+
+        button.row.subject:hover {
+          background-color: rgba(var(--rgb-primary-text-color), 0.04);
+        }
+
+        .subject-icon {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          flex-shrink: 0;
+          width: 32px;
+          color: var(--secondary-text-color);
+          --state-icon-color: var(--secondary-text-color);
+        }
+
+        .subject-icon state-badge {
+          width: 32px;
+          height: 32px;
+          margin: 0;
+        }
+
+        .subject-name {
+          flex: 1;
+          min-width: 0;
+        }
+
+        .subject-name .name {
+          display: block;
           font-weight: var(--ha-font-weight-medium);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .chevron {
+          flex-shrink: 0;
+          color: var(--secondary-text-color);
         }
 
         .sub {
@@ -377,9 +441,12 @@ class DialogLogbookDetail
         }
 
         /* Reserved at two chain rows, the typical chain height, so the swap
-           from spinner to content barely moves the dialog. */
+           from spinner to content barely moves the dialog. minmax(0, 1fr)
+           lets the chain shrink: a grid item defaults to its min-content
+           width, which a long automation name blows past. */
         .chain-area {
           display: grid;
+          grid-template-columns: minmax(0, 1fr);
           min-height: 114px;
         }
 

--- a/src/panels/logbook/dialog-logbook-detail.ts
+++ b/src/panels/logbook/dialog-logbook-detail.ts
@@ -13,6 +13,7 @@ import "../../components/ha-icon";
 import "../../components/ha-icon-next";
 import "../../components/ha-relative-time";
 import "../../components/ha-spinner";
+import "../../components/ha-svg-icon";
 import "../../components/item/ha-list-item-base";
 import "../../components/item/ha-list-item-button";
 import "../../components/item/ha-list-item-value";

--- a/src/panels/logbook/ha-logbook-chain.ts
+++ b/src/panels/logbook/ha-logbook-chain.ts
@@ -5,11 +5,11 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import { formatTimeWithSeconds } from "../../common/datetime/format_time";
-import { fireEvent } from "../../common/dom/fire_event";
+import { isNavigationClick } from "../../common/dom/is-navigation-click";
 import { navigate } from "../../common/navigate";
-import type { LocalizeKeys } from "../../common/translations/localize";
 import "../../components/ha-state-icon";
 import "../../components/ha-svg-icon";
+import { computeServiceLabel } from "../../data/compute-service-info";
 import type { LogbookEntry } from "../../data/logbook";
 import { createHistoricState, localizeTriggerSource } from "../../data/logbook";
 import type { TraceContexts } from "../../data/trace";
@@ -26,6 +26,8 @@ import {
   nodeColor,
 } from "./logbook-entry-model";
 import {
+  entityNameButtonStyle,
+  renderEntityName,
   renderLogbookCauseIcon,
   renderLogbookGlyph,
 } from "./logbook-entry-templates";
@@ -95,11 +97,25 @@ class HaLogbookChain extends LitElement {
             ? "ui.components.logbook.script_ran"
             : "ui.components.logbook.automation_triggered"
         );
+    const traceLink = computeTraceLink(
+      this.traceContexts,
+      this.subject.context_id
+    );
     return html`
       <div class="chain-row">
         <span class="chain-node run">${renderLogbookCauseIcon(cause)}</span>
         <span class="chain-content">
-          ${this._renderName(cause.name, cause.entityId)}
+          ${renderEntityName(this.hass, cause.name, cause.entityId)}
+          ${
+            traceLink
+              ? html`<a
+                  class="trace-link"
+                  href=${traceLink}
+                  @click=${this._traceClicked}
+                  >${this.hass.localize("ui.components.logbook.view_trace")}</a
+                >`
+              : nothing
+          }
           ${sub ? html`<span class="chain-secondary">${sub}</span>` : nothing}
         </span>
       </div>
@@ -149,7 +165,7 @@ class HaLogbookChain extends LitElement {
           ${this._renderOriginIcon(origin, historicStateObj)}
         </span>
         <span class="chain-content">
-          ${this._renderName(name, origin.entityId)}
+          ${renderEntityName(this.hass, name, origin.entityId)}
           ${
             secondary
               ? html`<span class="chain-secondary">${secondary}</span>`
@@ -181,9 +197,10 @@ class HaLogbookChain extends LitElement {
       originRow.context_service
     ) {
       return this.hass.localize("ui.dialogs.logbook_detail.action_used", {
-        name: this._actionName(
-          originRow.context_domain,
-          originRow.context_service
+        name: computeServiceLabel(
+          this.hass.localize,
+          this.hass.services,
+          `${originRow.context_domain}.${originRow.context_service}`
         ),
       });
     }
@@ -225,7 +242,7 @@ class HaLogbookChain extends LitElement {
           ${renderLogbookGlyph(this.hass, row, item.glyph)}
         </span>
         <span class="chain-content">
-          ${this._renderName(item.name, row.entity_id)}
+          ${renderEntityName(this.hass, item.name, row.entity_id)}
           ${
             traceLink
               ? html`<a
@@ -268,7 +285,7 @@ class HaLogbookChain extends LitElement {
           ${renderLogbookGlyph(this.hass, row, item.glyph)}
         </span>
         <span class="chain-content">
-          ${this._renderName(item.name, row.entity_id)}
+          ${renderEntityName(this.hass, item.name, row.entity_id)}
           ${
             item.context
               ? html`<span class="chain-secondary">${item.context}</span>`
@@ -287,51 +304,20 @@ class HaLogbookChain extends LitElement {
     `;
   }
 
-  private _renderName(name: string | undefined, entityId?: string) {
-    if (entityId && entityId in this.hass.states) {
-      return html`<button
-        class="link name"
-        .entityId=${entityId}
-        @click=${this._entityClicked}
-      >
-        ${name}
-      </button>`;
-    }
-    return html`<span class="name">${name}</span>`;
-  }
-
-  private _actionName(domain: string, service: string) {
-    return (
-      this.hass.localize(
-        `component.${domain}.services.${service}.name` as LocalizeKeys
-      ) ||
-      this.hass.services[domain]?.[service]?.name ||
-      `${domain}.${service}`
-    );
-  }
-
-  private _entityClicked(ev: Event) {
-    const entityId = (ev.currentTarget as HTMLElement & { entityId?: string })
-      .entityId;
-    if (!entityId) {
-      return;
-    }
-    fireEvent(this, "hass-more-info", { entityId });
-  }
-
   private _traceClicked(ev: MouseEvent) {
-    if (ev.defaultPrevented || ev.button !== 0 || ev.metaKey || ev.ctrlKey) {
+    const href = isNavigationClick(ev);
+    if (!href) {
       return;
     }
-    ev.preventDefault();
     // navigate() closes the dialogs above this chain.
-    navigate((ev.currentTarget as HTMLAnchorElement).getAttribute("href")!);
+    navigate(href);
   }
 
   static get styles(): CSSResultGroup {
     return [
       haStyle,
       buttonLinkStyle,
+      entityNameButtonStyle,
       css`
         :host {
           display: block;
@@ -430,16 +416,6 @@ class HaLogbookChain extends LitElement {
           text-overflow: ellipsis;
           white-space: nowrap;
           text-align: start;
-        }
-
-        button.link.name {
-          color: var(--primary-text-color);
-          text-align: inherit;
-          text-decoration: none;
-        }
-
-        button.link.name:hover {
-          text-decoration: underline;
         }
 
         .chain-secondary {

--- a/src/panels/logbook/ha-logbook-chain.ts
+++ b/src/panels/logbook/ha-logbook-chain.ts
@@ -1,0 +1,491 @@
+import type { HassEntity } from "home-assistant-js-websocket";
+import { mdiClockOutline, mdiFlash, mdiHomeAssistant } from "@mdi/js";
+import type { CSSResultGroup } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
+import { formatTimeWithSeconds } from "../../common/datetime/format_time";
+import { fireEvent } from "../../common/dom/fire_event";
+import { navigate } from "../../common/navigate";
+import type { LocalizeKeys } from "../../common/translations/localize";
+import "../../components/ha-state-icon";
+import "../../components/ha-svg-icon";
+import type { LogbookEntry } from "../../data/logbook";
+import { createHistoricState, localizeTriggerSource } from "../../data/logbook";
+import type { TraceContexts } from "../../data/trace";
+import { buttonLinkStyle, haStyle } from "../../resources/styles";
+import type { HomeAssistant } from "../../types";
+import type { LogbookChain } from "./logbook-chain-resolver";
+import type { LogbookCause } from "./logbook-entry-model";
+import {
+  classifyLogbookEntry,
+  computeLogbookItem,
+  computeTraceLink,
+  entityDisplay,
+  isSameLogbookEntry,
+  nodeColor,
+} from "./logbook-entry-model";
+import {
+  renderLogbookCauseIcon,
+  renderLogbookGlyph,
+} from "./logbook-entry-templates";
+
+@customElement("ha-logbook-chain")
+class HaLogbookChain extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public chain!: LogbookChain;
+
+  @property({ attribute: false }) public subject!: LogbookEntry;
+
+  @property({ attribute: false }) public traceContexts: TraceContexts = {};
+
+  protected render() {
+    const { rows, runRow, origins, syntheticRun, triggerRow } = this.chain;
+
+    if (!origins.length && !runRow && !syntheticRun && rows.length <= 1) {
+      return html`
+        <div class="box">
+          <p class="no-cause">
+            ${this.hass.localize("ui.dialogs.logbook_detail.no_known_cause")}
+          </p>
+        </div>
+      `;
+    }
+
+    // An entity chain shows only its subject's rows; a run chain shows
+    // everything the run did.
+    const subjectIsRun = classifyLogbookEntry(this.subject) === "automation";
+    const visibleRows = subjectIsRun
+      ? rows
+      : rows.filter(
+          (row) =>
+            classifyLogbookEntry(row) === "automation" ||
+            (this.subject.entity_id
+              ? row.entity_id === this.subject.entity_id
+              : isSameLogbookEntry(row, this.subject))
+        );
+
+    return html`
+      <div class="box">
+        <div class="chain">
+          ${origins.map((origin) =>
+            this._renderOriginNode(
+              origin,
+              runRow ?? this.subject,
+              origin.type === "state" ? triggerRow : undefined
+            )
+          )}
+          ${syntheticRun ? this._renderSyntheticRunNode(syntheticRun) : nothing}
+          ${visibleRows.map((row) =>
+            classifyLogbookEntry(row) === "automation"
+              ? this._renderRunNode(row)
+              : this._renderEffectNode(row)
+          )}
+        </div>
+      </div>
+    `;
+  }
+
+  private _renderSyntheticRunNode(cause: LogbookCause) {
+    const sub = this.subject.context_source
+      ? localizeTriggerSource(this.hass.localize, this.subject.context_source)
+      : this.hass.localize(
+          cause.type === "script"
+            ? "ui.components.logbook.script_ran"
+            : "ui.components.logbook.automation_triggered"
+        );
+    return html`
+      <div class="chain-row">
+        <span class="chain-node run">${renderLogbookCauseIcon(cause)}</span>
+        <span class="chain-content">
+          ${this._renderName(cause.name, cause.entityId)}
+          ${sub ? html`<span class="chain-secondary">${sub}</span>` : nothing}
+        </span>
+      </div>
+    `;
+  }
+
+  private _renderOriginNode(
+    origin: LogbookCause,
+    originRow: LogbookEntry,
+    triggerRow?: LogbookEntry
+  ) {
+    const name =
+      origin.name ||
+      this.hass.localize("ui.components.logbook.cause.scheduled");
+    const isState = origin.type === "state";
+    const triggerState = isState
+      ? (triggerRow?.state ?? originRow.context_state)
+      : undefined;
+    const stateObj = origin.entityId
+      ? this.hass.states[origin.entityId]
+      : undefined;
+    const triggerValue = triggerState
+      ? stateObj
+        ? this.hass.formatEntityState(stateObj, triggerState)
+        : triggerState
+      : undefined;
+    const secondary = isState
+      ? origin.entityId
+        ? entityDisplay(this.hass, origin.entityId).secondary
+        : undefined
+      : this._actionUsedText(originRow);
+    const isAvatar = origin.type === "user" && !origin.systemUser;
+    const historicStateObj =
+      stateObj && triggerState
+        ? createHistoricState(stateObj, triggerState)
+        : stateObj;
+    const color =
+      isState && historicStateObj
+        ? nodeColor("entity", historicStateObj)
+        : undefined;
+    return html`
+      <div class="chain-row">
+        <span
+          class="chain-node ${isAvatar ? "avatar" : ""}"
+          style=${color ? styleMap({ "--node-color": color }) : nothing}
+        >
+          ${this._renderOriginIcon(origin, historicStateObj)}
+        </span>
+        <span class="chain-content">
+          ${this._renderName(name, origin.entityId)}
+          ${
+            secondary
+              ? html`<span class="chain-secondary">${secondary}</span>`
+              : nothing
+          }
+        </span>
+        ${
+          triggerValue
+            ? html`<span class="chain-trailing">
+                <span class="trailing-state">${triggerValue}</span>
+                ${
+                  triggerRow
+                    ? html`<span class="trailing-time"
+                        >${this._formatTimeWithMs(triggerRow.when * 1000)}</span
+                      >`
+                    : nothing
+                }
+              </span>`
+            : nothing
+        }
+      </div>
+    `;
+  }
+
+  private _actionUsedText(originRow: LogbookEntry) {
+    if (
+      originRow.context_event_type === "call_service" &&
+      originRow.context_domain &&
+      originRow.context_service
+    ) {
+      return this.hass.localize("ui.dialogs.logbook_detail.action_used", {
+        name: this._actionName(
+          originRow.context_domain,
+          originRow.context_service
+        ),
+      });
+    }
+    return "";
+  }
+
+  private _renderOriginIcon(origin: LogbookCause, stateObj?: HassEntity) {
+    if (origin.type === "state") {
+      return stateObj
+        ? html`<ha-state-icon .stateObj=${stateObj}></ha-state-icon>`
+        : html`<ha-svg-icon .path=${mdiFlash}></ha-svg-icon>`;
+    }
+    if (origin.type === "scheduled") {
+      return html`<ha-svg-icon .path=${mdiClockOutline}></ha-svg-icon>`;
+    }
+    if (origin.type === "homeassistant") {
+      return html`<ha-svg-icon .path=${mdiHomeAssistant}></ha-svg-icon>`;
+    }
+    return renderLogbookCauseIcon(origin);
+  }
+
+  private _formatTimeWithMs(when: number) {
+    const time = formatTimeWithSeconds(
+      new Date(when),
+      this.hass.locale,
+      this.hass.config
+    );
+    const ms = String(Math.floor(when % 1000)).padStart(3, "0");
+    return `${time}.${ms}`;
+  }
+
+  private _renderRunNode(row: LogbookEntry) {
+    const item = computeLogbookItem(this.hass, row);
+    const time = this._formatTimeWithMs(item.when);
+    const traceLink = computeTraceLink(this.traceContexts, row.context_id);
+    return html`
+      <div class="chain-row">
+        <span class="chain-node run">
+          ${renderLogbookGlyph(this.hass, row, item.glyph)}
+        </span>
+        <span class="chain-content">
+          ${this._renderName(item.name, row.entity_id)}
+          ${
+            traceLink
+              ? html`<a
+                  class="trace-link"
+                  href=${traceLink}
+                  @click=${this._traceClicked}
+                  >${this.hass.localize("ui.components.logbook.view_trace")}</a
+                >`
+              : nothing
+          }
+        </span>
+        <span class="chain-trailing">
+          ${
+            item.value
+              ? html`<span class="trailing-state">${item.value.text}</span>`
+              : nothing
+          }
+          <span class="trailing-time">${time}</span>
+        </span>
+      </div>
+    `;
+  }
+
+  private _renderEffectNode(row: LogbookEntry) {
+    const item = computeLogbookItem(this.hass, row);
+    const stateObj = row.entity_id
+      ? this.hass.states[row.entity_id]
+      : undefined;
+    const historicStateObj = stateObj
+      ? createHistoricState(stateObj, row.state)
+      : undefined;
+    const color = nodeColor(item.category, historicStateObj);
+    const time = this._formatTimeWithMs(item.when);
+    return html`
+      <div class="chain-row">
+        <span
+          class="chain-node"
+          style=${color ? styleMap({ "--node-color": color }) : nothing}
+        >
+          ${renderLogbookGlyph(this.hass, row, item.glyph)}
+        </span>
+        <span class="chain-content">
+          ${this._renderName(item.name, row.entity_id)}
+          ${
+            item.context
+              ? html`<span class="chain-secondary">${item.context}</span>`
+              : nothing
+          }
+        </span>
+        <span class="chain-trailing">
+          ${
+            item.value
+              ? html`<span class="trailing-state">${item.value.text}</span>`
+              : nothing
+          }
+          <span class="trailing-time">${time}</span>
+        </span>
+      </div>
+    `;
+  }
+
+  private _renderName(name: string | undefined, entityId?: string) {
+    if (entityId && entityId in this.hass.states) {
+      return html`<button
+        class="link name"
+        .entityId=${entityId}
+        @click=${this._entityClicked}
+      >
+        ${name}
+      </button>`;
+    }
+    return html`<span class="name">${name}</span>`;
+  }
+
+  private _actionName(domain: string, service: string) {
+    return (
+      this.hass.localize(
+        `component.${domain}.services.${service}.name` as LocalizeKeys
+      ) ||
+      this.hass.services[domain]?.[service]?.name ||
+      `${domain}.${service}`
+    );
+  }
+
+  private _entityClicked(ev: Event) {
+    const entityId = (ev.currentTarget as HTMLElement & { entityId?: string })
+      .entityId;
+    if (!entityId) {
+      return;
+    }
+    fireEvent(this, "hass-more-info", { entityId });
+  }
+
+  private _traceClicked(ev: MouseEvent) {
+    if (ev.defaultPrevented || ev.button !== 0 || ev.metaKey || ev.ctrlKey) {
+      return;
+    }
+    ev.preventDefault();
+    // navigate() closes the dialogs above this chain.
+    navigate((ev.currentTarget as HTMLAnchorElement).getAttribute("href")!);
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      buttonLinkStyle,
+      css`
+        :host {
+          display: block;
+        }
+
+        .box {
+          border: 1px solid var(--divider-color);
+          border-radius: var(
+            --ha-card-border-radius,
+            var(--ha-border-radius-lg)
+          );
+          overflow: hidden;
+        }
+
+        .chain-row {
+          position: relative;
+          display: flex;
+          align-items: center;
+          gap: var(--ha-space-4);
+          min-height: 56px;
+          padding: var(--ha-space-2) var(--ha-space-4);
+          box-sizing: border-box;
+        }
+
+        /* Caret between rows: the chain reads top-down, cause to effects. */
+        .chain-row + .chain-row::before {
+          content: "";
+          position: absolute;
+          top: -3px;
+          inset-inline-start: 27px;
+          border-inline-start: 5px solid transparent;
+          border-inline-end: 5px solid transparent;
+          border-top: 6px solid var(--divider-color);
+        }
+
+        .chain-node {
+          position: relative;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          flex-shrink: 0;
+          width: 32px;
+          height: 32px;
+          border-radius: var(--ha-border-radius-circle);
+          background-color: var(--card-background-color);
+          color: var(--node-color, var(--secondary-text-color));
+          --mdc-icon-size: 18px;
+        }
+
+        .chain-node state-badge {
+          margin: 0;
+          color: inherit;
+        }
+
+        .chain-node::before {
+          content: "";
+          position: absolute;
+          inset: 0;
+          border-radius: inherit;
+          background-color: currentColor;
+          opacity: 0.15;
+        }
+
+        .chain-node > * {
+          position: relative;
+        }
+
+        .chain-node.run {
+          color: var(
+            --logbook-category-automation-color,
+            var(--light-blue-color)
+          );
+          border-radius: var(--ha-border-radius-md);
+        }
+
+        .chain-node.avatar::before {
+          display: none;
+        }
+
+        .chain-node.avatar ha-user-badge {
+          width: 32px;
+          height: 32px;
+          font-size: 14px;
+        }
+
+        .chain-content {
+          display: flex;
+          flex-direction: column;
+          flex: 1;
+          min-width: 0;
+        }
+
+        .chain-content .name {
+          font-weight: var(--ha-font-weight-medium);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          text-align: start;
+        }
+
+        button.link.name {
+          color: var(--primary-text-color);
+          text-align: inherit;
+          text-decoration: none;
+        }
+
+        button.link.name:hover {
+          text-decoration: underline;
+        }
+
+        .chain-secondary {
+          color: var(--secondary-text-color);
+          font-size: var(--ha-font-size-s);
+        }
+
+        .chain-trailing {
+          text-align: end;
+          flex-shrink: 0;
+        }
+
+        .trailing-state {
+          display: block;
+        }
+
+        .trailing-time {
+          display: block;
+          color: var(--secondary-text-color);
+          font-size: var(--ha-font-size-s);
+          font-variant-numeric: tabular-nums;
+        }
+
+        .trace-link {
+          flex-shrink: 0;
+          color: var(--primary-color);
+          font-size: var(--ha-font-size-s);
+          text-decoration: none;
+        }
+
+        .trace-link:hover {
+          text-decoration: underline;
+        }
+
+        .no-cause {
+          margin: 0;
+          padding: var(--ha-space-3) var(--ha-space-4);
+          color: var(--secondary-text-color);
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-logbook-chain": HaLogbookChain;
+  }
+}

--- a/src/panels/logbook/ha-logbook-chain.ts
+++ b/src/panels/logbook/ha-logbook-chain.ts
@@ -18,10 +18,10 @@ import type { HomeAssistant } from "../../types";
 import type { LogbookChain } from "./logbook-chain-resolver";
 import type { LogbookCause } from "./logbook-entry-model";
 import {
-  classifyLogbookEntry,
   computeLogbookItem,
   computeTraceLink,
   entityDisplay,
+  isRunRow,
   isSameLogbookEntry,
   nodeColor,
 } from "./logbook-entry-model";
@@ -55,18 +55,20 @@ class HaLogbookChain extends LitElement {
       `;
     }
 
-    // An entity chain shows only its subject's rows; a run chain shows
-    // everything the run did.
-    const subjectIsRun = classifyLogbookEntry(this.subject) === "automation";
-    const visibleRows = subjectIsRun
-      ? rows
-      : rows.filter(
-          (row) =>
-            classifyLogbookEntry(row) === "automation" ||
-            (this.subject.entity_id
-              ? row.entity_id === this.subject.entity_id
-              : isSameLogbookEntry(row, this.subject))
-        );
+    // The chain is the subject's cause path: the runs recorded before its
+    // rows (user → automation → script → entity). Sibling effects and runs
+    // recorded after the subject are not causes and stay out.
+    const isSubjectRow = (row: LogbookEntry) =>
+      this.subject.entity_id
+        ? row.entity_id === this.subject.entity_id
+        : isSameLogbookEntry(row, this.subject);
+    const firstSubjectIndex = rows.findIndex(isSubjectRow);
+    const visibleRows = rows.filter(
+      (row, index) =>
+        isSubjectRow(row) ||
+        (isRunRow(row) &&
+          (firstSubjectIndex === -1 || index < firstSubjectIndex))
+    );
 
     return html`
       <div class="box">
@@ -80,7 +82,7 @@ class HaLogbookChain extends LitElement {
           )}
           ${syntheticRun ? this._renderSyntheticRunNode(syntheticRun) : nothing}
           ${visibleRows.map((row) =>
-            classifyLogbookEntry(row) === "automation"
+            isRunRow(row)
               ? this._renderRunNode(row)
               : this._renderEffectNode(row)
           )}

--- a/src/panels/logbook/ha-logbook-chain.ts
+++ b/src/panels/logbook/ha-logbook-chain.ts
@@ -1,5 +1,5 @@
 import type { HassEntity } from "home-assistant-js-websocket";
-import { mdiClockOutline, mdiHomeAssistant, mdiStateMachine } from "@mdi/js";
+import { mdiStateMachine } from "@mdi/js";
 import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
@@ -214,12 +214,6 @@ class HaLogbookChain extends LitElement {
       return stateObj
         ? html`<ha-state-icon .stateObj=${stateObj}></ha-state-icon>`
         : html`<ha-svg-icon .path=${mdiStateMachine}></ha-svg-icon>`;
-    }
-    if (origin.type === "scheduled") {
-      return html`<ha-svg-icon .path=${mdiClockOutline}></ha-svg-icon>`;
-    }
-    if (origin.type === "homeassistant") {
-      return html`<ha-svg-icon .path=${mdiHomeAssistant}></ha-svg-icon>`;
     }
     return renderLogbookCauseIcon(origin);
   }

--- a/src/panels/logbook/ha-logbook-chain.ts
+++ b/src/panels/logbook/ha-logbook-chain.ts
@@ -1,5 +1,5 @@
 import type { HassEntity } from "home-assistant-js-websocket";
-import { mdiClockOutline, mdiFlash, mdiHomeAssistant } from "@mdi/js";
+import { mdiClockOutline, mdiHomeAssistant, mdiStateMachine } from "@mdi/js";
 import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
@@ -213,7 +213,7 @@ class HaLogbookChain extends LitElement {
     if (origin.type === "state") {
       return stateObj
         ? html`<ha-state-icon .stateObj=${stateObj}></ha-state-icon>`
-        : html`<ha-svg-icon .path=${mdiFlash}></ha-svg-icon>`;
+        : html`<ha-svg-icon .path=${mdiStateMachine}></ha-svg-icon>`;
     }
     if (origin.type === "scheduled") {
       return html`<ha-svg-icon .path=${mdiClockOutline}></ha-svg-icon>`;

--- a/src/panels/logbook/ha-logbook-chain.ts
+++ b/src/panels/logbook/ha-logbook-chain.ts
@@ -1,19 +1,21 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import { mdiStateMachine } from "@mdi/js";
-import type { CSSResultGroup } from "lit";
+import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import { formatTimeWithSeconds } from "../../common/datetime/format_time";
+import { fireEvent } from "../../common/dom/fire_event";
 import { isNavigationClick } from "../../common/dom/is-navigation-click";
 import { navigate } from "../../common/navigate";
+import "../../components/ha-icon-next";
 import "../../components/ha-state-icon";
 import "../../components/ha-svg-icon";
 import { computeServiceLabel } from "../../data/compute-service-info";
 import type { LogbookEntry } from "../../data/logbook";
 import { createHistoricState, localizeTriggerSource } from "../../data/logbook";
 import type { TraceContexts } from "../../data/trace";
-import { buttonLinkStyle, haStyle } from "../../resources/styles";
+import { haStyle } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import type { LogbookChain } from "./logbook-chain-resolver";
 import type { LogbookCause } from "./logbook-entry-model";
@@ -26,8 +28,6 @@ import {
   nodeColor,
 } from "./logbook-entry-model";
 import {
-  entityNameButtonStyle,
-  renderEntityName,
   renderLogbookCauseIcon,
   renderLogbookGlyph,
 } from "./logbook-entry-templates";
@@ -91,8 +91,40 @@ class HaLogbookChain extends LitElement {
     `;
   }
 
+  // A div rather than a button: a run row nests the trace link inside it.
+  private _renderRow(entityId: string | undefined, content: TemplateResult) {
+    if (!entityId || !(entityId in this.hass.states)) {
+      return html`<div class="chain-row">${content}</div>`;
+    }
+    return html`
+      <div
+        class="chain-row clickable"
+        role="button"
+        tabindex="0"
+        .entityId=${entityId}
+        @click=${this._entityClicked}
+        @keydown=${this._rowKeydown}
+      >
+        ${content}
+        <ha-icon-next class="chevron"></ha-icon-next>
+      </div>
+    `;
+  }
+
+  private _renderTraceLink(traceLink?: string) {
+    if (!traceLink) {
+      return nothing;
+    }
+    return html`<a
+      class="trace-link"
+      href=${traceLink}
+      @click=${this._traceClicked}
+      >${this.hass.localize("ui.components.logbook.view_trace")}</a
+    >`;
+  }
+
   private _renderSyntheticRunNode(cause: LogbookCause) {
-    const sub = this.subject.context_source
+    const mechanism = this.subject.context_source
       ? localizeTriggerSource(this.hass.localize, this.subject.context_source)
       : this.hass.localize(
           cause.type === "script"
@@ -103,25 +135,21 @@ class HaLogbookChain extends LitElement {
       this.traceContexts,
       this.subject.context_id
     );
-    return html`
-      <div class="chain-row">
+    return this._renderRow(
+      cause.entityId,
+      html`
         <span class="chain-node run">${renderLogbookCauseIcon(cause)}</span>
         <span class="chain-content">
-          ${renderEntityName(this.hass, cause.name, cause.entityId)}
+          <span class="name">${cause.name}</span>
           ${
-            traceLink
-              ? html`<a
-                  class="trace-link"
-                  href=${traceLink}
-                  @click=${this._traceClicked}
-                  >${this.hass.localize("ui.components.logbook.view_trace")}</a
-                >`
+            mechanism
+              ? html`<span class="chain-secondary">${mechanism}</span>`
               : nothing
           }
-          ${sub ? html`<span class="chain-secondary">${sub}</span>` : nothing}
+          ${this._renderTraceLink(traceLink)}
         </span>
-      </div>
-    `;
+      `
+    );
   }
 
   private _renderOriginNode(
@@ -158,8 +186,9 @@ class HaLogbookChain extends LitElement {
       isState && historicStateObj
         ? nodeColor("entity", historicStateObj)
         : undefined;
-    return html`
-      <div class="chain-row">
+    return this._renderRow(
+      origin.entityId,
+      html`
         <span
           class="chain-node ${isAvatar ? "avatar" : ""}"
           style=${color ? styleMap({ "--node-color": color }) : nothing}
@@ -167,7 +196,7 @@ class HaLogbookChain extends LitElement {
           ${this._renderOriginIcon(origin, historicStateObj)}
         </span>
         <span class="chain-content">
-          ${renderEntityName(this.hass, name, origin.entityId)}
+          <span class="name">${name}</span>
           ${
             secondary
               ? html`<span class="chain-secondary">${secondary}</span>`
@@ -188,8 +217,8 @@ class HaLogbookChain extends LitElement {
               </span>`
             : nothing
         }
-      </div>
-    `;
+      `
+    );
   }
 
   private _actionUsedText(originRow: LogbookEntry) {
@@ -232,23 +261,15 @@ class HaLogbookChain extends LitElement {
     const item = computeLogbookItem(this.hass, row);
     const time = this._formatTimeWithMs(item.when);
     const traceLink = computeTraceLink(this.traceContexts, row.context_id);
-    return html`
-      <div class="chain-row">
+    return this._renderRow(
+      row.entity_id,
+      html`
         <span class="chain-node run">
           ${renderLogbookGlyph(this.hass, row, item.glyph)}
         </span>
         <span class="chain-content">
-          ${renderEntityName(this.hass, item.name, row.entity_id)}
-          ${
-            traceLink
-              ? html`<a
-                  class="trace-link"
-                  href=${traceLink}
-                  @click=${this._traceClicked}
-                  >${this.hass.localize("ui.components.logbook.view_trace")}</a
-                >`
-              : nothing
-          }
+          <span class="name">${item.name}</span>
+          ${this._renderTraceLink(traceLink)}
         </span>
         <span class="chain-trailing">
           ${
@@ -258,8 +279,8 @@ class HaLogbookChain extends LitElement {
           }
           <span class="trailing-time">${time}</span>
         </span>
-      </div>
-    `;
+      `
+    );
   }
 
   private _renderEffectNode(row: LogbookEntry) {
@@ -272,8 +293,9 @@ class HaLogbookChain extends LitElement {
       : undefined;
     const color = nodeColor(item.category, historicStateObj);
     const time = this._formatTimeWithMs(item.when);
-    return html`
-      <div class="chain-row">
+    return this._renderRow(
+      row.entity_id,
+      html`
         <span
           class="chain-node"
           style=${color ? styleMap({ "--node-color": color }) : nothing}
@@ -281,7 +303,7 @@ class HaLogbookChain extends LitElement {
           ${renderLogbookGlyph(this.hass, row, item.glyph)}
         </span>
         <span class="chain-content">
-          ${renderEntityName(this.hass, item.name, row.entity_id)}
+          <span class="name">${item.name}</span>
           ${
             item.context
               ? html`<span class="chain-secondary">${item.context}</span>`
@@ -296,11 +318,29 @@ class HaLogbookChain extends LitElement {
           }
           <span class="trailing-time">${time}</span>
         </span>
-      </div>
-    `;
+      `
+    );
+  }
+
+  private _entityClicked(ev: Event) {
+    const target = ev.currentTarget as HTMLElement & { entityId: string };
+    fireEvent(target, "hass-more-info", { entityId: target.entityId });
+  }
+
+  private _rowKeydown(ev: KeyboardEvent) {
+    if (ev.key !== "Enter" && ev.key !== " ") {
+      return;
+    }
+    if (ev.target !== ev.currentTarget) {
+      return;
+    }
+    ev.preventDefault();
+    this._entityClicked(ev);
   }
 
   private _traceClicked(ev: MouseEvent) {
+    // The row underneath opens the more info; the link owns its own click.
+    ev.stopPropagation();
     const href = isNavigationClick(ev);
     if (!href) {
       return;
@@ -312,8 +352,6 @@ class HaLogbookChain extends LitElement {
   static get styles(): CSSResultGroup {
     return [
       haStyle,
-      buttonLinkStyle,
-      entityNameButtonStyle,
       css`
         :host {
           display: block;
@@ -333,9 +371,23 @@ class HaLogbookChain extends LitElement {
           display: flex;
           align-items: center;
           gap: var(--ha-space-4);
+          width: 100%;
           min-height: 56px;
           padding: var(--ha-space-2) var(--ha-space-4);
           box-sizing: border-box;
+        }
+
+        .chain-row.clickable {
+          cursor: pointer;
+        }
+
+        .chain-row.clickable:hover {
+          background-color: rgba(var(--rgb-primary-text-color), 0.04);
+        }
+
+        .chain-row.clickable:focus-visible {
+          outline: 2px solid var(--primary-color);
+          outline-offset: -2px;
         }
 
         /* Caret between rows: the chain reads top-down, cause to effects. */
@@ -411,12 +463,22 @@ class HaLogbookChain extends LitElement {
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
-          text-align: start;
         }
 
         .chain-secondary {
           color: var(--secondary-text-color);
           font-size: var(--ha-font-size-s);
+        }
+
+        .trace-link {
+          align-self: flex-start;
+          color: var(--primary-color);
+          font-size: var(--ha-font-size-s);
+          text-decoration: none;
+        }
+
+        .trace-link:hover {
+          text-decoration: underline;
         }
 
         .chain-trailing {
@@ -435,15 +497,9 @@ class HaLogbookChain extends LitElement {
           font-variant-numeric: tabular-nums;
         }
 
-        .trace-link {
+        .chevron {
           flex-shrink: 0;
-          color: var(--primary-color);
-          font-size: var(--ha-font-size-s);
-          text-decoration: none;
-        }
-
-        .trace-link:hover {
-          text-decoration: underline;
+          color: var(--secondary-text-color);
         }
 
         .no-cause {

--- a/src/panels/logbook/ha-logbook-chain.ts
+++ b/src/panels/logbook/ha-logbook-chain.ts
@@ -4,7 +4,7 @@ import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
-import { formatTimeWithSeconds } from "../../common/datetime/format_time";
+import { formatTimeWithMilliseconds } from "../../common/datetime/format_time";
 import { fireEvent } from "../../common/dom/fire_event";
 import { isNavigationClick } from "../../common/dom/is-navigation-click";
 import { navigate } from "../../common/navigate";
@@ -242,13 +242,11 @@ class HaLogbookChain extends LitElement {
   }
 
   private _formatTimeWithMs(when: number) {
-    const time = formatTimeWithSeconds(
+    return formatTimeWithMilliseconds(
       new Date(when),
       this.hass.locale,
       this.hass.config
     );
-    const ms = String(Math.floor(when % 1000)).padStart(3, "0");
-    return `${time}.${ms}`;
   }
 
   private _renderRunNode(row: LogbookEntry) {

--- a/src/panels/logbook/ha-logbook-chain.ts
+++ b/src/panels/logbook/ha-logbook-chain.ts
@@ -47,11 +47,9 @@ class HaLogbookChain extends LitElement {
 
     if (!origins.length && !runRow && !syntheticRun && rows.length <= 1) {
       return html`
-        <div class="box">
-          <p class="no-cause">
-            ${this.hass.localize("ui.dialogs.logbook_detail.no_known_cause")}
-          </p>
-        </div>
+        <p class="no-cause">
+          ${this.hass.localize("ui.dialogs.logbook_detail.no_known_cause")}
+        </p>
       `;
     }
 
@@ -71,22 +69,18 @@ class HaLogbookChain extends LitElement {
     );
 
     return html`
-      <div class="box">
-        <div class="chain">
-          ${origins.map((origin) =>
-            this._renderOriginNode(
-              origin,
-              runRow ?? this.subject,
-              origin.type === "state" ? triggerRow : undefined
-            )
-          )}
-          ${syntheticRun ? this._renderSyntheticRunNode(syntheticRun) : nothing}
-          ${visibleRows.map((row) =>
-            isRunRow(row)
-              ? this._renderRunNode(row)
-              : this._renderEffectNode(row)
-          )}
-        </div>
+      <div class="chain">
+        ${origins.map((origin) =>
+          this._renderOriginNode(
+            origin,
+            runRow ?? this.subject,
+            origin.type === "state" ? triggerRow : undefined
+          )
+        )}
+        ${syntheticRun ? this._renderSyntheticRunNode(syntheticRun) : nothing}
+        ${visibleRows.map((row) =>
+          isRunRow(row) ? this._renderRunNode(row) : this._renderEffectNode(row)
+        )}
       </div>
     `;
   }
@@ -357,23 +351,17 @@ class HaLogbookChain extends LitElement {
           display: block;
         }
 
-        .box {
-          border: 1px solid var(--divider-color);
-          border-radius: var(
-            --ha-card-border-radius,
-            var(--ha-border-radius-lg)
-          );
-          overflow: hidden;
-        }
-
+        /* The enclosing ha-grouped-list owns the frame; the rows only have to
+           line up with its own items. */
         .chain-row {
           position: relative;
           display: flex;
           align-items: center;
-          gap: var(--ha-space-4);
+          gap: var(--ha-space-3);
           width: 100%;
           min-height: 56px;
-          padding: var(--ha-space-2) var(--ha-space-4);
+          padding: var(--ha-space-2)
+            var(--ha-row-item-padding-inline, var(--ha-space-3));
           box-sizing: border-box;
         }
 
@@ -390,12 +378,16 @@ class HaLogbookChain extends LitElement {
           outline-offset: -2px;
         }
 
-        /* Caret between rows: the chain reads top-down, cause to effects. */
+        /* Caret between rows: the chain reads top-down, cause to effects.
+           Centered on the node: row padding + half the 32px node - half the
+           caret. */
         .chain-row + .chain-row::before {
           content: "";
           position: absolute;
           top: -3px;
-          inset-inline-start: 27px;
+          inset-inline-start: calc(
+            var(--ha-row-item-padding-inline, var(--ha-space-3)) + 11px
+          );
           border-inline-start: 5px solid transparent;
           border-inline-end: 5px solid transparent;
           border-top: 6px solid var(--divider-color);
@@ -504,7 +496,8 @@ class HaLogbookChain extends LitElement {
 
         .no-cause {
           margin: 0;
-          padding: var(--ha-space-3) var(--ha-space-4);
+          padding: var(--ha-space-3)
+            var(--ha-row-item-padding-inline, var(--ha-space-3));
           color: var(--secondary-text-color);
         }
       `,

--- a/src/panels/logbook/ha-logbook-entry.ts
+++ b/src/panels/logbook/ha-logbook-entry.ts
@@ -37,7 +37,6 @@ interface LogbookRenderItem extends LogbookItem {
 }
 
 export interface LogbookEntrySelectedDetail {
-  index: number;
   item: LogbookEntry;
 }
 
@@ -58,8 +57,6 @@ class HaLogbookEntry extends LitElement {
     {};
 
   @property({ attribute: false }) public systemUserIds = new Set<string>();
-
-  @property({ attribute: false }) public index = -1;
 
   @property({ type: Boolean, attribute: "no-row-click" }) public noRowClick =
     false;
@@ -183,10 +180,7 @@ class HaLogbookEntry extends LitElement {
     if (this.noRowClick) {
       return;
     }
-    fireEvent(this, "logbook-entry-selected", {
-      index: this.index,
-      item: this.item,
-    });
+    fireEvent(this, "logbook-entry-selected", { item: this.item });
   }
 
   private _rowKeydown(ev: KeyboardEvent) {

--- a/src/panels/logbook/ha-logbook-entry.ts
+++ b/src/panels/logbook/ha-logbook-entry.ts
@@ -556,6 +556,7 @@ class HaLogbookEntry extends LitElement {
 
         .entry.clickable {
           cursor: pointer;
+          user-select: none;
         }
 
         .entry.clickable:hover {

--- a/src/panels/logbook/ha-logbook-entry.ts
+++ b/src/panels/logbook/ha-logbook-entry.ts
@@ -1,58 +1,52 @@
-import { mdiCast, mdiCloud, mdiPuzzle, mdiRobot, mdiScriptText } from "@mdi/js";
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
-import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import { computeTimelineColor } from "../../components/chart/timeline-color";
 import { computeDomain } from "../../common/entity/compute_domain";
 import { formatTimeWithSeconds } from "../../common/datetime/format_time";
 import { useAmPm } from "../../common/datetime/use_am_pm";
 import { fireEvent } from "../../common/dom/fire_event";
-import { navigate } from "../../common/navigate";
 import { computeRTL } from "../../common/util/compute_rtl";
-import "../../components/entity/state-badge";
 import "../../components/ha-relative-time";
-import "../../components/ha-domain-icon";
-import "../../components/ha-state-icon";
-import "../../components/ha-svg-icon";
 import "../../components/ha-tooltip";
-import "../../components/user/ha-user-badge";
 import { UNAVAILABLE } from "../../data/entity/entity";
 import type { LogbookEntry } from "../../data/logbook";
-import type { TraceContexts } from "../../data/trace";
-import type { User } from "../../data/user";
 import { buttonLinkStyle, haStyle } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
-import { brandsUrl } from "../../util/brands-url";
 import type {
   LogbookCause,
   LogbookCauseType,
-  LogbookGlyph,
   LogbookItem,
   LogbookNameDetail,
   LogbookValue,
 } from "./logbook-entry-model";
+import { computeLogbookItem, nodeColor } from "./logbook-entry-model";
 import {
-  computeLogbookItem,
-  nodeColor,
-  TRIGGER_DOMAINS,
-} from "./logbook-entry-model";
+  renderLogbookCauseIcon,
+  renderLogbookGlyph,
+} from "./logbook-entry-templates";
 
 type EntryLayout = "timeline" | "list" | "inline";
 
 interface LogbookRenderItem extends LogbookItem {
-  traceLink: string | undefined;
   renderedTime: TemplateResult | string;
   renderedValue: TemplateResult | string;
 }
 
-// Names are the fixed system user names set by core (cloud/cast integrations).
-const SYSTEM_USER_ICONS: Record<string, string> = {
-  "Home Assistant Cloud": mdiCloud,
-  "Home Assistant Cast": mdiCast,
-};
+export interface LogbookEntrySelectedDetail {
+  index: number;
+  item: LogbookEntry;
+}
+
+declare global {
+  interface HASSDomEvents {
+    "logbook-entry-selected": LogbookEntrySelectedDetail;
+    "logbook-toggle-time": undefined;
+  }
+}
 
 @customElement("ha-logbook-entry")
 class HaLogbookEntry extends LitElement {
@@ -65,7 +59,10 @@ class HaLogbookEntry extends LitElement {
 
   @property({ attribute: false }) public systemUserIds = new Set<string>();
 
-  @property({ attribute: false }) public traceContexts: TraceContexts = {};
+  @property({ attribute: false }) public index = -1;
+
+  @property({ type: Boolean, attribute: "no-row-click" }) public noRowClick =
+    false;
 
   @property({ type: Boolean }) public narrow = false;
 
@@ -99,17 +96,6 @@ class HaLogbookEntry extends LitElement {
       systemUserIds: this.systemUserIds,
     });
 
-    const traceContext =
-      entry.domain &&
-      TRIGGER_DOMAINS.includes(entry.domain) &&
-      entry.context_id &&
-      entry.context_id in this.traceContexts
-        ? this.traceContexts[entry.context_id]
-        : undefined;
-    const traceLink = traceContext
-      ? `/config/${traceContext.domain}/trace/${traceContext.item_id}?run_id=${traceContext.run_id}`
-      : undefined;
-
     const hideName = this.nameDetail === "none";
     const layout: EntryLayout =
       !this.narrow && !this.noIcon ? "timeline" : hideName ? "inline" : "list";
@@ -125,10 +111,11 @@ class HaLogbookEntry extends LitElement {
 
     const ctx: LogbookRenderItem = {
       ...item,
-      traceLink,
       renderedTime,
-      renderedValue: this._renderValue(item.value, seenEntityIds, !!traceLink),
+      renderedValue: this._renderValue(item.value, seenEntityIds),
     };
+
+    const clickable = !this.noRowClick;
 
     return html`
       <div
@@ -138,7 +125,12 @@ class HaLogbookEntry extends LitElement {
           "last-of-day": this.lastOfDay,
           [`category-${ctx.category}`]: true,
           "time-am-pm": useAmPm(this.hass.locale),
+          clickable,
         })}"
+        role=${ifDefined(clickable ? "button" : undefined)}
+        tabindex=${ifDefined(clickable ? "0" : undefined)}
+        @click=${this._rowClicked}
+        @keydown=${this._rowKeydown}
       >
         ${
           layout === "timeline"
@@ -176,24 +168,36 @@ class HaLogbookEntry extends LitElement {
 
   private _toggleTime(e: Event) {
     e.stopPropagation();
-    fireEvent(this, "logbook-toggle-time" as any);
+    fireEvent(this, "logbook-toggle-time");
   }
 
   private _timeKeydown(e: KeyboardEvent) {
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
-      fireEvent(this, "logbook-toggle-time" as any);
+      e.stopPropagation();
+      fireEvent(this, "logbook-toggle-time");
     }
   }
 
-  private _handleTraceClick(ev: MouseEvent) {
-    // Let modified clicks open in a new tab; otherwise route in-app.
-    if (ev.defaultPrevented || ev.button !== 0 || ev.metaKey || ev.ctrlKey) {
+  private _rowClicked() {
+    if (this.noRowClick) {
+      return;
+    }
+    fireEvent(this, "logbook-entry-selected", {
+      index: this.index,
+      item: this.item,
+    });
+  }
+
+  private _rowKeydown(ev: KeyboardEvent) {
+    if (this.noRowClick || (ev.key !== "Enter" && ev.key !== " ")) {
+      return;
+    }
+    if (ev.target !== ev.currentTarget) {
       return;
     }
     ev.preventDefault();
-    navigate((ev.currentTarget as HTMLAnchorElement).getAttribute("href")!);
-    fireEvent(this, "closed");
+    this._rowClicked();
   }
 
   private _entityClicked(ev: Event) {
@@ -217,7 +221,6 @@ class HaLogbookEntry extends LitElement {
 
   private _renderTrailing(
     cause: LogbookCause | undefined,
-    traceLink: string | undefined,
     renderedTime: TemplateResult | string
   ) {
     return html`<span class="trailing">
@@ -225,22 +228,12 @@ class HaLogbookEntry extends LitElement {
         cause
           ? html`<ha-tooltip for="cause-badge">${cause.name}</ha-tooltip>
               <span class="cause-badge" id="cause-badge"
-                >${this._renderCauseIcon(cause)}</span
+                >${renderLogbookCauseIcon(cause)}</span
               >`
           : nothing
       }
-      ${traceLink ? this._renderTraceLink(traceLink) : nothing}
       ${this._renderTimeChip(renderedTime)}
     </span>`;
-  }
-
-  private _renderTraceLink(traceLink: string) {
-    return html`<a
-      class="trace-link"
-      href=${traceLink}
-      @click=${this._handleTraceClick}
-      >${this.hass.localize("ui.components.logbook.view_trace")}</a
-    >`;
   }
 
   private _renderTimeline(ctx: LogbookRenderItem) {
@@ -279,15 +272,9 @@ class HaLogbookEntry extends LitElement {
           : nothing
       }
       ${
-        causePhrase || ctx.traceLink
+        causePhrase
           ? html`<div class="secondary">
-              ${
-                causePhrase
-                  ? html`<span class="cause-phrase">${causePhrase}</span>`
-                  : nothing
-              }
-              ${causePhrase && ctx.traceLink ? html`·` : nothing}
-              ${ctx.traceLink ? this._renderTraceLink(ctx.traceLink) : nothing}
+              <span class="cause-phrase">${causePhrase}</span>
             </div>`
           : nothing
       }
@@ -297,9 +284,7 @@ class HaLogbookEntry extends LitElement {
   private _renderList(ctx: LogbookRenderItem) {
     const cause =
       this.showCause || ctx.category === "entity" ? ctx.cause : undefined;
-    const trailingTrace = this.showCause ? undefined : ctx.traceLink;
-    const thirdLineTrace = this.showCause ? ctx.traceLink : undefined;
-    const showThirdLine = this.showCause && (cause || thirdLineTrace);
+    const showThirdLine = this.showCause && cause;
     return html`
       <div class="primary">
         <span class="subject"
@@ -313,26 +298,22 @@ class HaLogbookEntry extends LitElement {
         <span class="secondary-text">${ctx.context ?? nothing}</span>
         ${this._renderTrailing(
           showThirdLine ? undefined : cause,
-          trailingTrace,
           ctx.renderedTime
         )}
       </div>
       ${
         showThirdLine
           ? html`<div class="secondary">
-              ${this._renderListCauseLine(cause, thirdLineTrace)}
+              ${this._renderListCauseLine(cause)}
             </div>`
           : nothing
       }
     `;
   }
 
-  private _renderListCauseLine(
-    cause: LogbookCause | undefined,
-    traceLink: string | undefined
-  ) {
+  private _renderListCauseLine(cause: LogbookCause | undefined) {
     if (!cause) {
-      return traceLink ? this._renderTraceLink(traceLink) : nothing;
+      return nothing;
     }
     const { localize } = this.hass;
     if (cause.entityId) {
@@ -357,12 +338,10 @@ class HaLogbookEntry extends LitElement {
         >
           ${cause.name}
         </button>
-        ${traceLink ? this._renderTraceLink(traceLink) : nothing}
       `;
     }
     return html`
       <span class="secondary-text">${this._renderCausePhrase(cause)}</span>
-      ${traceLink ? this._renderTraceLink(traceLink) : nothing}
     `;
   }
 
@@ -372,7 +351,6 @@ class HaLogbookEntry extends LitElement {
         <span class="primary-text">${ctx.renderedValue}</span>
         ${this._renderTrailing(
           ctx.category === "entity" ? ctx.cause : undefined,
-          ctx.traceLink,
           ctx.renderedTime
         )}
       </div>
@@ -381,21 +359,19 @@ class HaLogbookEntry extends LitElement {
 
   private _renderValue(
     value: LogbookValue | undefined,
-    seenEntityIds: string[],
-    noLink: boolean
+    seenEntityIds: string[]
   ): TemplateResult | string {
     if (!value) {
       return "";
     }
     return value.type === "message"
-      ? this._formatMessageWithPossibleEntity(value.text, seenEntityIds, noLink)
+      ? this._formatMessageWithPossibleEntity(value.text, seenEntityIds)
       : value.text;
   }
 
   private _renderEntity(
     entityId: string | undefined,
-    entityName: string | undefined,
-    noLink?: boolean
+    entityName: string | undefined
   ) {
     const hasState = entityId && entityId in this.hass.states;
     const displayName =
@@ -406,15 +382,13 @@ class HaLogbookEntry extends LitElement {
     if (!hasState) {
       return displayName;
     }
-    return noLink
-      ? displayName
-      : html`<button
-          class="link"
-          @click=${this._entityClicked}
-          .entityId=${entityId}
-        >
-          ${displayName}
-        </button>`;
+    return html`<button
+      class="link"
+      @click=${this._entityClicked}
+      .entityId=${entityId}
+    >
+      ${displayName}
+    </button>`;
   }
 
   private _renderCausePhrase(cause: LogbookCause): TemplateResult | string {
@@ -470,54 +444,9 @@ class HaLogbookEntry extends LitElement {
     }
   }
 
-  private _renderCauseIcon(cause: LogbookCause) {
-    if (cause.type === "user") {
-      const systemIcon = cause.systemUser
-        ? SYSTEM_USER_ICONS[cause.name]
-        : undefined;
-      if (systemIcon) {
-        return html`<ha-svg-icon
-          class="cause-icon"
-          .path=${systemIcon}
-        ></ha-svg-icon>`;
-      }
-      return html`<ha-user-badge
-        class="cause-icon cause-avatar"
-        .user=${{ id: cause.userId!, name: cause.name } as User}
-      ></ha-user-badge>`;
-    }
-    if (cause.type === "automation") {
-      return html`<ha-svg-icon
-        class="cause-icon"
-        .path=${mdiRobot}
-      ></ha-svg-icon>`;
-    }
-    if (cause.type === "script") {
-      return html`<ha-svg-icon
-        class="cause-icon"
-        .path=${mdiScriptText}
-      ></ha-svg-icon>`;
-    }
-    if (cause.type === "state") {
-      return nothing;
-    }
-    if (cause.brandDomain) {
-      return html`<ha-domain-icon
-        class="cause-icon"
-        .domain=${cause.brandDomain}
-        brand-fallback
-      ></ha-domain-icon>`;
-    }
-    return html`<ha-svg-icon
-      class="cause-icon"
-      .path=${mdiPuzzle}
-    ></ha-svg-icon>`;
-  }
-
   private _formatMessageWithPossibleEntity(
     message: string,
-    seenEntities: string[],
-    noLink?: boolean
+    seenEntities: string[]
   ) {
     if (message.indexOf(".") !== -1) {
       const messageParts = message.split(" ");
@@ -533,8 +462,7 @@ class HaLogbookEntry extends LitElement {
           return html`${messageParts.join(" ")}
           ${this._renderEntity(
             entityId,
-            this.hass.states[entityId].attributes.friendly_name,
-            noLink
+            this.hass.states[entityId].attributes.friendly_name
           )}
           ${messageEnd.join(" ")}`;
         }
@@ -571,47 +499,9 @@ class HaLogbookEntry extends LitElement {
     const unavailable =
       item.glyph.type === "state" && item.glyph.stateObj.state === UNAVAILABLE;
     return html`<div class="node-glyph" style=${style}>
-      ${this._renderGlyph(item.glyph)}
+      ${renderLogbookGlyph(this.hass, this.item, item.glyph)}
       ${unavailable ? html`<span class="node-badge"></span>` : nothing}
     </div>`;
-  }
-
-  private _renderGlyph(glyph: LogbookGlyph) {
-    if (glyph.type === "automation") {
-      return html`<ha-svg-icon
-        .path=${glyph.script ? mdiScriptText : mdiRobot}
-      ></ha-svg-icon>`;
-    }
-    if (glyph.type === "state") {
-      return html`<ha-state-icon
-        .stateObj=${glyph.stateObj}
-        .icon=${glyph.icon}
-      ></ha-state-icon>`;
-    }
-    return html`<state-badge
-      .overrideIcon=${glyph.icon}
-      .overrideImage=${this._brandImage(glyph.domain)}
-      .stateColor=${false}
-    ></state-badge>`;
-  }
-
-  private _brandImage(domain?: string): string | undefined {
-    if (
-      !domain ||
-      this.item.icon ||
-      this.item.state ||
-      !isComponentLoaded(this.hass.config, domain)
-    ) {
-      return undefined;
-    }
-    return brandsUrl(
-      {
-        domain,
-        type: "icon",
-        darkOptimized: this.hass.themes?.darkMode,
-      },
-      this.hass.auth.data.hassUrl
-    );
   }
 
   static get styles(): CSSResultGroup {
@@ -670,6 +560,19 @@ class HaLogbookEntry extends LitElement {
             --logbook-category-integration-color,
             var(--teal-color)
           );
+        }
+
+        .entry.clickable {
+          cursor: pointer;
+        }
+
+        .entry.clickable:hover {
+          background-color: rgba(var(--rgb-primary-text-color), 0.04);
+        }
+
+        .entry.clickable:focus-visible {
+          outline: 2px solid var(--primary-color);
+          outline-offset: -2px;
         }
 
         .time {
@@ -957,6 +860,7 @@ class HaLogbookEntry extends LitElement {
 
         .time-chip {
           flex-shrink: 0;
+          min-width: 4.5em;
           text-align: end;
           line-height: 1;
           font-size: var(--ha-font-size-s);
@@ -964,10 +868,6 @@ class HaLogbookEntry extends LitElement {
           font-variant-numeric: tabular-nums;
           cursor: pointer;
           user-select: none;
-        }
-
-        .time-chip {
-          min-width: 4.5em;
         }
 
         .entry.time-am-pm .time-chip {
@@ -1004,18 +904,6 @@ class HaLogbookEntry extends LitElement {
           white-space: nowrap;
           font-weight: var(--ha-font-weight-medium);
           color: var(--primary-text-color);
-        }
-
-        /* The trace link sits after the cause; it never shrinks, so a long
-           cause truncates instead. */
-        .trace-link {
-          flex-shrink: 0;
-          color: var(--primary-color);
-          text-decoration: none;
-        }
-
-        .trace-link:hover {
-          text-decoration: underline;
         }
 
         /* Entity names read as the subject, not a wall of blue links — the

--- a/src/panels/logbook/ha-logbook-entry.ts
+++ b/src/panels/logbook/ha-logbook-entry.ts
@@ -2,7 +2,6 @@ import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
-import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
 import { computeTimelineColor } from "../../components/chart/timeline-color";
 import { computeDomain } from "../../common/entity/compute_domain";
@@ -58,8 +57,7 @@ class HaLogbookEntry extends LitElement {
 
   @property({ attribute: false }) public systemUserIds = new Set<string>();
 
-  @property({ type: Boolean, attribute: "no-row-click" }) public noRowClick =
-    false;
+  @property({ type: Boolean, attribute: "no-detail" }) public noDetail = false;
 
   @property({ type: Boolean }) public narrow = false;
 
@@ -112,8 +110,6 @@ class HaLogbookEntry extends LitElement {
       renderedValue: this._renderValue(item.value, seenEntityIds),
     };
 
-    const clickable = !this.noRowClick;
-
     return html`
       <div
         class="entry ${classMap({
@@ -122,12 +118,7 @@ class HaLogbookEntry extends LitElement {
           "last-of-day": this.lastOfDay,
           [`category-${ctx.category}`]: true,
           "time-am-pm": useAmPm(this.hass.locale),
-          clickable,
         })}"
-        role=${ifDefined(clickable ? "button" : undefined)}
-        tabindex=${ifDefined(clickable ? "0" : undefined)}
-        @click=${this._rowClicked}
-        @keydown=${this._rowKeydown}
       >
         ${
           layout === "timeline"
@@ -163,42 +154,25 @@ class HaLogbookEntry extends LitElement {
     `;
   }
 
-  private _toggleTime(e: Event) {
-    e.stopPropagation();
+  private _toggleTime() {
     fireEvent(this, "logbook-toggle-time");
   }
 
   private _timeKeydown(e: KeyboardEvent) {
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
-      e.stopPropagation();
       fireEvent(this, "logbook-toggle-time");
     }
   }
 
-  private _rowClicked() {
-    if (this.noRowClick) {
-      return;
-    }
+  private _showDetail() {
     fireEvent(this, "logbook-entry-selected", { item: this.item });
-  }
-
-  private _rowKeydown(ev: KeyboardEvent) {
-    if (this.noRowClick || (ev.key !== "Enter" && ev.key !== " ")) {
-      return;
-    }
-    if (ev.target !== ev.currentTarget) {
-      return;
-    }
-    ev.preventDefault();
-    this._rowClicked();
   }
 
   private _entityClicked(ev: Event) {
     const entityId = (ev.currentTarget as any).entityId;
     if (!entityId) return;
     ev.preventDefault();
-    ev.stopPropagation();
     fireEvent(this, "hass-more-info", { entityId });
   }
 
@@ -218,16 +192,33 @@ class HaLogbookEntry extends LitElement {
     renderedTime: TemplateResult | string
   ) {
     return html`<span class="trailing">
-      ${
-        cause
-          ? html`<ha-tooltip for="cause-badge">${cause.name}</ha-tooltip>
-              <span class="cause-badge" id="cause-badge"
-                >${renderLogbookCauseIcon(cause)}</span
-              >`
-          : nothing
-      }
+      ${cause ? this._renderCauseBadge(cause) : nothing}
       ${this._renderTimeChip(renderedTime)}
     </span>`;
+  }
+
+  private _renderCauseBadge(cause: LogbookCause) {
+    const icon = renderLogbookCauseIcon(cause);
+    if (this.noDetail) {
+      return html`<ha-tooltip for="cause-badge">${cause.name}</ha-tooltip>
+        <span class="cause-badge" id="cause-badge">${icon}</span>`;
+    }
+    return html`<button
+      class="cause-badge"
+      aria-label=${this.hass.localize("ui.components.logbook.view_details")}
+      @click=${this._showDetail}
+    >
+      ${icon}
+    </button>`;
+  }
+
+  private _renderDetailsLink() {
+    if (this.noDetail) {
+      return nothing;
+    }
+    return html`<button class="link details-link" @click=${this._showDetail}>
+      ${this.hass.localize("ui.components.logbook.view_details")}
+    </button>`;
   }
 
   private _renderTimeline(ctx: LogbookRenderItem) {
@@ -267,6 +258,7 @@ class HaLogbookEntry extends LitElement {
         causePhrase
           ? html`<div class="secondary">
               <span class="cause-phrase">${causePhrase}</span>
+              ${this.noDetail ? nothing : html`·`} ${this._renderDetailsLink()}
             </div>`
           : nothing
       }
@@ -296,7 +288,7 @@ class HaLogbookEntry extends LitElement {
       ${
         showThirdLine
           ? html`<div class="secondary">
-              ${this._renderListCauseLine(cause)}
+              ${this._renderListCauseLine(cause)} ${this._renderDetailsLink()}
             </div>`
           : nothing
       }
@@ -321,8 +313,8 @@ class HaLogbookEntry extends LitElement {
         }),
       };
       const prefix = prefixMap[cause.type];
-      return html`
-        ${prefix ? html`<span class="cause-prefix">${prefix}</span>` : nothing}
+      return html`<span class="cause-line">
+        ${prefix ?? nothing}
         <button
           class="link cause-entity"
           @click=${this._entityClicked}
@@ -330,11 +322,11 @@ class HaLogbookEntry extends LitElement {
         >
           ${cause.name}
         </button>
-      `;
+      </span>`;
     }
-    return html`
-      <span class="secondary-text">${this._renderCausePhrase(cause)}</span>
-    `;
+    return html`<span class="cause-line"
+      >${this._renderCausePhrase(cause)}</span
+    >`;
   }
 
   private _renderInline(ctx: LogbookRenderItem) {
@@ -552,20 +544,6 @@ class HaLogbookEntry extends LitElement {
             --logbook-category-integration-color,
             var(--teal-color)
           );
-        }
-
-        .entry.clickable {
-          cursor: pointer;
-          user-select: none;
-        }
-
-        .entry.clickable:hover {
-          background-color: rgba(var(--rgb-primary-text-color), 0.04);
-        }
-
-        .entry.clickable:focus-visible {
-          outline: 2px solid var(--primary-color);
-          outline-offset: -2px;
         }
 
         .time {
@@ -847,6 +825,35 @@ class HaLogbookEntry extends LitElement {
           align-items: center;
         }
 
+        button.cause-badge {
+          border: none;
+          background: none;
+          color: inherit;
+          font: inherit;
+          /* Grow the hit target without moving the icons. */
+          padding: var(--ha-space-2);
+          margin: calc(-1 * var(--ha-space-2));
+          border-radius: var(--ha-border-radius-pill);
+          cursor: pointer;
+        }
+
+        button.cause-badge:hover {
+          background-color: rgba(var(--rgb-primary-text-color), 0.06);
+        }
+
+        button.cause-badge:focus-visible {
+          outline: 2px solid var(--primary-color);
+        }
+
+        .details-link {
+          flex-shrink: 0;
+        }
+
+        button.link.details-link {
+          color: var(--primary-color);
+          font-weight: var(--ha-font-weight-normal);
+        }
+
         ha-relative-time {
           display: contents;
         }
@@ -884,17 +891,25 @@ class HaLogbookEntry extends LitElement {
           font-size: 9px;
         }
 
-        .cause-prefix {
-          flex-shrink: 0;
+        /* The cause reads as one sentence on one line: it truncates as a
+           whole and only the details link is kept out of the ellipsis. */
+        .cause-phrase {
+          flex: 0 1 auto;
+          min-width: 0;
           white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        .cause-line {
+          flex: 1;
+          min-width: 0;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
 
         .cause-entity {
-          flex: 1;
-          min-width: 0;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
           font-weight: var(--ha-font-weight-medium);
           color: var(--primary-text-color);
         }

--- a/src/panels/logbook/ha-logbook-entry.ts
+++ b/src/panels/logbook/ha-logbook-entry.ts
@@ -9,7 +9,6 @@ import { computeDomain } from "../../common/entity/compute_domain";
 import { formatTimeWithSeconds } from "../../common/datetime/format_time";
 import { useAmPm } from "../../common/datetime/use_am_pm";
 import { fireEvent } from "../../common/dom/fire_event";
-import { computeRTL } from "../../common/util/compute_rtl";
 import "../../components/ha-relative-time";
 import "../../components/ha-tooltip";
 import { UNAVAILABLE } from "../../data/entity/entity";
@@ -27,6 +26,7 @@ import { computeLogbookItem, nodeColor } from "./logbook-entry-model";
 import {
   renderLogbookCauseIcon,
   renderLogbookGlyph,
+  transitionArrow,
 } from "./logbook-entry-templates";
 
 type EntryLayout = "timeline" | "list" | "inline";
@@ -238,10 +238,6 @@ class HaLogbookEntry extends LitElement {
 
   private _renderTimeline(ctx: LogbookRenderItem) {
     const hideName = this.nameDetail === "none";
-    const rtl = computeRTL(
-      this.hass.language,
-      this.hass.translationMetadata.translations
-    );
     const valueIsState = ctx.value?.type === "state";
     const causePhrase = ctx.cause
       ? this._renderCausePhrase(ctx.cause)
@@ -256,7 +252,9 @@ class HaLogbookEntry extends LitElement {
                   >${
                     ctx.renderedValue
                       ? valueIsState
-                        ? html`<span class="arrow">${rtl ? "←" : "→"}</span>`
+                        ? html`<span class="arrow"
+                            >${transitionArrow(this.hass)}</span
+                          >`
                         : " "
                       : nothing
                   }`

--- a/src/panels/logbook/ha-logbook-entry.ts
+++ b/src/panels/logbook/ha-logbook-entry.ts
@@ -266,8 +266,7 @@ class HaLogbookEntry extends LitElement {
   }
 
   private _renderList(ctx: LogbookRenderItem) {
-    const cause =
-      this.showCause || ctx.category === "entity" ? ctx.cause : undefined;
+    const cause = ctx.cause;
     const showThirdLine = this.showCause && cause;
     return html`
       <div class="primary">
@@ -333,10 +332,7 @@ class HaLogbookEntry extends LitElement {
     return html`
       <div class="primary">
         <span class="primary-text">${ctx.renderedValue}</span>
-        ${this._renderTrailing(
-          ctx.category === "entity" ? ctx.cause : undefined,
-          ctx.renderedTime
-        )}
+        ${this._renderTrailing(ctx.cause, ctx.renderedTime)}
       </div>
     `;
   }

--- a/src/panels/logbook/ha-logbook-entry.ts
+++ b/src/panels/logbook/ha-logbook-entry.ts
@@ -2,17 +2,18 @@ import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
 import { computeTimelineColor } from "../../components/chart/timeline-color";
 import { computeDomain } from "../../common/entity/compute_domain";
 import { formatTimeWithSeconds } from "../../common/datetime/format_time";
 import { useAmPm } from "../../common/datetime/use_am_pm";
 import { fireEvent } from "../../common/dom/fire_event";
-import "../../components/ha-relative-time";
+import "../../components/ha-icon-next";
 import "../../components/ha-tooltip";
 import { UNAVAILABLE } from "../../data/entity/entity";
 import type { LogbookEntry } from "../../data/logbook";
-import { buttonLinkStyle, haStyle } from "../../resources/styles";
+import { haStyle } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import type {
   LogbookCause,
@@ -31,7 +32,7 @@ import {
 type EntryLayout = "timeline" | "list" | "inline";
 
 interface LogbookRenderItem extends LogbookItem {
-  renderedTime: TemplateResult | string;
+  renderedTime: string;
   renderedValue: TemplateResult | string;
 }
 
@@ -42,7 +43,6 @@ export interface LogbookEntrySelectedDetail {
 declare global {
   interface HASSDomEvents {
     "logbook-entry-selected": LogbookEntrySelectedDetail;
-    "logbook-toggle-time": undefined;
   }
 }
 
@@ -72,8 +72,6 @@ class HaLogbookEntry extends LitElement {
 
   @property({ type: Boolean, attribute: false }) public lastOfDay = false;
 
-  @property({ type: Boolean, attribute: false }) public showRelative = false;
-
   @property({ type: Boolean, attribute: "show-cause" }) public showCause =
     false;
 
@@ -96,19 +94,22 @@ class HaLogbookEntry extends LitElement {
       !this.narrow && !this.noIcon ? "timeline" : hideName ? "inline" : "list";
     const node = layout === "timeline" ? "icon" : "dot";
 
-    const when = new Date(item.when);
-    const renderedTime = this.showRelative
-      ? html`<ha-relative-time
-          .datetime=${when}
-          format="short"
-        ></ha-relative-time>`
-      : formatTimeWithSeconds(when, this.hass.locale, this.hass.config);
+    const renderedTime = formatTimeWithSeconds(
+      new Date(item.when),
+      this.hass.locale,
+      this.hass.config
+    );
 
     const ctx: LogbookRenderItem = {
       ...item,
       renderedTime,
       renderedValue: this._renderValue(item.value, seenEntityIds),
     };
+
+    const clickable = !this.noDetail;
+    // On wide screens the hover state carries the affordance; a chevron would
+    // sit far away from the text it belongs to.
+    const chevron = clickable && layout !== "timeline";
 
     return html`
       <div
@@ -118,17 +119,16 @@ class HaLogbookEntry extends LitElement {
           "last-of-day": this.lastOfDay,
           [`category-${ctx.category}`]: true,
           "time-am-pm": useAmPm(this.hass.locale),
+          clickable,
         })}"
+        role=${ifDefined(clickable ? "button" : undefined)}
+        tabindex=${ifDefined(clickable ? "0" : undefined)}
+        @click=${this._rowClicked}
+        @keydown=${this._rowKeydown}
       >
         ${
           layout === "timeline"
-            ? html`<div
-                class="time"
-                role="button"
-                tabindex="0"
-                @click=${this._toggleTime}
-                @keydown=${this._timeKeydown}
-              >
+            ? html`<div class="time">
                 <span class="time-content">${renderedTime}</span>
               </div>`
             : nothing
@@ -141,99 +141,67 @@ class HaLogbookEntry extends LitElement {
         >
           ${this._renderNode(ctx, layout)}
         </div>
-        <div class="content">
-          ${
-            layout === "timeline"
-              ? this._renderTimeline(ctx)
-              : layout === "list"
-                ? this._renderList(ctx)
-                : this._renderInline(ctx)
-          }
+        <div class="body">
+          <div class="content">
+            ${
+              layout === "timeline"
+                ? this._renderTimeline(ctx)
+                : layout === "list"
+                  ? this._renderList(ctx)
+                  : this._renderInline(ctx)
+            }
+          </div>
+          ${chevron ? html`<ha-icon-next class="chevron"></ha-icon-next>` : nothing}
         </div>
       </div>
     `;
   }
 
-  private _toggleTime() {
-    fireEvent(this, "logbook-toggle-time");
-  }
-
-  private _timeKeydown(e: KeyboardEvent) {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      fireEvent(this, "logbook-toggle-time");
+  private _rowClicked() {
+    if (this.noDetail) {
+      return;
     }
-  }
-
-  private _showDetail() {
     fireEvent(this, "logbook-entry-selected", { item: this.item });
   }
 
-  private _entityClicked(ev: Event) {
-    const entityId = (ev.currentTarget as any).entityId;
-    if (!entityId) return;
+  private _rowKeydown(ev: KeyboardEvent) {
+    if (ev.key !== "Enter" && ev.key !== " ") {
+      return;
+    }
+    if (ev.target !== ev.currentTarget) {
+      return;
+    }
     ev.preventDefault();
-    fireEvent(this, "hass-more-info", { entityId });
-  }
-
-  private _renderTimeChip(renderedTime: TemplateResult | string) {
-    return html`<span
-      class="time-chip"
-      role="button"
-      tabindex="0"
-      @click=${this._toggleTime}
-      @keydown=${this._timeKeydown}
-      >${renderedTime}</span
-    >`;
+    this._rowClicked();
   }
 
   private _renderTrailing(
     cause: LogbookCause | undefined,
-    renderedTime: TemplateResult | string
+    renderedTime: string
   ) {
     return html`<span class="trailing">
       ${cause ? this._renderCauseBadge(cause) : nothing}
-      ${this._renderTimeChip(renderedTime)}
+      <span class="time-chip">${renderedTime}</span>
     </span>`;
   }
 
   private _renderCauseBadge(cause: LogbookCause) {
-    const icon = renderLogbookCauseIcon(cause);
-    if (this.noDetail) {
-      return html`<ha-tooltip for="cause-badge">${cause.name}</ha-tooltip>
-        <span class="cause-badge" id="cause-badge">${icon}</span>`;
-    }
-    return html`<button
-      class="cause-badge"
-      aria-label=${this.hass.localize("ui.components.logbook.view_details")}
-      @click=${this._showDetail}
-    >
-      ${icon}
-    </button>`;
-  }
-
-  private _renderDetailsLink() {
-    if (this.noDetail) {
-      return nothing;
-    }
-    return html`<button class="link details-link" @click=${this._showDetail}>
-      ${this.hass.localize("ui.components.logbook.view_details")}
-    </button>`;
+    return html`<ha-tooltip for="cause-badge">${cause.name}</ha-tooltip>
+      <span class="cause-badge" id="cause-badge"
+        >${renderLogbookCauseIcon(cause)}</span
+      >`;
   }
 
   private _renderTimeline(ctx: LogbookRenderItem) {
     const hideName = this.nameDetail === "none";
     const valueIsState = ctx.value?.type === "state";
-    const causePhrase = ctx.cause
-      ? this._renderCausePhrase(ctx.cause)
-      : undefined;
     return html`
       <div class="primary">
         <span class="primary-text"
           >${
             !hideName
               ? html`<span class="subject"
-                    >${this._renderEntity(ctx.entityId, ctx.name)}</span
+                    >${this._entityName(ctx.entityId, ctx.name)}</span
                   >${
                     ctx.renderedValue
                       ? valueIsState
@@ -255,10 +223,9 @@ class HaLogbookEntry extends LitElement {
           : nothing
       }
       ${
-        causePhrase
+        ctx.cause
           ? html`<div class="secondary">
-              <span class="cause-phrase">${causePhrase}</span>
-              ${this.noDetail ? nothing : html`·`} ${this._renderDetailsLink()}
+              ${this._renderCauseLine(ctx.cause)}
             </div>`
           : nothing
       }
@@ -270,9 +237,7 @@ class HaLogbookEntry extends LitElement {
     const showThirdLine = this.showCause && cause;
     return html`
       <div class="primary">
-        <span class="subject"
-          >${this._renderEntity(ctx.entityId, ctx.name)}</span
-        >
+        <span class="subject">${this._entityName(ctx.entityId, ctx.name)}</span>
         <span class="value" title=${ctx.value?.text ?? ""}
           >${ctx.renderedValue}</span
         >
@@ -286,18 +251,13 @@ class HaLogbookEntry extends LitElement {
       </div>
       ${
         showThirdLine
-          ? html`<div class="secondary">
-              ${this._renderListCauseLine(cause)} ${this._renderDetailsLink()}
-            </div>`
+          ? html`<div class="secondary">${this._renderCauseLine(cause)}</div>`
           : nothing
       }
     `;
   }
 
-  private _renderListCauseLine(cause: LogbookCause | undefined) {
-    if (!cause) {
-      return nothing;
-    }
+  private _renderCauseLine(cause: LogbookCause) {
     const { localize } = this.hass;
     if (cause.entityId) {
       const prefixMap: Partial<Record<LogbookCauseType, string>> = {
@@ -313,14 +273,7 @@ class HaLogbookEntry extends LitElement {
       };
       const prefix = prefixMap[cause.type];
       return html`<span class="cause-line">
-        ${prefix ?? nothing}
-        <button
-          class="link cause-entity"
-          @click=${this._entityClicked}
-          .entityId=${cause.entityId}
-        >
-          ${cause.name}
-        </button>
+        ${prefix ?? nothing}<span class="cause-entity">${cause.name}</span>
       </span>`;
     }
     return html`<span class="cause-line"
@@ -349,68 +302,37 @@ class HaLogbookEntry extends LitElement {
       : value.text;
   }
 
-  private _renderEntity(
+  private _entityName(
     entityId: string | undefined,
     entityName: string | undefined
   ) {
-    const hasState = entityId && entityId in this.hass.states;
-    const displayName =
+    return (
       entityName ||
-      (hasState
+      (entityId && entityId in this.hass.states
         ? this.hass.states[entityId].attributes.friendly_name || entityId
-        : entityId);
-    if (!hasState) {
-      return displayName;
-    }
-    return html`<button
-      class="link"
-      @click=${this._entityClicked}
-      .entityId=${entityId}
-    >
-      ${displayName}
-    </button>`;
+        : entityId)
+    );
   }
 
-  private _renderCausePhrase(cause: LogbookCause): TemplateResult | string {
+  private _renderCausePhrase(cause: LogbookCause): string {
     const { localize } = this.hass;
-    const nameEl = cause.entityId
-      ? html`<button
-          class="link"
-          @click=${this._entityClicked}
-          .entityId=${cause.entityId}
-        >
-          ${cause.name}
-        </button>`
-      : cause.name;
     switch (cause.type) {
       case "user":
         return localize("ui.components.logbook.cause.by", {
           name: cause.name,
         });
       case "automation":
-        return cause.entityId
-          ? html`${localize("ui.components.logbook.cause.by_automation", {
-              name: "",
-            })}${nameEl}`
-          : localize("ui.components.logbook.cause.by_automation", {
-              name: cause.name,
-            });
+        return localize("ui.components.logbook.cause.by_automation", {
+          name: cause.name,
+        });
       case "script":
-        return cause.entityId
-          ? html`${localize("ui.components.logbook.cause.by_script", {
-              name: "",
-            })}${nameEl}`
-          : localize("ui.components.logbook.cause.by_script", {
-              name: cause.name,
-            });
+        return localize("ui.components.logbook.cause.by_script", {
+          name: cause.name,
+        });
       case "state":
-        return cause.entityId
-          ? html`${localize("ui.components.logbook.cause.by_state_change", {
-              name: "",
-            })}${nameEl}`
-          : localize("ui.components.logbook.cause.by_state_change", {
-              name: cause.name,
-            });
+        return localize("ui.components.logbook.cause.by_state_change", {
+          name: cause.name,
+        });
       case "scheduled":
         return localize("ui.components.logbook.cause.scheduled");
       case "homeassistant":
@@ -440,7 +362,7 @@ class HaLogbookEntry extends LitElement {
           const messageEnd = messageParts.splice(i);
           messageEnd.shift();
           return html`${messageParts.join(" ")}
-          ${this._renderEntity(
+          ${this._entityName(
             entityId,
             this.hass.states[entityId].attributes.friendly_name
           )}
@@ -487,7 +409,6 @@ class HaLogbookEntry extends LitElement {
   static get styles(): CSSResultGroup {
     return [
       haStyle,
-      buttonLinkStyle,
       css`
         :host {
           display: block;
@@ -542,6 +463,20 @@ class HaLogbookEntry extends LitElement {
           );
         }
 
+        .entry.clickable {
+          cursor: pointer;
+          user-select: none;
+        }
+
+        .entry.clickable:hover {
+          background-color: rgba(var(--rgb-primary-text-color), 0.04);
+        }
+
+        .entry.clickable:focus-visible {
+          outline: 2px solid var(--primary-color);
+          outline-offset: -2px;
+        }
+
         .time {
           display: flex;
           flex-direction: column;
@@ -551,12 +486,6 @@ class HaLogbookEntry extends LitElement {
           font-size: var(--ha-font-size-s);
           color: var(--secondary-text-color);
           overflow: hidden;
-          cursor: pointer;
-          user-select: none;
-        }
-
-        .time:hover {
-          opacity: 0.75;
         }
 
         .time-content {
@@ -701,19 +630,33 @@ class HaLogbookEntry extends LitElement {
           box-sizing: border-box;
         }
 
+        /* Discreet divider between rows, aligned to the content so it does
+           not cross the rail. Suppressed on the last row of each day. */
+        .body {
+          display: flex;
+          align-items: stretch;
+          min-width: 0;
+          border-bottom: 1px solid var(--divider-color);
+        }
+
+        .entry.last-of-day .body {
+          border-bottom: none;
+        }
+
+        .chevron {
+          align-self: center;
+          flex-shrink: 0;
+          margin-inline-start: var(--ha-space-2);
+          color: var(--secondary-text-color);
+        }
+
         .content {
           display: flex;
           flex-direction: column;
           justify-content: center;
+          flex: 1;
           min-width: 0;
           gap: 2px;
-          /* Discreet divider between rows, aligned to the content so it does
-             not cross the rail. Suppressed on the last row of each day. */
-          border-bottom: 1px solid var(--divider-color);
-        }
-
-        .entry.last-of-day .content {
-          border-bottom: none;
         }
 
         /* List/inline: fixed padding instead of justify-content:center so
@@ -744,6 +687,13 @@ class HaLogbookEntry extends LitElement {
           color: var(--primary-text-color);
         }
 
+        /* Inline is the only layout carrying the trailing block in .primary,
+           and an icon badge has no baseline of its own — it would ride 5px
+           above the text and miss the chevron's centerline. */
+        .entry.layout-inline .primary {
+          align-items: center;
+        }
+
         .entry.layout-inline .primary-text:first-letter {
           text-transform: capitalize;
         }
@@ -763,14 +713,6 @@ class HaLogbookEntry extends LitElement {
           overflow: hidden;
           text-overflow: ellipsis;
           font-weight: var(--ha-font-weight-medium);
-        }
-
-        .primary > .subject button.link {
-          display: block;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-          max-width: 100%;
         }
 
         .subject {
@@ -821,39 +763,6 @@ class HaLogbookEntry extends LitElement {
           align-items: center;
         }
 
-        button.cause-badge {
-          border: none;
-          background: none;
-          color: inherit;
-          font: inherit;
-          /* Grow the hit target without moving the icons. */
-          padding: var(--ha-space-2);
-          margin: calc(-1 * var(--ha-space-2));
-          border-radius: var(--ha-border-radius-pill);
-          cursor: pointer;
-        }
-
-        button.cause-badge:hover {
-          background-color: rgba(var(--rgb-primary-text-color), 0.06);
-        }
-
-        button.cause-badge:focus-visible {
-          outline: 2px solid var(--primary-color);
-        }
-
-        .details-link {
-          flex-shrink: 0;
-        }
-
-        button.link.details-link {
-          color: var(--primary-color);
-          font-weight: var(--ha-font-weight-normal);
-        }
-
-        ha-relative-time {
-          display: contents;
-        }
-
         .time-chip {
           flex-shrink: 0;
           min-width: 4.5em;
@@ -862,16 +771,10 @@ class HaLogbookEntry extends LitElement {
           font-size: var(--ha-font-size-s);
           color: var(--secondary-text-color);
           font-variant-numeric: tabular-nums;
-          cursor: pointer;
-          user-select: none;
         }
 
         .entry.time-am-pm .time-chip {
           min-width: 6em;
-        }
-
-        .time-chip:hover {
-          opacity: 0.75;
         }
 
         .cause-icon {
@@ -887,16 +790,7 @@ class HaLogbookEntry extends LitElement {
           font-size: 9px;
         }
 
-        /* The cause reads as one sentence on one line: it truncates as a
-           whole and only the details link is kept out of the ellipsis. */
-        .cause-phrase {
-          flex: 0 1 auto;
-          min-width: 0;
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
-
+        /* The cause reads as one sentence on one line, truncating as a whole. */
         .cause-line {
           flex: 1;
           min-width: 0;
@@ -908,18 +802,6 @@ class HaLogbookEntry extends LitElement {
         .cause-entity {
           font-weight: var(--ha-font-weight-medium);
           color: var(--primary-text-color);
-        }
-
-        /* Entity names read as the subject, not a wall of blue links — the
-           colored node is the scan anchor. */
-        button.link {
-          color: var(--primary-text-color);
-          font-weight: var(--ha-font-weight-medium);
-          text-decoration: none;
-        }
-
-        button.link:hover {
-          text-decoration: underline;
         }
       `,
     ];

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -84,6 +84,8 @@ class HaLogbookRenderer extends LitElement {
     return (
       changedProps.has("entries") ||
       changedProps.has("noRowClick") ||
+      changedProps.has("userIdToName") ||
+      changedProps.has("systemUserIds") ||
       changedProps.has("_showRelative" as never) ||
       languageChanged
     );
@@ -112,7 +114,13 @@ class HaLogbookRenderer extends LitElement {
                 scroller
                 class="ha-scrollbar"
                 .items=${this.entries}
-                .renderItem=${this._getRenderRow(this._showRelative) as any}
+                .renderItem=${
+                  this._getRenderRow(
+                    this._showRelative,
+                    this.userIdToName,
+                    this.systemUserIds
+                  ) as any
+                }
               >
               </lit-virtualizer>`
             : this.entries.map((item, index) => this._renderItem(item, index))
@@ -121,9 +129,16 @@ class HaLogbookRenderer extends LitElement {
     `;
   }
 
+  // Memoized on every input the rows render from, so the virtualizer sees a
+  // new renderItem and refreshes already-rendered rows when one changes.
   private _getRenderRow = memoizeOne(
-    (_showRelative: boolean) => (item: LogbookEntry, index: number) =>
-      this._renderItem(item, index)
+    (
+      _showRelative: boolean,
+      _userIdToName: Record<string, string>,
+      _systemUserIds: Set<string>
+    ) =>
+      (item: LogbookEntry, index: number) =>
+        this._renderItem(item, index)
   );
 
   private _renderItem = (item: LogbookEntry, index: number) => {
@@ -177,8 +192,7 @@ class HaLogbookRenderer extends LitElement {
     }
     showLogbookDetailDialog(this, {
       entry: item,
-      previousState:
-        index >= 0 ? findPreviousState(this.entries, index) : undefined,
+      previousState: findPreviousState(this.entries, index),
       traceContexts: this.traceContexts,
       userIdToName: this.userIdToName,
       systemUserIds: this.systemUserIds,

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -6,6 +6,7 @@ import { customElement, eventOptions, property, state } from "lit/decorators";
 import { formatDate } from "../../common/datetime/format_date";
 import { capitalizeFirstLetter } from "../../common/string/capitalize-first-letter";
 import { restoreScroll } from "../../common/decorators/restore-scroll";
+import type { HASSDomEvent } from "../../common/dom/fire_event";
 import { fireEvent } from "../../common/dom/fire_event";
 import type { LogbookEntry } from "../../data/logbook";
 import type { TraceContexts } from "../../data/trace";
@@ -13,13 +14,14 @@ import { haStyle, haStyleScrollbar } from "../../resources/styles";
 import { loadVirtualizer } from "../../resources/virtualizer";
 import type { HomeAssistant } from "../../types";
 import "./ha-logbook-entry";
+import type { LogbookEntrySelectedDetail } from "./ha-logbook-entry";
 import type { LogbookNameDetail } from "./logbook-entry-model";
-import { sameDay } from "./logbook-entry-model";
+import { findPreviousState, sameDay } from "./logbook-entry-model";
+import { showLogbookDetailDialog } from "./show-dialog-logbook-detail";
 
 declare global {
   interface HASSDomEvents {
     "hass-logbook-live": { enable: boolean };
-    "logbook-toggle-time": undefined;
   }
 }
 
@@ -32,6 +34,7 @@ class HaLogbookRenderer extends LitElement {
 
   @property({ attribute: false }) public systemUserIds = new Set<string>();
 
+  // Not rendered by rows; read at click time and handed to the detail dialog.
   @property({ attribute: false }) public traceContexts: TraceContexts = {};
 
   @property({ attribute: false }) public entries: LogbookEntry[] = [];
@@ -47,6 +50,9 @@ class HaLogbookRenderer extends LitElement {
     false;
 
   @property({ type: Boolean, attribute: "show-cause" }) public showCause =
+    false;
+
+  @property({ type: Boolean, attribute: "no-row-click" }) public noRowClick =
     false;
 
   @property({ type: String, attribute: "name-detail" })
@@ -77,7 +83,7 @@ class HaLogbookRenderer extends LitElement {
 
     return (
       changedProps.has("entries") ||
-      changedProps.has("traceContexts") ||
+      changedProps.has("noRowClick") ||
       changedProps.has("_showRelative" as never) ||
       languageChanged
     );
@@ -97,6 +103,7 @@ class HaLogbookRenderer extends LitElement {
         class="container ha-scrollbar"
         @scroll=${this._saveScrollPos}
         @logbook-toggle-time=${this._handleToggleTime}
+        @logbook-entry-selected=${this._handleEntrySelected}
       >
         ${
           this.virtualize
@@ -139,9 +146,9 @@ class HaLogbookRenderer extends LitElement {
         <ha-logbook-entry
           .hass=${this.hass}
           .item=${item}
+          .index=${index}
           .userIdToName=${this.userIdToName}
           .systemUserIds=${this.systemUserIds}
-          .traceContexts=${this.traceContexts}
           .narrow=${this.narrow}
           .noIcon=${this.noIcon}
           .graphColor=${this.graphColor}
@@ -150,6 +157,7 @@ class HaLogbookRenderer extends LitElement {
           .lastOfDay=${lastOfDay}
           .showRelative=${this._showRelative}
           .showCause=${this.showCause}
+          .noRowClick=${this.noRowClick}
         ></ha-logbook-entry>
       </div>
     `;
@@ -157,6 +165,24 @@ class HaLogbookRenderer extends LitElement {
 
   private _handleToggleTime() {
     this._showRelative = !this._showRelative;
+  }
+
+  private _handleEntrySelected(ev: HASSDomEvent<LogbookEntrySelectedDetail>) {
+    ev.stopPropagation();
+    const { item } = ev.detail;
+    let index = ev.detail.index;
+    if (this.entries[index] !== item) {
+      // A recycled virtualizer row can deliver a stale index.
+      index = this.entries.indexOf(item);
+    }
+    showLogbookDetailDialog(this, {
+      entry: item,
+      previousState:
+        index >= 0 ? findPreviousState(this.entries, index) : undefined,
+      traceContexts: this.traceContexts,
+      userIdToName: this.userIdToName,
+      systemUserIds: this.systemUserIds,
+    });
   }
 
   private _formatDateHeader(date: Date): string {

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -52,8 +52,7 @@ class HaLogbookRenderer extends LitElement {
   @property({ type: Boolean, attribute: "show-cause" }) public showCause =
     false;
 
-  @property({ type: Boolean, attribute: "no-row-click" }) public noRowClick =
-    false;
+  @property({ type: Boolean, attribute: "no-detail" }) public noDetail = false;
 
   @property({ type: String, attribute: "name-detail" })
   public nameDetail?: LogbookNameDetail;
@@ -83,7 +82,7 @@ class HaLogbookRenderer extends LitElement {
 
     return (
       changedProps.has("entries") ||
-      changedProps.has("noRowClick") ||
+      changedProps.has("noDetail") ||
       changedProps.has("userIdToName") ||
       changedProps.has("systemUserIds") ||
       changedProps.has("_showRelative" as never) ||
@@ -171,7 +170,7 @@ class HaLogbookRenderer extends LitElement {
           .lastOfDay=${lastOfDay}
           .showRelative=${this._showRelative}
           .showCause=${this.showCause}
-          .noRowClick=${this.noRowClick}
+          .noDetail=${this.noDetail}
         ></ha-logbook-entry>
       </div>
     `;

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -16,7 +16,7 @@ import type { HomeAssistant } from "../../types";
 import "./ha-logbook-entry";
 import type { LogbookEntrySelectedDetail } from "./ha-logbook-entry";
 import type { LogbookNameDetail } from "./logbook-entry-model";
-import { findPreviousState, sameDay } from "./logbook-entry-model";
+import { sameDay } from "./logbook-entry-model";
 import { showLogbookDetailDialog } from "./show-dialog-logbook-detail";
 
 declare global {
@@ -161,7 +161,6 @@ class HaLogbookRenderer extends LitElement {
         <ha-logbook-entry
           .hass=${this.hass}
           .item=${item}
-          .index=${index}
           .userIdToName=${this.userIdToName}
           .systemUserIds=${this.systemUserIds}
           .narrow=${this.narrow}
@@ -184,15 +183,8 @@ class HaLogbookRenderer extends LitElement {
 
   private _handleEntrySelected(ev: HASSDomEvent<LogbookEntrySelectedDetail>) {
     ev.stopPropagation();
-    const { item } = ev.detail;
-    let index = ev.detail.index;
-    if (this.entries[index] !== item) {
-      // A recycled virtualizer row can deliver a stale index.
-      index = this.entries.indexOf(item);
-    }
     showLogbookDetailDialog(this, {
-      entry: item,
-      previousState: findPreviousState(this.entries, index),
+      entry: ev.detail.item,
       traceContexts: this.traceContexts,
       userIdToName: this.userIdToName,
       systemUserIds: this.systemUserIds,

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -2,7 +2,7 @@ import type { VisibilityChangedEvent } from "@lit-labs/virtualizer";
 import memoizeOne from "memoize-one";
 import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, eventOptions, property, state } from "lit/decorators";
+import { customElement, eventOptions, property } from "lit/decorators";
 import { formatDate } from "../../common/datetime/format_date";
 import { capitalizeFirstLetter } from "../../common/string/capitalize-first-letter";
 import { restoreScroll } from "../../common/decorators/restore-scroll";
@@ -60,8 +60,6 @@ class HaLogbookRenderer extends LitElement {
   // @ts-ignore
   @restoreScroll(".container") private _savedScrollPos?: number;
 
-  @state() private _showRelative = false;
-
   protected willUpdate(changedProps: PropertyValues<this>) {
     if (
       (!this.hasUpdated && this.virtualize) ||
@@ -85,7 +83,6 @@ class HaLogbookRenderer extends LitElement {
       changedProps.has("noDetail") ||
       changedProps.has("userIdToName") ||
       changedProps.has("systemUserIds") ||
-      changedProps.has("_showRelative" as never) ||
       languageChanged
     );
   }
@@ -103,7 +100,6 @@ class HaLogbookRenderer extends LitElement {
       <div
         class="container ha-scrollbar"
         @scroll=${this._saveScrollPos}
-        @logbook-toggle-time=${this._handleToggleTime}
         @logbook-entry-selected=${this._handleEntrySelected}
       >
         ${
@@ -115,7 +111,6 @@ class HaLogbookRenderer extends LitElement {
                 .items=${this.entries}
                 .renderItem=${
                   this._getRenderRow(
-                    this._showRelative,
                     this.userIdToName,
                     this.systemUserIds
                   ) as any
@@ -131,11 +126,7 @@ class HaLogbookRenderer extends LitElement {
   // Memoized on every input the rows render from, so the virtualizer sees a
   // new renderItem and refreshes already-rendered rows when one changes.
   private _getRenderRow = memoizeOne(
-    (
-      _showRelative: boolean,
-      _userIdToName: Record<string, string>,
-      _systemUserIds: Set<string>
-    ) =>
+    (_userIdToName: Record<string, string>, _systemUserIds: Set<string>) =>
       (item: LogbookEntry, index: number) =>
         this._renderItem(item, index)
   );
@@ -168,17 +159,12 @@ class HaLogbookRenderer extends LitElement {
           .nameDetail=${this.nameDetail}
           .firstOfDay=${firstOfDay}
           .lastOfDay=${lastOfDay}
-          .showRelative=${this._showRelative}
           .showCause=${this.showCause}
           .noDetail=${this.noDetail}
         ></ha-logbook-entry>
       </div>
     `;
   };
-
-  private _handleToggleTime() {
-    this._showRelative = !this._showRelative;
-  }
 
   private _handleEntrySelected(ev: HASSDomEvent<LogbookEntrySelectedDetail>) {
     ev.stopPropagation();

--- a/src/panels/logbook/logbook-chain-resolver.ts
+++ b/src/panels/logbook/logbook-chain-resolver.ts
@@ -48,7 +48,11 @@ const lookbackIso = (when: number) =>
 const justAfterIso = (when: number) =>
   new Date(when * 1000 + 1000).toISOString();
 
-// Effect rows never carry a context_id, run rows do.
+// Effect rows never carry a context_id, run rows do: the logbook processor
+// only emits it on rows described by the automation/script platforms. This
+// candidate discovery + verification is a workaround for that gap; once core
+// emits context_id on described rows too, the fast path by entry.context_id
+// covers every click and this can be deleted.
 const resolveRowsByContextEntity = async (
   entry: LogbookEntry,
   fetchEvents: LogbookFetcher

--- a/src/panels/logbook/logbook-chain-resolver.ts
+++ b/src/panels/logbook/logbook-chain-resolver.ts
@@ -1,5 +1,5 @@
 import type { LogbookEntry } from "../../data/logbook";
-import { getLogbookEvents } from "../../data/logbook";
+import { getLogbookDataFromServer } from "../../data/logbook";
 import type { HomeAssistant } from "../../types";
 import type { LogbookCause } from "./logbook-entry-model";
 import {
@@ -102,7 +102,7 @@ export const resolveLogbookChain = async (
   entry: LogbookEntry,
   options: ResolveOptions = {},
   fetchEvents: LogbookFetcher = (startDate, endDate, entityIds, contextId) =>
-    getLogbookEvents(hass, startDate, endDate, entityIds, contextId)
+    getLogbookDataFromServer(hass, startDate, endDate, entityIds, contextId)
 ): Promise<LogbookChain> => {
   const userIdToName = options.userIdToName ?? {};
   const { systemUserIds } = options;

--- a/src/panels/logbook/logbook-chain-resolver.ts
+++ b/src/panels/logbook/logbook-chain-resolver.ts
@@ -1,0 +1,180 @@
+import type { LogbookEntry } from "../../data/logbook";
+import { getLogbookEvents } from "../../data/logbook";
+import type { HomeAssistant } from "../../types";
+import type { LogbookCause } from "./logbook-entry-model";
+import {
+  classifyLogbookEntry,
+  computeContextCause,
+  computeLogbookCause,
+  computeUserCause,
+  isRunCause,
+  isSameLogbookEntry,
+} from "./logbook-entry-model";
+
+// No run start is available and a delayed script can start long before the
+// clicked entry.
+const LOOKBACK_MS = 24 * 60 * 60 * 1000;
+
+const WHEN_EPSILON = 0.001;
+
+const MAX_RUN_CANDIDATES = 3;
+
+export interface LogbookChain {
+  rows: LogbookEntry[];
+  runRow?: LogbookEntry;
+  // Causes shown above the run, topmost first.
+  origins: LogbookCause[];
+  // Stands in for the run row when it could not be fetched.
+  syntheticRun?: LogbookCause;
+  // The state change that fired a state trigger in `origins`.
+  triggerRow?: LogbookEntry;
+}
+
+export type LogbookFetcher = (
+  startDate: string,
+  endDate?: string,
+  entityIds?: string[],
+  contextId?: string
+) => Promise<LogbookEntry[]>;
+
+interface ResolveOptions {
+  userIdToName?: Record<string, string>;
+  systemUserIds?: Set<string>;
+}
+
+const lookbackIso = (when: number) =>
+  new Date(when * 1000 - LOOKBACK_MS).toISOString();
+
+const justAfterIso = (when: number) =>
+  new Date(when * 1000 + 1000).toISOString();
+
+// Effect rows never carry a context_id, run rows do.
+const resolveRowsByContextEntity = async (
+  entry: LogbookEntry,
+  fetchEvents: LogbookFetcher
+): Promise<LogbookEntry[]> => {
+  const contextEntityId = entry.context_entity_id!;
+  const runs = (
+    await fetchEvents(lookbackIso(entry.when), justAfterIso(entry.when), [
+      contextEntityId,
+    ])
+  )
+    .filter((row) => row.context_id && row.when <= entry.when + WHEN_EPSILON)
+    .sort((a, b) => b.when - a.when)
+    .slice(0, MAX_RUN_CANDIDATES);
+
+  for (const run of runs) {
+    // eslint-disable-next-line no-await-in-loop
+    const rows = await fetchEvents(
+      lookbackIso(entry.when),
+      undefined,
+      undefined,
+      run.context_id
+    );
+    if (rows.some((row) => isSameLogbookEntry(row, entry))) {
+      return rows;
+    }
+  }
+  return [];
+};
+
+const resolveTriggerRow = async (
+  entityId: string,
+  beforeWhen: number,
+  fetchEvents: LogbookFetcher
+): Promise<LogbookEntry | undefined> => {
+  const rows = await fetchEvents(
+    lookbackIso(beforeWhen),
+    justAfterIso(beforeWhen),
+    [entityId]
+  );
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const row = rows[i];
+    if (row.state !== undefined && row.when <= beforeWhen + WHEN_EPSILON) {
+      return row;
+    }
+  }
+  return undefined;
+};
+
+export const resolveLogbookChain = async (
+  hass: HomeAssistant,
+  entry: LogbookEntry,
+  options: ResolveOptions = {},
+  fetchEvents: LogbookFetcher = (startDate, endDate, entityIds, contextId) =>
+    getLogbookEvents(hass, startDate, endDate, entityIds, contextId)
+): Promise<LogbookChain> => {
+  const userIdToName = options.userIdToName ?? {};
+  const { systemUserIds } = options;
+
+  let rows: LogbookEntry[] = [];
+  if (entry.context_id) {
+    rows = await fetchEvents(
+      lookbackIso(entry.when),
+      undefined,
+      undefined,
+      entry.context_id
+    );
+  } else if (entry.context_entity_id) {
+    rows = await resolveRowsByContextEntity(entry, fetchEvents);
+  }
+  if (!rows.length) {
+    rows = [entry];
+  }
+
+  let runRow = rows.find((row) => classifyLogbookEntry(row) === "automation");
+  if (runRow && runRow !== entry && isSameLogbookEntry(entry, runRow)) {
+    // The clicked feed copy carries the call_service description that the
+    // fetched copy of the run row never has.
+    rows = rows.map((row) => (row === runRow ? entry : row));
+    runRow = entry;
+  }
+  const origins: LogbookCause[] = [];
+  let syntheticRun: LogbookCause | undefined;
+  if (runRow) {
+    const runCause = computeLogbookCause(
+      hass,
+      runRow,
+      userIdToName,
+      systemUserIds
+    );
+    if (runCause?.type !== "user" && !isSameLogbookEntry(entry, runRow)) {
+      // The run row is its own context origin and comes back without the
+      // user its effects carry: read the user from the clicked entry.
+      const userCause = computeUserCause(entry, userIdToName, systemUserIds);
+      if (userCause) {
+        origins.push(userCause);
+      }
+    }
+    if (runCause) {
+      origins.push(runCause);
+    }
+  } else {
+    const userCause = computeUserCause(entry, userIdToName, systemUserIds);
+    const contextCause = computeContextCause(hass, entry);
+    if (isRunCause(contextCause)) {
+      syntheticRun = contextCause;
+      if (userCause) {
+        origins.push(userCause);
+      }
+    } else {
+      const cause = userCause ?? contextCause;
+      if (cause) {
+        origins.push(cause);
+      }
+    }
+  }
+
+  const stateOrigin = origins.find(
+    (cause) => cause.type === "state" && cause.entityId
+  );
+  const triggerRow = stateOrigin
+    ? await resolveTriggerRow(
+        stateOrigin.entityId!,
+        (runRow ?? entry).when,
+        fetchEvents
+      )
+    : undefined;
+
+  return { rows, runRow, origins, syntheticRun, triggerRow };
+};

--- a/src/panels/logbook/logbook-chain-resolver.ts
+++ b/src/panels/logbook/logbook-chain-resolver.ts
@@ -3,11 +3,11 @@ import { getLogbookDataFromServer } from "../../data/logbook";
 import type { HomeAssistant } from "../../types";
 import type { LogbookCause } from "./logbook-entry-model";
 import {
-  classifyLogbookEntry,
   computeContextCause,
   computeLogbookCause,
   computeUserCause,
   isRunCause,
+  isRunRow,
   isSameLogbookEntry,
 } from "./logbook-entry-model";
 
@@ -126,7 +126,7 @@ export const resolveLogbookChain = async (
     rows = [entry];
   }
 
-  let runRow = rows.find((row) => classifyLogbookEntry(row) === "automation");
+  let runRow = rows.find(isRunRow);
   if (runRow && runRow !== entry && isSameLogbookEntry(entry, runRow)) {
     // The clicked feed copy carries the call_service description that the
     // fetched copy of the run row never has.

--- a/src/panels/logbook/logbook-entry-model.ts
+++ b/src/panels/logbook/logbook-entry-model.ts
@@ -339,8 +339,11 @@ const computeLogbookValue = (
       type: "state",
     };
   }
-  // Core sends run rows with a raw English message; use our own label.
-  const isAutomationRun = domain && TRIGGER_DOMAINS.includes(domain);
+  // Core sends run rows (carrying the automation/script entity) with a raw
+  // English message; use our own label. Domain-only entries (e.g. logbook.log)
+  // keep their custom message.
+  const isAutomationRun =
+    item.entity_id && domain && TRIGGER_DOMAINS.includes(domain);
   if (isAutomationRun) {
     return {
       text: hass.localize(

--- a/src/panels/logbook/logbook-entry-model.ts
+++ b/src/panels/logbook/logbook-entry-model.ts
@@ -36,6 +36,10 @@ export const classifyLogbookEntry = (
   return "integration";
 };
 
+// A run row is the acting automation or script; every other row is an effect.
+export const isRunRow = (item: LogbookEntry): boolean =>
+  classifyLogbookEntry(item) === "automation";
+
 // How much naming detail an entity row shows, from least to most. The value is
 // the broadest part shown: `none` (name hidden), `entity`, `device` (device ▸
 // entity), `area` (area ▸ device ▸ entity).

--- a/src/panels/logbook/logbook-entry-model.ts
+++ b/src/panels/logbook/logbook-entry-model.ts
@@ -12,13 +12,14 @@ import {
   localizeStateMessage,
   parseTriggerSource,
 } from "../../data/logbook";
+import type { TraceContexts } from "../../data/trace";
 import type { HomeAssistant } from "../../types";
 
 export type LogbookEntryCategory = "entity" | "automation" | "integration";
 
-export const TRIGGER_DOMAINS = ["automation", "script"];
+const TRIGGER_DOMAINS = ["automation", "script"];
 
-export const stripEntityId = (message: string, entityId?: string) =>
+const stripEntityId = (message: string, entityId?: string) =>
   entityId ? message.replace(entityId, " ") : message;
 
 export const classifyLogbookEntry = (
@@ -96,11 +97,48 @@ export const entityDisplay = (
   return { primary, secondary };
 };
 
-export const hasContext = (item: LogbookEntry) =>
+const hasContext = (item: LogbookEntry) =>
   item.context_event_type || item.context_state || item.context_message;
 
 export const sameDay = (a?: LogbookEntry, b?: LogbookEntry) =>
   !!a?.when && !!b?.when && isSameDay(a.when * 1000, b.when * 1000);
+
+// Entries are sorted newest first.
+export const findPreviousState = (
+  entries: LogbookEntry[],
+  index: number
+): string | undefined => {
+  const entityId = entries[index]?.entity_id;
+  if (!entityId) {
+    return undefined;
+  }
+  for (let i = index + 1; i < entries.length; i++) {
+    const entry = entries[i];
+    if (entry.entity_id === entityId && entry.state !== undefined) {
+      return entry.state;
+    }
+  }
+  return undefined;
+};
+
+export const isSameLogbookEntry = (a: LogbookEntry, b: LogbookEntry) =>
+  a.when === b.when &&
+  a.entity_id === b.entity_id &&
+  a.state === b.state &&
+  a.message === b.message &&
+  a.name === b.name;
+
+// Every entry of a run shares the run's context id, so effect rows resolve
+// to their cause's trace too.
+export const computeTraceLink = (
+  traceContexts: TraceContexts,
+  contextId?: string
+): string | undefined => {
+  const traceContext = contextId ? traceContexts[contextId] : undefined;
+  return traceContext
+    ? `/config/${traceContext.domain}/trace/${traceContext.item_id}?run_id=${traceContext.run_id}`
+    : undefined;
+};
 
 // Unavailable is flagged with an orange badge by the row, not a color change.
 export const nodeColor = (
@@ -131,8 +169,7 @@ export interface LogbookCause {
   brandDomain?: string;
 }
 
-export const computeLogbookCause = (
-  hass: HomeAssistant,
+export const computeUserCause = (
   item: LogbookEntry,
   userIdToName: Record<string, string>,
   systemUserIds?: Set<string>
@@ -140,15 +177,21 @@ export const computeLogbookCause = (
   const userName = item.context_user_id
     ? userIdToName[item.context_user_id]
     : undefined;
-  if (userName) {
-    return {
-      type: "user",
-      name: userName,
-      userId: item.context_user_id,
-      systemUser: systemUserIds?.has(item.context_user_id!),
-    };
+  if (!userName) {
+    return undefined;
   }
+  return {
+    type: "user",
+    name: userName,
+    userId: item.context_user_id,
+    systemUser: systemUserIds?.has(item.context_user_id!),
+  };
+};
 
+export const computeContextCause = (
+  hass: HomeAssistant,
+  item: LogbookEntry
+): LogbookCause | undefined => {
   if (
     item.context_event_type === "automation_triggered" ||
     item.context_event_type === "script_started"
@@ -239,6 +282,18 @@ export const computeLogbookCause = (
   return undefined;
 };
 
+export const computeLogbookCause = (
+  hass: HomeAssistant,
+  item: LogbookEntry,
+  userIdToName: Record<string, string>,
+  systemUserIds?: Set<string>
+): LogbookCause | undefined =>
+  computeUserCause(item, userIdToName, systemUserIds) ??
+  computeContextCause(hass, item);
+
+export const isRunCause = (cause?: LogbookCause): boolean =>
+  cause?.type === "automation" || cause?.type === "script";
+
 export type LogbookGlyph =
   | { type: "state"; stateObj: HassEntity; icon?: string }
   | { type: "automation"; script: boolean }
@@ -284,10 +339,8 @@ const computeLogbookValue = (
       type: "state",
     };
   }
-  const isAutomationRun =
-    domain &&
-    TRIGGER_DOMAINS.includes(domain) &&
-    (item.source || hasContext(item) || !!item.context_user_id);
+  // Core sends run rows with a raw English message; use our own label.
+  const isAutomationRun = domain && TRIGGER_DOMAINS.includes(domain);
   if (isAutomationRun) {
     return {
       text: hass.localize(
@@ -348,6 +401,13 @@ export const computeLogbookItem = (
     ? entityDisplay(hass, entry.entity_id, opts.nameDetail)
     : undefined;
 
+  const userCause = computeUserCause(
+    entry,
+    opts.userIdToName ?? {},
+    opts.systemUserIds
+  );
+  const contextCause = computeContextCause(hass, entry);
+
   return {
     category,
     glyph: computeLogbookGlyph(entry, category, historicStateObj, domain),
@@ -355,12 +415,10 @@ export const computeLogbookItem = (
     name: display?.primary ?? entry.name,
     context: display?.secondary,
     value: computeLogbookValue(hass, entry, domain, historicStateObj),
-    cause: computeLogbookCause(
-      hass,
-      entry,
-      opts.userIdToName ?? {},
-      opts.systemUserIds
-    ),
+    // A row shows the run over the user who started it; the dialog shows both.
+    cause: isRunCause(contextCause)
+      ? contextCause
+      : (userCause ?? contextCause),
     when: entry.when * 1000,
   };
 };

--- a/src/panels/logbook/logbook-entry-model.ts
+++ b/src/panels/logbook/logbook-entry-model.ts
@@ -103,24 +103,6 @@ const hasContext = (item: LogbookEntry) =>
 export const sameDay = (a?: LogbookEntry, b?: LogbookEntry) =>
   !!a?.when && !!b?.when && isSameDay(a.when * 1000, b.when * 1000);
 
-// Entries are sorted newest first.
-export const findPreviousState = (
-  entries: LogbookEntry[],
-  index: number
-): string | undefined => {
-  const entityId = entries[index]?.entity_id;
-  if (!entityId) {
-    return undefined;
-  }
-  for (let i = index + 1; i < entries.length; i++) {
-    const entry = entries[i];
-    if (entry.entity_id === entityId && entry.state !== undefined) {
-      return entry.state;
-    }
-  }
-  return undefined;
-};
-
 export const isSameLogbookEntry = (a: LogbookEntry, b: LogbookEntry) =>
   a.when === b.when &&
   a.entity_id === b.entity_id &&

--- a/src/panels/logbook/logbook-entry-templates.ts
+++ b/src/panels/logbook/logbook-entry-templates.ts
@@ -1,6 +1,8 @@
 import { mdiCast, mdiCloud, mdiPuzzle, mdiRobot, mdiScriptText } from "@mdi/js";
-import { html, nothing } from "lit";
+import { css, html, nothing } from "lit";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
+import { fireEvent } from "../../common/dom/fire_event";
+import { computeRTL } from "../../common/util/compute_rtl";
 import "../../components/entity/state-badge";
 import "../../components/ha-domain-icon";
 import "../../components/ha-state-icon";
@@ -84,6 +86,48 @@ const brandImage = (
     hass.auth.data.hassUrl
   );
 };
+
+const entityNameClicked = (ev: Event) => {
+  const target = ev.currentTarget as HTMLElement & { entityId?: string };
+  if (!target.entityId) {
+    return;
+  }
+  fireEvent(target, "hass-more-info", { entityId: target.entityId });
+};
+
+// The event bubbles from the button, so an enclosing dialog can react to it
+// (ha-adaptive-dialog closes on hass-more-info).
+export const renderEntityName = (
+  hass: HomeAssistant,
+  name: string | undefined,
+  entityId?: string
+) => {
+  if (entityId && entityId in hass.states) {
+    return html`<button
+      class="link name"
+      .entityId=${entityId}
+      @click=${entityNameClicked}
+    >
+      ${name}
+    </button>`;
+  }
+  return html`<span class="name">${name}</span>`;
+};
+
+export const entityNameButtonStyle = css`
+  button.link.name {
+    color: var(--primary-text-color);
+    text-align: inherit;
+    text-decoration: none;
+  }
+
+  button.link.name:hover {
+    text-decoration: underline;
+  }
+`;
+
+export const transitionArrow = (hass: HomeAssistant) =>
+  computeRTL(hass.language, hass.translationMetadata.translations) ? "←" : "→";
 
 export const renderLogbookGlyph = (
   hass: HomeAssistant,

--- a/src/panels/logbook/logbook-entry-templates.ts
+++ b/src/panels/logbook/logbook-entry-templates.ts
@@ -1,0 +1,109 @@
+import { mdiCast, mdiCloud, mdiPuzzle, mdiRobot, mdiScriptText } from "@mdi/js";
+import { html, nothing } from "lit";
+import { isComponentLoaded } from "../../common/config/is_component_loaded";
+import "../../components/entity/state-badge";
+import "../../components/ha-domain-icon";
+import "../../components/ha-state-icon";
+import "../../components/ha-svg-icon";
+import "../../components/user/ha-user-badge";
+import type { LogbookEntry } from "../../data/logbook";
+import type { User } from "../../data/user";
+import type { HomeAssistant } from "../../types";
+import { brandsUrl } from "../../util/brands-url";
+import type { LogbookCause, LogbookGlyph } from "./logbook-entry-model";
+
+// Names are the fixed system user names set by core (cloud/cast integrations).
+const SYSTEM_USER_ICONS: Record<string, string> = {
+  "Home Assistant Cloud": mdiCloud,
+  "Home Assistant Cast": mdiCast,
+};
+
+export const renderLogbookCauseIcon = (cause: LogbookCause) => {
+  if (cause.type === "user") {
+    const systemIcon = cause.systemUser
+      ? SYSTEM_USER_ICONS[cause.name]
+      : undefined;
+    if (systemIcon) {
+      return html`<ha-svg-icon
+        class="cause-icon"
+        .path=${systemIcon}
+      ></ha-svg-icon>`;
+    }
+    return html`<ha-user-badge
+      class="cause-icon cause-avatar"
+      .user=${{ id: cause.userId!, name: cause.name } as User}
+    ></ha-user-badge>`;
+  }
+  if (cause.type === "automation") {
+    return html`<ha-svg-icon
+      class="cause-icon"
+      .path=${mdiRobot}
+    ></ha-svg-icon>`;
+  }
+  if (cause.type === "script") {
+    return html`<ha-svg-icon
+      class="cause-icon"
+      .path=${mdiScriptText}
+    ></ha-svg-icon>`;
+  }
+  if (cause.type === "state") {
+    return nothing;
+  }
+  if (cause.brandDomain) {
+    return html`<ha-domain-icon
+      class="cause-icon"
+      .domain=${cause.brandDomain}
+      brand-fallback
+    ></ha-domain-icon>`;
+  }
+  return html`<ha-svg-icon
+    class="cause-icon"
+    .path=${mdiPuzzle}
+  ></ha-svg-icon>`;
+};
+
+const brandImage = (
+  hass: HomeAssistant,
+  entry: LogbookEntry,
+  domain?: string
+): string | undefined => {
+  if (
+    !domain ||
+    entry.icon ||
+    entry.state ||
+    !isComponentLoaded(hass.config, domain)
+  ) {
+    return undefined;
+  }
+  return brandsUrl(
+    {
+      domain,
+      type: "icon",
+      darkOptimized: hass.themes?.darkMode,
+    },
+    hass.auth.data.hassUrl
+  );
+};
+
+export const renderLogbookGlyph = (
+  hass: HomeAssistant,
+  entry: LogbookEntry,
+  glyph: LogbookGlyph
+) => {
+  if (glyph.type === "automation") {
+    return html`<ha-svg-icon
+      .path=${glyph.script ? mdiScriptText : mdiRobot}
+    ></ha-svg-icon>`;
+  }
+  if (glyph.type === "state") {
+    return html`<ha-state-icon
+      .stateObj=${glyph.stateObj}
+      .icon=${glyph.icon}
+    ></ha-state-icon>`;
+  }
+  return html`<state-badge
+    .overrideIcon=${glyph.icon}
+    .overrideImage=${brandImage(hass, entry, glyph.domain)}
+    .stateColor=${false}
+  ></state-badge>`;
+};

--- a/src/panels/logbook/logbook-entry-templates.ts
+++ b/src/panels/logbook/logbook-entry-templates.ts
@@ -1,5 +1,12 @@
-import { mdiCast, mdiCloud, mdiPuzzle, mdiRobot, mdiScriptText } from "@mdi/js";
-import { css, html, nothing } from "lit";
+import {
+  mdiCast,
+  mdiCloud,
+  mdiPuzzle,
+  mdiRobot,
+  mdiScriptText,
+  mdiStateMachine,
+} from "@mdi/js";
+import { css, html } from "lit";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import { fireEvent } from "../../common/dom/fire_event";
 import { computeRTL } from "../../common/util/compute_rtl";
@@ -49,7 +56,10 @@ export const renderLogbookCauseIcon = (cause: LogbookCause) => {
     ></ha-svg-icon>`;
   }
   if (cause.type === "state") {
-    return nothing;
+    return html`<ha-svg-icon
+      class="cause-icon"
+      .path=${mdiStateMachine}
+    ></ha-svg-icon>`;
   }
   if (cause.brandDomain) {
     return html`<ha-domain-icon

--- a/src/panels/logbook/logbook-entry-templates.ts
+++ b/src/panels/logbook/logbook-entry-templates.ts
@@ -7,9 +7,8 @@ import {
   mdiScriptText,
   mdiStateMachine,
 } from "@mdi/js";
-import { css, html } from "lit";
+import { html } from "lit";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
-import { fireEvent } from "../../common/dom/fire_event";
 import { computeRTL } from "../../common/util/compute_rtl";
 import "../../components/entity/state-badge";
 import "../../components/ha-domain-icon";
@@ -110,45 +109,6 @@ const brandImage = (
     hass.auth.data.hassUrl
   );
 };
-
-const entityNameClicked = (ev: Event) => {
-  const target = ev.currentTarget as HTMLElement & { entityId?: string };
-  if (!target.entityId) {
-    return;
-  }
-  fireEvent(target, "hass-more-info", { entityId: target.entityId });
-};
-
-// The event bubbles from the button, so an enclosing dialog can react to it
-// (ha-adaptive-dialog closes on hass-more-info).
-export const renderEntityName = (
-  hass: HomeAssistant,
-  name: string | undefined,
-  entityId?: string
-) => {
-  if (entityId && entityId in hass.states) {
-    return html`<button
-      class="link name"
-      .entityId=${entityId}
-      @click=${entityNameClicked}
-    >
-      ${name}
-    </button>`;
-  }
-  return html`<span class="name">${name}</span>`;
-};
-
-export const entityNameButtonStyle = css`
-  button.link.name {
-    color: var(--primary-text-color);
-    text-align: inherit;
-    text-decoration: none;
-  }
-
-  button.link.name:hover {
-    text-decoration: underline;
-  }
-`;
 
 export const transitionArrow = (hass: HomeAssistant) =>
   computeRTL(hass.language, hass.translationMetadata.translations) ? "←" : "→";

--- a/src/panels/logbook/logbook-entry-templates.ts
+++ b/src/panels/logbook/logbook-entry-templates.ts
@@ -1,5 +1,6 @@
 import {
   mdiCast,
+  mdiClockOutline,
   mdiCloud,
   mdiPuzzle,
   mdiRobot,
@@ -15,6 +16,7 @@ import "../../components/ha-domain-icon";
 import "../../components/ha-state-icon";
 import "../../components/ha-svg-icon";
 import "../../components/user/ha-user-badge";
+import { mdiHomeAssistant } from "../../resources/home-assistant-logo-svg";
 import type { LogbookEntry } from "../../data/logbook";
 import type { User } from "../../data/user";
 import type { HomeAssistant } from "../../types";
@@ -59,6 +61,18 @@ export const renderLogbookCauseIcon = (cause: LogbookCause) => {
     return html`<ha-svg-icon
       class="cause-icon"
       .path=${mdiStateMachine}
+    ></ha-svg-icon>`;
+  }
+  if (cause.type === "scheduled") {
+    return html`<ha-svg-icon
+      class="cause-icon"
+      .path=${mdiClockOutline}
+    ></ha-svg-icon>`;
+  }
+  if (cause.type === "homeassistant") {
+    return html`<ha-svg-icon
+      class="cause-icon"
+      .path=${mdiHomeAssistant}
     ></ha-svg-icon>`;
   }
   if (cause.brandDomain) {

--- a/src/panels/logbook/show-dialog-logbook-detail.ts
+++ b/src/panels/logbook/show-dialog-logbook-detail.ts
@@ -4,7 +4,6 @@ import type { TraceContexts } from "../../data/trace";
 
 export interface LogbookDetailDialogParams {
   entry: LogbookEntry;
-  previousState?: string;
   traceContexts?: TraceContexts;
   userIdToName?: Record<string, string>;
   systemUserIds?: Set<string>;

--- a/src/panels/logbook/show-dialog-logbook-detail.ts
+++ b/src/panels/logbook/show-dialog-logbook-detail.ts
@@ -1,0 +1,24 @@
+import { fireEvent } from "../../common/dom/fire_event";
+import type { LogbookEntry } from "../../data/logbook";
+import type { TraceContexts } from "../../data/trace";
+
+export interface LogbookDetailDialogParams {
+  entry: LogbookEntry;
+  previousState?: string;
+  traceContexts?: TraceContexts;
+  userIdToName?: Record<string, string>;
+  systemUserIds?: Set<string>;
+}
+
+export const loadLogbookDetailDialog = () => import("./dialog-logbook-detail");
+
+export const showLogbookDetailDialog = (
+  element: HTMLElement,
+  params: LogbookDetailDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-logbook-detail",
+    dialogImport: loadLogbookDetailDialog,
+    dialogParams: params,
+  });
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -694,6 +694,7 @@
         "automation_triggered": "Triggered",
         "script_ran": "Ran",
         "view_trace": "View trace",
+        "view_details": "View details",
         "trigger_type": {
           "calendar": "[%key:ui::panel::config::automation::editor::triggers::type::calendar::label%]",
           "conversation": "[%key:ui::panel::config::automation::editor::triggers::type::conversation::label%]",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2054,6 +2054,19 @@
         "description": "Description",
         "required_error_msg": "[%key:ui::panel::config::zone::detail::required_error_msg%]"
       },
+      "logbook_detail": {
+        "title": "Activity details",
+        "entity": "Entity",
+        "automation": "Automation",
+        "script": "Script",
+        "integration": "Integration",
+        "state": "State",
+        "event": "Event",
+        "time": "Time",
+        "what_happened": "What happened",
+        "no_known_cause": "No cause was recorded for this activity.",
+        "action_used": "Action used: {name}"
+      },
       "voice-settings": {
         "expose_header": "Expose",
         "aliases_header": "Aliases",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -694,7 +694,6 @@
         "automation_triggered": "Triggered",
         "script_ran": "Ran",
         "view_trace": "View trace",
-        "view_details": "View details",
         "trigger_type": {
           "calendar": "[%key:ui::panel::config::automation::editor::triggers::type::calendar::label%]",
           "conversation": "[%key:ui::panel::config::automation::editor::triggers::type::conversation::label%]",
@@ -2057,10 +2056,6 @@
       },
       "logbook_detail": {
         "title": "Activity details",
-        "entity": "Entity",
-        "automation": "Automation",
-        "script": "Script",
-        "integration": "Integration",
         "state": "State",
         "event": "Event",
         "time": "Time",

--- a/test/common/datetime/format_time.test.ts
+++ b/test/common/datetime/format_time.test.ts
@@ -3,6 +3,7 @@ import { expect, describe, it } from "vitest";
 import {
   formatTime,
   formatTimeWithSeconds,
+  formatTimeWithMilliseconds,
   formatTimeWeekday,
   formatTime24h,
 } from "../../../src/common/datetime/format_time";
@@ -82,6 +83,58 @@ describe("formatTimeWithSeconds", () => {
         demoConfig
       )
     ).toBe("23:12:13");
+  });
+});
+
+describe("formatTimeWithMilliseconds", () => {
+  const dateObj = new Date(2017, 10, 18, 23, 12, 13, 400);
+
+  it("Formats English times with milliseconds", () => {
+    expect(
+      formatTimeWithMilliseconds(
+        dateObj,
+        {
+          language: "en",
+          number_format: NumberFormat.language,
+          time_format: TimeFormat.am_pm,
+          date_format: DateFormat.language,
+          time_zone: TimeZone.local,
+          first_weekday: FirstWeekday.language,
+        },
+        demoConfig
+      )
+    ).toBe("11:12:13.400 PM");
+    expect(
+      formatTimeWithMilliseconds(
+        dateObj,
+        {
+          language: "en",
+          number_format: NumberFormat.language,
+          time_format: TimeFormat.twenty_four,
+          date_format: DateFormat.language,
+          time_zone: TimeZone.local,
+          first_weekday: FirstWeekday.language,
+        },
+        demoConfig
+      )
+    ).toBe("23:12:13.400");
+  });
+
+  it("Uses the locale decimal separator", () => {
+    expect(
+      formatTimeWithMilliseconds(
+        dateObj,
+        {
+          language: "fr",
+          number_format: NumberFormat.language,
+          time_format: TimeFormat.twenty_four,
+          date_format: DateFormat.language,
+          time_zone: TimeZone.local,
+          first_weekday: FirstWeekday.language,
+        },
+        demoConfig
+      )
+    ).toBe("23:12:13,400");
   });
 });
 

--- a/test/panels/logbook/logbook-chain-resolver.test.ts
+++ b/test/panels/logbook/logbook-chain-resolver.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from "vitest";
+import type { LogbookEntry } from "../../../src/data/logbook";
+import type { LogbookFetcher } from "../../../src/panels/logbook/logbook-chain-resolver";
+import { resolveLogbookChain } from "../../../src/panels/logbook/logbook-chain-resolver";
+import type { HomeAssistant } from "../../../src/types";
+
+const hass = {
+  language: "en",
+  translationMetadata: { translations: {} },
+  states: {},
+  entities: {},
+  devices: {},
+  areas: {},
+  floors: {},
+  localize: () => "",
+} as unknown as HomeAssistant;
+
+const USERS = { user_1: "Alice" };
+
+const entry = (partial: Partial<LogbookEntry>): LogbookEntry => ({
+  when: 0,
+  name: "",
+  ...partial,
+});
+
+const runRow = (when: number, contextId: string): LogbookEntry =>
+  entry({
+    when,
+    name: "Wake up",
+    entity_id: "automation.wake_up",
+    domain: "automation",
+    source: "state of binary_sensor.motion",
+    context_id: contextId,
+  });
+
+const effectRow = (when: number): LogbookEntry =>
+  entry({
+    when,
+    name: "Ceiling light",
+    entity_id: "light.ceiling",
+    state: "on",
+    context_event_type: "automation_triggered",
+    context_name: "Wake up",
+    context_entity_id: "automation.wake_up",
+    context_source: "state of binary_sensor.motion",
+  });
+
+interface FetchCall {
+  entityIds?: string[];
+  contextId?: string;
+}
+
+const makeFetcher = (
+  handler: (entityIds?: string[], contextId?: string) => LogbookEntry[]
+): { fetch: LogbookFetcher; calls: FetchCall[] } => {
+  const calls: FetchCall[] = [];
+  return {
+    calls,
+    fetch: async (_start, _end, entityIds, contextId) => {
+      calls.push({ entityIds, contextId });
+      return handler(entityIds, contextId);
+    },
+  };
+};
+
+describe("resolveLogbookChain", () => {
+  it("fetches by context id when the entry has one", async () => {
+    const run = runRow(10, "ctx_run");
+    const effect = { ...effectRow(11), context_id: "ctx_run" };
+    const { fetch, calls } = makeFetcher((entityIds, contextId) => {
+      if (contextId === "ctx_run") {
+        return [run, effect];
+      }
+      if (entityIds?.includes("binary_sensor.motion")) {
+        return [
+          entry({ when: 9.8, entity_id: "binary_sensor.motion", state: "on" }),
+        ];
+      }
+      return [];
+    });
+
+    const chain = await resolveLogbookChain(hass, effect, {}, fetch);
+
+    expect(calls[0].contextId).toBe("ctx_run");
+    expect(chain.runRow).toBe(run);
+    expect(chain.rows).toEqual([run, effect]);
+    expect(chain.origins).toHaveLength(1);
+    expect(chain.origins[0].type).toBe("state");
+    expect(chain.origins[0].entityId).toBe("binary_sensor.motion");
+    expect(chain.syntheticRun).toBeUndefined();
+    expect(chain.triggerRow?.when).toBe(9.8);
+  });
+
+  it("resolves the run through the context entity and verifies candidates", async () => {
+    const effect = effectRow(11);
+    const otherRun = runRow(10.9, "ctx_other");
+    const goodRun = runRow(10, "ctx_good");
+    const { fetch, calls } = makeFetcher((entityIds, contextId) => {
+      if (entityIds?.includes("automation.wake_up")) {
+        return [goodRun, otherRun];
+      }
+      if (contextId === "ctx_other") {
+        // The closest run does not contain the clicked entry.
+        return [
+          otherRun,
+          entry({ when: 11, entity_id: "light.desk", state: "on" }),
+        ];
+      }
+      if (contextId === "ctx_good") {
+        return [goodRun, effect];
+      }
+      return [];
+    });
+
+    const chain = await resolveLogbookChain(hass, effect, {}, fetch);
+
+    expect(calls[0].entityIds).toEqual(["automation.wake_up"]);
+    expect(calls[1].contextId).toBe("ctx_other");
+    expect(calls[2].contextId).toBe("ctx_good");
+    expect(chain.runRow?.context_id).toBe("ctx_good");
+    expect(chain.rows).toEqual([goodRun, effect]);
+  });
+
+  it("falls back to a synthetic run when no candidate matches", async () => {
+    const effect = effectRow(11);
+    const { fetch } = makeFetcher((entityIds) =>
+      entityIds?.includes("automation.wake_up")
+        ? [runRow(10, "ctx_unrelated")]
+        : []
+    );
+
+    const chain = await resolveLogbookChain(hass, effect, {}, fetch);
+
+    expect(chain.runRow).toBeUndefined();
+    expect(chain.rows).toEqual([effect]);
+    expect(chain.syntheticRun?.type).toBe("automation");
+    expect(chain.origins).toEqual([]);
+  });
+
+  it("keeps a direct user action as the only origin", async () => {
+    const direct = entry({
+      when: 5,
+      entity_id: "light.ceiling",
+      state: "on",
+      context_user_id: "user_1",
+      context_event_type: "call_service",
+      context_domain: "light",
+      context_service: "turn_on",
+    });
+    const { fetch, calls } = makeFetcher(() => []);
+
+    const chain = await resolveLogbookChain(
+      hass,
+      direct,
+      { userIdToName: USERS },
+      fetch
+    );
+
+    expect(calls).toHaveLength(0);
+    expect(chain.rows).toEqual([direct]);
+    expect(chain.origins).toHaveLength(1);
+    expect(chain.origins[0].type).toBe("user");
+    expect(chain.origins[0].name).toBe("Alice");
+    expect(chain.syntheticRun).toBeUndefined();
+  });
+
+  it("picks the last trigger state before the run, even minutes earlier", async () => {
+    const run = runRow(600, "ctx_run");
+    const effect = { ...effectRow(601), context_id: "ctx_run" };
+    const { fetch } = makeFetcher((entityIds, contextId) => {
+      if (contextId === "ctx_run") {
+        return [run, effect];
+      }
+      if (entityIds?.includes("binary_sensor.motion")) {
+        return [
+          entry({ when: 100, entity_id: "binary_sensor.motion", state: "on" }),
+          entry({ when: 480, entity_id: "binary_sensor.motion", state: "off" }),
+          entry({ when: 640, entity_id: "binary_sensor.motion", state: "on" }),
+        ];
+      }
+      return [];
+    });
+
+    const chain = await resolveLogbookChain(hass, effect, {}, fetch);
+
+    expect(chain.triggerRow?.when).toBe(480);
+    expect(chain.triggerRow?.state).toBe("off");
+  });
+
+  it("prefers the clicked copy of the run row over the fetched one", async () => {
+    const clicked = entry({
+      when: 10,
+      name: "Wake up",
+      entity_id: "automation.wake_up",
+      domain: "automation",
+      context_id: "ctx_run",
+      context_user_id: "user_1",
+      context_event_type: "call_service",
+      context_domain: "automation",
+      context_service: "trigger",
+    });
+    const fetched = entry({
+      when: 10,
+      name: "Wake up",
+      entity_id: "automation.wake_up",
+      domain: "automation",
+      context_id: "ctx_run",
+    });
+    const effect = { ...effectRow(11), context_id: "ctx_run" };
+    const { fetch } = makeFetcher((_entityIds, contextId) =>
+      contextId === "ctx_run" ? [fetched, effect] : []
+    );
+
+    const chain = await resolveLogbookChain(
+      hass,
+      clicked,
+      { userIdToName: USERS },
+      fetch
+    );
+
+    expect(chain.runRow).toBe(clicked);
+    expect(chain.rows).toEqual([clicked, effect]);
+    expect(chain.origins).toHaveLength(1);
+    expect(chain.origins[0].type).toBe("user");
+    expect(chain.origins[0].name).toBe("Alice");
+  });
+
+  it("surfaces the integration that triggered the run", async () => {
+    const clicked = entry({
+      when: 20,
+      name: "Wake up",
+      entity_id: "automation.wake_up",
+      domain: "automation",
+      context_id: "ctx_run",
+      context_event_type: "call_service",
+      context_domain: "homekit",
+      context_service: "turn_on",
+    });
+    const fetched = entry({
+      when: 20,
+      name: "Wake up",
+      entity_id: "automation.wake_up",
+      domain: "automation",
+      context_id: "ctx_run",
+    });
+    const effect = { ...effectRow(21), context_id: "ctx_run" };
+    const { fetch } = makeFetcher((_entityIds, contextId) =>
+      contextId === "ctx_run" ? [fetched, effect] : []
+    );
+
+    const chain = await resolveLogbookChain(hass, clicked, {}, fetch);
+
+    expect(chain.runRow).toBe(clicked);
+    expect(chain.origins).toHaveLength(1);
+    expect(chain.origins[0].type).toBe("integration");
+    expect(chain.origins[0].brandDomain).toBe("homekit");
+  });
+
+  it("keeps the user above a run row that does not carry one", async () => {
+    const fetched = entry({
+      when: 10,
+      name: "Wake up",
+      entity_id: "automation.wake_up",
+      domain: "automation",
+      context_id: "ctx_run",
+    });
+    const effect = {
+      ...effectRow(11),
+      context_id: "ctx_run",
+      context_user_id: "user_1",
+    };
+    const { fetch } = makeFetcher((_entityIds, contextId) =>
+      contextId === "ctx_run" ? [fetched, effect] : []
+    );
+
+    const chain = await resolveLogbookChain(
+      hass,
+      effect,
+      { userIdToName: USERS },
+      fetch
+    );
+
+    expect(chain.runRow).toBe(fetched);
+    expect(chain.origins).toHaveLength(1);
+    expect(chain.origins[0].type).toBe("user");
+    expect(chain.origins[0].name).toBe("Alice");
+  });
+
+  it("does not stack the user twice when the run row resolves it", async () => {
+    const fetched = entry({
+      when: 10,
+      name: "Wake up",
+      entity_id: "automation.wake_up",
+      domain: "automation",
+      context_id: "ctx_run",
+      context_user_id: "user_1",
+    });
+    const effect = {
+      ...effectRow(11),
+      context_id: "ctx_run",
+      context_user_id: "user_1",
+    };
+    const { fetch } = makeFetcher((_entityIds, contextId) =>
+      contextId === "ctx_run" ? [fetched, effect] : []
+    );
+
+    const chain = await resolveLogbookChain(
+      hass,
+      effect,
+      { userIdToName: USERS },
+      fetch
+    );
+
+    expect(chain.origins).toHaveLength(1);
+    expect(chain.origins[0].type).toBe("user");
+  });
+});

--- a/test/panels/logbook/logbook-chain-resolver.test.ts
+++ b/test/panels/logbook/logbook-chain-resolver.test.ts
@@ -81,6 +81,8 @@ describe("resolveLogbookChain", () => {
 
     const chain = await resolveLogbookChain(hass, effect, {}, fetch);
 
+    // One context fetch + one trigger fetch: no candidate discovery.
+    expect(calls).toHaveLength(2);
     expect(calls[0].contextId).toBe("ctx_run");
     expect(chain.runRow).toBe(run);
     expect(chain.rows).toEqual([run, effect]);

--- a/test/panels/logbook/logbook-entry-model.test.ts
+++ b/test/panels/logbook/logbook-entry-model.test.ts
@@ -6,7 +6,6 @@ import {
   entityDisplay,
   computeLogbookCause,
   computeLogbookGlyph,
-  findPreviousState,
   isSameLogbookEntry,
 } from "../../../src/panels/logbook/logbook-entry-model";
 import type { LogbookEntry } from "../../../src/data/logbook";
@@ -404,44 +403,6 @@ describe("computeLogbookItem", () => {
       {}
     );
     expect(model.value).toEqual({ text: "Ran", type: "state" });
-  });
-});
-
-describe("findPreviousState", () => {
-  const entries: LogbookEntry[] = [
-    entry({ when: 5, entity_id: "light.x", state: "on" }),
-    entry({ when: 4, entity_id: "sensor.y", state: "42" }),
-    entry({ when: 3, entity_id: "automation.z", domain: "automation" }),
-    entry({ when: 2, entity_id: "light.x", state: "off" }),
-    entry({ when: 1, entity_id: "light.x", state: "on" }),
-  ];
-
-  it("returns the nearest older state of the same entity", () => {
-    expect(findPreviousState(entries, 0)).toBe("off");
-    expect(findPreviousState(entries, 3)).toBe("on");
-  });
-
-  it("skips entries of other entities", () => {
-    expect(findPreviousState(entries, 1)).toBeUndefined();
-  });
-
-  it("skips state-less entries of the same entity", () => {
-    const list = [
-      entry({ when: 3, entity_id: "automation.z", state: "on" }),
-      entry({ when: 2, entity_id: "automation.z", domain: "automation" }),
-      entry({ when: 1, entity_id: "automation.z", state: "off" }),
-    ];
-    expect(findPreviousState(list, 0)).toBe("off");
-  });
-
-  it("returns undefined at the end of the list", () => {
-    expect(findPreviousState(entries, 4)).toBeUndefined();
-  });
-
-  it("returns undefined without an entity or for an out-of-range index", () => {
-    expect(findPreviousState(entries, 2)).toBeUndefined();
-    expect(findPreviousState(entries, 99)).toBeUndefined();
-    expect(findPreviousState([], 0)).toBeUndefined();
   });
 });
 

--- a/test/panels/logbook/logbook-entry-model.test.ts
+++ b/test/panels/logbook/logbook-entry-model.test.ts
@@ -572,4 +572,16 @@ describe("computeLogbookItem run rows", () => {
       type: "state",
     });
   });
+
+  it("keeps the custom message of a domain-only entry (logbook.log)", () => {
+    const hass = baseHass({
+      localize: ((key: string) => key) as HomeAssistant["localize"],
+    });
+    const model = computeLogbookItem(
+      hass,
+      entry({ domain: "script", name: "Backup", message: "Backup finished" }),
+      {}
+    );
+    expect(model.value).toEqual({ text: "Backup finished", type: "message" });
+  });
 });

--- a/test/panels/logbook/logbook-entry-model.test.ts
+++ b/test/panels/logbook/logbook-entry-model.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   computeLogbookItem,
+  computeTraceLink,
   classifyLogbookEntry,
   entityDisplay,
   computeLogbookCause,
   computeLogbookGlyph,
+  findPreviousState,
+  isSameLogbookEntry,
 } from "../../../src/panels/logbook/logbook-entry-model";
 import type { LogbookEntry } from "../../../src/data/logbook";
 import type { HomeAssistant } from "../../../src/types";
@@ -241,7 +244,7 @@ describe("computeLogbookCause", () => {
     const cause = computeLogbookCause(
       hass,
       entry({ context_user_id: "person_1" }),
-      { person_1: "Paul" },
+      { person_1: "Alice" },
       new Set(["cloud_user"])
     );
     expect(cause?.type).toBe("user");
@@ -401,5 +404,172 @@ describe("computeLogbookItem", () => {
       {}
     );
     expect(model.value).toEqual({ text: "Ran", type: "state" });
+  });
+});
+
+describe("findPreviousState", () => {
+  const entries: LogbookEntry[] = [
+    entry({ when: 5, entity_id: "light.x", state: "on" }),
+    entry({ when: 4, entity_id: "sensor.y", state: "42" }),
+    entry({ when: 3, entity_id: "automation.z", domain: "automation" }),
+    entry({ when: 2, entity_id: "light.x", state: "off" }),
+    entry({ when: 1, entity_id: "light.x", state: "on" }),
+  ];
+
+  it("returns the nearest older state of the same entity", () => {
+    expect(findPreviousState(entries, 0)).toBe("off");
+    expect(findPreviousState(entries, 3)).toBe("on");
+  });
+
+  it("skips entries of other entities", () => {
+    expect(findPreviousState(entries, 1)).toBeUndefined();
+  });
+
+  it("skips state-less entries of the same entity", () => {
+    const list = [
+      entry({ when: 3, entity_id: "automation.z", state: "on" }),
+      entry({ when: 2, entity_id: "automation.z", domain: "automation" }),
+      entry({ when: 1, entity_id: "automation.z", state: "off" }),
+    ];
+    expect(findPreviousState(list, 0)).toBe("off");
+  });
+
+  it("returns undefined at the end of the list", () => {
+    expect(findPreviousState(entries, 4)).toBeUndefined();
+  });
+
+  it("returns undefined without an entity or for an out-of-range index", () => {
+    expect(findPreviousState(entries, 2)).toBeUndefined();
+    expect(findPreviousState(entries, 99)).toBeUndefined();
+    expect(findPreviousState([], 0)).toBeUndefined();
+  });
+});
+
+describe("isSameLogbookEntry", () => {
+  const a = entry({
+    when: 1.234567,
+    entity_id: "light.x",
+    state: "on",
+    name: "Light",
+  });
+
+  it("matches an identical entry", () => {
+    expect(isSameLogbookEntry(a, { ...a })).toBe(true);
+  });
+
+  it("rejects an entry differing by any field", () => {
+    expect(isSameLogbookEntry(a, { ...a, when: 1.234568 })).toBe(false);
+    expect(isSameLogbookEntry(a, { ...a, entity_id: "light.y" })).toBe(false);
+    expect(isSameLogbookEntry(a, { ...a, state: "off" })).toBe(false);
+    expect(isSameLogbookEntry(a, { ...a, name: "Other" })).toBe(false);
+    expect(isSameLogbookEntry(a, { ...a, message: "turned on" })).toBe(false);
+  });
+
+  it("matches entity-less entries on name/message/when", () => {
+    const b = entry({ when: 2, name: "HACS", message: "2 updates available" });
+    expect(isSameLogbookEntry(b, { ...b })).toBe(true);
+    expect(isSameLogbookEntry(b, { ...b, message: "other" })).toBe(false);
+  });
+});
+
+describe("computeTraceLink", () => {
+  const traceContexts = {
+    ctx_1: { run_id: "run_9", domain: "automation", item_id: "auto_1" },
+  };
+
+  it("builds the trace URL for a known context", () => {
+    expect(computeTraceLink(traceContexts, "ctx_1")).toBe(
+      "/config/automation/trace/auto_1?run_id=run_9"
+    );
+  });
+
+  it("returns undefined for an unknown or missing context", () => {
+    expect(computeTraceLink(traceContexts, "ctx_2")).toBeUndefined();
+    expect(computeTraceLink(traceContexts, undefined)).toBeUndefined();
+    expect(computeTraceLink({}, "ctx_1")).toBeUndefined();
+  });
+});
+
+describe("computeLogbookItem cause", () => {
+  const hass = baseHass({ localize: (() => "") as HomeAssistant["localize"] });
+  const users = { user_1: "Alice" };
+
+  it("prefers the automation over the user who ran it", () => {
+    const model = computeLogbookItem(
+      hass,
+      entry({
+        entity_id: "light.ceiling",
+        state: "on",
+        context_user_id: "user_1",
+        context_event_type: "automation_triggered",
+        context_entity_id: "automation.wake_up",
+        context_name: "Wake up",
+      }),
+      { userIdToName: users }
+    );
+    expect(model.cause?.type).toBe("automation");
+    expect(model.cause?.name).toBe("Wake up");
+  });
+
+  it("keeps the user for a direct action call", () => {
+    const model = computeLogbookItem(
+      hass,
+      entry({
+        entity_id: "light.ceiling",
+        state: "on",
+        context_user_id: "user_1",
+        context_event_type: "call_service",
+        context_domain: "light",
+        context_service: "turn_on",
+      }),
+      { userIdToName: users }
+    );
+    expect(model.cause?.type).toBe("user");
+    expect(model.cause?.name).toBe("Alice");
+  });
+
+  it("falls back to the context cause without a user", () => {
+    const model = computeLogbookItem(
+      hass,
+      entry({
+        entity_id: "light.ceiling",
+        state: "on",
+        context_event_type: "automation_triggered",
+        context_name: "Wake up",
+      }),
+      { userIdToName: users }
+    );
+    expect(model.cause?.type).toBe("automation");
+  });
+
+  it("leaves the cause empty without any context", () => {
+    const model = computeLogbookItem(
+      hass,
+      entry({ entity_id: "light.ceiling", state: "on" }),
+      { userIdToName: users }
+    );
+    expect(model.cause).toBeUndefined();
+  });
+});
+
+describe("computeLogbookItem run rows", () => {
+  it("uses the run label instead of the raw backend message", () => {
+    const hass = baseHass({
+      localize: ((key: string) => key) as HomeAssistant["localize"],
+    });
+    const model = computeLogbookItem(
+      hass,
+      entry({
+        entity_id: "automation.wake_up",
+        domain: "automation",
+        name: "Wake up",
+        message: "triggered",
+      }),
+      {}
+    );
+    expect(model.value).toEqual({
+      text: "ui.components.logbook.automation_triggered",
+      type: "state",
+    });
   });
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

An activity row shows a change, not its cause. Entity names now carry their area and device, which leaves no room for the sentences that used to explain where an entry came from, so the compact views lost the trigger information (#53023). Finding out why a light turned on means opening the automation, then its trace, then the entity that triggered it.

Clicking any activity row now opens a details dialog:

- The entity with its area and device, and a shortcut to its more info dialog.
- The state it changed from and to, with the exact time.
- **What happened**: the cause path, read top to bottom. What started the run (a person, a state change, a schedule, an integration, a restart), the automations and scripts it went through, and the entity's own changes. Times go down to the millisecond, so events recorded in the same second keep their order.

Every row of the chain opens the more info of the entity behind it, and automation rows link to their trace.

The chain is built from logbook data only, no trace is fetched. Entries that carry a context id resolve directly; the others are matched to their run through the causing entity's own logbook.

Rows lose their inline links in the process: "View trace" moves into the dialog, and the time no longer toggles between absolute and relative (the dialog shows both). The logbook inside automation traces stays static.

## Screenshots

<img width="593" height="489" alt="CleanShot 2026-08-13 at 18 52 57" src="https://github.com/user-attachments/assets/3e120e0b-1440-4ab4-8403-7eeed3e85e4e" />

<img width="593" height="489" alt="CleanShot 2026-08-13 at 18 53 08" src="https://github.com/user-attachments/assets/7b0576c5-f382-4529-9917-a207401f5cee" />

<img width="593" height="365" alt="CleanShot 2026-08-13 at 18 53 33" src="https://github.com/user-attachments/assets/bca6fa64-ea7d-4b51-acce-5ff267bd1b23" />

<img width="593" height="524" alt="CleanShot 2026-08-13 at 18 54 09" src="https://github.com/user-attachments/assets/89e5247e-d875-4e77-8f97-b310e1a8c22e" />


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #53023
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
