### PR TITLE
Reject non same-origin back paths before using them as links

### DIFF
--- a/src/common/url/sanitize-navigation-path.ts
+++ b/src/common/url/sanitize-navigation-path.ts
@@ -1,0 +1,26 @@
+import { mainWindow } from "../dom/get_main_window";
+
+/**
+ * Checks that a path resolves to the origin the frontend is served from, so it
+ * is safe to use as a link target. Rejects URIs that carry their own scheme,
+ * like `javascript:`, and URLs pointing at another origin. Resolves against the
+ * main window, because that is where `navigate()` applies the path.
+ */
+const isSameOriginPath = (path: string): boolean => {
+  try {
+    const { origin } = mainWindow.location;
+    return new URL(path, origin).origin === origin;
+  } catch (_err) {
+    return false;
+  }
+};
+
+/**
+ * Returns the path if it is safe to navigate to, `undefined` otherwise. Use for
+ * paths that can be influenced by a URL parameter or by dashboard config before
+ * they end up in an `href` or in `navigate()`.
+ */
+export const sanitizeNavigationPath = (
+  path: string | null | undefined
+): string | undefined =>
+  path != null && isSameOriginPath(path) ? path : undefined;

--- a/src/layouts/hass-subpage.ts
+++ b/src/layouts/hass-subpage.ts
@@ -4,6 +4,7 @@ import { customElement, eventOptions, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { restoreScroll } from "../common/decorators/restore-scroll";
 import { goBack } from "../common/navigate";
+import { sanitizeNavigationPath } from "../common/url/sanitize-navigation-path";
 import "../components/ha-icon-button-arrow-prev";
 import "../components/ha-menu-button";
 import { haStyleScrollbar } from "../resources/styles";
@@ -29,16 +30,18 @@ class HassSubpage extends LitElement {
   @restoreScroll(".content") private _savedScrollPos?: number;
 
   protected render(): TemplateResult {
+    const backPath = sanitizeNavigationPath(this.backPath);
+
     return html`
       <div class="toolbar ${classMap({ narrow: this.narrow })}">
         <div class="toolbar-content">
           ${
             this.mainPage || history.state?.root
               ? html`<ha-menu-button></ha-menu-button>`
-              : this.backPath
+              : backPath
                 ? html`
                     <ha-icon-button-arrow-prev
-                      href=${this.backPath}
+                      href=${backPath}
                     ></ha-icon-button-arrow-prev>
                   `
                 : html`

--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -15,6 +15,7 @@ import { restoreScroll } from "../common/decorators/restore-scroll";
 import { isNavigationClick } from "../common/dom/is-navigation-click";
 import { goBack, navigate } from "../common/navigate";
 import type { LocalizeFunc } from "../common/translations/localize";
+import { sanitizeNavigationPath } from "../common/url/sanitize-navigation-path";
 import "../components/ha-icon-button-arrow-prev";
 import "../components/ha-menu-button";
 import "../components/ha-svg-icon";
@@ -164,17 +165,19 @@ export class HassTabsSubpage extends LitElement {
       this._narrow,
       this.localizeFunc || this.hass.localize
     );
+    const backPath = sanitizeNavigationPath(this.backPath);
+
     return html`
       <div class="toolbar ${classMap({ narrow: this._narrow })}">
         <slot name="toolbar">
           <div class="toolbar-content">
             ${
-              this.mainPage || (!this.backPath && history.state?.root)
+              this.mainPage || (!backPath && history.state?.root)
                 ? html`<ha-menu-button></ha-menu-button>`
-                : this.backPath
+                : backPath
                   ? html`
                       <ha-icon-button-arrow-prev
-                        .href=${this.backPath}
+                        .href=${backPath}
                       ></ha-icon-button-arrow-prev>
                     `
                   : html`

--- a/src/panels/energy/ha-panel-energy.ts
+++ b/src/panels/energy/ha-panel-energy.ts
@@ -2,6 +2,7 @@ import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { navigate } from "../../common/navigate";
+import { sanitizeNavigationPath } from "../../common/url/sanitize-navigation-path";
 import "../../components/ha-alert";
 import "../../components/ha-icon-button-arrow-prev";
 import "../../components/ha-menu-button";
@@ -161,7 +162,9 @@ class PanelEnergy extends LitElement {
         .route=${this.route}
         .panel=${this.panel}
         .backButton=${this._searchParms.has("historyBack")}
-        .backPath=${this._searchParms.get("backPath") || "/"}
+        .backPath=${
+          sanitizeNavigationPath(this._searchParms.get("backPath")) || "/"
+        }
         @reload-energy-panel=${this._reloadConfig}
       >
       </hui-root>

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -31,6 +31,7 @@ import { isNavigationClick } from "../../common/dom/is-navigation-click";
 import { goBack, navigate } from "../../common/navigate";
 import type { LocalizeKeys } from "../../common/translations/localize";
 import { constructUrlCurrentPath } from "../../common/url/construct-url";
+import { sanitizeNavigationPath } from "../../common/url/sanitize-navigation-path";
 import {
   addSearchParam,
   extractSearchParamsObject,
@@ -893,10 +894,12 @@ class HUIRoot extends LitElement {
     const curViewConfig =
       typeof this._curView === "number" ? views[this._curView] : undefined;
 
-    if (curViewConfig?.back_path != null) {
-      navigate(curViewConfig.back_path, { replace: true });
-    } else if (this.backPath) {
-      navigate(this.backPath, { replace: true });
+    const backPath = sanitizeNavigationPath(
+      curViewConfig?.back_path ?? this.backPath
+    );
+
+    if (backPath) {
+      navigate(backPath, { replace: true });
     } else if (history.length > 1) {
       goBack();
     } else if (!views[0].subview) {
@@ -918,11 +921,12 @@ class HUIRoot extends LitElement {
     const curViewConfig =
       typeof this._curView === "number" ? views[this._curView] : undefined;
 
-    if (curViewConfig?.back_path != null) {
-      return curViewConfig.back_path;
-    }
-    if (this.backPath) {
-      return this.backPath;
+    const backPath = sanitizeNavigationPath(
+      curViewConfig?.back_path ?? this.backPath
+    );
+
+    if (backPath) {
+      return backPath;
     }
     return curViewConfig?.subview ? this.route!.prefix : undefined;
   }

--- a/test/common/url/sanitize-navigation-path.test.ts
+++ b/test/common/url/sanitize-navigation-path.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeNavigationPath } from "../../../src/common/url/sanitize-navigation-path";
+
+describe("sanitizeNavigationPath", () => {
+  it("keeps paths on the current origin", () => {
+    expect(sanitizeNavigationPath("/")).toEqual("/");
+    expect(sanitizeNavigationPath("/config/areas")).toEqual("/config/areas");
+    expect(sanitizeNavigationPath("/energy?historyBack=1")).toEqual(
+      "/energy?historyBack=1"
+    );
+    expect(sanitizeNavigationPath("config/areas")).toEqual("config/areas");
+    expect(sanitizeNavigationPath(`${location.origin}/lovelace/0`)).toEqual(
+      `${location.origin}/lovelace/0`
+    );
+  });
+
+  /* eslint-disable no-script-url */
+  it("rejects URIs with their own scheme", () => {
+    expect(sanitizeNavigationPath("javascript:alert(1)")).toBeUndefined();
+    expect(sanitizeNavigationPath("JavaScript:alert(1)")).toBeUndefined();
+    // the URL parser strips tabs and newlines, just like the browser does for href
+    expect(sanitizeNavigationPath("java\tscript:alert(1)")).toBeUndefined();
+    expect(sanitizeNavigationPath(" javascript:alert(1)")).toBeUndefined();
+    expect(
+      sanitizeNavigationPath("data:text/html,<script>alert(1)</script>")
+    ).toBeUndefined();
+    expect(sanitizeNavigationPath("vbscript:msgbox(1)")).toBeUndefined();
+  });
+  /* eslint-enable no-script-url */
+
+  it("rejects other origins", () => {
+    expect(sanitizeNavigationPath("https://example.com/")).toBeUndefined();
+    expect(sanitizeNavigationPath("//example.com/")).toBeUndefined();
+    expect(sanitizeNavigationPath("\\\\example.com/")).toBeUndefined();
+  });
+
+  it("rejects missing values", () => {
+    expect(sanitizeNavigationPath(undefined)).toBeUndefined();
+    expect(sanitizeNavigationPath(null)).toBeUndefined();
+  });
+});

--- a/test/layouts/hass-subpage.test.ts
+++ b/test/layouts/hass-subpage.test.ts
@@ -1,0 +1,42 @@
+import { LitElement } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The real back button pulls in the localize context, which is not provided here.
+vi.mock("../../src/components/ha-icon-button-arrow-prev", () => ({}));
+vi.mock("../../src/components/ha-menu-button", () => ({}));
+customElements.define("ha-icon-button-arrow-prev", class extends LitElement {});
+customElements.define("ha-menu-button", class extends LitElement {});
+await import("../../src/layouts/hass-subpage");
+
+let host: HTMLDivElement | undefined;
+
+const mount = async (backPath: string) => {
+  host = document.createElement("div");
+  document.body.append(host);
+  const element = document.createElement("hass-subpage");
+  element.setAttribute("back-path", backPath);
+  host.append(element);
+  await (element as LitElement).updateComplete;
+  return element.shadowRoot!.querySelector("ha-icon-button-arrow-prev");
+};
+
+afterEach(() => {
+  host?.remove();
+  host = undefined;
+});
+
+describe("hass-subpage back path", () => {
+  it("links to a path on the current origin", async () => {
+    const backButton = await mount("/config/system");
+    expect(backButton!.getAttribute("href")).toEqual("/config/system");
+  });
+
+  // eslint-disable-next-line no-script-url
+  it.each(["javascript:alert(1)", "https://example.com/"])(
+    "does not link to %s",
+    async (backPath) => {
+      const backButton = await mount(backPath);
+      expect(backButton!.hasAttribute("href")).toBe(false);
+    }
+  );
+});

--- a/test/layouts/hass-tabs-subpage.test.ts
+++ b/test/layouts/hass-tabs-subpage.test.ts
@@ -1,0 +1,60 @@
+import { LitElement } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HassTabsSubpage } from "../../src/layouts/hass-tabs-subpage";
+import type { HomeAssistant } from "../../src/types";
+
+// The real back button pulls in the localize context, which is not provided here.
+vi.mock("../../src/components/ha-icon-button-arrow-prev", () => ({}));
+vi.mock("../../src/components/ha-menu-button", () => ({}));
+vi.mock("../../src/components/ha-tab", () => ({}));
+customElements.define("ha-icon-button-arrow-prev", class extends LitElement {});
+customElements.define("ha-menu-button", class extends LitElement {});
+customElements.define("ha-tab", class extends LitElement {});
+await import("../../src/layouts/hass-tabs-subpage");
+
+const hass = {
+  config: { components: [] },
+  language: "en",
+  localize: (key: string) => key,
+} as unknown as HomeAssistant;
+
+let host: HTMLDivElement | undefined;
+
+const mount = async (backPath: string) => {
+  host = document.createElement("div");
+  document.body.append(host);
+  const element = document.createElement(
+    "hass-tabs-subpage"
+  ) as HassTabsSubpage;
+  Object.assign(element, {
+    hass,
+    route: { prefix: "", path: "" },
+    tabs: [],
+    backPath,
+  });
+  host.append(element);
+  await element.updateComplete;
+  return element.shadowRoot!.querySelector("ha-icon-button-arrow-prev") as
+    (LitElement & { href?: string }) | null;
+};
+
+afterEach(() => {
+  host?.remove();
+  host = undefined;
+});
+
+describe("hass-tabs-subpage back path", () => {
+  it("links to a path on the current origin", async () => {
+    const backButton = await mount("/config");
+    expect(backButton!.href).toEqual("/config");
+  });
+
+  // eslint-disable-next-line no-script-url
+  it.each(["javascript:alert(1)", "https://example.com/"])(
+    "does not link to %s",
+    async (backPath) => {
+      const backButton = await mount(backPath);
+      expect(backButton!.href).toBeUndefined();
+    }
+  );
+});


### PR DESCRIPTION
## Proposed change

The `backPath` URL parameter of the energy panel was passed straight to the back button's `href`, so a back path could point anywhere instead of somewhere inside the frontend. Back paths are now validated to resolve to the frontend's own origin before they are used as a link target or passed to `navigate()`; a value that does not is ignored, and the back button falls back to normal history navigation. The same validation is applied in `hui-root`, `hass-subpage` and `hass-tabs-subpage`, which take a back path from a property or attribute.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
