### PR TITLE
Fix areas/floors reorder config page

### DIFF
--- a/src/common/util/preserve-unchanged-record.ts
+++ b/src/common/util/preserve-unchanged-record.ts
@@ -11,13 +11,23 @@
 export const preserveUnchangedRecord = <T>(
   previous: Record<string, T> | undefined,
   next: Record<string, T>,
-  equal: (a: T, b: T) => boolean
+  equal: (a: T, b: T) => boolean,
+  compareOrder = false
 ): Record<string, T> => {
   if (!previous) {
     return next;
   }
-  let changed = Object.keys(previous).length !== Object.keys(next).length;
-  for (const key of Object.keys(next)) {
+
+  const previousKeys = Object.keys(previous);
+  const nextKeys = Object.keys(next);
+
+  let changed = previousKeys.length !== nextKeys.length;
+
+  if (!changed && compareOrder) {
+    changed = previousKeys.some((key, index) => key !== nextKeys[index]);
+  }
+
+  for (const key of nextKeys) {
     const previousItem = previous[key];
     if (previousItem !== undefined && equal(previousItem, next[key])) {
       next[key] = previousItem;

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -300,7 +300,8 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         const updatedAreas = preserveUnchangedRecord(
           this.hass?.areas,
           areas,
-          deepEqual
+          deepEqual,
+          true
         );
         if (updatedAreas !== this.hass?.areas) {
           this._updateHass({ areas: updatedAreas });
@@ -314,7 +315,8 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         const updatedFloors = preserveUnchangedRecord(
           this.hass?.floors,
           floors,
-          deepEqual
+          deepEqual,
+          true
         );
         if (updatedFloors !== this.hass?.floors) {
           this._updateHass({ floors: updatedFloors });

--- a/test/common/util/preserve-unchanged-record.test.ts
+++ b/test/common/util/preserve-unchanged-record.test.ts
@@ -11,50 +11,90 @@ interface Item {
 const record = (...items: Item[]): Record<string, Item> =>
   Object.fromEntries(items.map((i) => [i.id, i]));
 
-describe("preserveUnchangedRecord", () => {
-  it("returns next as-is when there is no previous record", () => {
-    const next = record({ id: "a", name: "A" });
-    expect(preserveUnchangedRecord(undefined, next, deepEqual)).toBe(next);
-  });
+describe.each([false, true])(
+  "preserveUnchangedRecord (compareOrder: %s)",
+  (compareOrder) => {
+    it("returns next as-is when there is no previous record", () => {
+      const next = record({ id: "a", name: "A" });
+      expect(
+        preserveUnchangedRecord(undefined, next, deepEqual, compareOrder)
+      ).toBe(next);
+    });
 
-  it("returns the previous record when nothing changed", () => {
-    const previous = record({ id: "a", name: "A" }, { id: "b", name: "B" });
-    const next = record({ id: "a", name: "A" }, { id: "b", name: "B" });
-    expect(preserveUnchangedRecord(previous, next, deepEqual)).toBe(previous);
-  });
+    it("returns the previous record when nothing changed", () => {
+      const previous = record({ id: "a", name: "A" }, { id: "b", name: "B" });
+      const next = record({ id: "a", name: "A" }, { id: "b", name: "B" });
+      expect(
+        preserveUnchangedRecord(previous, next, deepEqual, compareOrder)
+      ).toBe(previous);
+    });
 
-  it("reuses unchanged item objects and only swaps the changed one", () => {
-    const previous = record({ id: "a", name: "A" }, { id: "b", name: "B" });
-    const next = record({ id: "a", name: "A" }, { id: "b", name: "B2" });
-    const result = preserveUnchangedRecord(previous, next, deepEqual);
-    expect(result).toBe(next);
-    expect(result.a).toBe(previous.a);
-    expect(result.b).toBe(next.b);
-  });
+    it("reuses unchanged item objects and only swaps the changed one", () => {
+      const previous = record({ id: "a", name: "A" }, { id: "b", name: "B" });
+      const next = record({ id: "a", name: "A" }, { id: "b", name: "B2" });
+      const result = preserveUnchangedRecord(
+        previous,
+        next,
+        deepEqual,
+        compareOrder
+      );
+      expect(result).toBe(next);
+      expect(result.a).toBe(previous.a);
+      expect(result.b).toBe(next.b);
+    });
 
-  it("deep-compares nested values", () => {
-    const previous = record({ id: "a", name: "A", labels: ["x", "y"] });
-    const next = record({ id: "a", name: "A", labels: ["x", "y"] });
-    // New nested array, equal content -> treated as unchanged.
-    expect(preserveUnchangedRecord(previous, next, deepEqual)).toBe(previous);
+    it("deep-compares nested values", () => {
+      const previous = record({ id: "a", name: "A", labels: ["x", "y"] });
+      const next = record({ id: "a", name: "A", labels: ["x", "y"] });
+      // New nested array, equal content -> treated as unchanged.
+      expect(
+        preserveUnchangedRecord(previous, next, deepEqual, compareOrder)
+      ).toBe(previous);
 
-    const changedNext = record({ id: "a", name: "A", labels: ["x", "z"] });
-    const result = preserveUnchangedRecord(previous, changedNext, deepEqual);
-    expect(result).toBe(changedNext);
-    expect(result.a).toBe(changedNext.a);
-  });
+      const changedNext = record({ id: "a", name: "A", labels: ["x", "z"] });
+      const result = preserveUnchangedRecord(
+        previous,
+        changedNext,
+        deepEqual,
+        compareOrder
+      );
+      expect(result).toBe(changedNext);
+      expect(result.a).toBe(changedNext.a);
+    });
 
-  it("returns next when an item is added", () => {
-    const previous = record({ id: "a", name: "A" });
-    const next = record({ id: "a", name: "A" }, { id: "b", name: "B" });
-    const result = preserveUnchangedRecord(previous, next, deepEqual);
-    expect(result).toBe(next);
-    expect(result.a).toBe(previous.a);
-  });
+    it("returns next when an item is added", () => {
+      const previous = record({ id: "a", name: "A" });
+      const next = record({ id: "a", name: "A" }, { id: "b", name: "B" });
+      const result = preserveUnchangedRecord(
+        previous,
+        next,
+        deepEqual,
+        compareOrder
+      );
+      expect(result).toBe(next);
+      expect(result.a).toBe(previous.a);
+    });
 
-  it("returns next when an item is removed", () => {
-    const previous = record({ id: "a", name: "A" }, { id: "b", name: "B" });
-    const next = record({ id: "a", name: "A" });
-    expect(preserveUnchangedRecord(previous, next, deepEqual)).toBe(next);
-  });
-});
+    it("returns next when an item is removed", () => {
+      const previous = record({ id: "a", name: "A" }, { id: "b", name: "B" });
+      const next = record({ id: "a", name: "A" });
+      expect(
+        preserveUnchangedRecord(previous, next, deepEqual, compareOrder)
+      ).toBe(next);
+    });
+
+    it("appropriately compares if order has changed", () => {
+      const previous = record({ id: "a", name: "A" }, { id: "b", name: "B" });
+      const next = record({ id: "b", name: "B" }, { id: "a", name: "A" });
+      const result = preserveUnchangedRecord(
+        previous,
+        next,
+        deepEqual,
+        compareOrder
+      );
+      expect(result).toBe(compareOrder ? next : previous);
+      expect(result.a).toBe(previous.a);
+      expect(result.b).toBe(previous.b);
+    });
+  }
+);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Reordering floors and areas on the config page does not currently work correctly:

- config_registry call is made to reorder the floors
- connection-mixin gets an update to the floorRegistry
- A perf optimization compares that each of the floors in the update is deepEqual with the previous update, _but ignores that the keys are in a different order_. It falsely optimizes this to think it does not need to update hass.
- The floors config page does not visually update when floors are reordered.

The fixes the preserve-unchanged function with an optional argument to also compare the order of the keys. It is not believed to be needed for entities or devices, so only areas and floors get the new behavior. 

This may be related to https://github.com/home-assistant/frontend/issues/29757, but the initial bug report was months before this code optimization was added, so if there is some other issue there don't want to close it prematurely. 

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
