### PR TITLE
Recover from a stale build after boot

### DIFF
--- a/src/dialogs/make-dialog-manager.ts
+++ b/src/dialogs/make-dialog-manager.ts
@@ -98,20 +98,31 @@ export const showDialog = async (
       return false;
     }
     LOADED[dialogTag] = {
-      element: dialogImport().then(() => {
-        const dialogEl = document.createElement(dialogTag) as
-          HassDialogNext | HassDialog;
+      element: dialogImport().then(
+        () => {
+          const dialogEl = document.createElement(dialogTag) as
+            HassDialogNext | HassDialog;
 
-        if ("showDialog" in dialogEl) {
-          // provide hass for legacy persistent dialogs
-          element.provideHass(dialogEl);
+          if ("showDialog" in dialogEl) {
+            // provide hass for legacy persistent dialogs
+            element.provideHass(dialogEl);
+          }
+
+          dialogEl.addEventListener("dialog-closed", _handleClosed);
+          dialogEl.addEventListener("dialog-closed", _handleClosedFocus);
+
+          return dialogEl;
+        },
+        (err) => {
+          // Don't cache a rejected import (e.g. a stale build's chunk 404s
+          // while the app stayed open): drop the entry so a later open
+          // re-imports instead of being permanently stuck on the rejected
+          // promise. The rejection still propagates to the global stale-build
+          // handler (logging-mixin) for recovery.
+          delete LOADED[dialogTag];
+          throw err;
         }
-
-        dialogEl.addEventListener("dialog-closed", _handleClosed);
-        dialogEl.addEventListener("dialog-closed", _handleClosedFocus);
-
-        return dialogEl;
-      }),
+      ),
     };
   }
 

--- a/src/external_app/external_messaging.ts
+++ b/src/external_app/external_messaging.ts
@@ -191,6 +191,10 @@ interface EMOutgoingMessageFocusElement extends EMMessage {
   };
 }
 
+interface EMOutgoingMessageReloadAndClearCache extends EMMessage {
+  type: "frontend/reload_and_clear_cache";
+}
+
 // These types are handled internally by the Android app via postMessage.
 // They are not sent by the frontend and should not be used directly.
 // They are intentionally listed here to prevent anyone from using them unintentionally.
@@ -220,6 +224,7 @@ type EMOutgoingMessageWithoutAnswer =
   | EMOutgoingMessageImprovConfigureDevice
   | EMOutgoingMessageAddEntityTo
   | EMOutgoingMessageFocusElement
+  | EMOutgoingMessageReloadAndClearCache
   | EMOutgoingMessageAssistSettings;
 
 export interface EMIncomingMessageRestart {
@@ -511,14 +516,26 @@ export class ExternalMessaging {
       // eslint-disable-next-line no-console
       console.log("Sending message to external app", msg);
     }
-    if (window.externalAppV2) {
-      window.externalAppV2.postMessage(
-        JSON.stringify({ type: "externalBus", payload: msg })
-      );
-    } else if (window.externalApp) {
-      window.externalApp.externalBus(JSON.stringify(msg));
-    } else {
-      window.webkit!.messageHandlers.externalBus.postMessage(msg);
-    }
+    fireExternalBusMessage(msg);
   }
 }
+
+/**
+ * Post a message to the companion app's external bus without needing an
+ * `ExternalMessaging` instance (i.e. without `hass`). Returns `false` when no
+ * external bridge is present, so callers can fall back to browser behavior.
+ */
+export const fireExternalBusMessage = (msg: EMMessage): boolean => {
+  if (window.externalAppV2) {
+    window.externalAppV2.postMessage(
+      JSON.stringify({ type: CALLBACK_EXTERNAL_BUS, payload: msg })
+    );
+  } else if (window.externalApp) {
+    window.externalApp.externalBus(JSON.stringify(msg));
+  } else if (window.webkit?.messageHandlers?.externalBus) {
+    window.webkit.messageHandlers.externalBus.postMessage(msg);
+  } else {
+    return false;
+  }
+  return true;
+};

--- a/src/layouts/hass-error-screen.ts
+++ b/src/layouts/hass-error-screen.ts
@@ -5,7 +5,7 @@ import { goBack } from "../common/navigate";
 import "../components/ha-button";
 import "../components/ha-top-app-bar-fixed";
 import type { HomeAssistant } from "../types";
-import { reloadFresh } from "../util/recover-stale-build";
+import { reloadForUpdate } from "../util/recover-stale-build";
 import "../components/ha-alert";
 
 @customElement("hass-error-screen")
@@ -69,7 +69,9 @@ class HassErrorScreen extends LitElement {
   }
 
   private _handleReload(): void {
-    reloadFresh();
+    // Dirty-aware: reloads when clean, or defers with a toast when an editor
+    // has unsaved changes.
+    reloadForUpdate();
   }
 
   static get styles(): CSSResultGroup {

--- a/src/layouts/hass-error-screen.ts
+++ b/src/layouts/hass-error-screen.ts
@@ -1,10 +1,11 @@
 import type { CSSResultGroup, TemplateResult } from "lit";
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { goBack } from "../common/navigate";
 import "../components/ha-button";
 import "../components/ha-top-app-bar-fixed";
 import type { HomeAssistant } from "../types";
+import { reloadFresh } from "../util/recover-stale-build";
 import "../components/ha-alert";
 
 @customElement("hass-error-screen")
@@ -18,6 +19,9 @@ class HassErrorScreen extends LitElement {
   @property({ type: Boolean }) public narrow = false;
 
   @property() public error?: string;
+
+  @property({ type: Boolean, attribute: "show-reload" }) public showReload =
+    false;
 
   protected render(): TemplateResult {
     if (!this.toolbar) {
@@ -39,6 +43,19 @@ class HassErrorScreen extends LitElement {
       <div class="content">
         <ha-alert alert-type="error">${this.error}</ha-alert>
         <slot>
+          ${
+            this.showReload
+              ? html`
+                  <ha-button
+                    appearance="filled"
+                    size="s"
+                    @click=${this._handleReload}
+                  >
+                    ${this.hass?.localize("ui.common.refresh")}
+                  </ha-button>
+                `
+              : nothing
+          }
           <ha-button appearance="plain" size="s" @click=${this._handleBack}>
             ${this.hass?.localize("ui.common.back")}
           </ha-button>
@@ -49,6 +66,10 @@ class HassErrorScreen extends LitElement {
 
   private _handleBack(): void {
     goBack();
+  }
+
+  private _handleReload(): void {
+    reloadFresh();
   }
 
   static get styles(): CSSResultGroup {

--- a/src/layouts/hass-router-page.ts
+++ b/src/layouts/hass-router-page.ts
@@ -5,6 +5,7 @@ import memoizeOne from "memoize-one";
 import { navigate } from "../common/navigate";
 import { computeRouteTail } from "../common/url/route";
 import type { Route } from "../types";
+import { recoverFromStaleBuild } from "../util/recover-stale-build";
 import { PanelReady } from "./panel-ready";
 
 const extractPage = (path: string, defaultPage: string) => {
@@ -182,9 +183,15 @@ export class HassRouterPage extends ReactiveElement {
         this._showLoadingScreenTimeout = undefined;
       }
 
-      // Show error screen
+      // A stale build (the panel's hashed chunk 404s after an upgrade while
+      // the app stayed open) is recoverable: reload onto the current build
+      // (or prompt when there are unsaved edits) instead of dead-ending.
+      const message = err instanceof Error ? err.message : String(err ?? "");
+      const stale = recoverFromStaleBuild(message, this);
+
+      // Show error screen, offering a reload action for a stale build.
       this.appendChild(
-        this.createErrorScreen(`Error while loading page ${newPage}.`)
+        this.createErrorScreen(`Error while loading page ${newPage}.`, stale)
       );
     });
 
@@ -285,10 +292,11 @@ export class HassRouterPage extends ReactiveElement {
     return document.createElement("hass-loading-screen");
   }
 
-  protected createErrorScreen(error: string) {
+  protected createErrorScreen(error: string, showReload = false) {
     import("./hass-error-screen");
     const errorEl = document.createElement("hass-error-screen");
     errorEl.error = error;
+    errorEl.showReload = showReload;
     return errorEl;
   }
 

--- a/src/layouts/hass-router-page.ts
+++ b/src/layouts/hass-router-page.ts
@@ -189,10 +189,15 @@ export class HassRouterPage extends ReactiveElement {
       const message = err instanceof Error ? err.message : String(err ?? "");
       const stale = recoverFromStaleBuild(message, this);
 
-      // Show error screen, offering a reload action for a stale build.
-      this.appendChild(
-        this.createErrorScreen(`Error while loading page ${newPage}.`, stale)
+      // Show error screen, offering a reload action for a stale build. Set
+      // `showReload` on the returned element rather than through
+      // createErrorScreen's signature, so router subclasses that override
+      // createErrorScreen (e.g. ToolsRouter) can't drop it.
+      const errorScreen = this.createErrorScreen(
+        `Error while loading page ${newPage}.`
       );
+      errorScreen.showReload = stale;
+      this.appendChild(errorScreen);
     });
 
     // If we don't show loading screen, just show the panel.
@@ -292,11 +297,10 @@ export class HassRouterPage extends ReactiveElement {
     return document.createElement("hass-loading-screen");
   }
 
-  protected createErrorScreen(error: string, showReload = false) {
+  protected createErrorScreen(error: string) {
     import("./hass-error-screen");
     const errorEl = document.createElement("hass-error-screen");
     errorEl.error = error;
-    errorEl.showReload = showReload;
     return errorEl;
   }
 

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -19,7 +19,7 @@ import type { HomeAssistant, Route } from "../types";
 import { storeState } from "../util/ha-pref-storage";
 import { renderLaunchScreenContent } from "../util/launch-screen";
 import { checkOnboardingSurveyToast } from "../util/onboarding-survey";
-import { reloadFresh } from "../util/recover-stale-build";
+import { reloadForUpdate } from "../util/recover-stale-build";
 import {
   registerServiceWorker,
   supportsServiceWorker,
@@ -248,11 +248,11 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
           if (registration) {
             registration.update();
           } else if (oldVersion) {
-            reloadFresh();
+            reloadForUpdate();
           }
         });
       } else if (oldVersion) {
-        reloadFresh();
+        reloadForUpdate();
       }
     }
   }

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -19,6 +19,7 @@ import type { HomeAssistant, Route } from "../types";
 import { storeState } from "../util/ha-pref-storage";
 import { renderLaunchScreenContent } from "../util/launch-screen";
 import { checkOnboardingSurveyToast } from "../util/onboarding-survey";
+import { reloadFresh } from "../util/recover-stale-build";
 import {
   registerServiceWorker,
   supportsServiceWorker,
@@ -247,13 +248,11 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
           if (registration) {
             registration.update();
           } else if (oldVersion) {
-            // @ts-ignore Firefox supports forceGet
-            location.reload(true);
+            reloadFresh();
           }
         });
       } else if (oldVersion) {
-        // @ts-ignore Firefox supports forceGet
-        location.reload(true);
+        reloadFresh();
       }
     }
   }

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -379,8 +379,7 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       // @ts-ignore
       this.hass!.callWS({ type: "get_config" }).then((config: HassConfig) => {
         if (config.safe_mode) {
-          // @ts-ignore Firefox supports forceGet
-          location.reload(true);
+          location.reload();
         }
         this._updateHass({ config });
         this.checkDataBaseMigration();

--- a/src/state/logging-mixin.ts
+++ b/src/state/logging-mixin.ts
@@ -2,6 +2,7 @@ import type { PropertyValues } from "lit";
 import type { HASSDomEvent } from "../common/dom/fire_event";
 import type { SystemLogLevel } from "../data/system_log";
 import type { Constructor } from "../types";
+import { recoverFromStaleBuild } from "../util/recover-stale-build";
 import type { HassBaseEl } from "./hass-base-mixin";
 
 interface WriteLogParams {
@@ -25,7 +26,31 @@ export const loggingMixin = <T extends Constructor<HassBaseEl>>(
   class extends superClass {
     protected hassConnected() {
       super.hassConnected();
+      // Resource-load errors (<script>, modulepreload <link>) do not bubble,
+      // so observe them in the capture phase. A stale build's hashed chunk
+      // 404 lands here (legacy build / modulepreload); recover instead of
+      // dead-ending.
+      window.addEventListener(
+        "error",
+        (ev) => {
+          const target = ev.target as
+            (HTMLScriptElement & HTMLLinkElement) | null;
+          if (
+            target &&
+            (target.tagName === "SCRIPT" || target.tagName === "LINK")
+          ) {
+            recoverFromStaleBuild(target.src || target.href, this);
+          }
+        },
+        true
+      );
       window.addEventListener("error", async (ev) => {
+        // A stale build can surface as a runtime error while evaluating a
+        // freshly (re)loaded chunk; recover rather than log it.
+        if (recoverFromStaleBuild(ev.error?.message || ev.message, this)) {
+          ev.preventDefault();
+          return;
+        }
         if (!this.hass?.connected) {
           return;
         }
@@ -59,6 +84,20 @@ export const loggingMixin = <T extends Constructor<HassBaseEl>>(
         }
       });
       window.addEventListener("unhandledrejection", async (ev) => {
+        // A failed dynamic import() of a stale build's chunk rejects here
+        // (dialogs, more-info, cards, config-flow, …); recover rather than
+        // silently logging it at debug level.
+        const reason: any = ev.reason;
+        const reasonMessage =
+          reason instanceof Error
+            ? reason.message
+            : typeof reason === "string"
+              ? reason
+              : "";
+        if (recoverFromStaleBuild(reasonMessage, this)) {
+          ev.preventDefault();
+          return;
+        }
         if (!this.hass?.connected) {
           return;
         }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2543,6 +2543,7 @@
       "dismiss": "Dismiss",
       "no_matching_link_found": "No matching My link found for {path}",
       "new_version_available": "A new version of the frontend is available. This page will update in {seconds, plural, one {# second} other {# seconds}}.",
+      "new_version_available_reload": "A new version of the frontend is available. Reload to update.",
       "update_now": "Update now",
       "theme_save_failed": "Unable to save theme settings to your user profile.",
       "theme_preferences_unavailable": "Unable to load user profile theme settings.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2543,7 +2543,7 @@
       "dismiss": "Dismiss",
       "no_matching_link_found": "No matching My link found for {path}",
       "new_version_available": "A new version of the frontend is available. This page will update in {seconds, plural, one {# second} other {# seconds}}.",
-      "new_version_available_reload": "A new version of the frontend is available. Reload to update.",
+      "new_version_available_reload": "A new version of the frontend is available. It will be applied once you have saved or discarded your changes.",
       "update_now": "Update now",
       "theme_save_failed": "Unable to save theme settings to your user profile.",
       "theme_preferences_unavailable": "Unable to load user profile theme settings.",

--- a/src/util/recover-stale-build.ts
+++ b/src/util/recover-stale-build.ts
@@ -1,0 +1,169 @@
+import { mainWindow } from "../common/dom/get_main_window";
+import * as staleBuildPatterns from "./stale-build-patterns.json";
+import { showToast } from "./toast";
+
+// Patterns live in a JSON single source (stale-build-patterns.json) so the
+// build can inject the exact same ones into the inline boot-time guard
+// (src/html/_bootstrap_recovery.html.template), which runs before any bundle
+// loads and therefore cannot import from here.
+const patterns = ((staleBuildPatterns as any).default ??
+  staleBuildPatterns) as { hashedEntry: string; moduleError: string };
+const HASHED_ENTRY = new RegExp(patterns.hashedEntry, "i");
+const MODULE_ERROR = new RegExp(patterns.moduleError, "i");
+
+const RELOAD_STORAGE_KEY = "haStaleBuildReload";
+const RELOAD_COOLDOWN = 60_000;
+// Reuse the service worker update toast id so we never show two competing
+// "new version available" toasts (see register-service-worker.ts).
+const UPDATE_TOAST_ID = "frontend-update-available";
+
+let reloading = false;
+let toastShown = false;
+
+/**
+ * True when the given string looks like a failed load of a content-hashed
+ * frontend chunk — i.e. a stale build referencing files that no longer exist
+ * on the server after an upgrade. Accepts either a URL (from a resource
+ * `error` event) or an error message (from a rejected dynamic `import()`).
+ */
+export const isStaleBuildError = (urlOrMessage: string | undefined): boolean =>
+  !!urlOrMessage &&
+  (HASHED_ENTRY.test(urlOrMessage) || MODULE_ERROR.test(urlOrMessage));
+
+/**
+ * Reload the page onto the current build.
+ *
+ * While a service worker controls the page its chunks are served CacheFirst
+ * (with `ignoreSearch`), so a cache-busting navigation alone would still be
+ * answered from the stale cache. We therefore first drop the worker and its
+ * caches, then navigate with a cache-busting query so the browser / proxy /
+ * WKWebView fetches a fresh index.html.
+ *
+ * Guarded by a monotonic sessionStorage counter — NOT the boot guard's URL
+ * param, which core.ts strips on every successful connect — so a recovery that
+ * boots and then immediately re-triggers the same missing chunk (a deep-linked
+ * panel, more-info from the URL, or a preloaded route) cannot reload-loop.
+ */
+export const reloadFresh = async (): Promise<void> => {
+  if (reloading) {
+    return;
+  }
+  const now = Date.now();
+  let attempts = 0;
+  let last = 0;
+  try {
+    const stored = sessionStorage.getItem(RELOAD_STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      attempts = Number(parsed.n) || 0;
+      last = Number(parsed.t) || 0;
+    }
+  } catch (_err) {
+    // sessionStorage unavailable (e.g. privacy mode); best-effort only.
+  }
+  if (now - last > RELOAD_COOLDOWN) {
+    attempts = 0;
+  }
+  if (attempts >= 1) {
+    // Already reloaded once recently and it still failed: stop, to avoid a
+    // reload loop on a genuinely broken (not merely stale) deploy.
+    return;
+  }
+  reloading = true;
+  try {
+    sessionStorage.setItem(
+      RELOAD_STORAGE_KEY,
+      JSON.stringify({ n: attempts + 1, t: now })
+    );
+  } catch (_err) {
+    // ignore
+  }
+
+  if ("serviceWorker" in navigator && navigator.serviceWorker.controller) {
+    try {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(registrations.map((reg) => reg.unregister()));
+    } catch (_err) {
+      // ignore
+    }
+    if ("caches" in window) {
+      try {
+        const keys = await caches.keys();
+        await Promise.all(keys.map((key) => caches.delete(key)));
+      } catch (_err) {
+        // ignore
+      }
+    }
+  }
+
+  const url = new URL(mainWindow.location.href);
+  url.searchParams.set("ha_cache_bust", String(now));
+  mainWindow.location.replace(url.href);
+};
+
+const showStaleBuildToast = (rootEl?: HTMLElement): void => {
+  if (toastShown) {
+    return;
+  }
+  const el =
+    rootEl ??
+    (mainWindow.document.querySelector("home-assistant") as HTMLElement | null);
+  if (!el) {
+    // Nowhere to anchor the toast yet; a later trigger can retry.
+    return;
+  }
+  toastShown = true;
+  // Auto-reload as soon as the user is no longer editing, so we never destroy
+  // unsaved work but still get them onto the current build promptly.
+  const reloadWhenClean = () => {
+    if (!window.isDirtyState) {
+      window.removeEventListener("dirty-state-changed", reloadWhenClean);
+      reloadFresh();
+    }
+  };
+  window.addEventListener("dirty-state-changed", reloadWhenClean);
+  showToast(el, {
+    id: UPDATE_TOAST_ID,
+    message: {
+      translationKey: "ui.notification_toast.new_version_available_reload",
+    },
+    action: {
+      action: () => reloadFresh(),
+      primary: true,
+      text: { translationKey: "ui.notification_toast.update_now" },
+    },
+    duration: -1,
+    dismissable: false,
+  });
+};
+
+/**
+ * Recover from a failed lazy load caused by a stale build (a content-hashed
+ * chunk that 404s after an upgrade while the app stayed open).
+ *
+ * - clean: reload onto the current build.
+ * - dirty (an editor has unsaved changes): show a non-dismissable toast and
+ *   auto-reload once the user saves/discards, so unsaved work is never lost.
+ *
+ * Returns `true` when the error was a stale-build error and recovery was
+ * started, so callers can skip their own error UI / logging.
+ */
+export const recoverFromStaleBuild = (
+  urlOrMessage: string | undefined,
+  rootEl?: HTMLElement
+): boolean => {
+  // In dev/demo the entry files are unhashed and rebuild churn can throw
+  // transient import errors; never auto-reload there.
+  if (__DEV__ || __DEMO__) {
+    return false;
+  }
+  if (!isStaleBuildError(urlOrMessage)) {
+    return false;
+  }
+  if (window.isDirtyState) {
+    showStaleBuildToast(rootEl);
+  } else {
+    reloadFresh();
+  }
+  return true;
+};

--- a/src/util/recover-stale-build.ts
+++ b/src/util/recover-stale-build.ts
@@ -31,64 +31,12 @@ export const isStaleBuildError = (urlOrMessage: string | undefined): boolean =>
   !!urlOrMessage &&
   (HASHED_ENTRY.test(urlOrMessage) || MODULE_ERROR.test(urlOrMessage));
 
-/**
- * Reload the page onto the current build.
- *
- * While a service worker controls the page its chunks are served CacheFirst
- * (with `ignoreSearch`), so a cache-busting navigation alone would still be
- * answered from the stale cache. We therefore first drop the worker and its
- * caches, then navigate with a cache-busting query so the browser / proxy /
- * WKWebView fetches a fresh index.html.
- *
- * Guarded by a monotonic sessionStorage counter — NOT the boot guard's URL
- * param, which core.ts strips on every successful connect — so a recovery that
- * boots and then immediately re-triggers the same missing chunk (a deep-linked
- * panel, more-info from the URL, or a preloaded route) cannot reload-loop.
- */
-export const reloadFresh = async (): Promise<void> => {
-  if (reloading) {
-    return;
-  }
-  const now = Date.now();
-  let attempts = 0;
-  let last = 0;
-  try {
-    const stored = sessionStorage.getItem(RELOAD_STORAGE_KEY);
-    if (stored) {
-      const parsed = JSON.parse(stored);
-      attempts = Number(parsed.n) || 0;
-      last = Number(parsed.t) || 0;
-    }
-  } catch (_err) {
-    // sessionStorage unavailable (e.g. privacy mode); best-effort only.
-  }
-  if (now - last > RELOAD_COOLDOWN) {
-    attempts = 0;
-  }
-  if (attempts >= 1) {
-    // Already reloaded once recently and it still failed: stop, to avoid a
-    // reload loop on a genuinely broken (not merely stale) deploy.
-    return;
-  }
-  reloading = true;
-  try {
-    sessionStorage.setItem(
-      RELOAD_STORAGE_KEY,
-      JSON.stringify({ n: attempts + 1, t: now })
-    );
-  } catch (_err) {
-    // ignore
-  }
-
-  // In the companion app (WKWebView) there is no service worker, and its
-  // top-level document HTTP cache is not cleared by the Cache API — so the
-  // web-level recovery below is ineffective there. Ask the native app to
-  // purge its cache and reload the web view instead. Returns false (and falls
-  // through to the browser path) when no external bridge is present.
-  if (fireExternalBusMessage({ type: "frontend/reload_and_clear_cache" })) {
-    return;
-  }
-
+const dropCachesAndReload = async (bust: number): Promise<void> => {
+  // A service worker serves chunks CacheFirst (with `ignoreSearch`), so a
+  // cache-busting navigation alone would still be answered from the stale
+  // cache. Drop the worker and its caches first, then navigate with a
+  // cache-busting query so a fresh index.html is fetched. (Android's WebView
+  // has a service worker, so this path recovers it too.)
   if ("serviceWorker" in navigator && navigator.serviceWorker.controller) {
     try {
       const registrations = await navigator.serviceWorker.getRegistrations();
@@ -107,8 +55,75 @@ export const reloadFresh = async (): Promise<void> => {
   }
 
   const url = new URL(mainWindow.location.href);
-  url.searchParams.set("ha_cache_bust", String(now));
+  url.searchParams.set("ha_cache_bust", String(bust));
   mainWindow.location.replace(url.href);
+};
+
+/**
+ * Reload the page onto the current build.
+ *
+ * Returns `true` when a reload was actually initiated, `false` when the loop
+ * guard blocked it — so callers can fall back to logging / an error screen
+ * instead of silently swallowing a still-failing chunk.
+ *
+ * Guarded by a monotonic sessionStorage counter — NOT the boot guard's URL
+ * param, which core.ts strips on every successful connect — so a recovery that
+ * boots and then immediately re-triggers the same missing chunk (a deep-linked
+ * panel, more-info from the URL, or a preloaded route) cannot reload-loop.
+ */
+export const reloadFresh = (): boolean => {
+  if (reloading) {
+    return false;
+  }
+  const now = Date.now();
+  let attempts = 0;
+  let last = 0;
+  let storageOk = true;
+  try {
+    const stored = sessionStorage.getItem(RELOAD_STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      attempts = Number(parsed.n) || 0;
+      last = Number(parsed.t) || 0;
+    }
+  } catch (_err) {
+    storageOk = false;
+  }
+  if (now - last > RELOAD_COOLDOWN) {
+    attempts = 0;
+  }
+  if (attempts >= 1) {
+    // Already reloaded once recently and it still failed: stop, to avoid a
+    // reload loop on a genuinely broken (not merely stale) deploy.
+    return false;
+  }
+  try {
+    sessionStorage.setItem(
+      RELOAD_STORAGE_KEY,
+      JSON.stringify({ n: attempts + 1, t: now })
+    );
+  } catch (_err) {
+    storageOk = false;
+  }
+  if (!storageOk) {
+    // Without a durable cooldown marker (e.g. private mode) we can't stop a
+    // loop across reloads, so fail closed rather than risk reloading forever.
+    return false;
+  }
+  reloading = true;
+
+  // `frontend/reload_and_clear_cache` is a WKWebView (iOS/macOS companion)
+  // command; the Android bridges (externalApp/externalAppV2) don't handle it.
+  // Only send it to the WebKit bridge — everything else takes the browser
+  // path below (Android's WebView has a service worker, so it recovers there).
+  if (window.webkit?.messageHandlers?.externalBus) {
+    fireExternalBusMessage({ type: "frontend/reload_and_clear_cache" });
+    return true;
+  }
+
+  // Fire and forget; the page navigates away once it resolves.
+  void dropCachesAndReload(now);
+  return true;
 };
 
 const showStaleBuildToast = (rootEl?: HTMLElement): void => {
@@ -123,8 +138,9 @@ const showStaleBuildToast = (rootEl?: HTMLElement): void => {
     return;
   }
   toastShown = true;
-  // Auto-reload as soon as the user is no longer editing, so we never destroy
-  // unsaved work but still get them onto the current build promptly.
+  // This toast is only shown while an editor is dirty, so it deliberately has
+  // no immediate-reload action that could discard unsaved work: it reloads
+  // automatically once the user saves or discards.
   const reloadWhenClean = () => {
     if (!window.isDirtyState) {
       window.removeEventListener("dirty-state-changed", reloadWhenClean);
@@ -137,14 +153,22 @@ const showStaleBuildToast = (rootEl?: HTMLElement): void => {
     message: {
       translationKey: "ui.notification_toast.new_version_available_reload",
     },
-    action: {
-      action: () => reloadFresh(),
-      primary: true,
-      text: { translationKey: "ui.notification_toast.update_now" },
-    },
     duration: -1,
     dismissable: false,
   });
+};
+
+/**
+ * Reload onto the current build, but never over unsaved work: when an editor
+ * is dirty, show a non-dismissable toast and defer the reload until the dirty
+ * state clears. Returns `true` when a reload or the deferral toast was started.
+ */
+export const reloadForUpdate = (rootEl?: HTMLElement): boolean => {
+  if (window.isDirtyState) {
+    showStaleBuildToast(rootEl);
+    return true;
+  }
+  return reloadFresh();
 };
 
 /**
@@ -156,7 +180,9 @@ const showStaleBuildToast = (rootEl?: HTMLElement): void => {
  *   auto-reload once the user saves/discards, so unsaved work is never lost.
  *
  * Returns `true` when the error was a stale-build error and recovery was
- * started, so callers can skip their own error UI / logging.
+ * actually started, so callers can skip their own error UI / logging. Returns
+ * `false` for a non-stale error, or when the loop guard blocked the reload (so
+ * the caller still surfaces/logs the failure).
  */
 export const recoverFromStaleBuild = (
   urlOrMessage: string | undefined,
@@ -170,10 +196,5 @@ export const recoverFromStaleBuild = (
   if (!isStaleBuildError(urlOrMessage)) {
     return false;
   }
-  if (window.isDirtyState) {
-    showStaleBuildToast(rootEl);
-  } else {
-    reloadFresh();
-  }
-  return true;
+  return reloadForUpdate(rootEl);
 };

--- a/src/util/recover-stale-build.ts
+++ b/src/util/recover-stale-build.ts
@@ -1,4 +1,5 @@
 import { mainWindow } from "../common/dom/get_main_window";
+import { fireExternalBusMessage } from "../external_app/external_messaging";
 import * as staleBuildPatterns from "./stale-build-patterns.json";
 import { showToast } from "./toast";
 
@@ -77,6 +78,15 @@ export const reloadFresh = async (): Promise<void> => {
     );
   } catch (_err) {
     // ignore
+  }
+
+  // In the companion app (WKWebView) there is no service worker, and its
+  // top-level document HTTP cache is not cleared by the Cache API — so the
+  // web-level recovery below is ineffective there. Ask the native app to
+  // purge its cache and reload the web view instead. Returns false (and falls
+  // through to the browser path) when no external bridge is present.
+  if (fireExternalBusMessage({ type: "frontend/reload_and_clear_cache" })) {
+    return;
   }
 
   if ("serviceWorker" in navigator && navigator.serviceWorker.controller) {

--- a/test/util/recover-stale-build.test.ts
+++ b/test/util/recover-stale-build.test.ts
@@ -66,6 +66,7 @@ describe("recover-stale-build", () => {
     } else {
       Reflect.deleteProperty(navigator, "serviceWorker");
     }
+    Reflect.deleteProperty(window, "externalApp");
     window.isDirtyState = false;
     globalThis.__DEV__ = false;
     globalThis.__DEMO__ = false;
@@ -121,6 +122,25 @@ describe("recover-stale-build", () => {
 
       // reloadFresh() ran (marker written before navigating) and did not toast.
       expect(reloadMarker()).not.toBeNull();
+      expect(notifications).toHaveLength(0);
+    });
+
+    it("uses the companion-app external command when a bridge is present", () => {
+      const externalBus = vi.fn();
+      (
+        window as unknown as {
+          externalApp: { externalBus: typeof externalBus };
+        }
+      ).externalApp = { externalBus };
+
+      expect(mod.recoverFromStaleBuild(STALE_URL, root)).toBe(true);
+
+      // Asks the native app to purge its cache and reload instead of the
+      // browser-only path.
+      expect(externalBus).toHaveBeenCalledOnce();
+      expect(externalBus.mock.calls[0][0]).toContain(
+        "frontend/reload_and_clear_cache"
+      );
       expect(notifications).toHaveLength(0);
     });
 

--- a/test/util/recover-stale-build.test.ts
+++ b/test/util/recover-stale-build.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ShowToastParams } from "../../src/managers/notification-manager";
+import type {
+  isStaleBuildError,
+  recoverFromStaleBuild,
+} from "../../src/util/recover-stale-build";
+
+interface RecoverModule {
+  isStaleBuildError: typeof isStaleBuildError;
+  recoverFromStaleBuild: typeof recoverFromStaleBuild;
+}
+
+const STALE_URL = "/frontend_latest/core.abc12345.js";
+// Set by reloadFresh() right before it navigates; used here to observe that
+// the reload path ran without having to mock window.location (jsdom forbids
+// redefining it).
+const RELOAD_KEY = "haStaleBuildReload";
+
+describe("recover-stale-build", () => {
+  let mod: RecoverModule;
+  let root: HTMLElement;
+  let notifications: ShowToastParams[];
+  let serviceWorkerDescriptor: PropertyDescriptor | undefined;
+
+  const latestNotification = () => notifications[notifications.length - 1];
+  const reloadMarker = () => sessionStorage.getItem(RELOAD_KEY);
+
+  beforeEach(async () => {
+    globalThis.__DEV__ = false;
+    globalThis.__DEMO__ = false;
+    window.isDirtyState = false;
+    sessionStorage.clear();
+
+    // No controlling service worker → reloadFresh() takes the synchronous
+    // path (no unregister/caches work) straight to the (jsdom no-op) navigate.
+    serviceWorkerDescriptor = Object.getOwnPropertyDescriptor(
+      navigator,
+      "serviceWorker"
+    );
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: { controller: null },
+    });
+
+    // Capture toasts fired via showToast (a "hass-notification" event).
+    notifications = [];
+    root = document.createElement("home-assistant");
+    root.addEventListener("hass-notification", (event) => {
+      notifications.push((event as CustomEvent<ShowToastParams>).detail);
+    });
+    document.body.append(root);
+
+    // Fresh module state per test (resets the reloading/toastShown singletons).
+    vi.resetModules();
+    mod = await import("../../src/util/recover-stale-build");
+  });
+
+  afterEach(() => {
+    root.remove();
+    if (serviceWorkerDescriptor) {
+      Object.defineProperty(
+        navigator,
+        "serviceWorker",
+        serviceWorkerDescriptor
+      );
+    } else {
+      Reflect.deleteProperty(navigator, "serviceWorker");
+    }
+    window.isDirtyState = false;
+    globalThis.__DEV__ = false;
+    globalThis.__DEMO__ = false;
+  });
+
+  describe("isStaleBuildError", () => {
+    it.each([
+      "/frontend_latest/core.abc12345.js",
+      "https://ha.local/frontend_es5/panel-config.deadbeef99.js",
+      "Failed to fetch dynamically imported module: /frontend_latest/x.abcdef12.js",
+      "Importing a module script failed.",
+      "error loading dynamically imported module",
+      "ChunkLoadError: Loading chunk 5 failed",
+    ])("detects a stale-build error: %s", (message) => {
+      expect(mod.isStaleBuildError(message)).toBe(true);
+    });
+
+    it.each([
+      undefined,
+      "",
+      "/frontend_latest/core.js", // dev, unhashed
+      "/static/translations/en-abc12345.json", // hashed, but not an entry chunk
+      "TypeError: x is not a function",
+    ])("ignores non-stale input: %s", (message) => {
+      expect(mod.isStaleBuildError(message)).toBe(false);
+    });
+  });
+
+  describe("recoverFromStaleBuild", () => {
+    it("does nothing in development", () => {
+      globalThis.__DEV__ = true;
+
+      expect(mod.recoverFromStaleBuild(STALE_URL, root)).toBe(false);
+      expect(reloadMarker()).toBeNull();
+      expect(notifications).toHaveLength(0);
+    });
+
+    it("does nothing in demo", () => {
+      globalThis.__DEMO__ = true;
+
+      expect(mod.recoverFromStaleBuild(STALE_URL, root)).toBe(false);
+      expect(reloadMarker()).toBeNull();
+    });
+
+    it("ignores a non-stale error", () => {
+      expect(mod.recoverFromStaleBuild("TypeError: boom", root)).toBe(false);
+      expect(reloadMarker()).toBeNull();
+      expect(notifications).toHaveLength(0);
+    });
+
+    it("reloads onto the current build when clean", () => {
+      expect(mod.recoverFromStaleBuild(STALE_URL, root)).toBe(true);
+
+      // reloadFresh() ran (marker written before navigating) and did not toast.
+      expect(reloadMarker()).not.toBeNull();
+      expect(notifications).toHaveLength(0);
+    });
+
+    it("shows a reload toast instead of reloading when dirty", () => {
+      window.isDirtyState = true;
+
+      expect(mod.recoverFromStaleBuild(STALE_URL, root)).toBe(true);
+
+      // Took the toast branch, not the reload branch.
+      expect(reloadMarker()).toBeNull();
+      expect(latestNotification()).toMatchObject({
+        id: "frontend-update-available",
+        message: {
+          translationKey: "ui.notification_toast.new_version_available_reload",
+        },
+        action: {
+          text: { translationKey: "ui.notification_toast.update_now" },
+        },
+        duration: -1,
+        dismissable: false,
+      });
+    });
+
+    it("does not reload again while the cooldown marker is set (loop guard)", async () => {
+      expect(mod.recoverFromStaleBuild(STALE_URL, root)).toBe(true);
+      const firstMarker = reloadMarker();
+      expect(firstMarker).not.toBeNull();
+
+      // Simulate the reloaded page: a fresh module (the in-memory reloading
+      // flag is reset) but the sessionStorage cooldown marker persists.
+      vi.resetModules();
+      const reloaded: RecoverModule =
+        await import("../../src/util/recover-stale-build");
+
+      reloaded.recoverFromStaleBuild("/frontend_latest/app.def67890.js", root);
+
+      // Guard blocked a second navigation: the marker is unchanged.
+      expect(reloadMarker()).toBe(firstMarker);
+    });
+  });
+});

--- a/test/util/recover-stale-build.test.ts
+++ b/test/util/recover-stale-build.test.ts
@@ -21,6 +21,7 @@ describe("recover-stale-build", () => {
   let root: HTMLElement;
   let notifications: ShowToastParams[];
   let serviceWorkerDescriptor: PropertyDescriptor | undefined;
+  let cachesDescriptor: PropertyDescriptor | undefined;
 
   const latestNotification = () => notifications[notifications.length - 1];
   const reloadMarker = () => sessionStorage.getItem(RELOAD_KEY);
@@ -32,11 +33,12 @@ describe("recover-stale-build", () => {
     sessionStorage.clear();
 
     // No controlling service worker → reloadFresh() takes the synchronous
-    // path (no unregister/caches work) straight to the (jsdom no-op) navigate.
+    // path straight to the (jsdom no-op) navigate.
     serviceWorkerDescriptor = Object.getOwnPropertyDescriptor(
       navigator,
       "serviceWorker"
     );
+    cachesDescriptor = Object.getOwnPropertyDescriptor(window, "caches");
     Object.defineProperty(navigator, "serviceWorker", {
       configurable: true,
       value: { controller: null },
@@ -66,7 +68,13 @@ describe("recover-stale-build", () => {
     } else {
       Reflect.deleteProperty(navigator, "serviceWorker");
     }
+    if (cachesDescriptor) {
+      Object.defineProperty(window, "caches", cachesDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "caches");
+    }
     Reflect.deleteProperty(window, "externalApp");
+    Reflect.deleteProperty(window, "webkit");
     window.isDirtyState = false;
     globalThis.__DEV__ = false;
     globalThis.__DEMO__ = false;
@@ -125,43 +133,70 @@ describe("recover-stale-build", () => {
       expect(notifications).toHaveLength(0);
     });
 
-    it("uses the companion-app external command when a bridge is present", () => {
-      const externalBus = vi.fn();
+    it("drops the service worker and caches before reloading", async () => {
+      const unregister = vi.fn().mockResolvedValue(true);
+      Object.defineProperty(navigator, "serviceWorker", {
+        configurable: true,
+        value: {
+          controller: {},
+          getRegistrations: vi.fn().mockResolvedValue([{ unregister }]),
+        },
+      });
+      const cacheDelete = vi.fn().mockResolvedValue(true);
+      Object.defineProperty(window, "caches", {
+        configurable: true,
+        value: {
+          keys: vi.fn().mockResolvedValue(["a", "b"]),
+          delete: cacheDelete,
+        },
+      });
+
+      expect(mod.recoverFromStaleBuild(STALE_URL, root)).toBe(true);
+
+      await vi.waitFor(() => expect(unregister).toHaveBeenCalledOnce());
+      expect(cacheDelete).toHaveBeenCalledTimes(2);
+    });
+
+    it("uses the companion-app command when the WebKit bridge is present", () => {
+      const postMessage = vi.fn();
       (
         window as unknown as {
-          externalApp: { externalBus: typeof externalBus };
+          webkit: {
+            messageHandlers: {
+              externalBus: { postMessage: typeof postMessage };
+            };
+          };
         }
-      ).externalApp = { externalBus };
+      ).webkit = { messageHandlers: { externalBus: { postMessage } } };
 
       expect(mod.recoverFromStaleBuild(STALE_URL, root)).toBe(true);
 
       // Asks the native app to purge its cache and reload instead of the
-      // browser-only path.
-      expect(externalBus).toHaveBeenCalledOnce();
-      expect(externalBus.mock.calls[0][0]).toContain(
-        "frontend/reload_and_clear_cache"
-      );
+      // browser path.
+      expect(postMessage).toHaveBeenCalledOnce();
+      expect(postMessage.mock.calls[0][0]).toMatchObject({
+        type: "frontend/reload_and_clear_cache",
+      });
       expect(notifications).toHaveLength(0);
     });
 
-    it("shows a reload toast instead of reloading when dirty", () => {
+    it("defers with a toast instead of reloading when dirty", () => {
       window.isDirtyState = true;
 
       expect(mod.recoverFromStaleBuild(STALE_URL, root)).toBe(true);
 
-      // Took the toast branch, not the reload branch.
+      // Took the toast branch, not the reload branch, and the toast has no
+      // immediate-reload action that could discard unsaved work.
       expect(reloadMarker()).toBeNull();
       expect(latestNotification()).toMatchObject({
         id: "frontend-update-available",
         message: {
           translationKey: "ui.notification_toast.new_version_available_reload",
         },
-        action: {
-          text: { translationKey: "ui.notification_toast.update_now" },
-        },
         duration: -1,
         dismissable: false,
       });
+      expect(latestNotification().action).toBeUndefined();
     });
 
     it("does not reload again while the cooldown marker is set (loop guard)", async () => {
@@ -175,9 +210,10 @@ describe("recover-stale-build", () => {
       const reloaded: RecoverModule =
         await import("../../src/util/recover-stale-build");
 
-      reloaded.recoverFromStaleBuild("/frontend_latest/app.def67890.js", root);
-
-      // Guard blocked a second navigation: the marker is unchanged.
+      // Blocked by the cooldown → returns false so the caller still surfaces it.
+      expect(
+        reloaded.recoverFromStaleBuild("/frontend_latest/app.def67890.js", root)
+      ).toBe(false);
       expect(reloadMarker()).toBe(firstMarker);
     });
   });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Recover from a stale build **after** boot. Builds on #53378 (which recovers the fatal first-load white screen); this PR handles the case where the app stayed open (or a tab was sleeping) across a Home Assistant upgrade, so a not-yet-loaded lazy chunk — a dialog, more-info, card, config-flow step, or panel — 404s because the previous build's content-hashed files were deleted. Today that dead-ends: dialogs fail silently (and the failed import stays cached, breaking that dialog until a full reload), panels show a Back-only error screen.

- New shared authority `src/util/recover-stale-build.ts`:
  - `isStaleBuildError()` — detects a failed hashed-chunk load (patterns come from `stale-build-patterns.json`, the single source shared with the boot guard from #53378).
  - `reloadFresh()` — reloads onto the current build: drops the service worker + Cache API and cache-bust navigates; **in the companion app** (WKWebView, no SW) it instead fires the native `frontend/reload_and_clear_cache` external command (shipped in home-assistant/iOS#5190). Guarded by a monotonic sessionStorage cooldown so a still-failing reload can't loop.
  - `recoverFromStaleBuild()` — clean → reload; **dirty** (an open editor has unsaved changes) → a non-dismissable toast that auto-reloads once the dirty state clears (reuses the `window.isDirtyState` coordination from #53124), so unsaved work is never lost. Inert in dev/demo.
- Hooked into the global `error`/`unhandledrejection` handlers (`logging-mixin`), the router's swallowed load error (`hass-router-page`), and a new **Reload** action on `hass-error-screen`.
- Fixed `make-dialog-manager` so a failed dialog import is no longer cached (a later open re-imports).
- Replaced the ineffective `location.reload(true)` in `home-assistant`'s `_checkUpdate` with `reloadFresh()`, and dropped the dead `forceGet` arg on the safe_mode reload.
- Added the outgoing `frontend/reload_and_clear_cache` message type and extracted `fireExternalBusMessage()` so it can be sent without a `hass`/bus reference.
- Unit tests for the detector and the clean / dirty / dev-demo / companion-app / loop-guard branches.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Minimal visual surface: a new **Refresh** button on the page-load error screen, and the existing update toast when a stale-build recovery is deferred because an editor is dirty. Happy to add a capture if useful.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53209
- This PR is related to issue or discussion: closes #53405, part of home-assistant/epics#113; builds on #53378; reuses the dirty-state coordination from #53124; companion-app command from home-assistant/iOS#5190
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
