### PR TITLE
Add default support to object selector fields

### DIFF
--- a/src/components/ha-selector/ha-selector-object.ts
+++ b/src/components/ha-selector/ha-selector-object.ts
@@ -218,6 +218,7 @@ export class HaObjectSelector extends LitElement {
       name: key,
       selector: field.selector,
       required: field.required ?? false,
+      ...("default" in field ? { default: field.default } : {}),
     }));
   });
 
@@ -237,10 +238,17 @@ export class HaObjectSelector extends LitElement {
   private async _addItem(ev) {
     ev.stopPropagation();
 
+    const schema = this._schema(this.selector);
+    const data = Object.fromEntries(
+      schema
+        .filter((field) => "default" in field)
+        .map((field) => [field.name, field.default])
+    );
+
     const newItem = await showFormDialog(this, {
       title: this.hass.localize("ui.common.add"),
-      schema: this._schema(this.selector),
-      data: {},
+      schema,
+      data,
       computeLabel: this._computeLabel,
       computeHelper: this._computeHelper,
       submitText: this.hass.localize("ui.common.add"),

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -418,6 +418,7 @@ interface ObjectSelectorField {
   label?: string;
   description?: string;
   required?: boolean;
+  default?: any;
 }
 
 export interface ObjectSelector {

--- a/test/components/ha-selector/ha-selector-object.test.ts
+++ b/test/components/ha-selector/ha-selector-object.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "../../../src/components/ha-selector/ha-selector-object";
+import type { HaObjectSelector } from "../../../src/components/ha-selector/ha-selector-object";
+import type { HaFormSchema } from "../../../src/components/ha-form/types";
+import type { ObjectSelector } from "../../../src/data/selector";
+import { showFormDialog } from "../../../src/dialogs/form/show-form-dialog";
+import type { HomeAssistant } from "../../../src/types";
+
+vi.mock("../../../src/dialogs/form/show-form-dialog", () => ({
+  showFormDialog: vi.fn(),
+}));
+
+const chooseDefault = {
+  active_choice: "Temperature",
+  Temperature: 4000,
+};
+
+const objectSelector: ObjectSelector = {
+  object: {
+    fields: {
+      required: {
+        selector: { text: {} },
+        required: true,
+      },
+      number: {
+        selector: { number: {} },
+        default: 0,
+      },
+      boolean: {
+        selector: { boolean: {} },
+        default: false,
+      },
+      text: {
+        selector: { text: {} },
+        default: "",
+      },
+      entities: {
+        selector: { entity: { multiple: true } },
+        default: [],
+      },
+      object: {
+        selector: { object: {} },
+        default: {},
+      },
+      choose: {
+        selector: {
+          choose: {
+            choices: {
+              Disabled: { selector: { boolean: {} } },
+              Temperature: { selector: { number: {} } },
+            },
+          },
+        },
+        default: chooseDefault,
+      },
+    },
+  },
+};
+
+const callPrivateMethod = <Result>(
+  element: object,
+  method: string,
+  ...args: unknown[]
+): Result =>
+  Reflect.apply(
+    Reflect.get(element, method) as (...methodArgs: unknown[]) => Result,
+    element,
+    args
+  );
+
+describe("ha-selector-object", () => {
+  beforeEach(() => {
+    vi.mocked(showFormDialog).mockReset();
+    vi.mocked(showFormDialog).mockResolvedValue(null);
+  });
+
+  it("includes explicit field defaults in the form schema", () => {
+    const element = document.createElement(
+      "ha-selector-object"
+    ) as HaObjectSelector;
+
+    const schema = callPrivateMethod<HaFormSchema[]>(
+      element,
+      "_schema",
+      objectSelector
+    );
+
+    expect(schema).toStrictEqual([
+      { name: "required", selector: { text: {} }, required: true },
+      { name: "number", selector: { number: {} }, required: false, default: 0 },
+      {
+        name: "boolean",
+        selector: { boolean: {} },
+        required: false,
+        default: false,
+      },
+      { name: "text", selector: { text: {} }, required: false, default: "" },
+      {
+        name: "entities",
+        selector: { entity: { multiple: true } },
+        required: false,
+        default: [],
+      },
+      {
+        name: "object",
+        selector: { object: {} },
+        required: false,
+        default: {},
+      },
+      {
+        name: "choose",
+        selector: {
+          choose: {
+            choices: {
+              Disabled: { selector: { boolean: {} } },
+              Temperature: { selector: { number: {} } },
+            },
+          },
+        },
+        required: false,
+        default: chooseDefault,
+      },
+    ]);
+  });
+
+  it("initializes new items with only explicit field defaults", async () => {
+    const element = document.createElement(
+      "ha-selector-object"
+    ) as HaObjectSelector;
+
+    element.hass = {
+      localize: (key: string) => key,
+    } as HomeAssistant;
+    element.selector = objectSelector;
+
+    await callPrivateMethod<Promise<void>>(element, "_addItem", {
+      stopPropagation: vi.fn(),
+    } as unknown as Event);
+
+    expect(showFormDialog).toHaveBeenCalledTimes(1);
+    expect(showFormDialog).toHaveBeenCalledWith(
+      element,
+      expect.objectContaining({
+        data: {
+          number: 0,
+          boolean: false,
+          text: "",
+          entities: [],
+          object: {},
+          choose: chooseDefault,
+        },
+      })
+    );
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add support for `default` values in object selector fields.

Object selector field defaults are passed through to the nested form schema and
used as the initial data when adding a new item.

Only explicitly configured defaults are used, preserving falsy values such as
`0`, `false`, and `""`, as well as structured values such as lists, mappings,
and `choose` selector defaults.

Fields without an explicit default keep their existing behavior. Editing an
existing item is unchanged and continues to use the item's current data.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52906
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request: https://github.com/home-assistant/core/pull/179810

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr