### PR TITLE
Fix and centralize selector initial value handling

### DIFF
--- a/src/components/ha-form/compute-initial-ha-form-data.ts
+++ b/src/components/ha-form/compute-initial-ha-form-data.ts
@@ -1,4 +1,4 @@
-import type { Selector } from "../../data/selector";
+import { getSelectorInitialValue } from "./get-selector-initial-value";
 import type { HaFormData, HaFormSchema } from "./types";
 
 const setDefaultValue = (
@@ -62,104 +62,9 @@ export const computeInitialHaFormData = (
         seconds: 0,
       };
     } else if ("selector" in field) {
-      const selector: Selector = field.selector;
-
-      if ("device" in selector) {
-        data[field.name] = selector.device?.multiple ? [] : "";
-      } else if ("entity" in selector) {
-        data[field.name] = selector.entity?.multiple ? [] : "";
-      } else if ("area" in selector) {
-        data[field.name] = selector.area?.multiple ? [] : "";
-      } else if ("label" in selector) {
-        data[field.name] = selector.label?.multiple ? [] : "";
-      } else if ("boolean" in selector) {
-        data[field.name] = false;
-      } else if (
-        "addon" in selector ||
-        "attribute" in selector ||
-        "file" in selector ||
-        "icon" in selector ||
-        "serial_port" in selector ||
-        "template" in selector ||
-        "text" in selector ||
-        "theme" in selector ||
-        "object" in selector
-      ) {
-        data[field.name] = "";
-      } else if ("number" in selector) {
-        data[field.name] = selector.number?.min ?? 0;
-      } else if ("select" in selector) {
-        if (selector.select?.options.length) {
-          const firstOption = selector.select.options[0];
-          const val =
-            typeof firstOption === "string" ? firstOption : firstOption.value;
-          data[field.name] = selector.select.multiple ? [val] : val;
-        }
-      } else if ("country" in selector) {
-        if (selector.country?.countries?.length) {
-          data[field.name] = selector.country.countries[0];
-        }
-      } else if ("language" in selector) {
-        if (selector.language?.languages?.length) {
-          data[field.name] = selector.language.languages[0];
-        }
-      } else if ("duration" in selector) {
-        data[field.name] = {
-          hours: 0,
-          minutes: 0,
-          seconds: 0,
-        };
-      } else if ("time" in selector) {
-        data[field.name] = "00:00:00";
-      } else if ("date" in selector || "datetime" in selector) {
-        const now = new Date().toISOString().slice(0, 10);
-        data[field.name] = `${now}T00:00:00`;
-      } else if ("color_rgb" in selector) {
-        data[field.name] = [0, 0, 0];
-      } else if ("color_temp" in selector) {
-        data[field.name] = selector.color_temp?.min_mireds ?? 153;
-      } else if (
-        "action" in selector ||
-        "trigger" in selector ||
-        "condition" in selector
-      ) {
-        data[field.name] = [];
-      } else if ("media" in selector || "target" in selector) {
-        data[field.name] = {};
-      } else if ("state" in selector) {
-        data[field.name] = selector.state?.multiple ? [] : "";
-      } else if ("choose" in selector) {
-        const firstChoice = Object.keys(selector.choose.choices)[0];
-        if (!firstChoice) {
-          data[field.name] = {};
-        } else {
-          data[field.name] = {
-            active_choice: firstChoice,
-            [firstChoice]: computeInitialHaFormData([
-              {
-                name: firstChoice,
-                selector: selector.choose.choices[firstChoice].selector,
-              },
-            ])[firstChoice],
-          };
-        }
-      } else if ("numeric_threshold" in selector) {
-        const mode = selector.numeric_threshold?.mode ?? "crossed";
-        const type = mode === "changed" ? "any" : "above";
-        data[field.name] =
-          type === "any"
-            ? { type }
-            : {
-                type,
-                value: {
-                  number: selector.numeric_threshold?.number?.min ?? 0,
-                  active_choice: "number",
-                },
-              };
-      } else {
-        throw new Error(
-          `Selector ${Object.keys(selector)[0]} not supported in initial form data`
-        );
+      const initialValue = getSelectorInitialValue(field.selector);
+      if (initialValue !== undefined) {
+        data[field.name] = initialValue;
       }
     }
   });

--- a/src/components/ha-form/compute-initial-ha-form-data.ts
+++ b/src/components/ha-form/compute-initial-ha-form-data.ts
@@ -1,5 +1,12 @@
-import { getSelectorInitialValue } from "./get-selector-initial-value";
+import {
+  getSelectorInitialValue,
+  getSelectorInitialValueOrUndefined,
+} from "./get-selector-initial-value";
 import type { HaFormData, HaFormSchema } from "./types";
+
+interface ComputeInitialHaFormDataOptions {
+  skipUnsupportedSelectors?: boolean;
+}
 
 const setDefaultValue = (
   field: HaFormSchema,
@@ -18,7 +25,8 @@ const setDefaultValue = (
 };
 
 export const computeInitialHaFormData = (
-  schema: HaFormSchema[] | readonly HaFormSchema[]
+  schema: HaFormSchema[] | readonly HaFormSchema[],
+  options?: ComputeInitialHaFormDataOptions
 ): Record<string, any> => {
   const data = {};
   schema.forEach((field) => {
@@ -33,7 +41,7 @@ export const computeInitialHaFormData = (
     } else if ("default" in field) {
       data[field.name] = setDefaultValue(field, field.default);
     } else if (field.type === "expandable") {
-      const expandableData = computeInitialHaFormData(field.schema);
+      const expandableData = computeInitialHaFormData(field.schema, options);
       if (field.required || Object.keys(expandableData).length) {
         // Only add expandable data if it's required or any of its children have initial values.
         data[field.name] = expandableData;
@@ -62,7 +70,9 @@ export const computeInitialHaFormData = (
         seconds: 0,
       };
     } else if ("selector" in field) {
-      const initialValue = getSelectorInitialValue(field.selector);
+      const initialValue = options?.skipUnsupportedSelectors
+        ? getSelectorInitialValueOrUndefined(field.selector)
+        : getSelectorInitialValue(field.selector);
       if (initialValue !== undefined) {
         data[field.name] = initialValue;
       }

--- a/src/components/ha-form/get-selector-fallback-value.ts
+++ b/src/components/ha-form/get-selector-fallback-value.ts
@@ -1,25 +1,88 @@
 import { DEFAULT_MIN_KELVIN } from "../../common/color/convert-light-color";
-import type { Selector } from "../../data/selector";
+import type {
+  Selector,
+  SelectorForType,
+  SelectorType,
+} from "../../data/selector";
+
+type SelectorFallbackValues = {
+  [T in SelectorType]: ((selector: SelectorForType<T>) => unknown) | undefined;
+};
+
+const SELECTOR_FALLBACK_VALUES = {
+  action: undefined,
+  addon: undefined,
+  automation_behavior: undefined,
+  app: undefined,
+  area: undefined,
+  areas_display: undefined,
+  attribute: undefined,
+  assist_pipeline: undefined,
+  boolean: () => false,
+  choose: undefined,
+  color_rgb: undefined,
+  condition: undefined,
+  config_entry: undefined,
+  conversation_agent: undefined,
+  constant: (selector) => selector.constant?.value,
+  country: undefined,
+  date: undefined,
+  datetime: undefined,
+  device: undefined,
+  duration: undefined,
+  entity: undefined,
+  entity_name: undefined,
+  statistic: undefined,
+  file: undefined,
+  floor: undefined,
+  label: undefined,
+  language: undefined,
+  navigation: undefined,
+  number: (selector) => selector.number?.min ?? 0,
+  numeric_threshold: undefined,
+  object: undefined,
+  period: undefined,
+  qr_code: undefined,
+  select: undefined,
+  selector: undefined,
+  serial_port: undefined,
+  state: undefined,
+  backup_location: undefined,
+  stt: undefined,
+  target: undefined,
+  template: undefined,
+  text: undefined,
+  time: undefined,
+  icon: undefined,
+  media: undefined,
+  theme: undefined,
+  timezone: undefined,
+  button_toggle: undefined,
+  trigger: undefined,
+  tts: undefined,
+  tts_voice: undefined,
+  location: undefined,
+  color_temp: (selector) => {
+    if (selector.color_temp?.unit === "kelvin") {
+      return selector.color_temp.min ?? DEFAULT_MIN_KELVIN;
+    }
+
+    return selector.color_temp?.min ?? selector.color_temp?.min_mireds ?? 153;
+  },
+  ui_action: undefined,
+  ui_clock_date_format: undefined,
+  ui_color: undefined,
+  ui_state_content: undefined,
+  ui_time_format: undefined,
+} satisfies SelectorFallbackValues;
 
 /**
  * Value a selector already displays when no field value is set.
  * Used when enabling an optional service/trigger/condition field.
  */
 export const getSelectorFallbackValue = (selector: Selector): unknown => {
-  if ("constant" in selector) {
-    return selector.constant?.value;
-  }
-  if ("boolean" in selector) {
-    return false;
-  }
-  if ("number" in selector) {
-    return selector.number?.min ?? 0;
-  }
-  if ("color_temp" in selector) {
-    if (selector.color_temp?.unit === "kelvin") {
-      return selector.color_temp.min ?? DEFAULT_MIN_KELVIN;
-    }
-    return selector.color_temp?.min ?? selector.color_temp?.min_mireds ?? 153;
-  }
-  return undefined;
+  const type = Object.keys(selector)[0] as SelectorType;
+  const fallbackValue = SELECTOR_FALLBACK_VALUES[type];
+
+  return fallbackValue?.(selector as never);
 };

--- a/src/components/ha-form/get-selector-fallback-value.ts
+++ b/src/components/ha-form/get-selector-fallback-value.ts
@@ -29,6 +29,7 @@ const SELECTOR_FALLBACK_VALUES = {
   date: undefined,
   datetime: undefined,
   device: undefined,
+  device_class: undefined,
   duration: undefined,
   entity: undefined,
   entity_name: undefined,

--- a/src/components/ha-form/get-selector-initial-value.ts
+++ b/src/components/ha-form/get-selector-initial-value.ts
@@ -25,12 +25,13 @@ const SELECTOR_INITIAL_VALUES = {
       return {};
     }
 
-    return {
-      active_choice: firstChoice,
-      [firstChoice]: getSelectorInitialValueOrUndefined(
-        selector.choose.choices[firstChoice].selector
-      ),
-    };
+    const childValue = getSelectorInitialValueOrUndefined(
+      selector.choose.choices[firstChoice].selector
+    );
+
+    return childValue === undefined
+      ? { active_choice: firstChoice }
+      : { active_choice: firstChoice, [firstChoice]: childValue };
   },
   color_rgb: () => [0, 0, 0],
   condition: () => [],

--- a/src/components/ha-form/get-selector-initial-value.ts
+++ b/src/components/ha-form/get-selector-initial-value.ts
@@ -42,6 +42,8 @@ const SELECTOR_INITIAL_VALUES = {
   date: () => `${new Date().toISOString().slice(0, 10)}T00:00:00`,
   datetime: () => `${new Date().toISOString().slice(0, 10)}T00:00:00`,
   device: (selector) => (selector.device?.multiple ? [] : ""),
+  device_class: (selector) =>
+    selector.device_class?.multiple ? [] : undefined,
   duration: () => ({
     hours: 0,
     minutes: 0,

--- a/src/components/ha-form/get-selector-initial-value.ts
+++ b/src/components/ha-form/get-selector-initial-value.ts
@@ -27,7 +27,7 @@ const SELECTOR_INITIAL_VALUES = {
 
     return {
       active_choice: firstChoice,
-      [firstChoice]: getSelectorInitialValue(
+      [firstChoice]: getSelectorInitialValueOrUndefined(
         selector.choose.choices[firstChoice].selector
       ),
     };
@@ -110,6 +110,13 @@ const SELECTOR_INITIAL_VALUES = {
   ui_state_content: undefined,
   ui_time_format: undefined,
 } satisfies SelectorInitialValues;
+
+export const getSelectorInitialValueOrUndefined = (
+  selector: Selector
+): unknown => {
+  const type = Object.keys(selector)[0] as SelectorType;
+  return SELECTOR_INITIAL_VALUES[type]?.(selector as never);
+};
 
 export const getSelectorInitialValue = (selector: Selector): unknown => {
   const type = Object.keys(selector)[0] as SelectorType;

--- a/src/components/ha-form/get-selector-initial-value.ts
+++ b/src/components/ha-form/get-selector-initial-value.ts
@@ -1,0 +1,123 @@
+import type {
+  Selector,
+  SelectorForType,
+  SelectorType,
+} from "../../data/selector";
+
+type SelectorInitialValues = {
+  [T in SelectorType]: ((selector: SelectorForType<T>) => unknown) | undefined;
+};
+
+const SELECTOR_INITIAL_VALUES = {
+  action: () => [],
+  addon: () => "",
+  automation_behavior: undefined,
+  app: undefined,
+  area: (selector) => (selector.area?.multiple ? [] : ""),
+  areas_display: undefined,
+  attribute: () => "",
+  assist_pipeline: undefined,
+  boolean: () => false,
+  choose: (selector) => {
+    const firstChoice = Object.keys(selector.choose.choices)[0];
+
+    if (!firstChoice) {
+      return {};
+    }
+
+    return {
+      active_choice: firstChoice,
+      [firstChoice]: getSelectorInitialValue(
+        selector.choose.choices[firstChoice].selector
+      ),
+    };
+  },
+  color_rgb: () => [0, 0, 0],
+  condition: () => [],
+  config_entry: undefined,
+  conversation_agent: undefined,
+  constant: (selector) => selector.constant?.value,
+  country: (selector) => selector.country?.countries?.[0],
+  date: () => `${new Date().toISOString().slice(0, 10)}T00:00:00`,
+  datetime: () => `${new Date().toISOString().slice(0, 10)}T00:00:00`,
+  device: (selector) => (selector.device?.multiple ? [] : ""),
+  duration: () => ({
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+  }),
+  entity: (selector) => (selector.entity?.multiple ? [] : ""),
+  entity_name: undefined,
+  statistic: undefined,
+  file: () => "",
+  floor: undefined,
+  label: (selector) => (selector.label?.multiple ? [] : ""),
+  language: (selector) => selector.language?.languages?.[0],
+  navigation: undefined,
+  number: (selector) => selector.number?.min ?? 0,
+  numeric_threshold: (selector) => {
+    const mode = selector.numeric_threshold?.mode ?? "crossed";
+    const type = mode === "changed" ? "any" : "above";
+
+    return type === "any"
+      ? { type }
+      : {
+          type,
+          value: {
+            number: selector.numeric_threshold?.number?.min ?? 0,
+            active_choice: "number",
+          },
+        };
+  },
+  object: (selector) => (selector.object?.multiple ? [] : ""),
+  period: undefined,
+  qr_code: undefined,
+  select: (selector) => {
+    const select = selector.select;
+
+    if (!select?.options.length) {
+      return undefined;
+    }
+
+    const firstOption = select.options[0];
+    const value =
+      typeof firstOption === "string" ? firstOption : firstOption.value;
+
+    return select.multiple ? [value] : value;
+  },
+  selector: undefined,
+  serial_port: () => "",
+  state: (selector) => (selector.state?.multiple ? [] : ""),
+  backup_location: undefined,
+  stt: undefined,
+  target: () => ({}),
+  template: () => "",
+  text: (selector) => (selector.text?.multiple ? [] : ""),
+  time: () => "00:00:00",
+  icon: () => "",
+  media: () => ({}),
+  theme: () => "",
+  timezone: undefined,
+  button_toggle: undefined,
+  trigger: () => [],
+  tts: undefined,
+  tts_voice: undefined,
+  location: undefined,
+  color_temp: (selector) => selector.color_temp?.min_mireds ?? 153,
+  ui_action: undefined,
+  ui_clock_date_format: undefined,
+  ui_color: undefined,
+  ui_state_content: undefined,
+  ui_time_format: undefined,
+} satisfies SelectorInitialValues;
+
+export const getSelectorInitialValue = (selector: Selector): unknown => {
+  const type = Object.keys(selector)[0] as SelectorType;
+  const initialValue = SELECTOR_INITIAL_VALUES[type];
+
+  if (!initialValue) {
+    throw new Error(`Selector ${type} not supported in initial form data`);
+  }
+
+  return initialValue(selector as never);
+};

--- a/src/components/ha-selector/ha-selector-object.ts
+++ b/src/components/ha-selector/ha-selector-object.ts
@@ -243,7 +243,9 @@ export class HaObjectSelector extends LitElement {
     const newItem = await showFormDialog(this, {
       title: this.hass.localize("ui.common.add"),
       schema,
-      data: computeInitialHaFormData(schema),
+      data: computeInitialHaFormData(schema, {
+        skipUnsupportedSelectors: true,
+      }),
       computeLabel: this._computeLabel,
       computeHelper: this._computeHelper,
       submitText: this.hass.localize("ui.common.add"),

--- a/src/components/ha-selector/ha-selector-object.ts
+++ b/src/components/ha-selector/ha-selector-object.ts
@@ -13,6 +13,7 @@ import type { ObjectSelector } from "../../data/selector";
 import { formatSelectorValue } from "../../data/selector/format_selector_value";
 import { showFormDialog } from "../../dialogs/form/show-form-dialog";
 import type { HomeAssistant } from "../../types";
+import { computeInitialHaFormData } from "../ha-form/compute-initial-ha-form-data";
 import type { HaFormSchema } from "../ha-form/types";
 import "../ha-input-helper-text";
 import "../ha-md-list";
@@ -237,10 +238,12 @@ export class HaObjectSelector extends LitElement {
   private async _addItem(ev) {
     ev.stopPropagation();
 
+    const schema = this._schema(this.selector);
+
     const newItem = await showFormDialog(this, {
       title: this.hass.localize("ui.common.add"),
-      schema: this._schema(this.selector),
-      data: {},
+      schema,
+      data: computeInitialHaFormData(schema),
       computeLabel: this._computeLabel,
       computeHelper: this._computeHelper,
       submitText: this.hass.localize("ui.common.add"),

--- a/src/components/ha-selector/ha-selector-object.ts
+++ b/src/components/ha-selector/ha-selector-object.ts
@@ -298,7 +298,7 @@ export class HaObjectSelector extends LitElement {
     const index = ev.currentTarget.index;
 
     if (!this.selector.object!.multiple) {
-      fireEvent(this, "value-changed", { value: undefined });
+      fireEvent(this, "value-changed", { value: "" });
       return;
     }
 

--- a/src/components/ha-selector/ha-selector.ts
+++ b/src/components/ha-selector/ha-selector.ts
@@ -3,7 +3,7 @@ import { html, LitElement } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { dynamicElement } from "../../common/dom/dynamic-element-directive";
-import type { Selector } from "../../data/selector";
+import type { Selector, SelectorType } from "../../data/selector";
 import {
   handleLegacyDeviceSelector,
   handleLegacyEntitySelector,
@@ -70,7 +70,7 @@ const LOAD_ELEMENTS = {
   ui_color: () => import("./ha-selector-ui-color"),
   ui_state_content: () => import("./ha-selector-ui-state-content"),
   ui_time_format: () => import("./ha-selector-ui-time-format"),
-};
+} satisfies Record<SelectorType, () => Promise<unknown>>;
 
 const LEGACY_UI_SELECTORS = new Set(["ui-action", "ui-color"]);
 

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -88,6 +88,20 @@ export type Selector =
   | UiTimeFormatSelector
   | BackupLocationSelector;
 
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type SelectorType = KeysOfUnion<Selector>;
+
+type UnionMemberWithKey<U, K extends PropertyKey> = U extends unknown
+  ? K extends keyof U
+    ? U
+    : never
+  : never;
+
+export type SelectorForType<T extends SelectorType> = UnionMemberWithKey<
+  Selector,
+  T
+>;
+
 export interface ActionSelector {
   action: {
     optionsInSidebar?: boolean;

--- a/test/components/ha-form/compute-initial-ha-form-data.test.ts
+++ b/test/components/ha-form/compute-initial-ha-form-data.test.ts
@@ -168,7 +168,7 @@ describe("computeInitialHaFormData", () => {
     ).toThrow("Selector ui_action not supported in initial form data");
   });
 
-  it("keeps an unsupported first choose child unset", () => {
+  it("omits a first choose child without an initial value", () => {
     const schema = [
       {
         name: "mode",
@@ -197,7 +197,6 @@ describe("computeInitialHaFormData", () => {
     expect(computeInitialHaFormData(schema)).toStrictEqual({
       mode: {
         active_choice: "First",
-        First: undefined,
       },
     });
   });

--- a/test/components/ha-form/compute-initial-ha-form-data.test.ts
+++ b/test/components/ha-form/compute-initial-ha-form-data.test.ts
@@ -155,4 +155,50 @@ describe("computeInitialHaFormData", () => {
       },
     });
   });
+
+  it("throws for an unsupported required selector", () => {
+    expect(() =>
+      computeInitialHaFormData([
+        requiredField({
+          ui_action: {
+            default_action: "none",
+          },
+        }),
+      ])
+    ).toThrow("Selector ui_action not supported in initial form data");
+  });
+
+  it("keeps an unsupported first choose child unset", () => {
+    const schema = [
+      {
+        name: "mode",
+        required: true,
+        selector: {
+          choose: {
+            choices: {
+              First: {
+                selector: {
+                  ui_action: {
+                    default_action: "none",
+                  },
+                },
+              },
+              Second: {
+                selector: {
+                  text: {},
+                },
+              },
+            },
+          },
+        },
+      },
+    ] as const;
+
+    expect(computeInitialHaFormData(schema)).toStrictEqual({
+      mode: {
+        active_choice: "First",
+        First: undefined,
+      },
+    });
+  });
 });

--- a/test/components/ha-form/compute-initial-ha-form-data.test.ts
+++ b/test/components/ha-form/compute-initial-ha-form-data.test.ts
@@ -56,6 +56,33 @@ describe("computeInitialHaFormData", () => {
     });
   });
 
+  it("leaves a required single device class selector unset", () => {
+    expect(
+      computeInitialHaFormData([
+        requiredField({
+          device_class: {
+            domain: "sensor",
+          },
+        }),
+      ])
+    ).toEqual({});
+  });
+
+  it("initializes a required multiple device class selector with an empty array", () => {
+    expect(
+      computeInitialHaFormData([
+        requiredField({
+          device_class: {
+            domain: "sensor",
+            multiple: true,
+          },
+        }),
+      ])
+    ).toEqual({
+      value: [],
+    });
+  });
+
   it("does not initialize optional text selectors", () => {
     expect(
       computeInitialHaFormData([
@@ -86,6 +113,32 @@ describe("computeInitialHaFormData", () => {
         },
       ])
     ).toEqual({});
+  });
+
+  it("initializes a required constant selector without losing falsy values", () => {
+    expect(
+      computeInitialHaFormData([
+        requiredField({
+          constant: {
+            value: false,
+          },
+        }),
+      ])
+    ).toEqual({
+      value: false,
+    });
+
+    expect(
+      computeInitialHaFormData([
+        requiredField({
+          constant: {
+            value: 0,
+          },
+        }),
+      ])
+    ).toEqual({
+      value: 0,
+    });
   });
 
   it("initializes a required choose selector from a constant first choice", () => {

--- a/test/components/ha-form/compute-initial-ha-form-data.test.ts
+++ b/test/components/ha-form/compute-initial-ha-form-data.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import { computeInitialHaFormData } from "../../../src/components/ha-form/compute-initial-ha-form-data";
+import type { Selector } from "../../../src/data/selector";
+import type { HaFormSchema } from "../../../src/components/ha-form/types";
+
+const requiredField = (selector: Selector): HaFormSchema => ({
+  name: "value",
+  required: true,
+  selector,
+});
+
+const optionalField = (selector: Selector): HaFormSchema => ({
+  name: "value",
+  required: false,
+  selector,
+});
+
+describe("computeInitialHaFormData", () => {
+  it("initializes required text selector with an empty string", () => {
+    expect(computeInitialHaFormData([requiredField({ text: {} })])).toEqual({
+      value: "",
+    });
+  });
+
+  it("initializes required multiple text selector with an empty array", () => {
+    expect(
+      computeInitialHaFormData([
+        requiredField({
+          text: {
+            multiple: true,
+          },
+        }),
+      ])
+    ).toEqual({
+      value: [],
+    });
+  });
+
+  it("initializes required object selector with an empty string", () => {
+    expect(computeInitialHaFormData([requiredField({ object: {} })])).toEqual({
+      value: "",
+    });
+  });
+
+  it("initializes required multiple object selector with an empty array", () => {
+    expect(
+      computeInitialHaFormData([
+        requiredField({
+          object: {
+            multiple: true,
+          },
+        }),
+      ])
+    ).toEqual({
+      value: [],
+    });
+  });
+
+  it("does not initialize optional text selectors", () => {
+    expect(
+      computeInitialHaFormData([
+        optionalField({ text: {} }),
+        {
+          ...optionalField({
+            text: {
+              multiple: true,
+            },
+          }),
+          name: "multiple",
+        },
+      ])
+    ).toEqual({});
+  });
+
+  it("does not initialize optional object selectors", () => {
+    expect(
+      computeInitialHaFormData([
+        optionalField({ object: {} }),
+        {
+          ...optionalField({
+            object: {
+              multiple: true,
+            },
+          }),
+          name: "multiple",
+        },
+      ])
+    ).toEqual({});
+  });
+
+  it("initializes a required choose selector from a constant first choice", () => {
+    const schema = [
+      {
+        name: "match",
+        required: true,
+        selector: {
+          choose: {
+            choices: {
+              Disabled: {
+                selector: {
+                  constant: {
+                    value: "",
+                  },
+                },
+              },
+              Enabled: {
+                selector: {
+                  number: {},
+                },
+              },
+            },
+          },
+        },
+      },
+    ] as const;
+
+    expect(computeInitialHaFormData(schema)).toEqual({
+      match: {
+        active_choice: "Disabled",
+        Disabled: "",
+      },
+    });
+  });
+
+  it("initializes a required choose selector from its child selector", () => {
+    const schema = [
+      {
+        name: "mode",
+        required: true,
+        selector: {
+          choose: {
+            choices: {
+              First: {
+                selector: {
+                  text: {
+                    multiple: true,
+                  },
+                },
+              },
+              Second: {
+                selector: {
+                  text: {},
+                },
+              },
+            },
+          },
+        },
+      },
+    ] as const;
+
+    expect(computeInitialHaFormData(schema)).toEqual({
+      mode: {
+        active_choice: "First",
+        First: [],
+      },
+    });
+  });
+});

--- a/test/components/ha-selector/ha-selector-object.test.ts
+++ b/test/components/ha-selector/ha-selector-object.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ObjectSelector } from "../../../src/data/selector";
 import type { HomeAssistant } from "../../../src/types";
 import type { HaObjectSelector } from "../../../src/components/ha-selector/ha-selector-object";
-import type { FormDialogParams } from "../../../src/dialogs/form/show-form-dialog";
+import type {
+  FormDialogData,
+  FormDialogParams,
+} from "../../../src/dialogs/form/show-form-dialog";
 import "../../../src/components/ha-selector/ha-selector-object";
 
 vi.mock("../../../src/components/ha-input-helper-text", () => {
@@ -51,12 +55,15 @@ const selectorConfig = {
 const getInternals = (selector: HaObjectSelector) =>
   selector as unknown as Record<string, unknown>;
 
-const mountSelector = async (value: Record<string, string>[]) => {
+const mountSelector = async (
+  value: FormDialogData[],
+  config: ObjectSelector = selectorConfig
+) => {
   const selector = document.createElement(
     "ha-selector-object"
   ) as HaObjectSelector;
   selector.hass = hass;
-  selector.selector = selectorConfig;
+  selector.selector = config;
   selector.value = value;
   document.body.append(selector);
   await selector.updateComplete;
@@ -66,8 +73,8 @@ const mountSelector = async (value: Record<string, string>[]) => {
 const resolveFormDialog = async (
   selector: HaObjectSelector,
   action: "_addItem" | "_editItem",
-  result: Record<string, string> | null,
-  item?: Record<string, string>,
+  result: FormDialogData | null,
+  item?: FormDialogData,
   index?: number
 ) => {
   let params: FormDialogParams | undefined;
@@ -87,12 +94,20 @@ const resolveFormDialog = async (
     );
   });
 
-  const event = {
+  interface ItemActionEvent {
+    stopPropagation: () => void;
+    currentTarget: {
+      item?: FormDialogData;
+      index?: number;
+    };
+  }
+
+  const event: ItemActionEvent = {
     stopPropagation: vi.fn(),
     currentTarget: { item, index },
   };
   const operation = (
-    getInternals(selector)[action] as (ev: typeof event) => Promise<void>
+    getInternals(selector)[action] as (event: ItemActionEvent) => Promise<void>
   )(event);
   await dialogShown;
   await operation;
@@ -105,6 +120,38 @@ afterEach(() => {
 });
 
 describe("ha-selector-object form dialog flow", () => {
+  it("initializes Add dialog data from the object field schema", async () => {
+    const selector = await mountSelector([], {
+      object: {
+        multiple: true,
+        fields: {
+          name: {
+            required: true,
+            selector: { text: {} },
+          },
+          states: {
+            required: true,
+            selector: {
+              text: {
+                multiple: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const params = await resolveFormDialog(selector, "_addItem", {
+      name: "A",
+      states: ["on"],
+    });
+
+    expect(params.data).toEqual({
+      name: "",
+      states: [],
+    });
+  });
+
   it("appends an item through the real Add flow", async () => {
     const first = { name: "A" };
     const selector = await mountSelector([first]);

--- a/test/components/ha-selector/ha-selector-object.test.ts
+++ b/test/components/ha-selector/ha-selector-object.test.ts
@@ -109,8 +109,7 @@ const resolveFormDialog = async (
   const operation = (
     getInternals(selector)[action] as (event: ItemActionEvent) => Promise<void>
   )(event);
-  await dialogShown;
-  await operation;
+  await Promise.all([dialogShown, operation]);
   return params!;
 };
 
@@ -149,6 +148,39 @@ describe("ha-selector-object form dialog flow", () => {
     expect(params.data).toEqual({
       name: "",
       states: [],
+    });
+  });
+
+  it("leaves unsupported required fields unset in Add dialog data", async () => {
+    const selector = await mountSelector([], {
+      object: {
+        multiple: true,
+        fields: {
+          name: {
+            required: true,
+            selector: { text: {} },
+          },
+          tap_action: {
+            required: true,
+            selector: {
+              ui_action: {
+                default_action: "none",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const params = await resolveFormDialog(selector, "_addItem", {
+      name: "A",
+      tap_action: {
+        action: "none",
+      },
+    });
+
+    expect(params.data).toEqual({
+      name: "",
     });
   });
 

--- a/test/components/ha-selector/ha-selector-object.test.ts
+++ b/test/components/ha-selector/ha-selector-object.test.ts
@@ -55,8 +55,16 @@ const selectorConfig = {
 const getInternals = (selector: HaObjectSelector) =>
   selector as unknown as Record<string, unknown>;
 
+interface ItemActionEvent {
+  stopPropagation: () => void;
+  currentTarget: {
+    item?: FormDialogData;
+    index?: number;
+  };
+}
+
 const mountSelector = async (
-  value: FormDialogData[],
+  value: FormDialogData | FormDialogData[] | "",
   config: ObjectSelector = selectorConfig
 ) => {
   const selector = document.createElement(
@@ -93,14 +101,6 @@ const resolveFormDialog = async (
       { once: true }
     );
   });
-
-  interface ItemActionEvent {
-    stopPropagation: () => void;
-    currentTarget: {
-      item?: FormDialogData;
-      index?: number;
-    };
-  }
 
   const event: ItemActionEvent = {
     stopPropagation: vi.fn(),
@@ -182,6 +182,40 @@ describe("ha-selector-object form dialog flow", () => {
     expect(params.data).toEqual({
       name: "",
     });
+  });
+
+  it("restores the initialized empty value after an add-delete round trip", async () => {
+    const selector = await mountSelector("", {
+      object: {
+        fields: {
+          name: {
+            selector: { text: {} },
+          },
+        },
+      },
+    });
+    const valueChanged = vi.fn();
+    selector.addEventListener("value-changed", valueChanged);
+
+    await resolveFormDialog(selector, "_addItem", { name: "A" });
+
+    expect(valueChanged.mock.calls[0][0].detail.value).toEqual({ name: "A" });
+
+    selector.value = valueChanged.mock.calls[0][0].detail.value;
+    await selector.updateComplete;
+
+    const event: ItemActionEvent = {
+      stopPropagation: vi.fn(),
+      currentTarget: {
+        index: 0,
+      },
+    };
+
+    (getInternals(selector)._deleteItem as (event: ItemActionEvent) => void)(
+      event
+    );
+
+    expect(valueChanged.mock.calls[1][0].detail.value).toBe("");
   });
 
   it("appends an item through the real Add flow", async () => {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Fix selector initial form data so it matches the value represented by the selector.

Some selectors can represent an empty or default value differently from the value previously stored in the form's initial data. For example, required `text` and `object` selectors with `multiple: true` represent an empty value as `[]`, while the form initialized them as `""`. As a result, changing a value and then returning it to its original empty state could still leave the form marked as changed.

This change moves selector-specific initial-value handling out of `computeInitialHaFormData` into an exhaustive selector-type mapping. `SelectorType` is derived from the `Selector` union, so adding a new selector type requires its loading, initial-value, and fallback behavior to be considered explicitly instead of allowing these paths to silently fall out of sync.

It also:

- initializes required multiple `text` and `object` selectors with `[]` while preserving `""` for their single-value forms;
- initializes nested object-selector Add dialogs from their form schema instead of starting them with an empty object;
- resolves the initial value of the first `choose` option from its child selector, including `constant` selectors;
- makes selector fallback handling exhaustive without changing its existing fallback semantics;
- makes the selector lazy-loader mapping exhaustive while preserving the existing dynamic imports and lazy loading;
- keeps form-level initialization, selector initial-value semantics, selector fallback semantics, and selector loading as separate runtime responsibilities.

Regression tests cover required and optional selector initialization, single and multiple `text` and `object` selectors, recursive `choose` initialization, and the nested object-selector Add/Edit/Cancel dialog flow.

### Performance and bundle impact

A local microbenchmark of the initialization path showed no practical runtime regression. Individual selector lookups differed by only `+0.005 µs/op` to `+0.016 µs/op`, while a mixed form containing 36 selector fields improved from `7.625 µs/op` to `2.638 µs/op`.

Production `yarn build --modern` A/B comparisons were also used to choose the final module boundaries. During development, a monolithic registry that combined loading, initial-value, and fallback behavior increased the cold-load `authorize` and `onboarding` entrypoints by approximately `3.5 KiB` and `5.1 KiB`, because unrelated selector code and dependencies were pulled into those entrypoints.

Keeping loading, initial-value, and fallback responsibilities separate reduced the final production bundle impact to:

- `app`: no change;
- `core`: no change;
- `authorize`: `+196 B`;
- `onboarding`: `+10 B`;
- total modern JavaScript: `+4,593 B` (`~0.014%`);
- JavaScript asset count: unchanged.

This preserves the existing lazy selector imports while still providing compile-time exhaustive checks for selector loading, initial values, and fallback values.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr