### PR TITLE
Fix outlined button border colors

### DIFF
--- a/gallery/src/pages/components/ha-button.markdown
+++ b/gallery/src/pages/components/ha-button.markdown
@@ -25,6 +25,9 @@ title: Button
   <ha-button appearance="filled">
     filled button
   </ha-button>
+  <ha-button appearance="outlined">
+    outlined button
+  </ha-button>
 
   <ha-button size="s">
     small
@@ -65,7 +68,7 @@ Check the [webawesome documentation](https://webawesome.com/docs/components/butt
 
 | Name       | Type                                           | Default  | Description                                                                       |
 | ---------- | ---------------------------------------------- | -------- | --------------------------------------------------------------------------------- |
-| appearance | "accent"/"filled"/"plain"                      | "accent" | Sets the button appearance.                                                       |
+| appearance | "accent"/"filled"/"outlined"/"plain"           | "accent" | Sets the button appearance.                                                       |
 | variants   | "brand"/"danger"/"neutral"/"warning"/"success" | "brand"  | Sets the button color variant. "brand" is default.                                |
 | size       | "xs"/"s"/"m"/"l"/"xl"                          | "m"      | Sets the button size.                                                             |
 | loading    | Boolean                                        | false    | Shows a loading indicator instead of the buttons label and disable buttons click. |

--- a/gallery/src/pages/components/ha-button.ts
+++ b/gallery/src/pages/components/ha-button.ts
@@ -9,7 +9,7 @@ import "../../../../src/components/ha-svg-icon";
 import { mdiHomeAssistant } from "../../../../src/resources/home-assistant-logo-svg";
 import { THEME_COMPARISON_PANELS } from "../../components/demo-theme-comparison";
 
-const appearances = ["accent", "filled", "plain"];
+const appearances = ["accent", "filled", "outlined", "plain"];
 const variants = ["brand", "danger", "neutral", "warning", "success"];
 
 @customElement("demo-components-ha-button")

--- a/src/components/ha-button.ts
+++ b/src/components/ha-button.ts
@@ -29,7 +29,7 @@ export type Appearance = "accent" | "filled" | "outlined" | "plain";
  *
  * @attr {("xs"|"s"|"m"|"l"|"xl")} size - Sets the button size.
  * @attr {("brand"|"neutral"|"danger"|"warning"|"success")} variant - Sets the button color variant. "primary" is default.
- * @attr {("accent"|"filled"|"plain")} appearance - Sets the button appearance.
+ * @attr {("accent"|"filled"|"outlined"|"plain")} appearance - Sets the button appearance.
  * @attr {boolean} loading - shows a loading indicator instead of the buttons label and disable buttons click.
  * @attr {boolean} disabled - Disables the button and prevents user interaction.
  */
@@ -199,6 +199,7 @@ export class HaButton extends Button {
         :host([appearance~="outlined"]) .button.disabled {
           background-color: transparent;
           color: var(--ha-color-on-disabled-quiet);
+          border-color: var(--ha-color-on-disabled-quiet);
         }
 
         @media (hover: hover) {

--- a/src/resources/theme/color/wa.globals.ts
+++ b/src/resources/theme/color/wa.globals.ts
@@ -5,9 +5,9 @@ export const waColorStyles = css`
     --wa-color-brand-fill-loud: var(--ha-color-fill-primary-loud-resting);
     --wa-color-brand-fill-normal: var(--ha-color-fill-primary-normal-resting);
     --wa-color-brand-fill-quiet: var(--ha-color-fill-primary-quiet-hover);
-    --wa-color-brand-border-loud: var(--ha-color-border-loud);
+    --wa-color-brand-border-loud: var(--ha-color-border-primary-loud);
     --wa-color-brand-border-normal: var(--ha-color-primary-50);
-    --wa-color-brand-border-quiet: var(--ha-color-border-quiet);
+    --wa-color-brand-border-quiet: var(--ha-color-border-primary-quiet);
     --wa-color-brand-on-loud: var(--ha-color-on-primary-loud);
     --wa-color-brand-on-normal: var(--ha-color-on-primary-normal);
     --wa-color-brand-on-quiet: var(--ha-color-on-primary-quiet);


### PR DESCRIPTION
## Proposed change

Two fixes for `appearance="outlined"` on `ha-button`.

**The brand outline was gray instead of blue.** The brand border pointed at a token that doesn't exist, and CSS resolves that by silently falling back to the neutral border. So the button drew a gray ring and looked like it was meant to.

**Disabled outlined buttons kept their color.** The disabled styling reset the background and the label but not the border, so a disabled danger button still had a red ring. The border now grays out with the label.

Also added `outlined` to the gallery. It has been a valid appearance from the start, but it was missing from the component's documented list, and the gallery builds its grid from that list — which is why the bugs went unnoticed. The demo grid, the example row and the API table now include it.

`filled-outlined` is deliberately left out: webawesome accepts it but HA doesn't expose it, and adding it is a design decision rather than a bug fix.

## Screenshots

<img width="1593" height="1876" alt="CleanShot 2026-08-19 at 14 59 42" src="https://github.com/user-attachments/assets/d7b875ec-1bfd-48b6-8389-64351bce4f58" />

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
