### PR TITLE
Treat contenteditable elements as text input for keyboard shortcuts

### DIFF
--- a/src/common/dom/can-override-input.ts
+++ b/src/common/dom/can-override-input.ts
@@ -13,6 +13,7 @@ export const canOverrideAlphanumericInput = (composedPath: EventTarget[]) => {
 
   if (
     el.tagName === "TEXTAREA" ||
+    (el as HTMLElement).isContentEditable ||
     el.parentElement?.tagName === "HA-SELECT" ||
     el.parentElement?.tagName === "HA-DROPDOWN"
   ) {

--- a/test/common/dom/can-override-input.test.ts
+++ b/test/common/dom/can-override-input.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { canOverrideAlphanumericInput } from "../../../src/common/dom/can-override-input";
+
+// jsdom does not implement isContentEditable — it is undefined on every element,
+// including one carrying contenteditable="true". These stubs therefore describe
+// the shape the function actually reads rather than using real elements.
+const stub = (props: Record<string, unknown>) =>
+  props as unknown as EventTarget;
+
+describe("canOverrideAlphanumericInput", () => {
+  it("allows shortcuts on a plain element", () => {
+    expect(canOverrideAlphanumericInput([stub({ tagName: "DIV" })])).toBe(true);
+  });
+
+  it("blocks shortcuts in a textarea", () => {
+    expect(canOverrideAlphanumericInput([stub({ tagName: "TEXTAREA" })])).toBe(
+      false
+    );
+  });
+
+  it("blocks shortcuts in a text input", () => {
+    expect(
+      canOverrideAlphanumericInput([stub({ tagName: "INPUT", type: "text" })])
+    ).toBe(false);
+  });
+
+  it("allows shortcuts on inputs that are not typed into", () => {
+    for (const type of ["button", "checkbox", "hidden", "radio", "range"]) {
+      expect(
+        canOverrideAlphanumericInput([stub({ tagName: "INPUT", type })])
+      ).toBe(true);
+    }
+  });
+
+  it("blocks shortcuts in a contenteditable element", () => {
+    expect(
+      canOverrideAlphanumericInput([
+        stub({ tagName: "DIV", isContentEditable: true }),
+      ])
+    ).toBe(false);
+  });
+
+  it("blocks shortcuts when a contenteditable element is the event target inside a shadow root", () => {
+    expect(
+      canOverrideAlphanumericInput([
+        stub({ tagName: "SPAN", isContentEditable: true }),
+        stub({ tagName: "DIV" }),
+        stub({ tagName: "MY-CARD" }),
+      ])
+    ).toBe(false);
+  });
+
+  it("blocks shortcuts inside a code editor", () => {
+    expect(
+      canOverrideAlphanumericInput([
+        stub({ tagName: "DIV" }),
+        stub({ tagName: "HA-CODE-EDITOR" }),
+      ])
+    ).toBe(false);
+  });
+
+  it("blocks shortcuts inside a menu", () => {
+    expect(
+      canOverrideAlphanumericInput([
+        stub({ tagName: "DIV" }),
+        stub({ tagName: "HA-MENU" }),
+      ])
+    ).toBe(false);
+  });
+
+  it("blocks shortcuts on a select or dropdown child", () => {
+    expect(
+      canOverrideAlphanumericInput([
+        stub({ tagName: "DIV", parentElement: { tagName: "HA-SELECT" } }),
+      ])
+    ).toBe(false);
+    expect(
+      canOverrideAlphanumericInput([
+        stub({ tagName: "DIV", parentElement: { tagName: "HA-DROPDOWN" } }),
+      ])
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Proposed change

`canOverrideAlphanumericInput` decides whether a keystroke belongs to a global shortcut or to whatever the user is typing into. It exempts `<textarea>` and the text-entry `<input>` types, but has no branch for `contenteditable`, so an element the user is actively typing into is treated as fair game for shortcuts.

For an admin that means `a` opens Assist, `c` the command palette, `d` the device quick bar, `e` the entity quick bar and `m` creates a My link — in the middle of a word. Where the surrounding code commits on blur, the dialog taking focus also commits a half-typed value.

This adds `isContentEditable` to the same guard clause that already exempts `TEXTAREA`.

The repository already treats contenteditable as a typing surface everywhere else it makes this decision:

- `src/components/list/ha-list-base.ts` — `target.matches("[contenteditable],input,select,textarea")`
- `src/panels/config/integrations/ha-config-integrations-dashboard.ts` — `(activeElement as HTMLElement | null)?.isContentEditable`

and the `HA-CODE-EDITOR` tag name check at the top of this same function is arguably this omission handled narrowly for CodeMirror, which is contenteditable itself. So this brings the shortcut guard in line with the rest of the codebase rather than introducing a new convention.

I have deliberately left the `HA-CODE-EDITOR` entry in place. It is redundant in the common case, but it matches against the whole composed path rather than the event target, and narrowing that is a separate change from this one.

## How I ran into it, and why there is no linked issue

I hit this in a custom card that renames a column with a contenteditable element. Your bug template asks people not to report issues for custom cards, and routes enhancements to Discussions rather than issues, so neither issue route seemed right for a defect that is in this function rather than in the card. A small PR seemed the most honest option — happy to move this to a discussion instead if you would prefer that.

The card can and does defend itself with `stopPropagation`, so nothing here is blocking on my side. I am raising it because the guard looks incomplete against the repo's own conventions, not to get a workaround removed.

## Testing

Added `test/common/dom/can-override-input.test.ts`, covering the existing behaviours as well as the new one. There was no test for this function previously.

One thing worth flagging for reviewers: **jsdom does not implement `isContentEditable`**. It returns `undefined` on every element, including one carrying `contenteditable="true"`. I confirmed that directly rather than assuming it. A test written against real elements in the jsdom environment would therefore pass or fail for the wrong reason, so the test uses stub objects describing the shape the function actually reads. If you would rather it used real elements, that would need a different test environment for this file.

Verified separately in a real browser on 2026.7.2 that a keystroke typed into a contenteditable element does reach the `tinykeys` handler on `window`, which is the behaviour this changes.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
