### PR TITLE
Fix missing Internet heading in Home Assistant URL settings

### DIFF
--- a/src/panels/config/network/ha-config-url-form.ts
+++ b/src/panels/config/network/ha-config-url-form.ts
@@ -154,14 +154,12 @@ class ConfigUrlForm extends SubscribeMixin(LitElement) {
             ${this.hass.localize("ui.panel.config.url.description")}
           </div>
 
+          <h4>
+            ${this.hass.localize("ui.panel.config.url.external_url_label")}
+          </h4>
           ${
             hasCloud
               ? html`
-                  <h4>
-                    ${this.hass.localize(
-                      "ui.panel.config.url.external_url_label"
-                    )}
-                  </h4>
                   <ha-md-list-item>
                     <span slot="headline"
                       >${this.hass.localize(


### PR DESCRIPTION
## Proposed change

The "Internet" heading above the external URL field in **Settings → System →
Network → Home Assistant URL** is rendered inside the `hasCloud` conditional, so
it is only shown to users who are logged in to Home Assistant Cloud. The
"Local network" heading below it has no such condition and always renders.

For everyone without a Cloud login this leaves the external URL field with no
label at all, and makes "Local network" the only heading on the card — sitting
*below* the unlabeled field. Reading the card top to bottom, the external field
looks like it belongs to the local network section.

This is a regression. Before #22379 the label was shown to non-Cloud users too,
inline beside the field rather than as a heading:

```ts
<div class="flex">
  ${hasCloud
    ? ""
    : this.hass.localize("ui.panel.config.url.external_url_label")}
</div>
<ha-textfield name="external_url" ...>
```

Cloud users got it as a section header above the toggle; everyone else got it
inline. #22379 converted both labels to `<h4>` headings, kept the `hasCloud`
branch, and dropped the non-Cloud one.

This PR moves the heading out of the conditional so it renders for every user,
leaving `hasCloud` to gate only the "Use Home Assistant Cloud" toggle. The
external section then has the same structure as the local one: a heading
followed by its list item. No new strings — `ui.panel.config.url.external_url_label`
already exists and is already translated.

I hit this on a self-hosted instance and typed my external URL into the field I
believed was the internal one, because nothing on screen said otherwise.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml

```

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: regression from #22379
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
