### PR TITLE
Keep numeric slider and buttons within min and max when the step overshoots

### DIFF
--- a/src/components/ha-control-number-buttons.ts
+++ b/src/components/ha-control-number-buttons.ts
@@ -53,8 +53,10 @@ export class HaControlNumberButton extends LitElement {
   });
 
   private _boundedValue(value: number) {
-    const clamped = conditionalClamp(value, this.min, this.max);
-    return Math.round(clamped / this._step) * this._step;
+    // Clamp after snapping: when the step does not divide the range evenly,
+    // snapping alone rounds past the bounds (min 1, max 99, step 10 → 0 / 100).
+    const stepped = Math.round(value / this._step) * this._step;
+    return conditionalClamp(stepped, this.min, this.max);
   }
 
   private get _step() {
@@ -67,10 +69,7 @@ export class HaControlNumberButton extends LitElement {
 
   private get _tenPercentStep() {
     if (this.max == null || this.min == null) return this._step;
-    const range = this.max - this.min / 10;
-
-    if (range <= this._step) return this._step;
-    return Math.max(range / 10);
+    return Math.max((this.max - this.min) / 10, this._step);
   }
 
   private _handlePlusButton() {

--- a/src/components/ha-control-slider.ts
+++ b/src/components/ha-control-slider.ts
@@ -115,7 +115,9 @@ export class HaControlSlider extends LitElement {
   }
 
   steppedValue(value: number) {
-    return Math.round(value / this.step) * this.step;
+    // Clamp after snapping: when the step does not divide the range evenly,
+    // snapping alone rounds past the bounds (min 1, max 99, step 10 → 0 / 100).
+    return this.boundedValue(Math.round(value / this.step) * this.step);
   }
 
   private _displayedValue(value: number) {
@@ -254,13 +256,9 @@ export class HaControlSlider extends LitElement {
     } else if (e.code === "End") {
       this.value = this.max;
     } else if (e.code === "PageUp") {
-      this.value = this.steppedValue(
-        this.boundedValue((this.value ?? 0) + this._tenPercentStep)
-      );
+      this.value = this.steppedValue((this.value ?? 0) + this._tenPercentStep);
     } else if (e.code === "PageDown") {
-      this.value = this.steppedValue(
-        this.boundedValue((this.value ?? 0) - this._tenPercentStep)
-      );
+      this.value = this.steppedValue((this.value ?? 0) - this._tenPercentStep);
     } else {
       const isRtl = mainWindow.document.dir === "rtl";
       let multiplier = 1;

--- a/test/components/ha-control-number-buttons.test.ts
+++ b/test/components/ha-control-number-buttons.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../../src/components/ha-control-number-buttons";
+import type { HaControlNumberButton } from "../../src/components/ha-control-number-buttons";
+
+class MockResizeObserver {
+  observe = vi.fn();
+
+  unobserve = vi.fn();
+
+  disconnect = vi.fn();
+}
+
+describe("ha-control-number-buttons step bounds", () => {
+  // An input_number with min 1, max 99 and step 10: the step grid does not
+  // divide the range, so snapping used to round past both bounds.
+  const RANGE = { min: 1, max: 99, step: 10 };
+
+  let buttons: HaControlNumberButton[] = [];
+
+  const mountButtons = async (
+    props: Partial<HaControlNumberButton>
+  ): Promise<HaControlNumberButton> => {
+    const el = document.createElement(
+      "ha-control-number-buttons"
+    ) as HaControlNumberButton;
+    Object.assign(el, props);
+    document.body.appendChild(el);
+    buttons.push(el);
+    await el.updateComplete;
+    return el;
+  };
+
+  const stepButton = (el: HaControlNumberButton, label: string) =>
+    el.shadowRoot!.querySelector<HTMLButtonElement>(`[aria-label="${label}"]`)!;
+
+  const changedValues = (el: HaControlNumberButton) => {
+    const values: (number | undefined)[] = [];
+    el.addEventListener("value-changed", (ev) => {
+      values.push((ev as CustomEvent).detail.value);
+    });
+    return values;
+  };
+
+  const pressKey = async (el: HaControlNumberButton, code: string) => {
+    el.shadowRoot!.querySelector('[role="spinbutton"]')!.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        code,
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      })
+    );
+    await el.updateComplete;
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+  });
+
+  afterEach(() => {
+    buttons.forEach((el) => el.remove());
+    buttons = [];
+    vi.unstubAllGlobals();
+  });
+
+  it("stops at the maximum instead of stepping past it", async () => {
+    const el = await mountButtons({ ...RANGE, value: 91 });
+    const values = changedValues(el);
+    stepButton(el, "increment").click();
+    await el.updateComplete;
+    expect(values).toEqual([99]);
+    expect(stepButton(el, "increment").disabled).toBe(true);
+  });
+
+  it("stops at the minimum instead of stepping past it", async () => {
+    const el = await mountButtons({ ...RANGE, value: 11 });
+    const values = changedValues(el);
+    stepButton(el, "decrement").click();
+    await el.updateComplete;
+    expect(values).toEqual([1]);
+    expect(stepButton(el, "decrement").disabled).toBe(true);
+  });
+
+  it("still snaps to the step grid away from the bounds", async () => {
+    const el = await mountButtons({ ...RANGE, value: 44 });
+    const values = changedValues(el);
+    stepButton(el, "increment").click();
+    stepButton(el, "decrement").click();
+    await el.updateComplete;
+    expect(values).toEqual([50, 40]);
+  });
+
+  it("steps without bounds when min and max are not set", async () => {
+    const el = await mountButtons({ step: 10, value: 50 });
+    const values = changedValues(el);
+    stepButton(el, "increment").click();
+    await el.updateComplete;
+    expect(values).toEqual([60]);
+  });
+
+  it("pages by ten percent of the range, but at least one step", async () => {
+    const wide = await mountButtons({ min: 10, max: 20, step: 1, value: 15 });
+    const wideValues = changedValues(wide);
+    await pressKey(wide, "PageUp");
+    expect(wideValues).toEqual([16]);
+
+    // A range narrower than ten steps must still page by a full step.
+    const narrow = await mountButtons({ min: 0, max: 5, step: 2, value: 0 });
+    const narrowValues = changedValues(narrow);
+    await pressKey(narrow, "PageUp");
+    expect(narrowValues).toEqual([2]);
+  });
+});

--- a/test/components/ha-control-number-buttons.test.ts
+++ b/test/components/ha-control-number-buttons.test.ts
@@ -98,6 +98,16 @@ describe("ha-control-number-buttons step bounds", () => {
     expect(values).toEqual([60]);
   });
 
+  it("keeps arrow keys inside the bounds", async () => {
+    const el = await mountButtons({ ...RANGE, value: 91 });
+    const values = changedValues(el);
+    await pressKey(el, "ArrowUp");
+    expect(values).toEqual([99]);
+    el.value = 11;
+    await pressKey(el, "ArrowDown");
+    expect(values).toEqual([99, 1]);
+  });
+
   it("pages by ten percent of the range, but at least one step", async () => {
     const wide = await mountButtons({ min: 10, max: 20, step: 1, value: 15 });
     const wideValues = changedValues(wide);

--- a/test/components/ha-control-slider.test.ts
+++ b/test/components/ha-control-slider.test.ts
@@ -144,6 +144,35 @@ describe("ha-control-slider step bounds", () => {
     expect(el.steppedValue(46)).toBe(50);
   });
 
+  it("stays inside the bounds along the whole pointer path", () => {
+    // The pointer handlers compose these two, so they have to hold together.
+    const el = createSlider(RANGE);
+    expect(el.steppedValue(el.percentageToValue(1))).toBe(99);
+    expect(el.steppedValue(el.percentageToValue(0))).toBe(1);
+  });
+
+  it("does not overshoot the maximum with a fractional step", () => {
+    // A 91-speed fan: 91 * (100 / 91) used to land on 100.00000000000001.
+    const el = createSlider({ min: 0, max: 100, step: 100 / 91 });
+    expect(el.steppedValue(el.percentageToValue(1))).toBe(100);
+  });
+
+  it("shows and announces the bound, not the overshoot", async () => {
+    const el = await mountSlider({
+      ...RANGE,
+      value: 99,
+      tooltipMode: "always",
+    });
+    expect(el.shadowRoot!.querySelector(".tooltip")!.textContent!.trim()).toBe(
+      "99"
+    );
+    expect(
+      el
+        .shadowRoot!.querySelector('[role="slider"]')!
+        .getAttribute("aria-valuenow")
+    ).toBe("99");
+  });
+
   it("keeps paging inside the bounds", async () => {
     const el = await mountSlider({ ...RANGE, value: 91 });
     const values = changedValues(el);

--- a/test/components/ha-control-slider.test.ts
+++ b/test/components/ha-control-slider.test.ts
@@ -8,6 +8,23 @@ const createSlider = (props: Partial<HaControlSlider>): HaControlSlider => {
   return el;
 };
 
+let sliders: HaControlSlider[] = [];
+
+const mountSlider = async (
+  props: Partial<HaControlSlider>
+): Promise<HaControlSlider> => {
+  const el = createSlider(props);
+  document.body.appendChild(el);
+  sliders.push(el);
+  await el.updateComplete;
+  return el;
+};
+
+afterEach(() => {
+  sliders.forEach((el) => el.remove());
+  sliders = [];
+});
+
 describe("ha-control-slider value mapping", () => {
   afterEach(() => {
     document.dir = "ltr";
@@ -54,18 +71,6 @@ describe("ha-control-slider display rounding", () => {
   // stepped percentage such as 29 snaps to 26 * step = 28.5714…
   const FAN_STEP = 100 / 91;
 
-  let sliders: HaControlSlider[] = [];
-
-  const mountSlider = async (
-    props: Partial<HaControlSlider>
-  ): Promise<HaControlSlider> => {
-    const el = createSlider(props);
-    document.body.appendChild(el);
-    sliders.push(el);
-    await el.updateComplete;
-    return el;
-  };
-
   const ariaValueNow = (el: HaControlSlider) =>
     el
       .shadowRoot!.querySelector('[role="slider"]')!
@@ -73,11 +78,6 @@ describe("ha-control-slider display rounding", () => {
 
   const tooltipText = (el: HaControlSlider) =>
     el.shadowRoot!.querySelector(".tooltip")!.textContent!.trim();
-
-  afterEach(() => {
-    sliders.forEach((el) => el.remove());
-    sliders = [];
-  });
 
   it("shows the fractional stepped value by default", async () => {
     const el = await mountSlider({ step: FAN_STEP, value: 29 });
@@ -111,5 +111,56 @@ describe("ha-control-slider display rounding", () => {
     const el = await mountSlider({ step: 0.5, value: 21.5 });
     expect(tooltipText(el)).toBe("21.5");
     expect(ariaValueNow(el)).toBe("21.5");
+  });
+});
+
+describe("ha-control-slider step bounds", () => {
+  // An input_number with min 1, max 99 and step 10: the step grid does not
+  // divide the range, so snapping used to round past both bounds.
+  const RANGE = { min: 1, max: 99, step: 10 };
+
+  const pressKey = async (el: HaControlSlider, code: string) => {
+    const slider = el.shadowRoot!.querySelector('[role="slider"]')!;
+    const init = { code, bubbles: true, composed: true, cancelable: true };
+    slider.dispatchEvent(new KeyboardEvent("keydown", init));
+    slider.dispatchEvent(new KeyboardEvent("keyup", init));
+    await el.updateComplete;
+  };
+
+  const changedValues = (el: HaControlSlider) => {
+    const values: (number | undefined)[] = [];
+    el.addEventListener("value-changed", (ev) => {
+      values.push((ev as CustomEvent).detail.value);
+    });
+    return values;
+  };
+
+  it("snaps within the bounds instead of rounding past them", () => {
+    const el = createSlider(RANGE);
+    expect(el.steppedValue(99)).toBe(99);
+    expect(el.steppedValue(1)).toBe(1);
+    // Values away from the bounds still snap to the step grid.
+    expect(el.steppedValue(44)).toBe(40);
+    expect(el.steppedValue(46)).toBe(50);
+  });
+
+  it("keeps paging inside the bounds", async () => {
+    const el = await mountSlider({ ...RANGE, value: 91 });
+    const values = changedValues(el);
+    await pressKey(el, "PageUp");
+    expect(values).toEqual([99]);
+    el.value = 1;
+    await pressKey(el, "PageDown");
+    expect(values).toEqual([99, 1]);
+  });
+
+  it("keeps arrow keys inside the bounds", async () => {
+    const el = await mountSlider({ ...RANGE, value: 91 });
+    const values = changedValues(el);
+    await pressKey(el, "ArrowUp");
+    expect(values).toEqual([99]);
+    el.value = 1;
+    await pressKey(el, "ArrowDown");
+    expect(values).toEqual([99, 1]);
   });
 });


### PR DESCRIPTION
## Proposed change

`ha-control-slider` and `ha-control-number-buttons` snapped the value to the step grid *after*
clamping it to the range, so for an entity whose bounds are not step multiples (min 1, max 99,
step 10) the snap rounded straight past them and sent 0 or 100, which core rejects. Both controls
now snap first and clamp last, which also keeps `min` and `max` reachable — the same rule core
applies in `input_number.increment`. Values away from the bounds still snap to the step grid.

Also fixes two typos in the number buttons' `_tenPercentStep`, which made <kbd>PageUp</kbd> /
<kbd>PageDown</kbd> jump by the wrong amount.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53427
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
