### PR TITLE
Reserve scrollbar gutter in more-info dialog to prevent flicker

### DIFF
--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -1063,12 +1063,9 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
           outline: none;
           flex: 1;
           overflow: auto;
-          /* Reserve the scrollbar gutter so toggling the scrollbar cannot
-             change the content width. Without this, on platforms with classic
-             (space-consuming) scrollbars the layout can enter a feedback loop
-             when the content height sits right at the overflow threshold:
-             scrollbar appears -> content narrows -> reflows to fit ->
-             scrollbar disappears -> content widens -> overflows again. */
+          /* Keep the content width constant when the scrollbar toggles;
+             otherwise width-dependent content can flicker at the overflow
+             threshold (#53228). */
           scrollbar-gutter: stable;
         }
 

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -1063,6 +1063,13 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
           outline: none;
           flex: 1;
           overflow: auto;
+          /* Reserve the scrollbar gutter so toggling the scrollbar cannot
+             change the content width. Without this, on platforms with classic
+             (space-consuming) scrollbars the layout can enter a feedback loop
+             when the content height sits right at the overflow threshold:
+             scrollbar appears -> content narrows -> reflows to fit ->
+             scrollbar disappears -> content widens -> overflows again. */
+          scrollbar-gutter: stable;
         }
 
         .content-wrapper.settings-view .fade-bottom {


### PR DESCRIPTION
## Proposed change

Reserve the scrollbar gutter on the more-info dialog's scroll container so that
toggling the vertical scrollbar can no longer change the content width.

On platforms with classic (space-consuming) scrollbars — e.g. desktop
Chrome/Edge on Windows — the dialog could enter a layout feedback loop when the
content height sits right at the overflow threshold: the scrollbar appears →
the content area becomes narrower → the width-dependent content (history graph)
gets shorter and now fits → the scrollbar is removed → the content area becomes
wider → it overflows again → repeat. The result is a rapid flicker (~10×/s) with
the content jumping horizontally by the scrollbar width on every cycle. The
`ResizeController` in `ScrollableFadeMixin`, which observes the scroll element,
reacts to each width change and keeps the loop alive.

The fix adds `scrollbar-gutter: stable` to the `.content` scroll container in
`ha-more-info-dialog`. With the gutter permanently reserved, the content width
stays constant whether or not the scrollbar is visible, so the feedback loop can
never start. On platforms with overlay scrollbars (mobile, macOS) the property
has no effect, so there is no visual change there.

The property is applied narrowly to the dialog's own scroll container rather
than to the shared `.ha-scrollbar` helper, to avoid reserving a gutter for
scroll areas throughout the app. This mirrors the existing use of
`scrollbar-gutter: stable` in `scroll-lock-mixin.ts`.

## Screenshots

<!--
  The visible flicker only occurs with classic (space-consuming) scrollbars
  (Windows desktop Chrome/Edge). A before/after recording on such a platform is
  the ideal screenshot here. The original report includes a screen recording of
  the flicker: https://github.com/home-assistant/frontend/issues/53228

  Verification of the mechanism (browser measurement): with `overflow: auto`
  the scroll container's content width shifts by 15px (360px -> 345px) when the
  scrollbar toggles; with `scrollbar-gutter: stable` it stays constant at 345px
  (0px shift), which removes the driver of the loop.
-->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #53228
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
