### PR TITLE
Lay out inline features in two columns

### DIFF
--- a/src/components/tile/ha-tile-container.ts
+++ b/src/components/tile/ha-tile-container.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { ifDefined } from "lit/directives/if-defined";
 import { stopPropagation } from "../../common/dom/stop_propagation";
@@ -11,9 +11,6 @@ import "../ha-ripple";
 export class HaTileContainer extends LitElement {
   @property({ attribute: false })
   public featurePosition: "bottom" | "inline" = "bottom";
-
-  @property({ attribute: false })
-  public featureColumns = 0;
 
   @property({ type: Boolean })
   public vertical = false;
@@ -27,6 +24,13 @@ export class HaTileContainer extends LitElement {
 
   @property({ attribute: false })
   public actionHandlerOptions?: ActionHandlerOptions;
+
+  @state() private _hasFeatures = false;
+
+  private _handleFeaturesSlotChange(ev: Event) {
+    this._hasFeatures =
+      (ev.target as HTMLSlotElement).assignedElements().length > 0;
+  }
 
   private _handleFocus(ev: FocusEvent) {
     if ((ev.target as HTMLElement).matches(":focus-visible")) {
@@ -42,7 +46,7 @@ export class HaTileContainer extends LitElement {
     const inline = this.featurePosition === "inline";
     const containerClasses = {
       horizontal: inline,
-      stacked: inline && this.featureColumns > 0,
+      stacked: inline && this._hasFeatures,
       "fixed-height": this.fixedInfoHeight,
     };
     const contentClasses = {
@@ -74,7 +78,10 @@ export class HaTileContainer extends LitElement {
           </div>
           <slot name="features-inline"></slot>
         </div>
-        <slot name="features"></slot>
+        <slot
+          name="features"
+          @slotchange=${this._handleFeaturesSlotChange}
+        ></slot>
       </div>
     `;
   }
@@ -176,7 +183,7 @@ export class HaTileContainer extends LitElement {
       padding: 0 var(--ha-space-3);
       padding-inline-start: 0;
     }
-    /* compact features unless the card reserves the height of a full features row */
+    /* compact features when the inline one is on its own, or when the card sizes to its content */
     .container.horizontal:not(.stacked) ::slotted([slot="features-inline"]),
     .container.horizontal:not(.fixed-height)
       ::slotted([slot="features-inline"]),

--- a/src/components/tile/ha-tile-container.ts
+++ b/src/components/tile/ha-tile-container.ts
@@ -43,10 +43,10 @@ export class HaTileContainer extends LitElement {
   }
 
   protected render() {
-    const inline = this.featurePosition === "inline";
+    const isInline = this.featurePosition === "inline";
     const containerClasses = {
-      horizontal: inline,
-      stacked: inline && this._hasFeatures,
+      inline: isInline,
+      "has-features-below": isInline && this._hasFeatures,
       "fixed-height": this.fixedInfoHeight,
     };
     const contentClasses = {
@@ -120,7 +120,7 @@ export class HaTileContainer extends LitElement {
       flex: 1;
       min-width: 0;
     }
-    .container.horizontal .row {
+    .container.inline .row {
       flex-direction: row;
     }
 
@@ -176,7 +176,7 @@ export class HaTileContainer extends LitElement {
       padding: 0 var(--ha-space-3) var(--ha-space-3) var(--ha-space-3);
     }
 
-    .container.horizontal ::slotted([slot="features-inline"]) {
+    .container.inline ::slotted([slot="features-inline"]) {
       /* size the feature on the 6 column grid track, so it lines up with neighbouring tiles */
       width: calc(50% - var(--column-gap, 0px) / 2 - var(--ha-space-3));
       flex: none;
@@ -184,14 +184,14 @@ export class HaTileContainer extends LitElement {
       padding-inline-start: 0;
     }
     /* compact features when the inline one is on its own, or when the card sizes to its content */
-    .container.horizontal:not(.stacked) ::slotted([slot="features-inline"]),
-    .container.horizontal:not(.fixed-height)
+    .container.inline:not(.has-features-below)
       ::slotted([slot="features-inline"]),
-    .container.horizontal:not(.fixed-height) ::slotted([slot="features"]) {
+    .container.inline:not(.fixed-height) ::slotted([slot="features-inline"]),
+    .container.inline:not(.fixed-height) ::slotted([slot="features"]) {
       --feature-height: var(--ha-space-9);
     }
 
-    .container.horizontal.stacked ::slotted([slot="features"]) {
+    .container.inline.has-features-below ::slotted([slot="features"]) {
       /* keep both columns under the inline feature, which sits on the grid track */
       --ha-card-feature-column-gap: calc(
         var(--column-gap, 0px) + var(--ha-space-3) * 2

--- a/src/components/tile/ha-tile-container.ts
+++ b/src/components/tile/ha-tile-container.ts
@@ -12,6 +12,9 @@ export class HaTileContainer extends LitElement {
   @property({ attribute: false })
   public featurePosition: "bottom" | "inline" = "bottom";
 
+  @property({ attribute: false })
+  public featureColumns = 0;
+
   @property({ type: Boolean })
   public vertical = false;
 
@@ -36,8 +39,12 @@ export class HaTileContainer extends LitElement {
   }
 
   protected render() {
-    const rowOrientationClass =
-      this.featurePosition === "inline" ? "horizontal" : "";
+    const inline = this.featurePosition === "inline";
+    const containerClasses = {
+      horizontal: inline,
+      stacked: inline && this.featureColumns > 0,
+      "fixed-height": this.fixedInfoHeight,
+    };
     const contentClasses = {
       vertical: this.vertical,
       "fixed-info-height": this.fixedInfoHeight,
@@ -56,20 +63,18 @@ export class HaTileContainer extends LitElement {
         <ha-ripple .disabled=${!this.interactive}></ha-ripple>
       </div>
       <div
-        class="container"
+        class="container ${classMap(containerClasses)}"
         @action=${stopPropagation}
         @click=${stopPropagation}
       >
-        <div class="row ${rowOrientationClass}">
+        <div class="row">
           <div class="content ${classMap(contentClasses)}">
             <slot name="icon"></slot>
             <slot name="info" id="info"></slot>
           </div>
-          <slot name="features"></slot>
+          <slot name="features-inline"></slot>
         </div>
-        <div class="features-bottom">
-          <slot name="features-bottom"></slot>
-        </div>
+        <slot name="features"></slot>
       </div>
     `;
   }
@@ -108,7 +113,7 @@ export class HaTileContainer extends LitElement {
       flex: 1;
       min-width: 0;
     }
-    .row.horizontal {
+    .container.horizontal .row {
       flex-direction: row;
     }
 
@@ -164,24 +169,30 @@ export class HaTileContainer extends LitElement {
       padding: 0 var(--ha-space-3) var(--ha-space-3) var(--ha-space-3);
     }
 
-    .row.horizontal ::slotted([slot="features"]) {
+    .container.horizontal ::slotted([slot="features-inline"]) {
+      /* size the feature on the 6 column grid track, so it lines up with neighbouring tiles */
       width: calc(50% - var(--column-gap, 0px) / 2 - var(--ha-space-3));
       flex: none;
-      --feature-height: var(--ha-space-9);
       padding: 0 var(--ha-space-3);
       padding-inline-start: 0;
     }
-
-    .features-bottom {
-      display: flex;
-      flex-wrap: wrap;
-      column-gap: var(--ha-space-3);
-      padding: 0 var(--ha-space-3);
+    /* compact features unless the card reserves the height of a full features row */
+    .container.horizontal:not(.stacked) ::slotted([slot="features-inline"]),
+    .container.horizontal:not(.fixed-height)
+      ::slotted([slot="features-inline"]),
+    .container.horizontal:not(.fixed-height) ::slotted([slot="features"]) {
+      --feature-height: var(--ha-space-9);
     }
-    ::slotted([slot="features-bottom"]) {
-      flex: 1 1 calc(50% - var(--ha-space-3) / 2);
-      min-width: 0;
-      padding-bottom: var(--ha-space-3);
+
+    .container.horizontal.stacked ::slotted([slot="features"]) {
+      /* keep both columns under the inline feature, which sits on the grid track */
+      --ha-card-feature-column-gap: calc(
+        var(--column-gap, 0px) + var(--ha-space-3) * 2
+      );
+      --ha-card-feature-divider: 1px solid var(--ha-color-border-neutral-quiet);
+      --ha-card-feature-divider-inset: calc(
+        var(--ha-space-3) + var(--column-gap, 0px) / 2
+      );
     }
     [role="button"] {
       cursor: pointer;

--- a/src/components/tile/ha-tile-container.ts
+++ b/src/components/tile/ha-tile-container.ts
@@ -183,11 +183,10 @@ export class HaTileContainer extends LitElement {
       padding: 0 var(--ha-space-3);
       padding-inline-start: 0;
     }
-    /* compact features when the inline one is on its own, or when the card sizes to its content */
+    /* the inline feature keeps the icon height, unless the card reserves a row it can fill */
     .container.inline:not(.has-features-below)
       ::slotted([slot="features-inline"]),
-    .container.inline:not(.fixed-height) ::slotted([slot="features-inline"]),
-    .container.inline:not(.fixed-height) ::slotted([slot="features"]) {
+    .container.inline:not(.fixed-height) ::slotted([slot="features-inline"]) {
       --feature-height: var(--ha-space-9);
     }
 

--- a/src/panels/lovelace/card-features/common/feature-layout.ts
+++ b/src/panels/lovelace/card-features/common/feature-layout.ts
@@ -5,8 +5,8 @@ import type {
 
 export interface CardFeatureLayout {
   inline: LovelaceCardFeatureConfig[];
-  stacked: LovelaceCardFeatureConfig[];
-  /** Columns filled by the stacked features, 0 when there are none */
+  below: LovelaceCardFeatureConfig[];
+  /** Columns filled by the below features, 0 when there are none */
   columns: number;
 }
 
@@ -17,17 +17,17 @@ export const computeCardFeatureLayout = (
   position: LovelaceCardFeaturePosition
 ): CardFeatureLayout => {
   if (position !== "inline") {
-    return { inline: [], stacked: features ?? [], columns: 1 };
+    return { inline: [], below: features ?? [], columns: 1 };
   }
   const inline = features?.slice(0, 1) ?? [];
-  const stacked = features?.slice(1) ?? [];
-  return { inline, stacked, columns: Math.min(stacked.length, INLINE_COLUMNS) };
+  const below = features?.slice(1) ?? [];
+  return { inline, below, columns: Math.min(below.length, INLINE_COLUMNS) };
 };
 
 export const computeCardFeatureRows = (
   features: LovelaceCardFeatureConfig[] | undefined,
   position: LovelaceCardFeaturePosition
 ): number => {
-  const { stacked, columns } = computeCardFeatureLayout(features, position);
-  return Math.ceil(stacked.length / Math.max(columns, 1));
+  const { below, columns } = computeCardFeatureLayout(features, position);
+  return Math.ceil(below.length / Math.max(columns, 1));
 };

--- a/src/panels/lovelace/card-features/common/feature-layout.ts
+++ b/src/panels/lovelace/card-features/common/feature-layout.ts
@@ -14,26 +14,20 @@ const INLINE_COLUMNS = 2;
 
 export const computeCardFeatureLayout = (
   features: LovelaceCardFeatureConfig[] | undefined,
-  position: LovelaceCardFeaturePosition,
-  maxColumns = INLINE_COLUMNS
+  position: LovelaceCardFeaturePosition
 ): CardFeatureLayout => {
   if (position !== "inline") {
     return { inline: [], below: features ?? [], columns: 1 };
   }
   const inline = features?.slice(0, 1) ?? [];
   const below = features?.slice(1) ?? [];
-  return { inline, below, columns: Math.min(below.length, maxColumns) };
+  return { inline, below, columns: Math.min(below.length, INLINE_COLUMNS) };
 };
 
 export const computeCardFeatureRows = (
   features: LovelaceCardFeatureConfig[] | undefined,
-  position: LovelaceCardFeaturePosition,
-  maxColumns = INLINE_COLUMNS
+  position: LovelaceCardFeaturePosition
 ): number => {
-  const { below, columns } = computeCardFeatureLayout(
-    features,
-    position,
-    maxColumns
-  );
+  const { below, columns } = computeCardFeatureLayout(features, position);
   return Math.ceil(below.length / Math.max(columns, 1));
 };

--- a/src/panels/lovelace/card-features/common/feature-layout.ts
+++ b/src/panels/lovelace/card-features/common/feature-layout.ts
@@ -14,20 +14,26 @@ const INLINE_COLUMNS = 2;
 
 export const computeCardFeatureLayout = (
   features: LovelaceCardFeatureConfig[] | undefined,
-  position: LovelaceCardFeaturePosition
+  position: LovelaceCardFeaturePosition,
+  maxColumns = INLINE_COLUMNS
 ): CardFeatureLayout => {
   if (position !== "inline") {
     return { inline: [], below: features ?? [], columns: 1 };
   }
   const inline = features?.slice(0, 1) ?? [];
   const below = features?.slice(1) ?? [];
-  return { inline, below, columns: Math.min(below.length, INLINE_COLUMNS) };
+  return { inline, below, columns: Math.min(below.length, maxColumns) };
 };
 
 export const computeCardFeatureRows = (
   features: LovelaceCardFeatureConfig[] | undefined,
-  position: LovelaceCardFeaturePosition
+  position: LovelaceCardFeaturePosition,
+  maxColumns = INLINE_COLUMNS
 ): number => {
-  const { below, columns } = computeCardFeatureLayout(features, position);
+  const { below, columns } = computeCardFeatureLayout(
+    features,
+    position,
+    maxColumns
+  );
   return Math.ceil(below.length / Math.max(columns, 1));
 };

--- a/src/panels/lovelace/card-features/common/feature-layout.ts
+++ b/src/panels/lovelace/card-features/common/feature-layout.ts
@@ -1,0 +1,33 @@
+import type {
+  LovelaceCardFeatureConfig,
+  LovelaceCardFeaturePosition,
+} from "../types";
+
+export interface CardFeatureLayout {
+  inline: LovelaceCardFeatureConfig[];
+  stacked: LovelaceCardFeatureConfig[];
+  /** Columns filled by the stacked features, 0 when there are none */
+  columns: number;
+}
+
+const INLINE_COLUMNS = 2;
+
+export const computeCardFeatureLayout = (
+  features: LovelaceCardFeatureConfig[] | undefined,
+  position: LovelaceCardFeaturePosition
+): CardFeatureLayout => {
+  if (position !== "inline") {
+    return { inline: [], stacked: features ?? [], columns: 1 };
+  }
+  const inline = features?.slice(0, 1) ?? [];
+  const stacked = features?.slice(1) ?? [];
+  return { inline, stacked, columns: Math.min(stacked.length, INLINE_COLUMNS) };
+};
+
+export const computeCardFeatureRows = (
+  features: LovelaceCardFeatureConfig[] | undefined,
+  position: LovelaceCardFeaturePosition
+): number => {
+  const { stacked, columns } = computeCardFeatureLayout(features, position);
+  return Math.ceil(stacked.length / Math.max(columns, 1));
+};

--- a/src/panels/lovelace/card-features/hui-card-features.ts
+++ b/src/panels/lovelace/card-features/hui-card-features.ts
@@ -1,5 +1,6 @@
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
 import type { HomeAssistant } from "../../../types";
 import "./hui-card-feature";
 import type {
@@ -32,22 +33,32 @@ export class HuiCardFeatures extends LitElement {
   @property({ attribute: false })
   public position?: LovelaceCardFeaturePosition;
 
+  @property({ type: Number, reflect: true })
+  public columns = 1;
+
   protected render() {
     if (!this.features) {
       return nothing;
     }
+    const lastIndex = this.features.length - 1;
+    const columns = Math.max(this.columns, 1);
     return html`
-      ${this.features.map(
-        (feature) => html`
+      ${this.features.map((feature, index) => {
+        const column = index % columns;
+        return html`
           <hui-card-feature
+            class=${classMap({
+              divided: column > 0,
+              wide: column === 0 && index === lastIndex,
+            })}
             .hass=${this.hass}
             .context=${this.context}
             .color=${this.color}
             .feature=${feature}
             .position=${this.position}
           ></hui-card-feature>
-        `
-      )}
+        `;
+      })}
     `;
   }
 
@@ -55,20 +66,38 @@ export class HuiCardFeatures extends LitElement {
     :host {
       --feature-color: var(--state-icon-color);
       --feature-height: 42px;
+      --feature-columns: 1;
       --feature-border-radius: var(
         --ha-card-features-border-radius,
         var(--ha-border-radius-lg)
       );
       --feature-button-spacing: 12px;
+      --feature-column-gap: var(
+        --ha-card-feature-column-gap,
+        var(--ha-card-feature-gap, 12px)
+      );
+      --feature-divider-inset: var(--ha-card-feature-divider-inset, 0px);
       pointer-events: none;
       position: relative;
       width: 100%;
-      display: flex;
-      flex-direction: column;
-      gap: var(--ha-card-feature-gap, 12px);
-      width: 100%;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: var(--ha-card-feature-gap, 12px) var(--feature-column-gap);
       box-sizing: border-box;
-      justify-content: space-evenly;
+      align-content: space-evenly;
+    }
+    :host([columns="2"]) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .wide {
+      grid-column: 1 / -1;
+    }
+    /* pull the divider out of the column and into the middle of the gutter */
+    .divided {
+      box-sizing: border-box;
+      margin-inline-start: calc(-1 * var(--feature-divider-inset));
+      padding-inline-start: var(--feature-divider-inset);
+      border-inline-start: var(--ha-card-feature-divider, none);
     }
   `;
 }

--- a/src/panels/lovelace/cards/hui-area-card.ts
+++ b/src/panels/lovelace/cards/hui-area-card.ts
@@ -36,6 +36,10 @@ import { UNAVAILABLE, UNKNOWN } from "../../../data/entity/entity";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import type { HomeAssistant } from "../../../types";
 import "../card-features/hui-card-features";
+import {
+  computeCardFeatureLayout,
+  computeCardFeatureRows,
+} from "../card-features/common/feature-layout";
 import type { LovelaceCardFeatureContext } from "../card-features/types";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { handleAction } from "../common/handle-action";
@@ -151,14 +155,12 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
   }
 
   public getCardSize(): number {
-    const featuresPosition =
-      this._config && this._featurePosition(this._config);
     const displayType = this._config?.display_type || "picture";
-    const featuresCount = this._config?.features?.length || 0;
+    const featureRows = this._config ? this._featureRows(this._config) : 0;
     return (
       1 +
       (displayType === "compact" ? (this._config?.vertical ? 1 : 0) : 2) +
-      (featuresPosition === "inline" ? 0 : featuresCount)
+      featureRows
     );
   }
 
@@ -170,13 +172,12 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
       ? this._featurePosition(this._config)
       : "bottom";
     const featuresCount = this._config?.features?.length || 0;
-    if (featuresCount) {
+    if (this._config && featuresCount) {
       if (featurePosition === "inline") {
         min_columns = 12;
         columns = 12;
-      } else {
-        rows += featuresCount;
       }
+      rows += this._featureRows(this._config);
     }
 
     const displayType = this._config?.display_type || "picture";
@@ -555,15 +556,13 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
     return config.features_position || "bottom";
   });
 
-  private _displayedFeatures = memoizeOne((config: AreaCardConfig) => {
-    const features = config.features || [];
-    const featurePosition = this._featurePosition(config);
+  private _featureLayout = memoizeOne((config: AreaCardConfig) =>
+    computeCardFeatureLayout(config.features, this._featurePosition(config))
+  );
 
-    if (featurePosition === "inline") {
-      return features.slice(0, 1);
-    }
-    return features;
-  });
+  private _featureRows = memoizeOne((config: AreaCardConfig) =>
+    computeCardFeatureRows(config.features, this._featurePosition(config))
+  );
 
   public willUpdate(changedProps: PropertyValues) {
     if (changedProps.has("_config") || this._ratio === null) {
@@ -601,7 +600,7 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
     const secondary = this._computeSensorsDisplay();
 
     const featurePosition = this._featurePosition(this._config);
-    const features = this._displayedFeatures(this._config);
+    const features = this._featureLayout(this._config);
 
     const displayType = this._config.display_type || "picture";
 
@@ -685,6 +684,7 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
         }
         <ha-tile-container
           .featurePosition=${featurePosition}
+          .featureColumns=${features.columns}
           .vertical=${Boolean(this._config.vertical)}
           .fixedInfoHeight=${fixedInfoHeight}
           .interactive=${Boolean(this._hasCardAction)}
@@ -710,14 +710,29 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
             .secondary=${secondary}
           ></ha-tile-info>
           ${
-            features.length > 0
+            features.inline.length > 0
               ? html`
                   <hui-card-features
-                    slot="features"
+                    slot="features-inline"
                     .hass=${this.hass}
                     .context=${this._featureContext}
                     .color=${this._config.color}
-                    .features=${features}
+                    .features=${features.inline}
+                    .position=${featurePosition}
+                  ></hui-card-features>
+                `
+              : nothing
+          }
+          ${
+            features.stacked.length > 0
+              ? html`
+                  <hui-card-features
+                    slot="features"
+                    .columns=${features.columns}
+                    .hass=${this.hass}
+                    .context=${this._featureContext}
+                    .color=${this._config.color}
+                    .features=${features.stacked}
                     .position=${featurePosition}
                   ></hui-card-features>
                 `

--- a/src/panels/lovelace/cards/hui-area-card.ts
+++ b/src/panels/lovelace/cards/hui-area-card.ts
@@ -556,12 +556,13 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
     return config.features_position || "bottom";
   });
 
+  /* area controls need the full width, so only the first feature goes inline */
   private _featureLayout = memoizeOne((config: AreaCardConfig) =>
-    computeCardFeatureLayout(config.features, this._featurePosition(config))
+    computeCardFeatureLayout(config.features, this._featurePosition(config), 1)
   );
 
   private _featureRows = memoizeOne((config: AreaCardConfig) =>
-    computeCardFeatureRows(config.features, this._featurePosition(config))
+    computeCardFeatureRows(config.features, this._featurePosition(config), 1)
   );
 
   public willUpdate(changedProps: PropertyValues) {

--- a/src/panels/lovelace/cards/hui-area-card.ts
+++ b/src/panels/lovelace/cards/hui-area-card.ts
@@ -723,7 +723,7 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
               : nothing
           }
           ${
-            features.stacked.length > 0
+            features.below.length > 0
               ? html`
                   <hui-card-features
                     slot="features"
@@ -731,7 +731,7 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
                     .hass=${this.hass}
                     .context=${this._featureContext}
                     .color=${this._config.color}
-                    .features=${features.stacked}
+                    .features=${features.below}
                     .position=${featurePosition}
                   ></hui-card-features>
                 `

--- a/src/panels/lovelace/cards/hui-area-card.ts
+++ b/src/panels/lovelace/cards/hui-area-card.ts
@@ -556,13 +556,12 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
     return config.features_position || "bottom";
   });
 
-  /* area controls need the full width, so only the first feature goes inline */
   private _featureLayout = memoizeOne((config: AreaCardConfig) =>
-    computeCardFeatureLayout(config.features, this._featurePosition(config), 1)
+    computeCardFeatureLayout(config.features, this._featurePosition(config))
   );
 
   private _featureRows = memoizeOne((config: AreaCardConfig) =>
-    computeCardFeatureRows(config.features, this._featurePosition(config), 1)
+    computeCardFeatureRows(config.features, this._featurePosition(config))
   );
 
   public willUpdate(changedProps: PropertyValues) {
@@ -733,7 +732,7 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
                     .context=${this._featureContext}
                     .color=${this._config.color}
                     .features=${features.below}
-                    .position=${featurePosition}
+                    .position=${"bottom"}
                   ></hui-card-features>
                 `
               : nothing

--- a/src/panels/lovelace/cards/hui-area-card.ts
+++ b/src/panels/lovelace/cards/hui-area-card.ts
@@ -619,8 +619,11 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
       "--tile-color": color,
     };
 
+    /* the picture takes the extra height, so only the compact type reserves a row */
     const fixedInfoHeight =
-      this.layout === "grid" && this._config.grid_options?.rows !== "auto";
+      displayType === "compact" &&
+      this.layout === "grid" &&
+      this._config.grid_options?.rows !== "auto";
 
     return html`
       <ha-card style=${styleMap(style)}>

--- a/src/panels/lovelace/cards/hui-area-card.ts
+++ b/src/panels/lovelace/cards/hui-area-card.ts
@@ -684,7 +684,6 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
         }
         <ha-tile-container
           .featurePosition=${featurePosition}
-          .featureColumns=${features.columns}
           .vertical=${Boolean(this._config.vertical)}
           .fixedInfoHeight=${fixedInfoHeight}
           .interactive=${Boolean(this._hasCardAction)}

--- a/src/panels/lovelace/cards/hui-area-card.ts
+++ b/src/panels/lovelace/cards/hui-area-card.ts
@@ -619,11 +619,8 @@ export class HuiAreaCard extends LitElement implements LovelaceCard {
       "--tile-color": color,
     };
 
-    /* the picture takes the extra height, so only the compact type reserves a row */
     const fixedInfoHeight =
-      displayType === "compact" &&
-      this.layout === "grid" &&
-      this._config.grid_options?.rows !== "auto";
+      this.layout === "grid" && this._config.grid_options?.rows !== "auto";
 
     return html`
       <ha-card style=${styleMap(style)}>

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -292,7 +292,6 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       <ha-card style=${styleMap(style)} class=${classMap({ active })}>
         <ha-tile-container
           .featurePosition=${featurePosition}
-          .featureColumns=${features.columns}
           .vertical=${Boolean(this._config.vertical)}
           .fixedInfoHeight=${fixedInfoHeight}
           .interactive=${this._hasCardAction}

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -22,10 +22,11 @@ import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import "../../../state-display/state-display";
 import type { HomeAssistant } from "../../../types";
 import "../card-features/hui-card-features";
-import type {
-  LovelaceCardFeatureConfig,
-  LovelaceCardFeatureContext,
-} from "../card-features/types";
+import {
+  computeCardFeatureLayout,
+  computeCardFeatureRows,
+} from "../card-features/common/feature-layout";
+import type { LovelaceCardFeatureContext } from "../card-features/types";
 import { findEntities } from "../common/find-entities";
 import { handleAction } from "../common/handle-action";
 import { hasAction } from "../common/has-action";
@@ -110,9 +111,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
   }
 
   public getCardSize(): number {
-    const featureRows = this._config
-      ? this._bottomFeatureRowCount(this._config)
-      : 0;
+    const featureRows = this._config ? this._featureRows(this._config) : 0;
     return 1 + (this._config?.vertical ? 1 : 0) + featureRows;
   }
 
@@ -122,11 +121,11 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     let rows = 1;
     const featurePosition = this._config && this._featurePosition(this._config);
     const featuresCount = this._config?.features?.length || 0;
-    if (featuresCount) {
+    if (this._config && featuresCount) {
       if (featurePosition === "inline") {
         min_columns = 12;
       }
-      rows += this._bottomFeatureRowCount(this._config!);
+      rows += this._featureRows(this._config);
     }
 
     if (this._config?.vertical) {
@@ -232,40 +231,12 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     return config.features_position || "bottom";
   });
 
-  private _inlineFeatures = memoizeOne(
-    (config: TileCardConfig): LovelaceCardFeatureConfig[] => {
-      const features = config.features || [];
-      const featurePosition = this._featurePosition(config);
-
-      if (featurePosition === "inline") {
-        return features.slice(0, 1);
-      }
-      return [];
-    }
+  private _featureLayout = memoizeOne((config: TileCardConfig) =>
+    computeCardFeatureLayout(config.features, this._featurePosition(config))
   );
 
-  private _bottomFeatureGroups = memoizeOne(
-    (config: TileCardConfig): LovelaceCardFeatureConfig[][] => {
-      const features = config.features || [];
-      const featurePosition = this._featurePosition(config);
-
-      if (featurePosition === "inline") {
-        return features.slice(1).map((feature) => [feature]);
-      }
-      return features.length ? [features] : [];
-    }
-  );
-
-  private _bottomFeatureRowCount = memoizeOne(
-    (config: TileCardConfig): number => {
-      const featuresCount = config.features?.length || 0;
-      const featurePosition = this._featurePosition(config);
-
-      if (featurePosition === "inline") {
-        return Math.ceil(Math.max(featuresCount - 1, 0) / 2);
-      }
-      return featuresCount;
-    }
+  private _featureRows = memoizeOne((config: TileCardConfig) =>
+    computeCardFeatureRows(config.features, this._featurePosition(config))
   );
 
   protected render() {
@@ -310,8 +281,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       : undefined;
 
     const featurePosition = this._featurePosition(this._config);
-    const inlineFeatures = this._inlineFeatures(this._config);
-    const bottomFeatureGroups = this._bottomFeatureGroups(this._config);
+    const features = this._featureLayout(this._config);
 
     const hasImage = Boolean(imageUrl);
 
@@ -322,6 +292,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       <ha-card style=${styleMap(style)} class=${classMap({ active })}>
         <ha-tile-container
           .featurePosition=${featurePosition}
+          .featureColumns=${features.columns}
           .vertical=${Boolean(this._config.vertical)}
           .fixedInfoHeight=${fixedInfoHeight}
           .interactive=${this._hasCardAction}
@@ -366,31 +337,32 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
             }
           </ha-tile-info>
           ${
-            inlineFeatures.length > 0
+            features.inline.length > 0
               ? html`
                   <hui-card-features
-                    slot="features"
+                    slot="features-inline"
                     .hass=${this.hass}
                     .context=${this._featureContext}
                     .color=${this._config.color}
-                    .features=${inlineFeatures}
+                    .features=${features.inline}
                   ></hui-card-features>
                 `
               : nothing
           }
-          ${bottomFeatureGroups.map(
-            (group) => html`
-              <hui-card-features
-                slot=${
-                  featurePosition === "inline" ? "features-bottom" : "features"
-                }
-                .hass=${this.hass}
-                .context=${this._featureContext}
-                .color=${this._config!.color}
-                .features=${group}
-              ></hui-card-features>
-            `
-          )}
+          ${
+            features.stacked.length > 0
+              ? html`
+                  <hui-card-features
+                    slot="features"
+                    .columns=${features.columns}
+                    .hass=${this.hass}
+                    .context=${this._featureContext}
+                    .color=${this._config.color}
+                    .features=${features.stacked}
+                  ></hui-card-features>
+                `
+              : nothing
+          }
         </ha-tile-container>
       </ha-card>
     `;

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -349,7 +349,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
               : nothing
           }
           ${
-            features.stacked.length > 0
+            features.below.length > 0
               ? html`
                   <hui-card-features
                     slot="features"
@@ -357,7 +357,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
                     .hass=${this.hass}
                     .context=${this._featureContext}
                     .color=${this._config.color}
-                    .features=${features.stacked}
+                    .features=${features.below}
                   ></hui-card-features>
                 `
               : nothing

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10465,7 +10465,7 @@
                 "bottom": "Bottom",
                 "bottom_description": "Displays all features stacked",
                 "inline": "Inline",
-                "inline_description": "Displays the first feature next to the name, the rest below"
+                "inline_description": "Displays features in two columns, starting next to the name"
               },
               "features_position_helper_vertical": "Always displayed at the bottom if the content layout is vertical",
               "content_layout": "Content layout",

--- a/test/panels/lovelace/card-features/common/feature-layout.test.ts
+++ b/test/panels/lovelace/card-features/common/feature-layout.test.ts
@@ -46,10 +46,6 @@ describe("computeCardFeatureLayout", () => {
   it("caps the features below at two columns", () => {
     expect(computeCardFeatureLayout(features(5), "inline").columns).toBe(2);
   });
-
-  it("caps the columns to the given maximum", () => {
-    expect(computeCardFeatureLayout(features(5), "inline", 1).columns).toBe(1);
-  });
 });
 
 describe("computeCardFeatureRows", () => {
@@ -65,12 +61,5 @@ describe("computeCardFeatureRows", () => {
       computeCardFeatureRows(features(count), "inline")
     );
     expect(rows).toEqual([0, 0, 1, 1, 2, 2, 3]);
-  });
-
-  it("counts one row per feature below when capped to one column", () => {
-    const rows = [0, 1, 2, 3, 4].map((count) =>
-      computeCardFeatureRows(features(count), "inline", 1)
-    );
-    expect(rows).toEqual([0, 0, 1, 2, 3]);
   });
 });

--- a/test/panels/lovelace/card-features/common/feature-layout.test.ts
+++ b/test/panels/lovelace/card-features/common/feature-layout.test.ts
@@ -46,6 +46,10 @@ describe("computeCardFeatureLayout", () => {
   it("caps the features below at two columns", () => {
     expect(computeCardFeatureLayout(features(5), "inline").columns).toBe(2);
   });
+
+  it("caps the columns to the given maximum", () => {
+    expect(computeCardFeatureLayout(features(5), "inline", 1).columns).toBe(1);
+  });
 });
 
 describe("computeCardFeatureRows", () => {
@@ -61,5 +65,12 @@ describe("computeCardFeatureRows", () => {
       computeCardFeatureRows(features(count), "inline")
     );
     expect(rows).toEqual([0, 0, 1, 1, 2, 2, 3]);
+  });
+
+  it("counts one row per feature below when capped to one column", () => {
+    const rows = [0, 1, 2, 3, 4].map((count) =>
+      computeCardFeatureRows(features(count), "inline", 1)
+    );
+    expect(rows).toEqual([0, 0, 1, 2, 3]);
   });
 });

--- a/test/panels/lovelace/card-features/common/feature-layout.test.ts
+++ b/test/panels/lovelace/card-features/common/feature-layout.test.ts
@@ -12,14 +12,14 @@ describe("computeCardFeatureLayout", () => {
   it("stacks every feature in bottom position", () => {
     const layout = computeCardFeatureLayout(features(3), "bottom");
     expect(layout.inline).toHaveLength(0);
-    expect(layout.stacked).toHaveLength(3);
+    expect(layout.below).toHaveLength(3);
     expect(layout.columns).toBe(1);
   });
 
   it("handles a missing feature list", () => {
     expect(computeCardFeatureLayout(undefined, "inline")).toEqual({
       inline: [],
-      stacked: [],
+      below: [],
       columns: 0,
     });
   });
@@ -32,18 +32,18 @@ describe("computeCardFeatureLayout", () => {
     ];
     const layout = computeCardFeatureLayout(configs, "inline");
     expect(layout.inline).toEqual([configs[0]]);
-    expect(layout.stacked).toEqual([configs[1], configs[2]]);
+    expect(layout.below).toEqual([configs[1], configs[2]]);
   });
 
   it("fills no column when the inline feature is alone", () => {
     expect(computeCardFeatureLayout(features(1), "inline").columns).toBe(0);
   });
 
-  it("fills one column for a single stacked feature", () => {
+  it("fills one column for a single feature below", () => {
     expect(computeCardFeatureLayout(features(2), "inline").columns).toBe(1);
   });
 
-  it("caps the stacked features at two columns", () => {
+  it("caps the features below at two columns", () => {
     expect(computeCardFeatureLayout(features(5), "inline").columns).toBe(2);
   });
 });

--- a/test/panels/lovelace/card-features/common/feature-layout.test.ts
+++ b/test/panels/lovelace/card-features/common/feature-layout.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeCardFeatureLayout,
+  computeCardFeatureRows,
+} from "../../../../../src/panels/lovelace/card-features/common/feature-layout";
+import type { LovelaceCardFeatureConfig } from "../../../../../src/panels/lovelace/card-features/types";
+
+const features = (count: number): LovelaceCardFeatureConfig[] =>
+  Array.from({ length: count }, () => ({ type: "toggle" }) as const);
+
+describe("computeCardFeatureLayout", () => {
+  it("stacks every feature in bottom position", () => {
+    const layout = computeCardFeatureLayout(features(3), "bottom");
+    expect(layout.inline).toHaveLength(0);
+    expect(layout.stacked).toHaveLength(3);
+    expect(layout.columns).toBe(1);
+  });
+
+  it("handles a missing feature list", () => {
+    expect(computeCardFeatureLayout(undefined, "inline")).toEqual({
+      inline: [],
+      stacked: [],
+      columns: 0,
+    });
+  });
+
+  it("puts the first feature inline and stacks the rest", () => {
+    const configs: LovelaceCardFeatureConfig[] = [
+      { type: "toggle" },
+      { type: "cover-open-close" },
+      { type: "cover-position" },
+    ];
+    const layout = computeCardFeatureLayout(configs, "inline");
+    expect(layout.inline).toEqual([configs[0]]);
+    expect(layout.stacked).toEqual([configs[1], configs[2]]);
+  });
+
+  it("fills no column when the inline feature is alone", () => {
+    expect(computeCardFeatureLayout(features(1), "inline").columns).toBe(0);
+  });
+
+  it("fills one column for a single stacked feature", () => {
+    expect(computeCardFeatureLayout(features(2), "inline").columns).toBe(1);
+  });
+
+  it("caps the stacked features at two columns", () => {
+    expect(computeCardFeatureLayout(features(5), "inline").columns).toBe(2);
+  });
+});
+
+describe("computeCardFeatureRows", () => {
+  it("counts one row per feature in bottom position", () => {
+    const rows = [0, 1, 2, 3].map((count) =>
+      computeCardFeatureRows(features(count), "bottom")
+    );
+    expect(rows).toEqual([0, 1, 2, 3]);
+  });
+
+  it("pairs the features below the inline one", () => {
+    const rows = [0, 1, 2, 3, 4, 5, 6].map((count) =>
+      computeCardFeatureRows(features(count), "inline")
+    );
+    expect(rows).toEqual([0, 0, 1, 1, 2, 2, 3]);
+  });
+});


### PR DESCRIPTION
## Proposed change

Follow up to #53310. When features are displayed inline, the ones below the first are now laid out in two columns instead of one per row, aligned with the inline feature and separated by a divider. The area card gets the same layout.

## Screenshots

<img width="416" height="128" alt="CleanShot 2026-08-13 at 16 19 54" src="https://github.com/user-attachments/assets/db36f6fe-d006-415f-b11b-7b9b63405084" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/53310
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47044
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
