### PR TITLE
Seed selector values when enabling optional service fields

### DIFF
--- a/src/components/ha-form/get-selector-fallback-value.ts
+++ b/src/components/ha-form/get-selector-fallback-value.ts
@@ -1,0 +1,25 @@
+import { DEFAULT_MIN_KELVIN } from "../../common/color/convert-light-color";
+import type { Selector } from "../../data/selector";
+
+/**
+ * Value a selector already displays when no field value is set.
+ * Used when enabling an optional service/trigger/condition field.
+ */
+export const getSelectorFallbackValue = (selector: Selector): unknown => {
+  if ("constant" in selector) {
+    return selector.constant?.value;
+  }
+  if ("boolean" in selector) {
+    return false;
+  }
+  if ("number" in selector) {
+    return selector.number?.min ?? 0;
+  }
+  if ("color_temp" in selector) {
+    if (selector.color_temp?.unit === "kelvin") {
+      return selector.color_temp.min ?? DEFAULT_MIN_KELVIN;
+    }
+    return selector.color_temp?.min ?? selector.color_temp?.min_mireds ?? 153;
+  }
+  return undefined;
+};

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -35,6 +35,7 @@ import {
 } from "../data/selector";
 import type { HomeAssistant, ValueChangedEvent } from "../types";
 import { documentationUrl } from "../util/documentation-url";
+import { getSelectorFallbackValue } from "./ha-form/get-selector-fallback-value";
 import "./ha-checkbox";
 import type { HaCheckbox } from "./ha-checkbox";
 import "./ha-icon-button";
@@ -799,20 +800,8 @@ export class HaServiceControl extends LitElement {
 
       let defaultValue = field?.default;
 
-      if (
-        defaultValue == null &&
-        field?.selector &&
-        "constant" in field.selector
-      ) {
-        defaultValue = field.selector.constant?.value;
-      }
-
-      if (
-        defaultValue == null &&
-        field?.selector &&
-        "boolean" in field.selector
-      ) {
-        defaultValue = false;
+      if (defaultValue == null && field?.selector) {
+        defaultValue = getSelectorFallbackValue(field.selector);
       }
 
       if (defaultValue != null) {

--- a/src/panels/config/automation/condition/types/ha-automation-condition-platform.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-platform.ts
@@ -7,6 +7,7 @@ import { createDurationData } from "../../../../../common/datetime/create_durati
 import { durationDataToSeconds } from "../../../../../common/datetime/duration_to_seconds";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { stopPropagation } from "../../../../../common/dom/stop_propagation";
+import { getSelectorFallbackValue } from "../../../../../components/ha-form/get-selector-fallback-value";
 import "../../../../../components/ha-checkbox";
 import "../../../../../components/ha-selector/ha-selector";
 import "../../../../../components/ha-settings-row";
@@ -429,20 +430,8 @@ export class HaPlatformCondition extends LitElement {
         Object.entries(this.description).find(([k, _value]) => k === key)?.[1];
       let defaultValue = field?.default;
 
-      if (
-        defaultValue == null &&
-        field?.selector &&
-        "constant" in field.selector
-      ) {
-        defaultValue = field.selector.constant?.value;
-      }
-
-      if (
-        defaultValue == null &&
-        field?.selector &&
-        "boolean" in field.selector
-      ) {
-        defaultValue = false;
+      if (defaultValue == null && field?.selector) {
+        defaultValue = getSelectorFallbackValue(field.selector);
       }
 
       if (defaultValue != null) {

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-platform.ts
@@ -4,6 +4,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../../common/dom/fire_event";
+import { getSelectorFallbackValue } from "../../../../../components/ha-form/get-selector-fallback-value";
 import "../../../../../components/ha-checkbox";
 import "../../../../../components/ha-selector/ha-selector";
 import "../../../../../components/ha-settings-row";
@@ -422,20 +423,8 @@ export class HaPlatformTrigger extends LitElement {
         Object.entries(this.description).find(([k, _value]) => k === key)?.[1];
       let defaultValue = field?.default;
 
-      if (
-        defaultValue == null &&
-        field?.selector &&
-        "constant" in field.selector
-      ) {
-        defaultValue = field.selector.constant?.value;
-      }
-
-      if (
-        defaultValue == null &&
-        field?.selector &&
-        "boolean" in field.selector
-      ) {
-        defaultValue = false;
+      if (defaultValue == null && field?.selector) {
+        defaultValue = getSelectorFallbackValue(field.selector);
       }
 
       if (defaultValue != null) {

--- a/test/components/ha-form/get-selector-fallback-value.test.ts
+++ b/test/components/ha-form/get-selector-fallback-value.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MIN_KELVIN } from "../../../src/common/color/convert-light-color";
+import { getSelectorFallbackValue } from "../../../src/components/ha-form/get-selector-fallback-value";
+
+describe("getSelectorFallbackValue", () => {
+  it("returns the constant selector value", () => {
+    expect(getSelectorFallbackValue({ constant: { value: "fixed" } })).toBe(
+      "fixed"
+    );
+    expect(getSelectorFallbackValue({ constant: { value: 0 } })).toBe(0);
+    expect(getSelectorFallbackValue({ constant: { value: false } })).toBe(
+      false
+    );
+  });
+
+  it("returns false for boolean selectors", () => {
+    expect(getSelectorFallbackValue({ boolean: null })).toBe(false);
+    expect(getSelectorFallbackValue({ boolean: {} })).toBe(false);
+  });
+
+  it("returns number min, or 0 when min is omitted", () => {
+    expect(getSelectorFallbackValue({ number: { min: 2000 } })).toBe(2000);
+    expect(getSelectorFallbackValue({ number: { min: 0, max: 100 } })).toBe(0);
+    expect(getSelectorFallbackValue({ number: null })).toBe(0);
+  });
+
+  it("returns kelvin min for color_temp, falling back to DEFAULT_MIN_KELVIN", () => {
+    expect(
+      getSelectorFallbackValue({
+        color_temp: { unit: "kelvin", min: 2000, max: 6500 },
+      })
+    ).toBe(2000);
+    expect(getSelectorFallbackValue({ color_temp: { unit: "kelvin" } })).toBe(
+      DEFAULT_MIN_KELVIN
+    );
+  });
+
+  it("returns mired min for color_temp, including legacy min_mireds", () => {
+    expect(
+      getSelectorFallbackValue({
+        color_temp: { unit: "mired", min: 154, max: 500 },
+      })
+    ).toBe(154);
+    expect(getSelectorFallbackValue({ color_temp: { min_mireds: 160 } })).toBe(
+      160
+    );
+    expect(getSelectorFallbackValue({ color_temp: null })).toBe(153);
+  });
+
+  it("returns undefined when the selector has no displayed fallback", () => {
+    expect(getSelectorFallbackValue({ text: null })).toBeUndefined();
+    expect(getSelectorFallbackValue({ entity: null })).toBeUndefined();
+    expect(getSelectorFallbackValue({ target: {} })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Proposed change
Enabling an optional service field checkbox (for example Color Temperature on Light Turn On) now writes the value the selector already displays into the action data. That marks the automation dirty so Save appears without needing a second slider change.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53172
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr