### PR TITLE
Ignore stale History statistics fetches after the selection changes

### DIFF
--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -125,7 +125,6 @@ class HaPanelHistory extends LitElement {
 
   private _fetchedEntityIds?: string[];
 
-  // Bumped on every stats request so an older fetch cannot overwrite a newer one.
   private _statsFetchId = 0;
 
   private _interval?: number;

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -125,6 +125,9 @@ class HaPanelHistory extends LitElement {
 
   private _fetchedEntityIds?: string[];
 
+  // Bumped on every stats request so an older fetch cannot overwrite a newer one.
+  private _statsFetchId = 0;
+
   private _interval?: number;
 
   public constructor() {
@@ -413,6 +416,7 @@ class HaPanelHistory extends LitElement {
   private async _getStats() {
     const statisticIds = this._getEntityIds();
     this._fetchedEntityIds = statisticIds;
+    const fetchId = ++this._statsFetchId;
 
     if (statisticIds.length === 0) {
       this._statisticsHistory = undefined;
@@ -436,6 +440,10 @@ class HaPanelHistory extends LitElement {
         ["mean", "state"]
       );
     } catch (_err) {
+      return;
+    }
+
+    if (fetchId !== this._statsFetchId) {
       return;
     }
 


### PR DESCRIPTION
## Proposed change

Stacked on #53630. `_getStats()` did not ignore in-flight `fetchStatistics` responses, so a slower request for a previous sources selection or date range could finish last and replace the charts the user is looking at. Domain, device class, and integration filters make that race easier to hit.

Each stats request now increments a fetch id, including the empty-selection path that clears the current statistics. The result is applied only when that id is still the latest.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: stacked on #53630
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr