### PR TITLE
Always group updates page entities by integration

### DIFF
--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -53,7 +53,7 @@ interface UpdateGroup {
   key: string;
   title: string;
   entities: UpdateEntity[];
-  showUpdateAll: boolean;
+  showUpdateButton: boolean;
 }
 
 const SYSTEM_KEY = "__system__";
@@ -218,7 +218,7 @@ class HaConfigSectionUpdates extends LitElement {
                       ${group.title}
                     </div>
                     ${
-                      group.showUpdateAll
+                      group.showUpdateButton
                         ? html`
                             <ha-button
                               appearance="plain"
@@ -227,10 +227,12 @@ class HaConfigSectionUpdates extends LitElement {
                               .disabled=${group.entities.every((entity) =>
                                 updateIsInstalling(entity)
                               )}
-                              @click=${this._updateAll}
+                              @click=${this._updateGroup}
                             >
                               ${this.hass.localize(
-                                "ui.panel.config.updates.update_all"
+                                group.entities.length > 1
+                                  ? "ui.panel.config.updates.update_all"
+                                  : "ui.common.update"
                               )}
                             </ha-button>
                           `
@@ -350,7 +352,7 @@ class HaConfigSectionUpdates extends LitElement {
     checkForEntityUpdates(this, this.hass);
   }
 
-  private async _updateAll(ev: Event) {
+  private async _updateGroup(ev: Event) {
     const group = (ev.currentTarget as any).group as UpdateGroup;
     const entityIds = group.entities
       .filter((entity) => !updateIsInstalling(entity))
@@ -442,7 +444,7 @@ class HaConfigSectionUpdates extends LitElement {
           key: domain,
           title: domainToName(localize, domain),
           entities: entries,
-          showUpdateAll: entries.length > 1,
+          showUpdateButton: true,
         });
       });
 
@@ -457,7 +459,7 @@ class HaConfigSectionUpdates extends LitElement {
           key: SYSTEM_KEY,
           title: localize("ui.panel.config.updates.group_system"),
           entities: systemEntities,
-          showUpdateAll: false,
+          showUpdateButton: false,
         });
       }
 
@@ -468,7 +470,7 @@ class HaConfigSectionUpdates extends LitElement {
           key: APPS_KEY,
           title: localize("ui.panel.config.updates.group_apps"),
           entities: appEntities,
-          showUpdateAll: true,
+          showUpdateButton: true,
         });
       }
 

--- a/src/panels/config/core/ha-config-section-updates.ts
+++ b/src/panels/config/core/ha-config-section-updates.ts
@@ -58,7 +58,6 @@ interface UpdateGroup {
 
 const SYSTEM_KEY = "__system__";
 const APPS_KEY = "__apps__";
-const INTEGRATIONS_KEY = "__integrations__";
 
 @customElement("ha-config-section-updates")
 class HaConfigSectionUpdates extends LitElement {
@@ -417,7 +416,6 @@ class HaConfigSectionUpdates extends LitElement {
       const systemEntities: UpdateEntity[] = [];
       const appEntities: UpdateEntity[] = [];
       const byDomain = new Map<string, UpdateEntity[]>();
-      const otherIntegrationEntities: UpdateEntity[] = [];
 
       for (const entity of entities) {
         if (isSystemUpdate(entity)) {
@@ -426,13 +424,10 @@ class HaConfigSectionUpdates extends LitElement {
         }
         const domain =
           entitySources?.[entity.entity_id]?.domain ??
-          entityRegistry[entity.entity_id]?.platform;
+          entityRegistry[entity.entity_id]?.platform ??
+          "unknown";
         if (domain === "hassio") {
           appEntities.push(entity);
-          continue;
-        }
-        if (!domain) {
-          otherIntegrationEntities.push(entity);
           continue;
         }
         if (!byDomain.has(domain)) {
@@ -441,21 +436,17 @@ class HaConfigSectionUpdates extends LitElement {
         byDomain.get(domain)!.push(entity);
       }
 
-      const multiInstanceGroups: UpdateGroup[] = [];
+      const integrationGroups: UpdateGroup[] = [];
       byDomain.forEach((entries, domain) => {
-        if (entries.length >= 2) {
-          multiInstanceGroups.push({
-            key: domain,
-            title: domainToName(localize, domain),
-            entities: entries,
-            showUpdateAll: true,
-          });
-        } else {
-          otherIntegrationEntities.push(...entries);
-        }
+        integrationGroups.push({
+          key: domain,
+          title: domainToName(localize, domain),
+          entities: entries,
+          showUpdateAll: entries.length > 1,
+        });
       });
 
-      multiInstanceGroups.sort((a, b) =>
+      integrationGroups.sort((a, b) =>
         caseInsensitiveStringCompare(a.title, b.title, language)
       );
 
@@ -470,16 +461,7 @@ class HaConfigSectionUpdates extends LitElement {
         });
       }
 
-      groups.push(...multiInstanceGroups);
-
-      if (otherIntegrationEntities.length) {
-        groups.push({
-          key: INTEGRATIONS_KEY,
-          title: localize("ui.panel.config.updates.group_integrations"),
-          entities: otherIntegrationEntities,
-          showUpdateAll: true,
-        });
-      }
+      groups.push(...integrationGroups);
 
       if (appEntities.length) {
         groups.push({

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2736,7 +2736,6 @@
           "caption": "Updates",
           "description": "Manage updates of Home Assistant, apps, and devices",
           "group_system": "Home Assistant",
-          "group_integrations": "Integrations",
           "group_apps": "Apps",
           "update_all": "Update all",
           "no_updates": "No updates available",


### PR DESCRIPTION
## Proposed change

On the updates page, update entities were grouped per integration only when an integration had two or more of them; everything else fell into a catch-all "Integrations" card. That card mixed unrelated devices and services together. The "Integrations" name was also very confusing, because it sounds like it's about HACS, but it's not.

Now every integration always gets its own card, titled with the integration name and sorted alphabetically. The catch-all card and its `group_integrations` translation key are removed. The "Update all" button is only rendered for cards with more than one entity.

Card order is unchanged: Home Assistant, then the integration cards, then Apps.

## Screenshots

Before:


https://github.com/user-attachments/assets/98904011-2f8f-4539-b51b-4077760f732d



After:

https://github.com/user-attachments/assets/0f1da953-0b5b-425d-9848-6940c967fd12



## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


---
_Generated by [Claude Code](https://claude.ai/code/session_01DTuGyvS1i7w1B1xEGCEVhs)_