### PR TITLE
Wait with showing pending http changes dialog until loading screen is…

### DIFF
--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -102,13 +102,12 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
     ) {
       this.checkDataBaseMigration();
     }
-    // Wait for `hass.user` to populate so the admin guard can run; it arrives
-    // asynchronously after `hass.config`.
-    if (
-      changedProps.has("hass") &&
-      this.hass?.user &&
-      oldHass?.user !== this.hass.user
-    ) {
+    // Wait for `hass.user` to first populate so the admin guard can run; it
+    // arrives asynchronously after `hass.config`. `hass.user` also gets a fresh
+    // reference at runtime (reconnect, profile refresh via subscribeUser), so
+    // only trigger on the initial population (null -> user). Reconnect re-checks
+    // come from connection-mixin, the launch-screen swap re-check from update().
+    if (changedProps.has("hass") && this.hass?.user && !oldHass?.user) {
       this.checkHttpPendingConfig();
     }
     if (
@@ -136,6 +135,9 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
       // partial-panel-resolver removes the launch screen after the first panel
       // is ready. Native apps request instant removal because their own splash
       // screen covers the frontend until frontend/loaded is sent.
+      // The launch screen is gone now, so it's safe to surface the HTTP pending
+      // config dialog; showing it earlier gets it torn out by this swap.
+      this.checkHttpPendingConfig();
     }
     super.update(changedProps);
   }
@@ -254,6 +256,13 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
 
   protected async checkHttpPendingConfig() {
     if (__DEMO__ || this._httpPendingDialogOpen) {
+      return;
+    }
+    // Only show once the main UI is rendered. During startup the root swaps
+    // the launch screen for the app, which clears its shadow root and would
+    // tear the freshly-appended dialog straight back out of the DOM (closing
+    // it). When called too early we skip; the swap in update() re-runs this.
+    if (this.render !== this.renderHass) {
       return;
     }
     if (!this.hass?.user?.is_admin) {

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -124,22 +124,26 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
   }
 
   protected update(changedProps: PropertyValues<this>) {
-    if (
-      this.hass?.states &&
-      this.hass.config &&
-      this.hass.services &&
-      this._databaseMigration === false
-    ) {
+    const removingLaunchScreen =
+      !!this.hass?.states &&
+      !!this.hass.config &&
+      !!this.hass.services &&
+      this._databaseMigration === false;
+    if (removingLaunchScreen) {
       this.render = this.renderHass;
       this.update = super.update;
       // partial-panel-resolver removes the launch screen after the first panel
       // is ready. Native apps request instant removal because their own splash
       // screen covers the frontend until frontend/loaded is sent.
-      // The launch screen is gone now, so it's safe to surface the HTTP pending
-      // config dialog; showing it earlier gets it torn out by this swap.
-      this.checkHttpPendingConfig();
     }
     super.update(changedProps);
+    if (removingLaunchScreen) {
+      // Surface the HTTP pending config dialog only after super.update() has
+      // committed the render swap above, which clears the launch screen from
+      // the shadow root. Appending the dialog before that render would let it
+      // tear the freshly-added dialog straight back out of the DOM.
+      this.checkHttpPendingConfig();
+    }
   }
 
   protected firstUpdated(changedProps: PropertyValues<this>) {


### PR DESCRIPTION
… gone

## Proposed change

Fixes the HTTP pending-config confirm dialog ("Confirm new HTTP server configuration") getting dismissed on its own right after it appears.

The dialog was surfaced during startup, while the app was still showing the launch screen. When the root swaps its template from the launch screen to the main app, lit-html clears the shadow root — which removed the freshly-appended <dialog> from the DOM, closing it before the user could confirm or revert. The auto-revert then kicked in after 5 minutes, defeating the whole confirm flow.

Changes in home-assistant.ts:

checkHttpPendingConfig() now no-ops while the launch screen is still shown (render !== renderHass), so it can't be torn out by the render swap.
The check is re-run right after the launch-screen → app render swap is committed (update(), after super.update()), so the dialog mounts into the stable main UI.
The willUpdate trigger now fires only on the first hass.user population instead of on every user-object change, since hass.user gets a fresh reference on every reconnect and profile refresh (via subscribeUser) — avoiding redundant fetchHttpConfig calls at runtime.


## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
