### PR TITLE
Show Z-Wave neighbor connections in the network visualization

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -526,14 +526,14 @@ export const fetchZwaveNetworkStatus = (
   });
 };
 
-/** Node IDs of the nodes the given node can reach directly. */
-export const fetchZwaveNodeNeighbors = (
+/** Node IDs of the nodes each node can reach directly, keyed by node ID. */
+export const fetchZwaveNetworkNeighbors = (
   hass: HomeAssistant,
-  device_id: string
-): Promise<number[]> =>
+  entry_id: string
+): Promise<Record<number, number[]>> =>
   hass.callWS({
-    type: "zwave_js/node_neighbors",
-    device_id,
+    type: "zwave_js/network_neighbors",
+    entry_id,
   });
 
 export const fetchZwaveDataCollectionStatus = (

--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -526,6 +526,16 @@ export const fetchZwaveNetworkStatus = (
   });
 };
 
+/** Node IDs of the nodes the given node can reach directly. */
+export const fetchZwaveNodeNeighbors = (
+  hass: HomeAssistant,
+  device_id: string
+): Promise<number[]> =>
+  hass.callWS({
+    type: "zwave_js/node_neighbors",
+    device_id,
+  });
+
 export const fetchZwaveDataCollectionStatus = (
   hass: HomeAssistant,
   entry_id: string

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
@@ -1,3 +1,4 @@
+import { mdiSpiderWeb } from "@mdi/js";
 import type {
   CallbackDataParams,
   TopLevelFormatterParams,
@@ -16,6 +17,7 @@ import type {
   NetworkLink,
   NetworkNode,
 } from "../../../../../components/chart/ha-network-graph";
+import "../../../../../components/ha-icon-button";
 import "../../../../../components/input/ha-input-search";
 import type { HaInputSearch } from "../../../../../components/input/ha-input-search";
 import type { DeviceRegistryEntry } from "../../../../../data/device/device_registry";
@@ -25,8 +27,8 @@ import type {
   ZWaveJSNodeStatus,
 } from "../../../../../data/zwave_js";
 import {
+  fetchZwaveNetworkNeighbors,
   fetchZwaveNetworkStatus,
-  fetchZwaveNodeNeighbors,
   getNodeIdFromDevice,
   NodeStatus,
   subscribeZwaveNodeStatistics,
@@ -34,6 +36,7 @@ import {
 import "../../../../../layouts/hass-subpage";
 import { SubscribeMixin } from "../../../../../mixins/subscribe-mixin";
 import type { HomeAssistant, Route } from "../../../../../types";
+import { showToast } from "../../../../../util/toast";
 
 @customElement("zwave_js-network-visualization")
 export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
@@ -56,7 +59,9 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
 
   @state() private _devices: Record<string, DeviceRegistryEntry> = {};
 
-  @state() private _neighbors: Record<number, number[]> = {};
+  @state() private _neighbors?: Record<number, number[]>;
+
+  @state() private _showNeighbors = false;
 
   @state() private _searchFilter = "";
 
@@ -64,6 +69,8 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
   private _nodeIdsByDeviceId: Record<string, number> = {};
 
   private _neighborLinks = new Set<string>();
+
+  private _loadingNeighbors = false;
 
   public hassSubscribe() {
     const subscriptions: Promise<UnsubscribeFunc>[] = [];
@@ -90,27 +97,34 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
 
     this._nodeIdsByDeviceId = nodeIdsByDeviceId;
     this._devices = devices;
-    this._fetchNeighbors(devices);
 
     return subscriptions;
   }
 
-  private async _fetchNeighbors(devices: Record<number, DeviceRegistryEntry>) {
-    const neighbors: Record<number, number[]> = {};
-    await Promise.all(
-      Object.entries(devices).map(async ([nodeId, device]) => {
-        try {
-          neighbors[nodeId] = await fetchZwaveNodeNeighbors(
-            this.hass!,
-            device.id
-          );
-        } catch (_err: unknown) {
-          // a node can fail to report neighbors, e.g. long range nodes
-          // which have no mesh neighbors at all
-        }
-      })
-    );
-    this._neighbors = neighbors;
+  private async _toggleNeighbors() {
+    this._showNeighbors = !this._showNeighbors;
+    if (!this._showNeighbors || this._neighbors || this._loadingNeighbors) {
+      return;
+    }
+    // fetched on demand: reading neighbors turns the radio off briefly
+    this._loadingNeighbors = true;
+    try {
+      this._neighbors = await fetchZwaveNetworkNeighbors(
+        this.hass,
+        this.configEntryId
+      );
+    } catch (err: unknown) {
+      this._showNeighbors = false;
+      showToast(this, {
+        message:
+          (err as { message?: string }).message ??
+          this.hass.localize(
+            "ui.panel.config.zwave_js.visualization.neighbors_error"
+          ),
+      });
+    } finally {
+      this._loadingNeighbors = false;
+    }
   }
 
   public connectedCallback() {
@@ -141,13 +155,22 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
           .data=${this._getNetworkData(
             this._nodeStatuses,
             this._nodeStatistics,
-            this._neighbors
+            this._showNeighbors ? this._neighbors : undefined
           )}
           .searchableAttributes=${this._getSearchableAttributes}
           .tooltipFormatter=${this._tooltipFormatter}
           @chart-click=${this._handleChartClick}
         >
           ${!this.narrow ? this._renderInputSearch("search") : nothing}
+          <ha-icon-button
+            slot="button"
+            class=${this._showNeighbors ? "active" : "inactive"}
+            .path=${mdiSpiderWeb}
+            .label=${this.hass.localize(
+              "ui.panel.config.zwave_js.visualization.toggle_neighbors"
+            )}
+            @click=${this._toggleNeighbors}
+          ></ha-icon-button>
         </ha-network-graph>
       </hass-subpage>
     `;
@@ -296,7 +319,7 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
     (
       nodeStatuses: Record<number, ZWaveJSNodeStatus>,
       nodeStatistics: Record<number, ZWaveJSNodeStatisticsUpdatedMessage>,
-      neighbors: Record<number, number[]>
+      neighbors: Record<number, number[]> | undefined
     ): NetworkData => {
       const style = getComputedStyle(this);
       const nodes: NetworkNode[] = [];
@@ -458,7 +481,7 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
       // the measured routes without overriding them.
       const neighborLinks: NetworkLink[] = [];
       const neighborKeys = new Set<string>();
-      Object.entries(neighbors).forEach(([nodeId, neighborIds]) => {
+      Object.entries(neighbors ?? {}).forEach(([nodeId, neighborIds]) => {
         neighborIds.forEach((neighborId) => {
           const target = String(neighborId);
           if (!nodeStatuses[neighborId] || target === nodeId) {
@@ -534,6 +557,17 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
         }
         ha-input-search {
           flex: 1;
+        }
+        /* ha-chart-base can't style re-slotted buttons, so mirror its look */
+        ha-icon-button[slot="button"] {
+          background: var(--card-background-color);
+          border-radius: var(--ha-border-radius-sm);
+          --ha-icon-button-size: 32px;
+          color: var(--primary-color);
+          border: 1px solid var(--divider-color);
+        }
+        ha-icon-button[slot="button"].inactive {
+          color: var(--state-inactive-color);
         }
       `,
     ];

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-network-visualization.ts
@@ -26,6 +26,7 @@ import type {
 } from "../../../../../data/zwave_js";
 import {
   fetchZwaveNetworkStatus,
+  fetchZwaveNodeNeighbors,
   getNodeIdFromDevice,
   NodeStatus,
   subscribeZwaveNodeStatistics,
@@ -55,10 +56,14 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
 
   @state() private _devices: Record<string, DeviceRegistryEntry> = {};
 
+  @state() private _neighbors: Record<number, number[]> = {};
+
   @state() private _searchFilter = "";
 
   // Route statistics reference repeaters by device registry ID
   private _nodeIdsByDeviceId: Record<string, number> = {};
+
+  private _neighborLinks = new Set<string>();
 
   public hassSubscribe() {
     const subscriptions: Promise<UnsubscribeFunc>[] = [];
@@ -85,8 +90,27 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
 
     this._nodeIdsByDeviceId = nodeIdsByDeviceId;
     this._devices = devices;
+    this._fetchNeighbors(devices);
 
     return subscriptions;
+  }
+
+  private async _fetchNeighbors(devices: Record<number, DeviceRegistryEntry>) {
+    const neighbors: Record<number, number[]> = {};
+    await Promise.all(
+      Object.entries(devices).map(async ([nodeId, device]) => {
+        try {
+          neighbors[nodeId] = await fetchZwaveNodeNeighbors(
+            this.hass!,
+            device.id
+          );
+        } catch (_err: unknown) {
+          // a node can fail to report neighbors, e.g. long range nodes
+          // which have no mesh neighbors at all
+        }
+      })
+    );
+    this._neighbors = neighbors;
   }
 
   public connectedCallback() {
@@ -116,7 +140,8 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
           .searchFilter=${this._searchFilter}
           .data=${this._getNetworkData(
             this._nodeStatuses,
-            this._nodeStatistics
+            this._nodeStatistics,
+            this._neighbors
           )}
           .searchableAttributes=${this._getSearchableAttributes}
           .tooltipFormatter=${this._tooltipFormatter}
@@ -184,6 +209,13 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
         sourceDevice?.name_by_user ?? sourceDevice?.name ?? source;
       const targetName =
         targetDevice?.name_by_user ?? targetDevice?.name ?? target;
+      if (this._neighborLinks.has(`${source}>${target}`)) {
+        return html`${sourceName} ↔ ${targetName}<br /><b
+            >${this.hass.localize(
+              "ui.panel.config.zwave_js.visualization.neighbor"
+            )}</b
+          >`;
+      }
       // links point away from the controller, so the route belongs to the target
       const stats =
         this._nodeStatistics[target] ?? this._nodeStatistics[source];
@@ -263,7 +295,8 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
   private _getNetworkData = memoizeOne(
     (
       nodeStatuses: Record<number, ZWaveJSNodeStatus>,
-      nodeStatistics: Record<number, ZWaveJSNodeStatisticsUpdatedMessage>
+      nodeStatistics: Record<number, ZWaveJSNodeStatisticsUpdatedMessage>,
+      neighbors: Record<number, number[]>
     ): NetworkData => {
       const style = getComputedStyle(this);
       const nodes: NetworkNode[] = [];
@@ -420,7 +453,49 @@ export class ZWaveJSNetworkVisualization extends SubscribeMixin(LitElement) {
         });
       });
 
-      return { nodes, links, categories };
+      // Neighbors are the nodes a node can reach directly. They are symmetric
+      // and carry no signal information, so they fill in the mesh underneath
+      // the measured routes without overriding them.
+      const neighborLinks: NetworkLink[] = [];
+      const neighborKeys = new Set<string>();
+      Object.entries(neighbors).forEach(([nodeId, neighborIds]) => {
+        neighborIds.forEach((neighborId) => {
+          const target = String(neighborId);
+          if (!nodeStatuses[neighborId] || target === nodeId) {
+            return;
+          }
+          const [a, b] = [nodeId, target].sort();
+          const key = `${a}>${b}`;
+          if (
+            neighborKeys.has(key) ||
+            links.some(
+              (link) =>
+                (link.source === nodeId && link.target === target) ||
+                (link.source === target && link.target === nodeId)
+            )
+          ) {
+            return;
+          }
+          neighborKeys.add(key);
+          neighborLinks.push({
+            source: a,
+            target: b,
+            // equal values in both directions render the link without an arrow
+            value: 1,
+            reverseValue: 1,
+            lineStyle: {
+              width: 1,
+              color: style.getPropertyValue("--disabled-color"),
+              type: "dashed",
+            },
+            // neighbors are plentiful, let the routes shape the layout
+            ignoreForceLayout: true,
+          });
+        });
+      });
+      this._neighborLinks = neighborKeys;
+
+      return { nodes, links: [...neighborLinks, ...links], categories };
     }
   );
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8321,7 +8321,8 @@
             "status": "Status",
             "version": "Version",
             "data_rate": "Data rate",
-            "area": "Area"
+            "area": "Area",
+            "neighbor": "In range of each other"
           },
           "node_status": {
             "0": "Unknown",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8322,7 +8322,9 @@
             "version": "Version",
             "data_rate": "Data rate",
             "area": "Area",
-            "neighbor": "In range of each other"
+            "neighbor": "In range of each other",
+            "toggle_neighbors": "Toggle neighbor connections",
+            "neighbors_error": "Failed to load neighbor connections"
           },
           "node_status": {
             "0": "Unknown",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8323,7 +8323,7 @@
             "data_rate": "Data rate",
             "area": "Area",
             "neighbor": "In range of each other",
-            "toggle_neighbors": "Toggle neighbor connections",
+            "toggle_neighbors": "Toggle neighbor connections. Loading neighbor data temporarily turns off the Z-Wave adapter.",
             "neighbors_error": "Failed to load neighbor connections"
           },
           "node_status": {


### PR DESCRIPTION
## Proposed change

The graph can only draw edges it can derive from `lwr`/`nlwr` route statistics, so it shows one path per node and nothing else — much sparser than the real mesh. Add a toggle (off by default, since neighbor data can clutter large graphs) that fetches the whole network's neighbors once via the new `zwave_js/network_neighbors` command — a single bulk call that reads the routing table safely with RF off — and draws the pairs no route already covers as faint dashed, arrow-free links beneath the routes.

Requires home-assistant/core#179363 for the WebSocket command. Stacked on #53676, which this targets as its base — GitHub will retarget it to `dev` when that merges.

## Screenshots

The same mocked network, rendered by the visualization page.

**Default** — routes only, neighbor toggle off:

![Z-Wave visualization with the neighbor toggle off: the Z-Wave Adapter connects to Hallway Switch, Kitchen Dimmer and Garage Door, chaining onward to Living Room Plug, Bedroom Sensor, Shed Lock and Mailbox Sensor, with Attic Sensor unconnected and the spider-web toggle button shown inactive.](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/zwave-neighbors-off-themed-abbc9b05.png)

**Neighbors toggled on** — the same routes, plus dashed links for in-range pairs no route already covers, which also brings the sleeping Attic Sensor into the mesh:

![Z-Wave visualization with the neighbor toggle active: the same solid route arrows, plus thin dashed undirected links joining Garage Door to Living Room Plug, Kitchen Dimmer to Hallway Switch and Bedroom Sensor, and Attic Sensor to Kitchen Dimmer.](https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/zwave-neighbors-on-themed-8465f31c.png)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: home-assistant/core#161100
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: home-assistant/core#179363

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr



