### PR TITLE
Dont ship unused old translation keys

### DIFF
--- a/build-scripts/gulp/merge-translations.js
+++ b/build-scripts/gulp/merge-translations.js
@@ -1,0 +1,38 @@
+import merge from "lodash.merge";
+
+const isMergeableObject = (value) =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+// Deep-merge `overlay` onto `base`, keeping only keys that already exist in
+// `base`. Overlay keys with no counterpart in the base - e.g. translations for
+// source strings that have since been removed from or renamed in en.json but
+// still linger in Lokalise - are dropped so we don't ship stale keys. `base` is
+// mutated and returned.
+export const restrictedMerge = (base, overlay) => {
+  for (const key of Object.keys(overlay)) {
+    if (!(key in base)) {
+      continue;
+    }
+    const baseValue = base[key];
+    const overlayValue = overlay[key];
+    if (isMergeableObject(baseValue) && isMergeableObject(overlayValue)) {
+      restrictedMerge(baseValue, overlayValue);
+    } else if (
+      !isMergeableObject(baseValue) &&
+      !isMergeableObject(overlayValue)
+    ) {
+      base[key] = overlayValue;
+    }
+    // Mismatched shapes keep the base (English) value as a safe fallback.
+  }
+  return base;
+};
+
+// Merge translation `objects` onto `startObj`. When `prune` is set, the result
+// is restricted to the key shape of `startObj` (the English master), so keys
+// that no longer exist in en.json are not shipped. Otherwise keys are merged
+// additively (used when building the English master itself, which starts empty).
+export const mergeTranslations = (startObj, objects, prune = false) =>
+  prune
+    ? objects.reduce(restrictedMerge, startObj)
+    : merge(startObj, ...objects);

--- a/build-scripts/gulp/merge-translations.js
+++ b/build-scripts/gulp/merge-translations.js
@@ -3,14 +3,21 @@ import merge from "lodash.merge";
 const isMergeableObject = (value) =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-// Deep-merge `overlay` onto `base`, keeping only keys that already exist in
-// `base`. Overlay keys with no counterpart in the base - e.g. translations for
-// source strings that have since been removed from or renamed in en.json but
-// still linger in Lokalise - are dropped so we don't ship stale keys. `base` is
-// mutated and returned.
+// Keys that must never be written to, to avoid prototype pollution when the
+// overlay comes from an untrusted source (JSON.parse can produce an own
+// `__proto__` key from `{"__proto__": ...}`).
+const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+// Deep-merge `overlay` onto `base`, keeping only keys that already exist as own
+// properties of `base`. Overlay keys with no counterpart in the base - e.g.
+// translations for source strings that have since been removed from or renamed
+// in en.json but still linger in Lokalise - are dropped so we don't ship stale
+// keys. `base` is mutated and returned.
 export const restrictedMerge = (base, overlay) => {
   for (const key of Object.keys(overlay)) {
-    if (!(key in base)) {
+    // Own-property check (not `in`) so inherited keys like `__proto__` or
+    // `toString` from the overlay are ignored rather than merged.
+    if (FORBIDDEN_KEYS.has(key) || !Object.hasOwn(base, key)) {
       continue;
     }
     const baseValue = base[key];

--- a/build-scripts/gulp/translations.js
+++ b/build-scripts/gulp/translations.js
@@ -2,7 +2,6 @@ import { deleteAsync } from "del";
 import { glob } from "glob";
 import gulp from "gulp";
 import rename from "gulp-rename";
-import merge from "lodash.merge";
 import { createHash } from "node:crypto";
 import { mkdir, readFile } from "node:fs/promises";
 import { basename, join } from "node:path";
@@ -10,6 +9,7 @@ import { PassThrough, Transform } from "node:stream";
 import { finished } from "node:stream/promises";
 import env from "../env.cjs";
 import paths from "../paths.cjs";
+import { mergeTranslations } from "./merge-translations.js";
 import "./fetch-nightly-translations.js";
 
 const inFrontendDir = "translations/frontend";
@@ -56,11 +56,12 @@ class CustomJSON extends Transform {
 class MergeJSON extends Transform {
   _objects = [];
 
-  constructor(stem, startObj = {}, reviver = null) {
+  constructor(stem, startObj = {}, reviver = null, prune = false) {
     super({ objectMode: true, allowHalfOpen: false });
     this._stem = stem;
     this._startObj = structuredClone(startObj);
     this._reviver = reviver;
+    this._prune = prune;
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -72,7 +73,11 @@ class MergeJSON extends Transform {
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   async _flush(callback) {
-    const mergedObj = merge(this._startObj, ...this._objects);
+    const mergedObj = mergeTranslations(
+      this._startObj,
+      this._objects,
+      this._prune
+    );
     this._outFile.contents = Buffer.from(JSON.stringify(mergedObj));
     this._outFile.stem = this._stem;
     callback(null, this._outFile);
@@ -257,7 +262,7 @@ const createTranslations = async () => {
     }
     const mergeStream = gulp
       .src(mergeFiles, { allowEmpty: true })
-      .pipe(new MergeJSON(locale, enMaster, emptyReviver));
+      .pipe(new MergeJSON(locale, enMaster, emptyReviver, true));
     mergesFinished.push(finished(mergeStream));
     mergeStream.pipe(hashStream, { end: false });
   }

--- a/test/build-scripts/merge-translations.test.js
+++ b/test/build-scripts/merge-translations.test.js
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment node
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  mergeTranslations,
+  restrictedMerge,
+} from "../../build-scripts/gulp/merge-translations.js";
+
+describe("restrictedMerge", () => {
+  it("overrides base values with overlay values", () => {
+    expect(restrictedMerge({ a: "en", b: "en" }, { a: "de" })).toEqual({
+      a: "de",
+      b: "en",
+    });
+  });
+
+  it("drops overlay keys that are absent from the base", () => {
+    // `removed` was deleted from en.json but still lingers in Lokalise.
+    expect(
+      restrictedMerge({ kept: "en" }, { kept: "de", removed: "de" })
+    ).toEqual({ kept: "de" });
+  });
+
+  it("recurses into nested objects and prunes there too", () => {
+    const base = { ui: { greeting: "hi", panel: { config: "config" } } };
+    const overlay = {
+      ui: {
+        greeting: "hallo",
+        removed: "weg",
+        panel: { config: "konfig", gone: "weg" },
+      },
+    };
+    expect(restrictedMerge(base, overlay)).toEqual({
+      ui: { greeting: "hallo", panel: { config: "konfig" } },
+    });
+  });
+
+  it("keeps the base value when the overlay shape does not match", () => {
+    expect(
+      restrictedMerge({ a: { nested: "en" } }, { a: "not an object" })
+    ).toEqual({ a: { nested: "en" } });
+  });
+});
+
+describe("mergeTranslations", () => {
+  it("prunes to the English master shape when pruning is enabled", () => {
+    const en = { a: "en", nested: { b: "en" } };
+    const de = { a: "de", nested: { b: "de", removed: "de" }, removed: "de" };
+    expect(mergeTranslations(en, [de], true)).toEqual({
+      a: "de",
+      nested: { b: "de" },
+    });
+  });
+
+  it("falls back to English for keys the overlay does not translate", () => {
+    const en = { a: "en", b: "en" };
+    const de = { a: "de" };
+    expect(mergeTranslations(en, [de], true)).toEqual({ a: "de", b: "en" });
+  });
+
+  it("applies overlays in order, later overlays winning", () => {
+    // Mirrors base-language + region subtag merging (de then de-CH).
+    const en = { a: "en", b: "en", c: "en" };
+    const de = { a: "de", b: "de" };
+    const deCH = { a: "de-CH" };
+    expect(mergeTranslations(en, [de, deCH], true)).toEqual({
+      a: "de-CH",
+      b: "de",
+      c: "en",
+    });
+  });
+
+  it("merges additively when pruning is disabled", () => {
+    const en = { a: "en" };
+    const extra = { a: "override", added: "added" };
+    expect(mergeTranslations(en, [extra], false)).toEqual({
+      a: "override",
+      added: "added",
+    });
+  });
+});

--- a/test/build-scripts/merge-translations.test.js
+++ b/test/build-scripts/merge-translations.test.js
@@ -42,6 +42,34 @@ describe("restrictedMerge", () => {
       restrictedMerge({ a: { nested: "en" } }, { a: "not an object" })
     ).toEqual({ a: { nested: "en" } });
   });
+
+  it("ignores inherited overlay keys not owned by the base", () => {
+    // `toString` exists on the prototype, so `key in base` would be true, but
+    // it is not an own key of en.json and must be dropped.
+    expect(restrictedMerge({ a: "en" }, { a: "de", toString: "evil" })).toEqual(
+      {
+        a: "de",
+      }
+    );
+  });
+
+  it("does not pollute the prototype via __proto__ overlay keys", () => {
+    const base = { a: "en" };
+    const overlay = JSON.parse('{"a":"de","__proto__":{"polluted":"yes"}}');
+    restrictedMerge(base, overlay);
+    expect(base).toEqual({ a: "de" });
+    expect({}.polluted).toBeUndefined();
+  });
+
+  it("does not merge into a constructor overlay key", () => {
+    const base = { a: "en" };
+    const overlay = JSON.parse(
+      '{"a":"de","constructor":{"prototype":{"polluted":"yes"}}}'
+    );
+    restrictedMerge(base, overlay);
+    expect(base).toEqual({ a: "de" });
+    expect({}.polluted).toBeUndefined();
+  });
 });
 
 describe("mergeTranslations", () => {


### PR DESCRIPTION


## Proposed change

We put every key we got back from lokalise on top of the base en.json. Also keys that have been removed from en.json but are still in lokalise because they are not cleaned up yet (we dont clean up because patch releases use the same lokalise branch as dev releases).

This makes sure we never ship keys that are not in the main en.json. In my tests this removed around 1600 keys from some translations... making it a considerable chunk.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
