### PR TITLE
Remove dead UV_THREADPOOL_SIZE assignment from gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,1 @@
-import { availableParallelism } from "node:os";
 import "./build-scripts/gulp/index.mjs";
-
-process.env.UV_THREADPOOL_SIZE = availableParallelism();


### PR DESCRIPTION
## Proposed change

`gulpfile.js` sets `process.env.UV_THREADPOOL_SIZE = availableParallelism()`, but libuv has already sized its threadpool by the time gulp evaluates the gulpfile, so the assignment does nothing. It cannot be fixed in place either, and making it take effect measurably changes nothing, so this removes it instead of plumbing the variable through the build.

### The line has no effect

Effective threadpool size, measured through the gulp CLI by submitting 24 concurrent `pbkdf2` jobs and dividing `24 × solo duration` by wall clock (12-core machine):

| how `UV_THREADPOOL_SIZE` is set                    | effective threads |
| -------------------------------------------------- | ----------------- |
| `gulpfile.js` as it is today                        | 3.4               |
| the line removed (this PR)                          | 3.4               |
| assignment hoisted into the first-evaluated import  | 3.6               |
| set in the environment before node starts           | 6.9               |

The first two rows are the point: identical, so the assignment buys nothing.

Import hoisting is not the only reason. Gulp's CLI resolves and loads the gulpfile through liftoff, which does async fs work first, and that is the first threadpool submission — so the pool is fixed at the default 4 before any line of `gulpfile.js` runs. That is why hoisting the assignment to the first import does not help, and why the variable has to come from the environment.

### Making it work is not worth it

`compress-app`, median of 3 interleaved runs against one fixed production output tree:

| | time |
| --- | --- |
| as-is | 67.3 s |
| `UV_THREADPOOL_SIZE=12` in the environment | 69.5 s |

No gain. zopfli runs in dedicated worker threads rather than on the libuv pool (#53488), and `gulp-brotli` keeps only one compression in flight per stream, so with two brotli streams a 4-thread pool is never saturated.

Raising both levers together does reach the pool: with brotli made concurrent, the brotli tasks drop from 38 s/41 s to 18 s/22 s once the pool is raised. Total `compress-app` still does not improve (69.8 s → 74.3 s), because zopfli is the critical path and the step is already CPU-saturated — faster brotli just takes cores from the zopfli workers.

Doing this properly would mean setting the variable in `.github/actions/build/action.yml` and at both `spawn` sites in `build-manager.mjs`/`dev-server.mjs`, since CI runs `gulp <target>` directly and never goes through those scripts. That is real surface area for no measured benefit.

The line dates to #19988, where it was aimed at the translations build; `build-translations` now runs in about 1 s, so there is nothing left for it to win there either.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue or discussion: measurements were taken with #53488 applied, which is what moves zopfli off the libuv pool
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
