### PR TITLE
Log console error when a dashboard resource fails to load

### DIFF
--- a/src/panels/lovelace/common/load-resources.ts
+++ b/src/panels/lovelace/common/load-resources.ts
@@ -15,13 +15,21 @@ const _loadLovelaceResource = (
     hass.auth.data.hassUrl
   ).toString();
 
+  const logLoadError = () => {
+    // eslint-disable-next-line no-console
+    console.error(
+      `Failed to load Lovelace resource ${normalizedUrl} (type: ${resource.type}). Check that the URL is correct and the file exists.`
+    );
+  };
+
   switch (resource.type) {
     case "css": {
       if (normalizedUrl in CSS_CACHE) {
         return CSS_CACHE[normalizedUrl];
       }
 
-      const loadTask = loadCSS(normalizedUrl);
+      // Catch before caching, so a cache hit cannot log the failure again
+      const loadTask = loadCSS(normalizedUrl).catch(logLoadError);
       CSS_CACHE[normalizedUrl] = loadTask;
       return loadTask;
     }
@@ -31,13 +39,13 @@ const _loadLovelaceResource = (
         return JS_CACHE[normalizedUrl];
       }
 
-      const loadTask = loadJS(normalizedUrl);
+      const loadTask = loadJS(normalizedUrl).catch(logLoadError);
       JS_CACHE[normalizedUrl] = loadTask;
       return loadTask;
     }
 
     case "module":
-      return loadModule(normalizedUrl);
+      return loadModule(normalizedUrl).catch(logLoadError);
 
     default:
       // eslint-disable-next-line

--- a/src/panels/lovelace/common/load-resources.ts
+++ b/src/panels/lovelace/common/load-resources.ts
@@ -15,10 +15,11 @@ const _loadLovelaceResource = (
     hass.auth.data.hassUrl
   ).toString();
 
-  const logLoadError = () => {
+  const logLoadError = (err: unknown) => {
     // eslint-disable-next-line no-console
     console.error(
-      `Failed to load Lovelace resource ${normalizedUrl} (type: ${resource.type}). Check that the URL is correct and the file exists.`
+      `Failed to load Lovelace resource ${normalizedUrl} (type: ${resource.type}). Check that the URL is correct and the file exists.`,
+      err
     );
   };
 

--- a/test/panels/lovelace/common/load-resources.test.ts
+++ b/test/panels/lovelace/common/load-resources.test.ts
@@ -23,7 +23,8 @@ describe("loadLovelaceResourcesAndWait", () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
-    vi.mocked(loadModule).mockImplementation((url) => Promise.reject(url));
+    const loadError = new Error("load failed");
+    vi.mocked(loadModule).mockImplementation(() => Promise.reject(loadError));
 
     await loadLovelaceResourcesAndWait(
       [{ id: "1", url: "/local/missing.js", type: "module" }],
@@ -35,6 +36,8 @@ describe("loadLovelaceResourcesAndWait", () => {
       "http://localhost:8123/local/missing.js"
     );
     expect(consoleError.mock.calls[0][0]).toContain("module");
+    // the rejection reason is forwarded, so any detail it carries is not lost
+    expect(consoleError.mock.calls[0][1]).toBe(loadError);
   });
 
   it("logs only once for a cached resource that failed to load", async () => {

--- a/test/panels/lovelace/common/load-resources.test.ts
+++ b/test/panels/lovelace/common/load-resources.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { loadJS, loadModule } from "../../../../src/common/dom/load_resource";
+import { loadLovelaceResourcesAndWait } from "../../../../src/panels/lovelace/common/load-resources";
+import type { HomeAssistant } from "../../../../src/types";
+
+vi.mock("../../../../src/common/dom/load_resource", () => ({
+  loadCSS: vi.fn(),
+  loadJS: vi.fn(),
+  loadModule: vi.fn(),
+}));
+
+const hass = {
+  auth: { data: { hassUrl: "http://localhost:8123" } },
+} as unknown as HomeAssistant;
+
+describe("loadLovelaceResourcesAndWait", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs an error naming the resource that failed to load", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    vi.mocked(loadModule).mockImplementation((url) => Promise.reject(url));
+
+    await loadLovelaceResourcesAndWait(
+      [{ id: "1", url: "/local/missing.js", type: "module" }],
+      hass
+    );
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls[0][0]).toContain(
+      "http://localhost:8123/local/missing.js"
+    );
+    expect(consoleError.mock.calls[0][0]).toContain("module");
+  });
+
+  it("logs only once for a cached resource that failed to load", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    vi.mocked(loadJS).mockImplementation((url) => Promise.reject(url));
+    const resources = [
+      { id: "2", url: "/local/broken.js", type: "js" as const },
+    ];
+
+    await loadLovelaceResourcesAndWait(resources, hass);
+    await loadLovelaceResourcesAndWait(resources, hass);
+
+    expect(loadJS).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Proposed change

Dashboard resources that fail to load are swallowed as an unhandled promise rejection carrying only a bare URL string, so nothing useful reaches the console. This logs an error naming the failing URL and resource type, once per failed resource. It complements the backend warning for missing `/local/` files by also covering storage-mode resources and remote URLs, which the backend cannot check.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: home-assistant/core#179316
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: home-assistant/core#179357

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
