### PR TITLE
Fix toggle action for covers that only support tilt

### DIFF
--- a/src/common/entity/can_toggle_state.ts
+++ b/src/common/entity/can_toggle_state.ts
@@ -3,7 +3,7 @@ import type { HomeAssistant } from "../../types";
 import { canToggleDomain } from "./can_toggle_domain";
 import { computeStateDomain } from "./compute_state_domain";
 import { supportsFeature } from "./supports-feature";
-import { SPECIAL_TOGGLE_ACTIONS } from "./get_toggle_action";
+import { getSpecialToggleAction } from "./get_toggle_action";
 
 export const canToggleState = (hass: HomeAssistant, stateObj: HassEntity) => {
   const domain = computeStateDomain(stateObj);
@@ -26,13 +26,10 @@ export const canToggleState = (hass: HomeAssistant, stateObj: HassEntity) => {
     return false;
   }
 
-  if (
-    domain in SPECIAL_TOGGLE_ACTIONS &&
-    SPECIAL_TOGGLE_ACTIONS[domain].feature
-  ) {
-    return SPECIAL_TOGGLE_ACTIONS[domain].feature.every((f) =>
-      supportsFeature(stateObj, f)
-    );
+  const toggleAction = getSpecialToggleAction(domain, stateObj);
+
+  if (toggleAction?.feature) {
+    return toggleAction.feature.every((f) => supportsFeature(stateObj, f));
   }
 
   return canToggleDomain(hass, domain);

--- a/src/common/entity/get_toggle_action.ts
+++ b/src/common/entity/get_toggle_action.ts
@@ -1,8 +1,10 @@
+import type { HassEntity } from "home-assistant-js-websocket";
 import { CameraEntityFeature } from "../../data/feature/camera_entity_feature";
 import { ClimateEntityFeature } from "../../data/feature/climate_entity_feature";
 import { CoverEntityFeature } from "../../data/feature/cover_entity_feature";
 import { MediaPlayerEntityFeature } from "../../data/feature/media-player_entity_feature";
 import { SirenEntityFeature } from "../../data/feature/siren_entity_feature";
+import { supportsFeature } from "./supports-feature";
 
 // These are domains which have nonstandard 'toggle' behavior.
 // Otherwise, any domain with a turn_on and turn_off service may be toggled.
@@ -61,12 +63,49 @@ export const SPECIAL_TOGGLE_ACTIONS: Record<string, SpecialToggleAction> = {
   },
 };
 
+// A cover that cannot open and close, but can tilt both ways, is toggled
+// through its tilt actions instead.
+const TILT_ONLY_COVER_TOGGLE_ACTION: SpecialToggleAction = {
+  on: "open_cover_tilt",
+  off: "close_cover_tilt",
+  feature: [CoverEntityFeature.OPEN_TILT, CoverEntityFeature.CLOSE_TILT],
+};
+
+export const usesCoverTiltToggleAction = (
+  domain: string,
+  stateObj?: HassEntity
+): boolean =>
+  domain === "cover" &&
+  !!stateObj &&
+  !(
+    supportsFeature(stateObj, CoverEntityFeature.OPEN) &&
+    supportsFeature(stateObj, CoverEntityFeature.CLOSE)
+  ) &&
+  supportsFeature(stateObj, CoverEntityFeature.OPEN_TILT) &&
+  supportsFeature(stateObj, CoverEntityFeature.CLOSE_TILT);
+
+// Some domains resolve their toggle action from the features of the entity
+// rather than from the domain alone.
+export const getSpecialToggleAction = (
+  domain: string,
+  stateObj?: HassEntity
+): SpecialToggleAction | undefined =>
+  usesCoverTiltToggleAction(domain, stateObj)
+    ? TILT_ONLY_COVER_TOGGLE_ACTION
+    : SPECIAL_TOGGLE_ACTIONS[domain];
+
 // This function assumes that the passed domain can toggle, it may otherwise
 // return a service that does not exist.
-export const getToggleAction = (domain: string, onOff: boolean): string => {
+export const getToggleAction = (
+  domain: string,
+  onOff: boolean,
+  stateObj?: HassEntity
+): string => {
+  const toggleAction = getSpecialToggleAction(domain, stateObj);
+
   return (
-    SPECIAL_TOGGLE_ACTIONS[domain]?.[onOff ? "on" : "off"] ||
-    SPECIAL_TOGGLE_ACTIONS[domain]?.["on"] ||
+    toggleAction?.[onOff ? "on" : "off"] ||
+    toggleAction?.["on"] ||
     (onOff ? "turn_on" : "turn_off")
   );
 };

--- a/src/components/entity/ha-entity-toggle.ts
+++ b/src/components/entity/ha-entity-toggle.ts
@@ -128,7 +128,7 @@ export class HaEntityToggle extends LitElement {
 
     const serviceDomain =
       stateDomain === "group" ? "homeassistant" : stateDomain;
-    const service = getToggleAction(stateDomain, turnOn);
+    const service = getToggleAction(stateDomain, turnOn, this.stateObj);
 
     const currentState = this.stateObj;
 

--- a/src/panels/lovelace/common/entity/toggle-entity.ts
+++ b/src/panels/lovelace/common/entity/toggle-entity.ts
@@ -1,11 +1,21 @@
+import type { HassEntity } from "home-assistant-js-websocket";
 import { STATES_OFF } from "../../../../common/const";
+import { computeStateDomain } from "../../../../common/entity/compute_state_domain";
+import { usesCoverTiltToggleAction } from "../../../../common/entity/get_toggle_action";
+import type { CoverEntity } from "../../../../data/cover";
+import { isFullyClosedTilt } from "../../../../data/cover";
 import type { HomeAssistant, ServiceCallResponse } from "../../../../types";
 import { turnOnOffEntity } from "./turn-on-off-entity";
+
+// A cover that toggles through its tilt does not reflect the tilt in its
+// state, so the tilt position decides whether it is off.
+const isOff = (stateObj: HassEntity): boolean =>
+  usesCoverTiltToggleAction(computeStateDomain(stateObj), stateObj)
+    ? isFullyClosedTilt(stateObj as CoverEntity)
+    : STATES_OFF.includes(stateObj.state);
 
 export const toggleEntity = (
   hass: HomeAssistant,
   entityId: string
-): Promise<ServiceCallResponse> => {
-  const turnOn = STATES_OFF.includes(hass.states[entityId].state);
-  return turnOnOffEntity(hass, entityId, turnOn);
-};
+): Promise<ServiceCallResponse> =>
+  turnOnOffEntity(hass, entityId, isOff(hass.states[entityId]));

--- a/src/panels/lovelace/common/entity/turn-on-off-entity.ts
+++ b/src/panels/lovelace/common/entity/turn-on-off-entity.ts
@@ -10,7 +10,7 @@ export const turnOnOffEntity = (
   const stateDomain = computeDomain(entityId);
   const serviceDomain = stateDomain === "group" ? "homeassistant" : stateDomain;
 
-  const service = getToggleAction(stateDomain, turnOn);
+  const service = getToggleAction(stateDomain, turnOn, hass.states[entityId]);
 
   return hass.callService(serviceDomain, service, { entity_id: entityId });
 };

--- a/test/common/entity/can_toggle_state.test.ts
+++ b/test/common/entity/can_toggle_state.test.ts
@@ -2,6 +2,7 @@ import { assert, describe, it } from "vitest";
 
 import { canToggleState } from "../../../src/common/entity/can_toggle_state";
 import { ClimateEntityFeature } from "../../../src/data/climate";
+import { CoverEntityFeature } from "../../../src/data/cover";
 
 describe("canToggleState", () => {
   const hass: any = {
@@ -61,6 +62,58 @@ describe("canToggleState", () => {
       entity_id: "climate.bla",
       attributes: {
         supported_features: 0,
+      },
+    };
+    assert.isFalse(canToggleState(hass, stateObj));
+  });
+
+  it("Detects tilt only cover with toggle", () => {
+    const stateObj: any = {
+      entity_id: "cover.blinds",
+      attributes: {
+        supported_features:
+          CoverEntityFeature.OPEN_TILT + CoverEntityFeature.CLOSE_TILT,
+      },
+    };
+    assert.isTrue(canToggleState(hass, stateObj));
+  });
+
+  it("Detects cover with toggle", () => {
+    const stateObj: any = {
+      entity_id: "cover.blinds",
+      attributes: {
+        supported_features: CoverEntityFeature.OPEN + CoverEntityFeature.CLOSE,
+      },
+    };
+    assert.isTrue(canToggleState(hass, stateObj));
+  });
+
+  it("Detects cover without toggle", () => {
+    const stateObj: any = {
+      entity_id: "cover.blinds",
+      attributes: {
+        supported_features: 0,
+      },
+    };
+    assert.isFalse(canToggleState(hass, stateObj));
+  });
+
+  // Tilt actions it does not support must not be offered either.
+  it("Detects cover that only stops its tilt without toggle", () => {
+    const stateObj: any = {
+      entity_id: "cover.blinds",
+      attributes: {
+        supported_features: CoverEntityFeature.STOP_TILT,
+      },
+    };
+    assert.isFalse(canToggleState(hass, stateObj));
+  });
+
+  it("Detects cover that only opens its tilt without toggle", () => {
+    const stateObj: any = {
+      entity_id: "cover.blinds",
+      attributes: {
+        supported_features: CoverEntityFeature.OPEN_TILT,
       },
     };
     assert.isFalse(canToggleState(hass, stateObj));

--- a/test/common/entity/get_toggle_action.test.ts
+++ b/test/common/entity/get_toggle_action.test.ts
@@ -1,0 +1,71 @@
+import { assert, describe, it } from "vitest";
+
+import { getToggleAction } from "../../../src/common/entity/get_toggle_action";
+import { CoverEntityFeature } from "../../../src/data/cover";
+
+const coverState = (supportedFeatures: number): any => ({
+  entity_id: "cover.bla",
+  state: "open",
+  attributes: { supported_features: supportedFeatures },
+});
+
+describe("getToggleAction", () => {
+  it("Falls back to the domain when no state is passed", () => {
+    assert.equal(getToggleAction("cover", true), "open_cover");
+    assert.equal(getToggleAction("cover", false), "close_cover");
+    assert.equal(getToggleAction("light", true), "turn_on");
+  });
+
+  it("Uses the regular actions for a cover that opens and closes", () => {
+    const stateObj = coverState(
+      CoverEntityFeature.OPEN +
+        CoverEntityFeature.CLOSE +
+        CoverEntityFeature.OPEN_TILT +
+        CoverEntityFeature.CLOSE_TILT
+    );
+    assert.equal(getToggleAction("cover", true, stateObj), "open_cover");
+    assert.equal(getToggleAction("cover", false, stateObj), "close_cover");
+  });
+
+  it("Uses the tilt actions for a tilt only cover", () => {
+    const stateObj = coverState(
+      CoverEntityFeature.OPEN_TILT +
+        CoverEntityFeature.CLOSE_TILT +
+        CoverEntityFeature.SET_TILT_POSITION
+    );
+    assert.equal(getToggleAction("cover", true, stateObj), "open_cover_tilt");
+    assert.equal(getToggleAction("cover", false, stateObj), "close_cover_tilt");
+  });
+
+  it("Uses the tilt actions for a tilt cover that also supports stop", () => {
+    const stateObj = coverState(
+      CoverEntityFeature.STOP +
+        CoverEntityFeature.OPEN_TILT +
+        CoverEntityFeature.CLOSE_TILT
+    );
+    assert.equal(getToggleAction("cover", true, stateObj), "open_cover_tilt");
+    assert.equal(getToggleAction("cover", false, stateObj), "close_cover_tilt");
+  });
+
+  it("Keeps the regular actions for a cover without tilt", () => {
+    assert.equal(
+      getToggleAction("cover", true, coverState(CoverEntityFeature.STOP)),
+      "open_cover"
+    );
+    assert.equal(getToggleAction("cover", false, coverState(0)), "close_cover");
+    assert.equal(
+      getToggleAction("cover", false, coverState(CoverEntityFeature.OPEN_TILT)),
+      "close_cover"
+    );
+  });
+
+  it("Leaves other domains untouched", () => {
+    const stateObj: any = {
+      entity_id: "lock.bla",
+      state: "locked",
+      attributes: {},
+    };
+    assert.equal(getToggleAction("lock", true, stateObj), "unlock");
+    assert.equal(getToggleAction("lock", false, stateObj), "lock");
+  });
+});

--- a/test/panels/lovelace/common/entity/toggle-entity.test.ts
+++ b/test/panels/lovelace/common/entity/toggle-entity.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CoverEntityFeature } from "../../../../../src/data/cover";
+import { toggleEntity } from "../../../../../src/panels/lovelace/common/entity/toggle-entity";
+import { handleAction } from "../../../../../src/panels/lovelace/common/handle-action";
+import type { HomeAssistant } from "../../../../../src/types";
+
+const TILT_ONLY_FEATURES =
+  CoverEntityFeature.OPEN_TILT +
+  CoverEntityFeature.CLOSE_TILT +
+  CoverEntityFeature.SET_TILT_POSITION;
+
+const makeHass = (
+  entityId: string,
+  attributes: Record<string, unknown>,
+  state = "open"
+) => {
+  const callService = vi.fn();
+  const hass = {
+    states: { [entityId]: { entity_id: entityId, state, attributes } },
+    callService,
+  } as unknown as HomeAssistant;
+  return { hass, callService };
+};
+
+describe("toggleEntity", () => {
+  it("closes the tilt of an open tilt only cover", () => {
+    const { hass, callService } = makeHass("cover.blinds", {
+      current_tilt_position: 50,
+      supported_features: TILT_ONLY_FEATURES,
+    });
+
+    toggleEntity(hass, "cover.blinds");
+
+    expect(callService).toHaveBeenCalledWith("cover", "close_cover_tilt", {
+      entity_id: "cover.blinds",
+    });
+  });
+
+  it("opens the tilt of a closed tilt only cover", () => {
+    const { hass, callService } = makeHass("cover.blinds", {
+      current_tilt_position: 0,
+      supported_features: TILT_ONLY_FEATURES,
+    });
+
+    toggleEntity(hass, "cover.blinds");
+
+    expect(callService).toHaveBeenCalledWith("cover", "open_cover_tilt", {
+      entity_id: "cover.blinds",
+    });
+  });
+
+  // A cover that supports stop but neither open nor close is still only
+  // toggleable through its tilt.
+  it("uses the tilt actions for a cover that also supports stop", () => {
+    const { hass, callService } = makeHass("cover.blinds", {
+      current_tilt_position: 50,
+      supported_features: TILT_ONLY_FEATURES + CoverEntityFeature.STOP,
+    });
+
+    toggleEntity(hass, "cover.blinds");
+
+    expect(callService).toHaveBeenCalledWith("cover", "close_cover_tilt", {
+      entity_id: "cover.blinds",
+    });
+  });
+
+  // The tilt actions must not be used for a cover that has no tilt, even
+  // though this path is reached without checking canToggleState.
+  it.each([
+    ["stop only", CoverEntityFeature.STOP],
+    ["stop tilt only", CoverEntityFeature.STOP_TILT],
+    ["open tilt only", CoverEntityFeature.OPEN_TILT],
+    ["no features", 0],
+  ])("uses the regular actions for a cover with %s", (_name, features) => {
+    const { hass, callService } = makeHass("cover.blinds", {
+      supported_features: features,
+    });
+
+    toggleEntity(hass, "cover.blinds");
+
+    expect(callService).toHaveBeenCalledWith("cover", "close_cover", {
+      entity_id: "cover.blinds",
+    });
+  });
+
+  it("uses the regular actions for a cover that opens and closes", () => {
+    const { hass, callService } = makeHass("cover.garage", {
+      supported_features: CoverEntityFeature.OPEN + CoverEntityFeature.CLOSE,
+    });
+
+    toggleEntity(hass, "cover.garage");
+
+    expect(callService).toHaveBeenCalledWith("cover", "close_cover", {
+      entity_id: "cover.garage",
+    });
+  });
+
+  it("uses the tilt actions for a configured toggle action", async () => {
+    const { hass, callService } = makeHass("cover.blinds", {
+      current_tilt_position: 50,
+      supported_features: TILT_ONLY_FEATURES,
+    });
+
+    await handleAction(
+      document.createElement("div"),
+      hass,
+      { entity: "cover.blinds", tap_action: { action: "toggle" } },
+      "tap"
+    );
+
+    expect(callService).toHaveBeenCalledWith("cover", "close_cover_tilt", {
+      entity_id: "cover.blinds",
+    });
+  });
+});


### PR DESCRIPTION
## Proposed change

Setting a card action to Toggle on a tilt-only cover called `cover.close_cover`, which those entities do not implement, so the call failed and nothing moved. The reported case is Lutron Serena blinds: the slats tilt, but there is no motor to raise or lower the blind.

`getToggleAction` picked the service from the domain alone, so every cover got `open_cover` / `close_cover` no matter what it actually supports. It now resolves per entity. A cover that cannot open and close, but can tilt both ways, uses `open_cover_tilt` / `close_cover_tilt` instead. This goes through the existing `feature` gate on `SPECIAL_TOGGLE_ACTIONS` rather than a special case, so a cover that supports neither pair keeps the regular actions and is still reported as not toggleable.

The direction comes from the tilt position instead of the state, because these covers report `open` regardless of where the slats sit. Reading the state would mean Toggle only ever closed them and never opened them again.

Added unit tests for `getToggleAction` and `toggleEntity` covering tilt-only covers, tilt plus stop, and the covers that must keep the regular actions. Also checked it in the demo with a tilt-only cover on a tile card, watching the service call go out.

Worth pushing back on: this makes `canToggleState` return true for tilt-only covers, which puts Toggle back in the action picker that #53210 took it out of. @piitaya suggested checking for tilt-only in `turn-on-off-entity.ts` on the issue, so I believe that is the intent, but it does undo part of that PR for these entities and I would rather it was confirmed than assumed.

Not covered here: `group_entities.ts` and `hui-toggle-group-card.ts` resolve one service for a whole group, so area controls containing a tilt-only cover still hit the old behaviour. Fixing that means splitting the call per entity, which felt like a separate change.

## Screenshots

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #53199
- This PR is related to issue or discussion: #53210
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

