### PR TITLE
Skip entities assigned to another area when resolving area targets

### DIFF
--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -1135,6 +1135,10 @@ export const resolveEntityIDs = (
     expanded.areas.forEach((id) => targetAreas.add(id));
   });
 
+  // Devices only reached through an area do not pull in entities that are
+  // explicitly assigned to another area, matching core.
+  const devicesNotViaArea = new Set(targetDevices);
+
   targetAreas.forEach((areaId) => {
     const expanded = expandAreaTarget(
       hass,
@@ -1153,6 +1157,7 @@ export const resolveEntityIDs = (
   Object.values(devices).forEach((device) => {
     if (device.parent_device_id && directDevices.has(device.parent_device_id)) {
       targetDevices.add(device.id);
+      devicesNotViaArea.add(device.id);
     }
   });
 
@@ -1163,7 +1168,11 @@ export const resolveEntityIDs = (
       entities,
       targetSelector
     );
-    expanded.entities.forEach((id) => targetEntities.add(id));
+    expanded.entities.forEach((id) => {
+      if (devicesNotViaArea.has(deviceId) || !entities[id]?.area_id) {
+        targetEntities.add(id);
+      }
+    });
   });
 
   return Array.from(targetEntities);

--- a/test/data/selector.test.ts
+++ b/test/data/selector.test.ts
@@ -1,7 +1,10 @@
 import type { HassEntity } from "home-assistant-js-websocket";
 import { describe, expect, it } from "vitest";
 import type { DeviceRegistryEntry } from "../../src/data/device/device_registry";
-import { filterSelectorEntities } from "../../src/data/selector";
+import {
+  filterSelectorEntities,
+  resolveEntityIDs,
+} from "../../src/data/selector";
 import type { HomeAssistant } from "../../src/types";
 
 const entity = {
@@ -130,5 +133,64 @@ describe("filterSelectorEntities device filter", () => {
         devices
       )
     ).toBe(false);
+  });
+});
+
+describe("resolveEntityIDs", () => {
+  const areaHass = {
+    states: {
+      "light.kitchen": { entity_id: "light.kitchen", state: "on" },
+      "sensor.kitchen_hub_temp": {
+        entity_id: "sensor.kitchen_hub_temp",
+        state: "20",
+      },
+      "sensor.hallway_probe": { entity_id: "sensor.hallway_probe", state: "5" },
+    },
+    entities: {
+      "light.kitchen": { entity_id: "light.kitchen", device_id: "hub" },
+      "sensor.kitchen_hub_temp": {
+        entity_id: "sensor.kitchen_hub_temp",
+        device_id: "hub",
+      },
+      "sensor.hallway_probe": {
+        entity_id: "sensor.hallway_probe",
+        device_id: "hub",
+        area_id: "hallway",
+      },
+    },
+    devices: { hub: { id: "hub", area_id: "kitchen" } },
+    areas: { kitchen: { area_id: "kitchen" }, hallway: { area_id: "hallway" } },
+  } as unknown as HomeAssistant;
+
+  const resolve = (target) =>
+    resolveEntityIDs(
+      areaHass,
+      target,
+      areaHass.entities,
+      areaHass.devices,
+      areaHass.areas
+    ).sort();
+
+  it("skips entities of an area device that are assigned to another area", () => {
+    expect(resolve({ area_id: "kitchen" })).toEqual([
+      "light.kitchen",
+      "sensor.kitchen_hub_temp",
+    ]);
+  });
+
+  it("keeps every entity of a directly targeted device", () => {
+    expect(resolve({ device_id: "hub" })).toEqual([
+      "light.kitchen",
+      "sensor.hallway_probe",
+      "sensor.kitchen_hub_temp",
+    ]);
+  });
+
+  it("keeps the entity when its own area is targeted as well", () => {
+    expect(resolve({ area_id: ["kitchen", "hallway"] })).toEqual([
+      "light.kitchen",
+      "sensor.hallway_probe",
+      "sensor.kitchen_hub_temp",
+    ]);
   });
 });


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When an area is targeted, `resolveEntityIDs` expanded every entity of the devices in that area, including entities explicitly assigned to another area. Core skips those (`async_extract_referenced_entity_ids`), so the frontend resolved more entities than the backend for the same target, which shows up in History, Activity, the logbook card, the state selector and the service control. Devices that are targeted directly, through a label, or as a child of a targeted device still bring all their entities, like in core.

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
