### PR TITLE
Skip source maps in the gallery build for e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -137,6 +137,7 @@ jobs:
         with:
           target: build-gallery
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          is-test: true
 
       - name: Upload gallery build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -277,7 +277,7 @@ module.exports.config = {
     };
   },
 
-  gallery({ isProdBuild, latestBuild }) {
+  gallery({ isProdBuild, latestBuild, isTestBuild }) {
     return {
       name: "gallery" + nameSuffix(latestBuild),
       entry: {
@@ -287,6 +287,7 @@ module.exports.config = {
       publicPath: publicPath(latestBuild),
       isProdBuild,
       latestBuild,
+      isTestBuild,
       defineOverlay: {
         __DEMO__: true,
       },

--- a/build-scripts/gulp/rspack.js
+++ b/build-scripts/gulp/rspack.js
@@ -252,6 +252,7 @@ gulp.task("rspack-prod-gallery", () =>
     createGalleryConfig({
       isProdBuild: true,
       latestBuild: true,
+      isTestBuild: env.isTestBuild(),
     })
   )
 );

--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -489,8 +489,10 @@ const createDemoConfig = ({
 const createCastConfig = ({ isProdBuild, latestBuild }) =>
   createRspackConfig(bundle.config.cast({ isProdBuild, latestBuild }));
 
-const createGalleryConfig = ({ isProdBuild, latestBuild }) =>
-  createRspackConfig(bundle.config.gallery({ isProdBuild, latestBuild }));
+const createGalleryConfig = ({ isProdBuild, latestBuild, isTestBuild }) =>
+  createRspackConfig(
+    bundle.config.gallery({ isProdBuild, latestBuild, isTestBuild })
+  );
 
 const createLandingPageConfig = ({ isProdBuild, latestBuild }) =>
   createRspackConfig(bundle.config.landingPage({ isProdBuild, latestBuild }));


### PR DESCRIPTION
## Proposed change

The gallery is the only e2e build that still generates source maps. `bundle.config.gallery` never accepted `isTestBuild`, so its production build always used `devtool: "nosources-source-map"` — even though that artifact is only ever loaded by Playwright. The demo and e2e-test-app builds already pass `is-test: true` and skip them.

Measured on the artifacts of a recent e2e run ([31646540214](https://github.com/home-assistant/frontend/actions/runs/31646540214)):

| artifact | `.map` files |
|---|---|
| `gallery-dist` (no `is-test`) | **693** (14 MB of a 105 MB dist) |
| `demo-dist` (`is-test: true`) | 1 |

This threads `isTestBuild` through the gallery config and sets `is-test: true` for the e2e gallery build, so those 693 maps are no longer generated. That saves build time on the `Build gallery` job (100s in that run, and it sits on the e2e critical path) and shrinks the artifact that four Playwright shards download.

`design_deployment.yaml` and `design_preview.yaml` also build the gallery but do not set `IS_TEST`, so they keep their source maps — only e2e changes.

Trade-off: a failing gallery e2e now reports minified stack traces. The demo and app suites already have that trade-off.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
