### PR TITLE
Fix sections view collapsing a few pixels below the column-fit threshold

### DIFF
--- a/src/panels/lovelace/views/compute-sections-column-count.ts
+++ b/src/panels/lovelace/views/compute-sections-column-count.ts
@@ -1,0 +1,29 @@
+/**
+ * Allow a column a few pixels under --column-min-width rather than dropping
+ * it. Subtracting wrapper padding (#53515) made 1080px viewports 8px short of
+ * the 3-column threshold, so span-2/3 sections stacked as a single column.
+ * 16px also covers a typical scrollbar without undoing 1-column sidebar
+ * stacking below ~720px.
+ */
+export const SECTION_COLUMN_FIT_TOLERANCE_PX = 16;
+
+export const parseCssPx = (value: string): number => {
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export const computeSectionsColumnCount = (
+  totalWidth: number,
+  padding: number,
+  minColumnWidth: number,
+  columnGap: number
+): number => {
+  if (totalWidth <= 0) {
+    return 1;
+  }
+  const columns = Math.floor(
+    (totalWidth - padding + columnGap + SECTION_COLUMN_FIT_TOLERANCE_PX) /
+      (minColumnWidth + columnGap)
+  );
+  return Math.max(1, columns);
+};

--- a/src/panels/lovelace/views/hui-sections-view.ts
+++ b/src/panels/lovelace/views/hui-sections-view.ts
@@ -33,6 +33,10 @@ import {
 import type { HuiSection } from "../sections/hui-section";
 import "../sections/hui-section-background";
 import type { Lovelace } from "../types";
+import {
+  computeSectionsColumnCount,
+  parseCssPx,
+} from "./compute-sections-column-count";
 import { generateDefaultSection } from "./default-section";
 import "./hui-view-footer";
 import "./hui-view-header";
@@ -40,8 +44,6 @@ import "./hui-view-sidebar";
 import { computeSectionsBackgroundAlignment } from "./sections-background-alignment";
 
 export const DEFAULT_MAX_COLUMNS = 4;
-
-const parsePx = (value: string) => parseInt(value.replace("px", ""));
 
 @customElement("hui-sections-view")
 export class SectionsView extends LitElement implements LovelaceViewElement {
@@ -93,18 +95,20 @@ export class SectionsView extends LitElement implements LovelaceViewElement {
       const container = this.shadowRoot!.querySelector(".container")!;
       const containerStyle = getComputedStyle(container);
 
-      const paddingLeft = parsePx(wrapperStyle.paddingLeft);
-      const paddingRight = parsePx(wrapperStyle.paddingRight);
+      const paddingLeft = parseCssPx(wrapperStyle.paddingLeft);
+      const paddingRight = parseCssPx(wrapperStyle.paddingRight);
       const padding = paddingLeft + paddingRight;
-      const minColumnWidth = parsePx(
+      const minColumnWidth = parseCssPx(
         style.getPropertyValue("--column-min-width")
       );
-      const columnGap = parsePx(containerStyle.columnGap);
+      const columnGap = parseCssPx(containerStyle.columnGap);
 
-      const columns = Math.floor(
-        (totalWidth - padding + columnGap) / (minColumnWidth + columnGap)
+      return computeSectionsColumnCount(
+        totalWidth,
+        padding,
+        minColumnWidth,
+        columnGap
       );
-      return Math.max(columns, 1);
     },
   });
 

--- a/test/panels/lovelace/views/compute-sections-column-count.test.ts
+++ b/test/panels/lovelace/views/compute-sections-column-count.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeSectionsColumnCount,
+  parseCssPx,
+} from "../../../../src/panels/lovelace/views/compute-sections-column-count";
+
+// Defaults from hui-sections-view: --column-min-width 320px, --column-gap 32px,
+// wrapper padding 0 var(--column-gap) → 64px.
+const MIN_COLUMN_WIDTH = 320;
+const COLUMN_GAP = 32;
+const PADDING = 64;
+
+const columnsFor = (totalWidth: number) =>
+  computeSectionsColumnCount(totalWidth, PADDING, MIN_COLUMN_WIDTH, COLUMN_GAP);
+
+describe("parseCssPx", () => {
+  it("parses integer pixel values", () => {
+    expect(parseCssPx("32px")).toBe(32);
+  });
+
+  it("parses fractional pixel values from zoom", () => {
+    expect(parseCssPx("31.68px")).toBe(31.68);
+  });
+
+  it("returns 0 for empty or non-numeric values", () => {
+    expect(parseCssPx("")).toBe(0);
+    expect(parseCssPx("auto")).toBe(0);
+  });
+});
+
+describe("computeSectionsColumnCount", () => {
+  it("returns 3 columns at 1080px (kiosk width just under the exact fit)", () => {
+    expect(columnsFor(1080)).toBe(3);
+  });
+
+  it("returns 3 columns at the exact 3-column fit of 1088px", () => {
+    expect(columnsFor(1088)).toBe(3);
+  });
+
+  it("returns 1 column at 670px so the sidebar still stacks", () => {
+    expect(columnsFor(670)).toBe(1);
+  });
+
+  it("returns 1 column when width is missing or zero", () => {
+    expect(columnsFor(0)).toBe(1);
+    expect(
+      computeSectionsColumnCount(-10, PADDING, MIN_COLUMN_WIDTH, COLUMN_GAP)
+    ).toBe(1);
+  });
+
+  it("still returns 3 columns with zoom-scaled fractional CSS pixels", () => {
+    const minColumnWidth = parseCssPx("316.8px");
+    const columnGap = parseCssPx("31.68px");
+    const padding = parseCssPx("31.68px") + parseCssPx("31.68px");
+    expect(
+      computeSectionsColumnCount(1080, padding, minColumnWidth, columnGap)
+    ).toBe(3);
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to the issue or discussion
  in the additional information section.
-->

Sections dashboards on ~1080px-wide screens (rotated 1080p kiosks, some tablets) dropped from 3 columns to 2 after 2026.8.1. Sections with `column_span` 2 or 3 then filled the row and looked like a single stacked column. At 99% zoom they snapped back.

[#53515](https://github.com/home-assistant/frontend/pull/53515) correctly started subtracting wrapper padding when counting columns, which moved the 3-column breakpoint from 1024px to 1088px. A 1080px viewport is 8px short, so `Math.floor` returned 2.

This keeps that padding math (sidebar stacking still depends on it) and allows 16px of slack before dropping a column. 1080px fits 3 columns again; 670px still fits 1.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

`max_columns: 3` sections view. Left is the previous 1080px result (2 columns, third section wraps). Right is 1080px with this change (3 columns).

| Before (1080px without slack) | After (1080px with slack) |
| --- | --- |
| ![Before: Column 3 wraps under Column 1](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/ha-53559-before-f3797950.png) | ![After: three columns side by side](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/ha-53559-after-e4655fd3.png) |

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53559
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/53515
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your PR.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and I can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr