### PR TITLE
Fix slow loading of entity rows in device page

### DIFF
--- a/src/panels/lovelace/entity-rows/entity-row-element-directive.ts
+++ b/src/panels/lovelace/entity-rows/entity-row-element-directive.ts
@@ -12,7 +12,10 @@ class EntityRowDirective extends Directive {
 
   private _name?: string;
 
+  private _lastHass?: HomeAssistant;
+
   render(entityId: string, name: string, hass: HomeAssistant) {
+    this._lastHass = hass;
     if (
       !this._element ||
       (this._entityId !== entityId &&
@@ -22,6 +25,15 @@ class EntityRowDirective extends Directive {
         entity: entityId,
         name,
       } as LovelaceRowConfig);
+      this._element.addEventListener(
+        "ll-upgrade",
+        () => {
+          if ("hass" in this._element!) {
+            this._element!.hass = this._lastHass;
+          }
+        },
+        { once: true }
+      );
     } else if (this._entityId !== entityId || this._name !== name) {
       (this._element as LovelaceRow).setConfig?.({
         entity: entityId,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The lazy loaded entity rows in the device page will sometimes appear very slowly, as they only appear on the next hass update _after_ the row is upgraded. If hass updates occur infrequently, it could take a very noticeable amount of time where certain rows are just missing.

On the first render, we create the element and might have to load it. Hass is not attached yet because we don't attach it until we see that the element has a hass property, which is not available until it is upgraded.

When the element finally does upgrade, there's no guarantee that any future render event is coming, so the newly upgraded element just hangs around with no hass attached until the next time the devices panel does a render update.

We can fix this by saving the last seen hass and manually attaching it as soon as the element fires the upgrade event.

A user claims this broke on 2026.8 beta, but I don't have any evidence of that directly or of why this would have changed. It seems to have been last refactored in March.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53467
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
