### PR TITLE
Lower description search weight in automation add-element search

### DIFF
--- a/src/panels/config/automation/add-automation-element/ha-automation-add-search.ts
+++ b/src/panels/config/automation/add-automation-element/ha-automation-add-search.ts
@@ -94,7 +94,7 @@ export const ITEM_SEARCH_KEYS: FuseWeightedKey[] = [
   },
   {
     name: "secondary",
-    weight: 7,
+    weight: 3,   // ← description, weighted too close to the name
   },
 ];
 


### PR DESCRIPTION
## Proposed change
The "Add trigger/condition/action" search in the automation editor weighted
a block's name (`primary`) and its description (`secondary`) almost
equally in Fuse.js (10 vs 7). Since `ignoreLocation: true` is set, a search
term matching anywhere in the (often long) description text scored close
to an exact match on the block's name.

This meant searching for a common word like "if" surfaced many unrelated
triggers/conditions/actions whose description happened to contain "if"
(e.g. "Triggers if a numeric sensor value changes..."), crowding out or
outranking the actual "If-then" block.

This PR lowers the `secondary` (description) weight from 7 to 3, matching
the convention already used for lower-priority text fields in every other
picker in the codebase (entity_picker.ts, device_picker.ts,
label_picker.ts, area_floor_picker.ts all use 3 for their least-important
field). This keeps descriptions searchable as a fallback while making sure
an exact name match is never buried under description noise.

Fixes #53042


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
This is a minimal, low-risk change (one weight value) rather than a
rewrite of the search/ranking logic, since issue #53042 is tagged
"Needs UX" — I didn't want to preempt a design-team decision on whether
descriptions should be searchable at all, or on stricter matching rules.
Happy to adjust the weight value or take a different approach if the
team prefers something more aggressive (e.g. excluding descriptions
from matching entirely, or a stricter threshold).

Tested locally with `yarn start`: opening an automation, adding a
condition, and searching "if" now shows the "If-then" block at the top
instead of buried among unrelated conditions whose descriptions merely
contain the word "if".

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
