### PR TITLE
Fix sensor card graph footers not receiving hass on lazy upgrade

### DIFF
--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -92,7 +92,19 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
     this._config = config;
 
     if (this._config.footer) {
-      this._footerElement = createHeaderFooterElement(this._config.footer);
+      const footerElement = createHeaderFooterElement(this._config.footer);
+      // A lazy loaded footer has no `hass` accessor before it is upgraded,
+      // so the forwarding in `shouldUpdate` skips it until then
+      footerElement.addEventListener(
+        "ll-upgrade",
+        () => {
+          if ("hass" in footerElement) {
+            footerElement.hass = this.hass;
+          }
+        },
+        { once: true }
+      );
+      this._footerElement = footerElement;
     } else if (this._footerElement) {
       this._footerElement = undefined;
     }

--- a/src/panels/lovelace/cards/hui-statistic-card.ts
+++ b/src/panels/lovelace/cards/hui-statistic-card.ts
@@ -175,7 +175,19 @@ export class HuiStatisticCard extends LitElement implements LovelaceCard {
     this._error = undefined;
 
     if (this._config.footer) {
-      this._footerElement = createHeaderFooterElement(this._config.footer);
+      const footerElement = createHeaderFooterElement(this._config.footer);
+      // A lazy loaded footer has no `hass` accessor before it is upgraded,
+      // so the forwarding in `shouldUpdate` skips it until then
+      footerElement.addEventListener(
+        "ll-upgrade",
+        () => {
+          if ("hass" in footerElement) {
+            footerElement.hass = this.hass;
+          }
+        },
+        { once: true }
+      );
+      this._footerElement = footerElement;
     } else if (this._footerElement) {
       this._footerElement = undefined;
     }

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -160,15 +160,16 @@ export class HuiGraphHeaderFooter
 
   private _subscribeHistory() {
     if (
-      !isComponentLoaded(this.hass!.config, "history") ||
+      !this.hass ||
+      !this._config ||
       this._subscribed ||
-      !this._config
+      !isComponentLoaded(this.hass.config, "history")
     ) {
       return;
     }
     this._setLoadingCoordinates();
     this._subscribed = subscribeHistoryStatesTimeWindow(
-      this.hass!,
+      this.hass,
       (combinedHistory) => {
         if (!this._subscribed || !this._config) {
           // Message came in before we had a chance to unload


### PR DESCRIPTION
## Proposed change

Lazily loaded header/footer elements stopped receiving `hass`, because `"hass" in element` is false on a custom element that has not been upgraded yet, so the forwarding side effect in `shouldUpdate` skipped them. A `graph` footer therefore completed its first update without `hass`, which left it throwing from `_subscribeHistory` on every later reconnect and delayed its graph until the next state change. This forwards `hass` on `ll-upgrade` — the same pattern #53471 used for entity rows — and guards the subscription so a `hass`-less reconnect is a silent no-op rather than a `TypeError`.

Scope notes for reviewers:

- Regression from #52926, which added the `"hass" in` guard to three hass-forwarding sites. #53471 already fixed entity rows; this fixes the remaining two.
- `hui-entities-card` needs no change: it forwards `hass` with bare assignments, which land as own properties that Lit replays at upgrade.
- `hui-history-graph-card` and `hui-trend-graph-card-feature` contain the same unguarded `this.hass!.config`, but always receive `hass` before connecting, so they are left alone.

## Screenshots

Sidebar view with three `graph: line` sensor cards, captured shortly after a cold reload. Before, the sensor and entity card graphs are missing entirely while the entities card footer (unaffected code path) renders; the sidebar card's graph arrived after 10.5s and the load produced 8-12 uncaught `TypeError`s. After, every graph is present at 1.07s with a clean console.

| Before | After |
| --- | --- |
| ![before](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/53558-before-920f9d7b.png) | ![after](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/53558-after-c7c2aa5a.png) |

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #53558
- This PR is related to issue or discussion: regression from #52926, same fix pattern as #53471
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
