### PR TITLE
Show Assist greeting in the assistant's language

### DIFF
--- a/src/components/ha-assist-chat.ts
+++ b/src/components/ha-assist-chat.ts
@@ -179,9 +179,10 @@ export class HaAssistChat extends LitElement {
       } catch (_err) {
         // Translation failed to load; fall back to the interface language.
       }
-      if (token !== this._greetingLoadToken) {
-        return;
-      }
+    }
+    if (token !== this._greetingLoadToken) {
+      // The pipeline changed while loading; a newer load owns the greeting.
+      return;
     }
     this._conversation = [
       {

--- a/src/components/ha-assist-chat.ts
+++ b/src/components/ha-assist-chat.ts
@@ -12,6 +12,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { consumeLocalize } from "../common/decorators/consume-context-entry";
+import { transform } from "../common/decorators/transform";
 import { supportsFeature } from "../common/entity/supports-feature";
 import type { LocalizeFunc } from "../common/translations/localize";
 import {
@@ -24,6 +25,7 @@ import {
 import {
   configContext,
   connectionContext,
+  internationalizationContext,
   statesContext,
 } from "../data/context";
 import { ConversationEntityFeature } from "../data/conversation";
@@ -33,8 +35,13 @@ import type {
   HomeAssistant,
   HomeAssistantConfig,
   HomeAssistantConnection,
+  HomeAssistantInternationalization,
 } from "../types";
 import { AudioRecorder } from "../util/audio-recorder";
+import {
+  findAvailableLanguage,
+  getTranslation,
+} from "../util/common-translation";
 import { documentationUrl } from "../util/documentation-url";
 import "./ha-alert";
 import "./ha-markdown";
@@ -66,6 +73,17 @@ export const assistPipelineChanged = (
   previous: AssistPipeline | undefined,
   current: AssistPipeline | undefined
 ): boolean => previous?.id !== current?.id;
+
+export const greetingTranslationLanguage = (
+  pipelineLanguage: string | undefined,
+  interfaceLanguage: string | undefined
+): string | undefined => {
+  if (!pipelineLanguage || pipelineLanguage === interfaceLanguage) {
+    return undefined;
+  }
+  const language = findAvailableLanguage(pipelineLanguage);
+  return language && language !== interfaceLanguage ? language : undefined;
+};
 
 @customElement("ha-assist-chat")
 export class HaAssistChat extends LitElement {
@@ -102,6 +120,13 @@ export class HaAssistChat extends LitElement {
   private _localize!: LocalizeFunc;
 
   @state()
+  @consume({ context: internationalizationContext, subscribe: true })
+  @transform<HomeAssistantInternationalization, string>({
+    transformer: ({ language }) => language,
+  })
+  private _language!: string;
+
+  @state()
   @consume({ context: statesContext, subscribe: true })
   private _states!: HomeAssistant["states"];
 
@@ -114,6 +139,8 @@ export class HaAssistChat extends LitElement {
   private _connection!: HomeAssistantConnection;
 
   private _conversationId: string | null = null;
+
+  private _greetingLoadToken = 0;
 
   private _initialPromptSubmitted = false;
 
@@ -131,15 +158,41 @@ export class HaAssistChat extends LitElement {
       (changedProperties.has("pipeline") &&
         assistPipelineChanged(changedProperties.get("pipeline"), this.pipeline))
     ) {
-      this._conversation = [
-        {
-          who: "hass",
-          text: this._localize("ui.dialogs.voice_command.how_can_i_help"),
-          thinking: "",
-          tool_calls: {},
-        },
-      ];
+      this._conversation = [];
+      this._loadGreeting();
     }
+  }
+
+  private async _loadGreeting(): Promise<void> {
+    const token = ++this._greetingLoadToken;
+    const language = greetingTranslationLanguage(
+      this.pipeline?.language,
+      this._language
+    );
+    let greeting: string | undefined;
+    if (language) {
+      try {
+        const result = await getTranslation(null, language, false);
+        if (result.language === language) {
+          greeting = result.data["ui.dialogs.voice_command.how_can_i_help"];
+        }
+      } catch (_err) {
+        // Translation failed to load; fall back to the interface language.
+      }
+      if (token !== this._greetingLoadToken) {
+        return;
+      }
+    }
+    this._conversation = [
+      {
+        who: "hass",
+        text:
+          greeting || this._localize("ui.dialogs.voice_command.how_can_i_help"),
+        thinking: "",
+        tool_calls: {},
+      },
+      ...this._conversation,
+    ];
   }
 
   protected firstUpdated(changedProperties: PropertyValues<this>): void {
@@ -157,7 +210,7 @@ export class HaAssistChat extends LitElement {
 
   protected updated(changedProps: PropertyValues) {
     super.updated(changedProps);
-    if (changedProps.has("_conversation")) {
+    if (changedProps.has("_conversation") && this._conversation.length) {
       this._scrollMessagesBottom();
     }
     if (

--- a/test/components/ha-assist-chat.test.ts
+++ b/test/components/ha-assist-chat.test.ts
@@ -1,9 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AssistPipeline } from "../../src/data/assist_pipeline";
 import {
   assistPipelineChanged,
+  greetingTranslationLanguage,
   initialPromptToSubmit,
 } from "../../src/components/ha-assist-chat";
+
+// common-translation depends on build-time defines and generated translation
+// metadata that are not available in unit tests.
+vi.mock("../../src/util/common-translation", () => ({
+  findAvailableLanguage: (language: string) =>
+    ({ en: "en", "en-US": "en", nl: "nl", pl: "pl" })[language],
+  getTranslation: vi.fn(),
+}));
 
 describe("initialPromptToSubmit", () => {
   it("returns a trimmed prompt when submission is requested", () => {
@@ -34,5 +43,27 @@ describe("ha-assist-chat pipeline updates", () => {
         { id: "second" } as AssistPipeline
       )
     ).toBe(true);
+  });
+});
+
+describe("greetingTranslationLanguage", () => {
+  it("returns the pipeline language when it differs from the interface language", () => {
+    expect(greetingTranslationLanguage("pl", "en")).toBe("pl");
+  });
+
+  it("returns undefined when the pipeline language matches the interface language", () => {
+    expect(greetingTranslationLanguage("nl", "nl")).toBeUndefined();
+  });
+
+  it("returns undefined when the pipeline language resolves to the interface language", () => {
+    expect(greetingTranslationLanguage("en-US", "en")).toBeUndefined();
+  });
+
+  it("returns undefined when there is no pipeline language", () => {
+    expect(greetingTranslationLanguage(undefined, "en")).toBeUndefined();
+  });
+
+  it("returns undefined when the pipeline language has no available translation", () => {
+    expect(greetingTranslationLanguage("xx", "en")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Proposed change
The greeting sits in the assistant's chat bubble, so render it in the pipeline's language instead of the interface language. Falls back to the interface language when no translation is available (issue #53703).

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->
<img width="579" height="573" alt="Screenshot 2026-08-19 at 16 06 08" src="https://github.com/user-attachments/assets/0598b437-bd73-437a-a65a-a2193978e67c" />

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53703
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
