### PR TITLE
Only show the sidebar tab switcher when its tabs are labelled

### DIFF
--- a/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
+++ b/src/panels/lovelace/strategies/home/home-overview-view-strategy.ts
@@ -587,10 +587,6 @@ export class HomeOverviewViewStrategy extends ReactiveElement {
       ...(sidebarSection && {
         sidebar: {
           sections: [sidebarSection],
-          content_label: hass.localize("ui.panel.lovelace.strategy.home.home"),
-          sidebar_label: hass.localize(
-            "ui.panel.lovelace.strategy.home.summaries"
-          ),
           visibility: [LARGE_SCREEN_CONDITION],
         },
       }),

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -176,6 +176,14 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
     const editMode = this.lovelace.editMode;
     const hasSidebar =
       this._config?.sidebar && (this._sidebarVisible || editMode);
+    // The narrow screen tab switcher is opt-in: a sidebar enables it by
+    // labelling both tabs, otherwise the sidebar stacks below the content.
+    const useMobileTabs = Boolean(
+      this.narrow &&
+      hasSidebar &&
+      this._config?.sidebar?.content_label &&
+      this._config?.sidebar?.sidebar_label
+    );
 
     const totalSectionCount =
       this._sectionColumnCount + (editMode ? 1 : 0) + (hasSidebar ? 1 : 0);
@@ -184,7 +192,8 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
       Math.min(this._maxColumns, totalSectionCount),
       1
     );
-    // On mobile with sidebar, use full width for whichever view is active
+    // On mobile with sidebar, content and sidebar both take full width
+    // (stacked, or switched between via the tabs when opted in)
     const contentColumnCount =
       hasSidebar && !this.narrow ? Math.max(1, columnCount - 1) : columnCount;
 
@@ -199,6 +208,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
           "top-margin": Boolean(this._config?.top_margin),
           "has-sidebar": Boolean(hasSidebar),
           narrow: this.narrow,
+          "mobile-tabs-enabled": useMobileTabs,
         })}"
         style=${styleMap({
           "--column-count": columnCount,
@@ -213,7 +223,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
           .config=${this._config?.header}
         ></hui-view-header>
         ${
-          this.narrow && hasSidebar
+          useMobileTabs
             ? html`
                 <div class="mobile-tabs">
                   <ha-control-select
@@ -246,7 +256,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
             <div
               class="content ${classMap({
                 dense: Boolean(this._config?.dense_section_placement),
-                "mobile-hidden": this.narrow && this._sidebarTabActive,
+                "mobile-hidden": useMobileTabs && this._sidebarTabActive,
               })}"
             >
               ${repeat(
@@ -334,7 +344,8 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
                   <hui-view-sidebar
                     class=${classMap({
                       "mobile-hidden":
-                        !hasSidebar || (this.narrow && !this._sidebarTabActive),
+                        !hasSidebar ||
+                        (useMobileTabs && !this._sidebarTabActive),
                     })}
                     .hass=${this.hass}
                     .badges=${this.badges}
@@ -613,6 +624,9 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
 
     .wrapper.narrow hui-view-sidebar {
       grid-column: 1 / -1;
+    }
+
+    .wrapper.narrow.mobile-tabs-enabled hui-view-sidebar {
       padding-bottom: calc(
         var(--ha-space-14) + var(--ha-space-3) + var(--safe-area-inset-bottom)
       );
@@ -663,7 +677,7 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
       grid-column: 1 / -1;
     }
 
-    .wrapper.narrow.has-sidebar .content {
+    .wrapper.narrow.mobile-tabs-enabled .content {
       padding-bottom: calc(
         var(--ha-space-14) + var(--ha-space-3) + var(--safe-area-inset-bottom)
       );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8999,7 +8999,6 @@
             "others": "Others",
             "scenes": "Scenes",
             "automations": "Automations",
-            "home": "Home",
             "favorites": "Favorites",
             "welcome_title": "No devices here yet",
             "welcome_content": "Add lights, switches, sensors, or other smart home devices to get started.",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The narrow-screen switcher between a view's content and its sidebar rendered whenever the viewport was ≤870px and the sidebar was visible, so between roughly 672px and 870px it put a fixed pill underneath the energy dashboard's sticky date selector — blank there, since the energy strategy sets no tab labels. It is now shown only when the sidebar labels both its tabs, which makes it opt-in without a new config option: the security dashboard keeps it, and the energy and home dashboards stack the sidebar below the content instead. The home strategy stops setting `content_label`/`sidebar_label`, and the translation key that leaves orphaned is removed.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53503
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


