### PR TITLE
Fix link to different port being handled as internal link

### DIFF
--- a/src/common/dom/is-navigation-click.ts
+++ b/src/common/dom/is-navigation-click.ts
@@ -23,24 +23,24 @@ export const isNavigationClick = (e: MouseEvent, preventDefault = true) => {
     return undefined;
   }
 
-  let href = anchor.href;
-  if (!href || href.indexOf("mailto:") !== -1) {
+  let url: URL;
+  try {
+    // anchor.href is always absolute; an empty or unparseable value throws.
+    url = new URL(anchor.href);
+  } catch {
     return undefined;
   }
 
-  const location = window.location;
-  const origin = location.origin || location.protocol + "//" + location.host;
-  if (!href.startsWith(origin)) {
-    return undefined;
-  }
-  href = href.slice(origin.length);
-
-  if (href === "#") {
+  // Only intercept same-origin links. A different scheme, host, or port is a
+  // different origin (e.g. another port like ":8123") and must trigger a full
+  // browser navigation instead of an in-app route change. Non-http(s) schemes
+  // such as mailto: resolve to a null origin and are excluded here too.
+  if (url.origin !== window.location.origin) {
     return undefined;
   }
 
   if (preventDefault) {
     e.preventDefault();
   }
-  return href;
+  return url.pathname + url.search + url.hash;
 };

--- a/src/panels/config/network/ha-config-http-form.ts
+++ b/src/panels/config/network/ha-config-http-form.ts
@@ -462,7 +462,7 @@ class HaConfigHttpForm extends LitElement {
             "ui.panel.config.network.http.restart_address.text"
           )}
         </p>
-        <a href=${url} rel="noreferrer noopener">${url}</a>
+        <a href=${url} target="_blank" rel="noreferrer noopener">${url}</a>
         <p class="dialog-note">
           ${this.hass.localize(
             "ui.panel.config.network.http.restart_address.note"

--- a/test/common/dom/is-navigation-click.test.ts
+++ b/test/common/dom/is-navigation-click.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { isNavigationClick } from "../../../src/common/dom/is-navigation-click";
+
+const createAnchor = (
+  href: string,
+  attributes: Record<string, string> = {}
+): HTMLAnchorElement => {
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  for (const [name, value] of Object.entries(attributes)) {
+    anchor.setAttribute(name, value);
+  }
+  return anchor;
+};
+
+const clickEvent = (
+  anchor: HTMLAnchorElement,
+  overrides: Partial<MouseEvent> = {}
+): MouseEvent =>
+  ({
+    defaultPrevented: false,
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    composedPath: () => [anchor],
+    preventDefault: vi.fn(),
+    ...overrides,
+  }) as unknown as MouseEvent;
+
+describe("isNavigationClick", () => {
+  it("returns the path for same-origin links", () => {
+    expect(
+      isNavigationClick(clickEvent(createAnchor(`${location.origin}/config`)))
+    ).toEqual("/config");
+    expect(
+      isNavigationClick(
+        clickEvent(createAnchor(`${location.origin}/energy?historyBack=1`))
+      )
+    ).toEqual("/energy?historyBack=1");
+    expect(
+      isNavigationClick(
+        clickEvent(createAnchor(`${location.origin}/config/areas#section`))
+      )
+    ).toEqual("/config/areas#section");
+  });
+
+  it("does not intercept a link on a different port", () => {
+    // The current origin has no port, so a ported URL shares its string prefix
+    // but is a different origin — it must not be treated as internal.
+    expect(
+      isNavigationClick(clickEvent(createAnchor(`${location.origin}:8123/`)))
+    ).toBeUndefined();
+  });
+
+  it("does not intercept a host that merely starts with the origin", () => {
+    expect(
+      isNavigationClick(
+        clickEvent(createAnchor(`${location.origin}.example.com/`))
+      )
+    ).toBeUndefined();
+  });
+
+  it("does not intercept other origins", () => {
+    expect(
+      isNavigationClick(clickEvent(createAnchor("https://example.com/")))
+    ).toBeUndefined();
+  });
+
+  it("calls preventDefault for intercepted navigations", () => {
+    const event = clickEvent(createAnchor(`${location.origin}/config`));
+    isNavigationClick(event);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("does not preventDefault when disabled", () => {
+    const event = clickEvent(createAnchor(`${location.origin}/config`));
+    expect(isNavigationClick(event, false)).toEqual("/config");
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ignores clicks with a target, download, or rel=external", () => {
+    expect(
+      isNavigationClick(
+        clickEvent(
+          createAnchor(`${location.origin}/config`, { target: "_blank" })
+        )
+      )
+    ).toBeUndefined();
+    expect(
+      isNavigationClick(
+        clickEvent(createAnchor(`${location.origin}/config`, { download: "" }))
+      )
+    ).toBeUndefined();
+    expect(
+      isNavigationClick(
+        clickEvent(
+          createAnchor(`${location.origin}/config`, { rel: "external" })
+        )
+      )
+    ).toBeUndefined();
+  });
+
+  it("ignores modified clicks and non-left buttons", () => {
+    const anchor = createAnchor(`${location.origin}/config`);
+    expect(
+      isNavigationClick(clickEvent(anchor, { button: 1 }))
+    ).toBeUndefined();
+    expect(
+      isNavigationClick(clickEvent(anchor, { metaKey: true }))
+    ).toBeUndefined();
+    expect(
+      isNavigationClick(clickEvent(anchor, { ctrlKey: true }))
+    ).toBeUndefined();
+    expect(
+      isNavigationClick(clickEvent(anchor, { shiftKey: true }))
+    ).toBeUndefined();
+    expect(
+      isNavigationClick(clickEvent(anchor, { defaultPrevented: true }))
+    ).toBeUndefined();
+  });
+
+  it("ignores mailto links and clicks without an anchor", () => {
+    expect(
+      isNavigationClick(clickEvent(createAnchor("mailto:test@example.com")))
+    ).toBeUndefined();
+    expect(
+      isNavigationClick(
+        clickEvent(undefined as any, {
+          composedPath: () => [document.createElement("div")],
+        })
+      )
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION


## Proposed change

Fixes links to a different port on the same host being treated as internal in-app navigation.

isNavigationClick decided whether a clicked link was internal with a naive href.startsWith(origin) check. When the current origin has no explicit port (e.g. http://homeassistant.local on port 80), a link to a different port like http://homeassistant.local:8123/ shares that string prefix, so it was wrongly treated as internal: the origin was sliced off, leaving :8123/, and the router navigated to a broken /config/:8123/.

It now parses the href with URL() and compares real origins (url.origin !== location.origin), which correctly accounts for scheme, host, and port. As a bonus this drops the separate mailto: check (non-http schemes resolve to a null origin) and the now-dead # guard. Added unit tests covering same-origin paths, different ports, prefix-only hosts, other origins, target/download/rel=external, modified clicks, and mailto:.

The target="_blank" on the "new address" link in the HTTP form is included so that link opens the (different-origin) address in a new tab.


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
