### PR TITLE
Ask which occurrences to change in the recurring event dialog

### DIFF
--- a/src/panels/calendar/confirm-event-dialog-box.ts
+++ b/src/panels/calendar/confirm-event-dialog-box.ts
@@ -2,7 +2,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import {
   fireEvent,
-  HASSDomCurrentTargetEvent,
+  type HASSDomCurrentTargetEvent,
 } from "../../common/dom/fire_event";
 import "../../components/ha-button";
 import "../../components/ha-dialog";

--- a/src/panels/calendar/confirm-event-dialog-box.ts
+++ b/src/panels/calendar/confirm-event-dialog-box.ts
@@ -1,14 +1,20 @@
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
-import "../../components/ha-dialog-footer";
-import "../../components/ha-svg-icon";
-import "../../components/ha-switch";
+import "../../components/ha-button";
 import "../../components/ha-dialog";
+import "../../components/ha-dialog-footer";
+import "../../components/radio/ha-radio-group";
+import type { HaRadioGroup } from "../../components/radio/ha-radio-group";
+import "../../components/radio/ha-radio-option";
 import { RecurrenceRange } from "../../data/calendar";
 import type { HomeAssistant } from "../../types";
 import type { ConfirmEventDialogBoxParams } from "./show-confirm-event-dialog-box";
-import "../../components/ha-button";
+
+// `RecurrenceRange.THISEVENT` is "", which the radio group treats as unselected
+// on its value-attribute and form-reset paths, so keep the options on their own
+// literals and map them when confirming.
+type RecurrenceScope = "this" | "future";
 
 @customElement("confirm-event-dialog-box")
 class ConfirmEventDialogBox extends LitElement {
@@ -18,11 +24,14 @@ class ConfirmEventDialogBox extends LitElement {
 
   @state() private _open = false;
 
-  @state()
-  private _closeState?: "canceled" | "confirmed" | "confirmedFuture";
+  @state() private _closeState?: "canceled" | "confirmed";
+
+  @state() private _scope: RecurrenceScope = "this";
 
   public async showDialog(params: ConfirmEventDialogBoxParams): Promise<void> {
     this._params = params;
+    this._scope = "this";
+    this._closeState = undefined;
     this._open = true;
   }
 
@@ -39,20 +48,27 @@ class ConfirmEventDialogBox extends LitElement {
       return nothing;
     }
 
+    const { destructive, recurring } = this._params;
+
     return html`
       <ha-dialog
         .open=${this._open}
         header-title=${this._params.title}
         width="small"
+        type="alert"
+        aria-describedby=${recurring ? nothing : "description"}
         @closed=${this._dialogClosed}
       >
-        <div>
-          <p>${this._params.text}</p>
-        </div>
+        ${
+          recurring
+            ? this._renderRecurrenceRange()
+            : html`<p id="description">${this._params.text}</p>`
+        }
         <ha-dialog-footer slot="footer">
           <ha-button
             appearance="plain"
             @click=${this._dismiss}
+            ?autofocus=${!recurring && destructive}
             slot="secondaryAction"
           >
             ${this.hass.localize("ui.common.cancel")}
@@ -60,27 +76,39 @@ class ConfirmEventDialogBox extends LitElement {
           <ha-button
             slot="primaryAction"
             @click=${this._confirm}
-            autofocus
-            variant="danger"
+            ?autofocus=${!recurring && !destructive}
+            variant=${destructive ? "danger" : "brand"}
           >
             ${this._params.confirmText}
           </ha-button>
-          ${
-            this._params.confirmFutureText
-              ? html`
-                  <ha-button
-                    @click=${this._confirmFuture}
-                    slot="primaryAction"
-                    variant="danger"
-                  >
-                    ${this._params.confirmFutureText}
-                  </ha-button>
-                `
-              : ""
-          }
         </ha-dialog-footer>
       </ha-dialog>
     `;
+  }
+
+  private _renderRecurrenceRange() {
+    const thisEvent = this.hass.localize(
+      "ui.components.calendar.event.recurrence_range.this_event"
+    );
+    const thisAndFuture = this.hass.localize(
+      "ui.components.calendar.event.recurrence_range.this_and_future"
+    );
+
+    return html`
+      <ha-radio-group
+        name="recurrence_range"
+        .label=${this._params!.text ?? this._params!.title}
+        .value=${this._scope}
+        @change=${this._scopeChanged}
+      >
+        <ha-radio-option value="this" autofocus>${thisEvent}</ha-radio-option>
+        <ha-radio-option value="future">${thisAndFuture}</ha-radio-option>
+      </ha-radio-group>
+    `;
+  }
+
+  private _scopeChanged(ev: Event): void {
+    this._scope = (ev.currentTarget as HaRadioGroup).value as RecurrenceScope;
   }
 
   private _dismiss(): void {
@@ -90,17 +118,11 @@ class ConfirmEventDialogBox extends LitElement {
 
   private _confirm(): void {
     this._closeState = "confirmed";
-    if (this._params!.confirm) {
-      this._params!.confirm(RecurrenceRange.THISEVENT);
-    }
-    this.closeDialog();
-  }
-
-  private _confirmFuture(): void {
-    this._closeState = "confirmedFuture";
-    if (this._params!.confirm) {
-      this._params!.confirm(RecurrenceRange.THISANDFUTURE);
-    }
+    this._params!.confirm?.(
+      this._scope === "future"
+        ? RecurrenceRange.THISANDFUTURE
+        : RecurrenceRange.THISEVENT
+    );
     this.closeDialog();
   }
 
@@ -108,10 +130,7 @@ class ConfirmEventDialogBox extends LitElement {
     if (!this._params) {
       return;
     }
-    if (
-      this._closeState !== "confirmed" &&
-      this._closeState !== "confirmedFuture"
-    ) {
+    if (this._closeState !== "confirmed") {
       this._params.cancel?.();
     }
     this._params = undefined;
@@ -125,18 +144,12 @@ class ConfirmEventDialogBox extends LitElement {
       pointer-events: initial !important;
       cursor: initial !important;
     }
-    a {
-      color: var(--primary-color);
-    }
     p {
       margin: 0;
       color: var(--primary-text-color);
     }
-    .no-bottom-padding {
-      padding-bottom: 0;
-    }
-    .secondary {
-      color: var(--secondary-text-color);
+    ha-radio-group::part(form-control-label) {
+      font-weight: var(--ha-font-weight-medium);
     }
     ha-dialog {
       /* Place above other dialogs */

--- a/src/panels/calendar/confirm-event-dialog-box.ts
+++ b/src/panels/calendar/confirm-event-dialog-box.ts
@@ -1,6 +1,9 @@
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { fireEvent } from "../../common/dom/fire_event";
+import {
+  fireEvent,
+  HASSDomCurrentTargetEvent,
+} from "../../common/dom/fire_event";
 import "../../components/ha-button";
 import "../../components/ha-dialog";
 import "../../components/ha-dialog-footer";
@@ -107,8 +110,8 @@ class ConfirmEventDialogBox extends LitElement {
     `;
   }
 
-  private _scopeChanged(ev: Event): void {
-    this._scope = (ev.currentTarget as HaRadioGroup).value as RecurrenceScope;
+  private _scopeChanged(ev: HASSDomCurrentTargetEvent<HaRadioGroup>): void {
+    this._scope = ev.currentTarget.value as RecurrenceScope;
   }
 
   private _dismiss(): void {

--- a/src/panels/calendar/dialog-calendar-event-detail.ts
+++ b/src/panels/calendar/dialog-calendar-event-detail.ts
@@ -224,18 +224,9 @@ class DialogCalendarEventDetail extends LitElement {
         : this.hass.localize(
             "ui.components.calendar.event.confirm_delete.prompt"
           ),
-      confirmText: entry.recurrence_id
-        ? this.hass.localize(
-            "ui.components.calendar.event.confirm_delete.delete_this"
-          )
-        : this.hass.localize(
-            "ui.components.calendar.event.confirm_delete.delete"
-          ),
-      confirmFutureText: entry.recurrence_id
-        ? this.hass.localize(
-            "ui.components.calendar.event.confirm_delete.delete_future"
-          )
-        : undefined,
+      confirmText: this.hass.localize("ui.common.delete"),
+      recurring: !!entry.recurrence_id,
+      destructive: true,
     });
     if (range === undefined) {
       // Cancel

--- a/src/panels/calendar/dialog-calendar-event-editor.ts
+++ b/src/panels/calendar/dialog-calendar-event-editor.ts
@@ -569,12 +569,8 @@ class DialogCalendarEventEditor extends DirtyStateProviderMixin<CalendarEventFor
         text: this.hass.localize(
           "ui.components.calendar.event.confirm_update.recurring_prompt"
         ),
-        confirmText: this.hass.localize(
-          "ui.components.calendar.event.confirm_update.update_this"
-        ),
-        confirmFutureText: this.hass.localize(
-          "ui.components.calendar.event.confirm_update.update_future"
-        ),
+        confirmText: this.hass.localize("ui.common.update"),
+        recurring: true,
       });
     }
     if (range === undefined) {
@@ -625,18 +621,9 @@ class DialogCalendarEventEditor extends DirtyStateProviderMixin<CalendarEventFor
         : this.hass.localize(
             "ui.components.calendar.event.confirm_delete.prompt"
           ),
-      confirmText: entry.recurrence_id
-        ? this.hass.localize(
-            "ui.components.calendar.event.confirm_delete.delete_this"
-          )
-        : this.hass.localize(
-            "ui.components.calendar.event.confirm_delete.delete"
-          ),
-      confirmFutureText: entry.recurrence_id
-        ? this.hass.localize(
-            "ui.components.calendar.event.confirm_delete.delete_future"
-          )
-        : undefined,
+      confirmText: this.hass.localize("ui.common.delete"),
+      recurring: !!entry.recurrence_id,
+      destructive: true,
     });
     if (range === undefined) {
       // Cancel

--- a/src/panels/calendar/show-confirm-event-dialog-box.ts
+++ b/src/panels/calendar/show-confirm-event-dialog-box.ts
@@ -1,14 +1,16 @@
-import type { TemplateResult } from "lit";
 import { fireEvent } from "../../common/dom/fire_event";
 import type { RecurrenceRange } from "../../data/calendar";
 
 export interface ConfirmEventDialogBoxParams {
+  title: string;
+  // Labels the recurrence range options when `recurring` is set
+  text?: string;
   confirmText?: string;
-  confirmFutureText?: string; // Prompt for future recurring events
+  // Let the user pick which occurrences of a recurring event are affected
+  recurring?: boolean;
+  destructive?: boolean;
   confirm?: (recurrenceRange: RecurrenceRange) => void;
   cancel?: () => void;
-  text?: string | TemplateResult;
-  title: string;
 }
 
 export const loadGenericDialog = () => import("./confirm-event-dialog-box");

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1312,18 +1312,18 @@
           "invalid_duration": "The duration of the event is not valid. Please check start and end date.",
           "not_all_required_fields": "Not all required fields are filled in",
           "end_auto_adjusted": "Event end was adjusted to prevent negative duration",
+          "recurrence_range": {
+            "this_event": "Only this event",
+            "this_and_future": "This and all future events"
+          },
           "confirm_delete": {
             "delete": "Delete event",
-            "delete_this": "Delete only this event",
-            "delete_future": "Delete all future events",
             "prompt": "Do you want to delete this event?",
-            "recurring_prompt": "Do you want to delete only this event, or this and all future occurrences of the event?"
+            "recurring_prompt": "Which events do you want to delete?"
           },
           "confirm_update": {
             "update": "Update event",
-            "update_this": "Update only this event",
-            "update_future": "Update all future events",
-            "recurring_prompt": "Do you want to update only this event, or this and all future occurrences of the event?"
+            "recurring_prompt": "Which events do you want to update?"
           },
           "repeat": {
             "label": "Repeat",


### PR DESCRIPTION
## Proposed change

Deleting or updating a recurring calendar event offered "only this event" and "all future events" as two long buttons, which the 320px dialog footer squeezed until every word wrapped onto its own line. The choice now lives in the dialog body as a radio group, leaving `Cancel` plus a single confirm action in the footer. The dialog is also an alert, so it stays a centered card on small viewports rather than stretching into a full-screen sheet, and the confirm action is only styled as destructive in the delete flows.

## Screenshots

<img width="640" height="564" alt="image" src="https://github.com/user-attachments/assets/86f385ab-b1d4-4d3c-a41b-0cf6744cb02a" />
<img width="640" height="564" alt="image" src="https://github.com/user-attachments/assets/a9c8e1a5-be6b-4204-b253-bda6c79816cf" />
<img width="640" height="352" alt="image" src="https://github.com/user-attachments/assets/fc8b66f4-8b08-4f54-a71d-b05f36bb8643" />


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53365
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

