### PR TITLE
Type component event handlers

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -26,7 +26,10 @@ import { styleMap } from "lit/directives/style-map";
 import { ensureArray } from "../../common/array/ensure-array";
 import { getAllGraphColors } from "../../common/color/colors";
 import { transform } from "../../common/decorators/transform";
-import type { HASSDomEvent } from "../../common/dom/fire_event";
+import type {
+  HASSDomCurrentTargetEvent,
+  HASSDomEvent,
+} from "../../common/dom/fire_event";
 import { fireEvent } from "../../common/dom/fire_event";
 import { listenMediaQuery } from "../../common/dom/media_query";
 import { afterNextRender } from "../../common/util/render-status";
@@ -1216,7 +1219,9 @@ export class HaChartBase extends LitElement {
   }
 
   // Long-press to solo on touch/pen devices (500ms, consistent with action-handler-directive)
-  private _legendPointerDown(ev: PointerEvent) {
+  private _legendPointerDown(
+    ev: PointerEvent & HASSDomCurrentTargetEvent<HTMLElement>
+  ) {
     // Mouse uses Ctrl/Cmd+click instead
     if (ev.pointerType === "mouse") {
       return;
@@ -1246,7 +1251,9 @@ export class HaChartBase extends LitElement {
     }
   }
 
-  private _toggleDataset(ev: MouseEvent) {
+  private _toggleDataset(
+    ev: MouseEvent & HASSDomCurrentTargetEvent<HTMLElement>
+  ) {
     ev.stopPropagation();
     if (!this.chart) {
       return;
@@ -1268,7 +1275,7 @@ export class HaChartBase extends LitElement {
     this._handleDatasetToggle(id);
   }
 
-  private _labelClick(ev: MouseEvent) {
+  private _labelClick(ev: MouseEvent & HASSDomCurrentTargetEvent<HTMLElement>) {
     ev.stopPropagation();
     if (!this.chart) {
       return;

--- a/src/components/chart/ha-sankey-chart.ts
+++ b/src/components/chart/ha-sankey-chart.ts
@@ -2,13 +2,10 @@ import { customElement, property, state } from "lit/decorators";
 import { LitElement, html, css } from "lit";
 import type { EChartsType } from "echarts/core";
 import type { SankeySeriesOption } from "echarts/types/dist/echarts";
-import type {
-  CallbackDataParams,
-  ECElementEvent,
-} from "echarts/types/src/util/types";
+import type { CallbackDataParams } from "echarts/types/src/util/types";
 import memoizeOne from "memoize-one";
 import { ResizeController } from "@lit-labs/observers/resize-controller";
-import { fireEvent } from "../../common/dom/fire_event";
+import { fireEvent, type HASSDomEvent } from "../../common/dom/fire_event";
 import SankeyChart from "../../resources/echarts/components/sankey/install";
 import type { HomeAssistant } from "../../types";
 import type { HaECOption } from "../../resources/echarts/echarts";
@@ -121,11 +118,15 @@ export class HaSankeyChart extends LitElement {
     return null;
   };
 
-  private _handleChartSankeyRoam = (ev: CustomEvent) => {
+  private _handleChartSankeyRoam = (
+    ev: HASSDomEvent<HASSDomEvents["chart-sankeyroam"]>
+  ) => {
     this._currentZoom = ev.detail.zoom;
   };
 
-  private _handleChartClick = (ev: CustomEvent<ECElementEvent>) => {
+  private _handleChartClick = (
+    ev: HASSDomEvent<HASSDomEvents["chart-click"]>
+  ) => {
     const detail = ev.detail;
     // Only handle node clicks (not links)
     if (detail.dataType !== "node") {

--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -216,11 +216,13 @@ export class StateHistoryChartLine extends LitElement {
     })}`;
   };
 
-  private _datasetHidden(ev: CustomEvent) {
+  private _datasetHidden(ev: HASSDomEvent<HASSDomEvents["dataset-hidden"]>) {
     this._hiddenStats.add(ev.detail.id);
   }
 
-  private _datasetUnhidden(ev: CustomEvent) {
+  private _datasetUnhidden(
+    ev: HASSDomEvent<HASSDomEvents["dataset-unhidden"]>
+  ) {
     this._hiddenStats.delete(ev.detail.id);
   }
 
@@ -229,7 +231,7 @@ export class StateHistoryChartLine extends LitElement {
     chartBase.zoom(start, end, true);
   }
 
-  private _handleDataZoom(ev: CustomEvent) {
+  private _handleDataZoom(ev: HASSDomEvent<HASSDomEvents["chart-zoom"]>) {
     fireEvent(this, "chart-zoom-with-index", {
       start: ev.detail.start ?? 0,
       end: ev.detail.end ?? 100,

--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -4,7 +4,6 @@ import { customElement, property, state } from "lit/decorators";
 import type {
   CustomSeriesOption,
   CustomSeriesRenderItem,
-  ECElementEvent,
   TooltipPositionCallbackParams,
 } from "echarts/types/dist/shared";
 import { formatDateTimeWithSeconds } from "../../common/datetime/format_date_time";
@@ -21,7 +20,7 @@ import echarts from "../../resources/echarts/echarts";
 import { luminosity } from "../../common/color/rgb";
 import { hex2rgb } from "../../common/color/convert-color";
 import { measureTextWidth } from "../../util/text";
-import { fireEvent } from "../../common/dom/fire_event";
+import { fireEvent, type HASSDomEvent } from "../../common/dom/fire_event";
 
 @customElement("state-history-chart-timeline")
 export class StateHistoryChartTimeline extends LitElement {
@@ -271,7 +270,7 @@ export class StateHistoryChartTimeline extends LitElement {
     chartBase.zoom(start, end, true);
   }
 
-  private _handleDataZoom(ev: CustomEvent) {
+  private _handleDataZoom(ev: HASSDomEvent<HASSDomEvents["chart-zoom"]>) {
     fireEvent(this, "chart-zoom-with-index", {
       start: ev.detail.start ?? 0,
       end: ev.detail.end ?? 100,
@@ -385,7 +384,9 @@ export class StateHistoryChartTimeline extends LitElement {
     this._chartData = datasets;
   }
 
-  private _handleChartClick(e: CustomEvent<ECElementEvent>): void {
+  private _handleChartClick(
+    e: HASSDomEvent<HASSDomEvents["chart-click"]>
+  ): void {
     if (e.detail.targetType === "axisLabel") {
       const dataset = this._chartData[e.detail.dataIndex];
       if (dataset) {

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -12,6 +12,10 @@ import {
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import { restoreScroll } from "../../common/decorators/restore-scroll";
 import type {
+  HASSDomEvent,
+  HASSDomTargetEvent,
+} from "../../common/dom/fire_event";
+import type {
   HistoryResult,
   LineChartUnit,
   TimelineEntity,
@@ -316,13 +320,13 @@ export class StateHistoryCharts extends LitElement {
     }
   }
 
-  private _yWidthChanged(e: CustomEvent<HASSDomEvents["y-width-changed"]>) {
+  private _yWidthChanged(e: HASSDomEvent<HASSDomEvents["y-width-changed"]>) {
     this._childYWidths[e.detail.chartIndex] = e.detail.value;
     this._maxYWidth = Math.max(...Object.values(this._childYWidths), 0);
   }
 
   private _handleTimelineSync(
-    e: CustomEvent<HASSDomEvents["chart-zoom-with-index"]>
+    e: HASSDomEvent<HASSDomEvents["chart-zoom-with-index"]>
   ) {
     if (!this.syncCharts || this._isSyncing) {
       return;
@@ -384,7 +388,7 @@ export class StateHistoryCharts extends LitElement {
   }
 
   @eventOptions({ passive: true })
-  private _saveScrollPos(e: Event) {
+  private _saveScrollPos(e: HASSDomTargetEvent<HTMLDivElement>) {
     this._savedScrollPos = (e.target as HTMLDivElement).scrollTop;
   }
 

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -204,12 +204,14 @@ export class StatisticsChart extends LitElement {
     `;
   }
 
-  private _datasetHidden(ev: CustomEvent) {
+  private _datasetHidden(ev: HASSDomEvent<HASSDomEvents["dataset-hidden"]>) {
     this._hiddenStats.add(ev.detail.id);
     this.requestUpdate("_hiddenStats");
   }
 
-  private _datasetUnhidden(ev: CustomEvent) {
+  private _datasetUnhidden(
+    ev: HASSDomEvent<HASSDomEvents["dataset-unhidden"]>
+  ) {
     this._hiddenStats.delete(ev.detail.id);
     this.requestUpdate("_hiddenStats");
   }

--- a/src/components/date-picker/date-range-picker.ts
+++ b/src/components/date-picker/date-range-picker.ts
@@ -15,6 +15,10 @@ import {
 } from "../../common/datetime/format_date";
 import { transform } from "../../common/decorators/transform";
 import { fireEvent } from "../../common/dom/fire_event";
+import type {
+  HASSDomEvent,
+  HASSDomTargetEvent,
+} from "../../common/dom/fire_event";
 import { configContext, internationalizationContext } from "../../data/context";
 import { TimeZone } from "../../data/translation";
 import { MobileAwareMixin } from "../../mixins/mobile-aware-mixin";
@@ -307,7 +311,7 @@ export class DateRangePicker extends MobileAwareMixin(LitElement) {
     });
   }
 
-  private _focusChanged(ev: CustomEvent<Date>) {
+  private _focusChanged(ev: HASSDomEvent<Date>) {
     const date = ev.detail;
     this._pickerMonth = formatDateMonth(
       date,
@@ -322,13 +326,19 @@ export class DateRangePicker extends MobileAwareMixin(LitElement) {
     this._focusDate = undefined;
   }
 
-  private _handleChange(ev: CustomEvent) {
+  private _handleChange(
+    ev: HASSDomTargetEvent<HTMLElementTagNameMap["calendar-range"]>
+  ) {
     const dateElement = ev.target as HTMLElementTagNameMap["calendar-range"];
     this._dateValue = dateElement.value;
     this._focusDate = undefined;
   }
 
-  private _clickDateRangeChip(ev: Event) {
+  private _clickDateRangeChip(
+    ev: HASSDomTargetEvent<
+      HaFilterChip & { index: number; range: [Date, Date] }
+    >
+  ) {
     const chip = ev.target as HaFilterChip & {
       index: number;
       range: [Date, Date];
@@ -336,7 +346,7 @@ export class DateRangePicker extends MobileAwareMixin(LitElement) {
     this._saveDateRangePreset(chip.range, chip.index);
   }
 
-  private _setDateRange(ev: CustomEvent<ActionDetail>) {
+  private _setDateRange(ev: HASSDomEvent<ActionDetail>) {
     const dateRange: [Date, Date] = Object.values(this.ranges!)[
       ev.detail.index
     ];
@@ -355,7 +365,9 @@ export class DateRangePicker extends MobileAwareMixin(LitElement) {
     });
   }
 
-  private _handleChangeTime(ev: ValueChangedEvent<string>) {
+  private _handleChangeTime(
+    ev: ValueChangedEvent<string> & HASSDomTargetEvent<HaBaseTimeInput>
+  ) {
     ev.stopPropagation();
     const time = ev.detail.value;
     const target = ev.target as HaBaseTimeInput;

--- a/src/components/date-picker/ha-dialog-date-picker.ts
+++ b/src/components/date-picker/ha-dialog-date-picker.ts
@@ -13,6 +13,10 @@ import {
 } from "../../common/datetime/format_date";
 import { valueToDate } from "../../common/datetime/value_to_date";
 import { transform } from "../../common/decorators/transform";
+import type {
+  HASSDomEvent,
+  HASSDomTargetEvent,
+} from "../../common/dom/fire_event";
 import { configContext, internationalizationContext } from "../../data/context";
 import { DialogMixin } from "../../dialogs/dialog-mixin";
 import type { HomeAssistantConfig } from "../../types";
@@ -167,7 +171,7 @@ export class HaDialogDatePicker extends DialogMixin<DatePickerDialogParams>(
     </ha-adaptive-popover>`;
   }
 
-  private _valueChanged(ev: Event) {
+  private _valueChanged(ev: HASSDomTargetEvent<CalendarDate>) {
     const dateElement = ev.target as CalendarDate;
     if (dateElement.value) {
       this._updateValue(dateElement.value);
@@ -198,7 +202,7 @@ export class HaDialogDatePicker extends DialogMixin<DatePickerDialogParams>(
     }
   }
 
-  private _focusChanged(ev: CustomEvent<Date>) {
+  private _focusChanged(ev: HASSDomEvent<Date>) {
     const date = ev.detail;
     this._pickerMonth = formatDateMonth(
       date,

--- a/src/components/ha-areas-floors-display-editor.ts
+++ b/src/components/ha-areas-floors-display-editor.ts
@@ -7,6 +7,10 @@ import { repeat } from "lit/directives/repeat";
 import memoizeOne from "memoize-one";
 import { consumeLocalize } from "../common/decorators/consume-context-entry";
 import { fireEvent } from "../common/dom/fire_event";
+import type {
+  HASSDomCurrentTargetEvent,
+  HASSDomEvent,
+} from "../common/dom/fire_event";
 import { computeFloorName } from "../common/entity/compute_floor_name";
 import { getAreaContext } from "../common/entity/context/get_area_context";
 import type { LocalizeFunc } from "../common/translations/localize";
@@ -191,7 +195,7 @@ export class HaAreasFloorsDisplayEditor extends LitElement {
     }
   );
 
-  private _floorMoved(ev: CustomEvent<HASSDomEvents["item-moved"]>) {
+  private _floorMoved(ev: HASSDomEvent<HASSDomEvents["item-moved"]>) {
     ev.stopPropagation();
     const newIndex = ev.detail.newIndex;
     const oldIndex = ev.detail.oldIndex;
@@ -215,7 +219,12 @@ export class HaAreasFloorsDisplayEditor extends LitElement {
     fireEvent(this, "value-changed", { value: newValue });
   }
 
-  private async _areaDisplayChanged(ev: ValueChangedEvent<DisplayValue>) {
+  private async _areaDisplayChanged(
+    ev: ValueChangedEvent<DisplayValue> &
+      HASSDomCurrentTargetEvent<
+        HTMLElementTagNameMap["ha-items-display-editor"] & { floorId?: string }
+      >
+  ) {
     ev.stopPropagation();
     const value = ev.detail.value;
     const currentFloorId = (ev.currentTarget as any).floorId;

--- a/src/components/ha-form/ha-form-boolean.ts
+++ b/src/components/ha-form/ha-form-boolean.ts
@@ -2,6 +2,7 @@ import type { TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
+import type { HASSDomTargetEvent } from "../../common/dom/fire_event";
 import "../ha-checkbox";
 import type { HaCheckbox } from "../ha-checkbox";
 import type {
@@ -43,7 +44,7 @@ export class HaFormBoolean extends LitElement implements HaFormElement {
     `;
   }
 
-  private _valueChanged(ev: Event) {
+  private _valueChanged(ev: HASSDomTargetEvent<HaCheckbox>) {
     fireEvent(this, "value-changed", {
       value: (ev.target as HaCheckbox).checked,
     });

--- a/src/components/ha-form/ha-form-float.ts
+++ b/src/components/ha-form/ha-form-float.ts
@@ -2,6 +2,7 @@ import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
+import type { HASSDomTargetEvent } from "../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../common/translations/localize";
 import "../input/ha-input";
 import type { HaInput } from "../input/ha-input";
@@ -70,7 +71,7 @@ export class HaFormFloat extends LitElement implements HaFormElement {
     }
   }
 
-  private _handleInput(ev: InputEvent) {
+  private _handleInput(ev: InputEvent & HASSDomTargetEvent<HaInput>) {
     const source = ev.target as HaInput;
     const rawValue = (source.value ?? "").replace(",", ".");
 

--- a/src/components/ha-form/ha-form-integer.ts
+++ b/src/components/ha-form/ha-form-integer.ts
@@ -2,6 +2,7 @@ import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
+import type { HASSDomTargetEvent } from "../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../common/translations/localize";
 import "../ha-checkbox";
 import type { HaCheckbox } from "../ha-checkbox";
@@ -153,7 +154,7 @@ export class HaFormInteger extends LitElement implements HaFormElement {
     );
   }
 
-  private _handleCheckboxChange(ev: Event) {
+  private _handleCheckboxChange(ev: HASSDomTargetEvent<HaCheckbox>) {
     const checked = (ev.target as HaCheckbox).checked;
     let value: HaFormIntegerData | undefined;
     if (checked) {
@@ -178,7 +179,9 @@ export class HaFormInteger extends LitElement implements HaFormElement {
     });
   }
 
-  private _valueChanged(ev: InputEvent) {
+  private _valueChanged(
+    ev: InputEvent & HASSDomTargetEvent<HaInput | HTMLInputElement>
+  ) {
     const source = ev.target as HaInput | HTMLInputElement;
     const rawValue = source.value;
 

--- a/src/components/ha-form/ha-form-multi_select.ts
+++ b/src/components/ha-form/ha-form-multi_select.ts
@@ -2,6 +2,7 @@ import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
+import type { HASSDomTargetEvent } from "../../common/dom/fire_event";
 import "../ha-check-list-item";
 import "../ha-checkbox";
 import type { HaCheckbox } from "../ha-checkbox";
@@ -140,7 +141,7 @@ export class HaFormMultiSelect extends LitElement implements HaFormElement {
     }
   }
 
-  private _valueChanged(ev: CustomEvent): void {
+  private _valueChanged(ev: HASSDomTargetEvent<HaCheckbox>): void {
     const { value, checked } = ev.target as HaCheckbox;
     this._handleValueChanged(value, checked);
   }

--- a/src/components/ha-form/ha-form-select.ts
+++ b/src/components/ha-form/ha-form-select.ts
@@ -4,7 +4,7 @@ import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../common/dom/fire_event";
 import type { SelectSelector } from "../../data/selector";
-import type { HomeAssistant } from "../../types";
+import type { HomeAssistant, ValueChangedEvent } from "../../types";
 import "../ha-selector/ha-selector-select";
 import type {
   HaFormElement,
@@ -78,7 +78,7 @@ export class HaFormSelect extends LitElement implements HaFormElement {
     `;
   }
 
-  private _valueChanged(ev: CustomEvent) {
+  private _valueChanged(ev: ValueChangedEvent<string>) {
     ev.stopPropagation();
     let value: HaFormSelectData | undefined = ev.detail.value;
 

--- a/src/components/ha-form/ha-form-string.ts
+++ b/src/components/ha-form/ha-form-string.ts
@@ -2,6 +2,7 @@ import type { PropertyValues, TemplateResult } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
+import type { HASSDomTargetEvent } from "../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../common/translations/localize";
 import "../ha-icon-button";
 import "../input/ha-input";
@@ -79,7 +80,7 @@ export class HaFormString extends LitElement implements HaFormElement {
     }
   }
 
-  protected _valueChanged(ev: Event): void {
+  protected _valueChanged(ev: HASSDomTargetEvent<HaInput>): void {
     let value: string | undefined = (ev.target as HaInput).value;
     if (this.data === value) {
       return;

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -275,10 +275,12 @@ export class HaForm extends LitElement implements HaFormElement {
 
       if (ev.target === this) return;
 
+      const changeEv = ev as
+        HaFormDataChangedEvent | HaFormDataContainerChangedEvent;
       const newValue =
         !schema.name || ("flatten" in schema && schema.flatten)
-          ? (ev as HaFormDataContainerChangedEvent).detail.value
-          : { [schema.name]: (ev as HaFormDataChangedEvent).detail.value };
+          ? (changeEv.detail.value as HaFormDataContainer)
+          : { [schema.name]: changeEv.detail.value as HaFormData };
 
       this.data = {
         ...this.data,

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -3,11 +3,19 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import { dynamicElement } from "../../common/dom/dynamic-element-directive";
 import { fireEvent } from "../../common/dom/fire_event";
-import type { HomeAssistant } from "../../types";
+import type { HomeAssistant, ValueChangedEvent } from "../../types";
 import "../ha-alert";
 import "../ha-selector/ha-selector";
 import { getHiddenFields } from "./conditions";
-import type { HaFormDataContainer, HaFormElement, HaFormSchema } from "./types";
+import type {
+  HaFormData,
+  HaFormDataContainer,
+  HaFormElement,
+  HaFormSchema,
+} from "./types";
+
+type HaFormDataChangedEvent = ValueChangedEvent<HaFormData>;
+type HaFormDataContainerChangedEvent = ValueChangedEvent<HaFormDataContainer>;
 
 const LOAD_ELEMENTS = {
   boolean: () => import("./ha-form-boolean"),
@@ -261,7 +269,7 @@ export class HaForm extends LitElement implements HaFormElement {
   }
 
   protected addValueChangedListener(element: Element | ShadowRoot) {
-    element.addEventListener("value-changed", (ev) => {
+    element.addEventListener("value-changed", (ev: Event) => {
       ev.stopPropagation();
       const schema = (ev.target as HaFormElement).schema as HaFormSchema;
 
@@ -269,8 +277,8 @@ export class HaForm extends LitElement implements HaFormElement {
 
       const newValue =
         !schema.name || ("flatten" in schema && schema.flatten)
-          ? ev.detail.value
-          : { [schema.name]: ev.detail.value };
+          ? (ev as HaFormDataContainerChangedEvent).detail.value
+          : { [schema.name]: (ev as HaFormDataChangedEvent).detail.value };
 
       this.data = {
         ...this.data,

--- a/src/components/ha-network.ts
+++ b/src/components/ha-network.ts
@@ -3,6 +3,7 @@ import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../common/dom/fire_event";
 import type {
   Adapter,
   IPv4ConfiguredAddress,
@@ -101,7 +102,9 @@ export class HaNetwork extends LitElement {
     `;
   }
 
-  private _handleAutoConfigureCheckboxClick(ev: Event) {
+  private _handleAutoConfigureCheckboxClick(
+    ev: HASSDomCurrentTargetEvent<HaCheckbox>
+  ) {
     const checkbox = ev.currentTarget as HaCheckbox;
     if (this.networkConfig === undefined) {
       return;
@@ -127,7 +130,9 @@ export class HaNetwork extends LitElement {
     });
   }
 
-  private _handleAdapterCheckboxClick(ev: Event) {
+  private _handleAdapterCheckboxClick(
+    ev: HASSDomCurrentTargetEvent<HaCheckbox>
+  ) {
     const checkbox = ev.currentTarget as HaCheckbox;
     const adapter_name = checkbox.id;
     if (this.networkConfig === undefined) {

--- a/src/components/ha-push-notifications-toggle.ts
+++ b/src/components/ha-push-notifications-toggle.ts
@@ -5,7 +5,7 @@ import { getAppKey } from "../data/notify_html5";
 import { showPromptDialog } from "../dialogs/generic/show-dialog-box";
 import type { HaSwitch } from "./ha-switch";
 import type { HomeAssistant } from "../types";
-import { fireEvent } from "../common/dom/fire_event";
+import { fireEvent, type HASSDomTargetEvent } from "../common/dom/fire_event";
 import "./ha-switch";
 
 export const pushSupported =
@@ -55,7 +55,7 @@ class HaPushNotificationsToggle extends LitElement {
     }
   }
 
-  private _handlePushChange(ev: Event) {
+  private _handlePushChange(ev: HASSDomTargetEvent<HaSwitch>) {
     // Somehow this is triggered on Safari on page load causing
     // it to get into a loop and crash the page.
     if (!pushSupported) return;

--- a/src/components/ha-segmented-bar.ts
+++ b/src/components/ha-segmented-bar.ts
@@ -4,6 +4,7 @@ import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { styleMap } from "lit/directives/style-map";
 import { fireEvent } from "../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../common/dom/fire_event";
 import "./ha-tooltip";
 
 export interface Segment {
@@ -120,7 +121,9 @@ class HaSegmentedBar extends LitElement {
     `;
   }
 
-  private _handleSegmentClick(ev: Event): void {
+  private _handleSegmentClick(
+    ev: HASSDomCurrentTargetEvent<HTMLElement>
+  ): void {
     const target = ev.currentTarget as HTMLElement;
     const index = Number(target.dataset.index);
     const segment = this.segments[index];
@@ -129,7 +132,7 @@ class HaSegmentedBar extends LitElement {
     }
   }
 
-  private _handleLegendClick(ev: Event): void {
+  private _handleLegendClick(ev: HASSDomCurrentTargetEvent<HTMLElement>): void {
     const target = ev.currentTarget as HTMLElement;
     const index = Number(target.dataset.index);
     const segment = this.segments[index];

--- a/src/components/ha-select.ts
+++ b/src/components/ha-select.ts
@@ -4,6 +4,7 @@ import { ifDefined } from "lit/directives/if-defined";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../common/dom/fire_event";
 import "./ha-dropdown";
+import type { HaDropdownSelectEvent } from "./ha-dropdown";
 import "./ha-dropdown-item";
 import "./ha-input-helper-text";
 import "./ha-picker-field";
@@ -169,7 +170,7 @@ export class HaSelect extends LitElement {
       : nothing;
   }
 
-  private _handleSelect(ev: CustomEvent<{ item: { value: string | number } }>) {
+  private _handleSelect(ev: HaDropdownSelectEvent<string | number>) {
     ev.stopPropagation();
     const value = ev.detail.item.value;
     if (value === this.value) {

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -17,7 +17,7 @@ import { stringCompare } from "../common/string/compare";
 import { computeRTL } from "../common/util/compute_rtl";
 import { throttle } from "../common/util/throttle";
 import { subscribeFrontendUserData } from "../data/frontend";
-import type { ActionHandlerDetail } from "../data/lovelace/action_handler";
+import type { ActionHandlerEvent } from "../data/lovelace/action_handler";
 import {
   FIXED_PANELS,
   getDefaultPanelUrlPath,
@@ -634,7 +634,7 @@ class HaSidebar extends SubscribeMixin(ScrollableFadeMixin(LitElement)) {
     });
   }
 
-  private _handleAction(ev: CustomEvent<ActionHandlerDetail>) {
+  private _handleAction(ev: ActionHandlerEvent) {
     if (ev.detail.action !== "hold") {
       return;
     }
@@ -646,7 +646,7 @@ class HaSidebar extends SubscribeMixin(ScrollableFadeMixin(LitElement)) {
     fireEvent(this, "hass-show-notifications");
   }
 
-  private _toggleSidebar(ev: CustomEvent) {
+  private _toggleSidebar(ev: ActionHandlerEvent) {
     if (ev.detail.action !== "tap") {
       return;
     }

--- a/src/components/ha-top-app-bar-fixed.ts
+++ b/src/components/ha-top-app-bar-fixed.ts
@@ -2,6 +2,7 @@ import type { CSSResultGroup, PropertyValues } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import type { HASSDomCurrentTargetEvent } from "../common/dom/fire_event";
 import { goBack } from "../common/navigate";
 import { haStyleScrollbar } from "../resources/styles";
 import "./ha-icon-button-arrow-prev";
@@ -324,7 +325,9 @@ export class HaTopAppBarFixed extends LitElement {
     this._subRowResizeObserver = undefined;
   }
 
-  private _subRowSlotChanged = (ev: Event) => {
+  private _subRowSlotChanged = (
+    ev: HASSDomCurrentTargetEvent<HTMLSlotElement>
+  ) => {
     const slot = ev.currentTarget as HTMLSlotElement;
     this._hasSubRow = slot
       .assignedNodes({ flatten: true })

--- a/src/components/input/ha-input-copy.ts
+++ b/src/components/input/ha-input-copy.ts
@@ -2,6 +2,7 @@ import { consume, type ContextType } from "@lit/context";
 import { mdiContentCopy, mdiEye, mdiEyeOff } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
+import type { HASSDomCurrentTargetEvent } from "../../common/dom/fire_event";
 import { copyToClipboard } from "../../common/util/copy-clipboard";
 import { internationalizationContext } from "../../data/context";
 import { showToast } from "../../util/toast";
@@ -111,7 +112,7 @@ export class HaInputCopy extends LitElement {
     `;
   }
 
-  private _focusInput(ev: Event) {
+  private _focusInput(ev: HASSDomCurrentTargetEvent<HaInput>) {
     const inputElement = ev.currentTarget as HaInput;
     inputElement.select();
   }

--- a/src/components/item/ha-row-item.ts
+++ b/src/components/item/ha-row-item.ts
@@ -2,6 +2,7 @@ import { HasSlotController } from "@home-assistant/webawesome/dist/internal/slot
 import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import type { HASSDomTargetEvent } from "../../common/dom/fire_event";
 
 /**
  * @element ha-row-item
@@ -56,7 +57,7 @@ export class HaRowItem extends LitElement {
   @state() private _hasEnd = false;
 
   private _onSlotChange(name: "start" | "end") {
-    return (ev: Event) => {
+    return (ev: HASSDomTargetEvent<HTMLSlotElement>) => {
       const slot = ev.target as HTMLSlotElement;
       const hasContent = slot
         .assignedNodes({ flatten: true })

--- a/src/components/trace/hat-graph-branch.ts
+++ b/src/components/trace/hat-graph-branch.ts
@@ -1,6 +1,7 @@
 import { css, html, LitElement, nothing, svg } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import type { HASSDomTargetEvent } from "../../common/dom/fire_event";
 import { BRANCH_HEIGHT, SPACING } from "./hat-graph-const";
 
 interface BranchConfig {
@@ -31,7 +32,7 @@ export class HatGraphBranch extends LitElement {
 
   private _maxHeight = 0;
 
-  private _updateBranches(ev: Event) {
+  private _updateBranches(ev: HASSDomTargetEvent<HTMLSlotElement>) {
     let total_width = 0;
     const heights: number[] = [];
     const branches: BranchConfig[] = [];

--- a/src/layouts/hass-subpage.ts
+++ b/src/layouts/hass-subpage.ts
@@ -3,6 +3,7 @@ import { css, html, LitElement } from "lit";
 import { customElement, eventOptions, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { restoreScroll } from "../common/decorators/restore-scroll";
+import type { HASSDomTargetEvent } from "../common/dom/fire_event";
 import { goBack } from "../common/navigate";
 import { sanitizeNavigationPath } from "../common/url/sanitize-navigation-path";
 import "../components/ha-icon-button-arrow-prev";
@@ -74,7 +75,7 @@ class HassSubpage extends LitElement {
   }
 
   @eventOptions({ passive: true })
-  private _saveScrollPos(e: Event) {
+  private _saveScrollPos(e: HASSDomTargetEvent<HTMLDivElement>) {
     this._savedScrollPos = (e.target as HTMLDivElement).scrollTop;
   }
 

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -17,7 +17,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { canShowPage } from "../common/config/can_show_page";
-import { fireEvent } from "../common/dom/fire_event";
+import { fireEvent, type HASSDomTargetEvent } from "../common/dom/fire_event";
 import type { LocalizeFunc } from "../common/translations/localize";
 import "../components/chips/ha-assist-chip";
 import "../components/data-table/ha-data-table";
@@ -740,7 +740,9 @@ export class HaTabsSubpageDataTable extends KeyboardShortcutMixin(LitElement) {
     this._dataTable.clearSelection();
   };
 
-  private _handleSearchChange(ev: InputEvent) {
+  private _handleSearchChange(
+    ev: InputEvent & HASSDomTargetEvent<HaInputSearch>
+  ) {
     const target = ev.target as HaInputSearch;
     if (this.filter === target.value) {
       return;

--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -12,6 +12,7 @@ import { classMap } from "lit/directives/class-map";
 import memoizeOne from "memoize-one";
 import { canShowPage } from "../common/config/can_show_page";
 import { restoreScroll } from "../common/decorators/restore-scroll";
+import type { HASSDomTargetEvent } from "../common/dom/fire_event";
 import { isNavigationClick } from "../common/dom/is-navigation-click";
 import { goBack, navigate } from "../common/navigate";
 import type { LocalizeFunc } from "../common/translations/localize";
@@ -232,7 +233,7 @@ export class HassTabsSubpage extends LitElement {
   }
 
   @eventOptions({ passive: true })
-  private _saveScrollPos(e: Event) {
+  private _saveScrollPos(e: HASSDomTargetEvent<HTMLDivElement>) {
     this._savedScrollPos = (e.target as HTMLDivElement).scrollTop;
   }
 

--- a/src/state-summary/state-card-input_number.ts
+++ b/src/state-summary/state-card-input_number.ts
@@ -5,7 +5,9 @@ import { customElement, property } from "lit/decorators";
 import { debounce } from "../common/util/debounce";
 import type { HASSDomTargetEvent } from "../common/dom/fire_event";
 import "../components/entity/state-info";
+import type { HaSlider } from "../components/ha-slider";
 import "../components/ha-slider";
+import type { HaInput } from "../components/input/ha-input";
 import "../components/input/ha-input";
 import { UNAVAILABLE } from "../data/entity/entity";
 import { setValue } from "../data/input_text";
@@ -154,14 +156,11 @@ class StateCardInputNumber extends LitElement {
   }
 
   private _selectedValueChanged(
-    ev: HASSDomTargetEvent<HTMLInputElement>
+    ev: HASSDomTargetEvent<HaSlider | HaInput>
   ): void {
-    if ((ev.target as HTMLInputElement).value !== this.stateObj.state) {
-      setValue(
-        this.hass!,
-        this.stateObj.entity_id,
-        (ev.target as HTMLInputElement).value
-      );
+    const value = String(ev.target.value);
+    if (value !== this.stateObj.state) {
+      setValue(this.hass!, this.stateObj.entity_id, value);
     }
   }
 }

--- a/src/state-summary/state-card-input_number.ts
+++ b/src/state-summary/state-card-input_number.ts
@@ -3,6 +3,7 @@ import type { TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { debounce } from "../common/util/debounce";
+import type { HASSDomTargetEvent } from "../common/dom/fire_event";
 import "../components/entity/state-info";
 import "../components/ha-slider";
 import "../components/input/ha-input";
@@ -152,7 +153,9 @@ class StateCardInputNumber extends LitElement {
     }
   }
 
-  private _selectedValueChanged(ev: Event): void {
+  private _selectedValueChanged(
+    ev: HASSDomTargetEvent<HTMLInputElement>
+  ): void {
     if ((ev.target as HTMLInputElement).value !== this.stateObj.state) {
       setValue(
         this.hass!,

--- a/src/state-summary/state-card-input_text.ts
+++ b/src/state-summary/state-card-input_text.ts
@@ -3,6 +3,7 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { stopPropagation } from "../common/dom/stop_propagation";
+import type { HASSDomTargetEvent } from "../common/dom/fire_event";
 import "../components/entity/state-info";
 import "../components/input/ha-input";
 import type { HaInput } from "../components/input/ha-input";
@@ -50,7 +51,7 @@ class StateCardInputText extends LitElement {
     }
   }
 
-  private _onInput(ev: InputEvent) {
+  private _onInput(ev: InputEvent & HASSDomTargetEvent<HaInput>) {
     this.value = (ev.target as HaInput).value ?? "";
   }
 

--- a/src/state-summary/state-card-number.ts
+++ b/src/state-summary/state-card-number.ts
@@ -3,6 +3,7 @@ import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { debounce } from "../common/util/debounce";
+import type { HASSDomTargetEvent } from "../common/dom/fire_event";
 import "../components/entity/state-info";
 import "../components/ha-slider";
 import "../components/input/ha-input";
@@ -124,7 +125,9 @@ class StateCardNumber extends LitElement {
     }
   }
 
-  private async _selectedValueChanged(ev: Event) {
+  private async _selectedValueChanged(
+    ev: HASSDomTargetEvent<HTMLInputElement>
+  ) {
     const value = (ev.target as HTMLInputElement).value;
     if (value === this.stateObj.state) {
       return;

--- a/src/state-summary/state-card-number.ts
+++ b/src/state-summary/state-card-number.ts
@@ -5,7 +5,9 @@ import { customElement, property } from "lit/decorators";
 import { debounce } from "../common/util/debounce";
 import type { HASSDomTargetEvent } from "../common/dom/fire_event";
 import "../components/entity/state-info";
+import type { HaSlider } from "../components/ha-slider";
 import "../components/ha-slider";
+import type { HaInput } from "../components/input/ha-input";
 import "../components/input/ha-input";
 import { UNAVAILABLE } from "../data/entity/entity";
 import { showNumberSlider } from "../data/number";
@@ -126,9 +128,9 @@ class StateCardNumber extends LitElement {
   }
 
   private async _selectedValueChanged(
-    ev: HASSDomTargetEvent<HTMLInputElement>
+    ev: HASSDomTargetEvent<HaSlider | HaInput>
   ) {
-    const value = (ev.target as HTMLInputElement).value;
+    const value = String(ev.target.value);
     if (value === this.stateObj.state) {
       return;
     }

--- a/src/state-summary/state-card-text.ts
+++ b/src/state-summary/state-card-text.ts
@@ -2,6 +2,7 @@ import type { TemplateResult } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { stopPropagation } from "../common/dom/stop_propagation";
+import type { HASSDomTargetEvent } from "../common/dom/fire_event";
 import { computeStateName } from "../common/entity/compute_state_name";
 import "../components/entity/state-badge";
 import "../components/input/ha-input";
@@ -36,7 +37,7 @@ class StateCardText extends LitElement {
     `;
   }
 
-  private _valueChanged(ev: InputEvent): void {
+  private _valueChanged(ev: InputEvent & HASSDomTargetEvent<HaInput>): void {
     const value = (ev.target as HaInput).value ?? "";
 
     // Filter out invalid text states


### PR DESCRIPTION
## Proposed change

Additional to #53452

Uses the documented Home Assistant event types for shared components, forms, charts, layouts, and state summary handlers.

These are type-only changes and do not change runtime behaviour.

## Type of change


- [x] Code quality improvements to existing code or addition of tests

## Checklist


- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure


[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
