### PR TITLE
Drop websocket collections created by an iframe panel on teardown

### DIFF
--- a/src/entrypoints/custom-panel.ts
+++ b/src/entrypoints/custom-panel.ts
@@ -1,3 +1,4 @@
+import type { Connection } from "home-assistant-js-websocket";
 import type { CSSResult } from "lit";
 import { fireEvent } from "../common/dom/fire_event";
 import { isNavigationClick } from "../common/dom/is-navigation-click";
@@ -7,6 +8,7 @@ import { navigate } from "../common/navigate";
 import type { CustomPanelInfo } from "../data/panel_custom";
 import { baseEntrypointStyles } from "../resources/styles";
 import { createCustomPanelElement } from "../util/custom-panel/create-custom-panel-element";
+import { dropRealmCollections } from "../util/custom-panel/drop-realm-collections";
 import { loadCustomPanel } from "../util/custom-panel/load-custom-panel";
 import { setCustomPanelProperties } from "../util/custom-panel/set-custom-panel-properties";
 
@@ -29,8 +31,14 @@ window.loadES5Adapter = () => {
 
 let panelEl: HTMLElement | undefined;
 let initialized = false;
+// Kept so we can clean up after ourselves on pagehide without depending on
+// `window.parent.customPanel`, which `_cleanupPanel()` may already have deleted.
+let connection: Connection | undefined;
 
 function setProperties(properties) {
+  if (properties.hass?.connection) {
+    connection = properties.hass.connection;
+  }
   if (!panelEl) {
     return;
   }
@@ -149,5 +157,10 @@ window.addEventListener("pagehide", () => {
   // allow disconnected callback to fire
   while (document.body.lastChild) {
     document.body.removeChild(document.body.lastChild);
+  }
+  // The connection is owned by the main window and outlives this realm, so any
+  // collection we created on it has to go with us.
+  if (connection) {
+    dropRealmCollections(connection);
   }
 });

--- a/src/util/custom-panel/drop-realm-collections.ts
+++ b/src/util/custom-panel/drop-realm-collections.ts
@@ -1,0 +1,40 @@
+import type { Connection } from "home-assistant-js-websocket";
+
+/** Duck-typed shape of a `getCollection()` result cached on a `Connection`. */
+interface CachedCollection {
+  refresh: () => Promise<unknown>;
+  subscribe: (subscriber: (state: any) => void) => () => void;
+}
+
+const isCachedCollection = (value: unknown): value is CachedCollection =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as CachedCollection).subscribe === "function" &&
+  typeof (value as CachedCollection).refresh === "function";
+
+/**
+ * Drop the websocket collections that were created by this window from the
+ * shared connection cache.
+ *
+ * `getCollection()` caches collections (entity registry, label registry, ...) on
+ * the `Connection` object. A custom panel embedded in an iframe shares the
+ * connection with the main window, so a collection the panel is the first to
+ * request is created inside the iframe's realm. When the iframe is removed, that
+ * realm is destroyed while the collection stays cached on the connection - its
+ * store, and the timer that hands the cached state to new subscribers, are gone.
+ * Every later subscriber (the main frontend or the next instance of the panel)
+ * then waits forever for a callback that can never fire.
+ *
+ * Must be called from the realm that is going away - `instanceof Function` is
+ * realm-specific and only matches collections created by this window.
+ */
+export const dropRealmCollections = (connection: Connection): void => {
+  // `getCollection()` stores collections on the connection under keys that are
+  // not part of its type, so treat it as the bag of properties it is.
+  const cache = connection as unknown as Record<string, unknown>;
+  for (const [key, value] of Object.entries(cache)) {
+    if (isCachedCollection(value) && value.subscribe instanceof Function) {
+      delete cache[key];
+    }
+  }
+};

--- a/src/util/custom-panel/drop-realm-collections.ts
+++ b/src/util/custom-panel/drop-realm-collections.ts
@@ -3,7 +3,7 @@ import type { Connection } from "home-assistant-js-websocket";
 /** Duck-typed shape of a `getCollection()` result cached on a `Connection`. */
 interface CachedCollection {
   refresh: () => Promise<unknown>;
-  subscribe: (subscriber: (state: any) => void) => () => void;
+  subscribe: (subscriber: (state: unknown) => void) => () => void;
 }
 
 const isCachedCollection = (value: unknown): value is CachedCollection =>


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

`getCollection()` caches collections (entity registry, label registry, config entries, ...) on the `Connection` object. A custom panel registered with `embed_iframe` shares that connection with the main window, so a collection the panel is the *first* to request gets created inside the **iframe's realm** — its store, its `subscribeUpdates` closure, and the `setTimeout` that hands the cached state to new subscribers all live there.

When the user navigates to another panel, `ha-panel-custom` removes the iframe and that realm is destroyed. The collection object stays cached on the connection, but everything inside it is dead. The next subscriber — the main frontend, or the next instance of the same panel — gets the stale object back from `getCollection()`, and `subscribe()` schedules `setTimeout(() => subscriber(store.state), 0)` in a realm that will never run a task again. The callback never fires, so the consumer waits forever.

This became much easier to hit once the registries moved to `LazyContextProvider`: they are only subscribed on first consumer, so an iframe panel is now frequently the first requester. Before that, the main window subscribed eagerly at startup and always owned the collections.

Concretely, in the KNX panel (`embed_iframe: true`): open `/knx/entities/view`, click *History* in the sidebar, then navigate back via *Settings → KNX → Entities*. The entity table renders empty. Inspecting the shared connection after the round trip:

```
conn._entityRegistry  -> created by a destroyed realm (neither main window nor current iframe)
conn._labelRegistry   -> created by a destroyed realm
LazyContextProvider(fullEntities): { _loaded: false, _subscribing: true, _pendingCallbacks: 1 }
```

`conn._entityRegistry.state` still holds all 375 entries — the data is there, it just can never be delivered. `fullEntitiesContext` and `labelsContext` never produce a value.

This also leaks the other way: after visiting an iframe panel, the main frontend's own registry-backed pages can inherit the dead collection.

**The fix** is for the iframe to clean up after itself. `src/entrypoints/custom-panel.ts` already runs a `pagehide` handler inside the panel iframe, which fires while the realm is still alive; it drops the collections that this realm created, so the next `getCollection()` recreates them in a living realm. `instanceof Function` is realm-specific, which makes the check exact — it matches only collections created by this window and leaves the main window's alone.

The connection is stashed in `setProperties` rather than read from `window.parent.customPanel` at teardown, because `_cleanupPanel()` deletes `window.customPanel` before removing the iframe on the panel-change path.

Note on the hook point: the more obvious place, `HaPanelCustom.disconnectedCallback` / `_cleanupPanel`, does **not** work. The element is detached before it runs, so the browsing context is already discarded and `this.querySelector("iframe").contentWindow` is `null` — the realm is unreachable exactly when you would want to identify it. Verified by probing it on a running instance.

One thing this does not fix: a `LazyContextProvider` in the main window that already loaded a value *from* the iframe's collection keeps that value and stops receiving updates until something makes it resubscribe. That is data going stale rather than a view going empty, and addressing it would need a way to invalidate loaded lazy providers.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/XKNX/knx-frontend/pull/430 (panel-side workaround, which this makes unnecessary)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
