### PR TITLE
Revalidate camera images instead of re-downloading them

### DIFF
--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -89,6 +89,10 @@ export class HuiImage extends LitElement {
 
   private _cameraImageObjectUrl?: string;
 
+  // Previous object URL still used by <img> or the aspect-ratio CSS
+  // background. Revoked after the replacement image has loaded and rendered.
+  private _pendingRevokeObjectUrl?: string;
+
   private _cameraImageRequestId = 0;
 
   private _ratio: {
@@ -129,7 +133,6 @@ export class HuiImage extends LitElement {
         this._stopIntersectionObserver();
         this._loadState = LoadState.Loading;
         this._clearCameraImage();
-        this._loadedImageSrc = undefined;
       }
     }
     if (changedProps.has("_imageVisible")) {
@@ -399,6 +402,9 @@ export class HuiImage extends LitElement {
     }
     await this.updateComplete;
     this._lastImageHeight = imgEl.offsetHeight;
+    // The aspect-ratio background (and the previous <img> decode) still
+    // referenced the old object URL until this render. Safe to drop now.
+    this._revokePendingCameraObjectUrl();
   }
 
   private async _onVideoLoad(
@@ -453,7 +459,7 @@ export class HuiImage extends LitElement {
     // started, or after _clearCameraImage() ran, can be told apart from the
     // current one instead of clobbering it or reviving a cleared image.
     const requestId = ++this._cameraImageRequestId;
-    
+
     let url: string;
     try {
       url = await fetchThumbnailUrlWithCache(
@@ -489,11 +495,7 @@ export class HuiImage extends LitElement {
       // Superseded by a newer poll or a clear while this request was in
       // flight. Drain the body so the connection can still be reused, but
       // leave all state alone - a newer request owns it now.
-      if (response.status === 304) {
-        await response.arrayBuffer();
-      } else if (response.ok) {
-        await response.blob();
-      }
+      await this._drainCameraImageResponse(response);
       return;
     }
 
@@ -502,7 +504,7 @@ export class HuiImage extends LitElement {
     // empty body still has to be consumed, or the request is torn down as
     // aborted and the connection cannot be reused.
     if (response.status === 304) {
-      await response.arrayBuffer();
+      await this._drainCameraImageResponse(response);
       // A 304 confirms the image already shown is still current, so a
       // stale error from an earlier failed poll no longer applies.
       this._loadState = LoadState.Loaded;
@@ -510,6 +512,7 @@ export class HuiImage extends LitElement {
     }
 
     if (!response.ok) {
+      await this._drainCameraImageResponse(response);
       this._onImageError();
       return;
     }
@@ -537,7 +540,30 @@ export class HuiImage extends LitElement {
     this._cameraImageObjectUrl = URL.createObjectURL(blob);
     this._cameraImageSrc = this._cameraImageObjectUrl;
     if (previousObjectUrl) {
-      URL.revokeObjectURL(previousObjectUrl);
+      if (this._pendingRevokeObjectUrl) {
+        // Still holding the last displayed image for the aspect-ratio
+        // background. The blob we are replacing never became visible.
+        URL.revokeObjectURL(previousObjectUrl);
+      } else {
+        this._pendingRevokeObjectUrl = previousObjectUrl;
+      }
+    }
+  }
+
+  private async _drainCameraImageResponse(response: Response): Promise<void> {
+    // An unconsumed body is torn down as aborted and the connection
+    // cannot be reused, including empty 304 and error responses.
+    try {
+      await response.arrayBuffer();
+    } catch (_err) {
+      // Already consumed or the connection was dropped.
+    }
+  }
+
+  private _revokePendingCameraObjectUrl(): void {
+    if (this._pendingRevokeObjectUrl) {
+      URL.revokeObjectURL(this._pendingRevokeObjectUrl);
+      this._pendingRevokeObjectUrl = undefined;
     }
   }
 
@@ -545,12 +571,16 @@ export class HuiImage extends LitElement {
     // Invalidate any in-flight request so it can't recreate state (or an
     // object URL that never gets revoked) after we've just cleared it.
     this._cameraImageRequestId++;
+    this._revokePendingCameraObjectUrl();
     if (this._cameraImageObjectUrl) {
       URL.revokeObjectURL(this._cameraImageObjectUrl);
       this._cameraImageObjectUrl = undefined;
     }
     this._cameraImageEtag = undefined;
     this._cameraImageSrc = undefined;
+    // May still point at a blob URL we just revoked (aspect-ratio cards
+    // render the last loaded src as the container background).
+    this._loadedImageSrc = undefined;
   }
 
   static styles = css`

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -95,6 +95,13 @@ export class HuiImage extends LitElement {
 
   private _cameraImageRequestId = 0;
 
+  // Last _cameraImageSrc that the <img> actually rendered. A 304 may only
+  // restore Loaded when it still matches; otherwise a decode failure would
+  // be hidden the next time the server confirms those bytes.
+  private _loadedCameraImageSrc?: string;
+
+  private _clearCameraImageTimeout?: number;
+
   private _ratio: {
     w: number;
     h: number;
@@ -102,6 +109,10 @@ export class HuiImage extends LitElement {
 
   public connectedCallback(): void {
     super.connectedCallback();
+    if (this._clearCameraImageTimeout) {
+      clearTimeout(this._clearCameraImageTimeout);
+      this._clearCameraImageTimeout = undefined;
+    }
     if (this._loadState === undefined) {
       this._loadState = LoadState.Loading;
     }
@@ -115,7 +126,11 @@ export class HuiImage extends LitElement {
     this._stopUpdateCameraInterval();
     this._stopIntersectionObserver();
     this._imageVisible = undefined;
-    this._clearCameraImage();
+    // Re-parent (edit-mode drag) reconnects immediately; keep the last frame.
+    this._clearCameraImageTimeout = window.setTimeout(
+      () => this._clearCameraImage(),
+      1
+    );
   }
 
   protected handleIntersectionCallback(entries: IntersectionObserverEntry[]) {
@@ -396,6 +411,7 @@ export class HuiImage extends LitElement {
     ev: HASSDomTargetEvent<HTMLImageElement>
   ): Promise<void> {
     this._loadState = LoadState.Loaded;
+    this._loadedCameraImageSrc = this._cameraImageSrc;
     const imgEl = ev.target;
     if (this._ratio && this._ratio.w > 0 && this._ratio.h > 0) {
       this._loadedImageSrc = imgEl.src;
@@ -486,7 +502,9 @@ export class HuiImage extends LitElement {
       response = await fetch(url, { headers });
     } catch (_err) {
       if (requestId === this._cameraImageRequestId) {
-        this._onImageError();
+        // fetch is CORS-mode; <img src> is not. If fetch is blocked
+        // (e.g. Cast without CORS), load the signed URL directly.
+        this._cameraImageSrc = url;
       }
       return;
     }
@@ -505,9 +523,12 @@ export class HuiImage extends LitElement {
     // aborted and the connection cannot be reused.
     if (response.status === 304) {
       await this._drainCameraImageResponse(response);
-      // A 304 confirms the image already shown is still current, so a
-      // stale error from an earlier failed poll no longer applies.
-      this._loadState = LoadState.Loaded;
+      // A 304 confirms the bytes we already have are current. Only restore
+      // Loaded if those bytes actually rendered; a decode/@error failure
+      // must not be hidden by the next unchanged poll.
+      if (this._cameraImageSrc === this._loadedCameraImageSrc) {
+        this._loadState = LoadState.Loaded;
+      }
       return;
     }
 
@@ -568,6 +589,10 @@ export class HuiImage extends LitElement {
   }
 
   private _clearCameraImage(): void {
+    if (this._clearCameraImageTimeout) {
+      clearTimeout(this._clearCameraImageTimeout);
+      this._clearCameraImageTimeout = undefined;
+    }
     // Invalidate any in-flight request so it can't recreate state (or an
     // object URL that never gets revoked) after we've just cleared it.
     this._cameraImageRequestId++;
@@ -578,6 +603,7 @@ export class HuiImage extends LitElement {
     }
     this._cameraImageEtag = undefined;
     this._cameraImageSrc = undefined;
+    this._loadedCameraImageSrc = undefined;
     // May still point at a blob URL we just revoked (aspect-ratio cards
     // render the last loaded src as the container background).
     this._loadedImageSrc = undefined;

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -85,6 +85,10 @@ export class HuiImage extends LitElement {
 
   private _cameraUpdater?: number;
 
+  private _cameraImageEtag?: string;
+
+  private _cameraImageObjectUrl?: string;
+
   private _ratio: {
     w: number;
     h: number;
@@ -105,6 +109,7 @@ export class HuiImage extends LitElement {
     this._stopUpdateCameraInterval();
     this._stopIntersectionObserver();
     this._imageVisible = undefined;
+    this._clearCameraImage();
   }
 
   protected handleIntersectionCallback(entries: IntersectionObserverEntry[]) {
@@ -121,7 +126,7 @@ export class HuiImage extends LitElement {
         this._stopUpdateCameraInterval();
         this._stopIntersectionObserver();
         this._loadState = LoadState.Loading;
-        this._cameraImageSrc = undefined;
+        this._clearCameraImage();
         this._loadedImageSrc = undefined;
       }
     }
@@ -442,15 +447,58 @@ export class HuiImage extends LitElement {
     } else {
       height = Math.ceil(this._lastImageHeight * devicePixelRatio);
     }
-    this._cameraImageSrc = await fetchThumbnailUrlWithCache(
+    const url = await fetchThumbnailUrlWithCache(
       this.hass,
       this.cameraImage,
       width,
       height
     );
-    if (this._cameraImageSrc === undefined) {
-      this._onImageError();
+    // The signed URL is regenerated on every poll, so the browser cache can
+    // never revalidate it. Send If-None-Match ourselves instead.
+    const headers: Record<string, string> = {};
+    if (this._cameraImageEtag) {
+      headers["If-None-Match"] = this._cameraImageEtag;
     }
+
+    let response: Response;
+    try {
+      response = await fetch(url, { headers });
+    } catch (_err) {
+      this._onImageError();
+      return;
+    }
+
+    // Unchanged since the last poll. Keeping the current object URL avoids
+    // restarting animated images (GIF/WebP) part-way through playback. The
+    // empty body still has to be consumed, or the request is torn down as
+    // aborted and the connection cannot be reused.
+    if (response.status === 304) {
+      await response.arrayBuffer();
+      return;
+    }
+
+    if (!response.ok) {
+      this._onImageError();
+      return;
+    }
+
+    this._cameraImageEtag = response.headers.get("etag") ?? undefined;
+
+    const previousObjectUrl = this._cameraImageObjectUrl;
+    this._cameraImageObjectUrl = URL.createObjectURL(await response.blob());
+    this._cameraImageSrc = this._cameraImageObjectUrl;
+    if (previousObjectUrl) {
+      URL.revokeObjectURL(previousObjectUrl);
+    }
+  }
+
+  private _clearCameraImage(): void {
+    if (this._cameraImageObjectUrl) {
+      URL.revokeObjectURL(this._cameraImageObjectUrl);
+      this._cameraImageObjectUrl = undefined;
+    }
+    this._cameraImageEtag = undefined;
+    this._cameraImageSrc = undefined;
   }
 
   static styles = css`

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -89,6 +89,8 @@ export class HuiImage extends LitElement {
 
   private _cameraImageObjectUrl?: string;
 
+  private _cameraImageRequestId = 0;
+
   private _ratio: {
     w: number;
     h: number;
@@ -447,6 +449,11 @@ export class HuiImage extends LitElement {
     } else {
       height = Math.ceil(this._lastImageHeight * devicePixelRatio);
     }
+    // Identifies this poll so a response that resolves after a newer poll
+    // started, or after _clearCameraImage() ran, can be told apart from the
+    // current one instead of clobbering it or reviving a cleared image.
+    const requestId = ++this._cameraImageRequestId;
+
     const url = await fetchThumbnailUrlWithCache(
       this.hass,
       this.cameraImage,
@@ -464,7 +471,21 @@ export class HuiImage extends LitElement {
     try {
       response = await fetch(url, { headers });
     } catch (_err) {
-      this._onImageError();
+      if (requestId === this._cameraImageRequestId) {
+        this._onImageError();
+      }
+      return;
+    }
+
+    if (requestId !== this._cameraImageRequestId) {
+      // Superseded by a newer poll or a clear while this request was in
+      // flight. Drain the body so the connection can still be reused, but
+      // leave all state alone - a newer request owns it now.
+      if (response.status === 304) {
+        await response.arrayBuffer();
+      } else if (response.ok) {
+        await response.blob();
+      }
       return;
     }
 
@@ -474,6 +495,9 @@ export class HuiImage extends LitElement {
     // aborted and the connection cannot be reused.
     if (response.status === 304) {
       await response.arrayBuffer();
+      // A 304 confirms the image already shown is still current, so a
+      // stale error from an earlier failed poll no longer applies.
+      this._loadState = LoadState.Loaded;
       return;
     }
 
@@ -482,10 +506,27 @@ export class HuiImage extends LitElement {
       return;
     }
 
+    let blob: Blob;
+    try {
+      blob = await response.blob();
+    } catch (_err) {
+      this._onImageError();
+      return;
+    }
+
+    if (requestId !== this._cameraImageRequestId) {
+      return;
+    }
+
+    // Only commit the ETag once the body has actually been read.
+    // Otherwise a failed read here would leave the old image displayed
+    // while future polls send the new ETag and the server keeps
+    // confirming it with 304, so this image version would never actually
+    // be shown.
     this._cameraImageEtag = response.headers.get("etag") ?? undefined;
 
     const previousObjectUrl = this._cameraImageObjectUrl;
-    this._cameraImageObjectUrl = URL.createObjectURL(await response.blob());
+    this._cameraImageObjectUrl = URL.createObjectURL(blob);
     this._cameraImageSrc = this._cameraImageObjectUrl;
     if (previousObjectUrl) {
       URL.revokeObjectURL(previousObjectUrl);
@@ -493,6 +534,9 @@ export class HuiImage extends LitElement {
   }
 
   private _clearCameraImage(): void {
+    // Invalidate any in-flight request so it can't recreate state (or an
+    // object URL that never gets revoked) after we've just cleared it.
+    this._cameraImageRequestId++;
     if (this._cameraImageObjectUrl) {
       URL.revokeObjectURL(this._cameraImageObjectUrl);
       this._cameraImageObjectUrl = undefined;

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -453,13 +453,21 @@ export class HuiImage extends LitElement {
     // started, or after _clearCameraImage() ran, can be told apart from the
     // current one instead of clobbering it or reviving a cleared image.
     const requestId = ++this._cameraImageRequestId;
-
-    const url = await fetchThumbnailUrlWithCache(
-      this.hass,
-      this.cameraImage,
-      width,
-      height
-    );
+    
+    let url: string;
+    try {
+      url = await fetchThumbnailUrlWithCache(
+        this.hass,
+        this.cameraImage,
+        width,
+        height
+      );
+    } catch (_err) {
+      if (requestId === this._cameraImageRequestId) {
+        this._onImageError();
+      }
+      return;
+    }
     // The signed URL is regenerated on every poll, so the browser cache can
     // never revalidate it. Send If-None-Match ourselves instead.
     const headers: Record<string, string> = {};


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

`hui-image` refreshes a still camera image every 10 seconds (`UPDATE_INTERVAL`). Each refresh calls `fetchThumbnailUrlWithCache`, whose signed URL is cached for 9 seconds. This is always shorter than the poll interval, so every tick mints a brand-new signed URL. The `<img>` `src` therefore changes every 10 seconds regardless of whether the underlying image changed.

Two consequences:

**Animated camera images can restart part-way through.** Any camera serving an animated GIF or WebP has its animation reset to frame 0 every 10 seconds. A loop longer than 10 seconds never reaches the end; a loop shorter than that plays fully, then gets cut off mid-way through its second pass. For example, the Environment Canada radar camera produces a 6.8 second loop, so it plays once and is then killed 47% into the next pass, over and over.

**Every poll re-downloads bytes the client already has.** Because the URL changes each time, the browser cache can never revalidate. Cameras can update less often than every 10 seconds, for example a coordinator-backed camera refreshing every 5 minutes sends 29 identical responses out of every 30. A ~2 MB animation works out to roughly 700 MB/hour for one open dashboard.

This PR changes `_updateCameraImageSrc` to fetch the image itself and send `If-None-Match` explicitly (the rotating signed URL defeats the browser's URL-keyed cache, so the conditional request has to be made by hand). On `304 Not Modified` the current image is left in place, so lit never re-renders `src` and the animation keeps playing. On `200` the body becomes an object URL, and the previous one is revoked.

This change requires the backend PR that adds `ETag`/`304` support to `/api/camera_proxy` (linked below). Without it no `ETag` header is returned, no `If-None-Match` is ever sent, and behaviour is identical to today. Therefore the two can land in either order.

Notes for reviewers:

- Camera images now load via `fetch` + object URL rather than letting `<img>` load the URL directly. This moves the image through JS memory. Object URLs are revoked when replaced, on disconnect, and when the connection drops.
- The 10 second poll is unchanged. With a matching backend it now costs a conditional request with an empty body instead of a full image.
- The `await response.arrayBuffer()` on the 304 path looks redundant but is not. A 304 body is empty, and leaving it unconsumed makes Chrome tear the request down as `net::ERR_ABORTED`. Every poll shows as a failed request in devtools, and the connection cannot be reused. Draining the zero-byte body makes the request record clean.

### Testing

Measured A/B against a local instance serving a 31-frame animated GIF (96,743 bytes) from a camera whose bytes change every 5 minutes, both runs on the same build of this branch with only this commit reverted for the baseline:

| | unpatched | patched |
|---|---|---|
| window | 103 s | 106 s |
| polls | 10 | 13 |
| `200 OK` (full download) | 10 | 1 |
| `304 Not Modified` | 0 | 12 |
| `<img>` `src` changes | 10 | 1 |
| image bytes transferred | 967,430 | 96,743 |

Unpatched, every poll re-downloads the image and restarts the animation, at exactly the 10s interval. Patched, the only full download and the only animation restart is the one poll where the image genuinely changed. Extrapolated to an hour of one open card, that is ~35 MB/h against ~1.2 MB/h; for the 2 MB radar animation that prompted this, ~700 MB/h against ~24 MB/h.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: https://github.com/home-assistant/core/pull/178570

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
