### PR TITLE
Fix backup progress segment order to match backend execution order

### DIFF
--- a/src/panels/config/backup/components/overview/ha-backup-overview-progress.ts
+++ b/src/panels/config/backup/components/overview/ha-backup-overview-progress.ts
@@ -41,20 +41,21 @@ const ADDON_STAGES: CreateBackupStage[] = [
   "docker_config",
 ];
 
-// Add-on restarts are awaited after the backup file is finished, so those
-// stages belong to the last creation group to keep the progress monotonic
-const MEDIA_STAGES: CreateBackupStage[] = [
-  "folders",
-  "finishing_file",
+const MEDIA_STAGES: CreateBackupStage[] = ["folders", "finishing_file"];
+
+// Emitted after the backup file is finished, when the backend waits for
+// cold-backup add-ons to come back up
+const AWAIT_RESTART_STAGES: CreateBackupStage[] = [
   "await_addon_restarts",
   "await_app_restarts",
 ];
 
-// Ordered groups matching actual backend execution order
+// Ordered groups matching actual backend execution order. The await restart
+// stages share the last creation group to keep the progress monotonic.
 const STAGE_ORDER: CreateBackupStage[][] = [
   HA_STAGES,
   ADDON_STAGES,
-  MEDIA_STAGES,
+  [...MEDIA_STAGES, ...AWAIT_RESTART_STAGES],
   ["upload_to_agents"],
   ["cleaning_up"],
 ];

--- a/src/panels/config/backup/components/overview/ha-backup-overview-progress.ts
+++ b/src/panels/config/backup/components/overview/ha-backup-overview-progress.ts
@@ -33,13 +33,15 @@ interface ProgressSegment {
 
 const HA_STAGES: CreateBackupStage[] = ["home_assistant"];
 
-const ADDON_STAGES: CreateBackupStage[] = [
-  "addons",
-  "apps",
+// Quick metadata writes emitted while the backup is initialized, before the
+// Home Assistant stage (docker_config only by older Supervisors)
+const SETUP_STAGES: CreateBackupStage[] = [
   "addon_repositories",
   "app_repositories",
   "docker_config",
 ];
+
+const ADDON_STAGES: CreateBackupStage[] = ["addons", "apps"];
 
 const MEDIA_STAGES: CreateBackupStage[] = ["folders", "finishing_file"];
 
@@ -53,7 +55,7 @@ const AWAIT_RESTART_STAGES: CreateBackupStage[] = [
 // Ordered groups matching actual backend execution order. The await restart
 // stages share the last creation group to keep the progress monotonic.
 const STAGE_ORDER: CreateBackupStage[][] = [
-  HA_STAGES,
+  [...SETUP_STAGES, ...HA_STAGES],
   ADDON_STAGES,
   [...MEDIA_STAGES, ...AWAIT_RESTART_STAGES],
   ["upload_to_agents"],

--- a/src/panels/config/backup/components/overview/ha-backup-overview-progress.ts
+++ b/src/panels/config/backup/components/overview/ha-backup-overview-progress.ts
@@ -39,17 +39,22 @@ const ADDON_STAGES: CreateBackupStage[] = [
   "addon_repositories",
   "app_repositories",
   "docker_config",
+];
+
+// Add-on restarts are awaited after the backup file is finished, so those
+// stages belong to the last creation group to keep the progress monotonic
+const MEDIA_STAGES: CreateBackupStage[] = [
+  "folders",
+  "finishing_file",
   "await_addon_restarts",
   "await_app_restarts",
 ];
 
-const MEDIA_STAGES: CreateBackupStage[] = ["folders", "finishing_file"];
-
 // Ordered groups matching actual backend execution order
 const STAGE_ORDER: CreateBackupStage[][] = [
+  HA_STAGES,
   ADDON_STAGES,
   MEDIA_STAGES,
-  HA_STAGES,
   ["upload_to_agents"],
   ["cleaning_up"],
 ];
@@ -165,21 +170,21 @@ export class HaBackupOverviewProgress extends LitElement {
       return [
         {
           label: this.hass.localize(
-            "ui.panel.config.backup.overview.progress.segments.apps"
+            "ui.panel.config.backup.overview.progress.segments.home_assistant"
           ),
           state: this._getSegmentState(0, currentGroupIndex),
           flex: 2,
         },
         {
           label: this.hass.localize(
-            "ui.panel.config.backup.overview.progress.segments.media"
+            "ui.panel.config.backup.overview.progress.segments.apps"
           ),
           state: this._getSegmentState(1, currentGroupIndex),
           flex: 2,
         },
         {
           label: this.hass.localize(
-            "ui.panel.config.backup.overview.progress.segments.home_assistant"
+            "ui.panel.config.backup.overview.progress.segments.media"
           ),
           state: this._getSegmentState(2, currentGroupIndex),
           flex: 2,
@@ -201,18 +206,18 @@ export class HaBackupOverviewProgress extends LitElement {
       ];
     }
 
-    // Non-HAOS: No app segment, just Media, HA, Upload and Cleaning up
+    // Non-HAOS: No app segment, just HA, Media, Upload and Cleaning up
     return [
       {
         label: this.hass.localize(
-          "ui.panel.config.backup.overview.progress.segments.media"
+          "ui.panel.config.backup.overview.progress.segments.home_assistant"
         ),
-        state: this._getSegmentState(1, currentGroupIndex),
+        state: this._getSegmentState(0, currentGroupIndex),
         flex: 2,
       },
       {
         label: this.hass.localize(
-          "ui.panel.config.backup.overview.progress.segments.home_assistant"
+          "ui.panel.config.backup.overview.progress.segments.media"
         ),
         state: this._getSegmentState(2, currentGroupIndex),
         flex: 2,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The segmented progress bar shown while a backup is being created listed the segments as Apps → Media → Home Assistant, but that does not match the order the backend actually uses. Since home-assistant/supervisor#5203 (July 2024), Supervisor backs up Home Assistant first (so a failing Core pre-backup aborts early), then add-ons, then folders.

Because of the mismatch, starting a backup immediately showed the "Apps" and "Media" segments as completed while "Home Assistant" was active, and the bar then jumped backwards (segments flipped back to pending) once the add-ons stage started.

This PR:

- Reorders the stage groups and rendered segments to Home Assistant → Apps → Media → Upload → Cleaning up, matching the backend execution order.
- Moves the `await_addon_restarts`/`await_app_restarts` stages into the last creation group, since Supervisor awaits add-on restarts after the backup file is finished (`home_assistant → addons → folders → finishing_file → await_addon_restarts`). Keeping them grouped with the app stages would make the bar regress again at the end of a backup.
- Applies the same order to the non-hassio variant (Home Assistant → Media → Upload → Cleaning up).

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/51922 (at least partially)
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: home-assistant/supervisor#5203 (the 2024 change that reordered backend stages)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
