### PR TITLE
Remove empty items on narrow data table secondary lines

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -736,11 +736,8 @@ export class HaDataTable extends LitElement {
     return this._isColumnVisible(key, column);
   }
 
-  private _hasCellValue(value: unknown): boolean {
-    return (
-      value !== undefined && value !== null && value !== "" && value !== nothing
-    );
-  }
+  private _hasCellValue = (value: unknown): boolean =>
+    value !== undefined && value !== null && value !== "" && value !== nothing;
 
   private async _sortFilterData() {
     const startTime = new Date().getTime();

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -484,13 +484,7 @@ export class HaDataTable extends LitElement {
                   : ""
               }
               ${Object.entries(columns).map(([key, column]) => {
-                if (
-                  column.hidden ||
-                  (this.columnOrder && this.columnOrder.includes(key)
-                    ? (this.hiddenColumns?.includes(key) ??
-                      column.defaultHidden)
-                    : column.defaultHidden)
-                ) {
+                if (!this._isColumnVisible(key, column)) {
                   return nothing;
                 }
                 const sorted = key === this.sortColumn;
@@ -658,10 +652,7 @@ export class HaDataTable extends LitElement {
         ${Object.entries(columns).map(([key, column]) => {
           if (
             (narrow && !column.main && !column.showNarrow) ||
-            column.hidden ||
-            (this.columnOrder && this.columnOrder.includes(key)
-              ? (this.hiddenColumns?.includes(key) ?? column.defaultHidden)
-              : column.defaultHidden)
+            !this._isColumnVisible(key, column)
           ) {
             return nothing;
           }
@@ -695,30 +686,15 @@ export class HaDataTable extends LitElement {
                         <div class="secondary">
                           ${join(
                             Object.entries(columns)
-                              .filter(
-                                ([key2, column2]) =>
-                                  !column2.hidden &&
-                                  !column2.main &&
-                                  !column2.showNarrow &&
-                                  !(this.columnOrder &&
-                                  this.columnOrder.includes(key2)
-                                    ? (this.hiddenColumns?.includes(key2) ??
-                                      column2.defaultHidden)
-                                    : column2.defaultHidden)
+                              .filter(([key2, column2]) =>
+                                this._isSecondaryColumnVisible(key2, column2)
                               )
                               .map(([key2, column2]) =>
                                 column2.template
                                   ? column2.template(row)
                                   : row[key2]
                               )
-                              // skip empty cells, so we don't render stray separators
-                              .filter(
-                                (value) =>
-                                  value !== undefined &&
-                                  value !== null &&
-                                  value !== "" &&
-                                  value !== nothing
-                              ),
+                              .filter(this._hasCellValue),
                             STRINGS_SEPARATOR_DOT
                           )}
                         </div>
@@ -739,6 +715,32 @@ export class HaDataTable extends LitElement {
       </div>
     `;
   };
+
+  private _isColumnVisible(key: string, column: DataTableColumnData): boolean {
+    if (column.hidden) {
+      return false;
+    }
+    if (!this.columnOrder?.includes(key)) {
+      return !column.defaultHidden;
+    }
+    return !(this.hiddenColumns?.includes(key) ?? column.defaultHidden);
+  }
+
+  private _isSecondaryColumnVisible(
+    key: string,
+    column: DataTableColumnData
+  ): boolean {
+    if (column.main || column.showNarrow) {
+      return false;
+    }
+    return this._isColumnVisible(key, column);
+  }
+
+  private _hasCellValue(value: unknown): boolean {
+    return (
+      value !== undefined && value !== null && value !== "" && value !== nothing
+    );
+  }
 
   private async _sortFilterData() {
     const startTime = new Date().getTime();

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -12,6 +12,7 @@ import {
 } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { ifDefined } from "lit/directives/if-defined";
+import { join } from "lit/directives/join";
 import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
 import { STRINGS_SEPARATOR_DOT } from "../../common/const";
@@ -692,28 +693,34 @@ export class HaDataTable extends LitElement {
                   : narrow && column.main
                     ? html`<div class="primary">${row[key]}</div>
                         <div class="secondary">
-                          ${Object.entries(columns)
-                            .filter(
-                              ([key2, column2]) =>
-                                !column2.hidden &&
-                                !column2.main &&
-                                !column2.showNarrow &&
-                                !(this.columnOrder &&
-                                this.columnOrder.includes(key2)
-                                  ? (this.hiddenColumns?.includes(key2) ??
-                                    column2.defaultHidden)
-                                  : column2.defaultHidden)
-                            )
-                            .map(
-                              ([key2, column2], i) =>
-                                html`${
-                                  i !== 0 ? STRINGS_SEPARATOR_DOT : nothing
-                                }${
-                                  column2.template
-                                    ? column2.template(row)
-                                    : row[key2]
-                                }`
-                            )}
+                          ${join(
+                            Object.entries(columns)
+                              .filter(
+                                ([key2, column2]) =>
+                                  !column2.hidden &&
+                                  !column2.main &&
+                                  !column2.showNarrow &&
+                                  !(this.columnOrder &&
+                                  this.columnOrder.includes(key2)
+                                    ? (this.hiddenColumns?.includes(key2) ??
+                                      column2.defaultHidden)
+                                    : column2.defaultHidden)
+                              )
+                              .map(([key2, column2]) =>
+                                column2.template
+                                  ? column2.template(row)
+                                  : row[key2]
+                              )
+                              // skip empty cells, so we don't render stray separators
+                              .filter(
+                                (value) =>
+                                  value !== undefined &&
+                                  value !== null &&
+                                  value !== "" &&
+                                  value !== nothing
+                              ),
+                            STRINGS_SEPARATOR_DOT
+                          )}
                         </div>
                         ${
                           column.extraTemplate

--- a/src/panels/config/common/data-table-columns.ts
+++ b/src/panels/config/common/data-table-columns.ts
@@ -203,12 +203,10 @@ export function getModifiedAtTableColumn<T>(
 }
 
 const renderDateTimeColumn = (valueDateTime: number, hass: HomeAssistant) =>
-  html`${
-    valueDateTime
-      ? formatShortDateTimeWithConditionalYear(
-          new Date(valueDateTime * 1000),
-          hass.locale,
-          hass.config
-        )
-      : nothing
-  }`;
+  valueDateTime
+    ? formatShortDateTimeWithConditionalYear(
+        new Date(valueDateTime * 1000),
+        hass.locale,
+        hass.config
+      )
+    : nothing;

--- a/test/components/ha-data-table.test.ts
+++ b/test/components/ha-data-table.test.ts
@@ -33,4 +33,17 @@ describe("ha-data-table narrow secondary line", () => {
       renderNarrowSecondary({ id: "1", name: "Test", area: "Kitchen" })
     ).toBe("Kitchen · filled");
   });
+
+  it("renders a blank secondary line when all secondary columns are empty", () => {
+    const emptyColumns: DataTableColumnContainer = {
+      name: { title: "Name", main: true },
+      area: { title: "Area" },
+      category: { title: "Category" },
+      empty_template: { title: "Empty", template: () => nothing },
+    };
+    const el = document.createElement("ha-data-table") as HaDataTable;
+    const container = document.createElement("div");
+    render((el as any)._renderRow(emptyColumns, true, { id: "1", name: "Test" }, 0), container);
+    expect(container.querySelector(".secondary")!.textContent!.trim()).toBe("");
+  });
 });

--- a/test/components/ha-data-table.test.ts
+++ b/test/components/ha-data-table.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { html, nothing, render } from "lit";
+import "../../src/components/data-table/ha-data-table";
+import type {
+  DataTableColumnContainer,
+  DataTableRowData,
+  HaDataTable,
+} from "../../src/components/data-table/ha-data-table";
+
+const columns: DataTableColumnContainer = {
+  name: { title: "Name", main: true },
+  area: { title: "Area" },
+  category: { title: "Category" },
+  empty_template: { title: "Empty", template: () => nothing },
+  filled_template: { title: "Filled", template: () => html`filled` },
+};
+
+// The narrow row puts every non-main column on a secondary line, joined by dots.
+const renderNarrowSecondary = (row: DataTableRowData) => {
+  const el = document.createElement("ha-data-table") as HaDataTable;
+  const container = document.createElement("div");
+  render((el as any)._renderRow(columns, true, row, 0), container);
+  return container.querySelector(".secondary")!.textContent!.trim();
+};
+
+describe("ha-data-table narrow secondary line", () => {
+  it("does not render separators for empty columns", () => {
+    expect(renderNarrowSecondary({ id: "1", name: "Test" })).toBe("filled");
+  });
+
+  it("separates only the columns that have a value", () => {
+    expect(
+      renderNarrowSecondary({ id: "1", name: "Test", area: "Kitchen" })
+    ).toBe("Kitchen · filled");
+  });
+});

--- a/test/components/ha-data-table.test.ts
+++ b/test/components/ha-data-table.test.ts
@@ -43,7 +43,10 @@ describe("ha-data-table narrow secondary line", () => {
     };
     const el = document.createElement("ha-data-table") as HaDataTable;
     const container = document.createElement("div");
-    render((el as any)._renderRow(emptyColumns, true, { id: "1", name: "Test" }, 0), container);
+    render(
+      (el as any)._renderRow(emptyColumns, true, { id: "1", name: "Test" }, 0),
+      container
+    );
     expect(container.querySelector(".secondary")!.textContent!.trim()).toBe("");
   });
 });


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Original change by @marcinbauer-ohf , validated, adusted and tested.

Change:

In narrow mode the main column renders every other visible column on a secondary line, but the dot separator was inserted based on the column index instead of whether the cell rendered anything. A row whose extra columns are all empty showed a secondary line consisting only of dots, and an empty column between two filled ones produced a double dot.

Filter empty cells out before joining, and return `nothing` instead of `html`${nothing}`` for missing timestamps so those cells are detectably empty too.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
From:
<img width="694" height="580" alt="image" src="https://github.com/user-attachments/assets/6ba392a2-6f9c-48bb-bb45-ccfbb02b4bed" />

To:
<img width="795" height="643" alt="image" src="https://github.com/user-attachments/assets/d8ee8d7d-d643-42cb-84c8-090f5470a6d2" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
