### PR TITLE
Add managed translation fetching to dev servers

### DIFF
--- a/.agents/skills/ha-frontend-testing/SKILL.md
+++ b/.agents/skills/ha-frontend-testing/SKILL.md
@@ -62,7 +62,7 @@ Managed app, demo, gallery, and E2E app workflows share one lifetime lock, so on
 
 `yarn dev:serve` also serves locally and supports `-c` for the core URL and `-p` for the port. The default is 8124, or 8123 in a devcontainer.
 
-Dev server commands support `--background`, `--status`, `--stop`, and `--logs [--follow]`. Prefer managed background mode while iterating so the watcher stays available across test runs without occupying the terminal. `yarn dev` and `yarn dev:serve` share one managed process slot because both write the app output.
+Dev server commands support `--background`, `--status`, `--stop`, and `--logs [--follow]`. `yarn dev`, `yarn dev:serve`, `yarn dev:demo`, and `yarn dev:gallery` also support `--fetch-translations`; this runs translation fetching, including first-time GitHub device authentication, under the workflow lock before starting the watcher. It works in foreground and background modes. Prefer managed background mode while iterating so the watcher stays available across test runs without occupying the terminal. `yarn dev` and `yarn dev:serve` share one managed process slot because both write the app output.
 
 ## Playwright E2E
 

--- a/build-scripts/dev-server.mjs
+++ b/build-scripts/dev-server.mjs
@@ -8,6 +8,9 @@
 //   --status           Report whether the suite's dev server is running.
 //   --stop             Stop a running background dev server.
 //   --logs [--follow]  Print (or follow) the background dev server log.
+//   --fetch-translations
+//                      Fetch nightly translations before starting (app,
+//                      app-serve, demo, and gallery only).
 //
 // Extra args (for example -p or -c on app-serve) are forwarded to the underlying
 // script. Suites use one of two liveness models:
@@ -73,6 +76,7 @@ const SUITES = new Map([
     "demo",
     {
       alias: "dev:demo",
+      fetchTranslations: true,
       liveness: "health",
       port: 8090,
       spawn: { cmd: gulpBin, args: ["develop-demo"] },
@@ -82,6 +86,7 @@ const SUITES = new Map([
     "gallery",
     {
       alias: "dev:gallery",
+      fetchTranslations: true,
       liveness: "health",
       port: 8100,
       spawn: { cmd: gulpBin, args: ["develop-gallery"] },
@@ -91,6 +96,7 @@ const SUITES = new Map([
     "app",
     {
       alias: "dev",
+      fetchTranslations: true,
       liveness: "process",
       readyLog: /Build done @/,
       spawn: { cmd: gulpBin, args: ["develop-app"] },
@@ -102,6 +108,7 @@ const SUITES = new Map([
       alias: "dev:serve",
       liveness: "process",
       acceptsArgs: true,
+      fetchTranslations: true,
       readyLog: /Build done @/,
       spawn: { cmd: developAndServeScript, args: [] },
     },
@@ -144,12 +151,14 @@ const usage = () => {
   const suites = [...SUITES.keys()].join("|");
   process.stderr.write(
     `Usage: node build-scripts/dev-server.mjs --suite <${suites}> ` +
-      `[--background | --status | --stop | --logs [--follow]]\n`
+      `[--background | --status | --stop | --logs [--follow]] ` +
+      `[--fetch-translations]\n`
   );
 };
 
 const parseArgs = (argv) => {
   const args = {
+    fetchTranslations: false,
     mode: "foreground",
     follow: false,
     modes: [],
@@ -165,6 +174,9 @@ const parseArgs = (argv) => {
       case "--follow":
         args.follow = true;
         break;
+      case "--fetch-translations":
+        args.fetchTranslations = true;
+        break;
       default:
         if (LIFECYCLE_MODE_FLAGS.has(arg)) {
           args.mode = LIFECYCLE_MODE_FLAGS.get(arg);
@@ -177,6 +189,28 @@ const parseArgs = (argv) => {
   }
   return args;
 };
+
+const translationPrebuildEnv = (token) => {
+  const env = workflowLockEnv(token);
+  delete env.SKIP_FETCH_NIGHTLY_TRANSLATIONS;
+  return env;
+};
+
+const suiteEnv = (token, fetchTranslations = false) => ({
+  ...workflowLockEnv(token),
+  ...(fetchTranslations && { SKIP_FETCH_NIGHTLY_TRANSLATIONS: "1" }),
+});
+
+const runPrebuild = (token, fetchTranslations = false) =>
+  fetchTranslations
+    ? spawnForeground({
+        cmd: gulpBin,
+        args: ["setup-and-fetch-nightly-translations"],
+        cwd: repoRoot,
+        env: translationPrebuildEnv(token),
+        processGroup: true,
+      })
+    : Promise.resolve(0);
 
 const logFileFor = (suite) => path.join(logDir, `${suite}.log`);
 const acquireSuite = (suite) => {
@@ -405,7 +439,7 @@ const isHttpServing = async (port, timeoutMs = 1000) => {
   return probeHost(0);
 };
 
-const runForegroundHealth = async (suite, cfg) => {
+const runForegroundHealth = async (suite, cfg, fetchTranslations = false) => {
   const { port } = cfg;
   const lock = acquireSuiteForStart(suite);
   if (!lock.token) {
@@ -427,11 +461,15 @@ const runForegroundHealth = async (suite, cfg) => {
     return 1;
   }
   try {
+    const prebuildCode = await runPrebuild(lock.token, fetchTranslations);
+    if (prebuildCode !== 0) {
+      return prebuildCode;
+    }
     return await spawnForeground({
       cmd: cfg.spawn.cmd,
       args: cfg.spawn.args,
       cwd: repoRoot,
-      env: workflowLockEnv(lock.token),
+      env: suiteEnv(lock.token, fetchTranslations),
       processGroup: true,
       onSpawn: (child) => updateSuite(suite, lock.token, child, port),
     });
@@ -440,7 +478,7 @@ const runForegroundHealth = async (suite, cfg) => {
   }
 };
 
-const runBackgroundHealth = async (suite, cfg) => {
+const runBackgroundHealth = async (suite, cfg, fetchTranslations = false) => {
   const { port } = cfg;
   const lock = acquireSuiteForStart(suite);
   if (!lock.token) {
@@ -463,12 +501,17 @@ const runBackgroundHealth = async (suite, cfg) => {
   }
   let child;
   try {
+    const prebuildCode = await runPrebuild(lock.token, fetchTranslations);
+    if (prebuildCode !== 0) {
+      releaseSuite(lock.token);
+      return prebuildCode;
+    }
     const logFile = logFileFor(suite);
     child = await spawnDetachedToLog({
       cmd: cfg.spawn.cmd,
       args: cfg.spawn.args,
       cwd: repoRoot,
-      env: workflowLockEnv(lock.token),
+      env: suiteEnv(lock.token, fetchTranslations),
       logFile,
     });
     updateSuite(suite, lock.token, child, port);
@@ -520,17 +563,26 @@ const spawnArgs = (cfg, passthrough) => [
   ...(cfg.acceptsArgs ? passthrough : []),
 ];
 
-const runForegroundProcess = async (suite, cfg, passthrough) => {
+const runForegroundProcess = async (
+  suite,
+  cfg,
+  passthrough,
+  fetchTranslations = false
+) => {
   const lock = acquireSuiteForStart(suite);
   if (!lock.token) {
     return lock.code;
   }
   try {
+    const prebuildCode = await runPrebuild(lock.token, fetchTranslations);
+    if (prebuildCode !== 0) {
+      return prebuildCode;
+    }
     return await spawnForeground({
       cmd: cfg.spawn.cmd,
       args: spawnArgs(cfg, passthrough),
       cwd: repoRoot,
-      env: workflowLockEnv(lock.token),
+      env: suiteEnv(lock.token, fetchTranslations),
       processGroup: true,
       onSpawn: (child) => updateSuite(suite, lock.token, child),
     });
@@ -539,7 +591,12 @@ const runForegroundProcess = async (suite, cfg, passthrough) => {
   }
 };
 
-const runBackgroundProcess = async (suite, cfg, passthrough) => {
+const runBackgroundProcess = async (
+  suite,
+  cfg,
+  passthrough,
+  fetchTranslations = false
+) => {
   const lock = acquireSuiteForStart(suite);
   if (!lock.token) {
     return lock.code;
@@ -547,12 +604,17 @@ const runBackgroundProcess = async (suite, cfg, passthrough) => {
 
   let child;
   try {
+    const prebuildCode = await runPrebuild(lock.token, fetchTranslations);
+    if (prebuildCode !== 0) {
+      releaseSuite(lock.token);
+      return prebuildCode;
+    }
     const logFile = logFileFor(suite);
     child = await spawnDetachedToLog({
       cmd: cfg.spawn.cmd,
       args: spawnArgs(cfg, passthrough),
       cwd: repoRoot,
-      env: workflowLockEnv(lock.token),
+      env: suiteEnv(lock.token, fetchTranslations),
       logFile,
     });
 
@@ -630,6 +692,17 @@ const main = async () => {
     usage();
     return 1;
   }
+  if (
+    args.fetchTranslations &&
+    (!["foreground", "background"].includes(args.mode) ||
+      !cfg.fetchTranslations)
+  ) {
+    process.stderr.write(
+      "--fetch-translations is only supported when starting app, app-serve, demo, or gallery.\n"
+    );
+    usage();
+    return 1;
+  }
   if (args.passthrough.length && !cfg.acceptsArgs) {
     process.stderr.write(
       `Ignoring unexpected arguments: ${args.passthrough.join(" ")}\n`
@@ -665,14 +738,26 @@ const main = async () => {
   const handlers =
     cfg.liveness === "health"
       ? {
-          foreground: () => runForegroundHealth(args.suite, cfg),
-          background: () => runBackgroundHealth(args.suite, cfg),
+          foreground: () =>
+            runForegroundHealth(args.suite, cfg, args.fetchTranslations),
+          background: () =>
+            runBackgroundHealth(args.suite, cfg, args.fetchTranslations),
         }
       : {
           foreground: () =>
-            runForegroundProcess(args.suite, cfg, args.passthrough),
+            runForegroundProcess(
+              args.suite,
+              cfg,
+              args.passthrough,
+              args.fetchTranslations
+            ),
           background: () =>
-            runBackgroundProcess(args.suite, cfg, args.passthrough),
+            runBackgroundProcess(
+              args.suite,
+              cfg,
+              args.passthrough,
+              args.fetchTranslations
+            ),
         };
   return handlers[mode]();
 };


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add `--fetch-translations` to managed app, demo, and gallery development commands. Translation setup runs after the development workflow acquires its lock and before the watcher starts, so setup and generated output use the same ownership contract in foreground and background modes.

The watcher skips its normal second fetch after the managed pre-build completes. Commands without the flag keep their existing behaviour, and the E2E app suite does not expose the option.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] New feature (thank you!)


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3283

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr