### PR TITLE
Add keyboard and screen reader navigation to the energy device charts

### DIFF
--- a/src/components/chart/chart-sonification.ts
+++ b/src/components/chart/chart-sonification.ts
@@ -27,26 +27,57 @@ const SONIFICATION_LANGUAGES = new Set(["de", "en", "es", "fr", "hmn", "it"]);
 // lead nowhere.
 const MIN_NAVIGABLE_POINTS = 2;
 
-// Mirrors the extension's own reading of a point: it takes `value` as [x, y] and
-// drops anything whose y is not a real number. That rejects gap-only series, and
-// also value-first pairs like the energy device charts' [amount, "sensor.foo"].
-// Counts no further than `limit` so this stays cheap on charts with many points.
+const itemValues = (raw: unknown): unknown[] | null => {
+  if (Array.isArray(raw)) {
+    return raw;
+  }
+  if (raw && typeof raw === "object") {
+    const { value } = raw as { value?: unknown };
+    if (Array.isArray(value)) {
+      return value;
+    }
+  }
+  return null;
+};
+
+// ECharts spells empty values and numbers as strings too, and neither names a
+// category.
+const NON_CATEGORY_STRINGS = new Set(["-", "NaN", "null", "undefined"]);
+
+const isCategoryKey = (value: unknown): boolean =>
+  typeof value === "string" &&
+  !NON_CATEGORY_STRINGS.has(value) &&
+  Number.isNaN(Number(value));
+
+// A chart with the value axis on x, like the energy device charts, encodes its
+// items value-first: [amount, "sensor.foo"]. The extension only reads a series
+// that way when every item has that shape, so mirror the same gate.
+const isValueFirstSeries = (data: readonly unknown[]): boolean =>
+  data.length > 0 &&
+  data.every((raw) => {
+    const values = itemValues(raw);
+    return (
+      !!values && typeof values[0] === "number" && isCategoryKey(values[1])
+    );
+  });
+
+// Mirrors the extension's own reading of a point: it takes `value` as [x, y]
+// (or [y, category] in a value-first series) and drops anything whose y is not
+// a real number, which rejects gap-only series. Counts no further than `limit`
+// so this stays cheap on charts with many points.
 const countNumericPoints = (data: unknown, limit: number): number => {
   if (!Array.isArray(data)) {
     return 0;
   }
+  const valueFirst = isValueFirstSeries(data);
   let found = 0;
   for (const raw of data) {
     let y: unknown = raw;
-    if (Array.isArray(raw)) {
-      y = raw.length > 1 ? raw[1] : raw[0];
+    const values = itemValues(raw);
+    if (values) {
+      y = valueFirst ? values[0] : values.length > 1 ? values[1] : values[0];
     } else if (raw && typeof raw === "object") {
-      const { value } = raw as { value?: unknown };
-      y = Array.isArray(value)
-        ? value.length > 1
-          ? value[1]
-          : value[0]
-        : value;
+      y = (raw as { value?: unknown }).value;
     }
     if (typeof y === "number" && !Number.isNaN(y)) {
       found += 1;
@@ -196,11 +227,14 @@ export const sonifyChart = async (
   const seriesIndex = readable.map((s) => allSeries.indexOf(s));
 
   // Chart2Music always reads out an axis label, and the extension picks the wrong
-  // axis to name when there is no category axis, so label both explicitly.
+  // axis to name when there is no category axis, so label both explicitly. On a
+  // horizontal chart the announced x is the category from the y axis and the
+  // announced y is the value from the x axis, so the sources swap.
   const isTimeAxis = xAxis?.type === "time";
+  const isHorizontal = xAxis?.type === "value" && yAxis?.type === "category";
   const x = {
     label:
-      xAxis?.name ||
+      (isHorizontal ? yAxis?.name : xAxis?.name) ||
       localize(
         isTimeAxis
           ? "ui.components.history_charts.time"
@@ -213,7 +247,9 @@ export const sonifyChart = async (
       : undefined,
   };
   const y = {
-    label: yAxis?.name || localize("ui.components.history_charts.value"),
+    label:
+      (isHorizontal ? xAxis?.name : yAxis?.name) ||
+      localize("ui.components.history_charts.value"),
   };
 
   let connection: ReturnType<typeof connect>;

--- a/src/components/chart/chart-sonification.ts
+++ b/src/components/chart/chart-sonification.ts
@@ -126,6 +126,10 @@ interface SonifyChartOptions {
   localize: LocalizeFunc;
   locale: FrontendLocaleData;
   config: HassConfig;
+  // Maps a category key or item name to what should be announced for it, so
+  // cards that key their data on ids (like the energy device charts) can have
+  // the display names read out instead. Returning undefined keeps the original.
+  formatLabel?: (label: string) => string | undefined;
   onError: (error: string) => void;
 }
 
@@ -194,6 +198,47 @@ const appendSonificationStyles = () => {
   document.head.append(style);
 };
 
+// Rebuilds the labels the extension would announce — the category axis's data,
+// or the item names on pies, which ignore whatever vestigial axes the chart
+// options carry — with each one run through the card's formatter. Returns
+// undefined when there is nothing to reword, so the extension's own labels
+// stay untouched.
+const buildValueLabels = (
+  categoryAxis: { type?: string; data?: unknown } | undefined,
+  firstSeries: { type?: string; data?: unknown } | undefined,
+  formatLabel?: (label: string) => string | undefined
+): string[] | undefined => {
+  if (!formatLabel) {
+    return undefined;
+  }
+  const axisData =
+    categoryAxis?.type === "category" &&
+    Array.isArray(categoryAxis.data) &&
+    categoryAxis.data.length
+      ? categoryAxis.data
+      : undefined;
+  const labels = axisData
+    ? axisData.map((entry) =>
+        entry && typeof entry === "object"
+          ? String((entry as { value?: unknown }).value ?? "")
+          : String(entry ?? "")
+      )
+    : firstSeries?.type === "pie" && Array.isArray(firstSeries.data)
+      ? firstSeries.data.map((raw) => {
+          const name = (raw as { name?: unknown } | null)?.name;
+          if (typeof name === "string") {
+            return name;
+          }
+          const values = itemValues(raw);
+          return values && isCategoryKey(values[1]) ? String(values[1]) : "";
+        })
+      : undefined;
+  if (!labels?.length || labels.every((label) => !label)) {
+    return undefined;
+  }
+  return labels.map((label) => formatLabel(label) ?? label);
+};
+
 export const sonifyChart = async (
   chart: EChartsType,
   options: SonifyChartOptions
@@ -210,8 +255,8 @@ export const sonifyChart = async (
   if (!chartOptions) {
     return null;
   }
-  const xAxis = ensureArray(chartOptions.xAxis)[0] as XAXisOption | undefined;
-  const yAxis = ensureArray(chartOptions.yAxis)[0] as YAXisOption | undefined;
+  const xAxis = ensureArray(chartOptions.xAxis)?.[0] as XAXisOption | undefined;
+  const yAxis = ensureArray(chartOptions.yAxis)?.[0] as YAXisOption | undefined;
 
   // Chart2Music throws while validating a group with no points, which is what
   // placeholder, legend-hidden and all-null series turn into, so only offer it
@@ -232,6 +277,11 @@ export const sonifyChart = async (
   // announced y is the value from the x axis, so the sources swap.
   const isTimeAxis = xAxis?.type === "time";
   const isHorizontal = xAxis?.type === "value" && yAxis?.type === "category";
+  const valueLabels = buildValueLabels(
+    isHorizontal ? yAxis : xAxis,
+    readable[0],
+    options.formatLabel
+  );
   const x = {
     label:
       (isHorizontal ? yAxis?.name : xAxis?.name) ||
@@ -240,6 +290,7 @@ export const sonifyChart = async (
           ? "ui.components.history_charts.time"
           : "ui.components.history_charts.category"
       ),
+    ...(valueLabels ? { valueLabels } : {}),
     // Time series carry raw timestamps, which would otherwise be announced as
     // epoch milliseconds.
     format: isTimeAxis

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -117,6 +117,11 @@ export class HaChartBase extends LitElement {
 
   @property({ type: String }) public height?: string;
 
+  // Lets cards that key their data on ids have display names announced
+  // instead when the chart is navigated with Chart2Music.
+  @property({ attribute: false })
+  public sonificationLabelFormatter?: (label: string) => string | undefined;
+
   @property({ attribute: "expand-legend", type: Boolean })
   public expandLegend?: boolean;
 
@@ -583,6 +588,7 @@ export class HaChartBase extends LitElement {
         localize: this.hass.localize,
         locale: this.hass.locale,
         config: this.hass.config,
+        formatLabel: this.sonificationLabelFormatter,
         onError: () => {
           // Charts the extension cannot describe stay silent rather than
           // dropping an error on someone who only pressed Tab.

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
@@ -194,6 +194,7 @@ export class HuiEnergyDevicesGraphCard
               this._legendData
             )}
             .height=${`${Math.max(modes.includes("pie") ? 300 : 100, (this._legendData?.length || 0) * 28 + 50)}px`}
+            .sonificationLabelFormatter=${this._sonificationLabel}
             .extraComponents=${[PieChart]}
             .expandLegend=${this._config.expand_legend}
             click-label-for-more-info
@@ -292,6 +293,14 @@ export class HuiEnergyDevicesGraphCard
       return options;
     }
   );
+
+  // The chart data is keyed on statistic ids, which is what Chart2Music would
+  // otherwise announce. Names that aren't statistics — the untracked slice —
+  // are already display text, so those stay as they are.
+  private _sonificationLabel = (label: string): string | undefined =>
+    this._deviceLabels[label] || this._data?.statsMetadata[label]
+      ? this._getDeviceName(label)
+      : undefined;
 
   private _getDeviceName(statisticId: string): string {
     const suffix = this._compoundStats.includes(statisticId)

--- a/test/components/chart/chart-sonification.test.ts
+++ b/test/components/chart/chart-sonification.test.ts
@@ -95,9 +95,9 @@ describe("canSonifyChart", () => {
     expect(canSonifyChart(series([{ type: "line" }]))).toBe(false);
   });
 
-  it("rejects value-first pairs, which the extension reads as a non-numeric y", () => {
-    // The energy device charts encode [amount, categoryName]. Chart2Music takes
-    // value as [x, y], so every one of those points is dropped.
+  it("accepts value-first pairs, like the energy device charts", () => {
+    // The energy device charts encode [amount, categoryName]. Since v0.1.1 the
+    // extension reads a series that way when every item has that shape.
     expect(
       canSonifyChart(
         series([
@@ -110,18 +110,77 @@ describe("canSonifyChart", () => {
           },
         ])
       )
+    ).toBe(true);
+    expect(
+      canSonifyChart(
+        series([
+          {
+            type: "bar",
+            data: [
+              [12.5, "sensor.a"],
+              [8.25, "sensor.b"],
+            ],
+          },
+        ])
+      )
+    ).toBe(true);
+  });
+
+  it("does not read empty markers or numeric strings as value-first pairs", () => {
+    // [2, "-"] is an ECharts gap inside an ordinary series and [1, "8"] is a
+    // numeric string y; treating either as [y, category] would fabricate
+    // points the chart never plotted.
+    expect(
+      canSonifyChart(
+        series([
+          {
+            type: "line",
+            data: [
+              [1, "-"],
+              [2, "-"],
+            ],
+          },
+        ])
+      )
+    ).toBe(false);
+    expect(
+      canSonifyChart(
+        series([
+          {
+            type: "line",
+            data: [
+              [1, "8"],
+              [2, "12"],
+            ],
+          },
+        ])
+      )
+    ).toBe(false);
+  });
+
+  it("reads a series value-first only when every item has that shape", () => {
+    // A lone [number, string] among ordinary pairs is an unreadable value, not
+    // a transposed one.
+    expect(
+      canSonifyChart(
+        series([
+          {
+            type: "bar",
+            data: [
+              [12.5, "sensor.a"],
+              ["-", "sensor.b"],
+            ],
+          },
+        ])
+      )
     ).toBe(false);
   });
 
   it("rejects a chart left with a single readable point", () => {
-    // The device pie's slices are all unreadable, leaving only its one-number
-    // total series — nothing the arrow keys could move between.
+    // One device slice alone offers nothing the arrow keys could move between.
     expect(
       canSonifyChart(
-        series([
-          { type: "pie", data: [{ value: [12.5, "sensor.a"] }] },
-          { type: "pie", data: [24.5] },
-        ])
+        series([{ type: "pie", data: [{ value: [12.5, "sensor.a"] }] }])
       )
     ).toBe(false);
   });

--- a/test/components/chart/chart-sonification.test.ts
+++ b/test/components/chart/chart-sonification.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, it } from "vitest";
-import { canSonifyChart } from "../../../src/components/chart/chart-sonification";
+import type { EChartsType } from "echarts/core";
+import { connect } from "echarts-extension-chart2music";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  canSonifyChart,
+  sonifyChart,
+} from "../../../src/components/chart/chart-sonification";
+import type { LocalizeFunc } from "../../../src/common/translations/localize";
+import type { FrontendLocaleData } from "../../../src/data/translation";
+import type { HomeAssistant } from "../../../src/types";
 import type { HaECSeries } from "../../../src/resources/echarts/echarts";
+
+vi.mock("echarts-extension-chart2music", () => ({
+  connect: vi.fn((_chart, options) => {
+    options.cc.setAttribute("aria-live", "assertive");
+    return { update: vi.fn(), dispose: vi.fn() };
+  }),
+}));
 
 const series = (
   items: { type: string; id?: string; name?: string; data?: unknown[] }[]
@@ -247,5 +262,165 @@ describe("canSonifyChart", () => {
         ])
       )
     ).toBe(false);
+  });
+});
+
+describe("sonifyChart", () => {
+  const mockedConnect = vi.mocked(connect);
+
+  const fakeChart = (option: Record<string, unknown>) =>
+    ({
+      getOption: () => option,
+      on: vi.fn(),
+      off: vi.fn(),
+    }) as unknown as EChartsType;
+
+  const sonify = (
+    option: Record<string, unknown>,
+    formatLabel?: (label: string) => string | undefined
+  ) =>
+    sonifyChart(fakeChart(option), {
+      cc: document.createElement("div"),
+      localize: ((key: string) => key) as LocalizeFunc,
+      locale: { language: "en" } as FrontendLocaleData,
+      config: {} as HomeAssistant["config"],
+      formatLabel,
+      onError: () => undefined,
+    });
+
+  const connectedAxes = () => mockedConnect.mock.lastCall![1]!.axes!;
+
+  beforeEach(() => {
+    mockedConnect.mockClear();
+  });
+
+  it("swaps the axis label sources on horizontal charts", async () => {
+    const sonification = await sonify({
+      xAxis: [{ type: "value", name: "kWh" }],
+      yAxis: [{ type: "category", name: "Device", data: ["a", "b"] }],
+      series: [
+        {
+          type: "bar",
+          data: [
+            [12.5, "a"],
+            [7.25, "b"],
+          ],
+        },
+      ],
+    });
+
+    expect(sonification).not.toBeNull();
+    // The announced x walks the categories of the y axis, and the announced y
+    // is the value from the x axis.
+    expect(connectedAxes()).toMatchObject({
+      x: { label: "Device" },
+      y: { label: "kWh" },
+    });
+  });
+
+  it("keeps the axis label sources on vertical charts", async () => {
+    await sonify({
+      xAxis: [{ type: "category", name: "Month", data: ["Jan", "Feb"] }],
+      yAxis: [{ type: "value", name: "kWh" }],
+      series: [{ type: "bar", data: [5, 9] }],
+    });
+
+    expect(connectedAxes()).toMatchObject({
+      x: { label: "Month" },
+      y: { label: "kWh" },
+    });
+    // Without a formatter the extension's own labels stay untouched.
+    expect(connectedAxes().x.valueLabels).toBeUndefined();
+  });
+
+  it("announces category keys through the label formatter", async () => {
+    await sonify(
+      {
+        xAxis: [{ type: "value", name: "kWh" }],
+        yAxis: [{ type: "category", data: ["sensor.a", "sensor.b"] }],
+        series: [
+          {
+            type: "bar",
+            data: [
+              { name: "sensor.a", value: [12.5, "sensor.a"] },
+              { name: "sensor.b", value: [7.25, "sensor.b"] },
+            ],
+          },
+        ],
+      },
+      (label) => (label === "sensor.a" ? "Dishwasher" : "Oven")
+    );
+
+    expect(connectedAxes().x.valueLabels).toEqual(["Dishwasher", "Oven"]);
+  });
+
+  it("formats pie slice names and keeps the ones the formatter declines", async () => {
+    await sonify(
+      {
+        series: [
+          {
+            type: "pie",
+            data: [
+              { name: "sensor.a", value: [12.5, "sensor.a"] },
+              { name: "Untracked consumption", value: [7.25, "untracked"] },
+            ],
+          },
+        ],
+      },
+      (label) => (label === "sensor.a" ? "Dishwasher" : undefined)
+    );
+
+    expect(connectedAxes().x.valueLabels).toEqual([
+      "Dishwasher",
+      "Untracked consumption",
+    ]);
+  });
+
+  it("labels pie slices even when the options carry hidden empty axes", async () => {
+    // ha-chart-base's merged options include default axes even for pies, so
+    // an empty category axis must not block the item-name labels.
+    await sonify(
+      {
+        xAxis: [{ type: "category", show: false, data: [] }],
+        yAxis: [{ type: "value", show: false }],
+        series: [
+          {
+            type: "pie",
+            data: [
+              { name: "sensor.a", value: [12.5, "sensor.a"] },
+              { name: "sensor.b", value: [7.25, "sensor.b"] },
+            ],
+          },
+        ],
+      },
+      (label) => (label === "sensor.a" ? "Dishwasher" : "Oven")
+    );
+
+    expect(connectedAxes().x.valueLabels).toEqual(["Dishwasher", "Oven"]);
+  });
+
+  it("never overrides labels on time axis charts", async () => {
+    await sonify(
+      {
+        xAxis: [{ type: "time" }],
+        yAxis: [{ type: "value", name: "°C" }],
+        series: [
+          {
+            type: "line",
+            data: [
+              [1700000000000, 21.5],
+              [1700003600000, 22.1],
+            ],
+          },
+        ],
+      },
+      () => "wrong"
+    );
+
+    expect(connectedAxes()).toMatchObject({
+      x: { label: "ui.components.history_charts.time" },
+      y: { label: "°C" },
+    });
+    expect(connectedAxes().x.valueLabels).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Proposed change

`echarts-extension-chart2music` 0.1.1 (#53753) can read the value-first data items the energy device charts use, so the guard that excluded those charts from sonification can be lifted: eligibility now mirrors the extension's new per-series rule. The axis labels also swap sources on horizontal charts, which previously announced the value-axis name for x.

With this, the energy device charts get a keyboard focus stop in both bar and pie mode, and the arrow keys announce each device's consumption.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #53533, #53753, https://github.com/julianna-langston/echarts-extension-chart2music/pull/16
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to backend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/frontend/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
