### PR TITLE
Group sankey devices by count as well as by value

### DIFF
--- a/src/panels/lovelace/cards/energy/common/sankey.ts
+++ b/src/panels/lovelace/cards/energy/common/sankey.ts
@@ -11,6 +11,11 @@ import type { HomeAssistant } from "../../../../../types";
 // Devices below this fraction of the home total are grouped into an "Other" node
 export const MIN_SANKEY_THRESHOLD_FACTOR = 0.001; // 0.1% of home total
 
+// Readable capacity of the default 400px card: ~18px per node including the
+// 6px nodeGap. Past this, bars collapse toward the 1px minimum and the labels
+// shrink with them.
+export const DEFAULT_MAX_SANKEY_DEVICES = 20;
+
 // While the graph is assembled, device nodes carry an ad-hoc `parent` field
 // that is not part of the chart's Node interface. The chart ignores it.
 export type SankeyDeviceNode = Node & { parent?: string };
@@ -44,6 +49,12 @@ export interface BuildSankeyDeviceNodesOptions {
   rootNodeId: string;
   /** Flows below this value are grouped into an "Other" node. */
   minThreshold: number;
+  /**
+   * Max named child nodes per parent. Once a parent has more rendered children
+   * than this, the smallest are grouped into that parent's "Other" node.
+   * Undefined means no cap.
+   */
+  maxDevices?: number;
   /** Per-parent untracked residual only shown when above this value. */
   untrackedFloor: number;
   /** Round the "Other" node value up (instantaneous cards only). */
@@ -76,6 +87,7 @@ export const buildSankeyDeviceNodes = (
     localize,
     rootNodeId,
     minThreshold,
+    maxDevices,
     untrackedFloor,
     ceilOtherValue,
     initialUntracked,
@@ -146,6 +158,95 @@ export const buildSankeyDeviceNodes = (
     return undefined;
   };
 
+  // The value threshold alone only catches devices that are a negligible share
+  // of the home total. A breaker panel with dozens of similar-sized circuit
+  // clamps sits entirely above it, so nothing groups and every node collapses to
+  // an unreadable sliver. Cap the child count too: drop the smallest children of
+  // an over-cap parent out of `renderedIds` and the passes below group them into
+  // that parent's "Other" node, leaving the flow arithmetic untouched.
+  if (
+    maxDevices !== undefined &&
+    Number.isFinite(maxDevices) &&
+    maxDevices > 0
+  ) {
+    const renderedChildren = new Map<
+      string,
+      { id: string; value: number; idx: number }[]
+    >();
+    const seenIds = new Set<string>();
+    devices.forEach((device, idx) => {
+      const id = getId(device);
+      // `seenIds` guards a config where two devices resolve to the same node id.
+      if (!id || !renderedIds.has(id) || seenIds.has(id)) {
+        return;
+      }
+      seenIds.add(id);
+      const parentKey =
+        findEffectiveParent(device.included_in_stat) ?? rootNodeId;
+      if (!renderedChildren.has(parentKey)) {
+        renderedChildren.set(parentKey, []);
+      }
+      renderedChildren.get(parentKey)!.push({
+        id,
+        value: deviceValues.get(id)!,
+        idx,
+      });
+    });
+
+    const demoted = new Set<string>();
+
+    // Taking the whole subtree keeps every surviving node's effective parent
+    // unchanged. Demoting a node alone would re-parent its children to the next
+    // rendered ancestor while the node's value - which already includes them -
+    // rolls into "Other", counting them twice.
+    const demoteSubtree = (id: string): void => {
+      if (demoted.has(id)) {
+        return;
+      }
+      demoted.add(id);
+      // `demoted` bounds the walk, so a cyclic included_in_stat cannot loop.
+      renderedChildren.get(id)?.forEach((child) => demoteSubtree(child.id));
+    };
+
+    // Top down, single pass: because demotion only ever removes children, no
+    // parent can be pushed over the cap by another parent's demotion.
+    const queue = [rootNodeId];
+    const visited = new Set(queue);
+    while (queue.length) {
+      const parentKey = queue.shift()!;
+      const children = renderedChildren.get(parentKey);
+      if (!children) {
+        continue;
+      }
+      let kept = children;
+      if (children.length > maxDevices) {
+        // Smallest first. Raw value includes children, so a parent never sorts
+        // below its own child; declaration order breaks ties so the layout is
+        // stable across renders.
+        const ranked = [...children].sort(
+          (a, b) => a.value - b.value || a.idx - b.idx
+        );
+        // Leave a slot for the "Other" node these demotions produce, so a parent
+        // that hits the cap ends up with exactly `maxDevices` nodes. It also
+        // guarantees at least two devices land in the bucket - a lone one is
+        // rendered by name below, which would make the cap a no-op.
+        const demoteCount = children.length - Math.max(maxDevices - 1, 0);
+        ranked
+          .slice(0, demoteCount)
+          .forEach((child) => demoteSubtree(child.id));
+        kept = children.filter((child) => !demoted.has(child.id));
+      }
+      kept.forEach((child) => {
+        if (!visited.has(child.id)) {
+          visited.add(child.id);
+          queue.push(child.id);
+        }
+      });
+    }
+
+    demoted.forEach((id) => renderedIds.delete(id));
+  }
+
   devices.forEach((device, idx) => {
     const id = getId(device);
     if (!id) {
@@ -154,8 +255,9 @@ export const buildSankeyDeviceNodes = (
     const value = deviceValues.get(id)!;
     const effectiveParent = findEffectiveParent(device.included_in_stat);
 
-    if (value < minThreshold) {
-      // Collect small consumers instead of folding them into untracked
+    if (!renderedIds.has(id)) {
+      // Below the value threshold or demoted by the count cap. Collect it
+      // instead of folding it into untracked.
       const parentKey = effectiveParent ?? rootNodeId;
       if (!smallConsumersByParent.has(parentKey)) {
         smallConsumersByParent.set(parentKey, []);

--- a/src/panels/lovelace/cards/energy/common/sankey.ts
+++ b/src/panels/lovelace/cards/energy/common/sankey.ts
@@ -41,6 +41,103 @@ export const fireSankeyNodeMoreInfo = (el: HTMLElement, node: Node): void => {
   }
 };
 
+export interface FindDevicesOverCapOptions {
+  devices: DeviceConsumptionEnergyPreference[];
+  /** Max named children per parent. Falsy or non-positive disables the cap. */
+  maxDevices: number | undefined;
+  rootNodeId: string;
+  renderedIds: ReadonlySet<string>;
+  deviceValues: ReadonlyMap<string, number>;
+  getId: (device: DeviceConsumptionEnergyPreference) => string | undefined;
+  /** First ancestor rendered as its own node, else undefined. */
+  getEffectiveParent: (
+    device: DeviceConsumptionEnergyPreference
+  ) => string | undefined;
+}
+
+/**
+ * Node ids to drop from the rendered set because their parent has more rendered
+ * children than `maxDevices`. Callers group the result into the parent's "Other"
+ * node, so the smallest devices merge instead of disappearing.
+ */
+export const findDevicesOverCap = ({
+  devices,
+  maxDevices,
+  rootNodeId,
+  renderedIds,
+  deviceValues,
+  getId,
+  getEffectiveParent,
+}: FindDevicesOverCapOptions): Set<string> => {
+  const grouped = new Set<string>();
+  if (!maxDevices || !Number.isFinite(maxDevices) || maxDevices <= 0) {
+    return grouped;
+  }
+
+  const childrenByParent = new Map<
+    string,
+    { id: string; value: number; idx: number }[]
+  >();
+  const seenIds = new Set<string>();
+  devices.forEach((device, idx) => {
+    const id = getId(device);
+    if (!id || !renderedIds.has(id) || seenIds.has(id)) {
+      return;
+    }
+    seenIds.add(id);
+    const parentKey = getEffectiveParent(device) ?? rootNodeId;
+    if (!childrenByParent.has(parentKey)) {
+      childrenByParent.set(parentKey, []);
+    }
+    childrenByParent.get(parentKey)!.push({
+      id,
+      value: deviceValues.get(id)!,
+      idx,
+    });
+  });
+
+  // Taking the whole subtree stops a grouped device's children from re-parenting
+  // upward while its value, which already includes them, rolls into "Other".
+  const groupSubtree = (id: string): void => {
+    if (grouped.has(id)) {
+      return;
+    }
+    grouped.add(id);
+    childrenByParent.get(id)?.forEach((child) => groupSubtree(child.id));
+  };
+
+  const queue = [rootNodeId];
+  const visited = new Set(queue);
+  while (queue.length) {
+    const children = childrenByParent.get(queue.shift()!);
+    if (!children) {
+      continue;
+    }
+    let kept = children;
+    if (children.length > maxDevices) {
+      // Raw value includes children, so a parent never sorts below its own
+      // child; declaration order breaks ties so the layout is stable.
+      const ranked = [...children].sort(
+        (a, b) => a.value - b.value || a.idx - b.idx
+      );
+      // At least two, because a lone grouped device is rendered by name instead
+      // and would void the cap.
+      ranked
+        .slice(0, Math.max(children.length - maxDevices, 2))
+        .forEach((child) => groupSubtree(child.id));
+      kept = children.filter((child) => !grouped.has(child.id));
+    }
+    kept.forEach((child) => {
+      if (!visited.has(child.id)) {
+        visited.add(child.id);
+        queue.push(child.id);
+      }
+    });
+  }
+
+  return grouped;
+};
+
 export interface BuildSankeyDeviceNodesOptions {
   devices: DeviceConsumptionEnergyPreference[];
   computedStyle: CSSStyleDeclaration;
@@ -158,94 +255,18 @@ export const buildSankeyDeviceNodes = (
     return undefined;
   };
 
-  // The value threshold alone only catches devices that are a negligible share
-  // of the home total. A breaker panel with dozens of similar-sized circuit
-  // clamps sits entirely above it, so nothing groups and every node collapses to
-  // an unreadable sliver. Cap the child count too: drop the smallest children of
-  // an over-cap parent out of `renderedIds` and the passes below group them into
-  // that parent's "Other" node, leaving the flow arithmetic untouched.
-  if (
-    maxDevices !== undefined &&
-    Number.isFinite(maxDevices) &&
-    maxDevices > 0
-  ) {
-    const renderedChildren = new Map<
-      string,
-      { id: string; value: number; idx: number }[]
-    >();
-    const seenIds = new Set<string>();
-    devices.forEach((device, idx) => {
-      const id = getId(device);
-      // `seenIds` guards a config where two devices resolve to the same node id.
-      if (!id || !renderedIds.has(id) || seenIds.has(id)) {
-        return;
-      }
-      seenIds.add(id);
-      const parentKey =
-        findEffectiveParent(device.included_in_stat) ?? rootNodeId;
-      if (!renderedChildren.has(parentKey)) {
-        renderedChildren.set(parentKey, []);
-      }
-      renderedChildren.get(parentKey)!.push({
-        id,
-        value: deviceValues.get(id)!,
-        idx,
-      });
-    });
-
-    const demoted = new Set<string>();
-
-    // Taking the whole subtree keeps every surviving node's effective parent
-    // unchanged. Demoting a node alone would re-parent its children to the next
-    // rendered ancestor while the node's value - which already includes them -
-    // rolls into "Other", counting them twice.
-    const demoteSubtree = (id: string): void => {
-      if (demoted.has(id)) {
-        return;
-      }
-      demoted.add(id);
-      // `demoted` bounds the walk, so a cyclic included_in_stat cannot loop.
-      renderedChildren.get(id)?.forEach((child) => demoteSubtree(child.id));
-    };
-
-    // Top down, single pass: because demotion only ever removes children, no
-    // parent can be pushed over the cap by another parent's demotion.
-    const queue = [rootNodeId];
-    const visited = new Set(queue);
-    while (queue.length) {
-      const parentKey = queue.shift()!;
-      const children = renderedChildren.get(parentKey);
-      if (!children) {
-        continue;
-      }
-      let kept = children;
-      if (children.length > maxDevices) {
-        // Smallest first. Raw value includes children, so a parent never sorts
-        // below its own child; declaration order breaks ties so the layout is
-        // stable across renders.
-        const ranked = [...children].sort(
-          (a, b) => a.value - b.value || a.idx - b.idx
-        );
-        // `maxDevices` budgets named devices, matching the option of the same
-        // name on the devices graph; the "Other" node is overhead on top, like
-        // the untracked residual. Demote at least two, because a lone device in
-        // the bucket is rendered by name below and would void the cap.
-        const demoteCount = Math.max(children.length - maxDevices, 2);
-        ranked
-          .slice(0, demoteCount)
-          .forEach((child) => demoteSubtree(child.id));
-        kept = children.filter((child) => !demoted.has(child.id));
-      }
-      kept.forEach((child) => {
-        if (!visited.has(child.id)) {
-          visited.add(child.id);
-          queue.push(child.id);
-        }
-      });
-    }
-
-    demoted.forEach((id) => renderedIds.delete(id));
-  }
+  // The value threshold only catches devices that are a negligible share of the
+  // home total, so a panel of dozens of similar-sized circuits never groups.
+  findDevicesOverCap({
+    devices,
+    maxDevices,
+    rootNodeId,
+    renderedIds,
+    deviceValues,
+    getId,
+    getEffectiveParent: (device) =>
+      findEffectiveParent(device.included_in_stat),
+  }).forEach((id) => renderedIds.delete(id));
 
   devices.forEach((device, idx) => {
     const id = getId(device);

--- a/src/panels/lovelace/cards/energy/common/sankey.ts
+++ b/src/panels/lovelace/cards/energy/common/sankey.ts
@@ -226,11 +226,11 @@ export const buildSankeyDeviceNodes = (
         const ranked = [...children].sort(
           (a, b) => a.value - b.value || a.idx - b.idx
         );
-        // Leave a slot for the "Other" node these demotions produce, so a parent
-        // that hits the cap ends up with exactly `maxDevices` nodes. It also
-        // guarantees at least two devices land in the bucket - a lone one is
-        // rendered by name below, which would make the cap a no-op.
-        const demoteCount = children.length - Math.max(maxDevices - 1, 0);
+        // `maxDevices` budgets named devices, matching the option of the same
+        // name on the devices graph; the "Other" node is overhead on top, like
+        // the untracked residual. Demote at least two, because a lone device in
+        // the bucket is rendered by name below and would void the cap.
+        const demoteCount = Math.max(children.length - maxDevices, 2);
         ranked
           .slice(0, demoteCount)
           .forEach((child) => demoteSubtree(child.id));

--- a/src/panels/lovelace/cards/energy/hui-energy-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sankey-card.ts
@@ -30,6 +30,7 @@ import { MobileAwareMixin } from "../../../../mixins/mobile-aware-mixin";
 import {
   buildSankeyDeviceNodes,
   buildSankeyLayout,
+  DEFAULT_MAX_SANKEY_DEVICES,
   fireSankeyNodeMoreInfo,
   MIN_SANKEY_THRESHOLD_FACTOR,
 } from "./common/sankey";
@@ -298,6 +299,7 @@ class HuiEnergySankeyCard
       localize: this.hass.localize,
       rootNodeId: "home",
       minThreshold: minEnergyThreshold,
+      maxDevices: this._config.max_devices ?? DEFAULT_MAX_SANKEY_DEVICES,
       untrackedFloor: 0,
       ceilOtherValue: false,
       initialUntracked: homeNode.value,

--- a/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-power-sankey-card.ts
@@ -23,6 +23,7 @@ import { MobileAwareMixin } from "../../../../mixins/mobile-aware-mixin";
 import {
   buildSankeyDeviceNodes,
   buildSankeyLayout,
+  DEFAULT_MAX_SANKEY_DEVICES,
   fireSankeyNodeMoreInfo,
   MIN_SANKEY_THRESHOLD_FACTOR,
 } from "./common/sankey";
@@ -297,6 +298,7 @@ class HuiPowerSankeyCard
       localize: this.hass.localize,
       rootNodeId: "home",
       minThreshold: minPowerThreshold,
+      maxDevices: this._config.max_devices ?? DEFAULT_MAX_SANKEY_DEVICES,
       untrackedFloor: 1,
       ceilOtherValue: true,
       initialUntracked: homeNode.value,

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -174,6 +174,7 @@ export interface EnergyCardSankeyConfig extends EnergyCardConfig {
   layout?: "auto" | "vertical" | "horizontal";
   group_by_floor?: boolean;
   group_by_area?: boolean;
+  max_devices?: number;
 }
 
 export interface EnergyDateSelectorCardConfig extends EnergyCardBaseConfig {

--- a/src/panels/lovelace/cards/water/hui-water-flow-sankey-card.ts
+++ b/src/panels/lovelace/cards/water/hui-water-flow-sankey-card.ts
@@ -22,6 +22,7 @@ import { MobileAwareMixin } from "../../../../mixins/mobile-aware-mixin";
 import {
   buildSankeyDeviceNodes,
   buildSankeyLayout,
+  DEFAULT_MAX_SANKEY_DEVICES,
   fireSankeyNodeMoreInfo,
   MIN_SANKEY_THRESHOLD_FACTOR,
 } from "../energy/common/sankey";
@@ -260,6 +261,7 @@ class HuiWaterFlowSankeyCard
       localize: this.hass.localize,
       rootNodeId,
       minThreshold: minFlowThreshold,
+      maxDevices: this._config.max_devices ?? DEFAULT_MAX_SANKEY_DEVICES,
       untrackedFloor: 1,
       ceilOtherValue: true,
       initialUntracked: effectiveTotalInflow,

--- a/src/panels/lovelace/cards/water/hui-water-sankey-card.ts
+++ b/src/panels/lovelace/cards/water/hui-water-sankey-card.ts
@@ -27,6 +27,7 @@ import { MobileAwareMixin } from "../../../../mixins/mobile-aware-mixin";
 import {
   buildSankeyDeviceNodes,
   buildSankeyLayout,
+  DEFAULT_MAX_SANKEY_DEVICES,
   fireSankeyNodeMoreInfo,
   MIN_SANKEY_THRESHOLD_FACTOR,
 } from "../energy/common/sankey";
@@ -241,6 +242,7 @@ class HuiWaterSankeyCard
       localize: this.hass.localize,
       rootNodeId: "home",
       minThreshold: minWaterThreshold,
+      maxDevices: this._config.max_devices ?? DEFAULT_MAX_SANKEY_DEVICES,
       untrackedFloor: 0,
       ceilOtherValue: false,
       initialUntracked: homeNode.value,

--- a/src/panels/lovelace/editor/config-elements/hui-energy-sankey-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-energy-sankey-card-editor.ts
@@ -5,6 +5,7 @@ import {
   assign,
   boolean,
   literal,
+  number,
   object,
   optional,
   string,
@@ -36,6 +37,7 @@ const cardConfigStruct = assign(
     ),
     group_by_floor: optional(boolean()),
     group_by_area: optional(boolean()),
+    max_devices: optional(number()),
   })
 );
 
@@ -93,6 +95,11 @@ export class HuiEnergySankeyCardEditor
             ],
           },
           {
+            name: "max_devices",
+            required: false,
+            selector: { number: { min: 1, mode: "box" } },
+          },
+          {
             type: "string",
             name: "collection_key",
             required: false,
@@ -134,6 +141,10 @@ export class HuiEnergySankeyCardEditor
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.generic.collection_key_description`
         );
+      case "max_devices":
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.energy-sankey.max_devices_description`
+        );
       default:
         return undefined;
     }
@@ -144,6 +155,7 @@ export class HuiEnergySankeyCardEditor
       case "layout":
       case "group_by_floor":
       case "group_by_area":
+      case "max_devices":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.energy-sankey.${schema.name}`
         );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9994,8 +9994,8 @@
               "description": "This card shows the distribution of energy in your home on a Sankey graph.",
               "group_by_floor": "Group by floor",
               "group_by_area": "Group by area",
-              "max_devices": "Maximum devices per group",
-              "max_devices_description": "Devices beyond this limit are grouped into an \"Other\" node, smallest first. Defaults to 20.",
+              "max_devices": "Maximum devices per parent",
+              "max_devices_description": "Devices beyond this limit are grouped into an \"Other\" node, smallest first. The limit applies per upstream device, not per floor or area. Defaults to 20.",
               "layout": "Graph direction",
               "layout_directions": {
                 "auto": "Automatic",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9994,6 +9994,8 @@
               "description": "This card shows the distribution of energy in your home on a Sankey graph.",
               "group_by_floor": "Group by floor",
               "group_by_area": "Group by area",
+              "max_devices": "Maximum devices per group",
+              "max_devices_description": "Devices beyond this limit are grouped into an \"Other\" node, smallest first. Defaults to 20.",
               "layout": "Graph direction",
               "layout_directions": {
                 "auto": "Automatic",

--- a/test/panels/lovelace/cards/energy/common/sankey.test.ts
+++ b/test/panels/lovelace/cards/energy/common/sankey.test.ts
@@ -479,7 +479,7 @@ describe("buildSankeyDeviceNodes", () => {
       );
     });
 
-    it("groups the smallest above the cap, leaving a slot for Other", () => {
+    it("groups the smallest above the cap, keeping the cap many by name", () => {
       const result = buildSankeyDeviceNodes(
         cumulativeOpts({
           devices: fiveDevices(),
@@ -488,10 +488,10 @@ describe("buildSankeyDeviceNodes", () => {
           initialUntracked: 150,
         })
       );
-      // cap - 1 named nodes plus Other = exactly the cap
-      expect(namedIds(result)).toEqual(["a", "b"]);
+      // the cap budgets named devices; Other is overhead on top
+      expect(namedIds(result)).toEqual(["a", "b", "c"]);
       const other = result.deviceNodes.find((n) => n.id === "other_home");
-      expect(other?.value).toBeCloseTo(60, 10);
+      expect(other?.value).toBeCloseTo(30, 10);
       expect(result.untrackedConsumption).toBeCloseTo(0, 10);
     });
 
@@ -536,12 +536,13 @@ describe("buildSankeyDeviceNodes", () => {
         "g",
         "b1",
         "b2",
+        "b3",
         "other_g",
         "untracked_g",
       ]);
-      // a's value already contains c, so Other is 10 + 20 + 8 and not 47
+      // a's value already contains c, so Other is 10 + 8 and not 27
       const other = result.deviceNodes.find((n) => n.id === "other_g");
-      expect(other?.value).toBeCloseTo(38, 10);
+      expect(other?.value).toBeCloseTo(18, 10);
       expect(result.deviceNodes.some((n) => n.id === "c")).toBe(false);
       const untracked = result.deviceNodes.find((n) => n.id === "untracked_g");
       expect(untracked?.value).toBeCloseTo(7, 10);
@@ -606,9 +607,9 @@ describe("buildSankeyDeviceNodes", () => {
         })
       );
       // p is over the cap; the three root-level nodes are exactly at it
-      expect(namedIds(result)).toEqual(["p", "c1", "c2", "r1", "r2"]);
+      expect(namedIds(result)).toEqual(["p", "c1", "c2", "c3", "r1", "r2"]);
       const other = result.deviceNodes.find((n) => n.id === "other_p");
-      expect(other?.value).toBeCloseTo(45, 10);
+      expect(other?.value).toBeCloseTo(25, 10);
       expect(result.parentLinks.other_p).toBe("p");
       expect(result.links).toContainEqual({ source: "p", target: "other_p" });
       expect(result.deviceNodes.some((n) => n.id === "other_home")).toBe(false);
@@ -710,7 +711,7 @@ describe("buildSankeyDeviceNodes", () => {
         })
       );
       const other = result.deviceNodes.find((n) => n.id === "other_home");
-      expect(other?.value).toBe(61);
+      expect(other?.value).toBe(31);
       expect(result.untrackedConsumption).toBeCloseTo(0, 10);
     });
 
@@ -722,9 +723,45 @@ describe("buildSankeyDeviceNodes", () => {
           maxDevices: 3,
           initialUntracked: 120,
         });
-      expect(namedIds(buildSankeyDeviceNodes(opts()))).toEqual(["a", "d"]);
-      expect(namedIds(buildSankeyDeviceNodes(opts()))).toEqual(["a", "d"]);
+      expect(namedIds(buildSankeyDeviceNodes(opts()))).toEqual(["a", "c", "d"]);
+      expect(namedIds(buildSankeyDeviceNodes(opts()))).toEqual(["a", "c", "d"]);
     });
+
+    // The documented promise is "more than 20 devices start grouping", so pin
+    // the boundary against the real default rather than a test-local cap.
+    it.each([
+      [DEFAULT_MAX_SANKEY_DEVICES, DEFAULT_MAX_SANKEY_DEVICES, false],
+      // one over the cap still demotes two, because a lone demoted device would
+      // be rendered by name and void the cap
+      [DEFAULT_MAX_SANKEY_DEVICES + 1, DEFAULT_MAX_SANKEY_DEVICES - 1, true],
+      [DEFAULT_MAX_SANKEY_DEVICES + 2, DEFAULT_MAX_SANKEY_DEVICES, true],
+      [DEFAULT_MAX_SANKEY_DEVICES + 12, DEFAULT_MAX_SANKEY_DEVICES, true],
+    ])(
+      "with %i devices at the default cap renders %i named nodes (grouped: %s)",
+      (deviceCount, expectedNamed, expectOther) => {
+        const list = Array.from({ length: deviceCount }, (_, i) => ({
+          stat_consumption: `d${i}`,
+        }));
+        const values = Object.fromEntries(
+          list.map((d, i) => [d.stat_consumption, 10 + i])
+        );
+        const total = Object.values(values).reduce((s, v) => s + v, 0);
+        const result = buildSankeyDeviceNodes(
+          cumulativeOpts({
+            devices: list,
+            values,
+            maxDevices: DEFAULT_MAX_SANKEY_DEVICES,
+            initialUntracked: total,
+          })
+        );
+        expect(namedIds(result)).toHaveLength(expectedNamed);
+        expect(result.deviceNodes.some((n) => n.id === "other_home")).toBe(
+          expectOther
+        );
+        // grouping never changes the total that comes off the root
+        expect(result.untrackedConsumption).toBeCloseTo(0, 10);
+      }
+    );
 
     it("keeps 32 circuit clamps readable at the default cap", () => {
       const clamps = Array.from({ length: 32 }, (_, i) => ({
@@ -741,11 +778,11 @@ describe("buildSankeyDeviceNodes", () => {
           initialUntracked: 1200,
         })
       );
-      expect(namedIds(result)).toHaveLength(DEFAULT_MAX_SANKEY_DEVICES - 1);
-      expect(result.deviceNodes).toHaveLength(DEFAULT_MAX_SANKEY_DEVICES);
-      // the 13 smallest clamps, values 20 through 32
+      expect(namedIds(result)).toHaveLength(DEFAULT_MAX_SANKEY_DEVICES);
+      expect(result.deviceNodes).toHaveLength(DEFAULT_MAX_SANKEY_DEVICES + 1);
+      // the 12 smallest clamps, values 20 through 31
       const other = result.deviceNodes.find((n) => n.id === "other_home");
-      expect(other?.value).toBeCloseTo(338, 10);
+      expect(other?.value).toBeCloseTo(306, 10);
 
       // flow conservation: every device node plus untracked accounts for home
       const { nodes } = buildSankeyLayout({

--- a/test/panels/lovelace/cards/energy/common/sankey.test.ts
+++ b/test/panels/lovelace/cards/energy/common/sankey.test.ts
@@ -7,6 +7,7 @@ import {
   buildSankeyDeviceNodes,
   buildSankeyLayout,
   DEFAULT_MAX_SANKEY_DEVICES,
+  findDevicesOverCap,
   getSankeyDeviceSections,
   groupSankeyDevicesByFloorAndArea,
 } from "../../../../../../src/panels/lovelace/cards/energy/common/sankey";
@@ -79,6 +80,86 @@ describe("getSankeyDeviceSections", () => {
       [grandparent, parent, child]
     );
     expect(sections).toEqual([[grandparent], [parent], [child]]);
+  });
+});
+
+describe("findDevicesOverCap", () => {
+  // Values keyed by node id, hierarchy by included_in_stat.
+  const overCapOpts = (
+    values: Record<string, number>,
+    parents: Record<string, string>,
+    // No default: passing `undefined` must mean "no cap", not "fall back to 3".
+    maxDevices: number | undefined,
+    rendered = Object.keys(values)
+  ) => {
+    const list: DeviceConsumptionEnergyPreference[] = Object.keys(values).map(
+      (id) => ({ stat_consumption: id, included_in_stat: parents[id] })
+    );
+    const renderedIds = new Set(rendered);
+    return {
+      devices: list,
+      maxDevices,
+      rootNodeId: "home",
+      renderedIds,
+      deviceValues: new Map(Object.entries(values)),
+      getId: (device: DeviceConsumptionEnergyPreference) =>
+        device.stat_consumption,
+      getEffectiveParent: (device: DeviceConsumptionEnergyPreference) => {
+        let current = device.included_in_stat;
+        for (let hops = 0; current && hops < list.length; hops++) {
+          if (renderedIds.has(current)) {
+            return current;
+          }
+          current = parents[current];
+        }
+        return undefined;
+      },
+    };
+  };
+
+  it.each([undefined, 0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "groups nothing for a cap of %s",
+    (maxDevices) => {
+      expect(
+        findDevicesOverCap(
+          overCapOpts({ a: 5, b: 4, c: 3, d: 2 }, {}, maxDevices)
+        )
+      ).toEqual(new Set());
+    }
+  );
+
+  it("groups the smallest children of an over-cap parent", () => {
+    expect(
+      findDevicesOverCap(overCapOpts({ a: 5, b: 4, c: 3, d: 2, e: 1 }, {}, 3))
+    ).toEqual(new Set(["d", "e"]));
+  });
+
+  it("groups a whole subtree, not just the parent", () => {
+    expect(
+      findDevicesOverCap(
+        overCapOpts(
+          { a: 50, b: 40, c: 30, small: 10, child: 9 },
+          { child: "small" },
+          3
+        )
+      )
+    ).toEqual(new Set(["small", "child", "c"]));
+  });
+
+  it("counts only rendered devices", () => {
+    // four devices, three rendered, so a cap of three does not fire
+    expect(
+      findDevicesOverCap(
+        overCapOpts({ a: 5, b: 4, c: 3, tiny: 0.001 }, {}, 3, ["a", "b", "c"])
+      )
+    ).toEqual(new Set());
+  });
+
+  it("terminates on a cyclic parent chain", () => {
+    // both devices parent each other, so neither is reachable from the root
+    expect(
+      findDevicesOverCap(overCapOpts({ a: 5, b: 4 }, { a: "b", b: "a" }, 1))
+    ).toEqual(new Set());
   });
 });
 

--- a/test/panels/lovelace/cards/energy/common/sankey.test.ts
+++ b/test/panels/lovelace/cards/energy/common/sankey.test.ts
@@ -6,6 +6,7 @@ import type {
 import {
   buildSankeyDeviceNodes,
   buildSankeyLayout,
+  DEFAULT_MAX_SANKEY_DEVICES,
   getSankeyDeviceSections,
   groupSankeyDevicesByFloorAndArea,
 } from "../../../../../../src/panels/lovelace/cards/energy/common/sankey";
@@ -422,6 +423,348 @@ describe("buildSankeyDeviceNodes", () => {
     );
     expect(result.deviceNodes).toEqual([]);
     expect(result.untrackedConsumption).toBe(10);
+  });
+
+  describe("device count cap", () => {
+    // Five devices all comfortably above minThreshold, so only the count cap
+    // can group any of them.
+    const fiveDevices = () =>
+      devices(
+        { stat_consumption: "a" },
+        { stat_consumption: "b" },
+        { stat_consumption: "c" },
+        { stat_consumption: "d" },
+        { stat_consumption: "e" }
+      );
+    const fiveValues = { a: 50, b: 40, c: 30, d: 20, e: 10 };
+
+    const namedIds = (result: { deviceNodes: SankeyDeviceNode[] }) =>
+      result.deviceNodes
+        .filter(
+          (n) => !n.id.startsWith("other_") && !n.id.startsWith("untracked_")
+        )
+        .map((n) => n.id);
+
+    it("does not group anything when maxDevices is unset", () => {
+      const result = buildSankeyDeviceNodes(
+        cumulativeOpts({
+          devices: fiveDevices(),
+          values: fiveValues,
+          initialUntracked: 150,
+        })
+      );
+      expect(namedIds(result)).toEqual(["a", "b", "c", "d", "e"]);
+      expect(result.deviceNodes.some((n) => n.id.startsWith("other_"))).toBe(
+        false
+      );
+      expect(result.untrackedConsumption).toBeCloseTo(0, 10);
+    });
+
+    it("does nothing at exactly the cap", () => {
+      const result = buildSankeyDeviceNodes(
+        cumulativeOpts({
+          devices: devices(
+            { stat_consumption: "a" },
+            { stat_consumption: "b" },
+            { stat_consumption: "c" }
+          ),
+          values: { a: 50, b: 40, c: 30 },
+          maxDevices: 3,
+          initialUntracked: 120,
+        })
+      );
+      expect(namedIds(result)).toEqual(["a", "b", "c"]);
+      expect(result.deviceNodes.some((n) => n.id.startsWith("other_"))).toBe(
+        false
+      );
+    });
+
+    it("groups the smallest above the cap, leaving a slot for Other", () => {
+      const result = buildSankeyDeviceNodes(
+        cumulativeOpts({
+          devices: fiveDevices(),
+          values: fiveValues,
+          maxDevices: 3,
+          initialUntracked: 150,
+        })
+      );
+      // cap - 1 named nodes plus Other = exactly the cap
+      expect(namedIds(result)).toEqual(["a", "b"]);
+      const other = result.deviceNodes.find((n) => n.id === "other_home");
+      expect(other?.value).toBeCloseTo(60, 10);
+      expect(result.untrackedConsumption).toBeCloseTo(0, 10);
+    });
+
+    it("never demotes exactly one device, which would render it by name", () => {
+      const result = buildSankeyDeviceNodes(
+        cumulativeOpts({
+          devices: devices(
+            { stat_consumption: "a" },
+            { stat_consumption: "b" },
+            { stat_consumption: "c" },
+            { stat_consumption: "d" }
+          ),
+          values: { a: 40, b: 30, c: 20, d: 10 },
+          maxDevices: 3,
+          initialUntracked: 100,
+        })
+      );
+      expect(namedIds(result)).toEqual(["a", "b"]);
+      const other = result.deviceNodes.find((n) => n.id === "other_home");
+      expect(other?.value).toBeCloseTo(30, 10);
+      expect(result.untrackedConsumption).toBeCloseTo(0, 10);
+    });
+
+    it("demotes a whole subtree so children never re-parent or double count", () => {
+      const result = buildSankeyDeviceNodes(
+        cumulativeOpts({
+          devices: devices(
+            { stat_consumption: "g" },
+            { stat_consumption: "a", included_in_stat: "g" },
+            { stat_consumption: "c", included_in_stat: "a" },
+            { stat_consumption: "b1", included_in_stat: "g" },
+            { stat_consumption: "b2", included_in_stat: "g" },
+            { stat_consumption: "b3", included_in_stat: "g" },
+            { stat_consumption: "b4", included_in_stat: "g" }
+          ),
+          values: { g: 100, a: 10, c: 9, b1: 30, b2: 25, b3: 20, b4: 8 },
+          maxDevices: 3,
+          initialUntracked: 100,
+        })
+      );
+      expect(result.deviceNodes.map((n) => n.id)).toEqual([
+        "g",
+        "b1",
+        "b2",
+        "other_g",
+        "untracked_g",
+      ]);
+      // a's value already contains c, so Other is 10 + 20 + 8 and not 47
+      const other = result.deviceNodes.find((n) => n.id === "other_g");
+      expect(other?.value).toBeCloseTo(38, 10);
+      expect(result.deviceNodes.some((n) => n.id === "c")).toBe(false);
+      const untracked = result.deviceNodes.find((n) => n.id === "untracked_g");
+      expect(untracked?.value).toBeCloseTo(7, 10);
+      expect(result.untrackedConsumption).toBeCloseTo(0, 10);
+    });
+
+    it("ranks by raw value, so a parent is never demoted before its own child", () => {
+      const result = buildSankeyDeviceNodes(
+        cumulativeOpts({
+          devices: devices(
+            { stat_consumption: "d" },
+            { stat_consumption: "e", included_in_stat: "d" },
+            { stat_consumption: "f" },
+            { stat_consumption: "h" },
+            { stat_consumption: "i" }
+          ),
+          values: { d: 50, e: 45, f: 10, h: 40, i: 30 },
+          maxDevices: 3,
+          initialUntracked: 130,
+        })
+      );
+      // Ranking on value-excluding-children would demote d (50 - 45 = 5) while
+      // keeping e, counting e both on its own and inside d's rolled-up value.
+      expect(result.deviceNodes.map((n) => n.id)).toEqual([
+        "d",
+        "e",
+        "h",
+        "other_home",
+        "untracked_d",
+      ]);
+      expect(result.parentLinks.e).toBe("d");
+      const other = result.deviceNodes.find((n) => n.id === "other_home");
+      expect(other?.value).toBeCloseTo(40, 10);
+      expect(result.untrackedConsumption).toBeCloseTo(0, 10);
+    });
+
+    it("applies the cap per parent and links Other to that parent", () => {
+      const result = buildSankeyDeviceNodes(
+        cumulativeOpts({
+          devices: devices(
+            { stat_consumption: "p" },
+            { stat_consumption: "c1", included_in_stat: "p" },
+            { stat_consumption: "c2", included_in_stat: "p" },
+            { stat_consumption: "c3", included_in_stat: "p" },
+            { stat_consumption: "c4", included_in_stat: "p" },
+            { stat_consumption: "c5", included_in_stat: "p" },
+            { stat_consumption: "r1" },
+            { stat_consumption: "r2" }
+          ),
+          values: {
+            p: 100,
+            c1: 30,
+            c2: 25,
+            c3: 20,
+            c4: 15,
+            c5: 10,
+            r1: 50,
+            r2: 40,
+          },
+          maxDevices: 3,
+          initialUntracked: 190,
+        })
+      );
+      // p is over the cap; the three root-level nodes are exactly at it
+      expect(namedIds(result)).toEqual(["p", "c1", "c2", "r1", "r2"]);
+      const other = result.deviceNodes.find((n) => n.id === "other_p");
+      expect(other?.value).toBeCloseTo(45, 10);
+      expect(result.parentLinks.other_p).toBe("p");
+      expect(result.links).toContainEqual({ source: "p", target: "other_p" });
+      expect(result.deviceNodes.some((n) => n.id === "other_home")).toBe(false);
+      expect(result.untrackedConsumption).toBeCloseTo(0, 10);
+    });
+
+    it("counts only rendered children, not ones already below the threshold", () => {
+      const result = buildSankeyDeviceNodes(
+        cumulativeOpts({
+          devices: devices(
+            { stat_consumption: "p" },
+            { stat_consumption: "c1", included_in_stat: "p" },
+            { stat_consumption: "c2", included_in_stat: "p" },
+            { stat_consumption: "c3", included_in_stat: "p" },
+            { stat_consumption: "s1", included_in_stat: "p" },
+            { stat_consumption: "s2", included_in_stat: "p" },
+            { stat_consumption: "s3", included_in_stat: "p" }
+          ),
+          values: {
+            p: 100,
+            c1: 30,
+            c2: 25,
+            c3: 20,
+            s1: 0.001,
+            s2: 0.002,
+            s3: 0.003,
+          },
+          maxDevices: 3,
+          initialUntracked: 100,
+        })
+      );
+      // three rendered children is at the cap, so no demotion happens
+      expect(namedIds(result)).toEqual(["p", "c1", "c2", "c3"]);
+      const other = result.deviceNodes.find((n) => n.id === "other_p");
+      expect(other?.value).toBeCloseTo(0.006, 10);
+    });
+
+    it("terminates on a cyclic included_in_stat and leaves it unchanged", () => {
+      const cyclic = () =>
+        cumulativeOpts({
+          devices: devices(
+            { stat_consumption: "a", included_in_stat: "b" },
+            { stat_consumption: "b", included_in_stat: "a" }
+          ),
+          values: { a: 5, b: 4 },
+          initialUntracked: 10,
+        });
+      // A cycle member always has a rendered parent inside the cycle, so it is
+      // never reachable from the root and the cap cannot touch it.
+      expect(
+        buildSankeyDeviceNodes({ ...cyclic(), maxDevices: 1 })
+      ).toStrictEqual(buildSankeyDeviceNodes(cyclic()));
+    });
+
+    it("treats a zero or non-finite cap as no cap", () => {
+      [0, Number.NaN, Number.POSITIVE_INFINITY].forEach((maxDevices) => {
+        const result = buildSankeyDeviceNodes(
+          cumulativeOpts({
+            devices: fiveDevices(),
+            values: fiveValues,
+            maxDevices,
+            initialUntracked: 150,
+          })
+        );
+        expect(namedIds(result)).toEqual(["a", "b", "c", "d", "e"]);
+      });
+    });
+
+    it("does not count devices without a node id (instantaneous cards)", () => {
+      const result = buildSankeyDeviceNodes(
+        cumulativeOpts({
+          devices: devices(
+            { stat_consumption: "a", stat_rate: "ra" },
+            { stat_consumption: "b", stat_rate: "rb" },
+            { stat_consumption: "c", stat_rate: "rc" },
+            { stat_consumption: "d" }
+          ),
+          values: { ra: 30, rb: 25, rc: 20 },
+          getId: (device) => device.stat_rate,
+          maxDevices: 3,
+          initialUntracked: 75,
+        })
+      );
+      // d has no stat_rate, so the three rendered nodes are at the cap
+      expect(namedIds(result)).toEqual(["ra", "rb", "rc"]);
+      expect(result.deviceNodes.some((n) => n.id.startsWith("other_"))).toBe(
+        false
+      );
+    });
+
+    it("ceils the capped Other value but still subtracts the raw total", () => {
+      const result = buildSankeyDeviceNodes(
+        cumulativeOpts({
+          devices: fiveDevices(),
+          values: { ...fiveValues, e: 10.5 },
+          maxDevices: 3,
+          ceilOtherValue: true,
+          initialUntracked: 150.5,
+        })
+      );
+      const other = result.deviceNodes.find((n) => n.id === "other_home");
+      expect(other?.value).toBe(61);
+      expect(result.untrackedConsumption).toBeCloseTo(0, 10);
+    });
+
+    it("breaks value ties on declaration order, stably across runs", () => {
+      const opts = () =>
+        cumulativeOpts({
+          devices: fiveDevices(),
+          values: { a: 50, b: 20, c: 20, d: 20, e: 10 },
+          maxDevices: 3,
+          initialUntracked: 120,
+        });
+      expect(namedIds(buildSankeyDeviceNodes(opts()))).toEqual(["a", "d"]);
+      expect(namedIds(buildSankeyDeviceNodes(opts()))).toEqual(["a", "d"]);
+    });
+
+    it("keeps 32 circuit clamps readable at the default cap", () => {
+      const clamps = Array.from({ length: 32 }, (_, i) => ({
+        stat_consumption: `clamp_${i}`,
+      }));
+      const values = Object.fromEntries(
+        clamps.map((clamp, i) => [clamp.stat_consumption, 20 + i])
+      );
+      const result = buildSankeyDeviceNodes(
+        cumulativeOpts({
+          devices: clamps,
+          values,
+          maxDevices: DEFAULT_MAX_SANKEY_DEVICES,
+          initialUntracked: 1200,
+        })
+      );
+      expect(namedIds(result)).toHaveLength(DEFAULT_MAX_SANKEY_DEVICES - 1);
+      expect(result.deviceNodes).toHaveLength(DEFAULT_MAX_SANKEY_DEVICES);
+      // the 13 smallest clamps, values 20 through 32
+      const other = result.deviceNodes.find((n) => n.id === "other_home");
+      expect(other?.value).toBeCloseTo(338, 10);
+
+      // flow conservation: every device node plus untracked accounts for home
+      const { nodes } = buildSankeyLayout({
+        hass: createMockHass(),
+        computedStyle,
+        localize: mockLocalize,
+        deviceNodes: result.deviceNodes,
+        parentLinks: result.parentLinks,
+        rootNodeId: "home",
+        groupByFloor: false,
+        groupByArea: false,
+        untrackedConsumption: result.untrackedConsumption,
+        untrackedFloor: 0,
+      });
+      const deviceTotal = nodes
+        .filter((n) => n.index === 4)
+        .reduce((sum, n) => sum + n.value, 0);
+      expect(deviceTotal).toBeCloseTo(1200, 10);
+    });
   });
 });
 


### PR DESCRIPTION
## Proposed change

The sankey cards' small-consumer grouping uses a value threshold (0.1% of the home total), which only catches devices that are a negligible share of consumption. A breaker panel with dozens of similar-sized circuit clamps sits entirely above it, so nothing groups and every node collapses toward the 1px minimum with labels shrinking to match.

This adds a count dimension: a parent shows at most `max_devices` devices by name (default 20, the readable capacity of the default 400px card), and its smallest children are grouped into the same per-parent "Other" node the value threshold already produces. Unlike `max_devices` on the energy devices graph, this aggregates rather than truncates, so the flow arithmetic is unchanged.

## Screenshots

32 circuit clamps, energy sankey card. Home total, device-layer sum and untracked consumption are numerically identical in both (8.1910 / 8.1910 / 4.5153).

| Before | After |
|--------|-------|
| <img src="https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/sankey-before-32-circuits-0fa65606.png" width="440"> | <img src="https://github.com/MindFreeze/gitshot-images/releases/download/_gitshot/sankey-after-capped-at-20-c3f03bd6.png" width="440"> |

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/orgs/home-assistant/discussions/2283#discussioncomment-18044167
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47457
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

