### PR TITLE
Show which energy power statistic is missing

### DIFF
--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -85,6 +85,10 @@ export class HaStatisticPicker extends LitElement {
 
   @property() public helper?: string;
 
+  @property({ attribute: "error-message" }) public errorMessage?: string;
+
+  @property({ type: Boolean }) public invalid = false;
+
   @property() public placeholder?: string;
 
   @property({ attribute: "statistic-types" })
@@ -526,6 +530,9 @@ export class HaStatisticPicker extends LitElement {
         .autofocus=${this.autofocus}
         .allowCustomValue=${this.allowCustomEntity}
         .disabled=${this.disabled}
+        .required=${this.required}
+        .invalid=${this.invalid}
+        .errorMessage=${this.errorMessage}
         .label=${this.label}
         use-top-label
         .placeholder=${placeholder}

--- a/src/components/ha-generic-picker.ts
+++ b/src/components/ha-generic-picker.ts
@@ -304,14 +304,21 @@ export class HaGenericPicker extends PickerMixin(LitElement) {
 
   private _renderHelper() {
     const showError = this.invalid && this.errorMessage;
-    const showHelper = !showError && this.helper;
 
-    if (!showError && !showHelper) {
+    if (!showError && !this.helper) {
       return nothing;
     }
 
     return html`<ha-input-helper-text .disabled=${this.disabled}>
-      ${showError ? this.errorMessage : this.helper}
+      ${
+        showError
+          ? html`<span class="error">${this.errorMessage}</span> ${
+                this.helper
+                  ? html`<span class="helper">${this.helper}</span>`
+                  : nothing
+              }`
+          : this.helper
+      }
     </ha-input-helper-text>`;
   }
 
@@ -447,6 +454,13 @@ export class HaGenericPicker extends PickerMixin(LitElement) {
         }
         :host([invalid]) ha-input-helper-text {
           color: var(--mdc-theme-error, var(--error-color, #b00020));
+        }
+        ha-input-helper-text .error,
+        ha-input-helper-text .helper {
+          display: block;
+        }
+        ha-input-helper-text .helper {
+          color: var(--secondary-text-color);
         }
 
         wa-popover {

--- a/src/panels/config/energy/dialogs/ha-energy-power-config.ts
+++ b/src/panels/config/energy/dialogs/ha-energy-power-config.ts
@@ -61,6 +61,10 @@ export class HaEnergyPowerConfig extends LitElement {
     }
   }
 
+  private get _requiredError(): string {
+    return this.hass.localize("ui.common.error_required");
+  }
+
   protected render(): TemplateResult {
     return html`
       <p class="power-section-label">
@@ -119,6 +123,9 @@ export class HaEnergyPowerConfig extends LitElement {
                   `${this.localizeBaseKey}.power_helper` as LocalizeKeys,
                   { unit: this._powerUnits?.join(", ") || "" }
                 )}
+                required
+                .invalid=${!this.powerConfig.stat_rate}
+                .errorMessage=${this._requiredError}
               ></ha-statistic-picker>
             `
           : nothing
@@ -138,11 +145,16 @@ export class HaEnergyPowerConfig extends LitElement {
                 .helper=${this.hass.localize(
                   `${this.localizeBaseKey}.type_inverted_description` as LocalizeKeys
                 )}
+                required
+                .invalid=${!this.powerConfig.stat_rate_inverted}
+                .errorMessage=${this._requiredError}
               ></ha-statistic-picker>
             `
           : nothing
       }
       ${
+        // These two exclude each other, so they keep their clear button
+        // (and therefore no required marker) to stay swappable.
         this.powerType === "two_sensors"
           ? html`
               <ha-statistic-picker
@@ -157,6 +169,8 @@ export class HaEnergyPowerConfig extends LitElement {
                   this.powerConfig.stat_rate_to,
                 ].filter((id): id is string => Boolean(id))}
                 @value-changed=${this._fromPowerChanged}
+                .invalid=${!this.powerConfig.stat_rate_from}
+                .errorMessage=${this._requiredError}
               ></ha-statistic-picker>
               <ha-statistic-picker
                 .hass=${this.hass}
@@ -170,6 +184,8 @@ export class HaEnergyPowerConfig extends LitElement {
                   this.powerConfig.stat_rate_from,
                 ].filter((id): id is string => Boolean(id))}
                 @value-changed=${this._toPowerChanged}
+                .invalid=${!this.powerConfig.stat_rate_to}
+                .errorMessage=${this._requiredError}
               ></ha-statistic-picker>
             `
           : nothing

--- a/test/panels/config/energy/ha-energy-power-config.test.ts
+++ b/test/panels/config/energy/ha-energy-power-config.test.ts
@@ -1,5 +1,12 @@
+import { render } from "lit";
 import { assert, describe, it } from "vitest";
-import { getPowerHelperEntityId } from "../../../../src/panels/config/energy/dialogs/power-config";
+import "../../../../src/panels/config/energy/dialogs/ha-energy-power-config";
+import type { HaEnergyPowerConfig } from "../../../../src/panels/config/energy/dialogs/ha-energy-power-config";
+import type { PowerConfig } from "../../../../src/data/energy";
+import {
+  getPowerHelperEntityId,
+  type PowerType,
+} from "../../../../src/panels/config/energy/dialogs/power-config";
 
 describe("getPowerHelperEntityId", () => {
   it("returns the helper for an inverted config", () => {
@@ -66,6 +73,103 @@ describe("getPowerHelperEntityId", () => {
       getPowerHelperEntityId(undefined, {
         stat_rate_inverted: "sensor.battery_power",
       })
+    );
+  });
+});
+
+// Renders the template directly so the async unit lookup in willUpdate is
+// skipped. localize echoes the key back.
+const renderPickers = (powerType: PowerType, powerConfig: PowerConfig) => {
+  const el = document.createElement(
+    "ha-energy-power-config"
+  ) as HaEnergyPowerConfig;
+  el.hass = { localize: (key: string) => key } as any;
+  el.powerType = powerType;
+  el.powerConfig = powerConfig;
+
+  const container = document.createElement("div");
+  render((el as any).render(), container);
+
+  return [...container.querySelectorAll("ha-statistic-picker")].map(
+    (picker: any) => ({
+      required: picker.required,
+      invalid: picker.invalid,
+      errorMessage: picker.errorMessage,
+    })
+  );
+};
+
+describe("ha-energy-power-config required power statistic", () => {
+  it("renders no picker when no power sensor is configured", () => {
+    assert.lengthOf(renderPickers("none", {}), 0);
+  });
+
+  it("marks an empty standard statistic as required and invalid", () => {
+    assert.deepEqual(renderPickers("standard", {}), [
+      {
+        required: true,
+        invalid: true,
+        errorMessage: "ui.common.error_required",
+      },
+    ]);
+  });
+
+  it("keeps the statistic required but valid once it is set", () => {
+    const [picker] = renderPickers("standard", { stat_rate: "sensor.power" });
+    assert.isTrue(picker.required);
+    assert.isFalse(picker.invalid);
+  });
+
+  it("marks an empty inverted statistic as required and invalid", () => {
+    const [picker] = renderPickers("inverted", {});
+    assert.isTrue(picker.required);
+    assert.isTrue(picker.invalid);
+  });
+
+  it("does not flag the inverted statistic when it is set", () => {
+    const [picker] = renderPickers("inverted", {
+      stat_rate_inverted: "sensor.power",
+    });
+    assert.isFalse(picker.invalid);
+  });
+
+  it("flags both two sensor statistics while they are empty", () => {
+    const pickers = renderPickers("two_sensors", {});
+    assert.lengthOf(pickers, 2);
+    assert.deepEqual(
+      pickers.map((p) => p.invalid),
+      [true, true]
+    );
+  });
+
+  // The two sensor statistics exclude each other, so they keep their clear
+  // button — and therefore no required marker — to stay swappable.
+  it("does not mark the two sensor statistics as required", () => {
+    const pickers = renderPickers("two_sensors", {});
+    assert.deepEqual(
+      pickers.map((p) => p.required),
+      [false, false]
+    );
+  });
+
+  it("flags only the statistic that is still missing", () => {
+    const pickers = renderPickers("two_sensors", {
+      stat_rate_from: "sensor.power_from",
+    });
+    assert.deepEqual(
+      pickers.map((p) => p.invalid),
+      [false, true]
+    );
+  });
+
+  it("clears both flags once the two sensor pair is complete", () => {
+    const pickers = renderPickers("two_sensors", {
+      stat_rate_from: "sensor.power_from",
+      stat_rate_to: "sensor.power_to",
+    });
+    assert.deepEqual(
+      pickers.map((p) => p.invalid),
+      [false, false]
     );
   });
 });


### PR DESCRIPTION
## Breaking change


## Proposed change

Changing the type of power measurement in the energy battery and grid dialogs clears the power statistic, so the config becomes invalid and Save is disabled. Nothing said why — a disabled Save looked the same as an unchanged form, and there was no indication the statistic was mandatory.

The power statistic pickers are now marked required, and the empty one is flagged, so the error points at the field that actually blocks saving. With "Two sensors" only the missing one is flagged. Those two exclude each other, so they keep their clear button — and therefore no required marker — to stay swappable.

`ha-statistic-picker` gains `invalid` and `errorMessage` and now forwards `required`, which was declared but never passed on. `ha-generic-picker` keeps the helper text next to the error instead of replacing it, so the guidance on what to pick stays visible while the field is flagged.

## Screenshots

<img width="1000" height="900" alt="image" src="https://github.com/user-attachments/assets/72372e03-93a8-4f60-af31-bfa175ed3030" />

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
