### PR TITLE
Cache compression output across builds to speed up releases

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -64,8 +64,10 @@ jobs:
           rm -rf dist home_assistant_frontend.egg-info
           python3 -m build
 
+      # Not gated on the restore step: a transient restore failure (it is
+      # continue-on-error) must not stop us persisting a freshly built cache.
       - name: Save compression cache
-        if: always() && steps.compress-cache.outcome == 'success'
+        if: success()
         continue-on-error: true
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -42,7 +42,20 @@ jobs:
       - name: Bump version
         run: script/version_bump.js nightly
 
+      # Warm the shared compression cache so releases reuse it (see release.yaml).
+      - name: Restore compression cache
+        id: compress-cache
+        continue-on-error: true
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .compress-cache
+          key: compress-cache-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            compress-cache-${{ runner.os }}-
+
       - name: Build nightly Python wheels
+        env:
+          COMPRESS_CACHE_DIR: ${{ github.workspace }}/.compress-cache
         run: |
           pip install build
           yarn install
@@ -50,6 +63,14 @@ jobs:
           script/build_frontend
           rm -rf dist home_assistant_frontend.egg-info
           python3 -m build
+
+      - name: Save compression cache
+        if: always() && steps.compress-cache.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .compress-cache
+          key: compress-cache-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Archive translations
         run: tar -czvf translations.tar.gz translations

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,10 +69,12 @@ jobs:
           export SKIP_FETCH_NIGHTLY_TRANSLATIONS=1
           script/release
 
-      # The build prunes the cache to this dist's files, so saving keeps it
-      # bounded. A unique key always writes; restore-keys picks the newest.
+      # The build keeps the cache under its size budget, so saving stays bounded.
+      # A unique key always writes; restore-keys picks the newest on the next
+      # run. Not gated on the restore step: a transient restore failure (it is
+      # continue-on-error) must not stop us persisting a freshly built cache.
       - name: Save compression cache
-        if: always() && steps.compress-cache.outcome == 'success'
+        if: success()
         continue-on-error: true
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,11 +49,35 @@ jobs:
         env:
           LOKALISE_TOKEN: ${{ secrets.LOKALISE_TOKEN }}
 
+      # Restore the content-addressed compression cache. Unchanged chunks and
+      # static assets are then reused instead of re-run through brotli/zopfli.
+      - name: Restore compression cache
+        id: compress-cache
+        continue-on-error: true
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .compress-cache
+          key: compress-cache-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            compress-cache-${{ runner.os }}-
+
       - name: Build and release package
+        env:
+          COMPRESS_CACHE_DIR: ${{ github.workspace }}/.compress-cache
         run: |
           python3 -m pip install build
           export SKIP_FETCH_NIGHTLY_TRANSLATIONS=1
           script/release
+
+      # The build prunes the cache to this dist's files, so saving keeps it
+      # bounded. A unique key always writes; restore-keys picks the newest.
+      - name: Save compression cache
+        if: always() && steps.compress-cache.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .compress-cache
+          key: compress-cache-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 dist/
 /hass_frontend/
 /translations/
+/.compress-cache/
 # Composite action source, not build output
 !/.github/actions/build/
 

--- a/build-scripts/brotli.mjs
+++ b/build-scripts/brotli.mjs
@@ -12,7 +12,8 @@
 import { availableParallelism } from "node:os";
 import { buffer as readStream } from "node:stream/consumers";
 import { promisify } from "node:util";
-import { brotliCompress } from "node:zlib";
+import { brotliCompress, constants } from "node:zlib";
+import { withCache } from "./compress-cache.mjs";
 import { ParallelTransform } from "./parallel-transform.mjs";
 
 const EXTENSION = ".br";
@@ -24,8 +25,13 @@ const compress = promisify(brotliCompress);
  * @param {boolean} [options.skipLarger] Drop files that compression grows.
  * @param {object} [options.params] Brotli parameters, passed to zlib as-is.
  */
-export default ({ skipLarger = false, params } = {}) =>
-  new ParallelTransform(availableParallelism(), async (file) => {
+export default ({ skipLarger = false, params } = {}) => {
+  // Isolate cache entries by anything that changes the output bytes: the brotli
+  // quality, and the node major that produced them.
+  const quality = params?.[constants.BROTLI_PARAM_QUALITY] ?? "default";
+  const namespace = `brotli-q${quality}-node${process.versions.node.split(".")[0]}`;
+
+  return new ParallelTransform(availableParallelism(), async (file) => {
     if (file.isNull()) {
       return file;
     }
@@ -33,10 +39,13 @@ export default ({ skipLarger = false, params } = {}) =>
       file.contents = await readStream(file.contents);
     }
 
-    const compressed = await compress(file.contents, { params });
-    if (skipLarger && compressed.length >= file.contents.length) {
+    const compressed = await withCache(namespace, file.contents, async () => {
+      const out = await compress(file.contents, { params });
       // Dropped rather than passed through, as gulp-brotli did: the
       // uncompressed file is already in the output directory.
+      return skipLarger && out.length >= file.contents.length ? undefined : out;
+    });
+    if (compressed === undefined) {
       return undefined;
     }
 
@@ -44,3 +53,4 @@ export default ({ skipLarger = false, params } = {}) =>
     file.path += EXTENSION;
     return file;
   });
+};

--- a/build-scripts/compress-cache.mjs
+++ b/build-scripts/compress-cache.mjs
@@ -1,0 +1,193 @@
+// Content-addressed cache for compression output.
+//
+// brotli (quality 11) and zopfli are the slowest part of a production build,
+// and they redo every file from scratch on every run. But production chunks are
+// content-hashed in their filenames, so a chunk that didn't change produces
+// byte-identical input here. Keying the compressed output by a hash of the
+// input bytes lets an unchanged file skip compression entirely, and lets a
+// nightly build warm the cache a release reuses the next day.
+//
+// Disabled unless COMPRESS_CACHE_DIR points at a directory. Local builds set
+// nothing and behave exactly as before. The compressed bytes are unchanged
+// either way; only whether they were recomputed differs.
+
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+
+const rootDir = process.env.COMPRESS_CACHE_DIR;
+export const cacheEnabled = Boolean(rootDir);
+
+// Total cache size to keep across builds, least-recently-used first when over.
+// The cache is shared between branches (a dev nightly warms it for a release,
+// which builds from rc/master), so pruning must NOT drop everything the current
+// build didn't touch — that would make each branch evict the other's
+// branch-specific files every run. Instead the current build is pinned and the
+// rest is kept up to this budget, so nothing is dropped unless the cache is
+// genuinely too large. Override with COMPRESS_CACHE_MAX_BYTES.
+const DEFAULT_MAX_BYTES = 1024 * 1024 * 1024; // 1 GiB
+const maxBytes = () =>
+  Number(process.env.COMPRESS_CACHE_MAX_BYTES) || DEFAULT_MAX_BYTES;
+
+// Every cache key touched this build, hits and writes alike, so a prune can pin
+// the current dist and never evict a file this build depends on.
+const touched = new Set();
+
+// Per-namespace directory, created lazily and only once.
+const dirs = new Map();
+
+let tmpCounter = 0;
+
+const sha256 = (contents) =>
+  createHash("sha256").update(contents).digest("hex");
+
+const namespaceDir = (namespace) => {
+  let dir = dirs.get(namespace);
+  if (!dir) {
+    const dirPath = path.join(rootDir, namespace);
+    dir = { path: dirPath, ready: undefined };
+    dirs.set(namespace, dir);
+  }
+  return dir;
+};
+
+const ensureDir = (dir) => {
+  dir.ready ??= mkdir(dir.path, { recursive: true });
+  return dir.ready;
+};
+
+// Written via a unique temp file and renamed into place so a concurrent reader
+// in the same build never sees a half-written entry (rename is atomic on the
+// same filesystem).
+const writeAtomic = async (dir, name, contents) => {
+  await ensureDir(dir);
+  tmpCounter += 1;
+  const tmp = path.join(dir.path, `.${process.pid}-${tmpCounter}.tmp`);
+  await writeFile(tmp, contents);
+  await rename(tmp, path.join(dir.path, name));
+};
+
+/**
+ * Return the cached compression result for `contents`, or run `compute` and
+ * cache what it returns. `compute` resolves to a Buffer for compressed output,
+ * or `undefined` when the file should be dropped (brotli skipLarger); both
+ * outcomes are cached, so a dropped file is not recompressed on the next build.
+ *
+ * @param {string} namespace Isolates entries by algorithm, parameters and tool
+ *   version, so a change to any of them can never return a stale result.
+ * @param {Buffer} contents Uncompressed input bytes, used as the cache key.
+ * @param {() => Promise<Buffer | undefined>} compute Runs on a cache miss.
+ * @returns {Promise<Buffer | undefined>}
+ */
+export const withCache = async (namespace, contents, compute) => {
+  if (!cacheEnabled) {
+    return compute();
+  }
+
+  const dir = namespaceDir(namespace);
+  const hash = sha256(contents);
+  touched.add(`${namespace}/${hash}`);
+
+  const dataPath = path.join(dir.path, hash);
+  const dropName = `${hash}.drop`;
+
+  try {
+    return await readFile(dataPath);
+  } catch {
+    // Miss (or unreadable) — fall through and compute.
+  }
+  if (existsSync(path.join(dir.path, dropName))) {
+    return undefined;
+  }
+
+  const result = await compute();
+  if (result === undefined) {
+    await writeAtomic(dir, dropName, "");
+  } else {
+    await writeAtomic(dir, hash, result);
+  }
+  return result;
+};
+
+/**
+ * Keep the cache under `maxBytes`, evicting least-recently-used entries first.
+ * Files this build touched are always kept (and their timestamp refreshed, so
+ * shared files stay warm across branches); the remainder — including another
+ * branch's entries — is kept up to the budget. No-op when the cache is disabled
+ * or nothing was compressed, so it never wipes a warm cache on a build that
+ * skipped compression.
+ */
+export const pruneCache = async () => {
+  if (!cacheEnabled || touched.size === 0 || !existsSync(rootDir)) {
+    return;
+  }
+
+  const now = new Date();
+  const pinned = [];
+  const others = [];
+
+  // Scan every namespace on disk, not just the ones this build used, so entries
+  // from an old tool version (a different namespace) are eligible for eviction.
+  const namespaces = await readdir(rootDir, { withFileTypes: true });
+  await Promise.all(
+    namespaces.map(async (ns) => {
+      if (!ns.isDirectory()) {
+        return;
+      }
+      const nsDir = path.join(rootDir, ns.name);
+      const entries = await readdir(nsDir);
+      await Promise.all(
+        entries.map(async (entry) => {
+          const entryPath = path.join(nsDir, entry);
+          // Stray temp files from an interrupted write are never valid entries.
+          if (entry.endsWith(".tmp")) {
+            await rm(entryPath, { force: true });
+            return;
+          }
+          const hash = entry.endsWith(".drop") ? entry.slice(0, -5) : entry;
+          const info = await stat(entryPath);
+          if (touched.has(`${ns.name}/${hash}`)) {
+            pinned.push({ entryPath, size: info.size });
+          } else {
+            others.push({ entryPath, size: info.size, mtimeMs: info.mtimeMs });
+          }
+        })
+      );
+    })
+  );
+
+  // Pinned files stay and are refreshed so they rank as most-recently-used for
+  // future prunes; they always count against the budget first.
+  let kept = 0;
+  await Promise.all(
+    pinned.map(async ({ entryPath, size }) => {
+      kept += size;
+      // A failed timestamp refresh only affects future LRU ordering, not
+      // correctness, so it is safe to ignore.
+      await utimes(entryPath, now, now).catch(() => undefined);
+    })
+  );
+
+  // Keep the most-recently-used others until the budget is spent; drop the rest.
+  others.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  const budget = maxBytes();
+  const toDelete = [];
+  for (const entry of others) {
+    if (kept + entry.size <= budget) {
+      kept += entry.size;
+    } else {
+      toDelete.push(entry.entryPath);
+    }
+  }
+  await Promise.all(toDelete.map((p) => rm(p, { force: true })));
+};

--- a/build-scripts/compress-cache.mjs
+++ b/build-scripts/compress-cache.mjs
@@ -36,8 +36,14 @@ export const cacheEnabled = Boolean(rootDir);
 // rest is kept up to this budget, so nothing is dropped unless the cache is
 // genuinely too large. Override with COMPRESS_CACHE_MAX_BYTES.
 const DEFAULT_MAX_BYTES = 1024 * 1024 * 1024; // 1 GiB
-const maxBytes = () =>
-  Number(process.env.COMPRESS_CACHE_MAX_BYTES) || DEFAULT_MAX_BYTES;
+const maxBytes = () => {
+  // A valid, explicit budget wins — including 0, which keeps only the current
+  // build (evict everything else). An unset or invalid value uses the default.
+  const configured = Number(process.env.COMPRESS_CACHE_MAX_BYTES);
+  return Number.isFinite(configured) && configured >= 0
+    ? configured
+    : DEFAULT_MAX_BYTES;
+};
 
 // Every cache key touched this build, hits and writes alike, so a prune can pin
 // the current dist and never evict a file this build depends on.
@@ -73,8 +79,21 @@ const writeAtomic = async (dir, name, contents) => {
   await ensureDir(dir);
   tmpCounter += 1;
   const tmp = path.join(dir.path, `.${process.pid}-${tmpCounter}.tmp`);
+  const dest = path.join(dir.path, name);
   await writeFile(tmp, contents);
-  await rename(tmp, path.join(dir.path, name));
+  try {
+    await rename(tmp, dest);
+  } catch (error) {
+    // Two files with identical contents can miss and write the same entry at
+    // once. On POSIX the rename just overwrites, but Windows rejects a rename
+    // onto an existing path. Either way the destination already holds the same
+    // bytes (content-addressed), so drop our temp and treat it as done.
+    if (existsSync(dest)) {
+      await rm(tmp, { force: true });
+    } else {
+      throw error;
+    }
+  }
 };
 
 /**

--- a/build-scripts/gulp/app.js
+++ b/build-scripts/gulp/app.js
@@ -50,7 +50,9 @@ gulp.task(
     "rspack-prod-app",
     gulp.parallel("gen-pages-app-prod", "gen-service-worker-app-prod"),
     // Don't compress running tests
-    ...(env.isTestBuild() || env.isStatsBuild() ? [] : ["compress-app"])
+    ...(env.isTestBuild() || env.isStatsBuild()
+      ? []
+      : ["compress-app", "prune-compress-cache"])
   )
 );
 

--- a/build-scripts/gulp/compress.js
+++ b/build-scripts/gulp/compress.js
@@ -59,6 +59,6 @@ gulp.task(
   )
 );
 
-// Drop cache entries this build didn't use, keeping the compression cache
-// bounded. No-op unless COMPRESS_CACHE_DIR is set.
+// Keep the compression cache under its size budget (LRU, this build pinned).
+// No-op unless COMPRESS_CACHE_DIR is set.
 gulp.task("prune-compress-cache", () => pruneCache());

--- a/build-scripts/gulp/compress.js
+++ b/build-scripts/gulp/compress.js
@@ -3,6 +3,7 @@
 import { constants } from "node:zlib";
 import gulp from "gulp";
 import brotli from "../brotli.mjs";
+import { pruneCache } from "../compress-cache.mjs";
 import paths from "../paths.cjs";
 import zopfli from "../zopfli.mjs";
 
@@ -57,3 +58,7 @@ gulp.task(
     compressAppOtherZopfli
   )
 );
+
+// Drop cache entries this build didn't use, keeping the compression cache
+// bounded. No-op unless COMPRESS_CACHE_DIR is set.
+gulp.task("prune-compress-cache", () => pruneCache());

--- a/build-scripts/zopfli.mjs
+++ b/build-scripts/zopfli.mjs
@@ -5,13 +5,22 @@
 // blocks the event loop for the whole compression step. Running one WASM
 // instance per worker parallelises it; the output bytes are unchanged.
 
+import { createRequire } from "node:module";
 import { availableParallelism } from "node:os";
 import { buffer as readStream } from "node:stream/consumers";
 import { Worker } from "node:worker_threads";
+import { withCache } from "./compress-cache.mjs";
 import { ParallelTransform } from "./parallel-transform.mjs";
 
 const WORKER_URL = new URL("./zopfli-worker.mjs", import.meta.url);
 const EXTENSION = ".gz";
+
+// Cache namespace tied to the zopfli version, since a different version can
+// produce different bytes for the same input.
+const ZOPFLI_VERSION = createRequire(import.meta.url)(
+  "@gfx/zopfli/package.json"
+).version;
+const NAMESPACE = `gzip-zopfli${ZOPFLI_VERSION}`;
 
 // Left empty on purpose: @gfx/zopfli then applies its own defaults, which is
 // what gulp-zopfli-green did, so compressed output stays byte-identical.
@@ -130,7 +139,9 @@ export default ({ threshold = 0 } = {}) => {
       // Passed through unrenamed and uncompressed, as gulp-zopfli-green did.
       return file;
     }
-    file.contents = await compress(file.contents);
+    file.contents = await withCache(NAMESPACE, file.contents, () =>
+      compress(file.contents)
+    );
     file.path += EXTENSION;
     return file;
   });


### PR DESCRIPTION
## Proposed change

The release build spends most of its time compressing the output: every file goes through brotli (quality 11) **and** zopfli, for both the modern and legacy build variants, and this is redone from scratch on every build. In a recent release the `Build and release package` step took ~25 min.

Production chunks carry a `[contenthash]` in their filename, so a file whose content is unchanged is byte-identical between builds. This adds a **content-addressed compression cache**: brotli/zopfli output is keyed by a hash of the *input bytes* and reused on a hit, so unchanged files skip compression entirely.

Key points:
- **Content-keyed, not filename-keyed**, so non-hashed static assets (`svg`/`xml`/`json`/`html`) — the most stable files — hit too.
- **Persisted across CI runs** via `actions/cache`, and **warmed daily by the nightly** (which builds a tree close to rc/master), so a release starts nearly warm.
- **Namespaced** by algorithm, parameters and tool version (brotli quality + node major; zopfli version), so a change can never return a stale result.
- **Shared between branches** (dev nightly, rc/master releases). Pruning is therefore **LRU by size with the current build pinned** (budget `COMPRESS_CACHE_MAX_BYTES`, default 1 GiB) rather than "drop everything this build didn't touch" — the latter would make each branch evict the other's branch-specific entries every run.
- **Disabled unless `COMPRESS_CACHE_DIR` is set**, so local and test builds are unchanged and produce byte-identical output.

### Measurements (local, 12-core, real production build — both variants)

| `compress-app` | Cold (empty cache) | Warm (full cache) |
|---|---|---|
| duration | **1.69 min** (101 s) | **2.44 s** |

`prune-compress-cache` runs in ~7 ms. One full dist's cache (br + gz, both variants) is **76 MB**, so the 1 GiB default holds ~13 dists — comfortably within GitHub's 10 GB cache limit while keeping cross-branch overlap warm. Output is byte-identical between cold and warm (verified). CI runners have 4 cores rather than 12, so the cold compression there is proportionally larger and the real saving per release scales with the unchanged fraction of the bundle.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
