### PR TITLE
Guard registry lookups in the target picker item row

### DIFF
--- a/src/components/target-picker/ha-target-picker-item-row.ts
+++ b/src/components/target-picker/ha-target-picker-item-row.ts
@@ -393,6 +393,9 @@ export class HaTargetPickerItemRow extends LitElement {
               nextEntries.referenced_entities =
                 entries?.referenced_entities.filter((entity_id) => {
                   const entity = this.hass.entities[entity_id];
+                  if (!entity) {
+                    return false;
+                  }
                   return (
                     entity.area_id === rowItem ||
                     !entity.device_id ||
@@ -416,6 +419,9 @@ export class HaTargetPickerItemRow extends LitElement {
       this.type === "label" && entries
         ? entries.referenced_entities.filter((entity_id) => {
             const entity = this.hass.entities[entity_id];
+            if (!entity) {
+              return false;
+            }
             return (
               entity.labels.includes(this.itemId) &&
               !entries.referenced_devices.includes(entity.device_id || "")
@@ -424,7 +430,7 @@ export class HaTargetPickerItemRow extends LitElement {
         : nextType === "device" && entries
           ? entries.referenced_entities.filter(
               (entity_id) =>
-                this.hass.entities[entity_id].area_id === this.itemId
+                this.hass.entities[entity_id]?.area_id === this.itemId
             )
           : [];
 
@@ -433,7 +439,7 @@ export class HaTargetPickerItemRow extends LitElement {
         ? entries.referenced_devices.filter(
             (device_id) =>
               !devicesInAreas.includes(device_id) &&
-              this.hass.devices[device_id].labels.includes(this.itemId)
+              this.hass.devices[device_id]?.labels.includes(this.itemId)
           )
         : [];
 
@@ -528,6 +534,12 @@ export class HaTargetPickerItemRow extends LitElement {
         entries.referenced_areas = entries.referenced_areas.filter(
           (area_id) => {
             const area = this.hass.areas[area_id];
+            // Absent from the registry is not a filter decision: drop the id
+            // without marking it hidden, so entities targeted through their
+            // own area or label are not dropped along with it.
+            if (!area) {
+              return false;
+            }
             if (
               (this.type === "floor" || area.labels.includes(this.itemId)) &&
               areaMeetsFilter(
@@ -560,6 +572,9 @@ export class HaTargetPickerItemRow extends LitElement {
         entries.referenced_devices = entries.referenced_devices.filter(
           (device_id) => {
             const device = this.hass.devices[device_id];
+            if (!device) {
+              return false;
+            }
             if (
               !hiddenAreaIds.includes(device.area_id || "") &&
               deviceMeetsFilter(
@@ -585,6 +600,11 @@ export class HaTargetPickerItemRow extends LitElement {
       entries.referenced_entities = entries.referenced_entities.filter(
         (entity_id) => {
           const entity = this.hass.entities[entity_id];
+          // Core can reference entities that are absent from the display
+          // registry (e.g. disabled ones expanded from an area).
+          if (!entity) {
+            return false;
+          }
           if (hiddenDeviceIds.includes(entity.device_id || "")) {
             return false;
           }

--- a/test/components/target-picker/ha-target-picker-item-row.test.ts
+++ b/test/components/target-picker/ha-target-picker-item-row.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import "../../../src/components/target-picker/ha-target-picker-item-row";
+import type { HaTargetPickerItemRow } from "../../../src/components/target-picker/ha-target-picker-item-row";
+import type { AreaRegistryEntry } from "../../../src/data/area/area_registry";
+import type { DeviceRegistryEntry } from "../../../src/data/device/device_registry";
+import type { EntityRegistryDisplayEntry } from "../../../src/data/entity/entity_registry";
+import type {
+  ExtractFromTargetResult,
+  TargetType,
+} from "../../../src/data/target";
+import type { HomeAssistant } from "../../../src/types";
+
+const extractResult = (
+  referenced: Partial<ExtractFromTargetResult>
+): ExtractFromTargetResult => ({
+  missing_areas: [],
+  missing_devices: [],
+  missing_floors: [],
+  missing_labels: [],
+  referenced_areas: [],
+  referenced_devices: [],
+  referenced_entities: [],
+  ...referenced,
+});
+
+const mkEntity = (
+  entity_id: string,
+  rest: Partial<EntityRegistryDisplayEntry> = {}
+): EntityRegistryDisplayEntry => ({ entity_id, labels: [], ...rest });
+
+const mkDevice = (
+  id: string,
+  rest: Partial<DeviceRegistryEntry> = {}
+): DeviceRegistryEntry =>
+  ({ id, area_id: null, labels: [], ...rest }) as DeviceRegistryEntry;
+
+interface Registries {
+  entities?: Record<string, EntityRegistryDisplayEntry>;
+  devices?: Record<string, DeviceRegistryEntry>;
+  areas?: Record<string, AreaRegistryEntry>;
+}
+
+// Runs the row's extraction against `result`, with only the registry entries in
+// `registries` available to filter it.
+const extractedBy = async (
+  result: ExtractFromTargetResult,
+  registries: Registries,
+  {
+    type = "area",
+    itemId = "area_1",
+  }: { type?: TargetType; itemId?: string } = {}
+) => {
+  const el = document.createElement(
+    "ha-target-picker-item-row"
+  ) as HaTargetPickerItemRow;
+  el.type = type;
+  el.itemId = itemId;
+  el.hass = {
+    areas: {},
+    devices: {},
+    entities: {},
+    states: {},
+    callWS: async () => result,
+    ...registries,
+  } as unknown as HomeAssistant;
+
+  await (el as any)._updateItemData();
+  return (el as any)._entries as ExtractFromTargetResult | undefined;
+};
+
+describe("ha-target-picker-item-row target extraction", () => {
+  it("drops entities that are missing from the entity registry", async () => {
+    // Disabled entities are referenced by core but never reach the display
+    // registry, which is the crash in #52964.
+    const entries = await extractedBy(
+      extractResult({
+        referenced_entities: ["light.known", "light.disabled"],
+      }),
+      {
+        entities: {
+          "light.known": mkEntity("light.known", { area_id: "area_1" }),
+        },
+      }
+    );
+
+    expect(entries).toBeDefined();
+    expect(entries!.referenced_entities).toEqual(["light.known"]);
+  });
+
+  it("keeps every entity when all registry entries resolve", async () => {
+    const entries = await extractedBy(
+      extractResult({
+        referenced_entities: ["light.one", "light.two"],
+      }),
+      {
+        entities: {
+          "light.one": mkEntity("light.one", { area_id: "area_1" }),
+          "light.two": mkEntity("light.two", { area_id: "area_1" }),
+        },
+      }
+    );
+
+    expect(entries).toBeDefined();
+    expect(entries!.referenced_entities).toEqual(["light.one", "light.two"]);
+  });
+
+  it("drops a device missing from the registry, and entities linked only through it", async () => {
+    const entries = await extractedBy(
+      extractResult({
+        referenced_devices: ["dev_known", "dev_missing"],
+        referenced_entities: ["light.on_known_dev", "light.on_missing_dev"],
+      }),
+      {
+        devices: { dev_known: mkDevice("dev_known") },
+        entities: {
+          "light.on_known_dev": mkEntity("light.on_known_dev", {
+            device_id: "dev_known",
+          }),
+          "light.on_missing_dev": mkEntity("light.on_missing_dev", {
+            device_id: "dev_missing",
+          }),
+        },
+      }
+    );
+
+    expect(entries).toBeDefined();
+    expect(entries!.referenced_devices).toEqual(["dev_known"]);
+    expect(entries!.referenced_entities).toEqual(["light.on_known_dev"]);
+  });
+
+  it("keeps an entity targeted through its own area when its device is missing", async () => {
+    // A device we do not know about is not a filter decision, so it must not
+    // take an entity that the area targets directly down with it.
+    const entries = await extractedBy(
+      extractResult({
+        referenced_devices: ["dev_missing"],
+        referenced_entities: ["light.explicit_area"],
+      }),
+      {
+        entities: {
+          "light.explicit_area": mkEntity("light.explicit_area", {
+            area_id: "area_1",
+            device_id: "dev_missing",
+          }),
+        },
+      }
+    );
+
+    expect(entries).toBeDefined();
+    expect(entries!.referenced_entities).toEqual(["light.explicit_area"]);
+  });
+
+  it("keeps devices of a floor whose area is missing from the registry", async () => {
+    // Same rule for areas: an area we do not know about must not mark itself
+    // hidden and drop the devices the floor references through it.
+    const entries = await extractedBy(
+      extractResult({
+        referenced_areas: ["area_missing"],
+        referenced_devices: ["dev_1"],
+        referenced_entities: ["light.on_dev1"],
+      }),
+      {
+        areas: {},
+        devices: { dev_1: mkDevice("dev_1", { area_id: "area_missing" }) },
+        entities: {
+          "light.on_dev1": mkEntity("light.on_dev1", { device_id: "dev_1" }),
+        },
+      },
+      { type: "floor", itemId: "floor_1" }
+    );
+
+    expect(entries).toBeDefined();
+    expect(entries!.referenced_devices).toEqual(["dev_1"]);
+    expect(entries!.referenced_entities).toEqual(["light.on_dev1"]);
+  });
+});


### PR DESCRIPTION
## Proposed change

Floor and area rows in the target picker showed no entity count at all: the registry lookups that post-process the `extract_from_target` response were unguarded, so a referenced entity missing from `hass.entities` threw, and the swallowed error left the row without a count. An id goes missing because core keeps disabled entities when expanding an area, while the frontend's display registry drops them. The lookups now skip ids the registry does not have, as neighbouring lookups in the same file already do, which means disabled entities are not included in the count.

## Screenshots

Floor targeted by an action, where one of the two entities in the floor's area is disabled.

Before — no count is rendered:

![Target picker row reading "QA Floor 52964" with no entity count on the right](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/52964-before-59a99482.png)

After — the count is rendered:

![The same target picker row reading "QA Floor 52964" with a "1 entity" pill on the right](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/52964-after-96d3cbc8.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52964
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
