### PR TITLE
Add local disk mounts to storage settings

### DIFF
--- a/src/components/ha-mount-picker.ts
+++ b/src/components/ha-mount-picker.ts
@@ -11,6 +11,7 @@ import {
   fetchSupervisorMounts,
   SupervisorMountType,
   SupervisorMountUsage,
+  supervisorMountDescription,
 } from "../data/supervisor/mounts";
 import type { HomeAssistant } from "../types";
 import "./ha-alert";
@@ -58,9 +59,7 @@ class HaMountPicker extends LitElement {
     ).map((mount) => ({
       value: mount.name,
       label: mount.name,
-      secondary: `${mount.server}${mount.port ? `:${mount.port}` : ""}${
-        mount.type === SupervisorMountType.NFS ? mount.path : `:${mount.share}`
-      }`,
+      secondary: supervisorMountDescription(mount),
       iconPath:
         mount.usage === SupervisorMountUsage.MEDIA
           ? mdiPlayBox
@@ -108,10 +107,16 @@ class HaMountPicker extends LitElement {
   private _filterMounts = memoizeOne(
     (mounts: SupervisorMounts, usage: this["usage"]) => {
       let filteredMounts = mounts.mounts.filter((mount) =>
-        [SupervisorMountType.CIFS, SupervisorMountType.NFS].includes(mount.type)
+        [
+          SupervisorMountType.CIFS,
+          SupervisorMountType.DISK,
+          SupervisorMountType.NFS,
+        ].includes(mount.type)
       );
       if (usage) {
-        filteredMounts = mounts.mounts.filter((mount) => mount.usage === usage);
+        filteredMounts = filteredMounts.filter(
+          (mount) => mount.usage === usage
+        );
       }
       return filteredMounts.sort((mountA, mountB) => {
         if (mountA.name === mounts.default_backup_mount) {

--- a/src/data/supervisor/mounts.ts
+++ b/src/data/supervisor/mounts.ts
@@ -3,6 +3,7 @@ import type { HomeAssistant } from "../../types";
 export enum SupervisorMountType {
   BIND = "bind",
   CIFS = "cifs",
+  DISK = "disk",
   NFS = "nfs",
 }
 
@@ -28,26 +29,40 @@ interface SupervisorMountBase {
   name: string;
   usage: SupervisorMountUsage;
   type: SupervisorMountType;
-  server: string;
-  port: number;
+  read_only?: boolean;
 }
 
 export interface SupervisorMountResponse extends SupervisorMountBase {
   state: SupervisorMountState | null;
 }
 
-export interface SupervisorNFSMount extends SupervisorMountResponse {
+// Supervisor omits port when the mount uses the protocol default.
+interface SupervisorNetworkMount extends SupervisorMountResponse {
+  server: string;
+  port?: number;
+}
+
+export interface SupervisorNFSMount extends SupervisorNetworkMount {
   type: SupervisorMountType.NFS;
   path: string;
 }
 
-export interface SupervisorCIFSMount extends SupervisorMountResponse {
+export interface SupervisorCIFSMount extends SupervisorNetworkMount {
   type: SupervisorMountType.CIFS;
   share: string;
   version?: CIFSVersion;
 }
 
-export type SupervisorMount = SupervisorNFSMount | SupervisorCIFSMount;
+// A disk mount is identified by device on the way in, but Supervisor resolves
+// that to a UUID and only ever reports uuid and filesystem back.
+export interface SupervisorDiskMount extends SupervisorMountResponse {
+  type: SupervisorMountType.DISK;
+  uuid: string;
+  filesystem?: string;
+}
+
+export type SupervisorMount =
+  SupervisorNFSMount | SupervisorCIFSMount | SupervisorDiskMount;
 
 export type SupervisorNFSMountRequestParams = SupervisorNFSMount;
 
@@ -57,13 +72,66 @@ export interface SupervisorCIFSMountRequestParams extends SupervisorCIFSMount {
   version?: CIFSVersion;
 }
 
+interface SupervisorDiskMountRequestParamsBase {
+  name: string;
+  usage: SupervisorMountUsage;
+  type: SupervisorMountType.DISK;
+  read_only?: boolean;
+}
+
+// Supervisor accepts exactly one identifier: device when creating from a
+// candidate, uuid when round-tripping a mount it already resolved.
+export type SupervisorDiskMountRequestParams =
+  | (SupervisorDiskMountRequestParamsBase & { device: string; uuid?: never })
+  | (SupervisorDiskMountRequestParamsBase & { uuid: string; device?: never });
+
 export type SupervisorMountRequestParams =
-  SupervisorNFSMountRequestParams | SupervisorCIFSMountRequestParams;
+  | SupervisorNFSMountRequestParams
+  | SupervisorCIFSMountRequestParams
+  | SupervisorDiskMountRequestParams;
 
 export interface SupervisorMounts {
   default_backup_mount: string | null;
   mounts: SupervisorMount[];
 }
+
+// Null when UDisks2 cannot attribute the device to a drive, which also happens
+// when the drive is unplugged between enumeration and lookup.
+export interface SupervisorMountCandidateDrive {
+  vendor: string;
+  model: string;
+  serial: string;
+  id: string;
+  size: number;
+  connection_bus: string;
+  removable: boolean;
+  ejectable: boolean;
+}
+
+export interface SupervisorMountCandidate {
+  device: string;
+  uuid: string;
+  label: string;
+  filesystem: string;
+  size: number;
+  read_only: boolean;
+  drive: SupervisorMountCandidateDrive | null;
+}
+
+export interface SupervisorMountCandidates {
+  candidates: SupervisorMountCandidate[];
+}
+
+// Identifies a mount in a list row. A disk mount has no server, share or path,
+// so it is described by what Supervisor does report for it.
+export const supervisorMountDescription = (mount: SupervisorMount): string => {
+  if (mount.type === SupervisorMountType.DISK) {
+    return [mount.filesystem, mount.uuid].filter(Boolean).join(" • ");
+  }
+  return `${mount.server}${mount.port ? `:${mount.port}` : ""}${
+    mount.type === SupervisorMountType.NFS ? mount.path : `:${mount.share}`
+  }`;
+};
 
 export const fetchSupervisorMounts = async (
   hass: HomeAssistant
@@ -71,6 +139,18 @@ export const fetchSupervisorMounts = async (
   hass.callWS({
     type: "supervisor/api",
     endpoint: `/mounts`,
+    method: "get",
+    timeout: null,
+  });
+
+// Returns an empty list on a host without UDisks2. A Supervisor predating disk
+// mounts answers 404, which callers use to hide the feature.
+export const fetchSupervisorMountCandidates = async (
+  hass: HomeAssistant
+): Promise<SupervisorMountCandidates> =>
+  hass.callWS({
+    type: "supervisor/api",
+    endpoint: `/mounts/candidates`,
     method: "get",
     timeout: null,
   });

--- a/src/data/supervisor/mounts.ts
+++ b/src/data/supervisor/mounts.ts
@@ -109,6 +109,7 @@ export interface SupervisorMountCandidateDrive {
 }
 
 export interface SupervisorMountCandidate {
+  type: SupervisorMountType.DISK;
   device: string;
   uuid: string;
   label: string;

--- a/src/data/supervisor/mounts.ts
+++ b/src/data/supervisor/mounts.ts
@@ -53,8 +53,7 @@ export interface SupervisorCIFSMount extends SupervisorNetworkMount {
   version?: CIFSVersion;
 }
 
-// A disk mount is identified by device on the way in, but Supervisor resolves
-// that to a UUID and only ever reports uuid and filesystem back.
+// Supervisor resolves device to uuid; responses report uuid and filesystem.
 export interface SupervisorDiskMount extends SupervisorMountResponse {
   type: SupervisorMountType.DISK;
   uuid: string;
@@ -79,8 +78,7 @@ interface SupervisorDiskMountRequestParamsBase {
   read_only?: boolean;
 }
 
-// Supervisor accepts exactly one identifier: device when creating from a
-// candidate, uuid when round-tripping a mount it already resolved.
+// Create from a candidate with device; round-trip a resolved mount with uuid.
 export type SupervisorDiskMountRequestParams =
   | (SupervisorDiskMountRequestParamsBase & { device: string; uuid?: never })
   | (SupervisorDiskMountRequestParamsBase & { uuid: string; device?: never });
@@ -95,8 +93,7 @@ export interface SupervisorMounts {
   mounts: SupervisorMount[];
 }
 
-// Null when UDisks2 cannot attribute the device to a drive, which also happens
-// when the drive is unplugged between enumeration and lookup.
+// Null when UDisks2 cannot attribute the device to a drive.
 export interface SupervisorMountCandidateDrive {
   vendor: string;
   model: string;
@@ -123,8 +120,7 @@ export interface SupervisorMountCandidates {
   candidates: SupervisorMountCandidate[];
 }
 
-// Identifies a mount in a list row. A disk mount has no server, share or path,
-// so it is described by what Supervisor does report for it.
+// Disk mounts have no server/share/path, so describe them by filesystem and uuid.
 export const supervisorMountDescription = (mount: SupervisorMount): string => {
   if (mount.type === SupervisorMountType.DISK) {
     return [mount.filesystem, mount.uuid].filter(Boolean).join(" • ");
@@ -144,8 +140,7 @@ export const fetchSupervisorMounts = async (
     timeout: null,
   });
 
-// Returns an empty list on a host without UDisks2. A Supervisor predating disk
-// mounts answers 404, which callers use to hide the feature.
+// Empty list without UDisks2. Older Supervisors return 404; hide the feature.
 export const fetchSupervisorMountCandidates = async (
   hass: HomeAssistant
 ): Promise<SupervisorMountCandidates> =>

--- a/src/data/supervisor/mounts.ts
+++ b/src/data/supervisor/mounts.ts
@@ -16,6 +16,7 @@ export enum SupervisorMountUsage {
 export enum SupervisorMountState {
   ACTIVE = "active",
   FAILED = "failed",
+  INACTIVE = "inactive",
   UNKNOWN = "unknown",
 }
 
@@ -78,10 +79,12 @@ interface SupervisorDiskMountRequestParamsBase {
   read_only?: boolean;
 }
 
-// Create from a candidate with device; round-trip a resolved mount with uuid.
+// At least one identifier is required. Both may be sent together, as a
+// candidate carries both; Supervisor then resolves by uuid and checks the
+// device agrees with it.
 export type SupervisorDiskMountRequestParams =
-  | (SupervisorDiskMountRequestParamsBase & { device: string; uuid?: never })
-  | (SupervisorDiskMountRequestParamsBase & { uuid: string; device?: never });
+  | (SupervisorDiskMountRequestParamsBase & { device: string; uuid?: string })
+  | (SupervisorDiskMountRequestParamsBase & { uuid: string; device?: string });
 
 export type SupervisorMountRequestParams =
   | SupervisorNFSMountRequestParams

--- a/src/panels/config/storage/dialog-mount-view.ts
+++ b/src/panels/config/storage/dialog-mount-view.ts
@@ -14,28 +14,92 @@ import type { SchemaUnion } from "../../../components/ha-form/types";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-dialog";
 import { extractApiErrorMessage } from "../../../data/hassio/common";
-import type { SupervisorMountRequestParams } from "../../../data/supervisor/mounts";
+import type {
+  SupervisorMountCandidate,
+  SupervisorMountRequestParams,
+} from "../../../data/supervisor/mounts";
 import {
   createSupervisorMount,
+  fetchSupervisorMountCandidates,
   removeSupervisorMount,
   SupervisorMountType,
   SupervisorMountUsage,
   updateSupervisorMount,
 } from "../../../data/supervisor/mounts";
+import { bytesToString } from "../../../util/bytes-to-string";
 import { DirtyStateProviderMixin } from "../../../mixins/dirty-state-provider-mixin";
 import { haStyle, haStyleDialog } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 import { documentationUrl } from "../../../util/documentation-url";
 import type { MountViewDialogParams } from "./show-dialog-view-mount";
 
+// Describes a device by the drive it belongs to, falling back to what UDisks2
+// did report: an unattributed device has no drive, and an unformatted-label
+// partition has no label.
+const mountCandidateLabel = (candidate: SupervisorMountCandidate): string => {
+  const drive = [candidate.drive?.vendor, candidate.drive?.model]
+    .filter(Boolean)
+    .join(" ");
+  const identity = candidate.label || candidate.device;
+  const size = bytesToString(candidate.size);
+  return drive ? `${drive} — ${identity}, ${size}` : `${identity}, ${size}`;
+};
+
 const mountSchema = memoizeOne(
   (
     localize: LocalizeFunc,
     existing?: boolean,
     mountType?: SupervisorMountType,
-    showCIFSVersion?: boolean
-  ) =>
-    [
+    showCIFSVersion?: boolean,
+    showDisk?: boolean,
+    candidates?: SupervisorMountCandidate[],
+    diskIdentity?: string,
+    readOnlyForced?: boolean,
+    allowBackupUsage = true
+  ) => {
+    // Supervisor rejects a read-only mount used for backups, so a device that
+    // can only be mounted read-only is not offered for one.
+    const usageOptions: [string, string][] = allowBackupUsage
+      ? [
+          [
+            SupervisorMountUsage.BACKUP,
+            localize(
+              "ui.panel.config.storage.network_mounts.mount_usage.backup"
+            ),
+          ],
+        ]
+      : [];
+    usageOptions.push(
+      [
+        SupervisorMountUsage.MEDIA,
+        localize("ui.panel.config.storage.network_mounts.mount_usage.media"),
+      ],
+      [
+        SupervisorMountUsage.SHARE,
+        localize("ui.panel.config.storage.network_mounts.mount_usage.share"),
+      ]
+    );
+
+    const typeOptions: [string, string][] = [
+      [
+        SupervisorMountType.CIFS,
+        localize("ui.panel.config.storage.network_mounts.mount_type.cifs"),
+      ],
+      [
+        SupervisorMountType.NFS,
+        localize("ui.panel.config.storage.network_mounts.mount_type.nfs"),
+      ],
+    ];
+    // Hidden on a Supervisor that does not support disk mounts, but always
+    // offered when editing one that already exists.
+    if (showDisk || mountType === SupervisorMountType.DISK) {
+      typeOptions.push([
+        SupervisorMountType.DISK,
+        localize("ui.panel.config.storage.network_mounts.mount_type.disk"),
+      ]);
+    }
+
+    return [
       {
         name: "name",
         required: true,
@@ -46,57 +110,34 @@ const mountSchema = memoizeOne(
         name: "usage",
         required: true,
         type: "select",
-        options: [
-          [
-            SupervisorMountUsage.BACKUP,
-            localize(
-              "ui.panel.config.storage.network_mounts.mount_usage.backup"
-            ),
-          ],
-          [
-            SupervisorMountUsage.MEDIA,
-            localize(
-              "ui.panel.config.storage.network_mounts.mount_usage.media"
-            ),
-          ],
-          [
-            SupervisorMountUsage.SHARE,
-            localize(
-              "ui.panel.config.storage.network_mounts.mount_usage.share"
-            ),
-          ],
-        ] as const,
-      },
-      {
-        name: "server",
-        required: true,
-        selector: { text: {} },
+        options: usageOptions,
       },
       {
         name: "type",
         required: true,
         type: "select",
-        options: [
-          [
-            SupervisorMountType.CIFS,
-            localize("ui.panel.config.storage.network_mounts.mount_type.cifs"),
-          ],
-          [
-            SupervisorMountType.NFS,
-            localize("ui.panel.config.storage.network_mounts.mount_type.nfs"),
-          ],
-        ],
+        options: typeOptions,
       },
-      ...(mountType === "nfs"
+      ...(mountType === SupervisorMountType.NFS
         ? ([
+            {
+              name: "server",
+              required: true,
+              selector: { text: {} },
+            },
             {
               name: "path",
               required: true,
               selector: { text: {} },
             },
           ] as const)
-        : mountType === "cifs"
+        : mountType === SupervisorMountType.CIFS
           ? ([
+              {
+                name: "server",
+                required: true,
+                selector: { text: {} },
+              },
               ...(showCIFSVersion
                 ? ([
                     {
@@ -148,8 +189,44 @@ const mountSchema = memoizeOne(
                 selector: { text: { type: "password" } },
               },
             ] as const)
-          : ([] as const)),
-    ] as const
+          : mountType === SupervisorMountType.DISK
+            ? existing
+              ? // Supervisor excludes a mounted device from the candidates, so
+                // an existing mount can only show what it resolved to.
+                ([
+                  {
+                    name: "device_identity",
+                    type: "constant",
+                    value: diskIdentity,
+                  },
+                  {
+                    name: "read_only",
+                    selector: { boolean: {} },
+                  },
+                ] as const)
+              : ([
+                  {
+                    name: "device",
+                    required: true,
+                    selector: {
+                      select: {
+                        options: (candidates ?? []).map((candidate) => ({
+                          value: candidate.device,
+                          label: mountCandidateLabel(candidate),
+                        })),
+                        mode: "dropdown",
+                      },
+                    },
+                  },
+                  {
+                    name: "read_only",
+                    disabled: readOnlyForced,
+                    selector: { boolean: {} },
+                  },
+                ] as const)
+            : ([] as const)),
+    ] as const;
+  }
 );
 
 @customElement("dialog-mount-view")
@@ -172,6 +249,12 @@ class ViewMountDialog extends DirtyStateProviderMixin<
 
   @state() private _showCIFSVersion?: boolean;
 
+  @state() private _candidates?: SupervisorMountCandidate[];
+
+  @state() private _diskSupported = false;
+
+  @state() private _diskIdentity?: string;
+
   @state() private _reloadMounts?: () => void;
 
   @state() private _open = false;
@@ -190,11 +273,34 @@ class ViewMountDialog extends DirtyStateProviderMixin<
     ) {
       this._showCIFSVersion = true;
     }
+    if (dialogParams.mount?.type === SupervisorMountType.DISK) {
+      this._diskIdentity = [
+        dialogParams.mount.filesystem,
+        dialogParams.mount.uuid,
+      ]
+        .filter(Boolean)
+        .join(" • ");
+    }
     this._initDirtyTracking({ type: "deep" }, this._data ?? {});
+    this._loadCandidates();
   }
 
   public closeDialog(): void {
     this._open = false;
+  }
+
+  private async _loadCandidates(): Promise<void> {
+    try {
+      const { candidates } = await fetchSupervisorMountCandidates(this.hass);
+      this._candidates = candidates;
+      this._diskSupported = true;
+    } catch (_err: any) {
+      // A Supervisor predating disk mounts answers 404. Any other failure
+      // leaves us unable to offer a device either, so in both cases the option
+      // is hidden rather than shown as broken.
+      this._candidates = [];
+      this._diskSupported = false;
+    }
   }
 
   private _dialogClosed(): void {
@@ -205,6 +311,9 @@ class ViewMountDialog extends DirtyStateProviderMixin<
     this._validationWarning = undefined;
     this._existing = undefined;
     this._showCIFSVersion = undefined;
+    this._candidates = undefined;
+    this._diskSupported = false;
+    this._diskIdentity = undefined;
     this._reloadMounts = undefined;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
@@ -249,6 +358,15 @@ class ViewMountDialog extends DirtyStateProviderMixin<
             ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
             : nothing
         }
+        ${
+          this._showNoCandidates
+            ? html`<ha-alert alert-type="info">
+                ${this.hass.localize(
+                  "ui.panel.config.storage.network_mounts.no_disk_candidates"
+                )}
+              </ha-alert>`
+            : nothing
+        }
         <ha-form
           autofocus
           .data=${this._data}
@@ -256,7 +374,12 @@ class ViewMountDialog extends DirtyStateProviderMixin<
             this.hass.localize,
             this._existing,
             this._data?.type,
-            this._showCIFSVersion
+            this._showCIFSVersion,
+            this._diskSupported,
+            this._candidates,
+            this._diskIdentity,
+            this._readOnlyForced,
+            this._allowBackupUsage
           )}
           .error=${this._validationError}
           .warning=${this._validationWarning}
@@ -308,6 +431,33 @@ class ViewMountDialog extends DirtyStateProviderMixin<
     `;
   }
 
+  // The device the mount already uses is excluded from candidates, so an empty
+  // list is only worth mentioning while creating one.
+  private get _showNoCandidates(): boolean {
+    return (
+      !this._existing &&
+      this._data?.type === SupervisorMountType.DISK &&
+      this._candidates?.length === 0
+    );
+  }
+
+  private get _readOnlyForced(): boolean {
+    if (this._existing || this._data?.type !== SupervisorMountType.DISK) {
+      return false;
+    }
+    const { device } = this._data;
+    return !!this._candidates?.find((candidate) => candidate.device === device)
+      ?.read_only;
+  }
+
+  // Backup usage is impossible for a read-only mount, whether the device forced
+  // that or the user chose it.
+  private get _allowBackupUsage(): boolean {
+    return !(
+      this._data?.type === SupervisorMountType.DISK && this._data.read_only
+    );
+  }
+
   private _computeLabelCallback = (
     // @ts-ignore
     schema: SchemaUnion<ReturnType<typeof mountSchema>>
@@ -352,6 +502,15 @@ class ViewMountDialog extends DirtyStateProviderMixin<
       ["1.0", "2.0"].includes(this._data.version)
     ) {
       this._validationWarning.version = "not_recomeded_cifs_version";
+    }
+    // A device the host reports as read-only cannot be mounted writable.
+    if (this._readOnlyForced) {
+      this._data!.read_only = true;
+    }
+    // Picking such a device while backup was selected leaves a combination
+    // Supervisor refuses, so drop the usage and make the user choose again.
+    if (!this._allowBackupUsage && this._data?.usage === "backup") {
+      delete (this._data as Partial<SupervisorMountRequestParams>).usage;
     }
     this._updateDirtyState(this._data ?? {});
   }

--- a/src/panels/config/storage/dialog-mount-view.ts
+++ b/src/panels/config/storage/dialog-mount-view.ts
@@ -33,9 +33,7 @@ import type { HomeAssistant } from "../../../types";
 import { documentationUrl } from "../../../util/documentation-url";
 import type { MountViewDialogParams } from "./show-dialog-view-mount";
 
-// Describes a device by the drive it belongs to, falling back to what UDisks2
-// did report: an unattributed device has no drive, and an unformatted-label
-// partition has no label.
+// Drive vendor/model, then label or device path, then size.
 const mountCandidateLabel = (candidate: SupervisorMountCandidate): string => {
   const drive = [candidate.drive?.vendor, candidate.drive?.model]
     .filter(Boolean)
@@ -57,8 +55,7 @@ const mountSchema = memoizeOne(
     readOnlyForced?: boolean,
     allowBackupUsage = true
   ) => {
-    // Supervisor rejects a read-only mount used for backups, so a device that
-    // can only be mounted read-only is not offered for one.
+    // Supervisor rejects read-only backup mounts.
     const usageOptions: [string, string][] = allowBackupUsage
       ? [
           [
@@ -90,8 +87,7 @@ const mountSchema = memoizeOne(
         localize("ui.panel.config.storage.network_mounts.mount_type.nfs"),
       ],
     ];
-    // Hidden on a Supervisor that does not support disk mounts, but always
-    // offered when editing one that already exists.
+    // Hide on Supervisors without disk mounts; always show when editing one.
     if (showDisk || mountType === SupervisorMountType.DISK) {
       typeOptions.push([
         SupervisorMountType.DISK,
@@ -191,8 +187,7 @@ const mountSchema = memoizeOne(
             ] as const)
           : mountType === SupervisorMountType.DISK
             ? existing
-              ? // Supervisor excludes a mounted device from the candidates, so
-                // an existing mount can only show what it resolved to.
+              ? // Mounted devices are not candidates; show what was resolved.
                 ([
                   {
                     name: "device_identity",
@@ -295,9 +290,7 @@ class ViewMountDialog extends DirtyStateProviderMixin<
       this._candidates = candidates;
       this._diskSupported = true;
     } catch (_err: any) {
-      // A Supervisor predating disk mounts answers 404. Any other failure
-      // leaves us unable to offer a device either, so in both cases the option
-      // is hidden rather than shown as broken.
+      // Older Supervisors return 404. Hide the option rather than show it broken.
       this._candidates = [];
       this._diskSupported = false;
     }
@@ -431,8 +424,7 @@ class ViewMountDialog extends DirtyStateProviderMixin<
     `;
   }
 
-  // The device the mount already uses is excluded from candidates, so an empty
-  // list is only worth mentioning while creating one.
+  // Empty candidate list is only relevant while creating a mount.
   private get _showNoCandidates(): boolean {
     return (
       !this._existing &&
@@ -450,8 +442,7 @@ class ViewMountDialog extends DirtyStateProviderMixin<
       ?.read_only;
   }
 
-  // Backup usage is impossible for a read-only mount, whether the device forced
-  // that or the user chose it.
+  // Backup usage is impossible for a read-only mount.
   private get _allowBackupUsage(): boolean {
     return !(
       this._data?.type === SupervisorMountType.DISK && this._data.read_only
@@ -503,12 +494,11 @@ class ViewMountDialog extends DirtyStateProviderMixin<
     ) {
       this._validationWarning.version = "not_recomeded_cifs_version";
     }
-    // A device the host reports as read-only cannot be mounted writable.
+    // Host reports this device as read-only.
     if (this._readOnlyForced) {
       this._data!.read_only = true;
     }
-    // Picking such a device while backup was selected leaves a combination
-    // Supervisor refuses, so drop the usage and make the user choose again.
+    // Read-only plus backup is invalid; drop usage so the user picks again.
     if (!this._allowBackupUsage && this._data?.usage === "backup") {
       delete (this._data as Partial<SupervisorMountRequestParams>).usage;
     }

--- a/src/panels/config/storage/dialog-mount-view.ts
+++ b/src/panels/config/storage/dialog-mount-view.ts
@@ -495,6 +495,11 @@ class ViewMountDialog extends DirtyStateProviderMixin<
     this._validationError = {};
     this._validationWarning = {};
     this._data = ev.detail.value;
+    // Network forms have no read-only control, so a value forced by a
+    // write-protected disk must not survive switching a new mount's type.
+    if (!this._existing && this._data?.type !== SupervisorMountType.DISK) {
+      delete (this._data as Partial<SupervisorMountRequestParams>).read_only;
+    }
     if (this._data?.name && !/^\w+$/.test(this._data.name)) {
       this._validationError.name = "invalid_name";
     }
@@ -526,6 +531,16 @@ class ViewMountDialog extends DirtyStateProviderMixin<
     const mountData = { ...this._data! };
     if (mountData.type === "cifs" && mountData.version === "auto") {
       mountData.version = undefined;
+    }
+    // Send the candidate's uuid alongside its device path: Supervisor resolves
+    // by uuid and rejects the request if the path now names a different disk.
+    if (mountData.type === SupervisorMountType.DISK && !this._existing) {
+      const candidate = this._candidates?.find(
+        (c) => c.device === mountData.device
+      );
+      if (candidate) {
+        mountData.uuid = candidate.uuid;
+      }
     }
     try {
       if (this._existing) {

--- a/src/panels/config/storage/dialog-mount-view.ts
+++ b/src/panels/config/storage/dialog-mount-view.ts
@@ -250,6 +250,10 @@ class ViewMountDialog extends DirtyStateProviderMixin<
 
   @state() private _diskSupported = false;
 
+  private _originalType?: SupervisorMountType;
+
+  private _candidatesRequest = 0;
+
   @state() private _diskIdentity?: string;
 
   @state() private _reloadMounts?: () => void;
@@ -261,6 +265,7 @@ class ViewMountDialog extends DirtyStateProviderMixin<
   ): Promise<Promise<void>> {
     this._data = dialogParams.mount;
     this._existing = dialogParams.mount !== undefined;
+    this._originalType = dialogParams.mount?.type;
     this._reloadMounts = dialogParams.reloadMounts;
     this._open = true;
     if (
@@ -289,12 +294,21 @@ class ViewMountDialog extends DirtyStateProviderMixin<
     this._open = false;
   }
 
+  // The dialog element is reused, so a slow response must not land in a
+  // later session.
   private async _loadCandidates(): Promise<void> {
+    const request = ++this._candidatesRequest;
     try {
       const { candidates } = await fetchSupervisorMountCandidates(this.hass);
+      if (request !== this._candidatesRequest) {
+        return;
+      }
       this._candidates = candidates;
       this._diskSupported = true;
     } catch (err: any) {
+      if (request !== this._candidatesRequest) {
+        return;
+      }
       if (err?.status_code === 404) {
         // Older Supervisors have no candidates endpoint. Hide the option
         // rather than show it broken.
@@ -317,7 +331,9 @@ class ViewMountDialog extends DirtyStateProviderMixin<
     this._validationError = undefined;
     this._validationWarning = undefined;
     this._existing = undefined;
+    this._originalType = undefined;
     this._showCIFSVersion = undefined;
+    this._candidatesRequest++;
     this._candidates = undefined;
     this._diskSupported = false;
     this._diskIdentity = undefined;
@@ -495,9 +511,13 @@ class ViewMountDialog extends DirtyStateProviderMixin<
     this._validationError = {};
     this._validationWarning = {};
     this._data = ev.detail.value;
-    // Network forms have no read-only control, so a value forced by a
-    // write-protected disk must not survive switching a new mount's type.
-    if (!this._existing && this._data?.type !== SupervisorMountType.DISK) {
+    // Network forms have no read-only control, so a disk's read-only value
+    // must not survive switching to a network type. A network mount that was
+    // already read-only keeps it.
+    if (
+      this._data?.type !== SupervisorMountType.DISK &&
+      (!this._existing || this._originalType === SupervisorMountType.DISK)
+    ) {
       delete (this._data as Partial<SupervisorMountRequestParams>).read_only;
     }
     if (this._data?.name && !/^\w+$/.test(this._data.name)) {

--- a/src/panels/config/storage/dialog-mount-view.ts
+++ b/src/panels/config/storage/dialog-mount-view.ts
@@ -87,8 +87,10 @@ const mountSchema = memoizeOne(
         localize("ui.panel.config.storage.network_mounts.mount_type.nfs"),
       ],
     ];
-    // Hide on Supervisors without disk mounts; always show when editing one.
-    if (showDisk || mountType === SupervisorMountType.DISK) {
+    // Offered when creating on a Supervisor with disk mounts, and kept when
+    // editing one. An existing network mount cannot become a disk mount: the
+    // edit form has no device picker to identify the disk with.
+    if ((showDisk && !existing) || mountType === SupervisorMountType.DISK) {
       typeOptions.push([
         SupervisorMountType.DISK,
         localize("ui.panel.config.storage.network_mounts.mount_type.disk"),
@@ -277,7 +279,10 @@ class ViewMountDialog extends DirtyStateProviderMixin<
         .join(" • ");
     }
     this._initDirtyTracking({ type: "deep" }, this._data ?? {});
-    this._loadCandidates();
+    // Candidates only matter when picking a disk for a new mount.
+    if (!this._existing) {
+      this._loadCandidates();
+    }
   }
 
   public closeDialog(): void {

--- a/src/panels/config/storage/dialog-mount-view.ts
+++ b/src/panels/config/storage/dialog-mount-view.ts
@@ -289,10 +289,19 @@ class ViewMountDialog extends DirtyStateProviderMixin<
       const { candidates } = await fetchSupervisorMountCandidates(this.hass);
       this._candidates = candidates;
       this._diskSupported = true;
-    } catch (_err: any) {
-      // Older Supervisors return 404. Hide the option rather than show it broken.
-      this._candidates = [];
-      this._diskSupported = false;
+    } catch (err: any) {
+      if (err?.status_code === 404) {
+        // Older Supervisors have no candidates endpoint. Hide the option
+        // rather than show it broken.
+        this._candidates = [];
+        this._diskSupported = false;
+        return;
+      }
+      // Any other failure is transient or a real error: keep the option and
+      // report it instead of pretending there are no disks.
+      this._candidates = undefined;
+      this._diskSupported = true;
+      this._error = extractApiErrorMessage(err);
     }
   }
 

--- a/src/panels/config/storage/ha-config-section-storage.ts
+++ b/src/panels/config/storage/ha-config-section-storage.ts
@@ -37,6 +37,7 @@ import {
   SupervisorMountUsage,
   fetchSupervisorMounts,
   reloadSupervisorMount,
+  supervisorMountDescription,
 } from "../../../data/supervisor/mounts";
 import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-subpage";
@@ -74,7 +75,11 @@ class HaConfigSectionStorage extends LitElement {
       return nothing;
     }
     const validMounts = this._mountsInfo?.mounts.filter((mount) =>
-      [SupervisorMountType.CIFS, SupervisorMountType.NFS].includes(mount.type)
+      [
+        SupervisorMountType.CIFS,
+        SupervisorMountType.DISK,
+        SupervisorMountType.NFS,
+      ].includes(mount.type)
     );
     const isHAOS = this._hostInfo?.features.includes("haos");
     return html`
@@ -193,13 +198,7 @@ class HaConfigSectionStorage extends LitElement {
                               ${mount.name}
                             </span>
                             <span slot="secondary">
-                              ${mount.server}${
-                                mount.port ? `:${mount.port}` : nothing
-                              }${
-                                mount.type === SupervisorMountType.NFS
-                                  ? mount.path
-                                  : `:${mount.share}`
-                              }
+                              ${supervisorMountDescription(mount)}
                             </span>
                             ${
                               mount.state !== SupervisorMountState.ACTIVE

--- a/src/panels/config/storage/ha-config-section-storage.ts
+++ b/src/panels/config/storage/ha-config-section-storage.ts
@@ -40,6 +40,7 @@ import {
   SupervisorMountUsage,
   fetchSupervisorMounts,
   reloadSupervisorMount,
+  supervisorMountDescription,
 } from "../../../data/supervisor/mounts";
 import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-subpage";
@@ -85,7 +86,11 @@ class HaConfigSectionStorage extends LitElement {
       return nothing;
     }
     const validMounts = this._mountsInfo?.mounts.filter((mount) =>
-      [SupervisorMountType.CIFS, SupervisorMountType.NFS].includes(mount.type)
+      [
+        SupervisorMountType.CIFS,
+        SupervisorMountType.DISK,
+        SupervisorMountType.NFS,
+      ].includes(mount.type)
     );
     const isHAOS = this._hostInfo?.features.includes("haos");
     return html`
@@ -205,14 +210,8 @@ class HaConfigSectionStorage extends LitElement {
                               ${mount.name}
                             </span>
                             <span slot="secondary">
-                              <span class="mount-address">
-                                ${mount.server}${
-                                  mount.port ? `:${mount.port}` : ""
-                                }${
-                                  mount.type === SupervisorMountType.NFS
-                                    ? mount.path
-                                    : `:${mount.share}`
-                                }
+<span class="mount-address">
+                                ${supervisorMountDescription(mount)}
                               </span>
                               ${this._renderMountUsage(mount)}
                             </span>

--- a/src/panels/config/storage/ha-config-section-storage.ts
+++ b/src/panels/config/storage/ha-config-section-storage.ts
@@ -210,7 +210,7 @@ class HaConfigSectionStorage extends LitElement {
                               ${mount.name}
                             </span>
                             <span slot="secondary">
-<span class="mount-address">
+                              <span class="mount-address">
                                 ${supervisorMountDescription(mount)}
                               </span>
                               ${this._renderMountUsage(mount)}
@@ -480,6 +480,7 @@ class HaConfigSectionStorage extends LitElement {
     .mount-state-failed {
       color: var(--error-color);
     }
+    .mount-state-inactive,
     .mount-state-unknown {
       color: var(--warning-color);
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3445,7 +3445,7 @@
           "agents": {
             "cloud_agent_description": "Note: It stores only the most recent backup, regardless of your retention settings, with a maximum size of 5 GB.",
             "cloud_agent_no_subcription": "You currently do not have an active Home Assistant Cloud subscription.",
-            "network_mount_agent_description": "Network storage",
+            "network_mount_agent_description": "Additional storage",
             "unavailable_agents": "Unavailable locations",
             "no_agents": "No locations configured",
             "encryption_turned_off": "Encryption turned off",
@@ -3730,7 +3730,7 @@
               "no_location": "No location selected",
               "no_location_description": "You have to select at least one location to create a backup.",
               "more_locations": "Explore more locations",
-              "manage_network_storage": "Manage network storage",
+              "manage_network_storage": "Manage storage",
               "ha_cloud_backup": "{home_assistant_cloud} backup",
               "ha_cloud_description": "Stores an encrypted backup offsite. This is ideal in case your local backup becomes inaccessible. The cloud stores one backup with a maximum size of 5 GB, and older backups are automatically deleted."
             },
@@ -8638,7 +8638,7 @@
           "join_chat": "Chat",
           "join_blog": "Blog",
           "join_newsletter": "Newsletter",
-          "media_storage": "You can add network storage to your Home Assistant instance in the {storage} panel."
+          "media_storage": "You can add additional storage to your Home Assistant instance in the {storage} panel."
         },
         "analytics": {
           "caption": "Analytics",
@@ -8901,15 +8901,16 @@
             "move": "Move"
           },
           "network_mounts": {
-            "title": "Network storage",
-            "add_title": "Add network storage",
-            "update_title": "Update network storage",
-            "no_mounts": "No connected network storage",
+            "title": "Additional storage",
+            "add_title": "Add storage",
+            "update_title": "Update storage",
+            "no_mounts": "No additional storage configured",
+            "no_disk_candidates": "No suitable disks were found. Connect a disk with a supported file system, then reopen this dialog.",
             "documentation": "Documentation",
             "not_supported": {
-              "title": "The operating system does not support network storage",
-              "supervised": "Network storage is not supported on this host",
-              "os": "To use network storage you need to run at least Home Assistant OS {version}",
+              "title": "The operating system does not support additional storage",
+              "supervised": "Additional storage is not supported on this host",
+              "os": "To use additional storage you need to run at least Home Assistant OS {version}",
               "navigate_to_updates": "Go to updates"
             },
             "mount_usage": {
@@ -8919,7 +8920,8 @@
             },
             "mount_type": {
               "nfs": "Network File System (NFS)",
-              "cifs": "Samba/Windows (CIFS)"
+              "cifs": "Samba/Windows (CIFS)",
+              "disk": "Local disk"
             },
             "cifs_versions": {
               "auto": "Auto (2.1+)",
@@ -8947,12 +8949,24 @@
                 "description": "This is the path of the remote share on your storage server"
               },
               "type": {
-                "title": "Protocol",
-                "description": "This determines how to communicate with the storage server"
+                "title": "Type",
+                "description": "This determines the kind of storage you want to add"
               },
               "usage": {
                 "title": "Usage",
                 "description": "This determines how the share is intended to be used"
+              },
+              "device": {
+                "title": "Disk",
+                "description": "This is the disk connected to your system that you want to use"
+              },
+              "device_identity": {
+                "title": "Disk",
+                "description": "This is the disk this storage was set up with, which cannot be changed"
+              },
+              "read_only": {
+                "title": "Read-only",
+                "description": "Home Assistant will not be able to write to this storage. Backup storage cannot be read-only"
               },
               "version": {
                 "title": "Samba/Windows (CIFS) version",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3527,7 +3527,7 @@
           "agents": {
             "cloud_agent_description": "Note: It stores only the most recent backup, regardless of your retention settings, with a maximum size of 5 GB.",
             "cloud_agent_no_subcription": "You currently do not have an active Home Assistant Cloud subscription.",
-            "network_mount_agent_description": "Network storage",
+            "network_mount_agent_description": "Additional storage",
             "unavailable_agents": "Unavailable locations",
             "no_agents": "No locations configured",
             "encryption_turned_off": "Encryption turned off",
@@ -3812,7 +3812,7 @@
               "no_location": "No location selected",
               "no_location_description": "You have to select at least one location to create a backup.",
               "more_locations": "Explore more locations",
-              "manage_network_storage": "Manage network storage",
+              "manage_network_storage": "Manage storage",
               "ha_cloud_backup": "{home_assistant_cloud} backup",
               "ha_cloud_description": "Stores an encrypted backup offsite. This is ideal in case your local backup becomes inaccessible. The cloud stores one backup with a maximum size of 5 GB, and older backups are automatically deleted."
             },
@@ -8802,7 +8802,7 @@
           "join_chat": "Chat",
           "join_blog": "Blog",
           "join_newsletter": "Newsletter",
-          "media_storage": "You can add network storage to your Home Assistant instance in the {storage} panel."
+          "media_storage": "You can add additional storage to your Home Assistant instance in the {storage} panel."
         },
         "analytics": {
           "caption": "Analytics",
@@ -9065,15 +9065,16 @@
             "move": "Move"
           },
           "network_mounts": {
-            "title": "Network storage",
-            "add_title": "Add network storage",
-            "update_title": "Update network storage",
-            "no_mounts": "No connected network storage",
+            "title": "Additional storage",
+            "add_title": "Add storage",
+            "update_title": "Update storage",
+            "no_mounts": "No additional storage configured",
+            "no_disk_candidates": "No suitable disks were found. Connect a disk with a supported file system, then reopen this dialog.",
             "documentation": "Documentation",
             "not_supported": {
-              "title": "The operating system does not support network storage",
-              "supervised": "Network storage is not supported on this host",
-              "os": "To use network storage you need to run at least Home Assistant OS {version}",
+              "title": "The operating system does not support additional storage",
+              "supervised": "Additional storage is not supported on this host",
+              "os": "To use additional storage you need to run at least Home Assistant OS {version}",
               "navigate_to_updates": "Go to updates"
             },
             "mount_usage": {
@@ -9083,7 +9084,8 @@
             },
             "mount_type": {
               "nfs": "Network File System (NFS)",
-              "cifs": "Samba/Windows (CIFS)"
+              "cifs": "Samba/Windows (CIFS)",
+              "disk": "Local disk"
             },
             "cifs_versions": {
               "auto": "Auto (2.1+)",
@@ -9111,12 +9113,24 @@
                 "description": "This is the path of the remote share on your storage server"
               },
               "type": {
-                "title": "Protocol",
-                "description": "This determines how to communicate with the storage server"
+                "title": "Type",
+                "description": "This determines the kind of storage you want to add"
               },
               "usage": {
                 "title": "Usage",
                 "description": "This determines how the share is intended to be used"
+              },
+              "device": {
+                "title": "Disk",
+                "description": "This is the disk connected to your system that you want to use"
+              },
+              "device_identity": {
+                "title": "Disk",
+                "description": "This is the disk this storage was set up with, which cannot be changed"
+              },
+              "read_only": {
+                "title": "Read-only",
+                "description": "Home Assistant will not be able to write to this storage. Backup storage cannot be read-only"
               },
               "version": {
                 "title": "Samba/Windows (CIFS) version",

--- a/test/data/supervisor-mounts.test.ts
+++ b/test/data/supervisor-mounts.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type {
+  SupervisorCIFSMount,
+  SupervisorDiskMount,
+  SupervisorNFSMount,
+} from "../../src/data/supervisor/mounts";
+import {
+  SupervisorMountState,
+  SupervisorMountType,
+  SupervisorMountUsage,
+  supervisorMountDescription,
+} from "../../src/data/supervisor/mounts";
+
+const nfsMount = (
+  overrides: Partial<SupervisorNFSMount> = {}
+): SupervisorNFSMount => ({
+  name: "my_nfs",
+  type: SupervisorMountType.NFS,
+  usage: SupervisorMountUsage.MEDIA,
+  state: SupervisorMountState.ACTIVE,
+  server: "nas.local",
+  path: "/export/media",
+  ...overrides,
+});
+
+const cifsMount = (
+  overrides: Partial<SupervisorCIFSMount> = {}
+): SupervisorCIFSMount => ({
+  name: "my_share",
+  type: SupervisorMountType.CIFS,
+  usage: SupervisorMountUsage.MEDIA,
+  state: SupervisorMountState.ACTIVE,
+  server: "nas.local",
+  share: "media",
+  ...overrides,
+});
+
+const diskMount = (
+  overrides: Partial<SupervisorDiskMount> = {}
+): SupervisorDiskMount => ({
+  name: "media_disk",
+  type: SupervisorMountType.DISK,
+  usage: SupervisorMountUsage.MEDIA,
+  state: SupervisorMountState.ACTIVE,
+  uuid: "e3f1a2b4-5c6d-7e8f-9a0b-1c2d3e4f5a6b",
+  filesystem: "ext4",
+  ...overrides,
+});
+
+describe("supervisorMountDescription", () => {
+  it("describes an NFS mount by server and path", () => {
+    expect(supervisorMountDescription(nfsMount())).toBe(
+      "nas.local/export/media"
+    );
+  });
+
+  it("describes a CIFS mount by server and share", () => {
+    expect(supervisorMountDescription(cifsMount())).toBe("nas.local:media");
+  });
+
+  it("includes the port only when Supervisor reports one", () => {
+    expect(supervisorMountDescription(nfsMount({ port: 2049 }))).toBe(
+      "nas.local:2049/export/media"
+    );
+    expect(supervisorMountDescription(nfsMount({ port: undefined }))).toBe(
+      "nas.local/export/media"
+    );
+  });
+
+  it("describes a disk mount by filesystem and uuid", () => {
+    expect(supervisorMountDescription(diskMount())).toBe(
+      "ext4 • e3f1a2b4-5c6d-7e8f-9a0b-1c2d3e4f5a6b"
+    );
+  });
+
+  it("omits the filesystem when Supervisor has not resolved one", () => {
+    expect(
+      supervisorMountDescription(diskMount({ filesystem: undefined }))
+    ).toBe("e3f1a2b4-5c6d-7e8f-9a0b-1c2d3e4f5a6b");
+  });
+
+  it("never describes a disk mount using network fields", () => {
+    // A disk mount has no server, share or path, which previously rendered as
+    // "undefined" in the storage panel and the mount picker.
+    expect(supervisorMountDescription(diskMount())).not.toContain("undefined");
+  });
+});

--- a/test/data/supervisor-mounts.test.ts
+++ b/test/data/supervisor-mounts.test.ts
@@ -80,8 +80,7 @@ describe("supervisorMountDescription", () => {
   });
 
   it("never describes a disk mount using network fields", () => {
-    // A disk mount has no server, share or path, which previously rendered as
-    // "undefined" in the storage panel and the mount picker.
+    // A disk mount has no server, share, or path.
     expect(supervisorMountDescription(diskMount())).not.toContain("undefined");
   });
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add the new `disk` mount type from home-assistant/supervisor#7137 to the storage settings: the add-storage dialog gets a "Local disk" type with a device picker fed by the new `/mounts/candidates` endpoint, and the storage panel copy changes from "Network storage" to "Additional storage". The disk option only appears when the Supervisor supports it (a 404 from the candidates endpoint hides it), and write-protected devices force the read-only toggle on.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Taken against a live Supervisor instance with a real USB flash drive:

The add-storage dialog with a candidate selected:

![Add storage dialog with Local disk selected and a real USB candidate in the Disk field](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/01-dialog-real-candidates-4fb41883.png)

The candidate dropdown (vendor/model — label, size):

![Disk dropdown open showing the candidate "usb 2.0 Flash Disk — FLASHKA, 1.97 GB"](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/02-candidate-dropdown-3d8b2ab1.png)

A failed create surfacing the Supervisor error with form state preserved:

![Dialog showing the Supervisor mount error in an alert above the preserved form](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/03-create-error-88e98f6c.png)

The empty state after unplugging the drive (Local disk stays offered; the candidate list is empty):

![Dialog showing the "No suitable disks were found" info alert with an empty Disk field](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/04-no-candidates-84d98c86.png)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/1747
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47453
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3297
- Link to backend pull request: https://github.com/home-assistant/supervisor/pull/7137

Notes:

- The translation key `network_mount_agent_description` and the helper `isNetworkMountAgent` now also cover disk mounts; they keep their names to avoid churning unrelated call sites, and a rename can be a follow-up.
- `ha-mount-picker` previously ignored its usage filter; it now filters correctly, which also benefits existing network mounts.
- Candidates are fetched over the WebSocket `supervisor/api` path like the other mount endpoints (Core's REST proxy does not allowlist `/mounts`).
- Localizing Supervisor errors via their `error_key` instead of showing the raw message is a possible follow-up.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
