### PR TITLE
Add child devices to the device registry

### DIFF
--- a/demo/src/stubs/devices.ts
+++ b/demo/src/stubs/devices.ts
@@ -14,6 +14,7 @@ const baseDevice = {
   name_by_user: null,
   disabled_by: null,
   configuration_url: null,
+  parent_device_id: null,
   created_at: 0,
   modified_at: 0,
 };

--- a/gallery/src/pages/components/ha-form.ts
+++ b/gallery/src/pages/components/ha-form.ts
@@ -87,6 +87,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     created_at: 0,
     modified_at: 0,
     primary_config_entry: null,
+    parent_device_id: null,
   },
   {
     area_id: "backyard",
@@ -111,6 +112,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     created_at: 0,
     modified_at: 0,
     primary_config_entry: null,
+    parent_device_id: null,
   },
   {
     area_id: null,
@@ -135,6 +137,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     created_at: 0,
     modified_at: 0,
     primary_config_entry: null,
+    parent_device_id: null,
   },
 ];
 

--- a/gallery/src/pages/components/ha-selector-replaced-device.ts
+++ b/gallery/src/pages/components/ha-selector-replaced-device.ts
@@ -50,6 +50,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     created_at: 0,
     modified_at: 0,
     primary_config_entry: null,
+    parent_device_id: null,
   },
   {
     area_id: "backyard",
@@ -74,6 +75,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     created_at: 0,
     modified_at: 0,
     primary_config_entry: null,
+    parent_device_id: null,
   },
 ];
 

--- a/gallery/src/pages/components/ha-selector.ts
+++ b/gallery/src/pages/components/ha-selector.ts
@@ -100,6 +100,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     created_at: 0,
     modified_at: 0,
     primary_config_entry: null,
+    parent_device_id: null,
   },
   {
     area_id: "backyard",
@@ -124,6 +125,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     created_at: 0,
     modified_at: 0,
     primary_config_entry: null,
+    parent_device_id: null,
   },
   {
     area_id: null,
@@ -148,6 +150,7 @@ const DEVICES: DeviceRegistryEntry[] = [
     created_at: 0,
     modified_at: 0,
     primary_config_entry: null,
+    parent_device_id: null,
   },
 ];
 

--- a/gallery/src/pages/misc/integration-card.ts
+++ b/gallery/src/pages/misc/integration-card.ts
@@ -238,6 +238,7 @@ const createDeviceRegistryEntries = (
     created_at: 0,
     modified_at: 0,
     primary_config_entry: null,
+    parent_device_id: null,
   },
 ];
 

--- a/src/common/entity/context/get_device_context.ts
+++ b/src/common/entity/context/get_device_context.ts
@@ -2,23 +2,31 @@ import type { AreaRegistryEntry } from "../../../data/area/area_registry";
 import type { DeviceRegistryEntry } from "../../../data/device/device_registry";
 import type { HomeAssistant } from "../../../types";
 
+/**
+ * Return the effective area id of a device: a child device without an area of
+ * its own inherits its parent's area (mirrors core's
+ * async_get_effective_area_id). Nesting is single-level, so no recursion.
+ */
+export const getDeviceAreaId = (
+  device: DeviceRegistryEntry,
+  devices: HomeAssistant["devices"]
+): string | undefined => {
+  if (device.area_id) {
+    return device.area_id;
+  }
+  if (device.parent_device_id) {
+    return devices[device.parent_device_id]?.area_id ?? undefined;
+  }
+  return undefined;
+};
+
 export const getDeviceArea = (
   device: DeviceRegistryEntry,
   areas: HomeAssistant["areas"],
-  // Used to resolve the effective area of a child device: a child without an
-  // area of its own inherits its parent's area (mirrors core's
-  // async_get_effective_area_id). Required so every caller stays consistent for
-  // child devices. Nesting is single-level, so no recursion.
+  // Required so every caller resolves a child device's effective area
+  // consistently, see getDeviceAreaId.
   devices: HomeAssistant["devices"]
 ): AreaRegistryEntry | undefined => {
-  if (device.area_id) {
-    return areas[device.area_id];
-  }
-  if (device.parent_device_id) {
-    const parent = devices[device.parent_device_id];
-    if (parent?.area_id) {
-      return areas[parent.area_id];
-    }
-  }
-  return undefined;
+  const areaId = getDeviceAreaId(device, devices);
+  return areaId ? areas[areaId] : undefined;
 };

--- a/src/common/entity/context/get_device_context.ts
+++ b/src/common/entity/context/get_device_context.ts
@@ -5,15 +5,16 @@ import type { HomeAssistant } from "../../../types";
 export const getDeviceArea = (
   device: DeviceRegistryEntry,
   areas: HomeAssistant["areas"],
-  // Pass hass.devices to resolve the effective area of a child device: a child
-  // without an area of its own inherits its parent's area (mirrors core's
-  // async_get_effective_area_id). Nesting is single-level, so no recursion.
-  devices?: HomeAssistant["devices"]
+  // Used to resolve the effective area of a child device: a child without an
+  // area of its own inherits its parent's area (mirrors core's
+  // async_get_effective_area_id). Required so every caller stays consistent for
+  // child devices. Nesting is single-level, so no recursion.
+  devices: HomeAssistant["devices"]
 ): AreaRegistryEntry | undefined => {
   if (device.area_id) {
     return areas[device.area_id];
   }
-  if (device.parent_device_id && devices) {
+  if (device.parent_device_id) {
     const parent = devices[device.parent_device_id];
     if (parent?.area_id) {
       return areas[parent.area_id];

--- a/src/common/entity/context/get_device_context.ts
+++ b/src/common/entity/context/get_device_context.ts
@@ -4,8 +4,20 @@ import type { HomeAssistant } from "../../../types";
 
 export const getDeviceArea = (
   device: DeviceRegistryEntry,
-  areas: HomeAssistant["areas"]
+  areas: HomeAssistant["areas"],
+  // Pass hass.devices to resolve the effective area of a child device: a child
+  // without an area of its own inherits its parent's area (mirrors core's
+  // async_get_effective_area_id). Nesting is single-level, so no recursion.
+  devices?: HomeAssistant["devices"]
 ): AreaRegistryEntry | undefined => {
-  const areaId = device.area_id;
-  return areaId ? areas[areaId] : undefined;
+  if (device.area_id) {
+    return areas[device.area_id];
+  }
+  if (device.parent_device_id && devices) {
+    const parent = devices[device.parent_device_id];
+    if (parent?.area_id) {
+      return areas[parent.area_id];
+    }
+  }
+  return undefined;
 };

--- a/src/common/entity/context/get_entity_context.ts
+++ b/src/common/entity/context/get_entity_context.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../../data/entity/entity_registry";
 import type { FloorRegistryEntry } from "../../../data/floor_registry";
 import type { HomeAssistant } from "../../../types";
+import { getDeviceAreaId } from "./get_device_context";
 
 interface EntityContext {
   entity: EntityRegistryDisplayEntry | null;
@@ -46,7 +47,11 @@ export const getEntityAreaId = (
   if (!entry) return undefined;
   const deviceId = entry.device_id;
   const device = deviceId ? devices[deviceId] : undefined;
-  return entry.area_id || device?.area_id || undefined;
+  return (
+    entry.area_id ||
+    (device ? getDeviceAreaId(device, devices) : undefined) ||
+    undefined
+  );
 };
 
 export const getEntityEntryContext = (
@@ -60,7 +65,8 @@ export const getEntityEntryContext = (
   const entity = entities[entry.entity_id];
   const deviceId = entry?.device_id;
   const device = deviceId ? devices[deviceId] : undefined;
-  const areaId = entry?.area_id || device?.area_id;
+  const areaId =
+    entry?.area_id || (device ? getDeviceAreaId(device, devices) : undefined);
   const area = areaId ? areas[areaId] : undefined;
   const floorId = area?.floor_id;
   const floor = floorId ? floors[floorId] : undefined;

--- a/src/components/device/dialog-device-replaced.ts
+++ b/src/components/device/dialog-device-replaced.ts
@@ -73,7 +73,7 @@ export class DialogDeviceReplaced
     ) =>
       candidates.map((deviceId) => {
         const device = devices[deviceId];
-        const area = device ? getDeviceArea(device, areas) : undefined;
+        const area = device ? getDeviceArea(device, areas, devices) : undefined;
         const configEntry = device?.primary_config_entry
           ? configEntryLookup?.[device.primary_config_entry]
           : undefined;

--- a/src/components/device/ha-device-picker.ts
+++ b/src/components/device/ha-device-picker.ts
@@ -242,7 +242,7 @@ export class HaDevicePicker extends LitElement {
           return html`<span slot="headline">${deviceId}</span>`;
         }
 
-        const area = getDeviceArea(device, this.hass.areas);
+        const area = getDeviceArea(device, this.hass.areas, this.hass.devices);
 
         const deviceName = device ? computeDeviceName(device) : undefined;
         const areaName = area ? computeAreaName(area) : undefined;

--- a/src/data/device/device_picker.ts
+++ b/src/data/device/device_picker.ts
@@ -53,7 +53,8 @@ export const computeDeviceAreaLabel = (
   translationMetadata: HomeAssistant["translationMetadata"],
   viaDeviceEntities?: EntityRegistryEntry[] | EntityRegistryDisplayEntry[]
 ): DeviceAreaLabel => {
-  const area = getDeviceArea(device, areas);
+  // Pass devices so a child device inherits its parent's area.
+  const area = getDeviceArea(device, areas, devices);
 
   const viaDevice = device.via_device_id
     ? devices[device.via_device_id]

--- a/src/data/device/device_picker.ts
+++ b/src/data/device/device_picker.ts
@@ -62,7 +62,9 @@ export const computeDeviceAreaLabel = (
   const viaDeviceName = viaDevice
     ? computeDeviceNameDisplay(viaDevice, localize, states, viaDeviceEntities)
     : undefined;
-  const viaDeviceArea = viaDevice ? getDeviceArea(viaDevice, areas) : undefined;
+  const viaDeviceArea = viaDevice
+    ? getDeviceArea(viaDevice, areas, devices)
+    : undefined;
   const viaDeviceAreaName = viaDeviceArea
     ? computeAreaName(viaDeviceArea)
     : undefined;

--- a/src/data/device/device_registry.ts
+++ b/src/data/device/device_registry.ts
@@ -15,6 +15,13 @@ export {
   subscribeDeviceRegistry,
 } from "../ws-device_registry";
 
+export type DeviceDisabler =
+  | "user"
+  | "integration"
+  | "config_entry"
+  // The device's parent device is disabled (child devices only).
+  | "device";
+
 export interface DeviceRegistryEntry extends RegistryEntry {
   id: string;
   config_entries: string[];
@@ -33,10 +40,46 @@ export interface DeviceRegistryEntry extends RegistryEntry {
   area_id: string | null;
   name_by_user: string | null;
   entry_type: "service" | null;
-  disabled_by: "user" | "integration" | "config_entry" | null;
+  disabled_by: DeviceDisabler | null;
   configuration_url: string | null;
   primary_config_entry: string | null;
+  // Set when this device is a child (logical part) of another device.
+  // null for regular top-level devices.
+  parent_device_id: string | null;
 }
+
+/**
+ * A child device as it arrives over the wire from
+ * `config/device_registry/list`. A child is a lightweight logical part of a
+ * parent device (e.g. an outlet of a power strip); it only carries its own
+ * fields and inherits the rest from its parent. It is never stored in
+ * `hass.devices` in this shape — {@link resolveChildDevices} turns every child
+ * into a complete {@link DeviceRegistryEntry} at ingestion, so downstream code
+ * only ever sees full device entries.
+ */
+export interface ChildDeviceRegistryEntry extends RegistryEntry {
+  id: string;
+  config_entry_id: string;
+  config_subentry_id: string | null;
+  identifiers: [string, string][];
+  name: string | null;
+  name_by_user: string | null;
+  labels: string[];
+  area_id: string | null;
+  disabled_by: DeviceDisabler | null;
+  parent_device_id: string;
+}
+
+/**
+ * The raw, mixed list returned by `config/device_registry/list`: full devices
+ * and stripped children, discriminated by the presence of full-device fields.
+ */
+export type DeviceRegistryListEntry =
+  DeviceRegistryEntry | ChildDeviceRegistryEntry;
+
+/** Whether a resolved device entry is a child (logical part) of another device. */
+export const isChildDevice = (device: DeviceRegistryEntry): boolean =>
+  device.parent_device_id !== null;
 
 export type DeviceEntityDisplayLookup = Record<
   string,

--- a/src/data/ws-device_registry.ts
+++ b/src/data/ws-device_registry.ts
@@ -11,10 +11,13 @@ import type {
 // A full device carries fields that stripped children never do; use one of
 // those as the discriminant. This keeps "is a stripped child" decoupled from
 // "has a parent", so a hypothetical full-featured sub-device would still be
-// treated as a complete entry.
+// treated as a complete entry. We key off `connections` rather than
+// `config_entries` because the latter is a deprecated compatibility field core
+// plans to drop; `connections` is present on every full device and never on a
+// stripped child.
 const isChildEntry = (
   entry: DeviceRegistryListEntry
-): entry is ChildDeviceRegistryEntry => !("config_entries" in entry);
+): entry is ChildDeviceRegistryEntry => !("connections" in entry);
 
 /**
  * Resolve the mixed device list from `config/device_registry/list` into a flat

--- a/src/data/ws-device_registry.ts
+++ b/src/data/ws-device_registry.ts
@@ -2,12 +2,84 @@ import type { Connection } from "home-assistant-js-websocket";
 import { createCollection } from "home-assistant-js-websocket";
 import type { Store } from "home-assistant-js-websocket/dist/store";
 import { debounce } from "../common/util/debounce";
-import type { DeviceRegistryEntry } from "./device/device_registry";
+import type {
+  ChildDeviceRegistryEntry,
+  DeviceRegistryEntry,
+  DeviceRegistryListEntry,
+} from "./device/device_registry";
+
+// A full device carries fields that stripped children never do; use one of
+// those as the discriminant. This keeps "is a stripped child" decoupled from
+// "has a parent", so a hypothetical full-featured sub-device would still be
+// treated as a complete entry.
+const isChildEntry = (
+  entry: DeviceRegistryListEntry
+): entry is ChildDeviceRegistryEntry => !("config_entries" in entry);
+
+/**
+ * Resolve the mixed device list from `config/device_registry/list` into a flat
+ * list of complete {@link DeviceRegistryEntry} objects.
+ *
+ * Children are stripped over the wire and inherit the rest from their parent:
+ * - config-entry association comes from the child's own `config_entry_id`, so
+ *   children still show up under their integration;
+ * - hardware/display fields (manufacturer, model, versions, ...) are inherited
+ *   from the parent, since a child is a logical part of the same hardware;
+ * - identity fields (`connections`, `via_device_id`) are NOT inherited — a
+ *   child is not the parent and has no connections of its own.
+ *
+ * Nesting is a single level (core rejects a child as another child's parent),
+ * so no recursion is needed.
+ */
+export const resolveChildDevices = (
+  entries: DeviceRegistryListEntry[]
+): DeviceRegistryEntry[] => {
+  const parents = new Map<string, DeviceRegistryEntry>();
+  for (const entry of entries) {
+    if (!isChildEntry(entry)) {
+      parents.set(entry.id, entry);
+    }
+  }
+
+  return entries.map((entry) => {
+    if (!isChildEntry(entry)) {
+      return entry;
+    }
+
+    const parent = parents.get(entry.parent_device_id);
+
+    return {
+      // Structural fields derived from the child's own config entry.
+      config_entries: [entry.config_entry_id],
+      config_entries_subentries: {
+        [entry.config_entry_id]: [entry.config_subentry_id],
+      },
+      primary_config_entry: entry.config_entry_id,
+      // Hardware/display fields inherited from the parent.
+      manufacturer: parent?.manufacturer ?? null,
+      model: parent?.model ?? null,
+      model_id: parent?.model_id ?? null,
+      sw_version: parent?.sw_version ?? null,
+      hw_version: parent?.hw_version ?? null,
+      serial_number: parent?.serial_number ?? null,
+      entry_type: parent?.entry_type ?? null,
+      configuration_url: parent?.configuration_url ?? null,
+      // Identity fields — a child has none of its own.
+      connections: [],
+      via_device_id: null,
+      // The child's own fields (id, name, area_id, labels, identifiers,
+      // parent_device_id, ...) win over everything above.
+      ...entry,
+    };
+  });
+};
 
 export const fetchDeviceRegistry = (conn: Connection) =>
-  conn.sendMessagePromise<DeviceRegistryEntry[]>({
-    type: "config/device_registry/list",
-  });
+  conn
+    .sendMessagePromise<DeviceRegistryListEntry[]>({
+      type: "config/device_registry/list",
+    })
+    .then(resolveChildDevices);
 
 const subscribeDeviceRegistryUpdates = (
   conn: Connection,

--- a/src/panels/config/dashboard/ha-config-updates.ts
+++ b/src/panels/config/dashboard/ha-config-updates.ts
@@ -88,7 +88,7 @@ class HaConfigUpdates extends LitElement {
 
           const areaName =
             deviceEntry && deviceEntry.entry_type !== "service"
-              ? getDeviceArea(deviceEntry, this._areas)?.name ||
+              ? getDeviceArea(deviceEntry, this._areas, this._devices)?.name ||
                 this._localize("ui.panel.config.updates.no_area")
               : undefined;
 

--- a/src/panels/config/devices/device-detail/ha-device-via-devices-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-via-devices-card.ts
@@ -75,7 +75,11 @@ export class HaDeviceViaDevicesCard extends LitElement {
           ? viaDevices
           : viaDevices.slice(0, MAX_VISIBLE_VIA_DEVICES)
         ).map((viaDevice) => {
-          const area = getDeviceArea(viaDevice, this.hass.areas);
+          const area = getDeviceArea(
+            viaDevice,
+            this.hass.areas,
+            this.hass.devices
+          );
           const entityCount = entityCounts[viaDevice.id] ?? 0;
           const secondary = [
             area?.name,

--- a/src/panels/config/devices/device-registry-detail/dialog-device-registry-detail.ts
+++ b/src/panels/config/devices/device-registry-detail/dialog-device-registry-detail.ts
@@ -125,7 +125,10 @@ class DialogDeviceRegistryDetail extends DirtyStateProviderMixin<DeviceFormState
             <div class="row">
               <ha-switch
                 .checked=${!this._disabledBy}
-                .disabled=${this._params.device.disabled_by === "config_entry"}
+                .disabled=${
+                  this._params.device.disabled_by === "config_entry" ||
+                  this._params.device.disabled_by === "device"
+                }
                 @change=${this._disabledByChanged}
               >
               </ha-switch>

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -33,6 +33,7 @@ import { computeDomain } from "../../../common/entity/compute_domain";
 import { computeEntityEntryName } from "../../../common/entity/compute_entity_name";
 import { computeStateDomain } from "../../../common/entity/compute_state_domain";
 import { computeStateName } from "../../../common/entity/compute_state_name";
+import { getDeviceArea } from "../../../common/entity/context/get_device_context";
 import { navigate } from "../../../common/navigate";
 import { stringCompare } from "../../../common/string/compare";
 import { slugify } from "../../../common/string/slugify";
@@ -442,7 +443,7 @@ export class HaConfigDevicePage extends LitElement {
     const batteryChargingState = batteryChargingEntity
       ? this.hass.states[batteryChargingEntity.entity_id]
       : undefined;
-    const area = device.area_id ? this.hass.areas[device.area_id] : undefined;
+    const area = getDeviceArea(device, this.hass.areas, this.hass.devices);
 
     const deviceInfo: TemplateResult[] = integrations.length
       ? [

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -488,7 +488,11 @@ export class HaConfigDeviceDashboard extends LitElement {
         const floorArea =
           getDeviceArea(device, areas, this.hass.devices) ??
           (device.via_device_id && this.hass.devices[device.via_device_id]
-            ? getDeviceArea(this.hass.devices[device.via_device_id], areas)
+            ? getDeviceArea(
+                this.hass.devices[device.via_device_id],
+                areas,
+                this.hass.devices
+              )
             : undefined);
         const floorId = floorArea?.floor_id;
         const floorName =

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -486,7 +486,7 @@ export class HaConfigDeviceDashboard extends LitElement {
         );
 
         const floorArea =
-          getDeviceArea(device, areas) ??
+          getDeviceArea(device, areas, this.hass.devices) ??
           (device.via_device_id && this.hass.devices[device.via_device_id]
             ? getDeviceArea(this.hass.devices[device.via_device_id], areas)
             : undefined);

--- a/src/panels/config/integrations/ha-config-entry-device-row.ts
+++ b/src/panels/config/integrations/ha-config-entry-device-row.ts
@@ -53,7 +53,7 @@ class HaConfigEntryDeviceRow extends LitElement {
 
     const entities = this._getEntities();
 
-    const area = getDeviceArea(device, this.hass.areas);
+    const area = getDeviceArea(device, this.hass.areas, this.hass.devices);
 
     const supportingText = [
       device.model || device.sw_version || device.manufacturer,

--- a/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/bluetooth/bluetooth-network-visualization.ts
@@ -240,7 +240,7 @@ export class BluetoothNetworkVisualization extends LitElement {
         const scannerDevice = this._sourceDevices[scanner.source] as
           DeviceRegistryEntry | undefined;
         const area = scannerDevice
-          ? getDeviceArea(scannerDevice, this.hass.areas)
+          ? getDeviceArea(scannerDevice, this.hass.areas, this.hass.devices)
           : undefined;
         nodes.push({
           id: scanner.source,
@@ -282,7 +282,7 @@ export class BluetoothNetworkVisualization extends LitElement {
         const device = this._sourceDevices[node.address] as
           DeviceRegistryEntry | undefined;
         const area = device
-          ? getDeviceArea(device, this.hass.areas)
+          ? getDeviceArea(device, this.hass.areas, this.hass.devices)
           : undefined;
         nodes.push({
           id: node.address,
@@ -350,7 +350,9 @@ export class BluetoothNetworkVisualization extends LitElement {
     const name = this._getBluetoothDeviceName(address);
     const btDevice = this._data.find((d) => d.address === address);
     const device = this._sourceDevices[address];
-    const area = device ? getDeviceArea(device, this.hass.areas) : undefined;
+    const area = device
+      ? getDeviceArea(device, this.hass.areas, this.hass.devices)
+      : undefined;
     const areaLine = area
       ? html`<br /><b
             >${this.hass.localize("ui.panel.config.bluetooth.area")}: </b

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-data.ts
@@ -64,7 +64,9 @@ export function createZHANetworkChartData(
 
     const haDevice = hass.devices[device.device_reg_id] as
       DeviceRegistryEntry | undefined;
-    const area = haDevice ? getDeviceArea(haDevice, hass.areas) : undefined;
+    const area = haDevice
+      ? getDeviceArea(haDevice, hass.areas, hass.devices)
+      : undefined;
     // Create node
     nodes.push({
       id: device.ieee,

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
@@ -162,7 +162,7 @@ export class ZHANetworkVisualizationPage extends LitElement {
     const haDevice = this.hass.devices[device.device_reg_id] as
       DeviceRegistryEntry | undefined;
     const area = haDevice
-      ? getDeviceArea(haDevice, this.hass.areas)
+      ? getDeviceArea(haDevice, this.hass.areas, this.hass.devices)
       : undefined;
     return html`<b>IEEE: </b>${device.ieee}<br /><b
         >${this.hass.localize("ui.panel.config.zha.visualization.device_type")}: </b

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-rebuild-network-routes/dialog-zwave_js-rebuild-network-routes-detail.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-rebuild-network-routes/dialog-zwave_js-rebuild-network-routes-detail.ts
@@ -177,7 +177,11 @@ class DialogZWaveJSRebuildNetworkRoutesDetail extends DialogMixin<ZWaveJSRebuild
             ) ||
             this._i18n.localize("ui.components.device-picker.unnamed_device");
 
-          const area = getDeviceArea(device, this._registries.areas);
+          const area = getDeviceArea(
+            device,
+            this._registries.areas,
+            this._registries.devices
+          );
 
           const areaName = area ? computeAreaName(area) : undefined;
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
@@ -183,7 +183,9 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
     const { id, name } = data as any;
     const device = this._devices[id] as DeviceRegistryEntry | undefined;
     const nodeStatus = this._nodeStatuses[id];
-    const area = device ? getDeviceArea(device, this.hass.areas) : undefined;
+    const area = device
+      ? getDeviceArea(device, this.hass.areas, this.hass.devices)
+      : undefined;
     return html`<ha-chart-tooltip-marker
         .color=${String((params as CallbackDataParams).color ?? "")}
       ></ha-chart-tooltip-marker>
@@ -295,7 +297,7 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
         const device = this._devices[node.node_id] as
           DeviceRegistryEntry | undefined;
         const area = device
-          ? getDeviceArea(device, this.hass.areas)
+          ? getDeviceArea(device, this.hass.areas, this.hass.devices)
           : undefined;
         nodes.push({
           id: String(node.node_id),

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6786,7 +6786,8 @@
           "disabled_by": {
             "user": "user",
             "integration": "integration",
-            "config_entry": "config entry"
+            "config_entry": "config entry",
+            "device": "parent device"
           },
           "enabled_description": "Disabled devices and services will not be shown and entities belonging to them will be disabled, too.",
           "open_configuration_url": "Visit",

--- a/test/common/entity/context/context-mock.ts
+++ b/test/common/entity/context/context-mock.ts
@@ -77,6 +77,7 @@ export const mockDevice = (
   disabled_by: null,
   configuration_url: null,
   primary_config_entry: null,
+  parent_device_id: null,
   created_at: 0,
   modified_at: 0,
   ...partial,

--- a/test/common/entity/context/get_device_context.test.ts
+++ b/test/common/entity/context/get_device_context.test.ts
@@ -1,43 +1,70 @@
-import { describe, expect, it } from "vitest";
+import { assert, describe, it } from "vitest";
 import { getDeviceArea } from "../../../../src/common/entity/context/get_device_context";
-import { mockArea, mockDevice } from "./context-mock";
+import type { AreaRegistryEntry } from "../../../../src/data/area/area_registry";
+import type { DeviceRegistryEntry } from "../../../../src/data/device/device_registry";
+import type { HomeAssistant } from "../../../../src/types";
+
+const area = (id: string): AreaRegistryEntry =>
+  ({ area_id: id, name: id }) as AreaRegistryEntry;
+
+const device = (
+  partial: Partial<DeviceRegistryEntry> & { id: string }
+): DeviceRegistryEntry =>
+  ({
+    area_id: null,
+    parent_device_id: null,
+    ...partial,
+  }) as DeviceRegistryEntry;
+
+const AREAS: HomeAssistant["areas"] = {
+  kitchen: area("kitchen"),
+  living_room: area("living_room"),
+};
 
 describe("getDeviceArea", () => {
+  it("returns the device's own area", () => {
+    const dev = device({ id: "d1", area_id: "kitchen" });
+    assert.strictEqual(getDeviceArea(dev, AREAS)?.area_id, "kitchen");
+  });
+
   it("returns undefined when the device has no area", () => {
-    const device = mockDevice({
-      id: "device_1",
-    });
-
-    const result = getDeviceArea(device, {});
-
-    expect(result).toBeUndefined();
+    const dev = device({ id: "d1" });
+    assert.strictEqual(getDeviceArea(dev, AREAS), undefined);
   });
 
-  it("returns the area when the device area exists", () => {
-    const device = mockDevice({
-      id: "device_2",
-      area_id: "area_1",
-    });
-
-    const area = mockArea({
-      area_id: "area_1",
-    });
-
-    const result = getDeviceArea(device, {
-      area_1: area,
-    });
-
-    expect(result).toEqual(area);
+  it("inherits the parent's area for a child without its own area", () => {
+    const parent = device({ id: "parent", area_id: "living_room" });
+    const child = device({ id: "child", parent_device_id: "parent" });
+    const devices = { parent, child };
+    assert.strictEqual(
+      getDeviceArea(child, AREAS, devices)?.area_id,
+      "living_room"
+    );
   });
 
-  it("returns undefined when the device area is missing", () => {
-    const device = mockDevice({
-      id: "device_3",
-      area_id: "area_2",
+  it("prefers the child's own area over the parent's", () => {
+    const parent = device({ id: "parent", area_id: "living_room" });
+    const child = device({
+      id: "child",
+      area_id: "kitchen",
+      parent_device_id: "parent",
     });
+    const devices = { parent, child };
+    assert.strictEqual(
+      getDeviceArea(child, AREAS, devices)?.area_id,
+      "kitchen"
+    );
+  });
 
-    const result = getDeviceArea(device, {});
+  it("does not inherit when devices are not provided", () => {
+    const child = device({ id: "child", parent_device_id: "parent" });
+    assert.strictEqual(getDeviceArea(child, AREAS), undefined);
+  });
 
-    expect(result).toBeUndefined();
+  it("returns undefined when the parent also has no area", () => {
+    const parent = device({ id: "parent" });
+    const child = device({ id: "child", parent_device_id: "parent" });
+    const devices = { parent, child };
+    assert.strictEqual(getDeviceArea(child, AREAS, devices), undefined);
   });
 });

--- a/test/common/entity/context/get_device_context.test.ts
+++ b/test/common/entity/context/get_device_context.test.ts
@@ -24,12 +24,12 @@ const AREAS: HomeAssistant["areas"] = {
 describe("getDeviceArea", () => {
   it("returns the device's own area", () => {
     const dev = device({ id: "d1", area_id: "kitchen" });
-    assert.strictEqual(getDeviceArea(dev, AREAS)?.area_id, "kitchen");
+    assert.strictEqual(getDeviceArea(dev, AREAS, {})?.area_id, "kitchen");
   });
 
   it("returns undefined when the device has no area", () => {
     const dev = device({ id: "d1" });
-    assert.strictEqual(getDeviceArea(dev, AREAS), undefined);
+    assert.strictEqual(getDeviceArea(dev, AREAS, {}), undefined);
   });
 
   it("inherits the parent's area for a child without its own area", () => {
@@ -54,11 +54,6 @@ describe("getDeviceArea", () => {
       getDeviceArea(child, AREAS, devices)?.area_id,
       "kitchen"
     );
-  });
-
-  it("does not inherit when devices are not provided", () => {
-    const child = device({ id: "child", parent_device_id: "parent" });
-    assert.strictEqual(getDeviceArea(child, AREAS), undefined);
   });
 
   it("returns undefined when the parent also has no area", () => {

--- a/test/common/entity/context/get_entity_context.test.ts
+++ b/test/common/entity/context/get_entity_context.test.ts
@@ -93,6 +93,62 @@ describe("getEntityContext", () => {
     });
   });
 
+  it("should inherit the parent device's area for an entity on a child device", () => {
+    const entity = mockEntity({
+      entity_id: "switch.outlet_1",
+      device_id: "child_1",
+    });
+    const childDevice = mockDevice({
+      id: "child_1",
+      parent_device_id: "parent_1",
+    });
+    const parentDevice = mockDevice({
+      id: "parent_1",
+      area_id: "area_1",
+    });
+    const area = mockArea({
+      area_id: "area_1",
+      floor_id: "floor_1",
+    });
+    const floor = mockFloor({
+      floor_id: "floor_1",
+    });
+    const stateObj = mockStateObj({
+      entity_id: "switch.outlet_1",
+    });
+
+    const hass = {
+      entities: {
+        "switch.outlet_1": entity,
+      },
+      devices: {
+        child_1: childDevice,
+        parent_1: parentDevice,
+      },
+      areas: {
+        area_1: area,
+      },
+      floors: {
+        floor_1: floor,
+      },
+    } as unknown as HomeAssistant;
+
+    const result = getEntityContext(
+      stateObj,
+      hass.entities,
+      hass.devices,
+      hass.areas,
+      hass.floors
+    );
+
+    expect(result).toEqual({
+      entity,
+      device: childDevice,
+      area,
+      floor,
+    });
+  });
+
   it("should return the correct context when the entity has an area but no device", () => {
     const entity = mockEntity({
       entity_id: "sensor.kitchen",

--- a/test/data/ws-device_registry.test.ts
+++ b/test/data/ws-device_registry.test.ts
@@ -1,0 +1,110 @@
+import { assert, describe, it } from "vitest";
+import { resolveChildDevices } from "../../src/data/ws-device_registry";
+import type {
+  ChildDeviceRegistryEntry,
+  DeviceRegistryEntry,
+} from "../../src/data/device/device_registry";
+
+const parent: DeviceRegistryEntry = {
+  id: "parent",
+  config_entries: ["entry-1"],
+  config_entries_subentries: { "entry-1": [null] },
+  connections: [["mac", "aa:bb:cc:dd:ee:ff"]],
+  identifiers: [["hue", "strip-1"]],
+  manufacturer: "Acme",
+  model: "Power Strip",
+  model_id: "PS-1",
+  name: "Power strip",
+  labels: ["strip"],
+  sw_version: "1.0",
+  hw_version: "2.0",
+  serial_number: "SN-1",
+  via_device_id: "bridge",
+  area_id: "living_room",
+  name_by_user: null,
+  entry_type: null,
+  disabled_by: null,
+  configuration_url: "http://strip.local",
+  primary_config_entry: "entry-1",
+  parent_device_id: null,
+  created_at: 0,
+  modified_at: 0,
+};
+
+const child: ChildDeviceRegistryEntry = {
+  id: "child",
+  config_entry_id: "entry-1",
+  config_subentry_id: "sub-1",
+  identifiers: [["hue", "outlet-1"]],
+  name: "Outlet 1",
+  name_by_user: "Coffee machine",
+  labels: ["outlet"],
+  area_id: "kitchen",
+  disabled_by: null,
+  parent_device_id: "parent",
+  created_at: 5,
+  modified_at: 6,
+};
+
+describe("resolveChildDevices", () => {
+  it("leaves full devices untouched", () => {
+    const [resolved] = resolveChildDevices([parent]);
+    assert.strictEqual(resolved, parent);
+  });
+
+  it("resolves a child into a complete device entry", () => {
+    const result = resolveChildDevices([parent, child]);
+    const resolved = result.find((d) => d.id === "child")!;
+
+    // Config-entry association comes from the child's own config entry.
+    assert.deepEqual(resolved.config_entries, ["entry-1"]);
+    assert.deepEqual(resolved.config_entries_subentries, {
+      "entry-1": ["sub-1"],
+    });
+    assert.strictEqual(resolved.primary_config_entry, "entry-1");
+
+    // Hardware/display fields are inherited from the parent.
+    assert.strictEqual(resolved.manufacturer, "Acme");
+    assert.strictEqual(resolved.model, "Power Strip");
+    assert.strictEqual(resolved.model_id, "PS-1");
+    assert.strictEqual(resolved.sw_version, "1.0");
+    assert.strictEqual(resolved.hw_version, "2.0");
+    assert.strictEqual(resolved.serial_number, "SN-1");
+    assert.strictEqual(resolved.configuration_url, "http://strip.local");
+    assert.strictEqual(resolved.entry_type, null);
+
+    // Identity fields are NOT inherited — a child is not the parent.
+    assert.deepEqual(resolved.connections, []);
+    assert.strictEqual(resolved.via_device_id, null);
+
+    // The child's own fields win.
+    assert.strictEqual(resolved.id, "child");
+    assert.strictEqual(resolved.name, "Outlet 1");
+    assert.strictEqual(resolved.name_by_user, "Coffee machine");
+    assert.strictEqual(resolved.area_id, "kitchen");
+    assert.deepEqual(resolved.labels, ["outlet"]);
+    assert.deepEqual(resolved.identifiers, [["hue", "outlet-1"]]);
+    assert.strictEqual(resolved.parent_device_id, "parent");
+    assert.strictEqual(resolved.created_at, 5);
+    assert.strictEqual(resolved.modified_at, 6);
+  });
+
+  it("falls back to null display fields when the parent is missing", () => {
+    const [resolved] = resolveChildDevices([child]);
+
+    assert.deepEqual(resolved.config_entries, ["entry-1"]);
+    assert.strictEqual(resolved.manufacturer, null);
+    assert.strictEqual(resolved.model, null);
+    assert.deepEqual(resolved.connections, []);
+    assert.strictEqual(resolved.via_device_id, null);
+    assert.strictEqual(resolved.parent_device_id, "parent");
+  });
+
+  it("preserves ordering of the mixed list", () => {
+    const result = resolveChildDevices([child, parent]);
+    assert.deepEqual(
+      result.map((d) => d.id),
+      ["child", "parent"]
+    );
+  });
+});

--- a/test/panels/lovelace/editor/card-editor/entity-tree-builder.test.ts
+++ b/test/panels/lovelace/editor/card-editor/entity-tree-builder.test.ts
@@ -52,6 +52,7 @@ const device = (id: string, overrides: Record<string, unknown> = {}) =>
     area_id: null,
     entry_type: null,
     primary_config_entry: null,
+    parent_device_id: null,
     config_entries: [],
     config_entries_subentries: {},
     connections: [],


### PR DESCRIPTION
## Proposed change

Frontend data-layer support for **child devices**, added in core PR home-assistant/core#178666 (architecture discussion home-assistant/architecture#1414).

Child devices arrive over the WebSocket as stripped entries in the flat `config/device_registry/list` response (discriminated by the absence of full-device fields). This PR resolves them into complete `DeviceRegistryEntry` objects at ingestion (`resolveChildDevices`), so `hass.devices` only ever holds full entries and the existing ~200 downstream consumers keep working unchanged:

- config-entry association comes from the child's own `config_entry_id`, so children still appear under their integration;
- hardware/display fields (manufacturer, model, versions, …) are inherited from the parent device;
- identity fields (`connections`, `via_device_id`) are not inherited.

It also adds:

- `parent_device_id`, the `ChildDeviceRegistryEntry` wire type, a `DeviceRegistryListEntry` union and an `isChildDevice` helper;
- the new `"device"` `disabled_by` value (a child disabled because its parent is) and its translation;
- **effective area resolution**: a child without an area of its own inherits its parent's area (mirroring core's `async_get_effective_area_id`), so children behave like a normal device everywhere they are listed — device dashboard (area column, grouping, filtering) and the device page header.

This is the data-layer PR only; the child-device UI (dedicated cards, integration-page nesting, picker indentation) follows in a separate PR.

## Screenshots

No visual changes in this PR (data layer only).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: home-assistant/architecture#1414
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: home-assistant/core#178666

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
