### PR TITLE
Fix Z-Wave network visualization showing wrong route edges

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -1,6 +1,7 @@
 import type { Connection, UnsubscribeFunc } from "home-assistant-js-websocket";
 import type { HomeAssistant } from "../types";
 import { callWS } from "../util/websocket";
+import type { DeviceRegistryEntry } from "./device/device_registry";
 
 export enum InclusionState {
   /** The controller isn't doing anything regarding inclusion. */
@@ -464,6 +465,27 @@ export interface RequestedGrant {
   /** Whether client side authentication is requested or to be granted */
   clientSideAuth: boolean;
 }
+
+/**
+ * Get the Z-Wave node ID of a device from its registry identifiers, which have
+ * the form `<home id>-<node id>[-<manufacturer>:<product type>:<product id>]`.
+ * Returns undefined for devices without a node, e.g. provisioning entries.
+ */
+export const getNodeIdFromDevice = (
+  device: DeviceRegistryEntry
+): number | undefined => {
+  for (const [domain, identifier] of device.identifiers) {
+    // a provisioning entry is identified by its DSK, whose blocks parse as numbers
+    if (domain !== "zwave_js" || identifier.startsWith("provision_")) {
+      continue;
+    }
+    const nodeId = parseInt(identifier.split("-")[1]);
+    if (!isNaN(nodeId)) {
+      return nodeId;
+    }
+  }
+  return undefined;
+};
 
 export const invokeZWaveCCApi = <T = unknown>(
   hass: HomeAssistant,

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
@@ -2,6 +2,7 @@ import type {
   CallbackDataParams,
   TopLevelFormatterParams,
 } from "echarts/types/dist/shared";
+import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -19,11 +20,13 @@ import "../../../../../components/input/ha-input-search";
 import type { HaInputSearch } from "../../../../../components/input/ha-input-search";
 import type { DeviceRegistryEntry } from "../../../../../data/device/device_registry";
 import type {
+  RssiError,
   ZWaveJSNodeStatisticsUpdatedMessage,
   ZWaveJSNodeStatus,
 } from "../../../../../data/zwave_js";
 import {
   fetchZwaveNetworkStatus,
+  getNodeIdFromDevice,
   NodeStatus,
   subscribeZwaveNodeStatistics,
 } from "../../../../../data/zwave_js";
@@ -54,19 +57,36 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
 
   @state() private _searchFilter = "";
 
-  public hassSubscribe() {
-    const devices = Object.values(this.hass.devices).filter((device) =>
-      device.config_entries.some((entry) => entry === this.configEntryId)
-    );
+  // Route statistics reference repeaters by device registry ID
+  private _nodeIdsByDeviceId: Record<string, number> = {};
 
-    return devices.map((device) =>
-      subscribeZwaveNodeStatistics(this.hass!, device.id, (message) => {
-        const nodeId = message.nodeId ?? message.node_id;
-        this._devices[nodeId!] = device;
-        this._nodeStatistics[nodeId!] = message;
-        this._handleUpdatedNodeStatistics();
-      })
-    );
+  public hassSubscribe() {
+    const subscriptions: Promise<UnsubscribeFunc>[] = [];
+    const devices: Record<number, DeviceRegistryEntry> = {};
+    const nodeIdsByDeviceId: Record<string, number> = {};
+
+    Object.values(this.hass.devices).forEach((device) => {
+      if (!device.config_entries.includes(this.configEntryId)) {
+        return;
+      }
+      const nodeId = getNodeIdFromDevice(device);
+      if (nodeId === undefined) {
+        return;
+      }
+      devices[nodeId] = device;
+      nodeIdsByDeviceId[device.id] = nodeId;
+      subscriptions.push(
+        subscribeZwaveNodeStatistics(this.hass!, device.id, (message) => {
+          this._nodeStatistics[nodeId] = message;
+          this._handleUpdatedNodeStatistics();
+        })
+      );
+    });
+
+    this._nodeIdsByDeviceId = nodeIdsByDeviceId;
+    this._devices = devices;
+
+    return subscriptions;
   }
 
   public connectedCallback() {
@@ -164,8 +184,10 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
         sourceDevice?.name_by_user ?? sourceDevice?.name ?? source;
       const targetName =
         targetDevice?.name_by_user ?? targetDevice?.name ?? target;
-      const route =
-        this._nodeStatistics[source]?.lwr || this._nodeStatistics[source]?.nlwr;
+      // links point away from the controller, so the route belongs to the target
+      const stats =
+        this._nodeStatistics[target] ?? this._nodeStatistics[source];
+      const route = stats?.lwr || stats?.nlwr;
       return html`${sourceName} →
       ${targetName}${
         route?.protocol_data_rate
@@ -333,55 +355,69 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
         });
       });
 
+      if (controllerNode === undefined) {
+        return { nodes, links, categories };
+      }
+      const controllerId = String(controllerNode);
+
       Object.entries(nodeStatistics).forEach(([nodeId, stats]) => {
         const route = stats.lwr || stats.nlwr;
-        if (route) {
-          const hops = [
-            ...route.repeaters.map((id, i) => [
-              Object.keys(this._devices).find(
-                (_nodeId) => this._devices[_nodeId]?.id === id
-              )?.[0],
-              route.repeater_rssi[i],
-            ]),
-            [controllerNode!, route.rssi],
-          ];
-          let sourceNode: string = nodeId;
-          hops.forEach(([repeater, rssi]) => {
-            const RSSI = typeof rssi === "number" && rssi <= 0 ? rssi : -100;
-            const existingLink = links.find(
-              (link) =>
-                link.source === sourceNode && link.target === String(repeater)
-            );
-            const width = this._getLineWidth(RSSI);
-            if (existingLink) {
-              existingLink.value = Math.max(existingLink.value!, RSSI);
-              existingLink.lineStyle = {
-                ...existingLink.lineStyle,
-                width: Math.max(existingLink.lineStyle!.width!, width),
-                type:
-                  route.protocol_data_rate > 1
-                    ? "solid"
-                    : existingLink.lineStyle!.type,
-              };
-            } else {
-              links.push({
-                source: sourceNode,
-                target: String(repeater),
-                value: RSSI,
-                lineStyle: {
-                  width,
-                  color:
-                    repeater === controllerNode
-                      ? style.getPropertyValue("--primary-color")
-                      : style.getPropertyValue("--disabled-color"),
-                  type: route.protocol_data_rate > 1 ? "solid" : "dotted",
-                },
-                symbolSize: width * 3,
-              });
-            }
-            sourceNode = String(repeater);
-          });
+        if (!route) {
+          return;
         }
+        // Routes go from the controller to the node via the repeaters, in order.
+        // Each station measures the hop leaving it: the controller reports
+        // `rssi`, repeater i reports `repeater_rssi[i]`.
+        const hops: [string, RssiError | number | null][] = [];
+        let hopRssi = route.rssi;
+        route.repeaters.forEach((deviceId, i) => {
+          const repeaterNodeId = this._nodeIdsByDeviceId[deviceId];
+          // skip repeaters we can't resolve, so the chain stays connected
+          if (repeaterNodeId !== undefined) {
+            hops.push([String(repeaterNodeId), hopRssi]);
+          }
+          hopRssi = route.repeater_rssi[i];
+        });
+        hops.push([nodeId, hopRssi]);
+
+        let sourceNode = controllerId;
+        hops.forEach(([target, rssi]) => {
+          if (target === sourceNode) {
+            return;
+          }
+          const RSSI = typeof rssi === "number" && rssi <= 0 ? rssi : -100;
+          const existingLink = links.find(
+            (link) => link.source === sourceNode && link.target === target
+          );
+          const width = this._getLineWidth(RSSI);
+          if (existingLink) {
+            existingLink.value = Math.max(existingLink.value!, RSSI);
+            existingLink.lineStyle = {
+              ...existingLink.lineStyle,
+              width: Math.max(existingLink.lineStyle!.width!, width),
+              type:
+                route.protocol_data_rate > 1
+                  ? "solid"
+                  : existingLink.lineStyle!.type,
+            };
+          } else {
+            links.push({
+              source: sourceNode,
+              target,
+              value: RSSI,
+              lineStyle: {
+                width,
+                color:
+                  sourceNode === controllerId
+                    ? style.getPropertyValue("--primary-color")
+                    : style.getPropertyValue("--disabled-color"),
+                type: route.protocol_data_rate > 1 ? "solid" : "dotted",
+              },
+              symbolSize: width * 3,
+            });
+          }
+          sourceNode = target;
+        });
       });
 
       return { nodes, links, categories };

--- a/test/data/zwave_js.test.ts
+++ b/test/data/zwave_js.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { getNodeIdFromDevice } from "../../src/data/zwave_js";
+import type { DeviceRegistryEntry } from "../../src/data/device/device_registry";
+
+const mockDevice = (identifiers: [string, string][]) =>
+  ({ identifiers }) as DeviceRegistryEntry;
+
+describe("getNodeIdFromDevice", () => {
+  it("reads the node ID from the identifier", () => {
+    expect(
+      getNodeIdFromDevice(mockDevice([["zwave_js", "3245146787-25"]]))
+    ).toBe(25);
+  });
+
+  it("reads the node ID from the extended identifier", () => {
+    expect(
+      getNodeIdFromDevice(mockDevice([["zwave_js", "3245146787-25-798:5:20"]]))
+    ).toBe(25);
+  });
+
+  it("returns multi-digit node IDs in full", () => {
+    expect(
+      getNodeIdFromDevice(mockDevice([["zwave_js", "3245146787-108"]]))
+    ).toBe(108);
+  });
+
+  it("ignores provisioning entries, whose DSK blocks parse as numbers", () => {
+    expect(
+      getNodeIdFromDevice(
+        mockDevice([
+          [
+            "zwave_js",
+            "provision_50285-00042-09924-30691-15973-33711-04005-03623",
+          ],
+        ])
+      )
+    ).toBeUndefined();
+  });
+
+  it("ignores identifiers of other integrations", () => {
+    expect(
+      getNodeIdFromDevice(mockDevice([["mqtt", "3245146787-25"]]))
+    ).toBeUndefined();
+  });
+
+  it("picks the Z-Wave identifier when a device has several", () => {
+    expect(
+      getNodeIdFromDevice(
+        mockDevice([
+          ["matter", "some-other-id"],
+          ["zwave_js", "3245146787-14"],
+        ])
+      )
+    ).toBe(14);
+  });
+
+  it("returns undefined when there is no node ID", () => {
+    expect(getNodeIdFromDevice(mockDevice([]))).toBeUndefined();
+    expect(
+      getNodeIdFromDevice(mockDevice([["zwave_js", "3245146787"]]))
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Proposed change

Route statistics identify repeaters by device registry ID, and the graph mapped those back to node IDs with `Object.keys(...).find(...)?.[0]`, which takes the **first character** of the node ID — so any repeater above node 9 pointed at node 1 (the controller) or at a node that does not exist, whose links the renderer silently drops. The device-to-node map is now built from the device identifiers up front, and each route is walked controller → repeaters → node so the hops, their RSSI and the controller highlight land on the right edges.

## Screenshots

The same mocked Z-Wave network, rendered by the visualization page. Node IDs are 7, 12, 14, 25, 31, 108, 115 and 60, with routes `12 → 14 → 25` and `31 → 108 → 115`.

**Before** — every node is drawn straight to the adapter, and Shed Lock and Attic Sensor lose their edges entirely:

![Z-Wave visualization before the fix: eight devices arranged around the Z-Wave Adapter, each connected directly to it by a single edge, while Shed Lock and Attic Sensor sit with no connections at all.](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/zwave-before-fix-themed-c56bfaef.png)

**After** — the repeater chains appear, and every node with route data is connected:

![Z-Wave visualization after the fix: the Z-Wave Adapter connects to Hallway Switch, Kitchen Dimmer and Garage Door, which then chain onward through Living Room Plug to Bedroom Sensor and through Shed Lock to Mailbox Sensor. Only Attic Sensor, which has no route statistics, is unconnected.](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/zwave-after-fix-themed-d985c2a9.png)

<details>
<summary>The same before/after as an edge diagram</summary>

![Diagram of the computed Z-Wave graph edges. Before: seven nodes all drawn straight to the controller plus a controller self-loop, with nodes 42 and 108 pointing at non-existent nodes "3" and "4" so their edges are dropped. After: the controller fans out to 7, 12, 14, 31 and 108, with repeater chains 12 to 14 to 25 and 31 to 42 to 108 to 115, and node 60 correctly edgeless because it has no route statistics.](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/zwave-graph-before-after-1b3c5a09.png)

</details>

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes home-assistant/core#161100
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


