### PR TITLE
Add expand_legend option to energy graph cards

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-detail-graph-card.ts
@@ -149,6 +149,7 @@ export class HuiEnergyDevicesDetailGraphCard
               this._yAxisFractionDigits,
               this._legendData
             )}
+            .expandLegend=${this._config.expand_legend}
             click-label-for-more-info
             @dataset-hidden=${this._datasetHidden}
             @dataset-unhidden=${this._datasetUnhidden}

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
@@ -192,6 +192,7 @@ export class HuiEnergyDevicesGraphCard
             )}
             .height=${`${Math.max(modes.includes("pie") ? 300 : 100, (this._legendData?.length || 0) * 28 + 50)}px`}
             .extraComponents=${[PieChart]}
+            .expandLegend=${this._config.expand_legend}
             click-label-for-more-info
             @chart-click=${this._handleChartClick}
             @dataset-hidden=${this._datasetHidden}

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -177,6 +177,7 @@ export class HuiEnergyUsageGraphCard
               this._legendData
             )}
             chart-type="bar"
+            .expandLegend=${this._config.expand_legend}
           ></ha-chart-base>
           ${
             !this._chartData.some((dataset) => dataset.data!.length)

--- a/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sources-graph-card.ts
@@ -121,6 +121,7 @@ export class HuiPowerSourcesGraphCard
               this._legendData,
               this._yAxisFractionDigits
             )}
+            .expandLegend=${this._config.expand_legend}
           ></ha-chart-base>
           ${
             !this._chartData.some((dataset) => dataset.data!.length)

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -189,6 +189,7 @@ export interface EnergyDistributionCardConfig extends EnergyCardConfig {
 export interface EnergyUsageGraphCardConfig extends EnergyCardConfig {
   type: "energy-usage-graph";
   show_legend?: boolean;
+  expand_legend?: boolean;
 }
 
 export interface EnergySolarGraphCardConfig extends EnergyCardConfig {
@@ -208,11 +209,13 @@ export interface EnergyDevicesGraphCardConfig extends EnergyCardConfig {
   max_devices?: number;
   hide_compound_stats?: boolean;
   modes?: ("bar" | "pie")[];
+  expand_legend?: boolean;
 }
 
 export interface EnergyDevicesDetailGraphCardConfig extends EnergyCardConfig {
   type: "energy-devices-detail-graph";
   max_devices?: number;
+  expand_legend?: boolean;
 }
 
 export interface EnergySourcesTableCardConfig extends EnergyCardConfig {
@@ -244,6 +247,7 @@ export interface EnergyCarbonGaugeCardConfig extends EnergyCardConfig {
 export interface PowerSourcesGraphCardConfig extends EnergyCardConfig {
   type: "power-sources-graph";
   show_legend?: boolean;
+  expand_legend?: boolean;
 }
 
 export interface EnergySankeyCardConfig extends EnergyCardSankeyConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-energy-devices-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-energy-devices-card-editor.ts
@@ -38,6 +38,7 @@ const cardConfigStruct = assign(
     max_devices: optional(number()),
     modes: optional(array(union([literal("bar"), literal("pie")]))),
     hide_compound_stats: optional(boolean()),
+    expand_legend: optional(boolean()),
   })
 );
 
@@ -89,6 +90,11 @@ export class HuiEnergyDevicesCardEditor
             name: "hide_compound_stats",
             required: false,
             visible: { field: "type", value: "energy-devices-graph" },
+            selector: { boolean: {} },
+          },
+          {
+            name: "expand_legend",
+            required: false,
             selector: { boolean: {} },
           },
           {

--- a/src/panels/lovelace/editor/config-elements/hui-energy-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-energy-graph-card-editor.ts
@@ -41,6 +41,19 @@ const SCHEMA: HaFormSchema[] = [
     selector: { boolean: {} },
   },
   {
+    name: "expand_legend",
+    visible: [
+      {
+        field: "type",
+        operator: "in",
+        value: ["power-sources-graph", "energy-usage-graph"],
+      },
+      { field: "show_legend", operator: "not_eq", value: false },
+    ],
+    required: false,
+    selector: { boolean: {} },
+  },
+  {
     name: "link_dashboard",
     visible: { field: "type", value: "energy-distribution" },
     required: false,
@@ -73,6 +86,7 @@ const cardConfigStruct = assign(
     title: optional(string()),
     collection_key: optional(string()),
     show_legend: optional(boolean()),
+    expand_legend: optional(boolean()),
     link_dashboard: optional(boolean()),
   })
 );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10095,6 +10095,7 @@
               "double_tap_action": "Double tap behavior",
               "entities": "Entities",
               "entity": "Entity",
+              "expand_legend": "Expand legend",
               "fit_mode": "Fit mode",
               "fit_mode_options": {
                 "contain": "Scaled (Contain)",


### PR DESCRIPTION
## Proposed change

`expand_legend` is implemented in `ha-chart-base` but was only wired up by the history and statistics graph cards, so setting it on an energy card did nothing. This passes it through on the four energy cards that render a collapsible custom legend: `energy-usage-graph`, `power-sources-graph`, `energy-devices-graph` (pie mode) and `energy-devices-detail-graph`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #53455
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47230
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
