### PR TITLE
Add favorites to Security dashboard

### DIFF
--- a/src/data/frontend.ts
+++ b/src/data/frontend.ts
@@ -44,6 +44,7 @@ export interface SecurityAlertEntityConfig {
 
 export interface SecurityFrontendSystemData {
   alert_entities?: SecurityAlertEntityConfig[];
+  favorite_entities?: string[];
 }
 
 export interface EnergyFrontendSystemData {

--- a/src/panels/home/components/home-favorite-entity-list-item.ts
+++ b/src/panels/home/components/home-favorite-entity-list-item.ts
@@ -1,12 +1,18 @@
+import { consume, type ContextType } from "@lit/context";
 import { mdiDelete } from "@mdi/js";
+import type { HassEntity } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
+import { consumeEntityState } from "../../../common/decorators/consume-context-entry";
 import { computeEntityPickerDisplay } from "../../../common/entity/compute_entity_name_display";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/entity/state-badge";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-settings-row";
-import type { HomeAssistant } from "../../../types";
+import {
+  internationalizationContext,
+  registriesContext,
+} from "../../../data/context";
 
 declare global {
   interface HASSDomEvents {
@@ -19,16 +25,33 @@ declare global {
 
 @customElement("home-favorite-entity-list-item")
 export class HomeFavoriteEntityListItem extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property({ attribute: "entity-id" }) public entityId!: string;
 
   @property({ type: Number }) public index = 0;
 
+  @state()
+  @consumeEntityState({ entityIdPath: ["entityId"] })
+  private _stateObj?: HassEntity;
+
+  @state()
+  @consume({ context: registriesContext, subscribe: true })
+  private _registries!: ContextType<typeof registriesContext>;
+
+  @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  private _i18n!: ContextType<typeof internationalizationContext>;
+
   protected render() {
-    const stateObj = this.hass.states[this.entityId];
+    const stateObj = this._stateObj;
     const { primary, secondary } = stateObj
-      ? computeEntityPickerDisplay(this.hass, stateObj)
+      ? computeEntityPickerDisplay(
+          {
+            ...this._registries,
+            language: this._i18n.language,
+            translationMetadata: this._i18n.translationMetadata,
+          },
+          stateObj
+        )
       : { primary: this.entityId, secondary: undefined };
 
     return html`
@@ -42,7 +65,7 @@ export class HomeFavoriteEntityListItem extends LitElement {
         }
         <ha-icon-button
           .path=${mdiDelete}
-          .label=${this.hass.localize("ui.common.delete")}
+          .label=${this._i18n.localize("ui.common.delete")}
           @click=${this._delete}
         ></ha-icon-button>
       </ha-settings-row>

--- a/src/panels/home/components/home-favorites-editor.ts
+++ b/src/panels/home/components/home-favorites-editor.ts
@@ -1,20 +1,20 @@
 import { mdiDragHorizontalVariant } from "@mdi/js";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
+import { consumeLocalize } from "../../../common/decorators/consume-context-entry";
 import { fireEvent, type HASSDomEvent } from "../../../common/dom/fire_event";
+import type { LocalizeFunc } from "../../../common/translations/localize";
 import type { HaEntityPicker } from "../../../components/entity/ha-entity-picker";
 import "../../../components/entity/ha-entity-picker";
 import "../../../components/ha-sortable";
 import "../../../components/ha-svg-icon";
 import type { HaEntityPickerEntityFilterFunc } from "../../../data/entity/entity";
-import type { HomeAssistant, ValueChangedEvent } from "../../../types";
+import type { ValueChangedEvent } from "../../../types";
 import "./home-favorite-entity-list-item";
 
 @customElement("home-favorites-editor")
 export class HomeFavoritesEditor extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @property({ attribute: false }) public favorites: string[] = [];
 
   @property() public label?: string;
@@ -25,6 +25,10 @@ export class HomeFavoritesEditor extends LitElement {
   public entityFilter?: HaEntityPickerEntityFilterFunc;
 
   @property({ attribute: "add-button-label" }) public addButtonLabel?: string;
+
+  @state()
+  @consumeLocalize()
+  private _localize!: LocalizeFunc;
 
   protected render() {
     return html`
@@ -44,7 +48,6 @@ export class HomeFavoritesEditor extends LitElement {
                 </div>
                 <home-favorite-entity-list-item
                   class="favorite-content"
-                  .hass=${this.hass}
                   .entityId=${entityId}
                   .index=${index}
                   @delete-favorite-entity=${this._remove}
@@ -58,7 +61,7 @@ export class HomeFavoritesEditor extends LitElement {
         add-button
         .addButtonLabel=${
           this.addButtonLabel ??
-          this.hass.localize(
+          this._localize(
             "ui.panel.lovelace.editor.strategy.home.add_favorite_entity"
           )
         }

--- a/src/panels/home/components/home-favorites-editor.ts
+++ b/src/panels/home/components/home-favorites-editor.ts
@@ -7,6 +7,7 @@ import type { HaEntityPicker } from "../../../components/entity/ha-entity-picker
 import "../../../components/entity/ha-entity-picker";
 import "../../../components/ha-sortable";
 import "../../../components/ha-svg-icon";
+import type { HaEntityPickerEntityFilterFunc } from "../../../data/entity/entity";
 import type { HomeAssistant, ValueChangedEvent } from "../../../types";
 import "./home-favorite-entity-list-item";
 
@@ -19,6 +20,11 @@ export class HomeFavoritesEditor extends LitElement {
   @property() public label?: string;
 
   @property() public helper?: string;
+
+  @property({ attribute: false })
+  public entityFilter?: HaEntityPickerEntityFilterFunc;
+
+  @property({ attribute: "add-button-label" }) public addButtonLabel?: string;
 
   protected render() {
     return html`
@@ -50,10 +56,14 @@ export class HomeFavoritesEditor extends LitElement {
       </ha-sortable>
       <ha-entity-picker
         add-button
-        .addButtonLabel=${this.hass.localize(
-          "ui.panel.lovelace.editor.strategy.home.add_favorite_entity"
-        )}
+        .addButtonLabel=${
+          this.addButtonLabel ??
+          this.hass.localize(
+            "ui.panel.lovelace.editor.strategy.home.add_favorite_entity"
+          )
+        }
         .excludeEntities=${this.favorites}
+        .entityFilter=${this.entityFilter}
         @value-changed=${this._add}
       ></ha-entity-picker>
     `;

--- a/src/panels/home/dialogs/dialog-edit-home.ts
+++ b/src/panels/home/dialogs/dialog-edit-home.ts
@@ -124,7 +124,6 @@ export class DialogEditHome
             ></ha-form>
 
             <home-favorites-editor
-              .hass=${this.hass}
               .favorites=${this._state.favorite_entities}
               .label=${this.hass.localize(
                 "ui.panel.lovelace.editor.strategy.home.favorite_entities"

--- a/src/panels/security/dialogs/dialog-edit-security.ts
+++ b/src/panels/security/dialogs/dialog-edit-security.ts
@@ -16,23 +16,15 @@ import {
 import { DialogMixin } from "../../../dialogs/dialog-mixin";
 import { DirtyStateProviderMixin } from "../../../mixins/dirty-state-provider-mixin";
 import { haStyleDialog } from "../../../resources/styles";
-import type { HomeAssistant, ValueChangedEvent } from "../../../types";
+import type { ValueChangedEvent } from "../../../types";
 import "../../home/components/home-favorites-editor";
 import "../components/security-alerts-editor";
 import { isSecurityPanelEntity } from "../strategies/security-view-strategy";
 import type { EditSecurityDialogParams } from "./show-dialog-edit-security";
 
-type SecurityDialogHass = Pick<
-  HomeAssistant,
-  | "states"
-  | "entities"
-  | "devices"
-  | "areas"
-  | "floors"
-  | "language"
-  | "translationMetadata"
-  | "localize"
->;
+type SecurityDialogContext = ContextType<typeof registriesContext> & {
+  states: ContextType<typeof statesContext>;
+};
 
 @customElement("dialog-edit-security")
 export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontendSystemData>()(
@@ -54,19 +46,14 @@ export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontend
   @consume({ context: registriesContext, subscribe: true })
   private _registries!: ContextType<typeof registriesContext>;
 
-  private _hassData?: SecurityDialogHass;
+  private _entityContext?: SecurityDialogContext;
 
   protected willUpdate(changedProps: PropertyValues): void {
     super.willUpdate(changedProps);
-    if (
-      changedProps.has("_states") ||
-      changedProps.has("_registries") ||
-      changedProps.has("_i18n")
-    ) {
-      this._hassData = {
+    if (changedProps.has("_states") || changedProps.has("_registries")) {
+      this._entityContext = {
         states: this._states,
         ...this._registries,
-        ...this._i18n,
       };
     }
   }
@@ -142,7 +129,6 @@ export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontend
         <ha-icon slot="leading-icon" icon="mdi:star-outline"></ha-icon>
         <div class="expansion-content">
           <home-favorites-editor
-            .hass=${this._hassData}
             .favorites=${this._state?.favorite_entities ?? []}
             .entityFilter=${this._alertEntityFilter}
             .addButtonLabel=${this._i18n.localize(
@@ -195,7 +181,9 @@ export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontend
   }
 
   private _alertEntityFilter = (entity: HassEntity) =>
-    this._hassData ? isSecurityPanelEntity(this._hassData, entity) : false;
+    this._entityContext
+      ? isSecurityPanelEntity(this._entityContext, entity)
+      : false;
 
   private async _save(): Promise<void> {
     if (!this.params || !this._state) return;

--- a/src/panels/security/dialogs/dialog-edit-security.ts
+++ b/src/panels/security/dialogs/dialog-edit-security.ts
@@ -65,9 +65,9 @@ export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontend
     }
     this._state = {
       ...this.params.config,
-      ...(this.params.config.favorite_entities
-        ? { favorite_entities: [...this.params.config.favorite_entities] }
-        : {}),
+      favorite_entities: this.params.config.favorite_entities
+        ? [...this.params.config.favorite_entities]
+        : [],
       alert_entities: this.params.config.alert_entities
         ? [...this.params.config.alert_entities]
         : [],

--- a/src/panels/security/dialogs/dialog-edit-security.ts
+++ b/src/panels/security/dialogs/dialog-edit-security.ts
@@ -1,5 +1,6 @@
 import { consume, type ContextType } from "@lit/context";
-import { css, html, LitElement, nothing } from "lit";
+import type { HassEntity } from "home-assistant-js-websocket";
+import { css, html, LitElement, nothing, type PropertyValues } from "lit";
 import { customElement, state } from "lit/decorators";
 import "../../../components/ha-button";
 import "../../../components/ha-dialog";
@@ -7,13 +8,31 @@ import "../../../components/ha-dialog-footer";
 import "../../../components/ha-expansion-panel";
 import "../../../components/ha-icon";
 import type { SecurityFrontendSystemData } from "../../../data/frontend";
-import { internationalizationContext } from "../../../data/context";
+import {
+  internationalizationContext,
+  registriesContext,
+  statesContext,
+} from "../../../data/context";
 import { DialogMixin } from "../../../dialogs/dialog-mixin";
 import { DirtyStateProviderMixin } from "../../../mixins/dirty-state-provider-mixin";
 import { haStyleDialog } from "../../../resources/styles";
-import type { ValueChangedEvent } from "../../../types";
+import type { HomeAssistant, ValueChangedEvent } from "../../../types";
+import "../../home/components/home-favorites-editor";
 import "../components/security-alerts-editor";
+import { isSecurityPanelEntity } from "../strategies/security-view-strategy";
 import type { EditSecurityDialogParams } from "./show-dialog-edit-security";
+
+type SecurityDialogHass = Pick<
+  HomeAssistant,
+  | "states"
+  | "entities"
+  | "devices"
+  | "areas"
+  | "floors"
+  | "language"
+  | "translationMetadata"
+  | "localize"
+>;
 
 @customElement("dialog-edit-security")
 export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontendSystemData>()(
@@ -27,6 +46,31 @@ export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontend
   @consume({ context: internationalizationContext, subscribe: true })
   private _i18n!: ContextType<typeof internationalizationContext>;
 
+  @state()
+  @consume({ context: statesContext, subscribe: true })
+  private _states!: ContextType<typeof statesContext>;
+
+  @state()
+  @consume({ context: registriesContext, subscribe: true })
+  private _registries!: ContextType<typeof registriesContext>;
+
+  private _hassData?: SecurityDialogHass;
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
+    if (
+      changedProps.has("_states") ||
+      changedProps.has("_registries") ||
+      changedProps.has("_i18n")
+    ) {
+      this._hassData = {
+        states: this._states,
+        ...this._registries,
+        ...this._i18n,
+      };
+    }
+  }
+
   public connectedCallback(): void {
     super.connectedCallback();
     if (!this.params) {
@@ -34,6 +78,9 @@ export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontend
     }
     this._state = {
       ...this.params.config,
+      ...(this.params.config.favorite_entities
+        ? { favorite_entities: [...this.params.config.favorite_entities] }
+        : {}),
       alert_entities: this.params.config.alert_entities
         ? [...this.params.config.alert_entities]
         : [],
@@ -86,6 +133,30 @@ export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontend
         expanded
         no-collapse
         .header=${this._i18n.localize(
+          "ui.panel.security.editor.favorite_entities"
+        )}
+        .secondary=${this._i18n.localize(
+          "ui.panel.security.editor.favorite_entities_description"
+        )}
+      >
+        <ha-icon slot="leading-icon" icon="mdi:star-outline"></ha-icon>
+        <div class="expansion-content">
+          <home-favorites-editor
+            .hass=${this._hassData}
+            .favorites=${this._state?.favorite_entities ?? []}
+            .entityFilter=${this._alertEntityFilter}
+            .addButtonLabel=${this._i18n.localize(
+              "ui.panel.security.editor.add_favorite_entity"
+            )}
+            @value-changed=${this._favoriteEntitiesChanged}
+          ></home-favorites-editor>
+        </div>
+      </ha-expansion-panel>
+      <ha-expansion-panel
+        outlined
+        expanded
+        no-collapse
+        .header=${this._i18n.localize(
           "ui.panel.security.editor.active_alert_entities"
         )}
         .secondary=${this._i18n.localize(
@@ -113,6 +184,19 @@ export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontend
     this._updateDirtyState(this._state);
   }
 
+  private _favoriteEntitiesChanged(
+    ev: ValueChangedEvent<SecurityFrontendSystemData["favorite_entities"]>
+  ): void {
+    this._state = {
+      ...this._state,
+      favorite_entities: ev.detail.value,
+    };
+    this._updateDirtyState(this._state);
+  }
+
+  private _alertEntityFilter = (entity: HassEntity) =>
+    this._hassData ? isSecurityPanelEntity(this._hassData, entity) : false;
+
   private async _save(): Promise<void> {
     if (!this.params || !this._state) return;
 
@@ -121,6 +205,9 @@ export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontend
     try {
       await this.params.saveConfig({
         ...this.params.config,
+        favorite_entities: this._state.favorite_entities?.length
+          ? this._state.favorite_entities
+          : undefined,
         alert_entities: this._state.alert_entities?.length
           ? this._state.alert_entities
           : undefined,
@@ -146,6 +233,10 @@ export class DialogEditSecurity extends DirtyStateProviderMixin<SecurityFrontend
         --expansion-panel-content-padding: 0;
         border-radius: var(--ha-border-radius-md);
         --ha-card-border-radius: var(--ha-border-radius-md);
+      }
+
+      ha-expansion-panel + ha-expansion-panel {
+        margin-top: var(--ha-space-4);
       }
 
       .expansion-content {

--- a/src/panels/security/ha-panel-security.ts
+++ b/src/panels/security/ha-panel-security.ts
@@ -183,6 +183,7 @@ class PanelSecurity extends LitElement {
         strategy: {
           ...SECURITY_LOVELACE_VIEW_CONFIG.strategy,
           alert_entities: this._config?.alert_entities,
+          favorite_entities: this._config?.favorite_entities,
         },
       },
       this.hass

--- a/src/panels/security/strategies/security-view-strategy.ts
+++ b/src/panels/security/strategies/security-view-strategy.ts
@@ -18,7 +18,10 @@ import type {
 import type { LovelaceViewConfig } from "../../../data/lovelace/config/view";
 import type { SecurityAlertEntityConfig } from "../../../data/frontend";
 import type { HomeAssistant } from "../../../types";
-import type { LogbookCardConfig } from "../../lovelace/cards/types";
+import type {
+  LogbookCardConfig,
+  TileCardConfig,
+} from "../../lovelace/cards/types";
 import { computeAreaTileCardConfig } from "../../lovelace/strategies/areas/helpers/areas-strategy-helper";
 import { computeSecurityAlertCardConfig } from "./security-alerts";
 
@@ -172,7 +175,6 @@ export class SecurityViewStrategy extends ReactiveElement {
     );
 
     if (favoriteEntities.length > 0) {
-      const computeTileCard = computeAreaTileCardConfig(hass, "", false);
       sections.push({
         type: "grid",
         column_span: 2,
@@ -184,7 +186,15 @@ export class SecurityViewStrategy extends ReactiveElement {
             ),
             heading_style: "title",
           },
-          ...favoriteEntities.map(computeTileCard),
+          ...favoriteEntities.map(
+            (entityId) =>
+              ({
+                type: "tile",
+                entity: entityId,
+                state_content: ["state", "area_name"],
+                show_entity_picture: true,
+              }) satisfies TileCardConfig
+          ),
         ],
       });
     }

--- a/src/panels/security/strategies/security-view-strategy.ts
+++ b/src/panels/security/strategies/security-view-strategy.ts
@@ -25,6 +25,7 @@ import { computeSecurityAlertCardConfig } from "./security-alerts";
 export interface SecurityViewStrategyConfig {
   type: "security";
   alert_entities?: SecurityAlertEntityConfig[];
+  favorite_entities?: string[];
 }
 
 export const securityEntityFilters: EntityFilter[] = [
@@ -163,6 +164,30 @@ export class SecurityViewStrategy extends ReactiveElement {
     );
 
     const entities = findEntities(allEntities, securityFilters);
+
+    const favoriteEntities = (config.favorite_entities ?? []).filter(
+      (entityId) =>
+        hass.states[entityId] &&
+        isSecurityPanelEntity(hass, hass.states[entityId])
+    );
+
+    if (favoriteEntities.length > 0) {
+      const computeTileCard = computeAreaTileCardConfig(hass, "", false);
+      sections.push({
+        type: "grid",
+        column_span: 2,
+        cards: [
+          {
+            type: "heading",
+            heading: hass.localize(
+              "ui.panel.lovelace.strategy.security.favorites"
+            ),
+            heading_style: "title",
+          },
+          ...favoriteEntities.map(computeTileCard),
+        ],
+      });
+    }
 
     const floorCount =
       hierarchy.floors.length + (hierarchy.areas.length ? 1 : 0);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2645,7 +2645,7 @@
           "title": "Edit security and safety page",
           "description": "Configure your security and safety display preferences.",
           "favorite_entities": "[%key:ui::panel::lovelace::editor::strategy::home::favorite_entities%]",
-          "favorite_entities_description": "Pin security and safety entities to the top of the page.",
+          "favorite_entities_description": "Pin entities to the top of the page.",
           "add_favorite_entity": "[%key:ui::panel::lovelace::editor::strategy::home::add_favorite_entity%]",
           "active_alert_entities": "Active alert entities",
           "active_alert_entities_description": "Display any entities that require attention.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2644,6 +2644,9 @@
         "editor": {
           "title": "Edit security and safety page",
           "description": "Configure your security and safety display preferences.",
+          "favorite_entities": "[%key:ui::panel::lovelace::editor::strategy::home::favorite_entities%]",
+          "favorite_entities_description": "Pin security and safety entities to the top of the page.",
+          "add_favorite_entity": "[%key:ui::panel::lovelace::editor::strategy::home::add_favorite_entity%]",
           "active_alert_entities": "Active alert entities",
           "active_alert_entities_description": "Display any entities that require attention.",
           "add_alert_entity": "Add entity",
@@ -9178,6 +9181,7 @@
             "devices": "Devices",
             "other_devices": "Other devices",
             "active_alerts": "Active alerts",
+            "favorites": "[%key:ui::panel::lovelace::strategy::home::favorites%]",
             "activity": "Activity"
           },
           "climate": {


### PR DESCRIPTION
## Breaking change


## Proposed change

Adds configurable favorites to the Security dashboard. Favorite entities are shown in their own section and can be managed alongside active alert entities in the Security dashboard editor.

Stacked on #53031.

## Screenshots

<img width="747" height="1336" alt="Security dashboard favorites" src="https://github.com/user-attachments/assets/d9779f29-805b-4ea3-bd83-bfa8542e53ec" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: closes #52951
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
