### PR TITLE
Type configuration event handlers

### DIFF
--- a/src/panels/config/areas/dialog-area-registry-detail.ts
+++ b/src/panels/config/areas/dialog-area-registry-detail.ts
@@ -3,6 +3,7 @@ import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
+import type { HASSDomTargetEvent } from "../../../common/dom/fire_event";
 import { DirtyStateProviderMixin } from "../../../mixins/dirty-state-provider-mixin";
 import "../../../components/entity/ha-entity-picker";
 import type { HaEntityPicker } from "../../../components/entity/ha-entity-picker";
@@ -455,7 +456,7 @@ class DialogAreaDetail
     return deviceReg && deviceReg.area_id === areaId;
   };
 
-  private _nameChanged(ev: InputEvent) {
+  private _nameChanged(ev: InputEvent & HASSDomTargetEvent<HaInput>) {
     this._error = undefined;
     this._name = (ev.target as HaInput).value ?? "";
     this._updateDirtyState(this._currentState());
@@ -479,7 +480,9 @@ class DialogAreaDetail
     this._updateDirtyState(this._currentState());
   }
 
-  private _pictureChanged(ev: ValueChangedEvent<string | null>) {
+  private _pictureChanged(
+    ev: ValueChangedEvent<string | null> & HASSDomTargetEvent<HaPictureUpload>
+  ) {
     this._error = undefined;
     this._picture = (ev.target as HaPictureUpload).value;
     this._updateDirtyState(this._currentState());
@@ -490,7 +493,9 @@ class DialogAreaDetail
     this._updateDirtyState(this._currentState());
   }
 
-  private _sensorChanged(ev: CustomEvent): void {
+  private _sensorChanged(
+    ev: ValueChangedEvent<string> & HASSDomTargetEvent<HaEntityPicker>
+  ): void {
     const deviceClass = (ev.target as HaEntityPicker).includeDeviceClasses![0];
     const key = `_${deviceClass}Entity`;
     this[key] = ev.detail.value || null;

--- a/src/panels/config/areas/dialog-floor-registry-detail.ts
+++ b/src/panels/config/areas/dialog-floor-registry-detail.ts
@@ -5,6 +5,7 @@ import { customElement, property, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../common/dom/fire_event";
+import type { HASSDomTargetEvent } from "../../../common/dom/fire_event";
 import "../../../components/chips/ha-chip-set";
 import "../../../components/chips/ha-input-chip";
 import "../../../components/ha-alert";
@@ -336,13 +337,13 @@ class DialogFloorDetail extends DirtyStateProviderMixin<FloorFormState>()(
     this._updateDirtyState(this._currentState());
   }
 
-  private _nameChanged(ev: InputEvent) {
+  private _nameChanged(ev: InputEvent & HASSDomTargetEvent<HaInput>) {
     this._error = undefined;
     this._name = (ev.target as HaInput).value ?? "";
     this._updateDirtyState(this._currentState());
   }
 
-  private _levelChanged(ev: InputEvent) {
+  private _levelChanged(ev: InputEvent & HASSDomTargetEvent<HaInput>) {
     this._error = undefined;
     this._level =
       (ev.target as HaInput).value === ""

--- a/src/panels/config/blueprint/dialog-import-blueprint.ts
+++ b/src/panels/config/blueprint/dialog-import-blueprint.ts
@@ -2,6 +2,7 @@ import { mdiClose, mdiOpenInNew } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
+import type { HASSDomTargetEvent } from "../../../common/dom/fire_event";
 import { withViewTransition } from "../../../common/util/view-transition";
 import "../../../components/ha-alert";
 import "../../../components/ha-button";
@@ -279,7 +280,7 @@ class DialogImportBlueprint extends DirtyStateProviderMixin<BlueprintImportState
     });
   }
 
-  private _inputChanged(ev: Event) {
+  private _inputChanged(ev: HASSDomTargetEvent<HaInput>) {
     this._updateDirtyState({
       value: (ev.target as HaInput).value ?? "",
       hasResult: !!this._result,

--- a/src/panels/config/blueprint/ha-blueprint-overview.ts
+++ b/src/panels/config/blueprint/ha-blueprint-overview.ts
@@ -13,7 +13,10 @@ import { LitElement, html } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { storage } from "../../../common/decorators/storage";
-import type { HASSDomEvent } from "../../../common/dom/fire_event";
+import type {
+  HASSDomCurrentTargetEvent,
+  HASSDomEvent,
+} from "../../../common/dom/fire_event";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import { navigate } from "../../../common/navigate";
@@ -483,7 +486,7 @@ class HaBlueprintOverview extends LitElement {
     this._createNew(blueprint);
   }
 
-  private _handleUsageClick = (ev: Event) => {
+  private _handleUsageClick = (ev: HASSDomCurrentTargetEvent<HTMLElement>) => {
     ev.stopPropagation();
     ev.preventDefault();
     const target = ev.currentTarget as HTMLElement | null;

--- a/src/panels/config/energy/dialogs/dialog-energy-battery-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-battery-settings.ts
@@ -2,6 +2,7 @@ import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import type { HASSDomEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-statistic-picker";
 import "../../../../components/ha-button";
 import "../../../../components/ha-dialog";
@@ -340,7 +341,7 @@ export class DialogEnergyBatterySettings
   }
 
   private _handlePowerConfigChanged(
-    ev: CustomEvent<{ powerType: PowerType; powerConfig: PowerConfig }>
+    ev: HASSDomEvent<HASSDomEvents["power-config-changed"]>
   ) {
     this._powerType = ev.detail.powerType;
     this._powerConfig = ev.detail.powerConfig;

--- a/src/panels/config/energy/dialogs/dialog-energy-customise.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-customise.ts
@@ -3,6 +3,7 @@ import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../../../../common/dom/fire_event";
 import type { LocalizeKeys } from "../../../../common/translations/localize";
 import "../../../../components/ha-alert";
 import "../../../../components/ha-button";
@@ -214,7 +215,7 @@ export class DialogEnergyCustomise
     `;
   }
 
-  private _toggleCard = (ev: Event): void => {
+  private _toggleCard = (ev: HASSDomCurrentTargetEvent<HaSwitch>): void => {
     const target = ev.currentTarget as HaSwitch;
     const cardKey = target.dataset.cardKey;
     if (!cardKey) {

--- a/src/panels/config/energy/dialogs/dialog-energy-gas-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-gas-settings.ts
@@ -2,6 +2,7 @@ import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-entity-picker";
 import "../../../../components/entity/ha-statistic-picker";
 import "../../../../components/ha-button";
@@ -353,7 +354,7 @@ export class DialogEnergyGasSettings
     `;
   }
 
-  private _handleCostChanged(ev: Event) {
+  private _handleCostChanged(ev: HASSDomCurrentTargetEvent<HaRadioGroup>) {
     this._costs = (ev.currentTarget as HaRadioGroup).value as CostType;
     this._updateFormDirtyState();
   }

--- a/src/panels/config/energy/dialogs/dialog-energy-grid-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-grid-settings.ts
@@ -639,8 +639,9 @@ export class DialogEnergyGridSettings
   }
 
   private _numberCostChanged(ev: HASSDomCurrentTargetEvent<HaInput>) {
-    const input = ev.currentTarget as HTMLInputElement;
-    const value = input.value ? parseFloat(input.value) : null;
+    const value = ev.currentTarget.value
+      ? parseFloat(ev.currentTarget.value)
+      : null;
     this._source = { ...this._source!, number_energy_price: value };
     this._updateFormDirtyState();
   }
@@ -661,11 +662,10 @@ export class DialogEnergyGridSettings
     this._updateFormDirtyState();
   }
 
-  private _numberCompensationChanged(
-    ev: HASSDomCurrentTargetEvent<HaInput>
-  ) {
-    const input = ev.currentTarget as HTMLInputElement;
-    const value = input.value ? parseFloat(input.value) : null;
+  private _numberCompensationChanged(ev: HASSDomCurrentTargetEvent<HaInput>) {
+    const value = ev.currentTarget.value
+      ? parseFloat(ev.currentTarget.value)
+      : null;
     this._source = { ...this._source!, number_energy_price_export: value };
     this._updateFormDirtyState();
   }

--- a/src/panels/config/energy/dialogs/dialog-energy-grid-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-grid-settings.ts
@@ -638,7 +638,7 @@ export class DialogEnergyGridSettings
     this._updateFormDirtyState();
   }
 
-  private _numberCostChanged(ev: HASSDomCurrentTargetEvent<HTMLInputElement>) {
+  private _numberCostChanged(ev: HASSDomCurrentTargetEvent<HaInput>) {
     const input = ev.currentTarget as HTMLInputElement;
     const value = input.value ? parseFloat(input.value) : null;
     this._source = { ...this._source!, number_energy_price: value };

--- a/src/panels/config/energy/dialogs/dialog-energy-grid-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-grid-settings.ts
@@ -662,7 +662,7 @@ export class DialogEnergyGridSettings
   }
 
   private _numberCompensationChanged(
-    ev: HASSDomCurrentTargetEvent<HTMLInputElement>
+    ev: HASSDomCurrentTargetEvent<HaInput>
   ) {
     const input = ev.currentTarget as HTMLInputElement;
     const value = input.value ? parseFloat(input.value) : null;

--- a/src/panels/config/energy/dialogs/dialog-energy-grid-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-grid-settings.ts
@@ -2,6 +2,10 @@ import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import type {
+  HASSDomCurrentTargetEvent,
+  HASSDomEvent,
+} from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-entity-picker";
 import "../../../../components/entity/ha-statistic-picker";
 import "../../../../components/ha-button";
@@ -593,7 +597,9 @@ export class DialogEnergyGridSettings
     this._updateFormDirtyState();
   }
 
-  private _handleImportCostTypeChanged(ev: Event) {
+  private _handleImportCostTypeChanged(
+    ev: HASSDomCurrentTargetEvent<HaRadioGroup>
+  ) {
     this._importCostType = (ev.currentTarget as HaRadioGroup).value as CostType;
     // Clear other cost fields when switching types
     this._source = {
@@ -605,7 +611,9 @@ export class DialogEnergyGridSettings
     this._updateFormDirtyState();
   }
 
-  private _handleExportCostTypeChanged(ev: Event) {
+  private _handleExportCostTypeChanged(
+    ev: HASSDomCurrentTargetEvent<HaRadioGroup>
+  ) {
     this._exportCostType = (ev.currentTarget as HaRadioGroup).value as CostType;
     // Clear other cost fields when switching types
     this._source = {
@@ -630,7 +638,7 @@ export class DialogEnergyGridSettings
     this._updateFormDirtyState();
   }
 
-  private _numberCostChanged(ev: Event) {
+  private _numberCostChanged(ev: HASSDomCurrentTargetEvent<HTMLInputElement>) {
     const input = ev.currentTarget as HTMLInputElement;
     const value = input.value ? parseFloat(input.value) : null;
     this._source = { ...this._source!, number_energy_price: value };
@@ -653,7 +661,9 @@ export class DialogEnergyGridSettings
     this._updateFormDirtyState();
   }
 
-  private _numberCompensationChanged(ev: Event) {
+  private _numberCompensationChanged(
+    ev: HASSDomCurrentTargetEvent<HTMLInputElement>
+  ) {
     const input = ev.currentTarget as HTMLInputElement;
     const value = input.value ? parseFloat(input.value) : null;
     this._source = { ...this._source!, number_energy_price_export: value };
@@ -661,7 +671,7 @@ export class DialogEnergyGridSettings
   }
 
   private _handlePowerConfigChanged(
-    ev: CustomEvent<{ powerType: PowerType; powerConfig: PowerConfig }>
+    ev: HASSDomEvent<HASSDomEvents["power-config-changed"]>
   ) {
     this._powerType = ev.detail.powerType;
     this._powerConfig = ev.detail.powerConfig;

--- a/src/panels/config/energy/dialogs/dialog-energy-solar-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-solar-settings.ts
@@ -3,6 +3,7 @@ import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-statistic-picker";
 import "../../../../components/ha-button";
 import "../../../../components/ha-checkbox";
@@ -290,7 +291,7 @@ export class DialogEnergySolarSettings
             );
   }
 
-  private _handleForecastChanged(ev: Event) {
+  private _handleForecastChanged(ev: HASSDomCurrentTargetEvent<HaRadioGroup>) {
     this._forecast = (ev.currentTarget as HaRadioGroup).value === "true";
     this._updateFormDirtyState();
   }

--- a/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
@@ -2,6 +2,7 @@ import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-entity-picker";
 import "../../../../components/entity/ha-statistic-picker";
 import "../../../../components/ha-button";
@@ -289,7 +290,7 @@ export class DialogEnergyWaterSettings
     `;
   }
 
-  private _handleCostChanged(ev: Event) {
+  private _handleCostChanged(ev: HASSDomCurrentTargetEvent<HaRadioGroup>) {
     this._costs = (ev.currentTarget as HaRadioGroup).value as CostType;
     this._updateFormDirtyState();
   }

--- a/src/panels/config/energy/dialogs/ha-energy-power-config.ts
+++ b/src/panels/config/energy/dialogs/ha-energy-power-config.ts
@@ -3,6 +3,7 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../../../../common/dom/fire_event";
 import { stopPropagation } from "../../../../common/dom/stop_propagation";
 import type { LocalizeKeys } from "../../../../common/translations/localize";
 import "../../../../components/entity/ha-statistic-picker";
@@ -234,7 +235,7 @@ export class HaEnergyPowerConfig extends LitElement {
     fireEvent(this, "hass-more-info", { entityId: this.helperEntityId! });
   }
 
-  private _handlePowerTypeChanged(ev: Event) {
+  private _handlePowerTypeChanged(ev: HASSDomCurrentTargetEvent<HaRadioGroup>) {
     const newPowerType = (ev.currentTarget as HaRadioGroup).value as PowerType;
     // Clear power config when switching types
     fireEvent(this, "power-config-changed", {

--- a/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-adapter-info-page.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-adapter-info-page.ts
@@ -3,6 +3,7 @@ import type { CSSResultGroup, TemplateResult } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
+import type { HASSDomCurrentTargetEvent } from "../../../../../common/dom/fire_event";
 import { computeDeviceName } from "../../../../../common/entity/compute_device_name";
 import "../../../../../components/ha-alert";
 import "../../../../../components/ha-button";
@@ -451,7 +452,9 @@ export class BluetoothAdapterInfoPage extends LitElement {
     return this._formatModeLabel(scannerState.current_mode);
   }
 
-  private async _handleEnable(ev: Event) {
+  private async _handleEnable(
+    ev: HASSDomCurrentTargetEvent<HTMLElement & { entry: ConfigEntry }>
+  ) {
     const button = ev.currentTarget as HTMLElement & { entry: ConfigEntry };
     const entryId = button.entry.entry_id;
     try {
@@ -474,7 +477,9 @@ export class BluetoothAdapterInfoPage extends LitElement {
     }
   }
 
-  private _openOptionFlow(ev: Event) {
+  private _openOptionFlow(
+    ev: HASSDomCurrentTargetEvent<HTMLElement & { entry: ConfigEntry }>
+  ) {
     ev.preventDefault();
     ev.stopPropagation();
     const button = ev.currentTarget as HTMLElement & { entry: ConfigEntry };

--- a/src/panels/config/integrations/integration-panels/matter/dialog-matter-lock-manage.ts
+++ b/src/panels/config/integrations/integration-panels/matter/dialog-matter-lock-manage.ts
@@ -3,6 +3,7 @@ import type { CSSResultGroup } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-alert";
 import "../../../../../components/ha-button";
 import "../../../../../components/ha-dialog-footer";
@@ -211,7 +212,9 @@ class DialogMatterLockManage extends LitElement {
     `;
   }
 
-  private _handleUserClick(ev: Event): void {
+  private _handleUserClick(
+    ev: HASSDomCurrentTargetEvent<HTMLElement & { user: MatterLockUser }>
+  ): void {
     // Ignore clicks that originated from the delete button
     const path = ev.composedPath();
     if (path.some((el) => (el as HTMLElement).tagName === "HA-ICON-BUTTON")) {
@@ -221,7 +224,9 @@ class DialogMatterLockManage extends LitElement {
     this._editUser(user);
   }
 
-  private _handleDeleteUserClick(ev: Event): void {
+  private _handleDeleteUserClick(
+    ev: HASSDomCurrentTargetEvent<HTMLElement & { user: MatterLockUser }>
+  ): void {
     ev.preventDefault();
     ev.stopPropagation();
     const user = (ev.currentTarget as any).user as MatterLockUser;

--- a/src/panels/config/integrations/integration-panels/zha/zha-add-group-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-add-group-page.ts
@@ -11,10 +11,7 @@ import { addGroup, fetchGroupableDevices } from "../../../../../data/zha";
 import "../../../../../layouts/hass-subpage";
 import type { HomeAssistant } from "../../../../../types";
 import "./zha-device-endpoint-list";
-import type {
-  DeviceEndpointSelectionChangedEvent,
-  ZHADeviceEndpointList,
-} from "./zha-device-endpoint-list";
+import type { ZHADeviceEndpointList } from "./zha-device-endpoint-list";
 
 @customElement("zha-add-group-page")
 export class ZHAAddGroupPage extends LitElement {
@@ -131,7 +128,7 @@ export class ZHAAddGroupPage extends LitElement {
   }
 
   private _handleAddSelectionChanged(
-    ev: HASSDomEvent<DeviceEndpointSelectionChangedEvent>
+    ev: HASSDomEvent<HASSDomEvents["selection-changed"]>
   ): void {
     this._selectedDevicesToAdd = ev.detail.value;
   }

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-endpoint-list.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-endpoint-list.ts
@@ -12,6 +12,7 @@ import "../../../../../components/ha-card";
 import "../../../../../components/ha-icon-button";
 import "../../../../../components/ha-list";
 import "../../../../../components/input/ha-input-search";
+import type { HaInputSearch } from "../../../../../components/input/ha-input-search";
 import "../../../../../components/item/ha-list-item-base";
 import "../../../../../components/item/ha-list-item-option";
 import type { HaListItemOption } from "../../../../../components/item/ha-list-item-option";
@@ -274,9 +275,9 @@ export class ZHADeviceEndpointList extends LitElement {
   }
 
   private _handleFilterChanged(
-    ev: HASSDomCurrentTargetEvent<HTMLInputElement>
+    ev: HASSDomCurrentTargetEvent<HaInputSearch>
   ): void {
-    this._filter = (ev.currentTarget as HTMLInputElement).value;
+    this._filter = ev.currentTarget.value ?? "";
   }
 
   private _handleItemSelected(

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-endpoint-list.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-endpoint-list.ts
@@ -4,6 +4,10 @@ import type { CSSResultGroup, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
+import type {
+  HASSDomCurrentTargetEvent,
+  HASSDomEvent,
+} from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-card";
 import "../../../../../components/ha-icon-button";
 import "../../../../../components/ha-list";
@@ -269,11 +273,16 @@ export class ZHADeviceEndpointList extends LitElement {
       .join(" · ");
   }
 
-  private _handleFilterChanged(ev: Event): void {
+  private _handleFilterChanged(
+    ev: HASSDomCurrentTargetEvent<HTMLInputElement>
+  ): void {
     this._filter = (ev.currentTarget as HTMLInputElement).value;
   }
 
-  private _handleItemSelected(ev: CustomEvent<number>): void {
+  private _handleItemSelected(
+    ev: HASSDomEvent<HASSDomEvents["ha-list-item-selected"]> &
+      HASSDomCurrentTargetEvent<HaListSelectable>
+  ): void {
     const list = ev.currentTarget as HaListSelectable;
     let selectedDeviceIds = this._selectedDeviceIds;
 
@@ -290,7 +299,10 @@ export class ZHADeviceEndpointList extends LitElement {
     }
   }
 
-  private _handleItemDeselected(ev: CustomEvent<number>): void {
+  private _handleItemDeselected(
+    ev: HASSDomEvent<HASSDomEvents["ha-list-item-deselected"]> &
+      HASSDomCurrentTargetEvent<HaListSelectable>
+  ): void {
     const list = ev.currentTarget as HaListSelectable;
     let selectedDeviceIds = this._selectedDeviceIds;
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-group-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-group-page.ts
@@ -19,10 +19,7 @@ import "../../../../../layouts/hass-subpage";
 import type { HomeAssistant } from "../../../../../types";
 import { formatAsPaddedHex } from "./functions";
 import "./zha-device-endpoint-list";
-import type {
-  DeviceEndpointSelectionChangedEvent,
-  ZHADeviceEndpointList,
-} from "./zha-device-endpoint-list";
+import type { ZHADeviceEndpointList } from "./zha-device-endpoint-list";
 import { showZHAAddGroupMembersDialog } from "./show-dialog-zha-add-group-members";
 
 @customElement("zha-group-page")
@@ -202,7 +199,7 @@ export class ZHAGroupPage extends LitElement {
   }
 
   private _handleRemoveSelectionChanged(
-    ev: HASSDomEvent<DeviceEndpointSelectionChangedEvent>
+    ev: HASSDomEvent<HASSDomEvents["selection-changed"]>
   ): void {
     this._selectedDevicesToRemove = ev.detail.value;
   }

--- a/src/panels/config/integrations/integration-panels/zha/zha-options-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-options-page.ts
@@ -3,7 +3,6 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import type {
   HASSDomCurrentTargetEvent,
-  HASSDomTargetEvent,
 } from "../../../../../common/dom/fire_event";
 import "../../../../../components/buttons/ha-progress-button";
 import "../../../../../components/ha-card";
@@ -11,7 +10,9 @@ import "../../../../../components/ha-md-list";
 import "../../../../../components/ha-md-list-item";
 import "../../../../../components/ha-select";
 import "../../../../../components/input/ha-input";
+import type { HaInput } from "../../../../../components/input/ha-input";
 import "../../../../../components/ha-switch";
+import type { HaSwitch } from "../../../../../components/ha-switch";
 import type { ZHAConfiguration } from "../../../../../data/zha";
 import {
   fetchZHAConfiguration,
@@ -22,6 +23,8 @@ import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant, Route } from "../../../../../types";
 
 const PREDEFINED_TIMEOUTS = [1800, 3600, 7200, 21600, 43200, 86400];
+type ZHASwitchChangeEvent = HASSDomCurrentTargetEvent<HaSwitch>;
+type ZHAInputChangeEvent = HASSDomCurrentTargetEvent<HaInput>;
 
 @customElement("zha-options-page")
 class ZHAOptionsPage extends LitElement {
@@ -349,69 +352,53 @@ class ZHAOptionsPage extends LitElement {
     `;
   }
 
-  private _enableIdentifyOnJoinChanged(
-    ev: HASSDomTargetEvent<HTMLInputElement>
-  ): void {
-    const checked = (ev.target as HTMLInputElement).checked;
-    this._configuration!.data.zha_options.enable_identify_on_join = checked;
+  private _enableIdentifyOnJoinChanged(ev: ZHASwitchChangeEvent): void {
+    this._configuration!.data.zha_options.enable_identify_on_join =
+      ev.currentTarget.checked;
     this.requestUpdate();
   }
 
-  private _enhancedLightTransitionChanged(
-    ev: HASSDomTargetEvent<HTMLInputElement>
-  ): void {
-    const checked = (ev.target as HTMLInputElement).checked;
-    this._configuration!.data.zha_options.enhanced_light_transition = checked;
+  private _enhancedLightTransitionChanged(ev: ZHASwitchChangeEvent): void {
+    this._configuration!.data.zha_options.enhanced_light_transition =
+      ev.currentTarget.checked;
     this.requestUpdate();
   }
 
-  private _lightTransitioningFlagChanged(
-    ev: HASSDomTargetEvent<HTMLInputElement>
-  ): void {
-    const checked = (ev.target as HTMLInputElement).checked;
-    this._configuration!.data.zha_options.light_transitioning_flag = checked;
+  private _lightTransitioningFlagChanged(ev: ZHASwitchChangeEvent): void {
+    this._configuration!.data.zha_options.light_transitioning_flag =
+      ev.currentTarget.checked;
     this.requestUpdate();
   }
 
-  private _groupMembersAssumeStateChanged(
-    ev: HASSDomTargetEvent<HTMLInputElement>
-  ): void {
-    const checked = (ev.target as HTMLInputElement).checked;
-    this._configuration!.data.zha_options.group_members_assume_state = checked;
+  private _groupMembersAssumeStateChanged(ev: ZHASwitchChangeEvent): void {
+    this._configuration!.data.zha_options.group_members_assume_state =
+      ev.currentTarget.checked;
     this.requestUpdate();
   }
 
-  private _enableMainsStartupPollingChanged(
-    ev: HASSDomTargetEvent<HTMLInputElement>
-  ): void {
-    const checked = (ev.target as HTMLInputElement).checked;
+  private _enableMainsStartupPollingChanged(ev: ZHASwitchChangeEvent): void {
     this._configuration!.data.zha_options.enable_mains_startup_polling =
-      checked;
+      ev.currentTarget.checked;
     this.requestUpdate();
   }
 
-  private _defaultLightTransitionChanged(
-    ev: HASSDomTargetEvent<HTMLInputElement>
-  ): void {
-    const value = Number((ev.target as HTMLInputElement).value);
-    this._configuration!.data.zha_options.default_light_transition = value;
+  private _defaultLightTransitionChanged(ev: ZHAInputChangeEvent): void {
+    this._configuration!.data.zha_options.default_light_transition = Number(
+      ev.currentTarget.value
+    );
     this.requestUpdate();
   }
 
-  private _customMainsSecondsChanged(
-    ev: HASSDomTargetEvent<HTMLInputElement>
-  ): void {
-    const seconds = Number((ev.target as HTMLInputElement).value);
-    this._configuration!.data.zha_options.consider_unavailable_mains = seconds;
+  private _customMainsSecondsChanged(ev: ZHAInputChangeEvent): void {
+    this._configuration!.data.zha_options.consider_unavailable_mains = Number(
+      ev.currentTarget.value
+    );
     this.requestUpdate();
   }
 
-  private _customBatterySecondsChanged(
-    ev: HASSDomTargetEvent<HTMLInputElement>
-  ): void {
-    const seconds = Number((ev.target as HTMLInputElement).value);
+  private _customBatterySecondsChanged(ev: ZHAInputChangeEvent): void {
     this._configuration!.data.zha_options.consider_unavailable_battery =
-      seconds;
+      Number(ev.currentTarget.value);
     this.requestUpdate();
   }
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-options-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-options-page.ts
@@ -1,6 +1,10 @@
 import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import type {
+  HASSDomCurrentTargetEvent,
+  HASSDomTargetEvent,
+} from "../../../../../common/dom/fire_event";
 import "../../../../../components/buttons/ha-progress-button";
 import "../../../../../components/ha-card";
 import "../../../../../components/ha-md-list";
@@ -345,50 +349,66 @@ class ZHAOptionsPage extends LitElement {
     `;
   }
 
-  private _enableIdentifyOnJoinChanged(ev: Event): void {
+  private _enableIdentifyOnJoinChanged(
+    ev: HASSDomTargetEvent<HTMLInputElement>
+  ): void {
     const checked = (ev.target as HTMLInputElement).checked;
     this._configuration!.data.zha_options.enable_identify_on_join = checked;
     this.requestUpdate();
   }
 
-  private _enhancedLightTransitionChanged(ev: Event): void {
+  private _enhancedLightTransitionChanged(
+    ev: HASSDomTargetEvent<HTMLInputElement>
+  ): void {
     const checked = (ev.target as HTMLInputElement).checked;
     this._configuration!.data.zha_options.enhanced_light_transition = checked;
     this.requestUpdate();
   }
 
-  private _lightTransitioningFlagChanged(ev: Event): void {
+  private _lightTransitioningFlagChanged(
+    ev: HASSDomTargetEvent<HTMLInputElement>
+  ): void {
     const checked = (ev.target as HTMLInputElement).checked;
     this._configuration!.data.zha_options.light_transitioning_flag = checked;
     this.requestUpdate();
   }
 
-  private _groupMembersAssumeStateChanged(ev: Event): void {
+  private _groupMembersAssumeStateChanged(
+    ev: HASSDomTargetEvent<HTMLInputElement>
+  ): void {
     const checked = (ev.target as HTMLInputElement).checked;
     this._configuration!.data.zha_options.group_members_assume_state = checked;
     this.requestUpdate();
   }
 
-  private _enableMainsStartupPollingChanged(ev: Event): void {
+  private _enableMainsStartupPollingChanged(
+    ev: HASSDomTargetEvent<HTMLInputElement>
+  ): void {
     const checked = (ev.target as HTMLInputElement).checked;
     this._configuration!.data.zha_options.enable_mains_startup_polling =
       checked;
     this.requestUpdate();
   }
 
-  private _defaultLightTransitionChanged(ev: Event): void {
+  private _defaultLightTransitionChanged(
+    ev: HASSDomTargetEvent<HTMLInputElement>
+  ): void {
     const value = Number((ev.target as HTMLInputElement).value);
     this._configuration!.data.zha_options.default_light_transition = value;
     this.requestUpdate();
   }
 
-  private _customMainsSecondsChanged(ev: Event): void {
+  private _customMainsSecondsChanged(
+    ev: HASSDomTargetEvent<HTMLInputElement>
+  ): void {
     const seconds = Number((ev.target as HTMLInputElement).value);
     this._configuration!.data.zha_options.consider_unavailable_mains = seconds;
     this.requestUpdate();
   }
 
-  private _customBatterySecondsChanged(ev: Event): void {
+  private _customBatterySecondsChanged(
+    ev: HASSDomTargetEvent<HTMLInputElement>
+  ): void {
     const seconds = Number((ev.target as HTMLInputElement).value);
     this._configuration!.data.zha_options.consider_unavailable_battery =
       seconds;
@@ -419,7 +439,15 @@ class ZHAOptionsPage extends LitElement {
     this.requestUpdate();
   }
 
-  private async _updateConfiguration(ev: Event): Promise<void> {
+  private async _updateConfiguration(
+    ev: HASSDomCurrentTargetEvent<
+      HTMLElement & {
+        progress: boolean;
+        actionSuccess: () => void;
+        actionError: () => void;
+      }
+    >
+  ): Promise<void> {
     const button = ev.currentTarget as HTMLElement & {
       progress: boolean;
       actionSuccess: () => void;

--- a/src/panels/config/integrations/integration-panels/zha/zha-options-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-options-page.ts
@@ -1,9 +1,7 @@
 import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import type {
-  HASSDomCurrentTargetEvent,
-} from "../../../../../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/buttons/ha-progress-button";
 import "../../../../../components/ha-card";
 import "../../../../../components/ha-md-list";
@@ -397,8 +395,9 @@ class ZHAOptionsPage extends LitElement {
   }
 
   private _customBatterySecondsChanged(ev: ZHAInputChangeEvent): void {
-    this._configuration!.data.zha_options.consider_unavailable_battery =
-      Number(ev.currentTarget.value);
+    this._configuration!.data.zha_options.consider_unavailable_battery = Number(
+      ev.currentTarget.value
+    );
     this.requestUpdate();
   }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-credential-user-edit.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-credential-user-edit.ts
@@ -2,6 +2,7 @@ import type { CSSResultGroup } from "lit";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../../../../../common/dom/fire_event";
 import type { LocalizeKeys } from "../../../../../common/translations/localize";
 import "../../../../../components/ha-alert";
 import "../../../../../components/ha-button";
@@ -478,7 +479,9 @@ class DialogZwaveCredentialUserEdit extends DirtyStateProviderMixin<CredentialFo
     }
   }
 
-  private _handleCredentialTypeChanged(ev: Event): void {
+  private _handleCredentialTypeChanged(
+    ev: HASSDomCurrentTargetEvent<HaRadioGroup>
+  ): void {
     this._credentialType = (ev.currentTarget as HaRadioGroup)
       .value as ZwaveCredentialType;
     // Switching types invalidates any data tied to the previous type's

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-custom-param.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-custom-param.ts
@@ -2,6 +2,7 @@ import { mdiCloseCircle } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
+import type { HASSDomTargetEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-button";
 import "../../../../../components/ha-select";
 import type { HaSelectSelectEvent } from "../../../../../components/ha-select";
@@ -129,7 +130,7 @@ class ZWaveJSCustomParam extends LitElement {
     return parsed;
   }
 
-  private _customParamNumberChanged(ev: Event) {
+  private _customParamNumberChanged(ev: HASSDomTargetEvent<HTMLInputElement>) {
     this._customParamNumber = this._tryParseNumber(
       (ev.target as HTMLInputElement).value
     );
@@ -139,7 +140,7 @@ class ZWaveJSCustomParam extends LitElement {
     this._valueSize = this._tryParseNumber(ev.detail.value) ?? 1;
   }
 
-  private _customValueChanged(ev: Event) {
+  private _customValueChanged(ev: HASSDomTargetEvent<HTMLInputElement>) {
     this._value = this._tryParseNumber((ev.target as HTMLInputElement).value);
   }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-custom-param.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-custom-param.ts
@@ -2,12 +2,13 @@ import { mdiCloseCircle } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
-import type { HASSDomTargetEvent } from "../../../../../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-button";
 import "../../../../../components/ha-select";
 import type { HaSelectSelectEvent } from "../../../../../components/ha-select";
 import "../../../../../components/ha-spinner";
 import "../../../../../components/input/ha-input";
+import type { HaInput } from "../../../../../components/input/ha-input";
 import {
   getZwaveNodeRawConfigParameter,
   setZwaveNodeRawConfigParameter,
@@ -130,18 +131,16 @@ class ZWaveJSCustomParam extends LitElement {
     return parsed;
   }
 
-  private _customParamNumberChanged(ev: HASSDomTargetEvent<HTMLInputElement>) {
-    this._customParamNumber = this._tryParseNumber(
-      (ev.target as HTMLInputElement).value
-    );
+  private _customParamNumberChanged(ev: HASSDomCurrentTargetEvent<HaInput>) {
+    this._customParamNumber = this._tryParseNumber(ev.currentTarget.value ?? "");
   }
 
   private _customValueSizeChanged(ev: HaSelectSelectEvent) {
     this._valueSize = this._tryParseNumber(ev.detail.value) ?? 1;
   }
 
-  private _customValueChanged(ev: HASSDomTargetEvent<HTMLInputElement>) {
-    this._value = this._tryParseNumber((ev.target as HTMLInputElement).value);
+  private _customValueChanged(ev: HASSDomCurrentTargetEvent<HaInput>) {
+    this._value = this._tryParseNumber(ev.currentTarget.value ?? "");
   }
 
   private _customValueFormatChanged(ev: HaSelectSelectEvent) {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-custom-param.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-custom-param.ts
@@ -132,7 +132,9 @@ class ZWaveJSCustomParam extends LitElement {
   }
 
   private _customParamNumberChanged(ev: HASSDomCurrentTargetEvent<HaInput>) {
-    this._customParamNumber = this._tryParseNumber(ev.currentTarget.value ?? "");
+    this._customParamNumber = this._tryParseNumber(
+      ev.currentTarget.value ?? ""
+    );
   }
 
   private _customValueSizeChanged(ev: HaSelectSelectEvent) {

--- a/src/panels/config/logs/system-log-card.ts
+++ b/src/panels/config/logs/system-log-card.ts
@@ -4,6 +4,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../../common/translations/localize";
 import "../../../components/buttons/ha-call-service-button";
 import "../../../components/ha-alert";
@@ -283,7 +284,9 @@ export class SystemLogCard extends LitElement {
     fileDownload(signedUrl.path, logFileName);
   }
 
-  private _openLog(ev: Event): void {
+  private _openLog(
+    ev: HASSDomCurrentTargetEvent<HTMLElement & { logItem: LoggedError }>
+  ): void {
     const item = (ev.currentTarget as any).logItem;
     showSystemLogDetailDialog(this, { item });
   }

--- a/src/panels/config/network/ha-config-url-form.ts
+++ b/src/panels/config/network/ha-config-url-form.ts
@@ -2,6 +2,7 @@ import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
+import type { HASSDomCurrentTargetEvent } from "../../../common/dom/fire_event";
 import { isIPAddress } from "../../../common/string/is_ip_address";
 import "../../../components/ha-alert";
 import "../../../components/ha-button";
@@ -363,12 +364,12 @@ class ConfigUrlForm extends SubscribeMixin(LitElement) {
     );
   }
 
-  private _toggleCloud(ev: Event) {
+  private _toggleCloud(ev: HASSDomCurrentTargetEvent<HaSwitch>) {
     this._cloudChecked = (ev.currentTarget as HaSwitch).checked;
     this._showCustomExternalUrl = !this._cloudChecked;
   }
 
-  private _toggleInternalAutomatic(ev: Event) {
+  private _toggleInternalAutomatic(ev: HASSDomCurrentTargetEvent<HaSwitch>) {
     this._showCustomInternalUrl = !(ev.currentTarget as HaSwitch).checked;
   }
 

--- a/src/panels/config/network/supervisor-network.ts
+++ b/src/panels/config/network/supervisor-network.ts
@@ -2,6 +2,10 @@ import { mdiDeleteOutline, mdiMenuDown, mdiPlus, mdiWifi } from "@mdi/js";
 import { css, type CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { cache } from "lit/directives/cache";
+import type {
+  HASSDomCurrentTargetEvent,
+  HASSDomTargetEvent,
+} from "../../../common/dom/fire_event";
 import "../../../components/ha-alert";
 import "../../../components/ha-button";
 import "../../../components/ha-card";
@@ -630,7 +634,9 @@ export class HassioNetwork extends LitElement {
     this._interface = { ...this._interfaces[this._curTabIndex] };
   }
 
-  private _handleRadioValueChanged(ev: Event): void {
+  private _handleRadioValueChanged(
+    ev: HASSDomCurrentTargetEvent<HaRadioGroup & { version: "ipv4" | "ipv6" }>
+  ): void {
     const source = ev.currentTarget as HaRadioGroup;
     const value = source.value as "disabled" | "auto" | "static";
     const version = (source as any).version as "ipv4" | "ipv6";
@@ -645,7 +651,9 @@ export class HassioNetwork extends LitElement {
     this.requestUpdate("_interface");
   }
 
-  private _handleRadioValueChangedAp(ev: Event): void {
+  private _handleRadioValueChangedAp(
+    ev: HASSDomCurrentTargetEvent<HaRadioGroup>
+  ): void {
     const source = ev.currentTarget as HaRadioGroup;
     const value = source.value as "open" | "wep" | "wpa-psk";
     this._wifiConfiguration!.auth = value;
@@ -653,7 +661,11 @@ export class HassioNetwork extends LitElement {
     this.requestUpdate("_wifiConfiguration");
   }
 
-  private _handleInputValueChanged(ev: Event): void {
+  private _handleInputValueChanged(
+    ev: HASSDomTargetEvent<
+      HaInput & { version: "ipv4" | "ipv6"; index: number }
+    >
+  ): void {
     const source = ev.target as HaInput;
     const value = source.value;
     const version = (ev.target as any).version as "ipv4" | "ipv6";
@@ -691,7 +703,7 @@ export class HassioNetwork extends LitElement {
     }
   }
 
-  private _handleInputValueChangedWifi(ev: Event): void {
+  private _handleInputValueChangedWifi(ev: HASSDomTargetEvent<HaInput>): void {
     const source = ev.target as HaInput;
     const value = source.value;
     const id = source.id;
@@ -708,7 +720,9 @@ export class HassioNetwork extends LitElement {
     this._wifiConfiguration![id] = value;
   }
 
-  private _addAddress(ev: Event): void {
+  private _addAddress(
+    ev: HASSDomTargetEvent<HTMLElement & { version: "ipv4" | "ipv6" }>
+  ): void {
     const version = (ev.target as any).version as "ipv4" | "ipv6";
     this._interface![version]!.address!.push(
       version === "ipv4" ? "0.0.0.0/24" : "::/64"
@@ -717,7 +731,11 @@ export class HassioNetwork extends LitElement {
     this.requestUpdate("_interface");
   }
 
-  private _removeAddress(ev: Event): void {
+  private _removeAddress(
+    ev: HASSDomTargetEvent<
+      HTMLElement & { index: number; version: "ipv4" | "ipv6" }
+    >
+  ): void {
     const source = ev.target as any;
     const index = source.index as number;
     const version = source.version as "ipv4" | "ipv6";
@@ -752,7 +770,11 @@ export class HassioNetwork extends LitElement {
     this.requestUpdate("_interface");
   }
 
-  private _removeNameserver(ev: Event): void {
+  private _removeNameserver(
+    ev: HASSDomTargetEvent<
+      HTMLElement & { index: number; version: "ipv4" | "ipv6" }
+    >
+  ): void {
     const source = ev.target as any;
     const index = source.index as number;
     const version = source.version as "ipv4" | "ipv6";

--- a/src/panels/config/tools/state/tools-state-renderer.ts
+++ b/src/panels/config/tools/state/tools-state-renderer.ts
@@ -11,6 +11,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import type { HASSDomCurrentTargetEvent } from "../../../../common/dom/fire_event";
 import { computeAreaName } from "../../../../common/entity/compute_area_name";
 import { computeDeviceName } from "../../../../common/entity/compute_device_name";
 import { computeEntityEntryName } from "../../../../common/entity/compute_entity_name";
@@ -260,7 +261,9 @@ class HaPanelDevStateRenderer extends LitElement {
     return output;
   }
 
-  private _copyEntity = async (ev: Event) => {
+  private _copyEntity = async (
+    ev: HASSDomCurrentTargetEvent<HTMLElement & { entity: HassEntity }>
+  ) => {
     ev.preventDefault();
     const entity = (ev.currentTarget as HTMLElement & { entity: HassEntity })
       .entity;
@@ -270,14 +273,18 @@ class HaPanelDevStateRenderer extends LitElement {
     });
   };
 
-  private _entityMoreInfo(ev: Event) {
+  private _entityMoreInfo(
+    ev: HASSDomCurrentTargetEvent<HTMLElement & { entity: HassEntity }>
+  ) {
     ev.preventDefault();
     const entity = (ev.currentTarget as HTMLElement & { entity: HassEntity })
       .entity;
     fireEvent(this, "hass-more-info", { entityId: entity.entity_id });
   }
 
-  private _entitySelected(ev: Event) {
+  private _entitySelected(
+    ev: HASSDomCurrentTargetEvent<HTMLElement & { entity: HassEntity }>
+  ) {
     ev.preventDefault();
     const entity = (ev.currentTarget as HTMLElement & { entity: HassEntity })
       .entity;

--- a/src/panels/config/tools/statistics/tools-statistics.ts
+++ b/src/panels/config/tools/statistics/tools-statistics.ts
@@ -16,7 +16,11 @@ import { consume, type ContextType } from "@lit/context";
 import { css, type CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
-import type { HASSDomEvent } from "../../../../common/dom/fire_event";
+import type {
+  HASSDomCurrentTargetEvent,
+  HASSDomEvent,
+  HASSDomTargetEvent,
+} from "../../../../common/dom/fire_event";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { computeAreaName } from "../../../../common/entity/compute_area_name";
 import {
@@ -596,7 +600,9 @@ class HaPanelDevStatistics extends KeyboardShortcutMixin(LitElement) {
     `;
   }
 
-  private _handleSearchChange(ev: InputEvent) {
+  private _handleSearchChange(
+    ev: InputEvent & HASSDomTargetEvent<HaInputSearch>
+  ) {
     if (this.filter === (ev.target as HaInputSearch).value) {
       return;
     }
@@ -706,7 +712,9 @@ class HaPanelDevStatistics extends KeyboardShortcutMixin(LitElement) {
     );
   }
 
-  private _showStatisticsAdjustSumDialog(ev: Event) {
+  private _showStatisticsAdjustSumDialog(
+    ev: HASSDomCurrentTargetEvent<HTMLElement & { statistic: StatisticData }>
+  ) {
     ev.stopPropagation();
     showStatisticsAdjustSumDialog(this, {
       statistic: (
@@ -782,7 +790,11 @@ class HaPanelDevStatistics extends KeyboardShortcutMixin(LitElement) {
     });
   };
 
-  private _fixIssue = async (ev: Event) => {
+  private _fixIssue = async (
+    ev: HASSDomCurrentTargetEvent<
+      HTMLElement & { data: StatisticsValidationResult[] }
+    >
+  ) => {
     const issues = (
       ev.currentTarget as HTMLElement & { data: StatisticsValidationResult[] }
     ).data.sort(

--- a/src/panels/config/tools/template/tools-template.ts
+++ b/src/panels/config/tools/template/tools-template.ts
@@ -9,6 +9,7 @@ import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import type { HASSDomTargetEvent } from "../../../../common/dom/fire_event";
 import { stopPropagation } from "../../../../common/dom/stop_propagation";
 import type { LocalizeKeys } from "../../../../common/translations/localize";
 import { debounce } from "../../../../common/util/debounce";
@@ -419,7 +420,7 @@ ${
     `;
   }
 
-  private _splitRepositioned(ev: Event) {
+  private _splitRepositioned(ev: HASSDomTargetEvent<HaSplitPanel>) {
     this._splitPosition = (ev.target as HaSplitPanel).position;
     this._storeSplitPosition();
   }


### PR DESCRIPTION
## Proposed change

Additional to #53452

Uses the documented Home Assistant event types for configuration panels and integration settings.

These are type-only changes and do not change runtime behaviour.

## Type of change


- [x] Code quality improvements to existing code or addition of tests

## Checklist


- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure


[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
