### PR TITLE
Fix cover button states to reflect current operation

### DIFF
--- a/src/data/cover.ts
+++ b/src/data/cover.ts
@@ -137,7 +137,15 @@ export function canCloseTilt(stateObj: CoverEntity): boolean {
 }
 
 export function canStopTilt(stateObj: CoverEntity): boolean {
-  return stateObj.state !== UNAVAILABLE;
+  if (stateObj.state === UNAVAILABLE) {
+    return false;
+  }
+  const assumedState = stateObj.attributes.assumed_state === true;
+  // Mirror canStop: stopping is only meaningful while the cover is moving.
+  // Covers have no tilt-specific movement state, so the shared opening/closing
+  // state drives this too. Without this guard the combined stop button
+  // (!canStop && !canStopTilt) stays enabled on an idle non-tilt cover.
+  return assumedState || isOpening(stateObj) || isClosing(stateObj);
 }
 
 interface CoverEntityAttributes extends HassEntityAttributeBase {

--- a/src/data/cover.ts
+++ b/src/data/cover.ts
@@ -68,7 +68,23 @@ export function canOpen(stateObj: CoverEntity) {
     return false;
   }
   const assumedState = stateObj.attributes.assumed_state === true;
-  return assumedState || (!isFullyOpen(stateObj) && !isOpening(stateObj));
+  if (assumedState) {
+    return true;
+  }
+  if (isFullyOpen(stateObj) || isOpening(stateObj)) {
+    return false;
+  }
+  // A cover that exposes a stop action is treated as a motor that must be
+  // stopped before it can reverse direction, so the open button is disabled
+  // while it is closing. A cover without a stop action can reverse instantly,
+  // so the open button stays available mid-travel.
+  if (
+    isClosing(stateObj) &&
+    supportsFeature(stateObj, CoverEntityFeature.STOP)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export function canClose(stateObj: CoverEntity): boolean {
@@ -76,11 +92,32 @@ export function canClose(stateObj: CoverEntity): boolean {
     return false;
   }
   const assumedState = stateObj.attributes.assumed_state === true;
-  return assumedState || (!isFullyClosed(stateObj) && !isClosing(stateObj));
+  if (assumedState) {
+    return true;
+  }
+  if (isFullyClosed(stateObj) || isClosing(stateObj)) {
+    return false;
+  }
+  // See canOpen: a cover with a stop action must stop before reversing, so the
+  // close button is disabled while it is opening. A cover without a stop action
+  // can reverse instantly.
+  if (
+    isOpening(stateObj) &&
+    supportsFeature(stateObj, CoverEntityFeature.STOP)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export function canStop(stateObj: CoverEntity): boolean {
-  return stateObj.state !== UNAVAILABLE;
+  if (stateObj.state === UNAVAILABLE) {
+    return false;
+  }
+  const assumedState = stateObj.attributes.assumed_state === true;
+  // Stopping is only meaningful while the cover is actually moving. For an
+  // assumed-state cover the movement is unknown, so keep the button available.
+  return assumedState || isOpening(stateObj) || isClosing(stateObj);
 }
 
 export function canOpenTilt(stateObj: CoverEntity): boolean {

--- a/test/data/cover.test.ts
+++ b/test/data/cover.test.ts
@@ -5,6 +5,7 @@ import {
   canClose,
   canOpen,
   canStop,
+  canStopTilt,
   CoverEntityFeature,
 } from "../../src/data/cover";
 
@@ -37,9 +38,12 @@ const mockCover = (options: MockCoverOptions): CoverEntity => {
 
 // A motor-style cover exposes a stop action.
 const MOTOR =
-  CoverEntityFeature.OPEN + CoverEntityFeature.CLOSE + CoverEntityFeature.STOP;
+  // eslint-disable-next-line no-bitwise
+  CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP;
+
 // A blind-style cover has open/close but no stop.
-const NO_STOP = CoverEntityFeature.OPEN + CoverEntityFeature.CLOSE;
+// eslint-disable-next-line no-bitwise
+const NO_STOP = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE;
 
 describe("cover button availability", () => {
   describe("canStop", () => {
@@ -182,6 +186,67 @@ describe("cover button availability", () => {
     it("is disabled when unavailable", () => {
       expect(
         canClose(mockCover({ state: "unavailable", supportedFeatures: MOTOR }))
+      ).toBe(false);
+    });
+  });
+
+  describe("canStopTilt", () => {
+    const TILT =
+      // eslint-disable-next-line no-bitwise
+      CoverEntityFeature.OPEN |
+      CoverEntityFeature.CLOSE |
+      CoverEntityFeature.STOP |
+      CoverEntityFeature.OPEN_TILT |
+      CoverEntityFeature.CLOSE_TILT |
+      CoverEntityFeature.STOP_TILT;
+
+    it("is disabled when the cover is idle (open)", () => {
+      expect(
+        canStopTilt(mockCover({ state: "open", supportedFeatures: TILT }))
+      ).toBe(false);
+    });
+
+    it("is disabled when the cover is idle (closed)", () => {
+      expect(
+        canStopTilt(mockCover({ state: "closed", supportedFeatures: TILT }))
+      ).toBe(false);
+    });
+
+    it("is enabled while opening", () => {
+      expect(
+        canStopTilt(mockCover({ state: "opening", supportedFeatures: TILT }))
+      ).toBe(true);
+    });
+
+    it("is enabled while closing", () => {
+      expect(
+        canStopTilt(mockCover({ state: "closing", supportedFeatures: TILT }))
+      ).toBe(true);
+    });
+
+    it("is disabled when idle on a non-tilt cover (drives the combined stop button)", () => {
+      expect(
+        canStopTilt(mockCover({ state: "closed", supportedFeatures: MOTOR }))
+      ).toBe(false);
+    });
+
+    it("is enabled for an assumed-state cover regardless of movement", () => {
+      expect(
+        canStopTilt(
+          mockCover({
+            state: "open",
+            supportedFeatures: TILT,
+            assumedState: true,
+          })
+        )
+      ).toBe(true);
+    });
+
+    it("is disabled when unavailable", () => {
+      expect(
+        canStopTilt(
+          mockCover({ state: "unavailable", supportedFeatures: TILT })
+        )
       ).toBe(false);
     });
   });

--- a/test/data/cover.test.ts
+++ b/test/data/cover.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+
+import type { CoverEntity } from "../../src/data/cover";
+import {
+  canClose,
+  canOpen,
+  canStop,
+  CoverEntityFeature,
+} from "../../src/data/cover";
+
+interface MockCoverOptions {
+  state: string;
+  supportedFeatures: number;
+  assumedState?: boolean;
+  currentPosition?: number;
+}
+
+const mockCover = (options: MockCoverOptions): CoverEntity => {
+  const attributes: Record<string, any> = {
+    supported_features: options.supportedFeatures,
+  };
+  if (options.assumedState !== undefined) {
+    attributes.assumed_state = options.assumedState;
+  }
+  if (options.currentPosition !== undefined) {
+    attributes.current_position = options.currentPosition;
+  }
+  return {
+    entity_id: "cover.test",
+    state: options.state,
+    last_changed: "2024-01-01T00:00:00Z",
+    last_updated: "2024-01-01T00:00:00Z",
+    context: { id: "1", parent_id: null, user_id: null },
+    attributes,
+  } as CoverEntity;
+};
+
+// A motor-style cover exposes a stop action.
+const MOTOR =
+  CoverEntityFeature.OPEN + CoverEntityFeature.CLOSE + CoverEntityFeature.STOP;
+// A blind-style cover has open/close but no stop.
+const NO_STOP = CoverEntityFeature.OPEN + CoverEntityFeature.CLOSE;
+
+describe("cover button availability", () => {
+  describe("canStop", () => {
+    it("is disabled when the cover is idle (open)", () => {
+      expect(
+        canStop(mockCover({ state: "open", supportedFeatures: MOTOR }))
+      ).toBe(false);
+    });
+
+    it("is disabled when the cover is idle (closed)", () => {
+      expect(
+        canStop(mockCover({ state: "closed", supportedFeatures: MOTOR }))
+      ).toBe(false);
+    });
+
+    it("is enabled while opening", () => {
+      expect(
+        canStop(mockCover({ state: "opening", supportedFeatures: MOTOR }))
+      ).toBe(true);
+    });
+
+    it("is enabled while closing", () => {
+      expect(
+        canStop(mockCover({ state: "closing", supportedFeatures: MOTOR }))
+      ).toBe(true);
+    });
+
+    it("is disabled when unavailable", () => {
+      expect(
+        canStop(mockCover({ state: "unavailable", supportedFeatures: MOTOR }))
+      ).toBe(false);
+    });
+
+    it("is enabled for an assumed-state cover regardless of movement", () => {
+      expect(
+        canStop(
+          mockCover({
+            state: "open",
+            supportedFeatures: MOTOR,
+            assumedState: true,
+          })
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("canOpen", () => {
+    it("is enabled when closed and idle", () => {
+      expect(
+        canOpen(mockCover({ state: "closed", supportedFeatures: MOTOR }))
+      ).toBe(true);
+    });
+
+    it("is disabled when fully open", () => {
+      expect(
+        canOpen(mockCover({ state: "open", supportedFeatures: MOTOR }))
+      ).toBe(false);
+    });
+
+    it("is disabled while already opening", () => {
+      expect(
+        canOpen(mockCover({ state: "opening", supportedFeatures: MOTOR }))
+      ).toBe(false);
+    });
+
+    it("is disabled while closing when a stop action exists (motor must stop first)", () => {
+      expect(
+        canOpen(mockCover({ state: "closing", supportedFeatures: MOTOR }))
+      ).toBe(false);
+    });
+
+    it("stays enabled while closing when there is no stop action (instant reverse)", () => {
+      expect(
+        canOpen(mockCover({ state: "closing", supportedFeatures: NO_STOP }))
+      ).toBe(true);
+    });
+
+    it("is enabled for an assumed-state cover while closing", () => {
+      expect(
+        canOpen(
+          mockCover({
+            state: "closing",
+            supportedFeatures: MOTOR,
+            assumedState: true,
+          })
+        )
+      ).toBe(true);
+    });
+
+    it("is disabled when unavailable", () => {
+      expect(
+        canOpen(mockCover({ state: "unavailable", supportedFeatures: MOTOR }))
+      ).toBe(false);
+    });
+  });
+
+  describe("canClose", () => {
+    it("is enabled when open and idle", () => {
+      expect(
+        canClose(mockCover({ state: "open", supportedFeatures: MOTOR }))
+      ).toBe(true);
+    });
+
+    it("is disabled when fully closed", () => {
+      expect(
+        canClose(mockCover({ state: "closed", supportedFeatures: MOTOR }))
+      ).toBe(false);
+    });
+
+    it("is disabled while already closing", () => {
+      expect(
+        canClose(mockCover({ state: "closing", supportedFeatures: MOTOR }))
+      ).toBe(false);
+    });
+
+    it("is disabled while opening when a stop action exists (motor must stop first)", () => {
+      expect(
+        canClose(mockCover({ state: "opening", supportedFeatures: MOTOR }))
+      ).toBe(false);
+    });
+
+    it("stays enabled while opening when there is no stop action (instant reverse)", () => {
+      expect(
+        canClose(mockCover({ state: "opening", supportedFeatures: NO_STOP }))
+      ).toBe(true);
+    });
+
+    it("is enabled for an assumed-state cover while opening", () => {
+      expect(
+        canClose(
+          mockCover({
+            state: "opening",
+            supportedFeatures: MOTOR,
+            assumedState: true,
+          })
+        )
+      ).toBe(true);
+    });
+
+    it("is disabled when unavailable", () => {
+      expect(
+        canClose(mockCover({ state: "unavailable", supportedFeatures: MOTOR }))
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Breaking change

<!-- Not a breaking change. -->

## Proposed change

Cover open/close/stop buttons now reflect the cover's **current operation** instead of only its position, in both the more-info dialog and the entity/device controls.

Previously the stop button was enabled whenever a cover was not `unavailable`, so an idle cover (open or closed) still showed an active stop button, and while a cover was moving the opposite-direction button stayed enabled even when it could not do anything useful.

Two sibling helpers in `src/data/cover.ts` are corrected:

- **`canStop`** — only enabled while the cover is `opening`/`closing` (plus the `assumed_state` escape hatch). An idle open/closed cover now correctly greys out stop.
- **`canStopTilt`** — was returning `true` for *any* non-unavailable cover, without checking movement or tilt support. Because the combined dialog stop button disables on `!canStop && !canStopTilt`, this stale `true` overrode the `canStop` fix and kept stop enabled on an idle cover in the more-info dialog. It now mirrors `canStop`.

Net behaviour:

- Idle cover (fully open or fully closed): stop **disabled**; the valid direction button(s) enabled.
- Cover moving, **with** a STOP action (e.g. most garage/gate motors): stop enabled; the same-direction button disabled; the opposite-direction button is **also disabled** — such covers must be stopped before they can reverse.
- Cover moving, **without** a STOP action (e.g. blinds that reverse instantly): stop is not applicable; the opposite-direction button stays **enabled** so the cover can reverse mid-travel.
- `assumed_state` covers keep all buttons enabled, since the true state is unknown.

Unit tests added in `test/data/cover.test.ts` covering motor-style (with stop), blind-style (no stop), `assumed_state`, and tilt covers across idle/opening/closing/unavailable states.

## Screenshots

https://github.com/user-attachments/assets/f451404c-06b0-4e64-8648-ab749799f049

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #17945
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
