### PR TITLE
Type application event contracts

### DIFF
--- a/src/data/connection-status.ts
+++ b/src/data/connection-status.ts
@@ -14,7 +14,7 @@ declare global {
   }
 
   interface GlobalEventHandlersEventMap {
-    "connection-status": HASSDomEvent<ConnectionStatus>;
+    "connection-status": HASSDomEvent<HASSDomEvents["connection-status"]>;
   }
 }
 

--- a/src/data/context/index.ts
+++ b/src/data/context/index.ts
@@ -207,7 +207,7 @@ declare global {
     "hass-related-context": RelatedContextItem | undefined;
   }
   interface HTMLElementEventMap {
-    "hass-related-context": HASSDomEvent<RelatedContextItem | undefined>;
+    "hass-related-context": HASSDomEvent<HASSDomEvents["hass-related-context"]>;
   }
 }
 

--- a/src/data/haptics.ts
+++ b/src/data/haptics.ts
@@ -24,7 +24,7 @@ declare global {
   }
 
   interface GlobalEventHandlersEventMap {
-    haptic: HASSDomEvent<HapticType>;
+    haptic: HASSDomEvent<HASSDomEvents["haptic"]>;
   }
 }
 

--- a/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
+++ b/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
@@ -2,6 +2,7 @@ import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
+import type { HASSDomTargetEvent } from "../../common/dom/fire_event";
 import "../../components/ha-dialog";
 import "../../components/ha-dialog-footer";
 import "../../components/ha-formfield";
@@ -161,18 +162,18 @@ class DialogConfigEntrySystemOptions extends DirtyStateProviderMixin<SystemOptio
     `;
   }
 
-  private _disableNewEntitiesChanged(ev: Event): void {
+  private _disableNewEntitiesChanged(ev: HASSDomTargetEvent<HaSwitch>): void {
     this._error = undefined;
-    this._disableNewEntities = !(ev.target as HaSwitch).checked;
+    this._disableNewEntities = !ev.target.checked;
     this._updateDirtyState({
       disableNewEntities: this._disableNewEntities,
       disablePolling: this._disablePolling,
     });
   }
 
-  private _disablePollingChanged(ev: Event): void {
+  private _disablePollingChanged(ev: HASSDomTargetEvent<HaSwitch>): void {
     this._error = undefined;
-    this._disablePolling = !(ev.target as HaSwitch).checked;
+    this._disablePolling = !ev.target.checked;
     this._updateDirtyState({
       disableNewEntities: this._disableNewEntities,
       disablePolling: this._disablePolling,

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -70,8 +70,10 @@ declare global {
   }
   // for add event listener
   interface HTMLElementEventMap {
-    "flow-update": HASSDomEvent<FlowUpdateEvent>;
-    "flow-step-footer-state-changed": HASSDomEvent<FlowStepFooterStateChangedEvent>;
+    "flow-update": HASSDomEvent<HASSDomEvents["flow-update"]>;
+    "flow-step-footer-state-changed": HASSDomEvent<
+      HASSDomEvents["flow-step-footer-state-changed"]
+    >;
   }
 }
 
@@ -741,7 +743,7 @@ class DataEntryFlowDialog extends DirtyStateProviderMixin<
   };
 
   private _handleFooterStateChanged = (
-    ev: HASSDomEvent<FlowStepFooterStateChangedEvent>
+    ev: HASSDomEvent<HASSDomEvents["flow-step-footer-state-changed"]>
   ) => {
     if (ev.detail.loading !== undefined) {
       this._formStepLoading = ev.detail.loading;

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -5,7 +5,7 @@ import { customElement, property, state } from "lit/decorators";
 import { createRef, ref } from "lit/directives/ref";
 import memoizeOne from "memoize-one";
 import { dynamicElement } from "../../common/dom/dynamic-element-directive";
-import { fireEvent } from "../../common/dom/fire_event";
+import { fireEvent, type HASSDomEvent } from "../../common/dom/fire_event";
 import { isNavigationClick } from "../../common/dom/is-navigation-click";
 import "../../components/ha-alert";
 import { computeInitialHaFormData } from "../../components/ha-form/compute-initial-ha-form-data";
@@ -153,7 +153,7 @@ class StepFlowForm extends LitElement {
     `;
   }
 
-  private _setError(ev: CustomEvent) {
+  private _setError(ev: HASSDomEvent<DataEntryFlowStepForm["errors"]>) {
     this._previewErrors = ev.detail;
   }
 

--- a/src/dialogs/more-info/controls/more-info-camera.ts
+++ b/src/dialogs/more-info/controls/more-info-camera.ts
@@ -2,9 +2,11 @@ import { consume } from "@lit/context";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { consumeLocalize } from "../../../common/decorators/consume-context-entry";
+import type { HASSDomCurrentTargetEvent } from "../../../common/dom/fire_event";
 import { slugify } from "../../../common/string/slugify";
 import type { LocalizeFunc } from "../../../common/translations/localize";
 import "../../../components/buttons/ha-progress-button";
+import type { HaProgressButton } from "../../../components/buttons/ha-progress-button";
 import "../../../components/ha-camera-stream";
 import type { CameraEntity } from "../../../data/camera";
 import { apiContext } from "../../../data/context";
@@ -66,8 +68,10 @@ class MoreInfoCamera extends LitElement {
     `;
   }
 
-  private async _downloadSnapshot(ev: CustomEvent) {
-    const button = ev.currentTarget as any;
+  private async _downloadSnapshot(
+    ev: HASSDomCurrentTargetEvent<HaProgressButton>
+  ) {
+    const button = ev.currentTarget;
     this._waiting = true;
 
     try {

--- a/src/dialogs/more-info/controls/more-info-counter.ts
+++ b/src/dialogs/more-info/controls/more-info-counter.ts
@@ -3,8 +3,10 @@ import type { HassEntity } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { consumeLocalize } from "../../../common/decorators/consume-context-entry";
+import type { HASSDomCurrentTargetEvent } from "../../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../../common/translations/localize";
 import "../../../components/ha-button";
+import type { HaButton } from "../../../components/ha-button";
 import { apiContext } from "../../../data/context";
 import { UNAVAILABLE } from "../../../data/entity/entity";
 import type { HomeAssistantApi } from "../../../types";
@@ -67,8 +69,10 @@ class MoreInfoCounter extends LitElement {
     `;
   }
 
-  private _handleActionClick(e: MouseEvent): void {
-    const action = (e.currentTarget as any).action;
+  private _handleActionClick(
+    e: MouseEvent & HASSDomCurrentTargetEvent<HaButton & { action: string }>
+  ): void {
+    const action = e.currentTarget.action;
     this._api.callService("counter", action, {
       entity_id: this.stateObj!.entity_id,
     });

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -17,6 +17,7 @@ import { classMap } from "lit/directives/class-map";
 import { ifDefined } from "lit/directives/if-defined";
 import { consumeLocalize } from "../../../common/decorators/consume-context-entry";
 import { fireEvent } from "../../../common/dom/fire_event";
+import type { HASSDomTargetEvent } from "../../../common/dom/fire_event";
 import { stateActive } from "../../../common/entity/state_active";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import type { LocalizeFunc } from "../../../common/translations/localize";
@@ -872,12 +873,14 @@ class MoreInfoMediaPlayer extends LitElement {
     });
   }
 
-  private async _handleMediaSeekChanged(e: Event): Promise<void> {
+  private async _handleMediaSeekChanged(
+    e: HASSDomTargetEvent<HaSlider>
+  ): Promise<void> {
     if (!this.stateObj) {
       return;
     }
 
-    const newValue = (e.target as any).value;
+    const newValue = e.target.value;
     this._api.callService("media_player", "media_seek", {
       entity_id: this.stateObj.entity_id,
       seek_position: newValue,

--- a/src/dialogs/more-info/controls/more-info-script.ts
+++ b/src/dialogs/more-info/controls/more-info-script.ts
@@ -19,7 +19,7 @@ import {
   hasRequiredScriptFields,
   requiredScriptFieldsFilled,
 } from "../../../data/script";
-import type { HomeAssistant } from "../../../types";
+import type { HomeAssistant, ValueChangedEvent } from "../../../types";
 import "../components/ha-more-info-state-header";
 
 @customElement("more-info-script")
@@ -209,7 +209,9 @@ class MoreInfoScript extends LitElement {
     });
   }
 
-  private _scriptDataChanged(ev: CustomEvent): void {
+  private _scriptDataChanged(
+    ev: ValueChangedEvent<Record<string, unknown>>
+  ): void {
     this._scriptData = { ...this._scriptData, ...ev.detail.value };
   }
 

--- a/src/dialogs/more-info/controls/more-info-timer.ts
+++ b/src/dialogs/more-info/controls/more-info-timer.ts
@@ -3,8 +3,10 @@ import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { consumeLocalize } from "../../../common/decorators/consume-context-entry";
+import type { HASSDomCurrentTargetEvent } from "../../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../../common/translations/localize";
 import "../../../components/ha-button";
+import type { HaButton } from "../../../components/ha-button";
 import "../../../components/ha-duration-input";
 import type { HaDurationData } from "../../../components/ha-duration-input";
 import { apiContext } from "../../../data/context";
@@ -137,8 +139,10 @@ class MoreInfoTimer extends LitElement {
     });
   }
 
-  private _handleActionClick(e: MouseEvent): void {
-    const action = (e.currentTarget as any).action;
+  private _handleActionClick(
+    e: MouseEvent & HASSDomCurrentTargetEvent<HaButton & { action: string }>
+  ): void {
+    const action = e.currentTarget.action;
     this._api.callService("timer", action, {
       entity_id: this.stateObj!.entity_id,
     });

--- a/src/dialogs/restart/dialog-restart.ts
+++ b/src/dialogs/restart/dialog-restart.ts
@@ -10,6 +10,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import { fireEvent } from "../../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../../common/dom/fire_event";
 import "../../components/animation/ha-fade-in";
 import "../../components/ha-adaptive-dialog";
 import "../../components/ha-alert";
@@ -334,7 +335,13 @@ class DialogRestart extends LitElement {
       }
     };
 
-  private async _handleAction(ev: Event) {
+  private async _handleAction(
+    ev: HASSDomCurrentTargetEvent<
+      HaListItemButton & {
+        action: "restart" | "reboot" | "shutdown" | "restart-safe-mode";
+      }
+    >
+  ) {
     if (this._loadingBackupInfo) {
       return;
     }
@@ -369,7 +376,7 @@ class DialogRestart extends LitElement {
 
     this._dialogOpen = false;
 
-    let actionFunc;
+    let actionFunc: () => Promise<void>;
 
     if (["restart", "restart-safe-mode"].includes(action)) {
       const serviceData =

--- a/src/dialogs/restart/dialog-restart.ts
+++ b/src/dialogs/restart/dialog-restart.ts
@@ -346,8 +346,7 @@ class DialogRestart extends LitElement {
       return;
     }
     this._loadingBackupInfo = true;
-    const action = (ev.currentTarget as HaListItemButton & { action: string })
-      .action as "restart" | "reboot" | "shutdown" | "restart-safe-mode";
+    const action = ev.currentTarget.action;
 
     const backupState = await this._loadBackupState();
 

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-dialog.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-dialog.ts
@@ -3,7 +3,7 @@ import type { CSSResultGroup, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
-import { fireEvent } from "../../common/dom/fire_event";
+import { fireEvent, type HASSDomEvent } from "../../common/dom/fire_event";
 import { computeDomain } from "../../common/entity/compute_domain";
 import { formatLanguageCode } from "../../common/language/format_language";
 import "../../components/chips/ha-assist-chip";
@@ -18,7 +18,7 @@ import { getLanguageScores } from "../../data/conversation";
 import { UNAVAILABLE } from "../../data/entity/entity";
 import type { EntityRegistryDisplayEntry } from "../../data/entity/entity_registry";
 import { haStyleDialog } from "../../resources/styles";
-import type { HomeAssistant } from "../../types";
+import type { HomeAssistant, ValueChangedEvent } from "../../types";
 import type { VoiceAssistantSetupDialogParams } from "./show-voice-assistant-setup-dialog";
 import "./voice-assistant-setup-step-area";
 import "./voice-assistant-setup-step-change-wake-word";
@@ -337,7 +337,7 @@ export class HaVoiceAssistantSetupDialog extends LitElement {
     this._language = ev.detail.item.value;
   }
 
-  private _languageChanged(ev: CustomEvent) {
+  private _languageChanged(ev: ValueChangedEvent<string | undefined>) {
     if (!ev.detail.value) {
       return;
     }
@@ -351,7 +351,7 @@ export class HaVoiceAssistantSetupDialog extends LitElement {
     this._step = this._previousSteps.pop()!;
   }
 
-  private async _goToNextStep(ev?: CustomEvent) {
+  private async _goToNextStep(ev?: HASSDomEvent<HASSDomEvents["next-step"]>) {
     if (ev?.detail?.updateConfig) {
       await this._fetchAssistConfiguration();
     }

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-change-wake-word.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-change-wake-word.ts
@@ -1,6 +1,7 @@
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../../common/dom/fire_event";
 import "../../components/item/ha-list-item-button";
 import type { HaListItemButton } from "../../components/item/ha-list-item-button";
 import "../../components/list/ha-list-base";
@@ -50,14 +51,14 @@ export class HaVoiceAssistantSetupStepChangeWakeWord extends LitElement {
       </ha-list-base>`;
   }
 
-  private async _wakeWordPicked(ev: Event) {
+  private async _wakeWordPicked(
+    ev: HASSDomCurrentTargetEvent<HaListItemButton & { value: string }>
+  ) {
     if (!this.assistEntityId) {
       return;
     }
 
-    const wakeWordId = (
-      ev.currentTarget as HaListItemButton & { value: string }
-    ).value;
+    const wakeWordId = ev.currentTarget.value;
 
     await setWakeWords(this.hass, this.assistEntityId, [wakeWordId]);
     this._nextStep();

--- a/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-pipeline.ts
+++ b/src/dialogs/voice-assistant-setup/voice-assistant-setup-step-pipeline.ts
@@ -19,7 +19,7 @@ import type { LanguageScore, LanguageScores } from "../../data/conversation";
 import { getLanguageScores, listAgents } from "../../data/conversation";
 import { listSTTEngines } from "../../data/stt";
 import { listTTSEngines, listTTSVoices } from "../../data/tts";
-import type { HomeAssistant } from "../../types";
+import type { HomeAssistant, ValueChangedEvent } from "../../types";
 import { documentationUrl } from "../../util/documentation-url";
 import { AssistantSetupStyles } from "./styles";
 import { STEP } from "./voice-assistant-setup-dialog";
@@ -265,8 +265,8 @@ export class HaVoiceAssistantSetupStepPipeline extends LitElement {
   }
 
   private async _createCloudPipeline(useLanguage: boolean): Promise<boolean> {
-    let cloudTtsEntityId;
-    let cloudSttEntityId;
+    let cloudTtsEntityId: string | undefined;
+    let cloudSttEntityId: string | undefined;
     for (const entity of Object.values(this.hass.entities)) {
       if (entity.platform === "cloud") {
         const domain = computeDomain(entity.entity_id);
@@ -327,7 +327,7 @@ export class HaVoiceAssistantSetupStepPipeline extends LitElement {
 
         const ttsVoices = await listTTSVoices(
           this.hass,
-          cloudTtsEntityId,
+          cloudTtsEntityId!,
           ttsEngine.supported_languages[0]
         );
 
@@ -357,9 +357,9 @@ export class HaVoiceAssistantSetupStepPipeline extends LitElement {
           language: (this.language || this.hass.config.language).split("-")[0],
           conversation_engine: "conversation.home_assistant",
           conversation_language: agent.supported_languages[0],
-          stt_engine: cloudSttEntityId,
+          stt_engine: cloudSttEntityId!,
           stt_language: sttEngine.supported_languages[0],
-          tts_engine: cloudTtsEntityId,
+          tts_engine: cloudTtsEntityId!,
           tts_language: ttsEngine.supported_languages[0],
           tts_voice: ttsVoices.voices![0].voice_id,
           wake_word_entity: null,
@@ -380,7 +380,9 @@ export class HaVoiceAssistantSetupStepPipeline extends LitElement {
     }
   }
 
-  private _valueChanged(ev: CustomEvent) {
+  private _valueChanged(
+    ev: ValueChangedEvent<(typeof OPTIONS)[number] | undefined>
+  ) {
     this._value = ev.detail.value;
   }
 
@@ -410,7 +412,7 @@ export class HaVoiceAssistantSetupStepPipeline extends LitElement {
     fireEvent(this, "next-step", { step: STEP.LOCAL, option: this._value });
   }
 
-  private _languageChanged(ev: CustomEvent) {
+  private _languageChanged(ev: ValueChangedEvent<string | undefined>) {
     if (!ev.detail.value) {
       return;
     }

--- a/src/external_app/external_app_entrypoint.ts
+++ b/src/external_app/external_app_entrypoint.ts
@@ -121,6 +121,14 @@ declare global {
   }
 
   interface GlobalEventHandlersEventMap {
-    "matter-commission-finish": HASSDomEvent<MatterCommissionFinish>;
+    "improv-discovered-device": HASSDomEvent<
+      HASSDomEvents["improv-discovered-device"]
+    >;
+    "improv-device-setup-done": HASSDomEvent<
+      HASSDomEvents["improv-device-setup-done"]
+    >;
+    "matter-commission-finish": HASSDomEvent<
+      HASSDomEvents["matter-commission-finish"]
+    >;
   }
 }

--- a/src/onboarding/ha-onboarding.ts
+++ b/src/onboarding/ha-onboarding.ts
@@ -37,7 +37,7 @@ import { subscribeUser } from "../data/ws-user";
 import { makeDialogManager } from "../dialogs/make-dialog-manager";
 import { litLocalizeLiteMixin } from "../mixins/lit-localize-lite-mixin";
 import { HassElement } from "../state/hass-element";
-import type { HomeAssistant } from "../types";
+import type { HomeAssistant, ValueChangedEvent } from "../types";
 import { storeState } from "../util/ha-pref-storage";
 import { registerServiceWorker } from "../util/register-service-worker";
 import "../components/progress/ha-progress-bar";
@@ -80,8 +80,8 @@ declare global {
   }
 
   interface GlobalEventHandlersEventMap {
-    "onboarding-step": HASSDomEvent<OnboardingEvent>;
-    "onboarding-progress": HASSDomEvent<OnboardingProgressEvent>;
+    "onboarding-step": HASSDomEvent<HASSDomEvents["onboarding-step"]>;
+    "onboarding-progress": HASSDomEvent<HASSDomEvents["onboarding-progress"]>;
   }
 }
 
@@ -332,7 +332,9 @@ class HaOnboarding extends litLocalizeLiteMixin(HassElement) {
     }
   }
 
-  private _handleProgress(ev: HASSDomEvent<OnboardingProgressEvent>) {
+  private _handleProgress(
+    ev: HASSDomEvent<HASSDomEvents["onboarding-progress"]>
+  ) {
     const stepSize = 100 / this._steps!.length;
     if (ev.detail.increase) {
       this._progress += ev.detail.increase * stepSize;
@@ -345,7 +347,9 @@ class HaOnboarding extends litLocalizeLiteMixin(HassElement) {
     }
   }
 
-  private async _handleStepDone(ev: HASSDomEvent<OnboardingEvent>) {
+  private async _handleStepDone(
+    ev: HASSDomEvent<HASSDomEvents["onboarding-step"]>
+  ) {
     const stepResult = ev.detail;
     this._steps = this._steps!.map((step) =>
       step.step === stepResult.type ? { ...step, done: true } : step
@@ -479,7 +483,7 @@ class HaOnboarding extends litLocalizeLiteMixin(HassElement) {
     });
   }
 
-  private _languageChanged(ev: CustomEvent) {
+  private _languageChanged(ev: ValueChangedEvent<string>) {
     const language = ev.detail.value;
     this.language = language;
     if (this.hass) {

--- a/src/onboarding/onboarding-analytics.ts
+++ b/src/onboarding/onboarding-analytics.ts
@@ -2,7 +2,7 @@ import { mdiOpenInNew } from "@mdi/js";
 import type { CSSResultGroup, TemplateResult, PropertyValues } from "lit";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { fireEvent } from "../common/dom/fire_event";
+import { fireEvent, type HASSDomEvent } from "../common/dom/fire_event";
 import type { LocalizeFunc } from "../common/translations/localize";
 import "../components/ha-analytics";
 import "../components/ha-button";
@@ -65,7 +65,9 @@ class OnboardingAnalytics extends LitElement {
     });
   }
 
-  private _preferencesChanged(event: CustomEvent): void {
+  private _preferencesChanged(
+    event: HASSDomEvent<HASSDomEvents["analytics-preferences-changed"]>
+  ): void {
     this._analyticsDetails = {
       ...this._analyticsDetails!,
       preferences: event.detail.preferences,

--- a/src/onboarding/onboarding-core-config.ts
+++ b/src/onboarding/onboarding-core-config.ts
@@ -19,7 +19,7 @@ import type { ConfigUpdateValues } from "../data/core";
 import { saveCoreConfig } from "../data/core";
 import { countryCurrency } from "../data/currency";
 import { onboardCoreConfigStep } from "../data/onboarding";
-import type { HomeAssistant } from "../types";
+import type { HomeAssistant, ValueChangedEvent } from "../types";
 import { getLocalLanguage } from "../util/common-translation";
 import "./onboarding-location";
 
@@ -132,7 +132,9 @@ class OnboardingCoreConfig extends LitElement {
     });
   }
 
-  private _handleFormChanged(ev: CustomEvent) {
+  private _handleFormChanged(
+    ev: ValueChangedEvent<{ country?: string; time_zone?: string }>
+  ) {
     const value = ev.detail.value as { country?: string; time_zone?: string };
     this._country = value.country || undefined;
     if (value.time_zone) {

--- a/src/onboarding/onboarding-restore-backup.ts
+++ b/src/onboarding/onboarding-restore-backup.ts
@@ -2,6 +2,7 @@ import type { TemplateResult, PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { storage } from "../common/decorators/storage";
+import type { HASSDomEvent } from "../common/dom/fire_event";
 import { navigate } from "../common/navigate";
 import type { LocalizeFunc } from "../common/translations/localize";
 import { removeSearchParam } from "../common/url/search-params";
@@ -280,7 +281,9 @@ class OnboardingRestoreBackup extends LitElement {
     setTimeout(() => this._loadBackupInfo(), delay);
   }
 
-  private async _backupUploaded(ev: CustomEvent) {
+  private async _backupUploaded(
+    ev: HASSDomEvent<HASSDomEvents["backup-uploaded"]>
+  ) {
     this._backupId = ev.detail.backupId;
     await this._loadBackupInfo();
   }

--- a/src/onboarding/restore-backup/onboarding-restore-backup-restore.ts
+++ b/src/onboarding/restore-backup/onboarding-restore-backup-restore.ts
@@ -2,6 +2,10 @@ import { css, html, LitElement, nothing, type CSSResultGroup } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { formatDateTimeWithBrowserDefaults } from "../../common/datetime/format_date_time";
 import { fireEvent } from "../../common/dom/fire_event";
+import type {
+  HASSDomCurrentTargetEvent,
+  HASSDomTargetEvent,
+} from "../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../common/translations/localize";
 import "../../components/buttons/ha-progress-button";
 import type { HaProgressButton } from "../../components/buttons/ha-progress-button";
@@ -9,6 +13,7 @@ import "../../components/ha-alert";
 import "../../components/ha-button";
 import "../../components/ha-icon-button-arrow-prev";
 import "../../components/input/ha-input";
+import type { HaInput } from "../../components/input/ha-input";
 import "../../components/item/ha-row-item";
 import {
   getPreferredAgentForDownload,
@@ -19,6 +24,7 @@ import { restoreOnboardingBackup } from "../../data/backup_onboarding";
 import "../../panels/config/backup/components/ha-backup-data-picker";
 import "../../panels/config/backup/components/ha-backup-formfield-label";
 import { onBoardingStyles } from "../styles";
+import type { ValueChangedEvent } from "../../types";
 
 @customElement("onboarding-restore-backup-restore")
 class OnboardingRestoreBackupRestore extends LitElement {
@@ -247,16 +253,20 @@ class OnboardingRestoreBackupRestore extends LitElement {
     fireEvent(this, "sign-out");
   }
 
-  private _selectedBackupChanged(ev: CustomEvent) {
+  private _selectedBackupChanged(ev: ValueChangedEvent<BackupData>) {
     ev.stopPropagation();
     this._selectedData = ev.detail.value;
   }
 
-  private _encryptionKeyChanged(ev): void {
+  private _encryptionKeyChanged(
+    ev: HASSDomTargetEvent<Omit<HaInput, "value"> & { value: string }>
+  ): void {
     this._encryptionKey = ev.target.value;
   }
 
-  private async _startRestore(ev: CustomEvent): Promise<void> {
+  private async _startRestore(
+    ev: HASSDomCurrentTargetEvent<HaProgressButton>
+  ): Promise<void> {
     const agentId = Object.keys(this.backup.agents)[0];
     const backupProtected = this.backup.agents[agentId].protected;
 

--- a/src/onboarding/restore-backup/onboarding-restore-backup-restore.ts
+++ b/src/onboarding/restore-backup/onboarding-restore-backup-restore.ts
@@ -280,7 +280,7 @@ class OnboardingRestoreBackupRestore extends LitElement {
     }
 
     this._loading = true;
-    const button = ev.currentTarget as HaProgressButton;
+    const button = ev.currentTarget;
     this._error = undefined;
     this._encryptionKeyWrong = false;
 

--- a/src/state/action-mixin.ts
+++ b/src/state/action-mixin.ts
@@ -20,7 +20,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
     }
 
     private async _handleAction(
-      ev: HASSDomEvent<{ config: ActionConfigParams; action: string }>
+      ev: HASSDomEvent<HASSDomEvents["hass-action"]>
     ) {
       if (!this.hass) return;
       handleAction(this, this.hass, ev.detail.config, ev.detail.action);

--- a/src/state/automation-editor-mixin.ts
+++ b/src/state/automation-editor-mixin.ts
@@ -23,13 +23,13 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       super.firstUpdated(changedProps);
       this.addEventListener("hass-automation-editor", (ev) =>
         this._handleShowAutomationEditor(
-          ev as HASSDomEvent<ShowAutomationEditorParams>
+          ev as HASSDomEvent<HASSDomEvents["hass-automation-editor"]>
         )
       );
     }
 
     private _handleShowAutomationEditor(
-      ev: HASSDomEvent<ShowAutomationEditorParams>
+      ev: HASSDomEvent<HASSDomEvents["hass-automation-editor"]>
     ) {
       showAutomationEditor(ev.detail.data, ev.detail.expanded);
     }

--- a/src/state/dialog-manager-mixin.ts
+++ b/src/state/dialog-manager-mixin.ts
@@ -18,7 +18,7 @@ declare global {
   }
   // for add event listener
   interface HTMLElementEventMap {
-    "register-dialog": HASSDomEvent<RegisterDialogParams>;
+    "register-dialog": HASSDomEvent<HASSDomEvents["register-dialog"]>;
   }
 }
 
@@ -45,7 +45,8 @@ export const dialogManagerMixin = <T extends Constructor<HassBaseEl>>(
         showDialog(
           this,
           dialogTag,
-          (showEv as HASSDomEvent<unknown>).detail,
+          (showEv as HASSDomEvent<HASSDomEvents[typeof dialogShowEvent]>)
+            .detail,
           dialogImport,
           undefined,
           addHistory

--- a/src/state/haptic-mixin.ts
+++ b/src/state/haptic-mixin.ts
@@ -1,6 +1,5 @@
 import type { PropertyValues } from "lit";
 import type { HASSDomEvent } from "../common/dom/fire_event";
-import type { HapticType } from "../data/haptics";
 import type { Constructor, HomeAssistant } from "../types";
 import { storeState } from "../util/ha-pref-storage";
 import type { HassBaseEl } from "./hass-base-mixin";
@@ -16,7 +15,7 @@ declare global {
   }
   // for add event listener
   interface HTMLElementEventMap {
-    "hass-vibrate": HASSDomEvent<VibrateParams>;
+    "hass-vibrate": HASSDomEvent<HASSDomEvents["hass-vibrate"]>;
   }
 }
 
@@ -30,7 +29,9 @@ const hapticPatterns = {
   selection: [20],
 };
 
-const handleHaptic = (hapticTypeEvent: HASSDomEvent<HapticType>) => {
+const handleHaptic = (
+  hapticTypeEvent: HASSDomEvent<HASSDomEvents["haptic"]>
+) => {
   navigator.vibrate(hapticPatterns[hapticTypeEvent.detail]);
 };
 

--- a/src/state/logging-mixin.ts
+++ b/src/state/logging-mixin.ts
@@ -15,7 +15,7 @@ declare global {
     write_log: WriteLogParams;
   }
   interface HTMLElementEventMap {
-    write_log: HASSDomEvent<WriteLogParams>;
+    write_log: HASSDomEvent<HASSDomEvents["write_log"]>;
   }
 }
 

--- a/src/state/more-info-mixin.ts
+++ b/src/state/more-info-mixin.ts
@@ -25,7 +25,9 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       import("../dialogs/more-info/ha-more-info-dialog");
     }
 
-    private async _handleMoreInfo(ev: HASSDomEvent<MoreInfoDialogParams>) {
+    private async _handleMoreInfo(
+      ev: HASSDomEvent<HASSDomEvents["hass-more-info"]>
+    ) {
       showDialog(
         this,
         "ha-more-info-dialog",

--- a/src/state/quick-bar-mixin.ts
+++ b/src/state/quick-bar-mixin.ts
@@ -2,6 +2,7 @@ import type { PropertyValues } from "lit";
 import memoizeOne from "memoize-one";
 import { isComponentLoaded } from "../common/config/is_component_loaded";
 import { canOverrideAlphanumericInput } from "../common/dom/can-override-input";
+import type { HASSDomEvent } from "../common/dom/fire_event";
 import { mainWindow } from "../common/dom/get_main_window";
 import { ShortcutManager } from "../common/keyboard/shortcuts";
 import { extractSearchParamsObject } from "../common/url/search-params";
@@ -39,7 +40,10 @@ export default <T extends Constructor<HassElement>>(superClass: T) =>
       this.addEventListener(
         "show-dialog",
         (ev) => {
-          if ((ev as CustomEvent).detail.dialogTag === "ha-quick-bar") {
+          if (
+            (ev as HASSDomEvent<HASSDomEvents["show-dialog"]>).detail
+              .dialogTag === "ha-quick-bar"
+          ) {
             // If quick bar is already open, prevent opening it again
             if (this._quickBarOpen) {
               ev.stopPropagation();
@@ -53,7 +57,10 @@ export default <T extends Constructor<HassElement>>(superClass: T) =>
       );
 
       this.addEventListener("dialog-closed", (ev) => {
-        if ((ev as CustomEvent).detail.dialog === "ha-quick-bar") {
+        if (
+          (ev as HASSDomEvent<HASSDomEvents["dialog-closed"]>).detail.dialog ===
+          "ha-quick-bar"
+        ) {
           this._quickBarOpen = false;
         }
       });

--- a/src/state/related-context-provider.ts
+++ b/src/state/related-context-provider.ts
@@ -76,7 +76,7 @@ export class RelatedContextProvider {
   }
 
   private _onRelatedContext = (
-    ev: HASSDomEvent<RelatedContextItem | undefined>
+    ev: HASSDomEvent<HASSDomEvents["hass-related-context"]>
   ): void => {
     // `fireEvent` coerces an undefined detail to `{}`, so a clear arrives
     // without an itemId; normalise that back to undefined.

--- a/src/state/sidebar-mixin.ts
+++ b/src/state/sidebar-mixin.ts
@@ -16,7 +16,9 @@ declare global {
   }
   // for add event listener
   interface HTMLElementEventMap {
-    "hass-dock-sidebar": HASSDomEvent<DockSidebarParams>;
+    "hass-dock-sidebar": HASSDomEvent<HASSDomEvents["hass-dock-sidebar"]>;
+  }
+  interface GlobalEventHandlersEventMap {
     "hass-kiosk-mode": HASSDomEvent<HASSDomEvents["hass-kiosk-mode"]>;
   }
 }

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -15,7 +15,7 @@ import type { HassBaseEl } from "./hass-base-mixin";
 declare global {
   // for add event listener
   interface HTMLElementEventMap {
-    settheme: HASSDomEvent<Partial<HomeAssistant["selectedTheme"]>>;
+    settheme: HASSDomEvent<HASSDomEvents["settheme"]>;
   }
   interface HASSDomEvents {
     settheme: Partial<HomeAssistant["selectedTheme"]>;

--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -1,6 +1,7 @@
 import type { PropertyValues } from "lit";
 import { atLeastVersion } from "../common/config/version";
 import { fireEvent } from "../common/dom/fire_event";
+import type { HASSDomEvent } from "../common/dom/fire_event";
 import type { LocalizeFunc } from "../common/translations/localize";
 import { computeLocalize } from "../common/translations/localize";
 import {
@@ -35,9 +36,7 @@ import type { HassBaseEl } from "./hass-base-mixin";
 declare global {
   // for fire event
   interface HASSDomEvents {
-    "hass-language-select": {
-      language: string;
-    };
+    "hass-language-select": string;
     "hass-number-format-select": NumberFormat;
     "hass-time-format-select": TimeFormat;
     "hass-date-format-select": DateFormat;
@@ -82,22 +81,42 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
     protected firstUpdated(changedProps: PropertyValues<this>) {
       super.firstUpdated(changedProps);
       this.addEventListener("hass-language-select", (e) => {
-        this._selectLanguage((e as CustomEvent).detail, true);
+        this._selectLanguage(
+          (e as HASSDomEvent<HASSDomEvents["hass-language-select"]>).detail,
+          true
+        );
       });
       this.addEventListener("hass-number-format-select", (e) => {
-        this._selectNumberFormat((e as CustomEvent).detail, true);
+        this._selectNumberFormat(
+          (e as HASSDomEvent<HASSDomEvents["hass-number-format-select"]>)
+            .detail,
+          true
+        );
       });
       this.addEventListener("hass-time-format-select", (e) => {
-        this._selectTimeFormat((e as CustomEvent).detail, true);
+        this._selectTimeFormat(
+          (e as HASSDomEvent<HASSDomEvents["hass-time-format-select"]>).detail,
+          true
+        );
       });
       this.addEventListener("hass-date-format-select", (e) => {
-        this._selectDateFormat((e as CustomEvent).detail, true);
+        this._selectDateFormat(
+          (e as HASSDomEvent<HASSDomEvents["hass-date-format-select"]>).detail,
+          true
+        );
       });
       this.addEventListener("hass-time-zone-select", (e) => {
-        this._selectTimeZone((e as CustomEvent).detail, true);
+        this._selectTimeZone(
+          (e as HASSDomEvent<HASSDomEvents["hass-time-zone-select"]>).detail,
+          true
+        );
       });
       this.addEventListener("hass-first-weekday-select", (e) => {
-        this._selectFirstWeekday((e as CustomEvent).detail, true);
+        this._selectFirstWeekday(
+          (e as HASSDomEvent<HASSDomEvents["hass-first-weekday-select"]>)
+            .detail,
+          true
+        );
       });
       this._loadCoreTranslations(getLocalLanguage());
     }


### PR DESCRIPTION
## Proposed change

Additional to #53452

Uses the documented Home Assistant event types for application state, dialogs, onboarding, and shared event contracts.

These are type-only changes and do not change runtime behaviour.

## Type of change


- [x] Code quality improvements to existing code or addition of tests

## Checklist


- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure


[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
