### PR TITLE
Run the frontend build in parallel with lint and tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,10 @@ concurrency:
 
 permissions:
   contents: read
+  # Lets a failing job cancel the rest of the run (see "Cancel the run on
+  # failure" steps). Read-only for pull requests from forks, so the cancel is a
+  # no-op there and the jobs simply run to completion.
+  actions: write
 
 jobs:
   prepare-dependencies:
@@ -76,6 +80,12 @@ jobs:
       - name: Check dependency licenses
         if: ${{ !cancelled() && steps.build_resources.outcome == 'success' }}
         run: yarn run lint:licenses
+      - name: Cancel the run on failure
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel "${{ github.run_id }}" --repo "${{ github.repository }}"
   test:
     name: Run tests
     needs: prepare-dependencies
@@ -95,12 +105,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Tests
         run: yarn run test
+      - name: Cancel the run on failure
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel "${{ github.run_id }}" --repo "${{ github.repository }}"
   build:
     name: Build frontend
-    needs:
-      - prepare-dependencies
-      - lint
-      - test
+    # Runs alongside lint and test rather than after them: the build only needs
+    # the dependency tree, and with the rspack cache it is no longer expensive
+    # enough to be worth serialising behind the other checks. If any job fails,
+    # it cancels the run, so a broken PR does not finish building.
+    needs: prepare-dependencies
     runs-on: ubuntu-latest
     steps:
       - name: Check out files from GitHub
@@ -146,3 +163,9 @@ jobs:
           path: hass_frontend/
           if-no-files-found: error
           retention-days: 7
+      - name: Cancel the run on failure
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel "${{ github.run_id }}" --repo "${{ github.repository }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,6 @@ concurrency:
 
 permissions:
   contents: read
-  # Lets a failing job cancel the rest of the run (see "Cancel the run on
-  # failure" steps). Read-only for pull requests from forks, so the cancel is a
-  # no-op there and the jobs simply run to completion.
-  actions: write
 
 jobs:
   prepare-dependencies:
@@ -80,12 +76,6 @@ jobs:
       - name: Check dependency licenses
         if: ${{ !cancelled() && steps.build_resources.outcome == 'success' }}
         run: yarn run lint:licenses
-      - name: Cancel the run on failure
-        if: failure()
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh run cancel "${{ github.run_id }}" --repo "${{ github.repository }}"
   test:
     name: Run tests
     needs: prepare-dependencies
@@ -105,18 +95,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Tests
         run: yarn run test
-      - name: Cancel the run on failure
-        if: failure()
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh run cancel "${{ github.run_id }}" --repo "${{ github.repository }}"
   build:
     name: Build frontend
     # Runs alongside lint and test rather than after them: the build only needs
     # the dependency tree, and with the rspack cache it is no longer expensive
-    # enough to be worth serialising behind the other checks. If any job fails,
-    # it cancels the run, so a broken PR does not finish building.
+    # enough to be worth serialising behind the other checks. The
+    # cancel-on-failure job below stops the run as soon as a check fails, so a
+    # broken pull request does not finish building.
     needs: prepare-dependencies
     runs-on: ubuntu-latest
     steps:
@@ -163,9 +148,54 @@ jobs:
           path: hass_frontend/
           if-no-files-found: error
           retention-days: 7
-      - name: Cancel the run on failure
-        if: failure()
-        continue-on-error: true
+
+  # Now that the checks run in parallel, a failing lint or test no longer stops
+  # the build from finishing on its own, so this watches them and cancels the
+  # whole run on the first failure.
+  #
+  # It is a separate job on purpose. Cancelling needs `actions: write`, and the
+  # other jobs check out the pull request and run its build scripts — handing
+  # them that scope would give PR-controlled code (or a compromised dependency)
+  # write access to Actions. This job never checks out the repository, so the
+  # elevated token stays away from PR code. It also cannot be a job that
+  # `needs` the checks: that would only start once they have all finished, which
+  # is exactly too late to cancel anything.
+  cancel-on-failure:
+    name: Cancel run on failure
+    needs: prepare-dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    timeout-minutes: 30
+    steps:
+      - name: Cancel the run when a check fails
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh run cancel "${{ github.run_id }}" --repo "${{ github.repository }}"
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          watched='^(Lint and check format|Run tests|Build frontend)$'
+          while :; do
+            jobs=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" \
+              --paginate --jq '.jobs[] | [.name, .status, (.conclusion // "")] | @tsv' \
+              2>/dev/null || true)
+
+            failed=$(printf '%s\n' "$jobs" | awk -F'\t' -v w="$watched" \
+              '$1 ~ w && ($3 == "failure" || $3 == "timed_out") { print $1 }')
+            if [ -n "$failed" ]; then
+              echo "Cancelling the run, these checks failed:"
+              printf '%s\n' "$failed"
+              gh run cancel "$RUN_ID" --repo "$REPO" || true
+              exit 0
+            fi
+
+            found=$(printf '%s\n' "$jobs" | awk -F'\t' -v w="$watched" '$1 ~ w' | wc -l)
+            running=$(printf '%s\n' "$jobs" | awk -F'\t' -v w="$watched" \
+              '$1 ~ w && $2 != "completed" { print $1 }')
+            if [ "$found" -ge 3 ] && [ -z "$running" ]; then
+              echo "All checks finished without failure"
+              exit 0
+            fi
+
+            sleep 15
+          done


### PR DESCRIPTION
## Proposed change

The `build` job waited for `lint` and `test` because a full build used to be expensive enough that we did not want to spend it on a PR that fails its checks. With the rspack persistent cache (#53611) it now takes ~3 min instead of ~5 — and it is the **longest** job in the run, so serialising it behind the others dominates CI wall-clock.

Measured on a recent run ([31645196702](https://github.com/home-assistant/frontend/actions/runs/31645196702)):

| Job | Duration |
|---|---|
| Prepare dependencies | 8s |
| Lint and check format | 86s |
| Run tests | 123s |
| Build frontend | 194s |
| **Total wall-clock** | **333s (~5.5 min)** |

`build` now depends only on `prepare-dependencies`, so all three run together:

> `8s + max(86s, 123s, 194s)` ≈ **202s (~3.4 min)** — about **2 min (~40%) off every successful run**. The build becomes the floor, so further gains have to come from the build itself.

### Not wasting builds on broken PRs

To keep the original intent, a small `cancel-on-failure` job watches the three checks and cancels the whole run on the first failure, so a PR that fails lint or tests does not finish an expensive build.

It is a separate job for two reasons:

- **Least privilege.** Cancelling needs `actions: write`. Granting that at workflow scope would hand it to the jobs that check out the PR and pass `GITHUB_TOKEN` into the gulp build, giving PR-controlled code (or a compromised dependency) write access to Actions. This job holds the scope on its own and never checks out the repository.
- **Timing.** It cannot just `needs:` the checks — a dependent job only starts once they have all finished, which is exactly too late to cancel anything. So it polls the run's job statuses every 15s and cancels on the first failure.

Costs worth naming: one extra **idle** runner slot for the duration of the run (polling only, negligible CPU), and a failing PR still spends up to ~15s of build time before the cancel lands.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: builds on #53611
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

