### PR TITLE
Decouple translations artifact from the nightly build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -38,6 +38,10 @@ jobs:
         run: ./script/translations_download
         env:
           LOKALISE_TOKEN: ${{ secrets.LOKALISE_TOKEN }}
+          # The nightly only builds the app (build-app), which does not merge
+          # backend translations — those are the whole-project core export and by
+          # far the slowest part of this step. Skip it, as the release does.
+          SKIP_BACKEND_TRANSLATIONS: "1"
 
       - name: Bump version
         run: script/version_bump.js nightly

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -38,9 +38,10 @@ jobs:
         run: ./script/translations_download
         env:
           LOKALISE_TOKEN: ${{ secrets.LOKALISE_TOKEN }}
-          # The nightly only builds the app (build-app), which does not merge
-          # backend translations — those are the whole-project core export and by
-          # far the slowest part of this step. Skip it, as the release does.
+          # The wheel only builds the app (build-app), which does not merge
+          # backend translations. Skipping the whole-project backend export (as
+          # the release does) keeps this off the build's critical path; the full
+          # translations artifact is produced in parallel by the job below.
           SKIP_BACKEND_TRANSLATIONS: "1"
 
       - name: Bump version
@@ -78,15 +79,37 @@ jobs:
           path: .compress-cache
           key: compress-cache-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
-      - name: Archive translations
-        run: tar -czvf translations.tar.gz translations
-
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels
           path: dist/home_assistant_frontend*.whl
           if-no-files-found: error
+
+  # The full translations (including the slow backend/core export) are only
+  # needed for the uploaded artifact, not the wheel, so they are downloaded in
+  # parallel here instead of blocking the build above.
+  translations:
+    name: Translations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node and install
+        uses: ./.github/actions/setup
+        with:
+          immutable: false
+
+      - name: Download translations
+        run: ./script/translations_download
+        env:
+          LOKALISE_TOKEN: ${{ secrets.LOKALISE_TOKEN }}
+
+      - name: Archive translations
+        run: tar -czvf translations.tar.gz translations
 
       - name: Upload translations
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Proposed change

The nightly's `Download translations` step is its slowest step (~8 min in [recent runs](https://github.com/home-assistant/frontend/actions/runs/31449569168)), almost entirely the Lokalise **backend** project export — a whole-project download of component/entity translations across all languages.

That backend export is **not needed to build the wheel**: the nightly only builds the app (`build-app`), which does not enable `translations-enable-merge-backend` (only demo/gallery/cast/e2e/landing-page do), and the shipped app fetches component translations from core at runtime. It is only needed for the uploaded `translations` artifact, which downstream consumers use.

So instead of skipping it outright (which would break that artifact), this **decouples** it:

- The **`nightly`** job builds the wheel and downloads frontend translations only (`SKIP_BACKEND_TRANSLATIONS: "1"`, as the release already does).
- A new **`translations`** job downloads the full set (including backend) and uploads the unchanged `translations` artifact, in parallel with the build.

Both jobs run in the same workflow run, so consumers still find both the `wheels` and `translations` artifacts. The slow backend export no longer sits on the build's critical path, so the nightly's wall-clock time drops from roughly *(download-all + build)* to *max(build, translations)*.

No build output or artifact contents change.

Result: https://github.com/home-assistant/frontend/actions/runs/31495013040

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
