### PR TITLE
Fix error badge creation on cold load

### DIFF
--- a/src/panels/lovelace/create-element/create-badge-element.ts
+++ b/src/panels/lovelace/create-element/create-badge-element.ts
@@ -1,5 +1,6 @@
 import type { LovelaceBadgeConfig } from "../../../data/lovelace/config/badge";
 import "../badges/hui-entity-badge";
+import "../badges/hui-error-badge";
 import {
   createLovelaceElement,
   getLovelaceElementClass,

--- a/src/panels/lovelace/create-element/create-heading-badge-element.ts
+++ b/src/panels/lovelace/create-element/create-heading-badge-element.ts
@@ -1,5 +1,6 @@
 import "../heading-badges/hui-button-heading-badge";
 import "../heading-badges/hui-entity-heading-badge";
+import "../heading-badges/hui-error-heading-badge";
 
 import {
   createLovelaceElement,

--- a/test/panels/lovelace/create-element/create-error-badge-element.test.ts
+++ b/test/panels/lovelace/create-element/create-error-badge-element.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import type { HuiErrorBadge } from "../../../../src/panels/lovelace/badges/hui-error-badge";
+import { createBadgeElement } from "../../../../src/panels/lovelace/create-element/create-badge-element";
+import { createHeadingBadgeElement } from "../../../../src/panels/lovelace/create-element/create-heading-badge-element";
+import type { HuiErrorHeadingBadge } from "../../../../src/panels/lovelace/heading-badges/hui-error-heading-badge";
+
+vi.hoisted(() => {
+  Object.assign(globalThis, {
+    __STATIC_PATH__: "/",
+    __HASS_URL__: "",
+    __BUILD__: "modern",
+    __VERSION__: "test",
+    __BACKWARDS_COMPAT__: false,
+    __SUPERVISOR__: false,
+    __NAMESPACE__: "frontend",
+  });
+});
+
+describe("error badge factories", () => {
+  it("creates a configured error badge on the first call", async () => {
+    const element = createBadgeElement({
+      type: "error",
+      error: "test error",
+    }) as HuiErrorBadge;
+    document.body.append(element);
+
+    await element.updateComplete;
+
+    expect(element.localName).toBe("hui-error-badge");
+    expect(element.shadowRoot?.textContent).toContain("test error");
+    element.remove();
+  });
+
+  it("creates a configured error heading badge on the first call", async () => {
+    const element = createHeadingBadgeElement({
+      type: "error",
+      error: "test heading error",
+    }) as HuiErrorHeadingBadge;
+    document.body.append(element);
+
+    await element.updateComplete;
+
+    expect(element.localName).toBe("hui-error-heading-badge");
+    expect(element.shadowRoot?.textContent).toContain("test heading error");
+    element.remove();
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Register `hui-error-badge` and `hui-error-heading-badge` from their factory modules so cold-load calls get the custom elements before the synchronous `setConfig()` call. The regression tests cover the first call through both factories.

This makes both error elements eager dependencies of the factory modules. That matches `ALWAYS_LOADED_TYPES`; let me know if you would prefer to keep them lazy and handle registration in the factory path instead.

Validation:

- focused Vitest: 2 tests
- pre-commit ESLint, Prettier, and Lit Analyzer
- full TypeScript check
- modern production build

## Screenshots
<!--
  If your PR includes visual changes, please add screenshots or a short video
  showing the before and after. This helps reviewers understand the impact of
  your changes.
  Note: Remove this section if this PR has no visual changes.
-->

Not applicable; there is no visual change.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53721
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
