### PR TITLE
Add more deep links to more-info dialogs

### DIFF
--- a/src/common/url/more-info-query-params.ts
+++ b/src/common/url/more-info-query-params.ts
@@ -49,7 +49,10 @@ export const createMoreInfoUrl = (
   url.searchParams.set(ENTITY_ID_PARAM, data.entityId);
   url.searchParams.set(VIEW_PARAM, data.view);
   if (!__DEMO__) {
-    url.hash = data.hash?.toString() ?? "";
+    const hashStr = data.hash?.toString() ?? "";
+    if (hashStr) {
+      url.hash = hashStr;
+    }
   }
 
   return `${url.pathname}${url.search}${url.hash}`;
@@ -59,9 +62,6 @@ export const removeMoreInfoUrl = (base: string): string => {
   const url = new URL(base, window.location.origin);
   url.searchParams.delete(ENTITY_ID_PARAM);
   url.searchParams.delete(VIEW_PARAM);
-  if (!__DEMO__) {
-    url.hash = "";
-  }
 
   return `${url.pathname}${url.search}${url.hash}`;
 };

--- a/src/common/url/more-info-query-params.ts
+++ b/src/common/url/more-info-query-params.ts
@@ -1,0 +1,78 @@
+import type { MoreInfoView } from "../../dialogs/more-info/const";
+import { isMoreInfoView } from "../../dialogs/more-info/const";
+import {
+  createQueryString,
+  decodeQueryParams,
+  type QueryParamConfig,
+  type SearchParamsSource,
+} from "./query-params";
+
+export const moreInfoQueryParamConfig = {
+  string: ["more-info-entity-id", "more-info-view"],
+} as const satisfies QueryParamConfig;
+
+export interface MoreInfoUrlData {
+  entityId?: string;
+  view?: MoreInfoView;
+  hash: URLSearchParams;
+}
+
+export interface CreateMoreInfoUrlData {
+  entityId: string;
+  view: MoreInfoView;
+  hash?: URLSearchParams;
+}
+
+export const decodeMoreInfoUrl = (
+  search: SearchParamsSource,
+  hash = ""
+): MoreInfoUrlData => {
+  const params = decodeQueryParams(search, moreInfoQueryParamConfig);
+
+  return {
+    entityId: params["more-info-entity-id"],
+    view: isMoreInfoView(params["more-info-view"])
+      ? params["more-info-view"]
+      : undefined,
+    hash: new URLSearchParams(
+      __DEMO__ ? "" : hash.startsWith("#") ? hash.substring(1) : hash
+    ),
+  };
+};
+
+export const createMoreInfoUrl = (
+  base: string,
+  data: CreateMoreInfoUrlData
+): string => {
+  const url = new URL(base, window.location.origin);
+  const moreInfoQuery = new URLSearchParams(
+    createQueryString(
+      {
+        "more-info-entity-id": data.entityId,
+        "more-info-view": data.view,
+      },
+      moreInfoQueryParamConfig
+    )
+  );
+
+  for (const [key, value] of moreInfoQuery) {
+    url.searchParams.set(key, value);
+  }
+  if (!__DEMO__) {
+    url.hash = data.hash?.toString() ?? "";
+  }
+
+  return `${url.pathname}${url.search}${url.hash}`;
+};
+
+export const removeMoreInfoUrl = (base: string): string => {
+  const url = new URL(base, window.location.origin);
+  for (const key of moreInfoQueryParamConfig.string) {
+    url.searchParams.delete(key);
+  }
+  if (!__DEMO__) {
+    url.hash = "";
+  }
+
+  return `${url.pathname}${url.search}${url.hash}`;
+};

--- a/src/common/url/more-info-query-params.ts
+++ b/src/common/url/more-info-query-params.ts
@@ -1,15 +1,11 @@
-import type { MoreInfoView } from "../../dialogs/more-info/const";
-import { isMoreInfoView } from "../../dialogs/more-info/const";
 import {
-  createQueryString,
-  decodeQueryParams,
-  type QueryParamConfig,
-  type SearchParamsSource,
-} from "./query-params";
+  isMoreInfoView,
+  type MoreInfoView,
+} from "../../dialogs/more-info/more-info-view";
+import type { SearchParamsSource } from "./query-params";
 
-export const moreInfoQueryParamConfig = {
-  string: ["more-info-entity-id", "more-info-view"],
-} as const satisfies QueryParamConfig;
+const ENTITY_ID_PARAM = "more-info-entity-id";
+const VIEW_PARAM = "more-info-view";
 
 export interface MoreInfoUrlData {
   entityId?: string;
@@ -27,13 +23,18 @@ export const decodeMoreInfoUrl = (
   search: SearchParamsSource,
   hash = ""
 ): MoreInfoUrlData => {
-  const params = decodeQueryParams(search, moreInfoQueryParamConfig);
+  const params =
+    typeof search === "string"
+      ? new URLSearchParams(search)
+      : search instanceof URLSearchParams
+        ? search
+        : new URLSearchParams(search);
+  const entityId = params.get(ENTITY_ID_PARAM) || undefined;
+  const view = params.get(VIEW_PARAM) || undefined;
 
   return {
-    entityId: params["more-info-entity-id"],
-    view: isMoreInfoView(params["more-info-view"])
-      ? params["more-info-view"]
-      : undefined,
+    entityId,
+    view: isMoreInfoView(view) ? view : undefined,
     hash: new URLSearchParams(
       __DEMO__ ? "" : hash.startsWith("#") ? hash.substring(1) : hash
     ),
@@ -45,19 +46,8 @@ export const createMoreInfoUrl = (
   data: CreateMoreInfoUrlData
 ): string => {
   const url = new URL(base, window.location.origin);
-  const moreInfoQuery = new URLSearchParams(
-    createQueryString(
-      {
-        "more-info-entity-id": data.entityId,
-        "more-info-view": data.view,
-      },
-      moreInfoQueryParamConfig
-    )
-  );
-
-  for (const [key, value] of moreInfoQuery) {
-    url.searchParams.set(key, value);
-  }
+  url.searchParams.set(ENTITY_ID_PARAM, data.entityId);
+  url.searchParams.set(VIEW_PARAM, data.view);
   if (!__DEMO__) {
     url.hash = data.hash?.toString() ?? "";
   }
@@ -67,9 +57,8 @@ export const createMoreInfoUrl = (
 
 export const removeMoreInfoUrl = (base: string): string => {
   const url = new URL(base, window.location.origin);
-  for (const key of moreInfoQueryParamConfig.string) {
-    url.searchParams.delete(key);
-  }
+  url.searchParams.delete(ENTITY_ID_PARAM);
+  url.searchParams.delete(VIEW_PARAM);
   if (!__DEMO__) {
     url.hash = "";
   }

--- a/src/common/url/more-info-query-params.ts
+++ b/src/common/url/more-info-query-params.ts
@@ -48,11 +48,8 @@ export const createMoreInfoUrl = (
   const url = new URL(base, window.location.origin);
   url.searchParams.set(ENTITY_ID_PARAM, data.entityId);
   url.searchParams.set(VIEW_PARAM, data.view);
-  if (!__DEMO__) {
-    const hashStr = data.hash?.toString() ?? "";
-    if (hashStr) {
-      url.hash = hashStr;
-    }
+  if (!__DEMO__ && data.hash !== undefined) {
+    url.hash = data.hash.toString();
   }
 
   return `${url.pathname}${url.search}${url.hash}`;

--- a/src/dialogs/more-info/const.ts
+++ b/src/dialogs/more-info/const.ts
@@ -7,21 +7,11 @@ import { isNumericEntity } from "../../data/history";
 import { CONTINUOUS_DOMAINS } from "../../data/logbook";
 import type { HomeAssistant } from "../../types";
 
-export const MORE_INFO_VIEWS = [
-  "info",
-  "history",
-  "settings",
-  "related",
-  "add_to",
-  "details",
-] as const;
-
-export type MoreInfoView = (typeof MORE_INFO_VIEWS)[number];
-
-export const isMoreInfoView = (
-  value: string | undefined
-): value is MoreInfoView =>
-  value !== undefined && (MORE_INFO_VIEWS as readonly string[]).includes(value);
+export {
+  isMoreInfoView,
+  MORE_INFO_VIEWS,
+  type MoreInfoView,
+} from "./more-info-view";
 
 export const DOMAINS_NO_INFO = ["camera", "configurator"];
 /**

--- a/src/dialogs/more-info/context.ts
+++ b/src/dialogs/more-info/context.ts
@@ -1,0 +1,9 @@
+import { createContext } from "@lit/context";
+
+export interface MoreInfoContext {
+  hash: URLSearchParams;
+  setHashParam: (key: string, value?: string) => void;
+}
+
+export const moreInfoContext =
+  createContext<MoreInfoContext>("more-info-context");

--- a/src/dialogs/more-info/controls/more-info-weather.ts
+++ b/src/dialogs/more-info/controls/more-info-weather.ts
@@ -11,6 +11,7 @@ import { formatDateWeekdayShort } from "../../../common/datetime/format_date";
 import { formatTime } from "../../../common/datetime/format_time";
 import { transform } from "../../../common/decorators/transform";
 import { formatNumber } from "../../../common/number/format_number";
+import type { HASSDomEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-alert";
 import "../../../components/ha-relative-time";
 import "../../../components/ha-spinner";
@@ -48,10 +49,15 @@ import type {
   HomeAssistantFormatters,
   HomeAssistantInternationalization,
 } from "../../../types";
+import { moreInfoContext, type MoreInfoContext } from "../context";
 
 @customElement("more-info-weather")
 class MoreInfoWeather extends LitElement {
   @property({ attribute: false }) public stateObj?: WeatherEntity;
+
+  @state()
+  @consume({ context: moreInfoContext, subscribe: true })
+  private _moreInfoContext?: MoreInfoContext;
 
   @state()
   @consume({ context: internationalizationContext, subscribe: true })
@@ -127,15 +133,33 @@ class MoreInfoWeather extends LitElement {
   protected willUpdate(changedProps: PropertyValues): void {
     super.willUpdate(changedProps);
 
-    if ((changedProps.has("stateObj") || !this._subscribed) && this.stateObj) {
+    if (
+      (changedProps.has("stateObj") ||
+        changedProps.has("_moreInfoContext") ||
+        !this._subscribed) &&
+      this.stateObj
+    ) {
       const oldState = changedProps.get("stateObj") as
         WeatherEntity | undefined;
       if (
         oldState?.entity_id !== this.stateObj?.entity_id ||
+        changedProps.has("_moreInfoContext") ||
         !this._subscribed
       ) {
-        this._forecastType = getDefaultForecastType(this.stateObj);
-        this._subscribeForecastEvents();
+        const supportedForecastTypes = getSupportedForecastTypes(this.stateObj);
+        const requestedForecastType =
+          this._moreInfoContext?.hash.get("forecast");
+        const selectedForecastType =
+          supportedForecastTypes.find(
+            (forecastType) => forecastType === requestedForecastType
+          ) ?? getDefaultForecastType(this.stateObj);
+        if (selectedForecastType !== requestedForecastType) {
+          this._moreInfoContext?.setHashParam("forecast", selectedForecastType);
+        }
+        if (this._forecastType !== selectedForecastType || !this._subscribed) {
+          this._forecastType = selectedForecastType;
+          this._subscribeForecastEvents();
+        }
       }
     } else if (changedProps.has("_forecastType")) {
       this._subscribeForecastEvents();
@@ -509,8 +533,17 @@ class MoreInfoWeather extends LitElement {
     `;
   }
 
-  private _handleForecastTypeChanged(ev: CustomEvent): void {
+  private _handleForecastTypeChanged(
+    ev: HASSDomEvent<{ name: ModernForecastType }>
+  ): void {
+    if (
+      !this.stateObj ||
+      !getSupportedForecastTypes(this.stateObj).includes(ev.detail.name)
+    ) {
+      return;
+    }
     this._forecastType = ev.detail.name;
+    this._moreInfoContext?.setHashParam("forecast", this._forecastType);
   }
 
   static get styles(): CSSResultGroup {

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -17,6 +17,7 @@ import {
   mdiTransitConnectionVariant,
 } from "@mdi/js";
 import type { HassEntity } from "home-assistant-js-websocket";
+import { provide } from "@lit/context";
 import type { PropertyValues } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
@@ -43,8 +44,10 @@ import { shouldHandleRequestSelectedEvent } from "../../common/mwc/handle-reques
 import {
   getHistoryState,
   navigate,
+  replaceCurrentUrl,
   updateHistoryState,
 } from "../../common/navigate";
+import { createMoreInfoUrl } from "../../common/url/more-info-query-params";
 import type { LocalizeKeys } from "../../common/translations/localize";
 import { computeRTL } from "../../common/util/compute_rtl";
 import { withViewTransition } from "../../common/util/view-transition";
@@ -85,6 +88,7 @@ import {
   EDITABLE_DOMAINS_WITH_UNIQUE_ID,
   type MoreInfoView,
 } from "./const";
+import { moreInfoContext, type MoreInfoContext } from "./context";
 import "./controls/more-info-default";
 import type { FavoritesDialogContext } from "./favorites";
 import { getFavoritesDialogHandler } from "./favorites";
@@ -102,6 +106,9 @@ export interface MoreInfoDialogParams {
   tab?: MoreInfoView;
   large?: boolean;
   data?: Record<string, any>;
+  hash?: URLSearchParams;
+  fromUrl?: boolean;
+  returnUrl?: string;
   parentElement?: LitElement;
 }
 
@@ -147,6 +154,12 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
 
   @state() private _data?: Record<string, any>;
 
+  @provide({ context: moreInfoContext })
+  @state()
+  private _moreInfoContext: MoreInfoContext = this._createMoreInfoContext();
+
+  private _returnUrl?: string;
+
   @state() private _currView: MoreInfoView = DEFAULT_VIEW;
 
   @state() private _initialView: MoreInfoView = DEFAULT_VIEW;
@@ -181,6 +194,8 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
     const view = params.view || params.tab || DEFAULT_VIEW;
 
     this._data = params.data;
+    this._moreInfoContext = this._createMoreInfoContext(params.hash);
+    this._returnUrl = params.returnUrl;
     this._currView = view;
     this._initialView = view;
     this._childViewStack = [];
@@ -216,6 +231,9 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
   }
 
   private _dialogClosed() {
+    if (this._returnUrl) {
+      replaceCurrentUrl(this._returnUrl);
+    }
     this._entityId = undefined;
     this._parentEntityIds = [];
     this._entry = undefined;
@@ -224,6 +242,8 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
     this._initialView = DEFAULT_VIEW;
     this._currView = DEFAULT_VIEW;
     this._childViewStack = [];
+    this._moreInfoContext = this._createMoreInfoContext();
+    this._returnUrl = undefined;
     this._isEscapeEnabled = true;
     window.removeEventListener("dialog-closed", this._enableEscapeKeyClose);
     window.removeEventListener("show-dialog", this._disableEscapeKeyClose);
@@ -271,7 +291,10 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
     return entity?.device_id ?? null;
   }
 
-  private _setView(view: MoreInfoView) {
+  private _setView(view: MoreInfoView, preserveHash = false) {
+    if (view !== this._currView && !preserveHash) {
+      this._moreInfoContext = this._createMoreInfoContext();
+    }
     updateHistoryState({
       dialogParams: {
         ...getHistoryState()?.dialogParams,
@@ -279,6 +302,38 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
       },
     });
     this._currView = view;
+    this._syncUrl();
+  }
+
+  private _syncUrl() {
+    if (!this._returnUrl || !this._entityId) {
+      return;
+    }
+    replaceCurrentUrl(
+      createMoreInfoUrl(this._returnUrl, {
+        entityId: this._entityId,
+        view: this._currView,
+        hash: this._moreInfoContext.hash,
+      })
+    );
+  }
+
+  private _createMoreInfoContext(hash?: URLSearchParams): MoreInfoContext {
+    return {
+      hash: new URLSearchParams(hash),
+      setHashParam: (key, value) => this._setHashParam(key, value),
+    };
+  }
+
+  private _setHashParam(key: string, value?: string) {
+    const hash = new URLSearchParams(this._moreInfoContext.hash);
+    if (value) {
+      hash.set(key, value);
+    } else {
+      hash.delete(key);
+    }
+    this._moreInfoContext = this._createMoreInfoContext(hash);
+    this._syncUrl();
   }
 
   private _goBack() {
@@ -306,7 +361,9 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
     if (this._parentEntityIds.length > 0) {
       this._entityId = this._parentEntityIds.pop();
       this._currView = DEFAULT_VIEW;
+      this._moreInfoContext = this._createMoreInfoContext();
       this._loadEntityRegistryEntry();
+      this._syncUrl();
     }
   }
 
@@ -1007,19 +1064,22 @@ export class MoreInfoDialog extends DirtyStateProviderMixin<
     }
     const view = ev.detail.view || ev.detail.tab || DEFAULT_VIEW;
     if (entityId === this._entityId) {
+      this._moreInfoContext = this._createMoreInfoContext(ev.detail.hash);
       this._infoEditMode = false;
       this._detailsYamlMode = false;
-      this._setView(view);
+      this._setView(view, true);
       return;
     }
     this._parentEntityIds = [...this._parentEntityIds, this._entityId!];
     this._entityId = entityId;
+    this._moreInfoContext = this._createMoreInfoContext(ev.detail.hash);
     this._currView = view === "details" ? view : DEFAULT_VIEW;
     this._initialView = view;
     this._infoEditMode = false;
     this._detailsYamlMode = false;
     this._childViewStack = [];
     this._loadEntityRegistryEntry();
+    this._syncUrl();
   }
 
   private _enableEscapeKeyClose = () => {

--- a/src/dialogs/more-info/more-info-view.ts
+++ b/src/dialogs/more-info/more-info-view.ts
@@ -1,0 +1,15 @@
+export const MORE_INFO_VIEWS = [
+  "info",
+  "history",
+  "settings",
+  "related",
+  "add_to",
+  "details",
+] as const;
+
+export type MoreInfoView = (typeof MORE_INFO_VIEWS)[number];
+
+export const isMoreInfoView = (
+  value: string | undefined
+): value is MoreInfoView =>
+  value !== undefined && (MORE_INFO_VIEWS as readonly string[]).includes(value);

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -6,12 +6,16 @@ import { storage } from "../common/decorators/storage";
 import { isNavigationClick } from "../common/dom/is-navigation-click";
 import { navigate } from "../common/navigate";
 import type { LocalizeFunc } from "../common/translations/localize";
+import { decodeMoreInfoUrl } from "../common/url/more-info-query-params";
+import { extractSearchParamsObject } from "../common/url/search-params";
+import { afterNextRender } from "../common/util/render-status";
 import { fetchHttpConfig } from "../data/http";
 import type { HttpConfigState } from "../data/http";
 import type { WindowWithPreloads } from "../data/preloads";
 import type { RecorderInfo } from "../data/recorder";
 import { getRecorderInfo } from "../data/recorder";
 import { showHttpPendingConfigDialog } from "../dialogs/http-pending-config/show-dialog-http-pending-config";
+import { showMoreInfoDialog } from "../dialogs/more-info/show-ha-more-info-dialog";
 import "../resources/custom-card-support";
 import { HassElement } from "../state/hass-element";
 import QuickBarMixin from "../state/quick-bar-mixin";
@@ -144,6 +148,7 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
       // the shadow root. Appending the dialog before that render would let it
       // tear the freshly-added dialog straight back out of the DOM.
       this.checkHttpPendingConfig();
+      this._restoreMoreInfoFromUrl();
     }
   }
 
@@ -177,6 +182,12 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
 
     // Handle history changes
     window.addEventListener("popstate", () => updateRoute());
+
+    // Restore a more-info dialog deep-linked in the current URL, if any.
+    window.addEventListener("location-changed", () =>
+      this._restoreMoreInfoFromUrl()
+    );
+    window.addEventListener("popstate", () => this._restoreMoreInfoFromUrl());
 
     // Handle clicking on links
     window.addEventListener("click", (ev) => {
@@ -294,6 +305,35 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
       onResolved: () => {
         this._httpPendingDialogOpen = false;
       },
+    });
+  }
+
+  private _restoreMoreInfoFromUrl() {
+    // Only restore once the main UI is rendered so the dialog has access to
+    // the loaded entities.
+    if (this.render !== this.renderHass) {
+      return;
+    }
+    const searchParams = extractSearchParamsObject();
+    if (!searchParams["more-info-entity-id"]) {
+      return;
+    }
+    const { entityId, view, hash } = decodeMoreInfoUrl(
+      window.location.search,
+      window.location.hash
+    );
+    if (!entityId) {
+      return;
+    }
+    // Wait for the next render to ensure the view is fully loaded
+    // because the more info dialog is closed when the url changes
+    afterNextRender(() => {
+      showMoreInfoDialog(this, {
+        entityId,
+        view,
+        hash,
+        fromUrl: true,
+      });
     });
   }
 

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -30,7 +30,6 @@ import { fireEvent } from "../../common/dom/fire_event";
 import { goBack, navigate, replaceCurrentUrl } from "../../common/navigate";
 import type { LocalizeKeys } from "../../common/translations/localize";
 import { constructUrlCurrentPath } from "../../common/url/construct-url";
-import { decodeMoreInfoUrl } from "../../common/url/more-info-query-params";
 import { sanitizeNavigationPath } from "../../common/url/sanitize-navigation-path";
 import {
   addSearchParam,
@@ -71,7 +70,6 @@ import {
   showAlertDialog,
   showConfirmationDialog,
 } from "../../dialogs/generic/show-dialog-box";
-import { showMoreInfoDialog } from "../../dialogs/more-info/show-ha-more-info-dialog";
 import { showQuickBar } from "../../dialogs/quick-bar/show-dialog-quick-bar";
 import { showVoiceCommandDialog } from "../../dialogs/voice-command-dialog/show-ha-voice-command-dialog";
 import { haStyle } from "../../resources/styles";
@@ -723,21 +721,6 @@ class HUIRoot extends LitElement {
     } else if (searchParams.conversation === "1") {
       this._clearParam("conversation");
       this._showVoiceCommandDialog();
-    } else if (searchParams["more-info-entity-id"]) {
-      const { entityId, view, hash } = decodeMoreInfoUrl(
-        window.location.search,
-        window.location.hash
-      );
-      // Wait for the next render to ensure the view is fully loaded
-      // because the more info dialog is closed when the url changes
-      afterNextRender(() => {
-        showMoreInfoDialog(this, {
-          entityId: entityId!,
-          view,
-          hash,
-          fromUrl: true,
-        });
-      });
     }
   }
 

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -30,6 +30,7 @@ import { fireEvent } from "../../common/dom/fire_event";
 import { goBack, navigate, replaceCurrentUrl } from "../../common/navigate";
 import type { LocalizeKeys } from "../../common/translations/localize";
 import { constructUrlCurrentPath } from "../../common/url/construct-url";
+import { decodeMoreInfoUrl } from "../../common/url/more-info-query-params";
 import { sanitizeNavigationPath } from "../../common/url/sanitize-navigation-path";
 import {
   addSearchParam,
@@ -70,7 +71,6 @@ import {
   showAlertDialog,
   showConfirmationDialog,
 } from "../../dialogs/generic/show-dialog-box";
-import { isMoreInfoView } from "../../dialogs/more-info/const";
 import { showMoreInfoDialog } from "../../dialogs/more-info/show-ha-more-info-dialog";
 import { showQuickBar } from "../../dialogs/quick-bar/show-dialog-quick-bar";
 import { showVoiceCommandDialog } from "../../dialogs/voice-command-dialog/show-ha-voice-command-dialog";
@@ -724,18 +724,18 @@ class HUIRoot extends LitElement {
       this._clearParam("conversation");
       this._showVoiceCommandDialog();
     } else if (searchParams["more-info-entity-id"]) {
-      const entityId = searchParams["more-info-entity-id"];
-      const view = searchParams["more-info-view"];
-      this._clearParam("more-info-entity-id");
-      if (view) {
-        this._clearParam("more-info-view");
-      }
+      const { entityId, view, hash } = decodeMoreInfoUrl(
+        window.location.search,
+        window.location.hash
+      );
       // Wait for the next render to ensure the view is fully loaded
       // because the more info dialog is closed when the url changes
       afterNextRender(() => {
         showMoreInfoDialog(this, {
-          entityId,
-          view: isMoreInfoView(view) ? view : undefined,
+          entityId: entityId!,
+          view,
+          hash,
+          fromUrl: true,
         });
       });
     }

--- a/src/state/more-info-mixin.ts
+++ b/src/state/more-info-mixin.ts
@@ -1,6 +1,12 @@
 import type { PropertyValues } from "lit";
 import type { HASSDomEvent } from "../common/dom/fire_event";
+import { mainWindow } from "../common/dom/get_main_window";
 import { computeDomain } from "../common/entity/compute_domain";
+import { replaceCurrentUrl } from "../common/navigate";
+import {
+  createMoreInfoUrl,
+  removeMoreInfoUrl,
+} from "../common/url/more-info-query-params";
 import { showDialog } from "../dialogs/make-dialog-manager";
 import type { MoreInfoDialogParams } from "../dialogs/more-info/ha-more-info-dialog";
 import type { Constructor } from "../types";
@@ -28,12 +34,19 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
     private async _handleMoreInfo(
       ev: HASSDomEvent<HASSDomEvents["hass-more-info"]>
     ) {
-      showDialog(
+      const view = ev.detail.view || ev.detail.tab || "info";
+      const currentUrl = `${mainWindow.location.pathname}${mainWindow.location.search}${mainWindow.location.hash}`;
+      const returnUrl = ev.detail.fromUrl
+        ? removeMoreInfoUrl(currentUrl)
+        : currentUrl;
+
+      replaceCurrentUrl(returnUrl);
+      const shown = await showDialog(
         this,
         "ha-more-info-dialog",
         {
           entityId: ev.detail.entityId,
-          view: ev.detail.view || ev.detail.tab,
+          view,
           large:
             ev.detail.large ??
             (ev.detail.entityId
@@ -42,9 +55,20 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
                 )
               : false),
           data: ev.detail.data,
+          hash: ev.detail.hash,
+          returnUrl,
         },
         () => import("../dialogs/more-info/ha-more-info-dialog"),
         ev.detail.parentElement
       );
+      if (shown && ev.detail.entityId) {
+        replaceCurrentUrl(
+          createMoreInfoUrl(returnUrl, {
+            entityId: ev.detail.entityId,
+            view,
+            hash: ev.detail.hash,
+          })
+        );
+      }
     }
   };

--- a/test/common/url/query-params.test.ts
+++ b/test/common/url/query-params.test.ts
@@ -278,11 +278,22 @@ describe("more-info query params", () => {
     );
   });
 
-  it("removes more-info query and hash state", () => {
+  it("removes more-info query params but preserves other hash state", () => {
     expect(
       removeMoreInfoUrl(
         "/lovelace/home?theme=dark&more-info-entity-id=weather.home&more-info-view=info#forecast=hourly"
       )
-    ).toBe("/lovelace/home?theme=dark");
+    ).toBe("/lovelace/home?theme=dark#forecast=hourly");
+  });
+
+  it("preserves an unrelated hash when creating a more-info url without a dialog hash", () => {
+    expect(
+      createMoreInfoUrl("/lovelace/home?theme=dark#some-anchor", {
+        entityId: "light.kitchen",
+        view: "info",
+      })
+    ).toBe(
+      "/lovelace/home?theme=dark&more-info-entity-id=light.kitchen&more-info-view=info#some-anchor"
+    );
   });
 });

--- a/test/common/url/query-params.test.ts
+++ b/test/common/url/query-params.test.ts
@@ -15,6 +15,11 @@ import {
   type QueryParamConfig,
 } from "../../../src/common/url/query-params";
 import {
+  createMoreInfoUrl,
+  decodeMoreInfoUrl,
+  removeMoreInfoUrl,
+} from "../../../src/common/url/more-info-query-params";
+import {
   createTodoQueryString,
   decodeTodoQueryParams,
 } from "../../../src/common/url/todo-query-params";
@@ -238,5 +243,46 @@ describe("todo query params", () => {
     const decoded = decodeTodoQueryParams(original);
     const encoded = createTodoQueryString(decoded);
     expect(encoded).toBe("add_item=true&entity_id=todo.tasks");
+  });
+});
+
+describe("more-info query params", () => {
+  it("decodes the entity, view, and named hash params", () => {
+    const params = decodeMoreInfoUrl(
+      "?more-info-entity-id=weather.home&more-info-view=info",
+      "#forecast=hourly"
+    );
+
+    expect(params.entityId).toBe("weather.home");
+    expect(params.view).toBe("info");
+    expect(params.hash.get("forecast")).toBe("hourly");
+  });
+
+  it("ignores invalid views", () => {
+    expect(
+      decodeMoreInfoUrl(
+        "?more-info-entity-id=weather.home&more-info-view=forecast"
+      ).view
+    ).toBeUndefined();
+  });
+
+  it("creates a link without dropping unrelated query params", () => {
+    expect(
+      createMoreInfoUrl("/lovelace/home?theme=dark", {
+        entityId: "weather.home",
+        view: "info",
+        hash: new URLSearchParams({ forecast: "hourly" }),
+      })
+    ).toBe(
+      "/lovelace/home?theme=dark&more-info-entity-id=weather.home&more-info-view=info#forecast=hourly"
+    );
+  });
+
+  it("removes more-info query and hash state", () => {
+    expect(
+      removeMoreInfoUrl(
+        "/lovelace/home?theme=dark&more-info-entity-id=weather.home&more-info-view=info#forecast=hourly"
+      )
+    ).toBe("/lovelace/home?theme=dark");
   });
 });

--- a/test/common/url/query-params.test.ts
+++ b/test/common/url/query-params.test.ts
@@ -296,4 +296,16 @@ describe("more-info query params", () => {
       "/lovelace/home?theme=dark&more-info-entity-id=light.kitchen&more-info-view=info#some-anchor"
     );
   });
+
+  it("clears an existing hash when an empty dialog hash is explicitly supplied", () => {
+    expect(
+      createMoreInfoUrl("/lovelace/home?theme=dark#some-anchor", {
+        entityId: "light.kitchen",
+        view: "info",
+        hash: new URLSearchParams(),
+      })
+    ).toBe(
+      "/lovelace/home?theme=dark&more-info-entity-id=light.kitchen&more-info-view=info"
+    );
+  });
 });

--- a/test/e2e/app.spec.ts
+++ b/test/e2e/app.spec.ts
@@ -211,7 +211,7 @@ test("keeps the launch screen until initial panel content renders", async ({
       name: "generated dashboard",
       path: "/?scenario=delayed-generated-dashboard#/climate",
       loadingSelector: "#ha-launch-screen",
-      readySelector: "hui-view",
+      readySelector: "hui-card",
       resolvers: ["resolveGeneratedDashboard"],
     },
     {

--- a/test/e2e/app.spec.ts
+++ b/test/e2e/app.spec.ts
@@ -327,6 +327,64 @@ test.describe("Light more-info dialog", () => {
   }
 });
 
+test.describe("Weather more-info deep link", () => {
+  test("opens and synchronizes the selected forecast", async ({ page }) => {
+    await goToPanel(
+      page,
+      "/?scenario=weather-more-info&more-info-entity-id=weather.test_weather&more-info-view=info#/lovelace"
+    );
+
+    const dialog = page.locator("ha-more-info-dialog");
+    const weather = dialog.locator("more-info-weather");
+    await expect(weather).toBeAttached({ timeout: SHELL_TIMEOUT });
+    await expect(page).toHaveURL(
+      /more-info-entity-id=weather\.test_weather&more-info-view=info/
+    );
+    await expect(
+      weather.locator("ha-tab-group-tab[active]").filter({ hasText: "Daily" })
+    ).toBeAttached();
+
+    await page.locator("ha-test").evaluate((el) => {
+      el.dispatchEvent(
+        new CustomEvent("hass-more-info", {
+          detail: {
+            entityId: "weather.test_weather",
+            hash: new URLSearchParams({ forecast: "hourly" }),
+          },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    });
+
+    await expect(
+      weather.locator("ha-tab-group-tab[active]").filter({ hasText: "Hourly" })
+    ).toBeAttached();
+
+    await dialog.getByRole("button", { name: "History" }).click();
+    await expect(page).toHaveURL(/more-info-view=history/);
+
+    await dialog.getByRole("button", { name: "Back" }).click();
+
+    await expect(
+      weather.locator("ha-tab-group-tab[active]").filter({ hasText: "Daily" })
+    ).toBeAttached();
+
+    await weather
+      .locator("ha-tab-group-tab")
+      .filter({ hasText: "Daily" })
+      .click();
+
+    await expect(
+      weather.locator("ha-tab-group-tab[active]").filter({ hasText: "Daily" })
+    ).toBeAttached();
+
+    await dialog.getByRole("button", { name: "Close" }).click();
+    await expect(dialog).toBeHidden();
+    await expect(page).not.toHaveURL(/more-info-entity-id/);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Theming
 // ---------------------------------------------------------------------------

--- a/test/e2e/app/src/scenarios/index.ts
+++ b/test/e2e/app/src/scenarios/index.ts
@@ -5,6 +5,10 @@ import type {
 } from "../../../../../src/data/entity/entity_registry";
 import type { LovelaceRawConfig } from "../../../../../src/data/lovelace/config/types";
 import type { MediaPlayerItem } from "../../../../../src/data/media-player";
+import {
+  WeatherEntityFeature,
+  type ForecastEvent,
+} from "../../../../../src/data/weather";
 import type { MockHomeAssistant } from "../../../../../src/fake_data/provide_hass";
 
 export type Scenario = (hass: MockHomeAssistant) => Promise<void> | void;
@@ -93,6 +97,51 @@ const lightMoreInfoScenario: Scenario = async (hass) => {
     aliases: [],
   };
   hass.mockWS("config/entity_registry/get", () => registryEntry);
+};
+
+const weatherMoreInfoScenario: Scenario = (hass) => {
+  hass.addEntities([
+    {
+      entity_id: "weather.test_weather",
+      state: "sunny",
+      attributes: {
+        friendly_name: "Test Weather",
+        supported_features:
+          WeatherEntityFeature.FORECAST_DAILY +
+          WeatherEntityFeature.FORECAST_HOURLY,
+        precipitation_unit: "mm",
+        pressure_unit: "hPa",
+        temperature: 20,
+        temperature_unit: "°C",
+        visibility_unit: "km",
+        wind_speed_unit: "km/h",
+      },
+    },
+  ]);
+
+  hass.mockWS("weather/subscribe_forecast", (message, _hass, onChange) => {
+    onChange?.({
+      type: message.forecast_type,
+      forecast: [
+        {
+          datetime: "2026-08-13T10:00:00Z",
+          temperature: 20,
+          condition: "sunny",
+        },
+        {
+          datetime: "2026-08-13T11:00:00Z",
+          temperature: 21,
+          condition: "sunny",
+        },
+        {
+          datetime: "2026-08-13T12:00:00Z",
+          temperature: 22,
+          condition: "sunny",
+        },
+      ],
+    } satisfies ForecastEvent);
+    return () => undefined;
+  });
 };
 
 const quickSearchAssistScenario: Scenario = async (hass) => {
@@ -253,6 +302,7 @@ export const scenarios: Record<string, Scenario> = {
   "delayed-media-browse": delayedMediaBrowseScenario,
   "delayed-media-browse-error": delayedMediaBrowseErrorScenario,
   "light-more-info": lightMoreInfoScenario,
+  "weather-more-info": weatherMoreInfoScenario,
   "quick-search-assist": quickSearchAssistScenario,
   "delayed-lovelace": delayedLovelaceScenario,
 };


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Keep more-info dialogs represented in the URL so links can be copied or reloaded without losing the selected entity and view. Weather forecast tabs also use the URL fragment to preserve the selected forecast type.

The dialog owns fragment state through a local Lit context and restores the original URL when it closes.

### URL examples

- `?more-info-entity-id=weather.home&more-info-view=info#forecast=hourly`
  - Useful to link directly to the hourly forecast tab. I could only find this one instance of more info that uses tab navigation but more may show up.
- `?more-info-entity-id=light.kitchen&more-info-view=details`
  - Pre-existing but now shown when navigated through so can be linked to.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 
