### PR TITLE
Add initial value setting to input_boolean helper dialog

### DIFF
--- a/src/panels/config/helpers/forms/ha-input_boolean-form.ts
+++ b/src/panels/config/helpers/forms/ha-input_boolean-form.ts
@@ -4,6 +4,9 @@ import { customElement, property, query, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-icon-picker";
 import "../../../../components/input/ha-input";
+import "../../../../components/radio/ha-radio-group";
+import type { HaRadioGroup } from "../../../../components/radio/ha-radio-group";
+import "../../../../components/radio/ha-radio-option";
 import type { InputBoolean } from "../../../../data/input_boolean";
 import { haStyle } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
@@ -22,6 +25,8 @@ class HaInputBooleanForm extends LitElement {
 
   @state() private _icon!: string;
 
+  @state() private _initial?: boolean;
+
   @query("[dialogInitialFocus]") private _focusElement?: HTMLElement;
 
   set item(item: InputBoolean) {
@@ -29,9 +34,11 @@ class HaInputBooleanForm extends LitElement {
     if (item) {
       this._name = item.name || "";
       this._icon = item.icon || "";
+      this._initial = item.initial;
     } else {
       this._name = "";
       this._icon = "";
+      this._initial = undefined;
     }
   }
 
@@ -70,8 +77,56 @@ class HaInputBooleanForm extends LitElement {
           )}
           .disabled=${this.disabled}
         ></ha-icon-picker>
+        <ha-radio-group
+          .label=${this.hass.localize(
+            "ui.dialogs.helper_settings.input_boolean.initial"
+          )}
+          .value=${
+            this._initial === undefined
+              ? "restore"
+              : this._initial
+                ? "on"
+                : "off"
+          }
+          .disabled=${this.disabled}
+          name="initial"
+          @change=${this._initialChanged}
+        >
+          <ha-radio-option value="restore">
+            ${this.hass.localize(
+              "ui.dialogs.helper_settings.input_boolean.restore"
+            )}
+          </ha-radio-option>
+          <ha-radio-option value="on">
+            ${this.hass.localize(
+              "ui.dialogs.helper_settings.input_boolean.turn_on"
+            )}
+          </ha-radio-option>
+          <ha-radio-option value="off">
+            ${this.hass.localize(
+              "ui.dialogs.helper_settings.input_boolean.turn_off"
+            )}
+          </ha-radio-option>
+        </ha-radio-group>
       </div>
     `;
+  }
+
+  private _initialChanged(ev: Event) {
+    const option = String((ev.currentTarget as HaRadioGroup).value);
+    const initial = option === "restore" ? undefined : option === "on";
+    if (initial === this._initial) {
+      return;
+    }
+    const newValue = { ...this._item } as InputBoolean;
+    if (initial === undefined) {
+      delete newValue.initial;
+    } else {
+      newValue.initial = initial;
+    }
+    fireEvent(this, "value-changed", {
+      value: newValue,
+    });
   }
 
   private _valueChanged(ev: CustomEvent) {
@@ -107,6 +162,9 @@ class HaInputBooleanForm extends LitElement {
         }
         ha-input {
           margin: var(--ha-space-2) 0;
+        }
+        ha-radio-group {
+          margin-top: var(--ha-space-5);
         }
       `,
     ];

--- a/src/panels/config/helpers/forms/ha-input_boolean-form.ts
+++ b/src/panels/config/helpers/forms/ha-input_boolean-form.ts
@@ -2,6 +2,7 @@ import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-expansion-panel";
 import "../../../../components/ha-icon-picker";
 import "../../../../components/input/ha-input";
 import "../../../../components/radio/ha-radio-group";
@@ -77,37 +78,47 @@ class HaInputBooleanForm extends LitElement {
           )}
           .disabled=${this.disabled}
         ></ha-icon-picker>
-        <ha-radio-group
-          .label=${this.hass.localize(
-            "ui.dialogs.helper_settings.input_boolean.initial"
+        <ha-expansion-panel
+          header=${this.hass.localize(
+            "ui.dialogs.helper_settings.generic.more_options"
           )}
-          .value=${
-            this._initial === undefined
-              ? "restore"
-              : this._initial
-                ? "on"
-                : "off"
-          }
-          .disabled=${this.disabled}
-          name="initial"
-          @change=${this._initialChanged}
+          outlined
         >
-          <ha-radio-option value="restore">
-            ${this.hass.localize(
-              "ui.dialogs.helper_settings.input_boolean.restore"
+          <ha-radio-group
+            .label=${this.hass.localize(
+              "ui.dialogs.helper_settings.input_boolean.initial"
             )}
-          </ha-radio-option>
-          <ha-radio-option value="on">
-            ${this.hass.localize(
-              "ui.dialogs.helper_settings.input_boolean.turn_on"
+            .hint=${this.hass.localize(
+              "ui.dialogs.helper_settings.input_boolean.initial_helper"
             )}
-          </ha-radio-option>
-          <ha-radio-option value="off">
-            ${this.hass.localize(
-              "ui.dialogs.helper_settings.input_boolean.turn_off"
-            )}
-          </ha-radio-option>
-        </ha-radio-group>
+            .value=${
+              this._initial === undefined
+                ? "restore"
+                : this._initial
+                  ? "on"
+                  : "off"
+            }
+            .disabled=${this.disabled}
+            name="initial"
+            @change=${this._initialChanged}
+          >
+            <ha-radio-option value="restore">
+              ${this.hass.localize(
+                "ui.dialogs.helper_settings.input_boolean.restore"
+              )}
+            </ha-radio-option>
+            <ha-radio-option value="on">
+              ${this.hass.localize(
+                "ui.dialogs.helper_settings.input_boolean.turn_on"
+              )}
+            </ha-radio-option>
+            <ha-radio-option value="off">
+              ${this.hass.localize(
+                "ui.dialogs.helper_settings.input_boolean.turn_off"
+              )}
+            </ha-radio-option>
+          </ha-radio-group>
+        </ha-expansion-panel>
       </div>
     `;
   }
@@ -163,8 +174,11 @@ class HaInputBooleanForm extends LitElement {
         ha-input {
           margin: var(--ha-space-2) 0;
         }
-        ha-radio-group {
-          margin-top: var(--ha-space-5);
+        ha-expansion-panel {
+          margin-top: var(--ha-space-4);
+        }
+        ha-expansion-panel ha-radio-group {
+          margin: var(--ha-space-4) 0;
         }
       `,
     ];

--- a/src/panels/config/helpers/forms/ha-input_boolean-form.ts
+++ b/src/panels/config/helpers/forms/ha-input_boolean-form.ts
@@ -1,9 +1,13 @@
+import { mdiInformationOutline } from "@mdi/js";
 import type { CSSResultGroup } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import { stopPropagation } from "../../../../common/dom/stop_propagation";
 import "../../../../components/ha-expansion-panel";
 import "../../../../components/ha-icon-picker";
+import "../../../../components/ha-svg-icon";
+import "../../../../components/ha-tooltip";
 import "../../../../components/input/ha-input";
 import "../../../../components/radio/ha-radio-group";
 import type { HaRadioGroup } from "../../../../components/radio/ha-radio-group";
@@ -85,12 +89,6 @@ class HaInputBooleanForm extends LitElement {
           outlined
         >
           <ha-radio-group
-            .label=${this.hass.localize(
-              "ui.dialogs.helper_settings.input_boolean.initial"
-            )}
-            .hint=${this.hass.localize(
-              "ui.dialogs.helper_settings.input_boolean.initial_helper"
-            )}
             .value=${
               this._initial === undefined
                 ? "restore"
@@ -102,6 +100,18 @@ class HaInputBooleanForm extends LitElement {
             name="initial"
             @change=${this._initialChanged}
           >
+            <span slot="label">
+              ${this.hass.localize(
+                "ui.dialogs.helper_settings.input_boolean.initial"
+              )}
+              <ha-svg-icon
+                id="initial-note"
+                tabindex="0"
+                class="note-icon"
+                .path=${mdiInformationOutline}
+                @click=${stopPropagation}
+              ></ha-svg-icon>
+            </span>
             <ha-radio-option value="restore">
               ${this.hass.localize(
                 "ui.dialogs.helper_settings.input_boolean.restore"
@@ -118,6 +128,11 @@ class HaInputBooleanForm extends LitElement {
               )}
             </ha-radio-option>
           </ha-radio-group>
+          <ha-tooltip for="initial-note" placement="top">
+            ${this.hass.localize(
+              "ui.dialogs.helper_settings.input_boolean.initial_helper"
+            )}
+          </ha-tooltip>
         </ha-expansion-panel>
       </div>
     `;
@@ -179,6 +194,12 @@ class HaInputBooleanForm extends LitElement {
         }
         ha-expansion-panel ha-radio-group {
           margin: var(--ha-space-4) 0;
+        }
+        .note-icon {
+          margin-inline-start: var(--ha-space-1);
+          color: var(--secondary-text-color);
+          --mdc-icon-size: 18px;
+          vertical-align: middle;
         }
       `,
     ];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2142,6 +2142,12 @@
           "icon": "Icon",
           "more_options": "[%key:ui::dialogs::restart::more_options%]"
         },
+        "input_boolean": {
+          "initial": "When Home Assistant starts",
+          "restore": "Restore previous state",
+          "turn_on": "Turn on",
+          "turn_off": "Turn off"
+        },
         "input_datetime": {
           "date": "Date",
           "time": "Time",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2143,7 +2143,8 @@
           "more_options": "[%key:ui::dialogs::restart::more_options%]"
         },
         "input_boolean": {
-          "initial": "When Home Assistant starts",
+          "initial": "Each time Home Assistant starts",
+          "initial_helper": "Changing this does not affect the toggle right now.",
           "restore": "Restore previous state",
           "turn_on": "Turn on",
           "turn_off": "Turn off"


### PR DESCRIPTION
## Proposed change

The input_boolean helper dialog now exposes what happens to the toggle when Home Assistant starts: restore the previous state (default), turn on, or turn off. This mirrors the `initial` field core already supports over the websocket, which previously had no UI. Leaving the default preserves today's behavior.

This was not added to the UI deliberately because it's not straightforward to explain but I want to propose this UI to handle it. This is how most smart plugs and switches handle it already so the precedent is there.

## Screenshots

The dialog is unchanged until "More options" is opened.

<img width="1600" alt="Create Toggle dialog with More options collapsed" src="https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/pr1-collapsed-7d45e431.png" />

Expanded, with "Restore previous state" as the default.

<img width="1600" alt="More options expanded, showing the three start-up options" src="https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/pr2-expanded-c27f78b1.png" />

The info icon notes that the choice takes effect on the next start rather than immediately.

<img width="1600" alt="Tooltip on the info icon next to the setting label" src="https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/pr3-tooltip-f0be0665.png" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #53500
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

