### PR TITLE
Fix map loading fully zoomed out when fitted before layout

### DIFF
--- a/src/components/map/ha-map.ts
+++ b/src/components/map/ha-map.ts
@@ -175,6 +175,8 @@ export class HaMap extends ReactiveElement {
 
   private _pauseAutoFit = false;
 
+  private _pendingFit?: () => void;
+
   public connectedCallback(): void {
     this._pauseAutoFit = false;
     document.addEventListener("visibilitychange", this._handleVisibilityChange);
@@ -204,6 +206,7 @@ export class HaMap extends ReactiveElement {
       this.Leaflet = undefined;
     }
 
+    this._pendingFit = undefined;
     this._loaded = false;
 
     if (this._resizeObserver) {
@@ -347,6 +350,10 @@ export class HaMap extends ReactiveElement {
       return;
     }
 
+    if (this._deferIfUnsized(() => this.fitMap(options))) {
+      return;
+    }
+
     if (
       !this._mapFocusItems.length &&
       !this._mapFocusZones.length &&
@@ -387,11 +394,48 @@ export class HaMap extends ReactiveElement {
     }, PROGRAMMITIC_FIT_DELAY);
   }
 
+  // Leaflet derives the zoom level that fits given bounds from the current
+  // size of the map container. When the container has not been laid out yet,
+  // that size is 0x0 and the computed zoom collapses to the minimum, leaving
+  // the map zoomed out to the world even after the container gets its size.
+  // Defer fitting until the resize observer reports a usable size.
+  private _deferIfUnsized(fit: () => void): boolean {
+    const size = this.leafletMap!.getSize();
+    if (size.x > 0 && size.y > 0) {
+      this._pendingFit = undefined;
+      return false;
+    }
+    const container = this.leafletMap!.getContainer();
+    if (container.clientWidth > 0 && container.clientHeight > 0) {
+      // The container was laid out since Leaflet last measured it.
+      this.leafletMap!.invalidateSize(false);
+      this._pendingFit = undefined;
+      return false;
+    }
+    this._pendingFit = fit;
+    return true;
+  }
+
+  private _runPendingFit(): void {
+    if (!this._pendingFit || !this.leafletMap) {
+      return;
+    }
+    const size = this.leafletMap.getSize();
+    if (size.x > 0 && size.y > 0) {
+      const pendingFit = this._pendingFit;
+      this._pendingFit = undefined;
+      pendingFit();
+    }
+  }
+
   public fitBounds(
     boundingbox: LatLngExpression[],
     options?: { zoom?: number; pad?: number }
   ) {
     if (!this.leafletMap || !this.Leaflet) {
+      return;
+    }
+    if (this._deferIfUnsized(() => this.fitBounds(boundingbox, options))) {
       return;
     }
     const bounds = this.Leaflet.latLngBounds(boundingbox).pad(
@@ -773,6 +817,7 @@ export class HaMap extends ReactiveElement {
     if (!this._resizeObserver) {
       this._resizeObserver = new ResizeObserver(() => {
         this.leafletMap?.invalidateSize({ debounceMoveend: true });
+        this._runPendingFit();
       });
     }
     this._resizeObserver.observe(this);

--- a/test/components/map/ha-map.test.ts
+++ b/test/components/map/ha-map.test.ts
@@ -1,0 +1,143 @@
+import type { HassEntities } from "home-assistant-js-websocket";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../../../src/components/map/ha-map";
+import type { HaMap } from "../../../src/components/map/ha-map";
+
+type ROCallback = (
+  entries: ResizeObserverEntry[],
+  observer: ResizeObserver
+) => void;
+
+const resizeCallbacks: ROCallback[] = [];
+
+class MockResizeObserver {
+  constructor(cb: ROCallback) {
+    resizeCallbacks.push(cb);
+  }
+
+  observe = vi.fn();
+
+  unobserve = vi.fn();
+
+  disconnect = vi.fn();
+}
+
+const STATES = {
+  "device_tracker.paulus": {
+    entity_id: "device_tracker.paulus",
+    state: "not_home",
+    attributes: {
+      friendly_name: "Paulus",
+      latitude: 52.372,
+      longitude: 4.89,
+    },
+    context: { id: "1", user_id: null, parent_id: null },
+    last_changed: "2026-01-01T00:00:00Z",
+    last_updated: "2026-01-01T00:00:00Z",
+  },
+  "device_tracker.anne_therese": {
+    entity_id: "device_tracker.anne_therese",
+    state: "not_home",
+    attributes: {
+      friendly_name: "Anne Therese",
+      latitude: 52.377,
+      longitude: 4.895,
+    },
+    context: { id: "2", user_id: null, parent_id: null },
+    last_changed: "2026-01-01T00:00:00Z",
+    last_updated: "2026-01-01T00:00:00Z",
+  },
+} as unknown as HassEntities;
+
+const createMap = async (): Promise<HaMap> => {
+  const el = document.createElement("ha-map");
+  el.entities = [
+    "device_tracker.paulus",
+    "device_tracker.anne_therese",
+  ] as string[];
+  el.clusterMarkers = false;
+  (el as any)._states = STATES;
+  (el as any)._config = {
+    config: { latitude: 52.3731339, longitude: 4.8903147 },
+  };
+  document.body.appendChild(el);
+  await vi.waitUntil(() => el.leafletMap !== undefined && (el as any)._loaded);
+  await el.updateComplete;
+  return el;
+};
+
+const setMapSize = (el: HaMap, width: number, height: number) => {
+  const mapDiv = el.shadowRoot!.getElementById("map")!;
+  Object.defineProperty(mapDiv, "clientWidth", {
+    value: width,
+    configurable: true,
+  });
+  Object.defineProperty(mapDiv, "clientHeight", {
+    value: height,
+    configurable: true,
+  });
+};
+
+const fireResizeObservers = () => {
+  resizeCallbacks.forEach((cb) => cb([], {} as ResizeObserver));
+};
+
+describe("ha-map", () => {
+  beforeEach(() => {
+    resizeCallbacks.length = 0;
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  it("fits the map to its entities once the container is laid out", async () => {
+    // While the container still has a 0x0 size (before browser layout),
+    // Leaflet cannot compute a fit zoom.
+    const el = await createMap();
+
+    // Container gets its size and the resize observer fires, as happens
+    // when the browser completes layout after the map loaded.
+    setMapSize(el, 800, 500);
+    fireResizeObservers();
+    await el.updateComplete;
+
+    const map = el.leafletMap!;
+    // The map should be fitted to the markers, not zoomed out to the world.
+    expect(map.getZoom()).toBeGreaterThanOrEqual(10);
+    expect(map.getCenter().lat).toBeCloseTo(52.3745, 2);
+    expect(map.getCenter().lng).toBeCloseTo(4.8925, 2);
+  });
+
+  it("does not defer fitting when the container already has a size", async () => {
+    const originalWidth = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      "clientWidth"
+    );
+    const originalHeight = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      "clientHeight"
+    );
+    Object.defineProperty(Element.prototype, "clientWidth", {
+      get: () => 800,
+      configurable: true,
+    });
+    Object.defineProperty(Element.prototype, "clientHeight", {
+      get: () => 500,
+      configurable: true,
+    });
+
+    try {
+      const el = await createMap();
+      const map = el.leafletMap!;
+      expect(map.getZoom()).toBeGreaterThanOrEqual(10);
+      expect(map.getCenter().lat).toBeCloseTo(52.3745, 2);
+      expect(map.getCenter().lng).toBeCloseTo(4.8925, 2);
+    } finally {
+      Object.defineProperty(Element.prototype, "clientWidth", originalWidth!);
+      Object.defineProperty(Element.prototype, "clientHeight", originalHeight!);
+    }
+  });
+});


### PR DESCRIPTION
## Proposed change

Sometimes a map card (or the map panel) loads fully zoomed out to the entire world instead of fitting the entities on it, and it stays that way until you hit "reset focus". I've been seeing this intermittently on my own dashboards and tracked it down.

Root cause: `ha-map` fits the map as soon as Leaflet finishes loading. Leaflet derives the fit zoom from the current container size (`getBoundsZoom` → `getSize`), so if the fit runs before the browser has laid out the card — a race that's easy to hit when the Leaflet chunks are already cached — the container measures 0×0, the computed zoom collapses to the minimum, and you get the world view. The `invalidateSize()` call from the resize observer later corrects the map's size but keeps the zoom, so the map never recovers on its own. That's why the bug is intermittent: it depends on whether module loading or layout wins the race.

The fix defers fitting while the container has no size and runs the pending fit once the resize observer reports a usable size. It also handles the case where the container was laid out but Leaflet's cached size is stale (calls `invalidateSize` and fits immediately). Applies to both `fitMap()` and `fitBounds()`.

Includes a regression test that drives the real `ha-map` element with real Leaflet in jsdom: a map that loads in a 0×0 container and then gets laid out must end up fitted to its markers (fails on `dev` — stuck at zoom 0 — and passes with the fix), plus a control test verifying an already-sized container still fits immediately without deferring.

Disclosure: this fix was authored by Claude (Anthropic's Fable 5 model) working under my direction — I reviewed the change and verified the repro and tests.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

I couldn't find an existing open issue for this in the tracker (searched for the world-zoom / zoomed-out symptoms) — happy to link one if it exists.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
